### PR TITLE
feat: add unified siclaw CLI entry for npx support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "0.1.0",
   "type": "module",
   "bin": {
-    "siclaw-tui": "./siclaw-tui.mjs",
-    "siclaw-gateway": "./siclaw-gateway.mjs",
-    "siclaw-agentbox": "./siclaw-agentbox.mjs"
+    "siclaw": "./siclaw.mjs"
   },
+  "files": [
+    "dist/",
+    "siclaw.mjs",
+    "skills/",
+    "settings.example.json"
+  ],
   "engines": {
     "node": ">=22.12.0"
   },
@@ -60,8 +64,10 @@
     "vitest": "^3.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run copy:web",
     "build:web": "cd src/gateway/web && npm install && npm run build",
+    "copy:web": "node -e \"const fs=require('fs');const p=require('path');const s=p.join('src','gateway','web','dist');const d=p.join('dist','gateway','web','dist');if(fs.existsSync(s)){fs.cpSync(s,d,{recursive:true});console.log('Copied web UI to '+d)}\"",
+    "prepublishOnly": "npm run build:web && npm run build",
     "dev": "tsx src/cli-main.ts",
     "dev:gateway": "npm run build:web && tsx src/gateway-main.ts",
     "dev:agentbox": "tsx src/agentbox-main.ts",

--- a/siclaw.mjs
+++ b/siclaw.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "package.json"), "utf-8"));
+
+const args = process.argv.slice(2);
+const subcommand = args[0];
+
+function printHelp() {
+  console.log(`siclaw v${pkg.version}
+
+Usage: siclaw [command] [options]
+
+Commands:
+  (default)    Start interactive TUI session
+  local        Start local gateway with web UI
+
+Options:
+  --prompt <text>   Run in non-interactive print mode
+  --continue        Continue the most recent session
+  --debug           Enable debug logging
+  --setup           Force provider setup wizard
+  --help, -h        Show this help
+  --version, -v     Show version
+`);
+}
+
+if (args.includes("--help") || args.includes("-h")) {
+  printHelp();
+  process.exit(0);
+}
+
+if (args.includes("--version") || args.includes("-v")) {
+  console.log(pkg.version);
+  process.exit(0);
+}
+
+if (subcommand === "local") {
+  // Remove "local" from argv so gateway-main doesn't see it as an unknown arg
+  process.argv.splice(2, 1);
+  await import("./dist/gateway-main.js");
+} else {
+  await import("./dist/cli-main.js");
+}


### PR DESCRIPTION
## Summary
- Add unified `siclaw.mjs` as single bin entry point, enabling `npm install siclaw` + `npx siclaw` workflow
- `npx siclaw` → TUI interactive mode (cli-main)
- `npx siclaw local` → local gateway with web UI (gateway-main with LocalSpawner)
- `--help`, `--version` flags

## Changes
- **`siclaw.mjs`** (new): Subcommand dispatcher — `local` routes to gateway-main, default routes to cli-main
- **`package.json`**: 
  - `bin`: single `"siclaw": "./siclaw.mjs"` replaces 3 separate entries
  - `files`: controls npm publish contents (`dist/`, `siclaw.mjs`, `skills/`, `settings.example.json`)
  - `prepublishOnly`: auto-builds web UI + TypeScript before publish
  - `copy:web`: copies Vite build output into `dist/gateway/web/dist/` (tsc doesn't copy non-TS assets)

## Test plan
- [ ] `node siclaw.mjs --help` prints usage
- [ ] `node siclaw.mjs --version` prints version
- [ ] `node siclaw.mjs` launches TUI
- [ ] `node siclaw.mjs local` starts local gateway
- [ ] `npm pack --dry-run` includes correct files