### PR TITLE
refactor: decouple DP workflow from blocking gate mechanism

### DIFF
--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -11,7 +11,7 @@ import type { AgentBoxSessionManager } from "./session.js";
 import type { SessionMode } from "../core/agent-factory.js";
 import type { BrainType } from "../core/brain-session.js";
 import { hasOpenAIProvider, ensureProxy } from "../core/llm-proxy.js";
-import { deepSearchEvents, deepSearchGate, HYPOTHESES_CONFIRMED_SENTINEL } from "../tools/deep-search/events.js";
+import { deepSearchEvents } from "../tools/deep-search/events.js";
 import { createChecklist, buildActivationMessage } from "../tools/dp-tools.js";
 import { loadConfig } from "../core/config.js";
 
@@ -235,33 +235,9 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
           }
         }
         dpState.checklist = null;
-        deepSearchGate.blocked = false;
         promptText = `The user has exited deep investigation mode. ${userText}`;
         console.log(`[agentbox-http] DP exited for SDK brain, session ${managed.id}`);
-      } else if (deepSearchGate.blocked && promptText.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
-        deepSearchGate.blocked = false;
-        if (dpState.checklist) {
-          const hypItem = dpState.checklist.items.find((i) => i.id === "hypotheses");
-          if (hypItem && hypItem.status !== "done") {
-            hypItem.status = "done";
-            if (!hypItem.summary) hypItem.summary = "Confirmed";
-          }
-          const dsItem = dpState.checklist.items.find((i) => i.id === "deep_search");
-          if (dsItem && dsItem.status !== "done") {
-            dsItem.status = "in_progress";
-          }
-        }
-        console.log(`[agentbox-http] DP hypotheses confirmed for SDK brain, session ${managed.id}`);
       }
-    }
-
-    // Universal fallback: clear gate regardless of brain type / dpState.
-    // Pi-agent's extension input handler should also clear it, but if the
-    // extension state wasn't restored (TTL release/restore race), this ensures
-    // the gate is cleared before the agent processes the confirmation message.
-    if (deepSearchGate.blocked && promptText.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
-      deepSearchGate.blocked = false;
-      console.log(`[agentbox-http] Gate cleared by universal fallback for session ${managed.id}`);
     }
 
     // Execute prompt asynchronously; notify SSE to close on completion
@@ -441,40 +417,6 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       managed._promptDoneCallbacks.delete(cleanup);
       unsubAll();
     });
-  });
-
-  /**
-   * POST /api/sessions/:sessionId/confirm-hypotheses - directly clear the deep_search gate
-   * Bypasses the steer/input pipeline to ensure the gate is reliably cleared.
-   */
-  addRoute("POST", "/api/sessions/:sessionId/confirm-hypotheses", async (_req, res, params) => {
-    const { sessionId } = params;
-
-    // Always clear the gate first — it's a process-level singleton, not per-session.
-    // The session may have been released by TTL, but the gate still needs clearing.
-    console.log(`[agentbox-http] Confirming hypotheses for session ${sessionId}, clearing gate`);
-    deepSearchGate.blocked = false;
-
-    const managed = sessionManager.get(sessionId);
-    if (!managed) {
-      sendJson(res, 200, { ok: true, gateCleared: true, sessionFound: false });
-      return;
-    }
-
-    // Also update SDK brain dpState checklist (pi-agent does this in extension input handler)
-    if (managed.dpState?.checklist) {
-      const hypItem = managed.dpState.checklist.items.find((i) => i.id === "hypotheses");
-      if (hypItem && hypItem.status !== "done") {
-        hypItem.status = "done";
-        if (!hypItem.summary) hypItem.summary = "Confirmed";
-      }
-      const dsItem = managed.dpState.checklist.items.find((i) => i.id === "deep_search");
-      if (dsItem && dsItem.status !== "done") {
-        dsItem.status = "in_progress";
-      }
-    }
-
-    sendJson(res, 200, { ok: true, gateCleared: true });
   });
 
   /**

--- a/src/core/brains/claude-sdk-brain.ts
+++ b/src/core/brains/claude-sdk-brain.ts
@@ -142,9 +142,6 @@ export class ClaudeSdkBrain implements BrainSession {
             (i) => i.status === "pending" || i.status === "in_progress",
           );
           if (pending.length === 0) break;
-          // Don't nudge if waiting for user hypothesis confirmation (gate blocked)
-          const { deepSearchGate } = await import("../../tools/deep-search/events.js");
-          if (deepSearchGate.blocked) break;
           nudges++;
           const nextPhase = pending[0].label;
           console.log(`[claude-sdk-brain] DP auto-continue (${nudges}/${MAX_DP_NUDGES}): ${nextPhase}`);

--- a/src/core/extensions/deep-investigation.ts
+++ b/src/core/extensions/deep-investigation.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@mariozechner/pi-coding-agent";
 import { Key, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { deepSearchEvents, deepSearchGate, HYPOTHESES_CONFIRMED_SENTINEL, type ProgressEvent } from "../../tools/deep-search/events.js";
+import { deepSearchEvents, type ProgressEvent } from "../../tools/deep-search/events.js";
 import {
   type ChecklistItemStatus,
   type DpChecklist,
@@ -202,7 +202,6 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
 
   function disableDpMode(ctx: ExtensionContext): void {
     if (!checklist) return;
-    deepSearchGate.blocked = false;
     checklist = null;
     updateStatus(ctx);
     persistState();
@@ -397,10 +396,10 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
     name: "propose_hypotheses",
     label: "Propose Hypotheses",
     description:
-      "Present hypotheses to the user for confirmation during deep investigation. " +
+      "Present hypotheses to the user during deep investigation. " +
       "Call this after triage to propose 3-5 ranked hypotheses. " +
-      "The tool will show the hypotheses to the user and wait for their confirmation or edits. " +
-      "Only available in deep investigation mode.",
+      "This is non-blocking — after presenting, proceed to call deep_search immediately. " +
+      "The user can interrupt with edits if needed.",
     parameters: Type.Object({
       hypotheses: Type.String({
         description:
@@ -414,50 +413,17 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
       }
 
       const { hypotheses: hypothesesText } = params as { hypotheses: string };
-      let userResponse: string;
 
+      // TUI mode: briefly flash hypotheses as a widget (auto-cleared on deep_search start)
       const hasTUI = ctx.hasUI && isThemeUsable(ctx);
-
       if (hasTUI) {
-        // TUI mode: render formatted hypotheses as a persistent widget above editor
         const widgetLines = formatHypothesesWidget(hypothesesText, ctx.ui.theme);
         ctx.ui.setWidget("dp-hypotheses", widgetLines);
-
-        // Simple confirmation select (hypotheses already visible in widget)
-        const choice = await ctx.ui.select("\uD83D\uDD0D Deep Investigation \u2014 Hypothesis Confirmation", [
-          "\u2714 Continue Validation",
-          "\u270F Supplement/Edit then Continue",
-          "\u2718 Exit Investigation",
-        ]);
-
-        // Clear widget after selection
-        ctx.ui.setWidget("dp-hypotheses", undefined);
-
-        if (choice?.startsWith("\u2714")) {
-          userResponse = "User confirmed. Please call deep_search to validate these hypotheses.";
-        } else if (choice?.startsWith("\u270F")) {
-          const feedback = await ctx.ui.editor("Supplement hypotheses or provide edits:", "");
-          if (feedback?.trim()) {
-            userResponse = `User feedback: ${feedback.trim()}\n\nPlease incorporate the edits and then call deep_search.`;
-          } else {
-            userResponse = "User confirmed. Please call deep_search to validate these hypotheses.";
-          }
-        } else if (choice?.startsWith("\u2718")) {
-          disableDpMode(ctx);
-          userResponse = "User chose to exit the investigation.";
-        } else {
-          // Escape pressed — default to confirm
-          userResponse = "User confirmed. Please call deep_search to validate these hypotheses.";
-        }
-      } else {
-        // RPC / gateway mode — block until user confirms via input handler
-        userResponse = "Hypotheses submitted for user review. Please wait for the user's confirmation before continuing — do not call deep_search on your own.";
-        deepSearchGate.blocked = true;
       }
 
       return {
-        content: [{ type: "text" as const, text: userResponse }],
-        details: { hypotheses: hypothesesText, autoConfirmed: hasTUI },
+        content: [{ type: "text" as const, text: "Hypotheses presented to user. Proceed to call deep_search with these hypotheses." }],
+        details: { hypotheses: hypothesesText },
       };
     },
   });
@@ -510,29 +476,6 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
       action: "transform" as const,
       text: `The user has exited deep investigation mode. ${userText}`,
     };
-  });
-
-  // --- input: clear gate when user confirms hypotheses (gateway mode) ---
-
-  api.on("input", async (event) => {
-    if (!deepSearchGate.blocked) return { action: "continue" as const };
-    if (event.text.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
-      deepSearchGate.blocked = false;
-      // Auto-mark hypotheses as done (user confirmed them)
-      if (checklist) {
-        const hypItem = checklist.items.find((i) => i.id === "hypotheses");
-        if (hypItem && hypItem.status !== "done") {
-          hypItem.status = "done";
-          if (!hypItem.summary) hypItem.summary = "Confirmed";
-        }
-        const dsItem = checklist.items.find((i) => i.id === "deep_search");
-        if (dsItem && dsItem.status !== "done") {
-          dsItem.status = "in_progress";
-        }
-        persistState();
-      }
-    }
-    return { action: "continue" as const };
   });
 
   // --- session_start: restore persisted state ---

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -167,15 +167,6 @@ export class AgentBoxClient {
   }
 
   /**
-   * Confirm hypotheses — directly clears the deep_search gate
-   */
-  async confirmHypotheses(sessionId: string): Promise<void> {
-    await this.fetch(`/api/sessions/${sessionId}/confirm-hypotheses`, {
-      method: "POST",
-    });
-  }
-
-  /**
    * Abort the current prompt execution
    */
   async abortSession(sessionId: string): Promise<void> {

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -1128,32 +1128,6 @@ export function createRpcMethods(
     return { status: "aborted" };
   });
 
-  methods.set("chat.confirmHypotheses", async (_params, context: RpcContext) => {
-    const userId = requireAuth(context);
-
-    // Try activeStream first; fallback to agentBoxManager (covers race where
-    // chat.confirmHypotheses arrives before SSE subscription is established)
-    const stream = activeStreams.get(userId);
-    let endpoint: string;
-    let sessionId: string;
-    if (stream) {
-      endpoint = stream.endpoint;
-      sessionId = stream.sessionId;
-    } else {
-      const handle = await findAgentBoxForSession(userId);
-      if (!handle) throw new Error("No active agent session");
-      endpoint = handle.endpoint;
-      const abClient = new AgentBoxClient(endpoint);
-      const sessions = await abClient.listSessions();
-      if (!sessions.sessions?.length) throw new Error("No active session");
-      sessionId = sessions.sessions[0].id;
-    }
-
-    const client = new AgentBoxClient(endpoint);
-    await client.confirmHypotheses(sessionId);
-    return { status: "confirmed" };
-  });
-
   methods.set("chat.dpProgress", async (_params, context: RpcContext) => {
     const userId = requireAuth(context);
     const snap = dpProgressSnapshots.get(userId);

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -918,7 +918,7 @@ export function usePilot() {
         sendMessage('[DP_EXIT]\nPlease briefly summarize the current investigation progress and findings.');
     }, [dismissDpChecklist, sendMessage]);
 
-    /** Optimistic UI: immediately show hypothesis tree + deep_search in_progress when user confirms */
+    /** Optimistic UI: immediately show hypothesis tree + deep_search in_progress */
     const confirmHypotheses = useCallback((hypotheses: Array<{ id: string; text: string; confidence: number }>) => {
         // Mark triage+hypotheses as done, deep_search as in_progress
         setDpChecklist(prev => {
@@ -948,10 +948,7 @@ export function usePilot() {
                 maxCalls: 10,
             })),
         });
-        // Try to clear gate via dedicated RPC. This may fail if the agent session
-        // has already ended (normal — the steer message's input handler clears it instead).
-        sendRpc('chat.confirmHypotheses').catch(() => {});
-    }, [sendRpc]);
+    }, []);
 
     const createSession = useCallback(() => {
         // Don't create a DB session yet — just reset UI to "new chat" state.

--- a/src/tools/deep-search/events.ts
+++ b/src/tools/deep-search/events.ts
@@ -10,9 +10,3 @@ import type { ProgressEvent } from "./sub-agent.js";
  */
 export const deepSearchEvents = new EventEmitter();
 export type { ProgressEvent };
-
-/** Gate: blocks deep_search until user confirms hypotheses in gateway mode */
-export const deepSearchGate = { blocked: false };
-
-/** Sentinel substring present in the user message when hypotheses are confirmed via the gateway UI */
-export const HYPOTHESES_CONFIRMED_SENTINEL = "user has confirmed hypotheses";

--- a/src/tools/deep-search/tool.ts
+++ b/src/tools/deep-search/tool.ts
@@ -4,7 +4,7 @@ import { investigate, writeReport } from "./engine.js";
 import { formatResult, formatSummary } from "./format.js";
 import { NORMAL_BUDGET, QUICK_BUDGET } from "./types.js";
 import { Text } from "@mariozechner/pi-tui";
-import { deepSearchEvents, deepSearchGate } from "./events.js";
+import { deepSearchEvents } from "./events.js";
 import type { KubeconfigRef, LlmConfigRef } from "../../core/agent-factory.js";
 
 interface DeepSearchHypothesis {
@@ -165,16 +165,6 @@ Do triage first before calling this tool — confirm the problem exists and gath
     }),
     renderResult: renderDeepSearchResult,
     async execute(_toolCallId, rawParams) {
-      // Hard gate: refuse to execute if hypotheses have not been confirmed by the user.
-      // This prevents the model from skipping hypothesis review (e.g. after user Modify feedback).
-      if (deepSearchGate.blocked) {
-        console.warn(`[deep_search] Gate blocked — refusing execution. This usually means the model called deep_search before user confirmed hypotheses.`);
-        return {
-          content: [{ type: "text", text: "BLOCKED: User has not yet confirmed hypotheses. STOP making tool calls and wait for the user's confirmation message.\nDo NOT fall back to manual kubectl investigation. The user will confirm shortly — just wait." }],
-          details: {},
-        };
-      }
-
       const params = rawParams as DeepSearchParams;
       const budget = params.budget === "quick" ? QUICK_BUDGET : NORMAL_BUDGET;
 

--- a/src/tools/dp-tools.ts
+++ b/src/tools/dp-tools.ts
@@ -13,7 +13,6 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
-import { deepSearchGate } from "./deep-search/events.js";
 
 // --- Shared types ---
 
@@ -124,7 +123,6 @@ export function createManageChecklistTool(dpState: DpState): ToolDefinition {
       const conclusionItem = dpState.checklist.items.find((i) => i.id === "conclusion");
       if (conclusionItem?.status === "done") {
         dpState.checklist = null;
-        deepSearchGate.blocked = false;
       }
 
       return {
@@ -137,17 +135,19 @@ export function createManageChecklistTool(dpState: DpState): ToolDefinition {
 
 /**
  * Create the propose_hypotheses tool.
- * In SDK/gateway mode: returns "waiting for confirmation" + blocks the gate.
+ * Non-blocking: presents hypotheses to the user and immediately tells
+ * the model to proceed. The frontend renders them for user review;
+ * if the user wants changes they can send a follow-up message.
  */
 export function createProposeHypothesesTool(dpState: DpState): ToolDefinition {
   return {
     name: "propose_hypotheses",
     label: "Propose Hypotheses",
     description:
-      "Present hypotheses to the user for confirmation during deep investigation. " +
+      "Present hypotheses to the user during deep investigation. " +
       "Call this after triage to propose 3-5 ranked hypotheses. " +
-      "The tool will show the hypotheses to the user and wait for their confirmation or edits. " +
-      "Only available in deep investigation mode.",
+      "This is non-blocking — after presenting, proceed to call deep_search immediately. " +
+      "The user can interrupt with edits if needed.",
     parameters: Type.Object({
       hypotheses: Type.String({
         description:
@@ -162,13 +162,9 @@ export function createProposeHypothesesTool(dpState: DpState): ToolDefinition {
 
       const { hypotheses: hypothesesText } = params as { hypotheses: string };
 
-      // Gateway/SDK mode — block gate, wait for user confirmation
-      deepSearchGate.blocked = true;
-      const userResponse = "Hypotheses submitted for user review.\n\nSTOP. Do NOT call any more tools. Do NOT call deep_search. Do NOT fall back to manual investigation.\nWait for the user to confirm — their confirmation message will appear as a new user message.\nYour next output should ONLY be a brief text message telling the user you are waiting for their confirmation.";
-
       return {
-        content: [{ type: "text" as const, text: userResponse }],
-        details: { hypotheses: hypothesesText, autoConfirmed: false },
+        content: [{ type: "text" as const, text: "Hypotheses presented to user. Proceed to call deep_search with these hypotheses." }],
+        details: { hypotheses: hypothesesText },
       };
     },
   };
@@ -205,7 +201,6 @@ export function createEndInvestigationTool(dpState: DpState): ToolDefinition {
         }
       }
       dpState.checklist = null;
-      deepSearchGate.blocked = false;
       return {
         content: [{ type: "text" as const, text: `Investigation ended: ${reason}` }],
         details: {},


### PR DESCRIPTION
## Summary

This PR decouples the Deep Investigation (DP) workflow from the blocking gate mechanism that previously prevented `deep_search` from executing until the user explicitly confirmed hypotheses.

### Problem

The `deepSearchGate` singleton and the DP checklist were two independent state machines that frequently fell out of sync, especially after WebSocket disconnects:

- The checklist could show hypotheses as "confirmed" while the gate remained blocked
- Network interruptions during the hypothesis confirmation handshake left the gate permanently locked
- Reconnecting users had to restart the entire investigation from scratch
- The model was stuck in a deadlock: checklist said "proceed", gate said "wait"

### Changes

**Gate removal** (`-196 lines`):
- Remove `deepSearchGate` singleton and `HYPOTHESES_CONFIRMED_SENTINEL` from `events.ts`
- Remove gate check from `deep_search` tool execution path
- Remove `/confirm-hypotheses` HTTP endpoint from AgentBox
- Remove `chat.confirmHypotheses` RPC method from gateway
- Remove gate-clearing logic from `claude-sdk-brain` DP auto-continue
- Remove sentinel input handlers from both pi-agent extension and HTTP server

**Non-blocking hypothesis presentation** (`+19 lines`):
- `propose_hypotheses` tool now returns immediately with "proceed to deep_search"
- TUI mode shows hypotheses as a widget without blocking select dialog
- Frontend `confirmHypotheses` becomes a pure optimistic UI update (no RPC call)

**Also includes** (from earlier commits on this branch):
- Decouple deep investigation capability from UI toggle — `deep_search` is always available as a model tool regardless of DP mode
- Improve deep search engine budget and prompt tuning
- Harden kubeconfig propagation to AgentBox pods
- Fix MCP mounts and skill label scanning

### Design Philosophy

DP workflow steps are now **observational, not controlling** — they track and display investigation progress without blocking model execution. Users can still interrupt or redirect via normal chat messages at any point.

## Test Plan

- [x] `tsc --noEmit` passes with zero errors
- [x] `vitest run` — 685 tests pass (3 pre-existing timeout failures in restricted-bash unrelated to this change)
- [ ] Manual: trigger DP via web UI magnifying glass, verify deep_search proceeds without confirmation gate
- [ ] Manual: disconnect WebSocket mid-investigation, reconnect, verify model can continue
- [ ] Manual: TUI mode `/dp` command — hypotheses display as widget, no blocking select