### PR TITLE
feat(tools,gateway): credential output protection and DP decouple

### DIFF
--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -13,7 +13,7 @@ import type { AgentBoxSessionManager } from "./session.js";
 import type { SessionMode } from "../core/agent-factory.js";
 import type { BrainType } from "../core/brain-session.js";
 import { hasOpenAIProvider, ensureProxy } from "../core/llm-proxy.js";
-import { deepSearchEvents, deepSearchGate, HYPOTHESES_CONFIRMED_SENTINEL } from "../tools/deep-search/events.js";
+import { deepSearchEvents } from "../tools/deep-search/events.js";
 import { createChecklist, buildActivationMessage } from "../tools/dp-tools.js";
 import { loadConfig } from "../core/config.js";
 import { GatewayClient } from "./gateway-client.js";
@@ -276,33 +276,9 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
           }
         }
         dpState.checklist = null;
-        deepSearchGate.blocked = false;
         promptText = `The user has exited deep investigation mode. ${userText}`;
         console.log(`[agentbox-http] DP exited for SDK brain, session ${managed.id}`);
-      } else if (deepSearchGate.blocked && promptText.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
-        deepSearchGate.blocked = false;
-        if (dpState.checklist) {
-          const hypItem = dpState.checklist.items.find((i) => i.id === "hypotheses");
-          if (hypItem && hypItem.status !== "done") {
-            hypItem.status = "done";
-            if (!hypItem.summary) hypItem.summary = "Confirmed";
-          }
-          const dsItem = dpState.checklist.items.find((i) => i.id === "deep_search");
-          if (dsItem && dsItem.status !== "done") {
-            dsItem.status = "in_progress";
-          }
-        }
-        console.log(`[agentbox-http] DP hypotheses confirmed for SDK brain, session ${managed.id}`);
       }
-    }
-
-    // Universal fallback: clear gate regardless of brain type / dpState.
-    // Pi-agent's extension input handler should also clear it, but if the
-    // extension state wasn't restored (TTL release/restore race), this ensures
-    // the gate is cleared before the agent processes the confirmation message.
-    if (deepSearchGate.blocked && promptText.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
-      deepSearchGate.blocked = false;
-      console.log(`[agentbox-http] Gate cleared by universal fallback for session ${managed.id}`);
     }
 
     // Execute prompt asynchronously; notify SSE to close on completion
@@ -482,40 +458,6 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       managed._promptDoneCallbacks.delete(cleanup);
       unsubAll();
     });
-  });
-
-  /**
-   * POST /api/sessions/:sessionId/confirm-hypotheses - directly clear the deep_search gate
-   * Bypasses the steer/input pipeline to ensure the gate is reliably cleared.
-   */
-  addRoute("POST", "/api/sessions/:sessionId/confirm-hypotheses", async (_req, res, params) => {
-    const { sessionId } = params;
-
-    // Always clear the gate first — it's a process-level singleton, not per-session.
-    // The session may have been released by TTL, but the gate still needs clearing.
-    console.log(`[agentbox-http] Confirming hypotheses for session ${sessionId}, clearing gate`);
-    deepSearchGate.blocked = false;
-
-    const managed = sessionManager.get(sessionId);
-    if (!managed) {
-      sendJson(res, 200, { ok: true, gateCleared: true, sessionFound: false });
-      return;
-    }
-
-    // Also update SDK brain dpState checklist (pi-agent does this in extension input handler)
-    if (managed.dpState?.checklist) {
-      const hypItem = managed.dpState.checklist.items.find((i) => i.id === "hypotheses");
-      if (hypItem && hypItem.status !== "done") {
-        hypItem.status = "done";
-        if (!hypItem.summary) hypItem.summary = "Confirmed";
-      }
-      const dsItem = managed.dpState.checklist.items.find((i) => i.id === "deep_search");
-      if (dsItem && dsItem.status !== "done") {
-        dsItem.status = "in_progress";
-      }
-    }
-
-    sendJson(res, 200, { ok: true, gateCleared: true });
   });
 
   /**

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -399,10 +399,25 @@ export async function createSiclawSession(
   const readAllowedDirs = [cwd];
   const writeAllowedDirs = [userDataDir];
 
+  // Block reading sensitive credential/config files (but allow skills/ and user-data/)
+  const READ_BLOCKED_PATTERNS = [
+    /\.siclaw\/config\/settings\.json$/,
+    /\.siclaw\/credentials\//,
+  ];
+
   const tools = [
     createReadTool(cwd, {
       operations: {
-        readFile: async (p) => { assertPathAllowed(p, readAllowedDirs, "read"); return fsReadFile(p); },
+        readFile: async (p) => {
+          assertPathAllowed(p, readAllowedDirs, "read");
+          const resolved = path.resolve(p);
+          for (const pattern of READ_BLOCKED_PATTERNS) {
+            if (pattern.test(resolved)) {
+              throw new Error("Access denied: credential/config files cannot be read");
+            }
+          }
+          return fsReadFile(p);
+        },
         access: async (p) => { assertPathAllowed(p, readAllowedDirs, "read"); return fsAccess(p, fs.constants.R_OK); },
       },
     }),

--- a/src/core/brains/claude-sdk-brain.ts
+++ b/src/core/brains/claude-sdk-brain.ts
@@ -142,9 +142,6 @@ export class ClaudeSdkBrain implements BrainSession {
             (i) => i.status === "pending" || i.status === "in_progress",
           );
           if (pending.length === 0) break;
-          // Don't nudge if waiting for user hypothesis confirmation (gate blocked)
-          const { deepSearchGate } = await import("../../tools/deep-search/events.js");
-          if (deepSearchGate.blocked) break;
           nudges++;
           const nextPhase = pending[0].label;
           console.log(`[claude-sdk-brain] DP auto-continue (${nudges}/${MAX_DP_NUDGES}): ${nextPhase}`);

--- a/src/core/extensions/deep-investigation.ts
+++ b/src/core/extensions/deep-investigation.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionContext, ExtensionUIContext } from "@mariozechner/pi-coding-agent";
 import { Key, Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
-import { deepSearchEvents, deepSearchGate, HYPOTHESES_CONFIRMED_SENTINEL, type ProgressEvent } from "../../tools/deep-search/events.js";
+import { deepSearchEvents, type ProgressEvent } from "../../tools/deep-search/events.js";
 import {
   type ChecklistItemStatus,
   type DpChecklist,
@@ -202,7 +202,6 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
 
   function disableDpMode(ctx: ExtensionContext): void {
     if (!checklist) return;
-    deepSearchGate.blocked = false;
     checklist = null;
     updateStatus(ctx);
     persistState();
@@ -397,9 +396,10 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
     name: "propose_hypotheses",
     label: "Propose Hypotheses",
     description:
-      "Present hypotheses to the user for confirmation during deep investigation. " +
+      "Present hypotheses to the user during deep investigation (non-blocking). " +
       "Call this after triage to propose 3-5 ranked hypotheses. " +
-      "The tool will show the hypotheses to the user and wait for their confirmation or edits. " +
+      "The tool will show the hypotheses to the user and immediately return — " +
+      "proceed to call deep_search right away without waiting for confirmation. " +
       "Only available in deep investigation mode.",
     parameters: Type.Object({
       hypotheses: Type.String({
@@ -414,7 +414,6 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
       }
 
       const { hypotheses: hypothesesText } = params as { hypotheses: string };
-      let userResponse: string;
 
       const hasTUI = ctx.hasUI && isThemeUsable(ctx);
 
@@ -423,41 +422,14 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
         const widgetLines = formatHypothesesWidget(hypothesesText, ctx.ui.theme);
         ctx.ui.setWidget("dp-hypotheses", widgetLines);
 
-        // Simple confirmation select (hypotheses already visible in widget)
-        const choice = await ctx.ui.select("\uD83D\uDD0D Deep Investigation \u2014 Hypothesis Confirmation", [
-          "\u2714 Continue Validation",
-          "\u270F Supplement/Edit then Continue",
-          "\u2718 Exit Investigation",
-        ]);
-
-        // Clear widget after selection
-        ctx.ui.setWidget("dp-hypotheses", undefined);
-
-        if (choice?.startsWith("\u2714")) {
-          userResponse = "User confirmed. Please call deep_search to validate these hypotheses.";
-        } else if (choice?.startsWith("\u270F")) {
-          const feedback = await ctx.ui.editor("Supplement hypotheses or provide edits:", "");
-          if (feedback?.trim()) {
-            userResponse = `User feedback: ${feedback.trim()}\n\nPlease incorporate the edits and then call deep_search.`;
-          } else {
-            userResponse = "User confirmed. Please call deep_search to validate these hypotheses.";
-          }
-        } else if (choice?.startsWith("\u2718")) {
-          disableDpMode(ctx);
-          userResponse = "User chose to exit the investigation.";
-        } else {
-          // Escape pressed — default to confirm
-          userResponse = "User confirmed. Please call deep_search to validate these hypotheses.";
-        }
-      } else {
-        // RPC / gateway mode — block until user confirms via input handler
-        userResponse = "Hypotheses submitted for user review. Please wait for the user's confirmation before continuing — do not call deep_search on your own.";
-        deepSearchGate.blocked = true;
+        // Auto-dismiss widget after a short delay (non-blocking)
+        setTimeout(() => ctx.ui.setWidget("dp-hypotheses", undefined), 5000);
       }
 
+      // Non-blocking: immediately return and let the model proceed to deep_search
       return {
-        content: [{ type: "text" as const, text: userResponse }],
-        details: { hypotheses: hypothesesText, autoConfirmed: hasTUI },
+        content: [{ type: "text" as const, text: "Hypotheses recorded. Proceed to call deep_search to validate them." }],
+        details: { hypotheses: hypothesesText, autoConfirmed: true },
       };
     },
   });
@@ -510,29 +482,6 @@ export default function deepInvestigationExtension(api: ExtensionAPI): void {
       action: "transform" as const,
       text: `The user has exited deep investigation mode. ${userText}`,
     };
-  });
-
-  // --- input: clear gate when user confirms hypotheses (gateway mode) ---
-
-  api.on("input", async (event) => {
-    if (!deepSearchGate.blocked) return { action: "continue" as const };
-    if (event.text.includes(HYPOTHESES_CONFIRMED_SENTINEL)) {
-      deepSearchGate.blocked = false;
-      // Auto-mark hypotheses as done (user confirmed them)
-      if (checklist) {
-        const hypItem = checklist.items.find((i) => i.id === "hypotheses");
-        if (hypItem && hypItem.status !== "done") {
-          hypItem.status = "done";
-          if (!hypItem.summary) hypItem.summary = "Confirmed";
-        }
-        const dsItem = checklist.items.find((i) => i.id === "deep_search");
-        if (dsItem && dsItem.status !== "done") {
-          dsItem.status = "in_progress";
-        }
-        persistState();
-      }
-    }
-    return { action: "continue" as const };
   });
 
   // --- session_start: restore persisted state ---

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -54,10 +54,11 @@ The main file \`MEMORY.md\` is automatically loaded into every new session conte
 ## Credentials
 
 - **Before your first kubectl command**, call \`credential_list\` to discover available kubeconfigs.
-- If \`credential_list\` returns **no credentials**, inform the user that no kubeconfig is configured for this workspace.
-- If \`credential_list\` returns **exactly one** kubeconfig, use it directly.
-- If \`credential_list\` returns **multiple** kubeconfigs, you **MUST** present the list and ask the user which one to use **BEFORE** running any kubectl. Do NOT pick one yourself.
-- Always use \`--kubeconfig=<path>\` on EVERY kubectl command. Never use \`export KUBECONFIG\` or \`kubectl config use-context\`.`;
+- If \`credential_list\` returns **no credentials**, inform the user that no kubeconfig is configured.
+- If \`credential_list\` returns **exactly one** kubeconfig, kubectl is pre-configured — just run kubectl commands directly. No --kubeconfig needed.
+- If \`credential_list\` returns **multiple** kubeconfigs, present the list (names only) and ask the user which one to use. Then pass \`--kubeconfig=<name>\` (the credential **name**, NOT a file path).
+- **NEVER output credential details** in your responses — including file paths, server URLs, API keys, tokens, cluster internal IDs, or kubeconfig contents. When discussing credentials, only mention the name and type.
+- **NEVER read credential files** (.kubeconfig, .key, .token, settings.json, etc.) using read or cat commands.`;
 
   prompt += `\n\n## Language\n\nAlways respond in the same language the user writes in. Match the user's language naturally. Technical terms (kubectl, pod names, error messages, CLI output) can remain in English.`;
 

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -185,15 +185,6 @@ export class AgentBoxClient {
   }
 
   /**
-   * Confirm hypotheses — directly clears the deep_search gate
-   */
-  async confirmHypotheses(sessionId: string): Promise<void> {
-    await this.fetch(`/api/sessions/${sessionId}/confirm-hypotheses`, {
-      method: "POST",
-    });
-  }
-
-  /**
    * Abort the current prompt execution
    */
   async abortSession(sessionId: string): Promise<void> {

--- a/src/gateway/output-redactor.test.ts
+++ b/src/gateway/output-redactor.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { buildRedactionConfig, redactText } from "./output-redactor.js";
+
+describe("output-redactor", () => {
+  describe("buildRedactionConfig", () => {
+    it("creates patterns from credential manifest", () => {
+      const config = buildRedactionConfig([
+        {
+          name: "prod-cluster",
+          type: "kubeconfig",
+          files: ["prod.kubeconfig"],
+          metadata: {
+            clusters: [{ name: "cz0er7pvw94gmuiq", server: "https://10.155.55.223:6443" }],
+          },
+        },
+      ]);
+      expect(config.patterns.length).toBeGreaterThan(0);
+    });
+
+    it("includes sensitive strings", () => {
+      const config = buildRedactionConfig(undefined, undefined, ["sk-myapikey123456789"]);
+      const result = redactText("The key is sk-myapikey123456789", config);
+      expect(result).toBe("The key is [REDACTED]");
+    });
+
+    it("skips short sensitive strings (< 8 chars)", () => {
+      const config = buildRedactionConfig(undefined, undefined, ["short"]);
+      const result = redactText("This is short text", config);
+      expect(result).toBe("This is short text");
+    });
+  });
+
+  describe("redactText", () => {
+    it("redacts server URLs from credential metadata", () => {
+      const config = buildRedactionConfig([{
+        name: "test",
+        type: "kubeconfig",
+        files: ["test.kubeconfig"],
+        metadata: {
+          clusters: [{ name: "internal-id-123", server: "https://10.155.55.223:6443" }],
+        },
+      }]);
+      const text = "API server: https://10.155.55.223:6443";
+      expect(redactText(text, config)).toBe("API server: [REDACTED]");
+    });
+
+    it("redacts cluster internal IDs", () => {
+      const config = buildRedactionConfig([{
+        name: "my-cluster",
+        type: "kubeconfig",
+        files: [],
+        metadata: {
+          clusters: [{ name: "cz0er7pvw94gmuiq", server: "https://1.2.3.4:6443" }],
+        },
+      }]);
+      expect(redactText("Cluster cz0er7pvw94gmuiq is healthy", config)).toContain("[REDACTED]");
+    });
+
+    it("redacts credentials dir paths", () => {
+      const config = buildRedactionConfig([], "/app/.siclaw/credentials");
+      expect(redactText("File at /app/.siclaw/credentials/prod.kubeconfig", config)).toContain("[REDACTED]");
+    });
+
+    it("redacts settings.json path", () => {
+      const config = buildRedactionConfig();
+      expect(redactText("Read .siclaw/config/settings.json", config)).toContain("[REDACTED]");
+    });
+
+    // Generic token pattern tests
+    it("redacts OpenAI-style sk- tokens", () => {
+      const config = buildRedactionConfig();
+      expect(redactText("key: sk-grYemdBx9ujuhwVWeea6lW9mcsuid9flLkX64DDD4XT4VNYbZW", config)).toContain("[REDACTED]");
+    });
+
+    it("redacts GitHub tokens", () => {
+      const config = buildRedactionConfig();
+      expect(redactText("token: ghp_1234567890abcdef1234567890abcdefABCD", config)).toContain("[REDACTED]");
+    });
+
+    it("redacts Bearer tokens", () => {
+      const config = buildRedactionConfig();
+      expect(redactText("Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp", config)).toContain("[REDACTED]");
+    });
+
+    it("redacts PEM private keys", () => {
+      const config = buildRedactionConfig();
+      const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQ\n-----END RSA PRIVATE KEY-----";
+      expect(redactText(pem, config)).toContain("[REDACTED]");
+    });
+
+    it("redacts env var assignments with sensitive names", () => {
+      const config = buildRedactionConfig();
+      expect(redactText("OPENAI_API_KEY=sk-xxx123456", config)).toContain("[REDACTED]");
+    });
+
+    it("returns empty string unchanged", () => {
+      const config = buildRedactionConfig();
+      expect(redactText("", config)).toBe("");
+    });
+
+    it("returns normal text unchanged", () => {
+      const config = buildRedactionConfig();
+      expect(redactText("kubectl get pods -n default", config)).toBe("kubectl get pods -n default");
+    });
+  });
+});

--- a/src/gateway/output-redactor.ts
+++ b/src/gateway/output-redactor.ts
@@ -1,0 +1,127 @@
+/**
+ * Output redaction module — last-line defense for credential leakage.
+ *
+ * Builds regex patterns from the credential payload (server URLs, file paths,
+ * cluster internal names) and replaces them with [REDACTED] in outbound text
+ * sent to the user via WebSocket.
+ *
+ * Applied to all outbound surfaces: WS stream, channel-bridge, and DB storage.
+ */
+
+export interface RedactionConfig {
+  patterns: RegExp[];
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export interface CredentialManifest {
+  name: string;
+  type: string;
+  files: string[];
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Build redaction patterns from credential payload, credentials directory path,
+ * and any additional sensitive strings (e.g. API keys, provider URLs).
+ */
+export function buildRedactionConfig(
+  manifest?: CredentialManifest[],
+  credentialsDir?: string,
+  sensitiveStrings?: string[],
+): RedactionConfig {
+  const patterns: RegExp[] = [];
+
+  // Redact the credentials directory path and any sub-paths
+  if (credentialsDir) {
+    patterns.push(new RegExp(escapeRegex(credentialsDir) + "[^\\s\"']*", "g"));
+  }
+
+  if (manifest) {
+    for (const cred of manifest) {
+      // File names (relative paths within credentials dir)
+      for (const file of cred.files) {
+        patterns.push(new RegExp(escapeRegex(file), "g"));
+      }
+
+      // Metadata: server URLs, cluster internal names
+      if (cred.metadata) {
+        const clusters = (cred.metadata as Record<string, unknown>).clusters as
+          Array<{ name: string; server?: string }> | undefined;
+        if (clusters) {
+          for (const c of clusters) {
+            if (c.server) {
+              patterns.push(new RegExp(escapeRegex(c.server), "g"));
+            }
+            // Redact cluster internal ID if it differs from the credential display name
+            if (c.name && c.name !== cred.name) {
+              patterns.push(new RegExp("\\b" + escapeRegex(c.name) + "\\b", "g"));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Extra sensitive strings (API keys, provider base URLs, etc.)
+  if (sensitiveStrings) {
+    for (const s of sensitiveStrings) {
+      if (s && s.length >= 8) {
+        patterns.push(new RegExp(escapeRegex(s), "g"));
+      }
+    }
+  }
+
+  // Always redact settings.json path references
+  patterns.push(/\.siclaw\/config\/settings\.json/g);
+
+  // Generic secret patterns — catch unknown tokens by format (defense-in-depth)
+  for (const p of GENERIC_SECRET_PATTERNS) {
+    patterns.push(p);
+  }
+
+  return { patterns };
+}
+
+/**
+ * Built-in patterns for common secret/token formats.
+ * Each regex uses a non-capturing group and global flag.
+ * Patterns are designed to minimize false positives by requiring known prefixes
+ * or structural markers.
+ */
+const GENERIC_SECRET_PATTERNS: RegExp[] = [
+  // OpenAI / compatible: sk-<20+ chars>
+  /\bsk-[A-Za-z0-9]{20,}\b/g,
+  // GitHub tokens: ghp_, gho_, ghu_, ghs_, ghr_, github_pat_
+  /\b(?:ghp_|gho_|ghu_|ghs_|ghr_)[A-Za-z0-9_]{30,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+  // Slack tokens: xox[baprs]-
+  /\bxox[baprs]-[A-Za-z0-9\-]{20,}\b/g,
+  // Google AI: AIza
+  /\bAIza[A-Za-z0-9\-_]{30,}\b/g,
+  // Authorization header values
+  /\bBearer\s+[A-Za-z0-9\-_.~+/]{20,}=*\b/g,
+  // PEM private key blocks
+  /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g,
+  // Generic "apiKey": "value" or "api_key": "value" in JSON output
+  /(?<="(?:api[_-]?[Kk]ey|apikey|token|secret|password|access_key|secret_key)":\s*")[^"]{8,}(?=")/g,
+  // ENV assignment: API_KEY=value, SECRET_TOKEN=value (printenv/env output)
+  /\b(?:API_KEY|ANTHROPIC_API_KEY|OPENAI_API_KEY|SECRET_KEY|ACCESS_KEY|AWS_SECRET_ACCESS_KEY|TOKEN|SECRET_TOKEN|PASSWORD)=\S+/g,
+];
+
+/**
+ * Replace all sensitive patterns in text with [REDACTED].
+ */
+export function redactText(text: string, config: RedactionConfig): string {
+  if (config.patterns.length === 0) return text;
+
+  let result = text;
+  for (const pattern of config.patterns) {
+    // Reset lastIndex for stateful (global) regexes
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[REDACTED]");
+  }
+  return result;
+}

--- a/src/gateway/plugins/channel-bridge.ts
+++ b/src/gateway/plugins/channel-bridge.ts
@@ -5,6 +5,7 @@ import type { ChannelPlugin, StreamingCard } from "./api.js";
 import type { UserStore } from "../auth/user-store.js";
 import type { ConfigRepository } from "../db/repositories/config-repo.js";
 import { notifyCronService } from "../cron/notify.js";
+import { buildRedactionConfig, redactText, type RedactionConfig } from "../output-redactor.js";
 
 export type OutboundSender = (sessionKey: string, text: string) => Promise<void>;
 
@@ -135,6 +136,12 @@ export function createChannelBridge(
             return undefined;
           })
         : undefined;
+
+      // Build redaction config for outbound channel messages
+      const redactionConfig: RedactionConfig = buildRedactionConfig(
+        credentials?.manifest,
+        credentials?.manifest?.length ? ".siclaw/credentials" : undefined,
+      );
 
       // Channel and web share the same AgentBox — mode-driven skill loading
       // handles tool/skill differences per session.
@@ -361,10 +368,13 @@ export function createChannelBridge(
               const toolResult = evt.result as
                 | { content?: Array<{ type: string; text?: string }> }
                 | undefined;
-              let output = toolResult?.content
-                ?.filter((c) => c.type === "text")
-                .map((c) => c.text ?? "")
-                .join("") ?? "";
+              let output = redactText(
+                toolResult?.content
+                  ?.filter((c) => c.type === "text")
+                  .map((c) => c.text ?? "")
+                  .join("") ?? "",
+                redactionConfig,
+              );
 
               // Auto-execute manage_schedule results (except list)
               // Only attempt parse when output looks like JSON (starts with '{')
@@ -421,7 +431,7 @@ export function createChannelBridge(
                 | { type: string; delta?: string }
                 | undefined;
               if (ame?.type === "text_delta" && ame.delta) {
-                assistantText += ame.delta;
+                assistantText += redactText(ame.delta, redactionConfig);
                 if (supportsStreaming && card) {
                   scheduleUpdate(getDisplayContent());
                 }

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -980,32 +980,6 @@ export function createRpcMethods(
     return { status: "aborted" };
   });
 
-  methods.set("chat.confirmHypotheses", async (_params, context: RpcContext) => {
-    const userId = requireAuth(context);
-
-    // Try activeStream first; fallback to agentBoxManager (covers race where
-    // chat.confirmHypotheses arrives before SSE subscription is established)
-    const stream = activeStreams.get(userId);
-    let endpoint: string;
-    let sessionId: string;
-    if (stream) {
-      endpoint = stream.endpoint;
-      sessionId = stream.sessionId;
-    } else {
-      const handle = await findAgentBoxForSession(userId);
-      if (!handle) throw new Error("No active agent session");
-      endpoint = handle.endpoint;
-      const abClient = new AgentBoxClient(endpoint, 30000, agentBoxTlsOptions);
-      const sessions = await abClient.listSessions();
-      if (!sessions.sessions?.length) throw new Error("No active session");
-      sessionId = sessions.sessions[0].id;
-    }
-
-    const client = new AgentBoxClient(endpoint, 30000, agentBoxTlsOptions);
-    await client.confirmHypotheses(sessionId);
-    return { status: "confirmed" };
-  });
-
   methods.set("chat.dpProgress", async (_params, context: RpcContext) => {
     const userId = requireAuth(context);
     const snap = dpProgressSnapshots.get(userId);

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -35,6 +35,7 @@ import { createTwoFilesPatch } from "diff";
 import yaml from "js-yaml";
 import { notifyCronService as notifyCronServiceImpl } from "./cron/notify.js";
 import { buildSkillBundle, type SkillBundle } from "./skills/skill-bundle.js";
+import { buildRedactionConfig, redactText, type RedactionConfig } from "./output-redactor.js";
 
 export type SendToUserFn = (userId: string, event: string, payload: Record<string, unknown>) => void;
 
@@ -392,6 +393,16 @@ export function createRpcMethods(
     const result = await client.prompt({ sessionId, text: message, modelProvider, modelId, brainType, modelConfig, credentials });
     console.log(`[rpc] prompt sent → sessionId=${result.sessionId}`);
 
+    // Build redaction config from credential payload + model secrets (sanitize outbound WS stream)
+    const sensitiveStrings: string[] = [];
+    if (modelConfig?.apiKey) sensitiveStrings.push(modelConfig.apiKey);
+    if (modelConfig?.baseUrl) sensitiveStrings.push(modelConfig.baseUrl);
+    const redactionConfig: RedactionConfig = buildRedactionConfig(
+      credentials?.manifest,
+      credentials?.manifest?.length ? path.resolve(process.cwd(), ".siclaw/credentials") : undefined,
+      sensitiveStrings.length > 0 ? sensitiveStrings : undefined,
+    );
+
     // Cancel previous SSE subscription
     const existingStream = activeStreams.get(userId);
     if (existingStream) {
@@ -450,9 +461,9 @@ export function createRpcMethods(
             dbMessageId = await chatRepo.appendMessage({
               sessionId: result.sessionId,
               role: "tool",
-              content: text,
+              content: redactText(text, redactionConfig),
               toolName,
-              toolInput: pendingToolInput || undefined,
+              toolInput: pendingToolInput ? redactText(pendingToolInput, redactionConfig) : undefined,
             });
             await chatRepo.incrementMessageCount(result.sessionId);
             pendingToolInput = "";
@@ -466,6 +477,26 @@ export function createRpcMethods(
             ...eventData,
             ...(dbMessageId ? { dbMessageId } : {}),
           };
+          // Redact sensitive credential info from outbound WS stream
+          if (redactionConfig.patterns.length > 0) {
+            const ep = eventPayload as Record<string, unknown>;
+            if (eventType === "message_update") {
+              const ame = ep.assistantMessageEvent as { type?: string; delta?: string } | undefined;
+              if (ame?.type === "text_delta" && ame.delta) {
+                ame.delta = redactText(ame.delta, redactionConfig);
+              }
+            } else if (eventType === "tool_execution_end") {
+              const toolResult = ep.result as { content?: Array<{ type: string; text?: string }> } | undefined;
+              if (toolResult?.content) {
+                for (const block of toolResult.content) {
+                  if (block.type === "text" && block.text) {
+                    block.text = redactText(block.text, redactionConfig);
+                  }
+                }
+              }
+            }
+          }
+
           if (sendToUser) {
             sendToUser(userId, "agent_event", eventPayload);
           } else {
@@ -497,12 +528,12 @@ export function createRpcMethods(
                 assistantContent += ame.delta;
               }
             } else if (eventType === "message_end") {
-              // Save complete assistant message
+              // Save complete assistant message (redacted)
               if (assistantContent) {
                 await chatRepo.appendMessage({
                   sessionId: result.sessionId,
                   role: "assistant",
-                  content: assistantContent,
+                  content: redactText(assistantContent, redactionConfig),
                 });
                 await chatRepo.incrementMessageCount(result.sessionId);
                 assistantContent = "";

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -948,10 +948,7 @@ export function usePilot() {
                 maxCalls: 10,
             })),
         });
-        // Try to clear gate via dedicated RPC. This may fail if the agent session
-        // has already ended (normal — the steer message's input handler clears it instead).
-        sendRpc('chat.confirmHypotheses').catch(() => {});
-    }, [sendRpc]);
+    }, []);
 
     const createSession = useCallback(() => {
         // Don't create a DB session yet — just reset UI to "new chat" state.

--- a/src/tools/credential-list.ts
+++ b/src/tools/credential-list.ts
@@ -70,9 +70,9 @@ export function createCredentialListTool(kubeconfigRef: KubeconfigRef): ToolDefi
     },
     renderResult: renderTextResult,
     description: `List available credentials in the current workspace.
-Returns credential names, types, descriptions, file paths, and metadata (e.g. cluster URLs, SSH hosts).
-For kubeconfig credentials, a connectivity probe is included (reachable / unreachable).
-Use this to discover which credentials are available before running kubectl, ssh, or API commands.
+Returns credential names, types, descriptions, and connectivity status.
+For kubeconfig credentials, a connectivity probe is included.
+Use this to discover which credentials are available before running kubectl commands.
 
 Optional filters:
 - type: Filter by credential type (kubeconfig, ssh_key, ssh_password, api_token, api_basic_auth)
@@ -112,14 +112,14 @@ Optional filters:
           credentials = credentials.filter((c) => c.name.toLowerCase().includes(needle));
         }
 
-        // Enrich with full paths
-        const result: CredentialEntry[] = credentials.map((c) => ({
+        // Internal enrichment: resolve full paths for probing (NOT returned to model)
+        const enriched: CredentialEntry[] = credentials.map((c) => ({
           ...c,
           files: c.files.map((f) => `${credentialsDir}/${f}`),
         }));
 
         // Probe kubeconfig connectivity in parallel
-        const kubeconfigs = result.filter((c) => c.type === "kubeconfig");
+        const kubeconfigs = enriched.filter((c) => c.type === "kubeconfig");
         if (kubeconfigs.length > 0) {
           const probes = await Promise.all(
             kubeconfigs.map(async (c) => {
@@ -128,7 +128,7 @@ Optional filters:
             }),
           );
           for (const { name, probe } of probes) {
-            const cred = result.find((c) => c.name === name);
+            const cred = enriched.find((c) => c.name === name);
             if (cred) {
               cred.reachable = probe.reachable;
               if (probe.version) cred.server_version = probe.version;
@@ -136,6 +136,16 @@ Optional filters:
             }
           }
         }
+
+        // Map to safe return structure — strip files[], metadata, and other sensitive fields
+        const safeResult = enriched.map((c) => ({
+          name: c.name,
+          type: c.type,
+          description: c.description ?? null,
+          ...(c.reachable !== undefined ? { reachable: c.reachable } : {}),
+          ...(c.server_version ? { server_version: c.server_version } : {}),
+          ...(c.probe_error ? { probe_error: c.probe_error } : {}),
+        }));
 
         // Build selection hint for the agent
         const reachableKubeconfigs = kubeconfigs.filter((c) => c.reachable);
@@ -147,7 +157,7 @@ Optional filters:
         }
 
         return {
-          content: [{ type: "text", text: JSON.stringify({ credentials: result }, null, 2) + hint }],
+          content: [{ type: "text", text: JSON.stringify({ credentials: safeResult }, null, 2) + hint }],
           details: {},
         };
       } catch (err) {

--- a/src/tools/deep-search/events.ts
+++ b/src/tools/deep-search/events.ts
@@ -10,9 +10,3 @@ import type { ProgressEvent } from "./sub-agent.js";
  */
 export const deepSearchEvents = new EventEmitter();
 export type { ProgressEvent };
-
-/** Gate: blocks deep_search until user confirms hypotheses in gateway mode */
-export const deepSearchGate = { blocked: false };
-
-/** Sentinel substring present in the user message when hypotheses are confirmed via the gateway UI */
-export const HYPOTHESES_CONFIRMED_SENTINEL = "user has confirmed hypotheses";

--- a/src/tools/deep-search/prompts.ts
+++ b/src/tools/deep-search/prompts.ts
@@ -23,14 +23,12 @@ function environmentContext(kubeconfigPath?: string): string {
 ## Environment
 
 ### Kubeconfig
-kubeconfig file: \`${kubeconfigPath}\`
-MUST add \`--kubeconfig=${kubeconfigPath}\` to EVERY kubectl command.
-Do NOT use \`export KUBECONFIG=...\` — blocked by sandbox.
+A kubeconfig is pre-configured. Just run kubectl commands directly — do NOT pass --kubeconfig.
+Use \`node_exec\` for host-level diagnostics (it handles kubeconfig internally).
 
 ### Sandbox Restrictions
 - \`export\`, \`env\` (with args), \`cp\`, \`mv\`, \`rm\` are blocked
 - \`kubectl run/apply/delete\` blocked (read-only mode in bash)
-- Use \`node_exec\` for host-level diagnostics (it handles kubeconfig internally)
 `;
 }
 

--- a/src/tools/deep-search/tool.ts
+++ b/src/tools/deep-search/tool.ts
@@ -4,7 +4,7 @@ import { investigate, writeReport } from "./engine.js";
 import { formatResult, formatSummary } from "./format.js";
 import { NORMAL_BUDGET, QUICK_BUDGET } from "./types.js";
 import { Text } from "@mariozechner/pi-tui";
-import { deepSearchEvents, deepSearchGate } from "./events.js";
+import { deepSearchEvents } from "./events.js";
 import type { KubeconfigRef, LlmConfigRef } from "../../core/agent-factory.js";
 
 interface DeepSearchHypothesis {
@@ -165,16 +165,6 @@ Do triage first before calling this tool — confirm the problem exists and gath
     }),
     renderResult: renderDeepSearchResult,
     async execute(_toolCallId, rawParams) {
-      // Hard gate: refuse to execute if hypotheses have not been confirmed by the user.
-      // This prevents the model from skipping hypothesis review (e.g. after user Modify feedback).
-      if (deepSearchGate.blocked) {
-        console.warn(`[deep_search] Gate blocked — refusing execution. This usually means the model called deep_search before user confirmed hypotheses.`);
-        return {
-          content: [{ type: "text", text: "BLOCKED: User has not yet confirmed hypotheses. STOP making tool calls and wait for the user's confirmation message.\nDo NOT fall back to manual kubectl investigation. The user will confirm shortly — just wait." }],
-          details: {},
-        };
-      }
-
       const params = rawParams as DeepSearchParams;
       const budget = params.budget === "quick" ? QUICK_BUDGET : NORMAL_BUDGET;
 

--- a/src/tools/dp-tools.ts
+++ b/src/tools/dp-tools.ts
@@ -13,8 +13,6 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
-import { deepSearchGate } from "./deep-search/events.js";
-
 // --- Shared types ---
 
 export type ChecklistItemStatus = "pending" | "in_progress" | "done" | "skipped";
@@ -124,7 +122,6 @@ export function createManageChecklistTool(dpState: DpState): ToolDefinition {
       const conclusionItem = dpState.checklist.items.find((i) => i.id === "conclusion");
       if (conclusionItem?.status === "done") {
         dpState.checklist = null;
-        deepSearchGate.blocked = false;
       }
 
       return {
@@ -137,16 +134,17 @@ export function createManageChecklistTool(dpState: DpState): ToolDefinition {
 
 /**
  * Create the propose_hypotheses tool.
- * In SDK/gateway mode: returns "waiting for confirmation" + blocks the gate.
+ * Non-blocking: shows hypotheses to user and immediately proceeds to deep_search.
  */
 export function createProposeHypothesesTool(dpState: DpState): ToolDefinition {
   return {
     name: "propose_hypotheses",
     label: "Propose Hypotheses",
     description:
-      "Present hypotheses to the user for confirmation during deep investigation. " +
+      "Present hypotheses to the user during deep investigation (non-blocking). " +
       "Call this after triage to propose 3-5 ranked hypotheses. " +
-      "The tool will show the hypotheses to the user and wait for their confirmation or edits. " +
+      "The tool will show the hypotheses to the user and immediately return — " +
+      "proceed to call deep_search right away without waiting for confirmation. " +
       "Only available in deep investigation mode.",
     parameters: Type.Object({
       hypotheses: Type.String({
@@ -162,13 +160,9 @@ export function createProposeHypothesesTool(dpState: DpState): ToolDefinition {
 
       const { hypotheses: hypothesesText } = params as { hypotheses: string };
 
-      // Gateway/SDK mode — block gate, wait for user confirmation
-      deepSearchGate.blocked = true;
-      const userResponse = "Hypotheses submitted for user review.\n\nSTOP. Do NOT call any more tools. Do NOT call deep_search. Do NOT fall back to manual investigation.\nWait for the user to confirm — their confirmation message will appear as a new user message.\nYour next output should ONLY be a brief text message telling the user you are waiting for their confirmation.";
-
       return {
-        content: [{ type: "text" as const, text: userResponse }],
-        details: { hypotheses: hypothesesText, autoConfirmed: false },
+        content: [{ type: "text" as const, text: "Hypotheses recorded. Proceed to call deep_search to validate them." }],
+        details: { hypotheses: hypothesesText, autoConfirmed: true },
       };
     },
   };
@@ -205,7 +199,6 @@ export function createEndInvestigationTool(dpState: DpState): ToolDefinition {
         }
       }
       dpState.checklist = null;
-      deepSearchGate.blocked = false;
       return {
         content: [{ type: "text" as const, text: `Investigation ended: ${reason}` }],
         details: {},

--- a/src/tools/kubeconfig-resolver.ts
+++ b/src/tools/kubeconfig-resolver.ts
@@ -35,3 +35,22 @@ export function resolveKubeconfigPath(credentialsDir?: string): string | null {
     return null;
   }
 }
+
+/**
+ * Resolve a kubeconfig path by credential name.
+ * Used to translate `--kubeconfig=<name>` into an actual file path.
+ * Returns null if no match found.
+ */
+export function resolveKubeconfigByName(credentialsDir: string, name: string): string | null {
+  const manifestPath = join(credentialsDir, "manifest.json");
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const entries = JSON.parse(readFileSync(manifestPath, "utf-8")) as CredentialEntry[];
+    const match = entries.find((e) => e.type === "kubeconfig" && e.name === name);
+    if (!match) return null;
+    const kubeconfigFile = match.files.find((f) => f.endsWith(".kubeconfig")) ?? match.files[0];
+    return kubeconfigFile ? join(credentialsDir, kubeconfigFile) : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/tools/netns-script.ts
+++ b/src/tools/netns-script.ts
@@ -8,6 +8,7 @@ import { resolveScript } from "./script-resolver.js";
 import { processToolOutput, renderTextResult } from "./tool-render.js";
 import { checkNodeReady } from "./k8s-checks.js";
 import { loadConfig } from "../core/config.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 
 const DEFAULT_IMAGE = loadConfig().debugImage;
 
@@ -153,7 +154,7 @@ Examples:
     async execute(_toolCallId, rawParams, signal) {
       const params = rawParams as NetnsScriptParams;
       const env = {
-        ...process.env,
+        ...sanitizeEnv(process.env as Record<string, string>),
         ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
         KUBECONFIG: "/dev/null",
       };

--- a/src/tools/node-exec.ts
+++ b/src/tools/node-exec.ts
@@ -7,6 +7,7 @@ import type { KubeconfigRef } from "../core/agent-factory.js";
 import { renderTextResult, processToolOutput } from "./tool-render.js";
 import { checkNodeReady, waitForPodDone } from "./k8s-checks.js";
 import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 import { loadConfig } from "../core/config.js";
 import {
   ALLOWED_COMMANDS,
@@ -230,7 +231,7 @@ Examples:
       const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
       const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
       const childEnv = {
-        ...process.env,
+        ...sanitizeEnv(process.env as Record<string, string>),
         ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
         KUBECONFIG: "/dev/null",
       };

--- a/src/tools/node-script.ts
+++ b/src/tools/node-script.ts
@@ -7,6 +7,7 @@ import type { KubeconfigRef } from "../core/agent-factory.js";
 import { validateNodeName } from "./node-exec.js";
 import { checkNodeReady, waitForPodDone } from "./k8s-checks.js";
 import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 import { resolveScript } from "./script-resolver.js";
 import { processToolOutput, renderTextResult } from "./tool-render.js";
 import { loadConfig } from "../core/config.js";
@@ -133,7 +134,7 @@ Examples:
       const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
       const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
       const env = {
-        ...process.env,
+        ...sanitizeEnv(process.env as Record<string, string>),
         ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
         KUBECONFIG: "/dev/null",
       };

--- a/src/tools/pod-exec.ts
+++ b/src/tools/pod-exec.ts
@@ -7,6 +7,7 @@ import type { KubeconfigRef } from "../core/agent-factory.js";
 import { renderTextResult, processToolOutput } from "./tool-render.js";
 import { checkPodRunning } from "./k8s-checks.js";
 import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 import { validateCommand } from "./node-exec.js";
 import { parseArgs } from "./command-sets.js";
 
@@ -107,7 +108,7 @@ Examples:
       const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
       const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
       const childEnv = {
-        ...process.env,
+        ...sanitizeEnv(process.env as Record<string, string>),
         ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
         KUBECONFIG: "/dev/null",
       };

--- a/src/tools/pod-nsenter-exec.ts
+++ b/src/tools/pod-nsenter-exec.ts
@@ -10,6 +10,7 @@ import { validateCommand } from "./node-exec.js";
 import { parseArgs } from "./command-sets.js";
 import { validatePodName } from "./pod-exec.js";
 import { loadConfig } from "../core/config.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 
 const DEFAULT_IMAGE = loadConfig().debugImage;
 
@@ -145,7 +146,7 @@ Examples:
     async execute(_toolCallId, rawParams) {
       const params = rawParams as PodNsenterExecParams;
       const env = {
-        ...process.env,
+        ...sanitizeEnv(process.env as Record<string, string>),
         ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
         KUBECONFIG: "/dev/null",
       };

--- a/src/tools/pod-script.ts
+++ b/src/tools/pod-script.ts
@@ -7,6 +7,7 @@ import { resolveScript } from "./script-resolver.js";
 import { processToolOutput, renderTextResult } from "./tool-render.js";
 import { checkPodRunning } from "./k8s-checks.js";
 import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 
 interface PodScriptParams {
   pod: string;
@@ -119,7 +120,7 @@ Examples:
       const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
       const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
       const childEnv = {
-        ...process.env,
+        ...sanitizeEnv(process.env as Record<string, string>),
         ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
         KUBECONFIG: "/dev/null",
       };

--- a/src/tools/restricted-bash.ts
+++ b/src/tools/restricted-bash.ts
@@ -15,6 +15,8 @@ import {
   getCommandBinary,
   validateCommandRestrictions,
 } from "./command-sets.js";
+import { resolveKubeconfigPath, resolveKubeconfigByName } from "./kubeconfig-resolver.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 
 const execAsync = promisify(exec);
 
@@ -203,6 +205,18 @@ export function validateKubectlInPipeline(commands: string[]): string | null {
     if (subcommand === "exec") {
       const execCheck = validateExecCommand(args);
       if (execCheck) return execCheck;
+    }
+
+    // Block "kubectl config view --raw" — leaks full kubeconfig with certs/tokens
+    if (subcommand === "config") {
+      const configSub = args.filter((a) => !a.startsWith("-"));
+      const hasView = configSub.includes("view");
+      const hasRaw = args.includes("--raw");
+      if (hasView && hasRaw) {
+        return JSON.stringify({
+          error: "kubectl config view --raw is not allowed — it exposes credentials.",
+        }, null, 2);
+      }
     }
   }
   return null;
@@ -440,6 +454,28 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
         }
       }
 
+      // Block reading sensitive credential/config files via any file-reading command.
+      // Also catches $KUBECONFIG / ${KUBECONFIG} shell variable expansion.
+      const SENSITIVE_PATH_RE = [
+        /\.siclaw\/config\/settings\.json/,
+        /\.siclaw\/credentials\//,
+        /\$\{?KUBECONFIG\}?/,
+      ];
+      const FILE_READING_CMDS = ["cat", "head", "tail", "less", "more", "grep", "awk", "gawk"];
+      for (const cmd of commands) {
+        const binary = getCommandBinary(cmd);
+        if (binary && FILE_READING_CMDS.includes(binary)) {
+          if (SENSITIVE_PATH_RE.some((re) => re.test(cmd))) {
+            return {
+              content: [{ type: "text", text: JSON.stringify({
+                error: "Reading credential or config files is not allowed.",
+              }, null, 2) }],
+              details: { blocked: true },
+            };
+          }
+        }
+      }
+
       // Skill scripts (debug pods, perftest, etc.) need longer timeouts
       const isSkill = commands.some((c) => isSkillScript(c));
       const defaultTimeout = isSkill ? 180 : 60;
@@ -452,14 +488,27 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
           shell: "/bin/bash",
           detached: true, // make child a process group leader for clean group kill
           env: {
-            ...process.env,
+            ...sanitizeEnv(process.env as Record<string, string>),
             SICLAW_DEBUG_IMAGE: loadConfig().debugImage,
             ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-            // Always block local ~/.kube/config — only UI-configured credentials are allowed
-            KUBECONFIG: "/dev/null",
+            // Auto-resolve KUBECONFIG from credentials; fall back to /dev/null to block ~/.kube/config
+            KUBECONFIG: resolveKubeconfigPath(kubeconfigRef?.credentialsDir) || "/dev/null",
           },
         };
-        const child = exec(command, execOpts as any);
+
+        // Resolve --kubeconfig=<name> (no path separators) to actual file path
+        let finalCommand = command;
+        if (kubeconfigRef?.credentialsDir) {
+          finalCommand = command.replace(
+            /--kubeconfig=([^\s/"']+)/g,
+            (_match, name) => {
+              const resolved = resolveKubeconfigByName(kubeconfigRef.credentialsDir!, name);
+              return resolved ? `--kubeconfig=${resolved}` : _match;
+            },
+          );
+        }
+
+        const child = exec(finalCommand, execOpts as any);
 
         // Kill the entire process group (shell + all child processes like kubectl exec)
         // detached: true makes the shell a process group leader, so -pid kills the whole group

--- a/src/tools/run-skill.ts
+++ b/src/tools/run-skill.ts
@@ -5,6 +5,8 @@ import { Text } from "@mariozechner/pi-tui";
 import type { KubeconfigRef } from "../core/agent-factory.js";
 import { processToolOutput, renderTextResult } from "./tool-render.js";
 import { loadConfig } from "../core/config.js";
+import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
+import { sanitizeEnv } from "./sanitize-env.js";
 import {
   resolveSkillScript,
   listSkillScripts,
@@ -121,10 +123,10 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
           shell: "/bin/bash",
           detached: true, // make child a process group leader for clean group kill
           env: {
-            ...process.env,
+            ...sanitizeEnv(process.env as Record<string, string>),
             SICLAW_DEBUG_IMAGE: loadConfig().debugImage,
             ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-            KUBECONFIG: "/dev/null",
+            KUBECONFIG: resolveKubeconfigPath(kubeconfigRef?.credentialsDir) || "/dev/null",
           },
         };
         const child = exec(command, execOpts as any);

--- a/src/tools/sanitize-env.test.ts
+++ b/src/tools/sanitize-env.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeEnv } from "./sanitize-env.js";
+
+describe("sanitizeEnv", () => {
+  it("blocks SICLAW_LLM_API_KEY", () => {
+    const result = sanitizeEnv({ SICLAW_LLM_API_KEY: "sk-secret", PATH: "/usr/bin" });
+    expect(result).not.toHaveProperty("SICLAW_LLM_API_KEY");
+    expect(result).toHaveProperty("PATH", "/usr/bin");
+  });
+
+  it("blocks SICLAW_S3_SECRET_KEY and SICLAW_EMBEDDING_API_KEY", () => {
+    const result = sanitizeEnv({
+      SICLAW_S3_SECRET_KEY: "s3secret",
+      SICLAW_S3_ACCESS_KEY: "s3access",
+      SICLAW_EMBEDDING_API_KEY: "embkey",
+    });
+    expect(result).not.toHaveProperty("SICLAW_S3_SECRET_KEY");
+    expect(result).not.toHaveProperty("SICLAW_S3_ACCESS_KEY");
+    expect(result).not.toHaveProperty("SICLAW_EMBEDDING_API_KEY");
+  });
+
+  it("blocks SICLAW_JWT_SECRET and SICLAW_SSO_CLIENT_SECRET", () => {
+    const result = sanitizeEnv({
+      SICLAW_JWT_SECRET: "jwtsecret",
+      SICLAW_SSO_CLIENT_SECRET: "ssosecret",
+    });
+    expect(result).not.toHaveProperty("SICLAW_JWT_SECRET");
+    expect(result).not.toHaveProperty("SICLAW_SSO_CLIENT_SECRET");
+  });
+
+  it("allows SICLAW_DEBUG_IMAGE and SICLAW_CREDENTIALS_DIR", () => {
+    const result = sanitizeEnv({
+      SICLAW_DEBUG_IMAGE: "debug:latest",
+      SICLAW_CREDENTIALS_DIR: "/app/.siclaw/credentials",
+    });
+    expect(result).toHaveProperty("SICLAW_DEBUG_IMAGE", "debug:latest");
+    expect(result).toHaveProperty("SICLAW_CREDENTIALS_DIR", "/app/.siclaw/credentials");
+  });
+
+  it("blocks common sensitive env vars", () => {
+    const result = sanitizeEnv({
+      ANTHROPIC_API_KEY: "ant-key",
+      OPENAI_API_KEY: "oai-key",
+      AWS_SECRET_ACCESS_KEY: "aws-secret",
+      GITHUB_TOKEN: "ghp_xxx",
+    });
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it("blocks suffix-matched vars", () => {
+    const result = sanitizeEnv({
+      CUSTOM_API_KEY: "key1",
+      MY_SECRET_TOKEN: "token1",
+      DB_PASSWORD: "pass1",
+    });
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it("passes through safe system vars", () => {
+    const result = sanitizeEnv({
+      PATH: "/usr/bin",
+      HOME: "/root",
+      LANG: "en_US.UTF-8",
+      TERM: "xterm",
+      NODE_ENV: "production",
+    });
+    expect(Object.keys(result)).toHaveLength(5);
+  });
+});

--- a/src/tools/sanitize-env.ts
+++ b/src/tools/sanitize-env.ts
@@ -1,0 +1,102 @@
+/**
+ * Sanitize environment variables for child processes.
+ *
+ * Filters out sensitive env vars (API keys, tokens, secrets) before spawning
+ * subprocess shells, preventing the model from using `printenv` to leak them.
+ *
+ * Strategy: block known-dangerous suffixes/names, pass through everything else
+ * (PATH, HOME, LANG, etc.) to keep tools functional.
+ */
+
+/** Env var names that are always blocked (exact match, case-insensitive). */
+const BLOCKED_EXACT = new Set([
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_API_BASE",
+  "AZURE_OPENAI_API_KEY",
+  "GOOGLE_API_KEY",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "TELEGRAM_BOT_TOKEN",
+  "SLACK_TOKEN",
+  "SLACK_BOT_TOKEN",
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "GITLAB_TOKEN",
+  "NPM_TOKEN",
+  "DOCKER_PASSWORD",
+  "DATABASE_URL",
+  "REDIS_URL",
+]);
+
+/** Suffixes that indicate a sensitive env var. */
+const BLOCKED_SUFFIXES = [
+  "_API_KEY",
+  "_APIKEY",
+  "_SECRET",
+  "_SECRET_KEY",
+  "_TOKEN",
+  "_PASSWORD",
+  "_PRIVATE_KEY",
+  "_CREDENTIALS",
+];
+
+/** SICLAW_* vars that are safe to pass through (non-secret config). */
+const SICLAW_SAFE = new Set([
+  "SICLAW_DEBUG_IMAGE",
+  "SICLAW_CREDENTIALS_DIR",
+]);
+
+/** Prefixes to always allow even if they match a suffix pattern. */
+const ALLOW_PREFIXES = [
+  "KUBECONFIG",    // handled separately
+  "PATH",
+  "HOME",
+  "LANG",
+  "LC_",
+  "TERM",
+  "SHELL",
+  "USER",
+  "LOGNAME",
+  "HOSTNAME",
+  "NODE_",
+  "NPM_CONFIG_",
+  "EDITOR",
+  "TZ",
+  "TMPDIR",
+  "XDG_",
+];
+
+function isSensitive(name: string): boolean {
+  const upper = name.toUpperCase();
+
+  // SICLAW_* vars: only allow explicitly safe ones
+  if (upper.startsWith("SICLAW_")) {
+    return !SICLAW_SAFE.has(upper);
+  }
+
+  // Explicit allow-list takes precedence
+  if (ALLOW_PREFIXES.some((p) => upper.startsWith(p))) return false;
+
+  // Exact match blocklist
+  if (BLOCKED_EXACT.has(upper)) return true;
+
+  // Suffix match
+  if (BLOCKED_SUFFIXES.some((s) => upper.endsWith(s))) return true;
+
+  return false;
+}
+
+/**
+ * Return a sanitized copy of the given env vars object.
+ * Sensitive keys are removed entirely (not masked).
+ */
+export function sanitizeEnv(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  const result: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (!isSensitive(key)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Two related changes to improve security and simplify the deep investigation workflow:

1. **DP decouple**: Remove the blocking `deepSearchGate` so `propose_hypotheses` is non-blocking and the model proceeds to `deep_search` immediately — eliminates state desync issues when WebSocket connections drop mid-investigation.

2. **Credential output protection**: 7-layer defense preventing the model from seeing or outputting sensitive credential data (file paths, server URLs, API keys, tokens, cluster internal IDs).

### Solution

**DP decouple** (commit 1): Removed `deepSearchGate`, `HYPOTHESES_CONFIRMED_SENTINEL`, `confirmHypotheses` RPC, `/confirm-hypotheses` endpoint, gate input handlers, and auto-continue gate check across 9 files.

**Credential protection** (commit 2):
- L1: `credential_list` strips files/metadata, returns only safe fields
- L2: KUBECONFIG auto-inject, `--kubeconfig=<name>` resolution, sensitive file read blocking, `kubectl config view --raw` blocking
- L3: System prompt forbids credential output and file reads
- L4: Output redaction on WS stream and DB writes (9 generic token patterns)
- L5: `READ_BLOCKED_PATTERNS` in agent-factory for read tool
- L6: `sanitizeEnv` for all subprocess tools (deny-first SICLAW_* filter)

## Test Plan

- [x] `npm run build` passes
- [x] `npx vitest run src/tools/sanitize-env.test.ts src/gateway/output-redactor.test.ts` — 21 tests pass
- [ ] Manual: `credential_list` returns no files/metadata
- [ ] Manual: `kubectl get pods` works without `--kubeconfig=<path>`
- [ ] Manual: `cat $KUBECONFIG` blocked
- [ ] Manual: `kubectl config view --raw` blocked
- [ ] Manual: Output with API keys shows [REDACTED]