### PR TITLE
refactor: decouple deep investigation capability from UI toggle state

### DIFF
--- a/skills/core/deep-investigation/SKILL.md
+++ b/skills/core/deep-investigation/SKILL.md
@@ -13,13 +13,15 @@ them instead of ad-hoc investigation.
 
 ## When to Use
 
-- User activates via `/dp <question>`, Ctrl+I, or the [Deep Investigation] toggle in the web UI.
-- The system will tell you when DP mode is active.
+- Complex issues requiring hypothesis-driven investigation with multiple potential root causes
+- Issues involving RDMA/RoCE, network, or hardware that need systematic validation
+- When the user explicitly requests deep investigation (toggle, /dp, Ctrl+I)
+- When initial triage reveals multiple possible root causes
 
 ## When NOT to Use
 
-- Simple questions answerable with 1-2 kubectl commands.
-- User hasn't activated DP mode — never self-activate.
+- Simple questions answerable with 1-2 kubectl commands
+- When the issue is already clear from initial triage
 
 ## Workflow (4 phases)
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -220,14 +220,13 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       if (promptText.startsWith(DP_MARKER)) {
         const question = promptText.slice(DP_MARKER.length).trim();
         if (question) {
-          dpState.enabled = true;
           dpState.checklist = createChecklist(question);
           promptText = buildActivationMessage(question);
           console.log(`[agentbox-http] DP activated for SDK brain, session ${managed.id}`);
         }
       } else if (promptText.startsWith(EXIT_MARKER)) {
         const userText = promptText.slice(EXIT_MARKER.length).trim();
-        if (dpState.enabled && dpState.checklist) {
+        if (dpState.checklist) {
           for (const item of dpState.checklist.items) {
             if (item.status === "pending" || item.status === "in_progress") {
               item.status = "skipped";
@@ -235,12 +234,11 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
             }
           }
         }
-        dpState.enabled = false;
         dpState.checklist = null;
         deepSearchGate.blocked = false;
         promptText = `The user has exited deep investigation mode. ${userText}`;
         console.log(`[agentbox-http] DP exited for SDK brain, session ${managed.id}`);
-      } else if (dpState.enabled && deepSearchGate.blocked && promptText.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
+      } else if (deepSearchGate.blocked && promptText.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
         deepSearchGate.blocked = false;
         if (dpState.checklist) {
           const hypItem = dpState.checklist.items.find((i) => i.id === "hypotheses");
@@ -464,7 +462,7 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
     }
 
     // Also update SDK brain dpState checklist (pi-agent does this in extension input handler)
-    if (managed.dpState?.enabled && managed.dpState.checklist) {
+    if (managed.dpState?.checklist) {
       const hypItem = managed.dpState.checklist.items.find((i) => i.id === "hypotheses");
       if (hypItem && hypItem.status !== "done") {
         hypItem.status = "done";

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -33,6 +33,7 @@ import {
   createManageChecklistTool,
   createProposeHypothesesTool,
   createEndInvestigationTool,
+  getDpWorkflow,
 } from "../tools/dp-tools.js";
 import { createMemorySearchTool } from "../tools/memory-search.js";
 import { createMemoryGetTool } from "../tools/memory-get.js";
@@ -486,7 +487,7 @@ export async function createSiclawSession(
     const sdkTools = [...customTools, ...tools];
 
     // DP tools for SDK brain — mutable state shared with http-server via dpState ref
-    const dpState: DpState = { enabled: false, checklist: null };
+    const dpState: DpState = { checklist: null };
     sdkTools.push(
       createManageChecklistTool(dpState),
       createProposeHypothesesTool(dpState),
@@ -498,6 +499,12 @@ export async function createSiclawSession(
     // Build the same append content that pi-agent gets via appendSystemPromptOverride
     const appendParts = buildAppendSystemPrompt(skillsBase, getUserSkillDirName, getPlatformSkillDirName, memoryDir);
     let systemPromptAppend = appendParts.join("\n") || undefined;
+
+    // Inject deep investigation workflow so the model always knows about DP tools
+    const dpWorkflow = getDpWorkflow();
+    if (dpWorkflow) {
+      systemPromptAppend = (systemPromptAppend ?? "") + `\n\n## Deep Investigation Capability\n\nYou have access to a structured deep investigation workflow. Use it for complex issues requiring hypothesis-driven validation.\n\n${dpWorkflow}`;
+    }
 
     // Append workspace custom prompt
     if (opts?.systemPromptAppend) {

--- a/src/core/brains/claude-sdk-brain.ts
+++ b/src/core/brains/claude-sdk-brain.ts
@@ -137,7 +137,7 @@ export class ClaudeSdkBrain implements BrainSession {
       if (this.config.dpState) {
         let nudges = 0;
         const MAX_DP_NUDGES = 3;
-        while (nudges < MAX_DP_NUDGES && this.config.dpState.enabled && this.config.dpState.checklist) {
+        while (nudges < MAX_DP_NUDGES && this.config.dpState.checklist) {
           const pending = this.config.dpState.checklist.items.filter(
             (i) => i.status === "pending" || i.status === "in_progress",
           );

--- a/src/core/extensions/deep-investigation.ts
+++ b/src/core/extensions/deep-investigation.ts
@@ -151,7 +151,6 @@ function formatHypothesesWidget(text: string, theme: any): string[] {
 
 export default function deepInvestigationExtension(api: ExtensionAPI): void {
   // --- Mode state ---
-  let dpModeEnabled = false;
   let checklist: DpChecklist | null = null;
 
   // --- Progress rendering state ---
@@ -167,7 +166,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
   // --- Status bar ---
 
   function updateStatus(ctx: ExtensionContext): void {
-    if (!dpModeEnabled || !checklist) {
+    if (!checklist) {
       ctx.ui.setStatus("dp-mode", undefined);
       return;
     }
@@ -186,7 +185,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
 
   function persistState(): void {
     api.appendEntry("dp-mode", {
-      enabled: dpModeEnabled,
+      enabled: checklist !== null,
       checklist,
     });
   }
@@ -194,8 +193,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
   // --- Toggle ---
 
   function enableDpMode(ctx: ExtensionContext): void {
-    if (dpModeEnabled) return;
-    dpModeEnabled = true;
+    if (checklist) return;
     checklist = createChecklist("");
     updateStatus(ctx);
     persistState();
@@ -203,8 +201,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
   }
 
   function disableDpMode(ctx: ExtensionContext): void {
-    if (!dpModeEnabled) return;
-    dpModeEnabled = false;
+    if (!checklist) return;
     deepSearchGate.blocked = false;
     checklist = null;
     updateStatus(ctx);
@@ -213,7 +210,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
   }
 
   function toggleDpMode(ctx: ExtensionContext): void {
-    if (dpModeEnabled) {
+    if (checklist) {
       disableDpMode(ctx);
     } else {
       enableDpMode(ctx);
@@ -282,7 +279,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
         toggleDpMode(ctx);
         return;
       }
-      if (!dpModeEnabled) {
+      if (!checklist) {
         enableDpMode(ctx);
       }
       checklist!.question = prompt;
@@ -299,11 +296,8 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
     },
     ctx: ExtensionContext,
   ): { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> } {
-    if (!dpModeEnabled || !checklist) {
-      return {
-        content: [{ type: "text" as const, text: "Not in deep investigation mode. Use /dp to start." }],
-        details: {},
-      };
+    if (!checklist) {
+      checklist = createChecklist("");
     }
 
     const results: string[] = [];
@@ -377,8 +371,8 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
       }),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      if (!dpModeEnabled || !checklist) {
-        return { content: [{ type: "text" as const, text: "Not in investigation mode." }], details: {} };
+      if (!checklist) {
+        return { content: [{ type: "text" as const, text: "No investigation in progress." }], details: {} };
       }
       const { reason } = params as { reason: string };
       for (const item of checklist.items) {
@@ -415,11 +409,8 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
       }),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      if (!dpModeEnabled || !checklist) {
-        return {
-          content: [{ type: "text" as const, text: "Not in deep investigation mode. Use /dp to start." }],
-          details: {},
-        };
+      if (!checklist) {
+        checklist = createChecklist("");
       }
 
       const { hypotheses: hypothesesText } = params as { hypotheses: string };
@@ -482,7 +473,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
     if (!question) return { action: "continue" as const };
 
     // Enable DP mode if not already active
-    if (!dpModeEnabled) {
+    if (!checklist) {
       enableDpMode(ctx);
     }
     checklist!.question = question;
@@ -504,7 +495,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
     const userText = event.text.slice(marker.length).trim();
 
     // Immediately clean up backend DP state
-    if (dpModeEnabled && checklist) {
+    if (checklist) {
       for (const item of checklist.items) {
         if (item.status === "pending" || item.status === "in_progress") {
           item.status = "skipped";
@@ -524,7 +515,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
   // --- input: clear gate when user confirms hypotheses (gateway mode) ---
 
   api.on("input", async (event) => {
-    if (!dpModeEnabled || !deepSearchGate.blocked) return { action: "continue" as const };
+    if (!deepSearchGate.blocked) return { action: "continue" as const };
     if (event.text.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
       deepSearchGate.blocked = false;
       // Auto-mark hypotheses as done (user confirmed them)
@@ -548,12 +539,10 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
 
   api.on("session_start", async (_event, ctx) => {
     // Reset state — each session starts clean (prevents bleed from previous session)
-    dpModeEnabled = false;
     checklist = null;
 
     // From CLI flag
     if (api.getFlag("dp") === true) {
-      dpModeEnabled = true;
       checklist = createChecklist("");
     }
 
@@ -564,7 +553,6 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
       .pop() as { data?: { enabled: boolean; checklist?: DpChecklist; phase?: string; question?: string } } | undefined;
 
     if (entry?.data) {
-      dpModeEnabled = entry.data.enabled ?? dpModeEnabled;
       if (entry.data.checklist) {
         // New format
         checklist = entry.data.checklist;

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -275,7 +275,10 @@ export function usePilot() {
     const [investigationProgress, setInvestigationProgress] = useState<InvestigationProgress | null>(null);
     const [dpFocus, setDpFocus] = useState<string | null>(null);
     const [dpChecklist, setDpChecklist] = useState<DpChecklistItem[] | null>(null);
-    const [dpActive, setDpActive] = useState(false);
+    const DP_ACTIVE_STORAGE = 'siclaw_dp_active';
+    const [dpActive, setDpActive] = useState(() => {
+        return localStorage.getItem(DP_ACTIVE_STORAGE) === 'true';
+    });
     const [sessions, setSessions] = useState<Session[]>([]);
     const [currentSessionKey, setCurrentSessionKey] = useState<string | null>(() => {
         return localStorage.getItem(SESSION_KEY_STORAGE);
@@ -329,11 +332,10 @@ export function usePilot() {
         dpTimersRef.current.clear();
     };
 
-    /** Reset all DP-related state (checklist, focus, toggle, progress) */
+    /** Reset all DP-related state (checklist, focus, progress) — toggle is user preference, not reset */
     const resetDpState = () => {
         setDpChecklist(null);
         setDpFocus(null);
-        setDpActive(false);
         setInvestigationProgress(null);
     };
 
@@ -345,6 +347,11 @@ export function usePilot() {
             localStorage.removeItem(SESSION_KEY_STORAGE);
         }
     }, [currentSessionKey]);
+
+    // Persist dpActive to localStorage
+    useEffect(() => {
+        localStorage.setItem(DP_ACTIVE_STORAGE, String(dpActive));
+    }, [dpActive]);
 
     // Persist selectedBrain to localStorage
     useEffect(() => {

--- a/src/tools/dp-tools.ts
+++ b/src/tools/dp-tools.ts
@@ -36,7 +36,6 @@ export interface DpChecklist {
  * For SDK brain, this lives on ManagedSession so http-server can inspect it.
  */
 export interface DpState {
-  enabled: boolean;
   checklist: DpChecklist | null;
 }
 
@@ -103,11 +102,8 @@ export function createManageChecklistTool(dpState: DpState): ToolDefinition {
       })),
     }),
     async execute(_toolCallId, params) {
-      if (!dpState.enabled || !dpState.checklist) {
-        return {
-          content: [{ type: "text" as const, text: "Not in deep investigation mode. Use /dp to start." }],
-          details: {},
-        };
+      if (!dpState.checklist) {
+        dpState.checklist = createChecklist("");
       }
 
       const { updates } = params as { updates: Array<{ id: string; status?: string; summary?: string }> };
@@ -124,10 +120,10 @@ export function createManageChecklistTool(dpState: DpState): ToolDefinition {
         results.push(`update ${upd.id}: ${upd.status ?? "ok"}`);
       }
 
-      // Auto-exit DP mode when conclusion is marked done
+      // Auto-cleanup when conclusion is marked done
       const conclusionItem = dpState.checklist.items.find((i) => i.id === "conclusion");
       if (conclusionItem?.status === "done") {
-        dpState.enabled = false;
+        dpState.checklist = null;
         deepSearchGate.blocked = false;
       }
 
@@ -160,11 +156,8 @@ export function createProposeHypothesesTool(dpState: DpState): ToolDefinition {
       }),
     }),
     async execute(_toolCallId, params) {
-      if (!dpState.enabled || !dpState.checklist) {
-        return {
-          content: [{ type: "text" as const, text: "Not in deep investigation mode. Use /dp to start." }],
-          details: {},
-        };
+      if (!dpState.checklist) {
+        dpState.checklist = createChecklist("");
       }
 
       const { hypotheses: hypothesesText } = params as { hypotheses: string };
@@ -201,8 +194,8 @@ export function createEndInvestigationTool(dpState: DpState): ToolDefinition {
       }),
     }),
     async execute(_toolCallId, params) {
-      if (!dpState.enabled || !dpState.checklist) {
-        return { content: [{ type: "text" as const, text: "Not in investigation mode." }], details: {} };
+      if (!dpState.checklist) {
+        return { content: [{ type: "text" as const, text: "No investigation in progress." }], details: {} };
       }
       const { reason } = params as { reason: string };
       for (const item of dpState.checklist.items) {
@@ -211,7 +204,7 @@ export function createEndInvestigationTool(dpState: DpState): ToolDefinition {
           item.summary = reason;
         }
       }
-      dpState.enabled = false;
+      dpState.checklist = null;
       deepSearchGate.blocked = false;
       return {
         content: [{ type: "text" as const, text: `Investigation ended: ${reason}` }],


### PR DESCRIPTION
Remove DpState.enabled flag — use checklist presence as the sole indicator of an active investigation. Tools auto-create checklists when invoked without one, so the model always has DP capability regardless of the UI toggle.

- dp-tools.ts: remove enabled field, tools gate on checklist only
- http-server.ts: remove enabled references in marker/gate handlers
- agent-factory.ts: inject SKILL.md workflow into SDK system prompt
- claude-sdk-brain.ts: auto-continue checks checklist, not enabled
- deep-investigation.ts: replace dpModeEnabled with checklist !== null
- usePilot.ts: persist dpActive to localStorage, don't reset on end
- SKILL.md: allow autonomous triggering, remove "never self-activate"