### PR TITLE
feat: multi-tab isolation, stateless Gateway, AgentBox self-governance

### DIFF
--- a/k8s/agentbox-headless-service.yaml
+++ b/k8s/agentbox-headless-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentbox-hs
+  namespace: siclaw
+spec:
+  clusterIP: None
+  selector:
+    siclaw.io/app: agentbox
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -105,6 +105,39 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
     ensureProxy().catch(err => console.warn("[agentbox] LLM proxy pre-start failed:", err));
   }
 
+  // ── Idle self-destruct: exit when no SSE connections and no sessions for 5 min ──
+  const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+  let activeSseCount = 0;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function resetIdleTimer(): void {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+  }
+
+  function checkIdle(): void {
+    if (activeSseCount === 0 && sessionManager.activeCount() === 0) {
+      if (idleTimer) return; // already scheduled
+      idleTimer = setTimeout(() => {
+        // Re-check before exiting (new connection may have arrived)
+        if (activeSseCount === 0 && sessionManager.activeCount() === 0) {
+          console.log("[agentbox] No connections for 5 min, shutting down");
+          process.exit(0);
+        }
+        idleTimer = null;
+      }, IDLE_TIMEOUT_MS);
+      console.log(`[agentbox] Idle detected, will shut down in ${IDLE_TIMEOUT_MS / 1000}s if no activity`);
+    }
+  }
+
+  // Start initial idle check (pod may never receive any connections)
+  checkIdle();
+
+  // Wire session release → idle check (session released after TTL)
+  sessionManager.onSessionRelease = () => checkIdle();
+
   const routes: Route[] = [];
 
   // Route registration helper
@@ -352,6 +385,10 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
 
     console.log(`[agentbox-http] Starting SSE stream for session ${sessionId}`);
 
+    // Track active SSE connections for idle self-destruct
+    activeSseCount++;
+    resetIdleTimer();
+
     // Set SSE response headers
     res.writeHead(200, {
       "Content-Type": "text/event-stream",
@@ -432,12 +469,23 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       deepSearchEvents.off("progress", deepProgressSSEHandler);
     };
 
+    // Decrement SSE counter and check idle (called once per SSE lifecycle)
+    let sseCountDecremented = false;
+    const decrementSse = () => {
+      if (!sseCountDecremented) {
+        sseCountDecremented = true;
+        activeSseCount--;
+        checkIdle();
+      }
+    };
+
     // Close SSE when prompt completes
     const cleanup = () => {
       console.log(`[agentbox-http] SSE closing for session ${sessionId} (prompt done, ${sseEventCount} events sent)`);
       clearInterval(heartbeat);
       unsubAll();
       closeSSE();
+      decrementSse();
     };
     managed._promptDoneCallbacks.add(cleanup);
 
@@ -448,6 +496,7 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       clearInterval(heartbeat);
       managed._promptDoneCallbacks.delete(cleanup);
       unsubAll();
+      decrementSse();
     });
 
     // Handle response errors
@@ -457,6 +506,7 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       clearInterval(heartbeat);
       managed._promptDoneCallbacks.delete(cleanup);
       unsubAll();
+      decrementSse();
     });
   });
 

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -74,6 +74,9 @@ export class AgentBoxSessionManager {
   private sessions = new Map<string, ManagedSession>();
   private defaultSessionId = "default";
 
+  /** Callback fired after a session is released — used by http-server to check idle status */
+  onSessionRelease?: () => void;
+
   // ── Shared components (AgentBox-level, outlive individual sessions) ──
   private _sharedMemoryIndexer: MemoryIndexer | null = null;
   /** Whether shared components have been initialized */
@@ -322,6 +325,14 @@ export class AgentBoxSessionManager {
   }
 
   /**
+   * Get the number of active (in-memory) sessions.
+   * Used by http-server idle self-destruct to decide when to start the shutdown timer.
+   */
+  activeCount(): number {
+    return this.sessions.size;
+  }
+
+  /**
    * Schedule a delayed release for a session.
    * The release happens after SESSION_RELEASE_TTL_MS of idle time.
    * If a new prompt arrives before the TTL expires, getOrCreate() cancels the timer.
@@ -400,6 +411,8 @@ export class AgentBoxSessionManager {
     if (this.sessions.get(sessionId) === managed) {
       this.sessions.delete(sessionId);
       console.log(`[agentbox-session] Session released: ${sessionId} (${this.sessions.size} remaining)`);
+      // Notify http-server to check idle status
+      this.onSessionRelease?.();
     } else {
       console.log(`[agentbox-session] Session ${sessionId} was replaced during release, skipping delete`);
     }

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -32,7 +32,7 @@ console.log(`[gateway] Using spawner: ${spawner.name}`);
 
 // Create AgentBox Manager
 const agentBoxManager = new AgentBoxManager(spawner, {
-  idleTimeoutMs: 5 * 60 * 1000, // 5-minute idle timeout
+  namespace: process.env.SICLAW_K8S_NAMESPACE || "default",
 });
 agentBoxManager.startHealthCheck();
 

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -187,6 +187,8 @@ export class K8sSpawner implements BoxSpawner {
         },
       },
       spec: {
+        hostname: podName,
+        subdomain: "agentbox-hs",
         automountServiceAccountToken: false,
         restartPolicy: "Never",
         volumes: [

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -3,26 +3,26 @@
  *
  * Manages the lifecycle of AgentBoxes and provides a high-level API:
  * - Get or create an AgentBox by userId
- * - Automatic health checks and reclamation
- * - Multiple Spawner support
+ * - K8s: stateless, queries K8s API each time (no in-memory cache)
+ * - Local dev: in-memory cache for fast lookups
  */
 
 import type { BoxSpawner } from "./spawner.js";
 import type { AgentBoxConfig, AgentBoxHandle, AgentBoxInfo } from "./types.js";
 
 export interface AgentBoxManagerConfig {
-  /** Idle timeout (ms); box is automatically reclaimed after this period */
-  idleTimeoutMs?: number;
-  /** Health check interval (ms) */
+  /** Health check interval (ms) — local dev only */
   healthCheckIntervalMs?: number;
   /** Maximum number of retries */
   maxRetries?: number;
+  /** K8s namespace */
+  namespace?: string;
 }
 
 const DEFAULT_CONFIG: Required<AgentBoxManagerConfig> = {
-  idleTimeoutMs: 30 * 60 * 1000, // 30 minutes
   healthCheckIntervalMs: 60 * 1000, // 1 minute
   maxRetries: 3,
+  namespace: "default",
 };
 
 interface ManagedBox {
@@ -37,20 +37,27 @@ export class AgentBoxManager {
   private spawner: BoxSpawner;
   private config: Required<AgentBoxManagerConfig>;
 
-  /** "userId:workspaceId" → ManagedBox */
+  /**
+   * In-memory cache — used ONLY for local dev spawners (process, local).
+   * K8s spawner queries the K8s API each time and bypasses this cache.
+   */
   private boxes = new Map<string, ManagedBox>();
 
-  /** Health check timer */
+  /** Health check timer (local dev only) */
   private healthCheckTimer?: ReturnType<typeof setInterval>;
 
   /** Optional async resolver that provides extra env vars for new AgentBoxes */
   private envResolver?: EnvResolver;
 
+  /** Whether the spawner is K8s-based (stateless, no in-memory cache) */
+  private readonly isK8s: boolean;
+
   constructor(spawner: BoxSpawner, config?: AgentBoxManagerConfig) {
     this.spawner = spawner;
     this.config = { ...DEFAULT_CONFIG, ...config };
+    this.isK8s = spawner.name === "k8s";
 
-    console.log(`[agentbox-manager] Initialized with spawner: ${spawner.name}`);
+    console.log(`[agentbox-manager] Initialized with spawner: ${spawner.name}${this.isK8s ? " (stateless, K8s API discovery)" : " (in-memory cache)"}`);
   }
 
   /**
@@ -76,10 +83,10 @@ export class AgentBoxManager {
   }
 
   /**
-   * Start health check
+   * Start health check (local dev only — removes stale entries from in-memory cache)
    */
   startHealthCheck(): void {
-    if (this.healthCheckTimer) return;
+    if (this.isK8s || this.healthCheckTimer) return;
 
     this.healthCheckTimer = setInterval(async () => {
       await this.runHealthCheck();
@@ -107,25 +114,21 @@ export class AgentBoxManager {
   }
 
   /**
-   * Run health check
+   * Build deterministic pod name (must match K8sSpawner.podName)
+   */
+  private podName(userId: string, workspaceId: string): string {
+    const sanitizedUser = userId.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 30);
+    const wsSuffix = workspaceId
+      ? workspaceId.replace(/[^a-z0-9]/g, "").slice(0, 8)
+      : "default";
+    return `agentbox-${sanitizedUser}-${wsSuffix}`;
+  }
+
+  /**
+   * Run health check (local dev only — cleans stale entries)
    */
   private async runHealthCheck(): Promise<void> {
-    const now = Date.now();
-
     for (const [key, managed] of this.boxes.entries()) {
-      const idleTime = now - managed.lastActiveAt.getTime();
-
-      // Check if idle timeout has been exceeded
-      if (idleTime > this.config.idleTimeoutMs) {
-        console.log(
-          `[agentbox-manager] Box ${key} idle for ${idleTime}ms, stopping...`,
-        );
-        await this.spawner.stop(managed.handle.boxId);
-        this.boxes.delete(key);
-        continue;
-      }
-
-      // Check whether the Pod still exists
       const info = await this.spawner.get(managed.handle.boxId);
       if (!info || info.status === "stopped" || info.status === "error") {
         console.log(`[agentbox-manager] Box ${key} is gone, removing from cache`);
@@ -138,28 +141,78 @@ export class AgentBoxManager {
    * Get or create an AgentBox
    */
   async getOrCreate(userId: string, workspaceId = "default", config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
+    if (this.isK8s) {
+      return this.getOrCreateK8s(userId, workspaceId, config);
+    }
+    return this.getOrCreateLocal(userId, workspaceId, config);
+  }
+
+  /**
+   * K8s path: stateless — queries K8s API each time, uses Pod IP endpoint.
+   * Any Gateway pod can call this (K8s API is cluster-wide).
+   */
+  private async getOrCreateK8s(userId: string, workspaceId: string, config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
+    const name = this.podName(userId, workspaceId);
+
+    // 1. Check if pod already exists and is running
+    const info = await this.spawner.get(name);
+    if (info && info.status === "running" && info.endpoint) {
+      return { boxId: name, userId, endpoint: info.endpoint };
+    }
+
+    // 2. Pod doesn't exist or not running → create
+    console.log(`[agentbox-manager] Creating new AgentBox for user: ${userId} workspace: ${workspaceId}`);
+
+    const resolvedEnv = await this.resolveEnv(config?.env);
+    const handle = await this.spawner.spawn({
+      userId,
+      workspaceId,
+      ...config,
+      env: Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined,
+    });
+
+    // 3. Return handle with Pod IP endpoint (from spawner.spawn → waitForPodReady)
+    return handle;
+  }
+
+  /**
+   * Local dev path: in-memory cache
+   */
+  private async getOrCreateLocal(userId: string, workspaceId: string, config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
     const key = this.boxKey(userId, workspaceId);
 
     // Check cache
     const existing = this.boxes.get(key);
     if (existing) {
-      // Update last active time
       existing.lastActiveAt = new Date();
-
-      // Verify the Box still exists
       const info = await this.spawner.get(existing.handle.boxId);
       if (info && info.status === "running") {
         return existing.handle;
       }
-
-      // Box is stale, remove from cache
       this.boxes.delete(key);
     }
 
-    // Create a new AgentBox
     console.log(`[agentbox-manager] Creating new AgentBox for user: ${userId} workspace: ${workspaceId}`);
 
-    // Resolve extra env vars from DB (e.g. LLM/Embedding provider config)
+    const resolvedEnv = await this.resolveEnv(config?.env);
+    const handle = await this.spawner.spawn({
+      userId,
+      workspaceId,
+      ...config,
+      env: Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined,
+    });
+
+    this.boxes.set(key, {
+      handle,
+      lastActiveAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    return handle;
+  }
+
+  /** Resolve merged env vars */
+  private async resolveEnv(configEnv?: Record<string, string>): Promise<Record<string, string>> {
     let resolvedEnv: Record<string, string> | undefined;
     if (this.envResolver) {
       try {
@@ -168,31 +221,22 @@ export class AgentBoxManager {
         console.warn("[agentbox-manager] envResolver failed, continuing without extra env:", err);
       }
     }
-
-    const mergedEnv = { ...config?.env, ...resolvedEnv };
-
-    const handle = await this.spawner.spawn({
-      userId,
-      workspaceId,
-      ...config,
-      env: Object.keys(mergedEnv).length > 0 ? mergedEnv : undefined,
-    });
-
-    const managed: ManagedBox = {
-      handle,
-      lastActiveAt: new Date(),
-      createdAt: new Date(),
-    };
-
-    this.boxes.set(key, managed);
-
-    return handle;
+    return { ...configEnv, ...resolvedEnv };
   }
 
   /**
-   * Get an AgentBox (without auto-creating)
+   * Get an AgentBox (without auto-creating).
+   *
+   * NOTE: This is synchronous, so for K8s it cannot query the API.
+   * Returns undefined for K8s — callers should use getOrCreate() or
+   * the async getAsync() instead.
    */
   get(userId: string, workspaceId = "default"): AgentBoxHandle | undefined {
+    if (this.isK8s) {
+      // Cannot query K8s API synchronously — return undefined.
+      // Callers that need K8s handles should use getOrCreate() or getAsync().
+      return undefined;
+    }
     const key = this.boxKey(userId, workspaceId);
     const managed = this.boxes.get(key);
     if (managed) {
@@ -203,15 +247,35 @@ export class AgentBoxManager {
   }
 
   /**
+   * Get an AgentBox asynchronously (without auto-creating).
+   * For K8s: queries the K8s API to find the running pod.
+   */
+  async getAsync(userId: string, workspaceId = "default"): Promise<AgentBoxHandle | undefined> {
+    if (this.isK8s) {
+      const name = this.podName(userId, workspaceId);
+      const info = await this.spawner.get(name);
+      if (info && info.status === "running" && info.endpoint) {
+        return { boxId: name, userId, endpoint: info.endpoint };
+      }
+      return undefined;
+    }
+    return this.get(userId, workspaceId);
+  }
+
+  /**
    * Stop the AgentBox for a given user and workspace
    */
   async stop(userId: string, workspaceId = "default"): Promise<void> {
+    if (this.isK8s) {
+      const name = this.podName(userId, workspaceId);
+      console.log(`[agentbox-manager] Stopping AgentBox ${name}`);
+      await this.spawner.stop(name);
+      return;
+    }
     const key = this.boxKey(userId, workspaceId);
     const managed = this.boxes.get(key);
     if (!managed) return;
-
     console.log(`[agentbox-manager] Stopping AgentBox for ${key}`);
-
     await this.spawner.stop(managed.handle.boxId);
     this.boxes.delete(key);
   }
@@ -220,6 +284,16 @@ export class AgentBoxManager {
    * Stop ALL AgentBoxes for a given user (across all workspaces)
    */
   async stopAll(userId: string): Promise<void> {
+    if (this.isK8s) {
+      const allBoxes = await this.spawner.list();
+      for (const box of allBoxes) {
+        if (box.userId === userId) {
+          console.log(`[agentbox-manager] Stopping AgentBox ${box.boxId}`);
+          await this.spawner.stop(box.boxId);
+        }
+      }
+      return;
+    }
     const toRemove: string[] = [];
     for (const [key, managed] of this.boxes) {
       if (key.startsWith(userId + ":")) {
@@ -235,6 +309,11 @@ export class AgentBoxManager {
 
   /** Get all active user IDs with running AgentBoxes (deduplicated) */
   activeUserIds(): string[] {
+    if (this.isK8s) {
+      // Cannot determine from in-memory state — return empty.
+      // Callers (e.g. notifyAllSkillReload) should use spawner.list() instead.
+      return [];
+    }
     const userIds = new Set<string>();
     for (const key of this.boxes.keys()) {
       const userId = key.split(":")[0];
@@ -245,6 +324,11 @@ export class AgentBoxManager {
 
   /** Get all AgentBox handles for a given user (across all workspaces) */
   getForUser(userId: string): AgentBoxHandle[] {
+    if (this.isK8s) {
+      // Cannot query K8s API synchronously — return empty.
+      // Skill reload notifications will be picked up on next prompt.
+      return [];
+    }
     const handles: AgentBoxHandle[] = [];
     for (const [key, managed] of this.boxes) {
       if (key.startsWith(userId + ":")) {
@@ -262,9 +346,10 @@ export class AgentBoxManager {
   }
 
   /**
-   * Update last active time
+   * Update last active time (no-op for K8s — AgentBox self-governs)
    */
   touch(userId: string, workspaceId = "default"): void {
+    if (this.isK8s) return;
     const key = this.boxKey(userId, workspaceId);
     const managed = this.boxes.get(key);
     if (managed) {

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { AgentBoxManager } from "./agentbox/manager.js";
 import { AgentBoxClient, type PromptOptions, type AgentBoxTlsOptions } from "./agentbox/client.js";
+import type { WebSocket } from "ws";
 import type { BroadcastFn, RpcHandler, RpcContext } from "./ws-protocol.js";
 import type { Database } from "./db/index.js";
 import { ChatRepository } from "./db/repositories/chat-repo.js";
@@ -64,6 +65,8 @@ export function createRpcMethods(
   methods: Map<string, RpcHandler>;
   buildCredentialPayload: (userId: string, workspaceId: string, isDefault: boolean) => Promise<{ manifest: Array<{ name: string; type: string; description?: string | null; files: string[]; metadata?: Record<string, unknown> }>; files: Array<{ name: string; content: string; mode?: number }> }>;
   getSkillBundle: (userId: string, env: "prod" | "dev") => Promise<SkillBundle>;
+  /** Abort all SSE streams associated with a specific WebSocket connection */
+  cleanupForWs: (ws: WebSocket) => void;
 } {
   const methods = new Map<string, RpcHandler>();
 
@@ -96,10 +99,13 @@ export function createRpcMethods(
   async function findAgentBoxForSession(userId: string, sessionId?: string): Promise<import("./agentbox/types.js").AgentBoxHandle | undefined> {
     if (sessionId) {
       const wsId = await resolveSessionWorkspace(sessionId);
-      const handle = agentBoxManager.get(userId, wsId);
+      const handle = await agentBoxManager.getAsync(userId, wsId);
       if (handle) return handle;
     }
-    // Fallback: try any active box for this user
+    // Fallback: try any active box for this user (async for K8s)
+    const handle = await agentBoxManager.getAsync(userId);
+    if (handle) return handle;
+    // Final fallback: sync path for local dev
     const handles = agentBoxManager.getForUser(userId);
     return handles[0];
   }
@@ -274,11 +280,12 @@ export function createRpcMethods(
     }
   }
 
-  // Active SSE subscriptions (userId → stream info)
+  // Active SSE subscriptions (userId:sessionId → stream info)
   const activeStreams = new Map<string, {
     abort: () => void;
     endpoint: string;
     sessionId: string;
+    ws?: WebSocket;
   }>();
 
   // Cached deep_search progress snapshots for reconnecting clients
@@ -320,7 +327,7 @@ export function createRpcMethods(
     if (chatRepo) {
       if (sessionId) {
         const existing = await chatRepo.getSession(sessionId);
-        if (!existing) sessionId = null;
+        if (!existing || existing.userId !== userId) sessionId = null;
       }
       if (!sessionId) {
         const created = await chatRepo.createSession(userId, "New Chat", effectiveWorkspaceId);
@@ -403,21 +410,23 @@ export function createRpcMethods(
       sensitiveStrings.length > 0 ? sensitiveStrings : undefined,
     );
 
-    // Cancel previous SSE subscription
-    const existingStream = activeStreams.get(userId);
+    // Cancel previous SSE subscription for this session
+    const streamKey = `${userId}:${result.sessionId}`;
+    const existingStream = activeStreams.get(streamKey);
     if (existingStream) {
       existingStream.abort();
     }
 
-    // Clear stale DP progress snapshot for this user (new prompt = fresh state)
-    dpProgressSnapshots.delete(userId);
+    // Clear stale DP progress snapshot for this session (new prompt = fresh state)
+    dpProgressSnapshots.delete(streamKey);
 
     // Subscribe to SSE events and forward to WebSocket
     const abortController = new AbortController();
-    activeStreams.set(userId, {
+    activeStreams.set(streamKey, {
       abort: () => abortController.abort(),
       endpoint: handle.endpoint,
       sessionId: result.sessionId,
+      ws: context.ws,
     });
 
     // Async SSE processing
@@ -435,10 +444,6 @@ export function createRpcMethods(
           const eventData = event as Record<string, unknown>;
           const eventType = eventData.type as string;
           sseEventCount++;
-
-          // Keep agentbox alive during long-running prompts —
-          // without this, the idle timeout (5min) kills the pod mid-execution
-          agentBoxManager.touch(userId, effectiveWorkspaceId);
 
           // Only log key lifecycle events to avoid flooding
           if (eventType === "agent_start" || eventType === "agent_end" || eventType === "message_end" || eventType === "message_start" || eventType.includes("error")) {
@@ -507,10 +512,10 @@ export function createRpcMethods(
           if (eventType === "tool_progress" && eventData.toolName === "deep_search") {
             const progress = eventData.progress as Record<string, unknown> | undefined;
             if (progress) {
-              let snap = dpProgressSnapshots.get(userId);
+              let snap = dpProgressSnapshots.get(streamKey);
               if (!snap) {
                 snap = { sessionId: result.sessionId, events: [], updatedAt: Date.now() };
-                dpProgressSnapshots.set(userId, snap);
+                dpProgressSnapshots.set(streamKey, snap);
               }
               snap.events.push(progress);
               snap.updatedAt = Date.now();
@@ -555,7 +560,7 @@ export function createRpcMethods(
       } finally {
         const sseDurationMs = Date.now() - sseStartTime;
         console.log(`[rpc] SSE stream ended for userId=${userId} sessionId=${result.sessionId} (${sseEventCount} events, ${sseDurationMs}ms)`);
-        activeStreams.delete(userId);
+        activeStreams.delete(streamKey);
         activePromptUsers?.delete(userId);
         // Signal frontend that agent prompt is truly done
         const donePayload = {
@@ -969,9 +974,11 @@ export function createRpcMethods(
   methods.set("chat.steer", async (params, context: RpcContext) => {
     const userId = requireAuth(context);
     const text = params.text as string;
+    const sessionId = params.sessionId as string | undefined;
     if (!text) throw new Error("Missing required param: text");
 
-    const stream = activeStreams.get(userId);
+    const streamKey = sessionId ? `${userId}:${sessionId}` : undefined;
+    const stream = streamKey ? activeStreams.get(streamKey) : undefined;
     if (!stream) throw new Error("No active agent session");
 
     const client = new AgentBoxClient(stream.endpoint, 30000, agentBoxTlsOptions);
@@ -979,10 +986,12 @@ export function createRpcMethods(
     return { status: "steered" };
   });
 
-  methods.set("chat.clearQueue", async (_params, context: RpcContext) => {
+  methods.set("chat.clearQueue", async (params, context: RpcContext) => {
     const userId = requireAuth(context);
+    const sessionId = params.sessionId as string | undefined;
 
-    const stream = activeStreams.get(userId);
+    const streamKey = sessionId ? `${userId}:${sessionId}` : undefined;
+    const stream = streamKey ? activeStreams.get(streamKey) : undefined;
     if (!stream) throw new Error("No active agent session");
 
     const client = new AgentBoxClient(stream.endpoint, 30000, agentBoxTlsOptions);
@@ -990,11 +999,13 @@ export function createRpcMethods(
     return cleared;
   });
 
-  methods.set("chat.abort", async (_params, context: RpcContext) => {
+  methods.set("chat.abort", async (params, context: RpcContext) => {
     const userId = requireAuth(context);
+    const sessionId = params.sessionId as string | undefined;
 
-    const stream = activeStreams.get(userId);
-    if (stream) {
+    const streamKey = sessionId ? `${userId}:${sessionId}` : undefined;
+    const stream = streamKey ? activeStreams.get(streamKey) : undefined;
+    if (stream && streamKey) {
       // Abort the AgentBox session FIRST (stops the agent prompt, waits for idle)
       try {
         const client = new AgentBoxClient(stream.endpoint, 30000, agentBoxTlsOptions);
@@ -1005,17 +1016,34 @@ export function createRpcMethods(
 
       // THEN abort the gateway SSE loop — this triggers prompt_done to the frontend
       stream.abort();
-      activeStreams.delete(userId);
+      activeStreams.delete(streamKey);
     }
 
     return { status: "aborted" };
   });
 
-  methods.set("chat.dpProgress", async (_params, context: RpcContext) => {
+  methods.set("chat.confirmHypotheses", async (params, context: RpcContext) => {
     const userId = requireAuth(context);
-    const snap = dpProgressSnapshots.get(userId);
+    const sessionId = params.sessionId as string | undefined;
+
+    // Hypotheses confirmation is handled via steer messages from the frontend.
+    // This RPC is a gate-clear signal — acknowledge it so the frontend knows it was received.
+    const streamKey = sessionId ? `${userId}:${sessionId}` : undefined;
+    const stream = streamKey ? activeStreams.get(streamKey) : undefined;
+    if (stream) {
+      const client = new AgentBoxClient(stream.endpoint, 30000, agentBoxTlsOptions);
+      await client.steerSession(stream.sessionId, "[hypotheses confirmed]");
+    }
+    return { status: "confirmed" };
+  });
+
+  methods.set("chat.dpProgress", async (params, context: RpcContext) => {
+    const userId = requireAuth(context);
+    const sessionId = params.sessionId as string | undefined;
+    const snapKey = sessionId ? `${userId}:${sessionId}` : userId;
+    const snap = dpProgressSnapshots.get(snapKey);
     if (!snap || Date.now() - snap.updatedAt > 600_000) {
-      dpProgressSnapshots.delete(userId);
+      dpProgressSnapshots.delete(snapKey);
       return { events: null };
     }
     return { sessionId: snap.sessionId, events: snap.events };
@@ -1089,7 +1117,7 @@ export function createRpcMethods(
     }
 
     // Fallback: get from AgentBox
-    const handle = agentBoxManager.get(userId, workspaceId ?? "default");
+    const handle = await agentBoxManager.getAsync(userId, workspaceId ?? "default");
     if (!handle) return { sessions: [] };
 
     const client = new AgentBoxClient(handle.endpoint, 30000, agentBoxTlsOptions);
@@ -1128,7 +1156,7 @@ export function createRpcMethods(
     const userId = requireAuth(context);
     const workspaceId = (params?.workspaceId as string) ?? "default";
 
-    const handle = agentBoxManager.get(userId, workspaceId);
+    const handle = await agentBoxManager.getAsync(userId, workspaceId);
     if (!handle) return { boxStatus: "not_created" };
 
     try {
@@ -3336,7 +3364,18 @@ export function createRpcMethods(
     return buildSkillBundle(userId, env, skillWriter, skillRepo, skillContentRepo, disabled);
   }
 
-  return { methods, buildCredentialPayload, getSkillBundle };
+  /** Abort all SSE streams associated with a specific WebSocket connection */
+  function cleanupForWs(ws: WebSocket): void {
+    for (const [key, stream] of activeStreams.entries()) {
+      if (stream.ws === ws) {
+        console.log(`[rpc] Cleaning up SSE stream ${key} (WS closed)`);
+        stream.abort();
+        activeStreams.delete(key);
+      }
+    }
+  }
+
+  return { methods, buildCredentialPayload, getSkillBundle, cleanupForWs };
 }
 
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -20,6 +20,7 @@ import { PermissionRepository } from "./db/repositories/permission-repo.js";
 import { UserRepository } from "./db/repositories/user-repo.js";
 import { ModelConfigRepository } from "./db/repositories/model-config-repo.js";
 import { SystemConfigRepository } from "./db/repositories/system-config-repo.js";
+import { WorkspaceRepository } from "./db/repositories/workspace-repo.js";
 import { CertificateManager } from "./security/cert-manager.js";
 import { createMtlsMiddleware } from "./security/mtls-middleware.js";
 
@@ -108,10 +109,7 @@ export interface StartGatewayOptions {
 export async function startGateway(opts: StartGatewayOptions): Promise<GatewayServer> {
   const { config, agentBoxManager, extraRpcMethods, extraHttpHandlers } = opts;
 
-  // Track users with active internal API calls (cron, triggers) to prevent WS teardown from killing their pods
-  const activeInternalUsers = new Set<string>();
-
-  // Track users with active SSE prompt streams (web UI) to prevent WS teardown from killing mid-execution pods
+  // Track users with active SSE prompt streams (web UI)
   const activePromptUsers = new Set<string>();
 
   const clients = new Set<WebSocket>();
@@ -170,6 +168,9 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
     });
   }
 
+  // Workspace repo (used by internal API to resolve default workspace)
+  const internalWorkspaceRepo = db ? new WorkspaceRepository(db) : null;
+
   // System config repo (used by JWT, SSO, cert-manager, etc.)
   const sysConfigRepo = db ? new SystemConfigRepository(db) : null;
 
@@ -187,7 +188,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
   };
 
   // Create RPC methods using AgentBoxManager
-  const { methods: rpcMethods, buildCredentialPayload, getSkillBundle } = createRpcMethods(agentBoxManager, broadcast, db, sendToUser, activePromptUsers, agentBoxTlsOptions);
+  const { methods: rpcMethods, buildCredentialPayload, getSkillBundle, cleanupForWs } = createRpcMethods(agentBoxManager, broadcast, db, sendToUser, activePromptUsers, agentBoxTlsOptions);
 
   // Apply DB-stored agentbox image override (takes effect on next pod spawn)
   if (sysConfigRepo) {
@@ -722,30 +723,27 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
 
           console.log(`[gateway] agent-prompt from=${caller} user=${userId} session=${data.sessionId}`);
 
-          // Protect from WS teardown while internal call is active
-          activeInternalUsers.add(userId);
-          try {
-            // 1. Get or create user's AgentBox (default workspace for internal API calls)
-            const handle = await agentBoxManager.getOrCreate(userId, "default");
-            const client = new AgentBoxClient(handle.endpoint);
+          // 1. Get or create user's AgentBox (resolve real workspace ID from DB)
+          const wsId = internalWorkspaceRepo
+            ? (await internalWorkspaceRepo.getOrCreateDefault(userId)).id
+            : "default";
+          const handle = await agentBoxManager.getOrCreate(userId, wsId);
+          const client = new AgentBoxClient(handle.endpoint);
 
-            // 2. Send prompt
-            const promptResult = await client.prompt({ sessionId: data.sessionId, text: data.text });
+          // 2. Send prompt
+          const promptResult = await client.prompt({ sessionId: data.sessionId, text: data.text });
 
-            // 3. Wait for completion with timeout
-            const resultText = await Promise.race([
-              waitForAgentCompletion(client, promptResult.sessionId),
-              rejectAfterTimeout(timeoutMs, data.sessionId),
-            ]);
+          // 3. Wait for completion with timeout
+          const resultText = await Promise.race([
+            waitForAgentCompletion(client, promptResult.sessionId),
+            rejectAfterTimeout(timeoutMs, data.sessionId),
+          ]);
 
-            const durationMs = Date.now() - startTime;
-            console.log(`[gateway] agent-prompt completed user=${userId} duration=${durationMs}ms resultLen=${resultText.length}`);
+          const durationMs = Date.now() - startTime;
+          console.log(`[gateway] agent-prompt completed user=${userId} duration=${durationMs}ms resultLen=${resultText.length}`);
 
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ status: "success", resultText, durationMs }));
-          } finally {
-            activeInternalUsers.delete(userId);
-          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ status: "success", resultText, durationMs }));
         } catch (err) {
           const durationMs = Date.now() - startTime;
           const errMsg = err instanceof Error ? err.message : String(err);
@@ -903,9 +901,6 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
     }
   });
 
-  // Grace period timers for delayed agentbox teardown
-  const teardownTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
   // -- WebSocket keep-alive: ping every 30s, terminate unresponsive clients --
   const PING_INTERVAL = 30_000;
   const aliveClients = new WeakSet<WebSocket>();
@@ -941,23 +936,6 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
         userConnections.set(auth.userId, conns);
       }
       conns.add(ws);
-
-      // Cancel pending teardown if user reconnected within grace period
-      const pendingTeardown = teardownTimers.get(auth.userId);
-      if (pendingTeardown) {
-        clearTimeout(pendingTeardown);
-        teardownTimers.delete(auth.userId);
-        console.log(`[gateway] Cancelled AgentBox teardown for ${auth.username} (reconnected)`);
-      }
-
-      // Create AgentBox on first connection for this user
-      if (conns.size === 1) {
-        agentBoxManager.getOrCreate(auth.userId).then((handle) => {
-          console.log(`[gateway] AgentBox ready for ${auth.username}: ${handle.boxId}`);
-        }).catch((err) => {
-          console.error(`[gateway] AgentBox create failed for ${auth.username}:`, err.message);
-        });
-      }
     }
 
     ws.on("message", async (data) => {
@@ -969,11 +947,6 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
         return;
       }
       console.log(`[gateway] RPC: ${frame.method} id=${frame.id} user=${authWs.auth?.username || "anonymous"}`);
-
-      // Keep agentbox alive while user is active
-      if (authWs.auth?.userId) {
-        agentBoxManager.touch(authWs.auth.userId);
-      }
 
       // Build RPC context with auth info and event sender
       const context: RpcContext = {
@@ -989,6 +962,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
             console.warn(`[gateway] WS not open, dropping event: ${event} for userId=${authWs.auth?.userId ?? "unknown"}`);
           }
         },
+        ws,
       };
 
       await dispatchRpc(rpcMethods, frame, ws, context);
@@ -997,28 +971,16 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
     ws.on("close", () => {
       clients.delete(ws);
 
-      // Remove from per-user tracking and stop AgentBox when last connection closes
+      // Abort SSE streams associated with this WS connection
+      cleanupForWs(ws);
+
+      // Remove from per-user tracking
       if (auth?.userId) {
         const conns = userConnections.get(auth.userId);
         if (conns) {
           conns.delete(ws);
           if (conns.size === 0) {
             userConnections.delete(auth.userId);
-            // Grace period: wait 30s before stopping (in case user refreshes the page)
-            console.log(`[gateway] Last WS for ${auth.username} closed, will stop AgentBox in 30s`);
-            const timer = setTimeout(() => {
-              teardownTimers.delete(auth.userId);
-              // Skip teardown if the agent is still running (internal API or web prompt)
-              if (activeInternalUsers.has(auth.userId) || activePromptUsers.has(auth.userId)) {
-                console.log(`[gateway] Skipping AgentBox teardown for ${auth.username} (active prompt/internal API)`);
-                return;
-              }
-              console.log(`[gateway] Stopping all AgentBoxes for ${auth.username} (no reconnect)`);
-              agentBoxManager.stopAll(auth.userId).catch((err) => {
-                console.error(`[gateway] AgentBox stopAll failed for ${auth.username}:`, err.message);
-              });
-            }, 30_000);
-            teardownTimers.set(auth.userId, timer);
           }
         }
       }
@@ -1031,13 +993,6 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
       clients.delete(ws);
     });
   });
-
-  // Keep AgentBox alive for all users with active WebSocket connections
-  setInterval(() => {
-    for (const userId of userConnections.keys()) {
-      agentBoxManager.touch(userId);
-    }
-  }, 60_000);
 
   // Short keep-alive so idle HTTP connections free up quickly.
   // Browsers limit per-host connections (Chrome: 6). Page assets can fill all

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -281,7 +281,7 @@ export function usePilot() {
     });
     const [sessions, setSessions] = useState<Session[]>([]);
     const [currentSessionKey, setCurrentSessionKey] = useState<string | null>(() => {
-        return localStorage.getItem(SESSION_KEY_STORAGE);
+        return sessionStorage.getItem(SESSION_KEY_STORAGE);
     });
     const [isLoading, setIsLoading] = useState(false);
     const [pendingMessages, setPendingMessages] = useState<string[]>([]);
@@ -314,6 +314,9 @@ export function usePilot() {
     // Stale-loading watchdog: reset UI if no agent events for too long while loading
     const lastAgentEventRef = useRef<number>(0);
     const staleTimerRef = useRef<ReturnType<typeof setInterval>>();
+    // Ref to track current sessionKey for WS event filtering (avoids stale closures)
+    const currentSessionKeyRef = useRef(currentSessionKey);
+    useEffect(() => { currentSessionKeyRef.current = currentSessionKey; }, [currentSessionKey]);
     // DP-related timeout refs (for cleanup on abort/session switch)
     const dpTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
 
@@ -339,12 +342,12 @@ export function usePilot() {
         setInvestigationProgress(null);
     };
 
-    // Persist currentSessionKey to localStorage
+    // Persist currentSessionKey to sessionStorage (per-tab isolation)
     useEffect(() => {
         if (currentSessionKey) {
-            localStorage.setItem(SESSION_KEY_STORAGE, currentSessionKey);
+            sessionStorage.setItem(SESSION_KEY_STORAGE, currentSessionKey);
         } else {
-            localStorage.removeItem(SESSION_KEY_STORAGE);
+            sessionStorage.removeItem(SESSION_KEY_STORAGE);
         }
     }, [currentSessionKey]);
 
@@ -365,8 +368,13 @@ export function usePilot() {
     const handleWsMessage = useCallback((msg: WsMessage) => {
         // Event frames: { type: "event", event: "agent_event", payload: { type: "message_update", ... } }
         if (msg.type === 'event' && msg.payload) {
-            lastAgentEventRef.current = Date.now();
             const payload = msg.payload as Record<string, unknown>;
+
+            // Filter events by sessionId — ignore events from other tabs' sessions
+            const eventSessionId = payload.sessionId as string | undefined;
+            if (eventSessionId && eventSessionId !== currentSessionKeyRef.current) return;
+
+            lastAgentEventRef.current = Date.now();
             const eventType = payload.type as string;
 
             switch (eventType) {
@@ -789,7 +797,7 @@ export function usePilot() {
         // During agent execution: steer instead of sending a new prompt
         if (isLoading) {
             try {
-                await sendRpc('chat.steer', { text });
+                await sendRpc('chat.steer', { text, sessionId: currentSessionKeyRef.current });
                 setPendingMessages(prev => [...prev, text]);
             } catch (err) {
                 console.error('Failed to steer:', err);
@@ -852,7 +860,7 @@ export function usePilot() {
                 : m
         ));
         try {
-            await sendRpc('chat.abort');
+            await sendRpc('chat.abort', { sessionId: currentSessionKeyRef.current });
         } catch (err) {
             console.error('Failed to abort:', err);
         }
@@ -865,7 +873,7 @@ export function usePilot() {
         setPendingMessages([]);
         if (!isConnected) return;
         try {
-            await sendRpc('chat.clearQueue');
+            await sendRpc('chat.clearQueue', { sessionId: currentSessionKeyRef.current });
         } catch (err) {
             console.error('Failed to clear queue:', err);
         }
@@ -880,11 +888,11 @@ export function usePilot() {
         // Clear server queue and re-steer remaining messages
         if (!isConnected) return;
         try {
-            await sendRpc('chat.clearQueue');
+            await sendRpc('chat.clearQueue', { sessionId: currentSessionKeyRef.current });
             // Re-steer remaining messages (get fresh state after splice)
             setPendingMessages(prev => {
                 for (const msg of prev) {
-                    sendRpc('chat.steer', { text: msg }).catch(() => {});
+                    sendRpc('chat.steer', { text: msg, sessionId: currentSessionKeyRef.current }).catch(() => {});
                 }
                 return prev;
             });
@@ -948,7 +956,10 @@ export function usePilot() {
                 maxCalls: 10,
             })),
         });
-    }, []);
+        // Try to clear gate via dedicated RPC. This may fail if the agent session
+        // has already ended (normal — the steer message's input handler clears it instead).
+        sendRpc('chat.confirmHypotheses', { sessionId: currentSessionKeyRef.current }).catch(() => {});
+    }, [sendRpc]);
 
     const createSession = useCallback(() => {
         // Don't create a DB session yet — just reset UI to "new chat" state.
@@ -1055,7 +1066,7 @@ export function usePilot() {
     const restoreDpProgress = useCallback(async () => {
         if (!isConnected) return;
         try {
-            const snap = await sendRpc<{ sessionId?: string; events: Array<Record<string, unknown>> | null }>('chat.dpProgress');
+            const snap = await sendRpc<{ sessionId?: string; events: Array<Record<string, unknown>> | null }>('chat.dpProgress', { sessionId: currentSessionKeyRef.current });
             if (!snap.events || snap.events.length === 0) return;
             // Replay events through the same reducer used for live progress
             let state: InvestigationProgress = { hypotheses: [] };

--- a/src/gateway/ws-protocol.ts
+++ b/src/gateway/ws-protocol.ts
@@ -71,6 +71,8 @@ export interface RpcContext {
   auth?: { userId: string; username: string };
   /** Send an event to the requesting WebSocket client only */
   sendEvent: SendEventFn;
+  /** Reference to the originating WebSocket connection */
+  ws?: WebSocket;
 }
 
 export type RpcHandler = (


### PR DESCRIPTION
## Summary
- **Multi-tab isolation**: `activeStreams`/`dpProgressSnapshots` keyed by `userId:sessionId` instead of `userId`; frontend filters events by sessionId and uses `sessionStorage` for per-tab session key
- **Stateless Gateway**: K8s path queries K8s API each time (no in-memory cache), resolves real workspace UUID from DB, removes WS preconnect and teardown timers, binds SSE lifecycle to WS via `cleanupForWs()`
- **AgentBox self-governance**: SSE connection counting + 5-min idle self-destruct (`process.exit(0)` with `restartPolicy: Never`), K8s headless service for future DNS discovery

## Changed files
| File | Change |
|------|--------|
| `src/gateway/rpc-methods.ts` | sessionId ownership check, composite keys, cleanupForWs, confirmHypotheses RPC |
| `src/gateway/server.ts` | Remove teardown timers & WS preconnect, resolve workspace UUID from DB |
| `src/gateway/ws-protocol.ts` | Add `ws` to RpcContext |
| `src/gateway/agentbox/manager.ts` | K8s stateless path with Pod IP, `getAsync()`, remove in-memory cache for K8s |
| `src/gateway/agentbox/k8s-spawner.ts` | Pod hostname/subdomain for DNS |
| `src/gateway/web/src/hooks/usePilot.ts` | sessionStorage, sessionId filtering, pass sessionId to control RPCs |
| `src/agentbox/http-server.ts` | SSE connection counting + 5-min idle self-destruct |
| `src/agentbox/session.ts` | `activeCount()`, `onSessionRelease` callback |
| `k8s/agentbox-headless-service.yaml` | New headless service |

## Test plan
- [x] Two tabs simultaneously sending messages — streams independent, no cross-tab event leakage
- [x] User A passing User B's sessionId → chat.send creates new session (ownership check)
- [x] WS disconnect → reconnect → sessionStorage restores sessionId → loads history
- [x] Close all tabs → 5 min later AgentBox pod status becomes Completed
- [x] Send message after self-destruct → new AgentBox pod auto-created
- [x] Only one AgentBox pod per user-workspace (no duplicate "default" pod)