### PR TITLE
docs: add Claude operating manual and architecture design docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,30 @@
 
 <!-- 1-3 sentences: what problem does this solve and how. -->
 
+### Problem
+
+<!-- What broke or was missing? What symptom/impact did it cause? -->
+
+### Solution
+
+<!-- What changed and why this approach over alternatives? -->
+
 ## Test Plan
 
 - [ ] `npx tsc --noEmit` passes
 - [ ] `npm test` passes
 - [ ] Manual verification (describe below if applicable)
 
-## Checklist
+## Architecture Checklist
+
+<!-- Skip items that clearly don't apply. -->
+
+- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
+- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
+- [ ] **SQLite DDL parity**: New tables added to both `schema-sqlite.ts` AND `migrate-sqlite.ts`.
+- [ ] **Both brain types**: Tool changes work with pi-agent (TypeBox) and claude-sdk (MCP/Zod).
+
+## General Checklist
 
 - [ ] Changes are focused on a single logical change
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,178 @@
+# Siclaw — Operating Manual for Claude
+
+> This file is auto-loaded by Claude Code at the start of every session.
+> Keep it concise. Deep reference lives in `docs/design/`.
+
+---
+
+## What This Project Is
+
+**Siclaw** is an AI-powered SRE copilot — a "cyber-twin" that runs Kubernetes diagnostics via natural language. It accumulates investigation experience across sessions, learns from team knowledge, and engages in deep technical discussion rather than just giving commands.
+
+**Three runtime modes share one agent core:**
+```
+TUI (single-user terminal)
+Gateway + LocalSpawner (multi-user, local dev — all users share one process + filesystem)
+Gateway + K8sSpawner  (production — one isolated pod per user)
+```
+
+---
+
+## Critical Architecture Invariants
+
+> Full spec: `docs/design/invariants.md` — read it before touching resource sync, skills, or security.
+
+### 🔴 Local Mode: Shared Filesystem
+
+`LocalSpawner` runs ALL AgentBox instances **in-process with Gateway**, sharing the same filesystem. This means:
+
+- `skillsHandler.materialize()` **must NOT be called in local mode** — it wipes `skillsDir` entirely, destroying `skills/core/` and other users' data
+- Local skills sync must write only to `skills/team/` and `skills/user/{userId}/` scoped paths
+- Any component designed for K8s pod isolation is **not directly reusable** in local mode
+
+### 🔴 Skill Bundle Contract
+
+`buildSkillBundle()` packages **only team + personal skills** (never core skills). Core skills are baked into the Docker image / repo checkout. Calling `skillsHandler.materialize()` does NOT restore core skills — it only writes what's in the bundle.
+
+### 🔴 Shell Security: Whitelist-Only
+
+The security model is whitelist-only (not blacklist). A binary must be explicitly listed in `ALLOWED_COMMANDS` (`src/tools/command-sets.ts`) to execute. `sed`, `awk`, `nc`, `wget` are **intentionally excluded**. kubectl is **read-only** (13 safe subcommands; all write ops permanently blocked).
+
+### 🔴 sql.js: Single-Process Lock
+
+SQLite via sql.js loads the entire DB into memory. Only **one process** can hold `.siclaw/data.sqlite` at a time (PID lockfile). Local mode is single-process by design.
+
+### 🔴 Two Separate Databases
+
+| Database | Purpose | Engine |
+|----------|---------|--------|
+| Gateway DB | Users, sessions, skills, channels, MCP config | sql.js (WASM) |
+| Memory DB | Embeddings, chunks, investigation records | node:sqlite (native) |
+
+Never confuse them. Adding a table to Gateway DB requires changes in both `schema-sqlite.ts` AND `migrate-sqlite.ts`.
+
+### 🟡 mTLS Scope
+
+mTLS is used **only in K8s mode** (Gateway ↔ AgentBox pods). LocalSpawner uses plain HTTP on 127.0.0.1. Do not add mTLS dependencies to local mode code paths.
+
+### 🟡 Brain Type Feature Gap
+
+Memory tools (`memory_search`, investigation history) are **pi-agent only** — not available in claude-sdk brain. When adding new tools, test both brain types (TypeBox for pi-agent, Zod/MCP for claude-sdk).
+
+---
+
+## Current Development Phase
+
+> Full roadmap: `docs/design/roadmap.md`
+
+| Phase | Status | Description |
+|-------|--------|-------------|
+| IM Phase 0 | ✅ Done | Raw memory loop (write + search + inject) |
+| IM Phase 1 | ✅ Done (PR #17) | Structured extraction, SQLite investigations table |
+| **KR0** | 🔄 In Progress | Qdrant + knowledge base ingestion |
+| **IM Phase 2** | 🔄 In Progress | Diagnostic path learning from history |
+| PM1 | ⏳ Next | 4-layer config cascade (System → Team → Personal → Workspace) |
+
+**Open research**: R1 (Contextual vs Late Chunking), R3 (config merge strategy), T1 (KG storage: Kuzu vs SQLite)
+
+---
+
+## PR & Code Review Standards
+
+> Full conventions: `CONTRIBUTING.md`
+
+**Before approving any PR, verify:**
+
+1. **Deployment mode awareness**: Does the change respect local vs K8s isolation? If it touches resource sync, skills materialization, or filesystem writes, re-read `docs/design/invariants.md §1-2`
+2. **Security model intact**: No new shell execution paths that bypass `command-sets.ts`. No weakening of the 4-pass pipeline. Skill scripts still go through review gate.
+3. **PR description complete**: Must have Problem + Solution (not just diff summary). See `CONTRIBUTING.md` for format.
+4. **TypeScript conventions**: ESM-only (`.js` imports), strict mode, named exports, no default exports in barrels.
+5. **Both brain types**: Tool changes must work with both pi-agent (TypeBox) and claude-sdk (MCP/Zod) if applicable.
+6. **SQLite DDL parity**: New tables need entries in both `schema-sqlite.ts` and `migrate-sqlite.ts`.
+
+**Common review pitfalls:**
+- Calling `skillsHandler.materialize()` in local mode code paths (ADR-003, ADR-002)
+- Missing `migrate-sqlite.ts` DDL for new tables (breaks SQLite/local deployments)
+- Path traversal in file writes — validate with `resolvePathUnderDir()` pattern, don't roll your own
+- Duplicate helper functions across files — extract to shared utility
+
+---
+
+## Key File Map
+
+```
+Entry Points
+  src/cli-main.ts              TUI entry
+  src/gateway-main.ts          Gateway entry (--k8s flag for K8s mode)
+  src/agentbox-main.ts         AgentBox entry (K8s pod)
+  src/cron-main.ts             Cron worker entry
+
+Agent Core
+  src/core/agent-factory.ts    Session factory — assembles tools + brain + skills
+  src/core/brain-session.ts    BrainSession interface
+  src/core/prompt.ts           SRE system prompt builder
+  src/core/brains/pi-agent-brain.ts
+  src/core/brains/claude-sdk-brain.ts
+
+Security (read before touching)
+  src/tools/command-sets.ts    4-pass validation + ALLOWED_COMMANDS (1146 lines)
+  src/tools/restricted-bash.ts Shell tool using command-sets
+  src/gateway/skills/script-evaluator.ts  Skill script security review
+
+Resource Sync (read before touching)
+  src/shared/resource-sync.ts  Types, contracts, RESOURCE_DESCRIPTORS
+  src/agentbox/resource-handlers.ts  mcpHandler + skillsHandler
+  src/agentbox/resource-sync.ts      syncAllResources() for K8s startup
+  src/gateway/agentbox/local-spawner.ts  Local mode (in-process)
+  src/gateway/resource-notifier.ts   Gateway → AgentBox reload notifications
+
+Database
+  src/gateway/db/index.ts          createDb() — SQLite vs MySQL selection
+  src/gateway/db/schema-sqlite.ts  Drizzle SQLite schema (all tables)
+  src/gateway/db/migrate-sqlite.ts DDL_STATEMENTS (must stay in sync with schema)
+  src/memory/indexer.ts            Hybrid search engine
+  src/memory/schema.ts             Memory DB schema
+
+Skills
+  src/gateway/skills/skill-bundle.ts  buildSkillBundle() — team + personal only
+  src/tools/run-skill.ts              run_skill tool
+  src/tools/script-resolver.ts        Skill path resolution
+  skills/core/                        Built-in diagnostic skills
+
+Investigation
+  src/tools/deep-search/types.ts    Budget constants (Normal/Quick)
+  src/tools/deep-search/engine.ts   4-phase workflow engine
+  src/tools/deep-search/sub-agent.ts Sub-agent factory (minimal tool set)
+```
+
+---
+
+## Tech Stack Quick Reference
+
+```
+Runtime:    Node.js ≥22.12.0  (ESM-only, no CommonJS)
+Language:   TypeScript 5.9    (strict mode, .js imports required)
+Tests:      vitest            (npm test)
+Type check: npx tsc --noEmit
+Frontend:   React + Vite + Tailwind
+Agent:      pi-coding-agent 0.55.3 / claude-agent-sdk 0.1.58
+DB (gateway): Drizzle ORM → sql.js SQLite or MySQL2
+DB (memory):  node:sqlite + FTS5
+```
+
+---
+
+## Collaboration Notes
+
+**When starting a session as reviewer:**
+1. This file is already loaded (you're reading it)
+2. For architecture-sensitive PRs, load `docs/design/invariants.md`
+3. For roadmap/planning work, load `docs/design/roadmap.md`
+4. For "why was X designed this way", load `docs/design/decisions.md`
+
+**When starting a session as developer:**
+1. Check `docs/design/roadmap.md` for current phase priorities
+2. Before touching resource sync or skills: re-read invariants §1-3
+3. New architectural decisions should get an ADR in `docs/design/decisions.md`
+
+**PR comments are posted via `gh` CLI as the authenticated GitHub user.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ npm run dev:gateway
 npm run dev:agentbox
 ```
 
+## Design Documents
+
+Before making significant changes, read the relevant design doc:
+
+| Document | When to read |
+|----------|-------------|
+| [`docs/design/invariants.md`](docs/design/invariants.md) | Touching resource sync, skills, security, or DB schema |
+| [`docs/design/roadmap.md`](docs/design/roadmap.md) | Planning work or checking current priorities |
+| [`docs/design/decisions.md`](docs/design/decisions.md) | Wondering "why was X designed this way?" |
+
+New architectural decisions should get an ADR entry in `docs/design/decisions.md`.
+
+---
+
 ## Project Architecture
 
 Siclaw has four entry points, each serving a different deployment role:

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -1,0 +1,205 @@
+# Architecture Decision Records (ADR)
+
+> **Format**: Context → Decision → Consequences
+>
+> These are decisions with non-obvious rationale. Future contributors should read the relevant ADR
+> before proposing changes to these areas. If a decision needs revisiting, update this file.
+
+---
+
+## ADR-001: sql.js (WASM SQLite) for Default Local Database
+
+**Status**: Active
+
+**Context**:
+The local/TUI deployment needs persistent storage with zero installation requirements. Options considered:
+- Native `better-sqlite3`: Requires native compilation, breaks on Node version mismatches
+- `node:sqlite` (built-in): Only available in Node.js 22.5+, not available in older LTS
+- `sql.js` (WASM): Pure JavaScript, zero native deps, runs anywhere Node.js runs
+- MySQL: Requires separate server process, too heavy for single-user local dev
+
+**Decision**:
+Use `sql.js` for local/default SQLite deployment. `node:sqlite` (built-in) is used only for the memory database (chunked embeddings) where WAL mode and performance matter more.
+
+**Consequences**:
+- ✅ Zero installation friction for local dev and TUI mode
+- ✅ Works on any platform without native compilation
+- ⚠️ Loads entire database into memory (fine for local scale, not for large deployments)
+- ⚠️ Single-process only (lockfile enforcement required)
+- ⚠️ Must call `flushSqliteDb()` before exit; 30s auto-flush for crash safety
+- ❌ Not suitable for multi-instance Gateway (use MySQL for production)
+
+**Revisit when**: Database size consistently exceeds ~100MB on local installs.
+
+---
+
+## ADR-002: LocalSpawner Runs AgentBox In-Process (Not Child Process)
+
+**Status**: Active
+
+**Context**:
+For local development, AgentBox instances need to be spawned per-user. Options:
+- **Child process** (ProcessSpawner): Fork a new Node.js process per user, communicate via HTTP. True process isolation but adds startup latency, IPC complexity, and debugging friction.
+- **In-process** (LocalSpawner): Create a new HTTP server (on a new port) within the Gateway process. Shares memory, faster startup, easier debugging.
+- **K8s Pod** (K8sSpawner): Full isolation but requires a K8s cluster.
+
+**Decision**:
+LocalSpawner runs AgentBox HTTP servers in-process, one per user, on ports 4000+. This is explicitly a **development convenience mode**, not a production isolation model.
+
+**Consequences**:
+- ✅ Fast spin-up (no process fork overhead)
+- ✅ Easy to debug (single process, single debugger session)
+- ✅ Shared memory allows direct in-process resource sync (no HTTP round-trips)
+- ⚠️ All users share the same filesystem — components designed for K8s pod isolation CANNOT be directly reused (e.g., `skillsHandler.materialize()`)
+- ⚠️ A crash in one user's session affects all users
+- ❌ Not a multi-tenant production model — use K8sSpawner for that
+
+**ProcessSpawner** exists as a middle ground (true process isolation, local machine) but is not the default. It may be promoted if local dev isolation needs increase.
+
+---
+
+## ADR-003: Skill Bundles Exclude Core Skills
+
+**Status**: Active
+
+**Context**:
+The skill bundle API (`/api/internal/skills/bundle`) delivers skills to AgentBox instances. Should it include core (built-in) skills?
+
+Options:
+- **Include all**: Bundle contains core + team + personal. Simple for AgentBox (one source of truth). Expensive: Gateway must serialize all core skill files on every request.
+- **Exclude core**: Bundle contains only team + personal. Core skills are baked into the Docker image / repo checkout. AgentBox reads them from disk directly.
+
+**Decision**:
+Bundles contain **only team + personal skills**. Core skills are baked into the AgentBox Docker image at build time and read from `skills/core/` at runtime.
+
+**Consequences**:
+- ✅ Bundle requests are small and fast (no large static skill content)
+- ✅ Core skills are versioned with the code, not the database
+- ⚠️ `skillsHandler.materialize()` does NOT restore core skills — it only writes what's in the bundle
+- ⚠️ In local mode, `materialize()` would wipe core skills from disk — see ADR-002 for why local mode cannot safely call `materialize()`
+- ⚠️ If a user disables a core skill, the `disabledBuiltins` list in the bundle tells AgentBox which core skills to skip
+
+---
+
+## ADR-004: Shell Security via Whitelist (Not Blacklist)
+
+**Status**: Active
+
+**Context**:
+The agent needs to run shell commands for K8s diagnostics. How do we bound the blast radius?
+
+Options:
+- **Blacklist dangerous commands**: Maintain a list of blocked patterns. Simpler but constantly needs updating as new attack vectors emerge.
+- **Whitelist allowed commands**: Only explicitly approved binaries can run. Safer by default but requires conscious additions.
+- **Full sandbox** (seccomp, gVisor): Maximum safety but high operational complexity and latency.
+
+**Decision**:
+Whitelist-only model with 4-pass validation: binary allowlist → per-command validators → kubectl subcommands → per-flag restrictions. Approximately 80+ allowed binaries, each with documented reasoning.
+
+**Consequences**:
+- ✅ New binaries cannot be used until consciously reviewed and added
+- ✅ Defense-in-depth: even if an attacker controls the command string, unknown binaries are blocked
+- ✅ Per-command flag restrictions prevent specific attack vectors (e.g., `curl -d` blocked to prevent POSTing sensitive data)
+- ⚠️ Legitimate diagnostic tools may need to be explicitly added (file an issue explaining the use case)
+- ❌ `sed`, `awk` are intentionally excluded — use `grep`/`jq`/`yq` instead
+- ❌ Skill scripts are exempt from the allowlist — this is intentional (skill review gate is the safety mechanism)
+
+**Revisit when**: A legitimate diagnostic binary is frequently blocked and the use case is well-scoped.
+
+---
+
+## ADR-005: Hybrid Memory Search (Vector + FTS5)
+
+**Status**: Active
+
+**Context**:
+Memory search needs to handle both semantic similarity ("find memories about OOMKilled pods") and exact keyword matching ("find memories mentioning node-23"). Pure vector search misses exact terms; pure BM25 misses semantic similarity.
+
+**Decision**:
+Hybrid scoring: `score = vectorWeight × cosineSimilarity + ftsWeight × BM25`
+
+Default: `vectorWeight = 0.85`, `ftsWeight = 0.15` (architecture.md), code defaults may differ — consult `src/memory/indexer.ts` for current values.
+
+**Consequences**:
+- ✅ Handles both "find semantically similar incidents" and "find the exact error message I saw"
+- ✅ CJK-aware: Chinese queries use bigram OR matching; Latin queries use AND
+- ⚠️ Requires embedding API to be configured — memory search is unavailable without it
+- ⚠️ In-memory cosine similarity over all chunks: acceptable for personal-scale (~1000 chunks), not for team-scale (use sqlite-vec extension for that)
+
+**Future**: When chunk count consistently exceeds ~10k, evaluate sqlite-vec GPU-accelerated vector search.
+
+---
+
+## ADR-006: mTLS Only for K8s Mode
+
+**Status**: Active
+
+**Context**:
+Gateway needs to authenticate AgentBox requests. Options:
+- **Shared secret / API key**: Simple but static, hard to rotate, provides no identity beyond "valid key"
+- **JWT from Gateway**: Gateway signs a JWT for each AgentBox. Simpler than mTLS but asymmetric — Gateway authenticates AgentBox but not vice versa.
+- **mTLS (mutual TLS)**: Both sides present certificates. Identity is cryptographically bound to the certificate (no secrets in env vars). Industry standard for service mesh.
+
+**Decision**:
+mTLS for K8s mode only. LocalSpawner mode uses plain HTTP (same machine, in-process — mTLS would add latency for zero security benefit on loopback).
+
+- CA: 10-year, stored in DB, auto-renewed at 30-day threshold
+- Client certs: issued per-pod at spawn time, identity in CN/OU
+- Protected: `/api/internal/*` endpoints on Gateway HTTPS port 3002
+
+**Consequences**:
+- ✅ Zero-secret identity: no API keys in pod environment variables
+- ✅ Certificate rotation is automatic (new cert on each pod spawn)
+- ✅ Certificate encodes userId + workspaceId — Gateway can authorize without DB lookup
+- ⚠️ Certificate generation adds ~100ms to pod spawn time
+- ⚠️ CA must be backed up — losing it requires re-issuing certs for all active pods
+- ❌ Local dev (LocalSpawner) has no mTLS — internal APIs on 127.0.0.1 only
+
+---
+
+## ADR-007: Two Brain Implementations (pi-agent and claude-sdk)
+
+**Status**: Active
+
+**Context**:
+The agent runtime needs to support different LLM backends. Should there be one unified brain or multiple implementations?
+
+**Decision**:
+Maintain two brain implementations behind the `BrainSession` interface:
+- **pi-agent** (`@mariozechner/pi-coding-agent`): Primary brain, full feature set including memory indexer
+- **claude-sdk** (`@anthropic-ai/claude-agent-sdk`): Secondary brain, uses in-process MCP server for tool exposure, adds LLM proxy for non-Anthropic providers
+
+**Consequences**:
+- ✅ Users can switch brain type per-session based on model/provider preference
+- ✅ Anthropic SDK features (Claude-specific) available via claude-sdk brain
+- ⚠️ Feature parity gap: memory tools, context tracking, and `steer()` mid-run injection only work in pi-agent
+- ⚠️ Dual implementation means new features must be considered for both brains
+- ❌ Avoid adding brain-specific features unless they are truly backend-specific — prefer the `BrainSession` interface
+
+**Note**: When adding new tools, test with both brain types. Tool protocol differs (TypeBox for pi-agent, Zod/MCP for claude-sdk).
+
+---
+
+## ADR-008: Cron HA via Database Coordination (Not Leader Election)
+
+**Status**: Active
+
+**Context**:
+Multiple Gateway instances can run in K8s. Cron jobs must fire exactly once. Options:
+- **Single cron pod**: Designate one pod as cron leader. Simple but a SPOF.
+- **External scheduler** (k8s CronJob): Offload to K8s. Requires separate Job management complexity.
+- **DB-based coordination**: Each instance registers, claims jobs via `assignedTo` field, detects dead instances via heartbeat.
+
+**Decision**:
+DB-based coordination with heartbeat. Each cron instance:
+1. Registers in `cron_instances` table with heartbeat every 30s
+2. Reconciles every 60s: claims unassigned or orphaned jobs (from instances dead > 90s)
+3. Runs job, updates `lastRunAt` + `lastResult`
+4. Releases jobs on graceful shutdown
+
+**Consequences**:
+- ✅ No single point of failure
+- ✅ No external dependencies (reuses existing DB)
+- ✅ Job ownership is explicit and auditable
+- ⚠️ Up to 90s delay in job reassignment after a crash (dead threshold)
+- ⚠️ Duplicate firing possible in edge case: instance A marks job "executing" but crashes before updating `lastRunAt`; instance B reclaims and fires again. Acceptable for SRE automation use cases; add idempotency guards in critical skill scripts.

--- a/docs/design/invariants.md
+++ b/docs/design/invariants.md
@@ -1,0 +1,320 @@
+# Architecture Invariants & Component Contracts
+
+> **Purpose**: Constraints and contracts that every contributor and reviewer must understand.
+> Violating these invariants causes silent bugs, security regressions, or production outages.
+>
+> Source of truth: this document + referenced source files.
+
+---
+
+## 1. Deployment Mode Isolation Contract
+
+Siclaw runs in three modes that differ fundamentally in process and filesystem topology.
+
+### 1.1 Mode Summary
+
+| Aspect | TUI | Gateway + LocalSpawner | Gateway + K8sSpawner |
+|--------|-----|------------------------|----------------------|
+| Process | Single monolithic | Gateway + in-process AgentBoxes | Gateway Pod + one Pod per user |
+| Filesystem | Shared (single user) | **ALL users share one filesystem** | Each pod has isolated filesystem |
+| Database | SQLite only | SQLite (default) or MySQL | MySQL (required) |
+| Auth | None | JWT | mTLS (cert per pod) + JWT |
+| Skills source | Local `./skills/` | DB → shared `./skills/` | DB → pod-local emptyDir |
+| MCP source | Local file | DB merge + local file | DB merge |
+
+### 1.2 ⚠️ Critical: LocalSpawner Filesystem Sharing
+
+**Invariant**: In local mode (`LocalSpawner`), every AgentBox instance runs in the same Node.js process as Gateway and shares the same working directory and filesystem.
+
+**Consequences**:
+- Any code that writes/deletes files in `./skills/` affects ALL users simultaneously
+- `skillsHandler.materialize()` is **NOT safe** in local mode — it wipes `skillsDir` before writing. This is designed for K8s pods with isolated filesystems
+- Per-user skill sync in local mode must write only to scoped subdirectories (`skills/team/` and `skills/user/{userId}/`) without touching `skills/core/`
+- The sql.js SQLite lockfile prevents multi-process access; local mode is single-process by design
+
+**Source**: `src/gateway/agentbox/local-spawner.ts`, `src/agentbox/resource-handlers.ts:90-129`
+
+### 1.3 K8s Pod Isolation
+
+**Invariant**: Each K8s AgentBox pod is fully isolated: its own emptyDir volume for skills, its own mTLS client certificate, its own process. Skills sync via `skillsHandler.materialize()` is safe here because there is no shared filesystem.
+
+**Consequences**:
+- The skills directory in a pod is fully managed by resource sync — it is wiped and rebuilt on every sync
+- Core skills are NOT in the pod's initial image; they arrive via the skill bundle
+- Pod self-destructs after 5 minutes of idle (no SSE connections, no sessions)
+
+**Source**: `src/gateway/agentbox/k8s-spawner.ts`, `src/agentbox/http-server.ts` (IDLE_TIMEOUT_MS)
+
+---
+
+## 2. Skill Bundle Contract
+
+### 2.1 What a Bundle Contains
+
+**Invariant**: `buildSkillBundle()` packages **only team + personal skills** from the database. Core (builtin) skills are NEVER included in bundles.
+
+```
+Bundle = team skills (DB, published tag) + personal skills (DB, approved status)
+Bundle ≠ core skills (baked into image/repo checkout)
+```
+
+**Source**: `src/gateway/skills/skill-bundle.ts:1-10` — explicit comment: "Only includes team + personal skills — builtin skills are baked into the AgentBox Docker image."
+
+### 2.2 Skill Directory Tiers
+
+```
+skills/
+├── core/          ← Built-in, read-only, baked into image. Never overwritten by sync.
+├── team/          ← Admin-managed via WebUI, synced from DB
+├── user/{userId}/ ← Personal skills, synced from DB per user
+└── extension/     ← Optional overlay builds
+```
+
+**Loading priority** (highest wins): `user/{userId}` > `team` > `core`
+
+### 2.3 Skill Activation Gate
+
+Scripts in a skill follow this workflow before execution is permitted:
+
+```
+draft → (request review) → pending → (AI + static analysis) → approved/rejected
+```
+
+- **Static analysis**: 27 `DANGER_PATTERNS` (Critical/High/Medium severity) in `ScriptEvaluator`
+- **AI analysis**: LLM semantic review with mandatory rule — "Skills MUST be strictly read-only"
+- **Human gate**: `skill_reviewer` role must approve before `published` status
+- Skills with unapproved scripts **cannot** be executed via `run_skill`
+
+**Source**: `src/gateway/skills/script-evaluator.ts`
+
+### 2.4 Skill Script Execution
+
+- Interpreter: `bash` for `.sh`, `python3` for `.py` (detected automatically)
+- Timeout: default 180s, max 300s
+- Args passed as array to `spawn()` — no shell interpolation (injection-safe)
+- Max output: 10 MB combined stdout+stderr
+- Env injected: `SICLAW_DEBUG_IMAGE`, `KUBECONFIG`, `SICLAW_CREDENTIALS_DIR`
+
+**Source**: `src/tools/run-skill.ts`
+
+---
+
+## 3. Shell Security Model
+
+**Invariant**: The shell security system is **whitelist-only**, not blacklist-based. A command must be explicitly listed in `ALLOWED_COMMANDS` to execute. When in doubt, it is blocked.
+
+### 3.1 The 4-Pass Validation Pipeline
+
+Every command through `bash`, `node_exec`, `pod_exec`, or `pod_nsenter_exec` passes all 4 passes:
+
+```
+Pass 1 — Shell Operators    Block: $(), backticks, <(), >(), file redirections
+Pass 2 — Binary Allowlist   Only ALLOWED_COMMANDS set can execute
+Pass 3 — kubectl Subcommands Read-only only: get, describe, logs, top, events, ...
+Pass 4 — Per-Command Flags  ~25 commands have flag-level restrictions
+```
+
+**Source**: `src/tools/command-sets.ts` (1146 lines)
+
+### 3.2 Explicitly Excluded Binaries
+
+These are **intentionally NOT in the allowlist** despite being common:
+
+| Command | Reason excluded |
+|---------|----------------|
+| `sed` | Has `-i` (in-place write), `-e`/`r`/`w` file ops, `e` command execution |
+| `awk`/`gawk` | `system()`, `getline`, pipe-to-shell execution capabilities |
+| `bc` | `!command` shell escape |
+| `nc`/`netcat`/`ncat` | Arbitrary TCP connections, potential exfiltration |
+| `wget` | File download with write, recursive crawl |
+| `bash`/`sh` (direct) | Unrestricted shell — the restricted-bash tool wraps it with validation |
+
+### 3.3 kubectl Hard Restrictions
+
+Allowed subcommands (read-only):
+```
+get, describe, logs, top, events, api-resources, api-versions,
+cluster-info, config, version, explain, auth, exec
+```
+
+**All write operations are permanently blocked**: `apply`, `create`, `delete`, `patch`, `scale`, `drain`, `cordon`, `edit`, `replace`, `label`, `taint`, `rollout undo`.
+
+`kubectl exec` commands pass through the binary allowlist (Pass 2) for the exec'd command.
+
+### 3.4 Skill Script Exemption
+
+Skill scripts (`skills/` directory) are **exempt from the binary allowlist** for `run_skill`. The path is verified via `fs.realpathSync()` to block symlink traversal. This is the only way to run otherwise-blocked binaries in a controlled manner — via the skill review gate.
+
+---
+
+## 4. File I/O Path Restrictions
+
+**Invariant**: Agent file tools (`read`, `edit`, `write`, `grep`, `find`, `ls`) are path-scoped. The agent cannot write to credentials, config, or system directories.
+
+```
+Read allowed:  builtin skills, dynamic skills, userDataDir, reports (~/.siclaw/reports/)
+Write allowed: userDataDir ONLY (memory files, PROFILE.md, investigation notes)
+Blocked:       credentials dir, config dir, system dirs (/etc, /var, etc.)
+```
+
+**Source**: `src/core/agent-factory.ts` — `assertPathAllowed()` wrapper on all file tools
+
+---
+
+## 5. Database Invariants
+
+### 5.1 Two Separate Databases
+
+Siclaw maintains **two independent SQLite databases** with completely different schemas:
+
+| Database | Purpose | Engine | Location |
+|----------|---------|--------|----------|
+| Gateway DB | Users, sessions, skills, channels, cron, MCP config | sql.js (WASM) | `.siclaw/data.sqlite` |
+| Memory DB | Embeddings, chunks, investigation records, FTS index | node:sqlite (native) | `{memoryDir}/.memory.db` |
+
+These are never merged. Do not confuse them.
+
+### 5.2 sql.js Single-Process Lock
+
+**Invariant**: sql.js loads the entire SQLite file into memory. **Only one process can hold the database at a time.** A PID-based lockfile (`.siclaw/data.sqlite.lock`) prevents concurrent access.
+
+**Consequences**:
+- Local mode is single-process by design — do not attempt to run multiple Gateway instances against the same SQLite file
+- `flushSqliteDb()` must be called before process exit to persist in-memory state to disk
+- Periodic auto-flush runs every 30 seconds
+- In containers (PID 1 always), the lock reclaim logic handles stale locks from previous container instances
+
+**Source**: `src/gateway/db/index.ts`
+
+### 5.3 SQLite DDL in Two Places
+
+When adding a new table, it must be declared in **both**:
+1. `src/gateway/db/schema-sqlite.ts` — Drizzle ORM table definition
+2. `src/gateway/db/migrate-sqlite.ts` — `DDL_STATEMENTS` array (idempotent `CREATE TABLE IF NOT EXISTS`)
+
+MySQL only needs `src/gateway/db/schema-mysql.ts` and is handled by Drizzle migrations.
+
+---
+
+## 6. Resource Sync Architecture
+
+### 6.1 The Fetch → Materialize → PostReload Contract
+
+```
+fetch(client)       Pull payload from Gateway API
+     ↓
+materialize(payload) Write payload to local filesystem
+     ↓
+postReload(context)  Notify active sessions to pick up changes
+```
+
+- `fetch` is network I/O with retry (3 attempts, exponential backoff: 1s, 2s, 4s)
+- `materialize` is local filesystem write — **idempotent but destructive for skills** (wipes then rebuilds)
+- `postReload` calls `brain.reload()` on active sessions
+
+### 6.2 When to Use Each Handler
+
+| Handler | Safe in LocalSpawner? | Safe in K8s pod? | Notes |
+|---------|----------------------|------------------|-------|
+| `mcpHandler.materialize()` | ✅ Yes | ✅ Yes | Merges, does not wipe |
+| `skillsHandler.materialize()` | ❌ No | ✅ Yes | Wipes entire skillsDir first |
+
+For local mode skills sync, write directly to `skills/team/` and `skills/user/{userId}/` without delegating to `skillsHandler.materialize()`.
+
+---
+
+## 7. Memory System Invariants
+
+### 7.1 Hybrid Search Formula
+
+```
+finalScore = (vectorWeight × cosineSimilarity) + (ftsWeight × bm25Score)
+```
+
+Default weights: `vectorWeight = 0.85`, `ftsWeight = 0.15` (architecture.md reference; code default may differ — check `src/memory/indexer.ts`)
+
+- Minimum score threshold: `0.35` (results below this are filtered)
+- Default top-K: `10` results
+- CJK queries use OR for bigrams; Latin queries use AND
+
+### 7.2 Chunking Contract
+
+- Chunks are split on heading boundaries (H1 > H2 > H3 hierarchy)
+- Max chunk size: ~400 tokens (~1600 bytes)
+- Overlap: ~80 tokens between adjacent chunks
+- Each chunk tracks: file path, heading breadcrumb, start/end line
+
+### 7.3 Embedding Dependency
+
+Memory search (`memory_search` tool) is only available when an embedding provider is configured in `settings.json`. If no embedding is configured, the tool is not registered. Check `config.embedding` before assuming memory tools are available.
+
+---
+
+## 8. Deep Investigation Invariants
+
+### 8.1 Budget Constants
+
+| Metric | Normal | Quick |
+|--------|--------|-------|
+| maxContextCalls | 8 | 5 |
+| maxHypotheses | 5 | 3 |
+| maxCallsPerHypothesis | 10 | 8 |
+| maxTotalCalls | 60 | 30 |
+| maxParallel | 3 | 3 |
+| maxDurationMs | 300,000 (5 min) | 180,000 (3 min) |
+
+**Source**: `src/tools/deep-search/types.ts`
+
+### 8.2 Early Exit
+
+`EARLY_EXIT_CONFIDENCE = 101` — effectively **disabled** by default (101 > 100% is unreachable). The intended threshold is 80% for "root-cause-first" mode. Do not lower this without testing that sub-agents reliably report calibrated confidence scores.
+
+### 8.3 Sub-Agent Tool Set
+
+Sub-agents get a **minimal tool set** — not the full agent tool inventory:
+- `read`, `restricted-bash`, `node_exec` only
+- No memory tools, no skill management, no scheduling
+- Skills pre-loaded from `skills/core/` and `skills/extension/` as text in prompt (not via `run_skill`)
+
+---
+
+## 9. TypeScript & Build Invariants
+
+```
+Module system:  ESM only — no CommonJS, no require()
+Import syntax:  Always use .js extensions: import { X } from "./x.js"
+Strict mode:    TypeScript strict: true
+Exports:        Named exports preferred; no default exports in barrel files
+Node version:   ≥22.12.0 (required for ESM stability + node:sqlite)
+Test runner:    vitest
+```
+
+**Barrel files** (`index.ts`) use re-exports (`export { X } from "./x.js"`). Do not introduce CommonJS interop shims.
+
+---
+
+## 10. Brain Type Differences
+
+| Feature | pi-agent | claude-sdk |
+|---------|----------|-----------|
+| Backend | `@mariozechner/pi-coding-agent` | `@anthropic-ai/claude-agent-sdk` |
+| Memory tools | ✅ Available (hybrid search + investigation history) | ❌ Not integrated |
+| Tool protocol | TypeBox ToolDefinition | In-process MCP server (Zod) |
+| `steer()` | Native mid-run injection | Queued post-query |
+| Context tracking | ✅ Available | ❌ Not available |
+| Default | ✅ Yes | Optional (`brainType: "claude-sdk"`) |
+
+Memory-dependent features (investigations, `memory_search`) only work with pi-agent brain.
+
+---
+
+## 11. mTLS Scope
+
+**Invariant**: mTLS is used **only between Gateway and AgentBox in K8s mode**. It is not used in LocalSpawner mode (same-machine, in-process) or TUI mode (no network).
+
+- CA: 10-year, stored in DB (`system_config` table), auto-renewed when <30 days remain
+- Client certs: issued per-pod at spawn time, short-lived
+- Identity encoded in certificate CN/OU: `userId`, `workspaceId`, `boxId`
+- Protected endpoints: `/api/internal/*` on Gateway HTTPS port (3002)
+
+**Source**: `src/gateway/security/cert-manager.ts`

--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -1,0 +1,193 @@
+# Siclaw Roadmap
+
+> **Last updated**: 2026-03-06
+> **Product vision**: Siclaw is every SRE's cyber-twin — an AI colleague that accumulates experience,
+> learns proactively, understands work context, and engages in deep technical discussion.
+>
+> **Core differentiator**: The knowledge feedback loop — not more agents, but deeper SRE expertise accumulation.
+
+---
+
+## Architecture Layers
+
+Siclaw is built in four interconnected layers:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Persona & Workspace System  (PM roadmap)            │
+│  4-layer patch: System → Team → Personal → Workspace │
+└─────────────────────┬───────────────────────────────┘
+                      │
+┌─────────────────────┴───────────────────────────────┐
+│  Knowledge Streams (KR roadmap)                      │
+│  Stream A: Team KB (Qdrant)  Stream B: Investigation │
+│            external docs         Memory (SQLite)     │
+└─────────────────────┬───────────────────────────────┘
+                      │
+┌─────────────────────┴───────────────────────────────┐
+│  Investigation Engine (IM roadmap)                   │
+│  Deep search · Hypothesis validation · Memory loop   │
+└─────────────────────┬───────────────────────────────┘
+                      │
+┌─────────────────────┴───────────────────────────────┐
+│  Agent Runtime (current foundation)                  │
+│  TUI · Gateway · AgentBox · Skills · Tools · MCP     │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Roadmap A — Investigation Memory (IM)
+
+The knowledge feedback loop: every investigation produces structured experience that improves future diagnoses.
+
+### IM Phase 0 — Raw Memory Loop ✅ Complete
+- Write investigation notes to markdown memory files
+- Vector + FTS hybrid search over memory
+- Inject relevant memories into agent context at session start
+
+### IM Phase 1 — Structured Knowledge Extraction ✅ Complete (PR #17)
+- Dual-output: raw markdown + structured `investigations` SQLite table
+- Schema: `question`, `root_cause_category`, `affected_entities`, `environment_tags`, `causal_chain`, `confidence`, `conclusion`
+- Hybrid retrieval: vector similarity + structured field filtering
+- Investigation records persist across sessions
+
+### IM Phase 2 — Diagnostic Path Learning 🔄 In Progress
+- Extract reusable diagnostic patterns from investigation histories
+- Build "playbook index": symptom patterns → hypothesis templates → validated tools
+- Feed patterns into Phase 2 (hypothesis generation) of deep investigation engine
+- Automatic pattern confidence scoring based on historical outcomes
+
+### IM Phase 3 — Cross-Investigation Correlation ⏳ Planned
+- Detect recurring failures across multiple investigations
+- Build causal graphs: environment change → failure pattern → root cause
+- Surface "this looks like the incident from 2 weeks ago" proactively
+- Temporal decay for outdated patterns
+
+### IM Phase 4 — Active Learning ⏳ Planned
+- Agent identifies gaps in its own knowledge ("I've seen this symptom but never found the cause")
+- Proactively asks questions or suggests follow-up investigations
+- Knowledge completeness scoring per failure category
+
+### IM Phase 5 — Team Knowledge Merge ⏳ Planned
+- Merge investigation memories across team members (with consent model)
+- Conflict resolution for contradictory findings
+- Attribution tracking (who discovered what)
+
+---
+
+## Roadmap B — Knowledge Base & Retrieval (KR)
+
+External knowledge ingestion: team docs, runbooks, architecture diagrams → searchable by the agent.
+
+### KR0 — Qdrant + Basic Ingestion 🔄 Next Priority
+- Stand up Qdrant vector store (embedded or self-hosted)
+- Ingest: team docs (Confluence/Notion/markdown), runbooks, architecture diagrams
+- Chunking strategy: heading-aware hierarchical chunking (Anthropic Contextual Retrieval pattern)
+- Basic semantic search for agent via `knowledge_search` tool
+- Evaluate: Contextual Retrieval vs Late Chunking for technical docs
+
+### KR1 — Source Connectors ⏳ Planned
+- Connectors: GitHub (issues, PRs, wikis), Confluence, Notion, local filesystem
+- Incremental sync (only re-ingest changed content)
+- Source attribution in search results
+
+### KR2 — Knowledge Graph Overlay ⏳ Planned
+- Entity extraction: services, nodes, deployments, configs
+- Relationship graph: "service A depends on service B via env var X"
+- Graph-augmented retrieval: entity → related docs → context
+- Storage options: Kuzu (embedded KG) vs SQLite relation tables (T1 open research)
+
+### KR3 — Knowledge Quality & Trust ⏳ Planned
+- Content freshness scoring (docs older than 90 days get staleness warning)
+- Conflict detection: runbook says X, investigation found Y
+- Trust levels: verified (admin-reviewed), contributed (team), auto-ingested
+
+### KR4 — Proactive Knowledge Surfacing ⏳ Planned
+- Agent detects "current environment differs from documented architecture"
+- Surfaces relevant runbooks before user asks
+- "What changed since last deployment" cross-references knowledge base
+
+### KR5 — Multi-Team Knowledge Federation ⏳ Planned
+- Team A shares runbooks with Team B (with ACL)
+- Federated search across multiple Qdrant collections
+- Knowledge licensing and access control model
+
+---
+
+## Roadmap C — Persona & Workspace System (PM)
+
+The "cyber-twin" model: one person, multiple workspaces (personas), each accumulating context independently.
+
+### PM0 — Workspace Foundation ✅ Complete (in Agent Runtime)
+- Workspace CRUD via WebUI
+- Per-workspace: skills, tools, environments, credentials, allowed models
+- `{userId}:{workspaceId}` as fundamental isolation unit
+
+### PM1 — 4-Layer Config Cascade ⏳ Planned
+- Full implementation of: System → Team → Personal → Workspace patch model
+- JSON Merge Patch vs Strategic Merge Patch evaluation (R3 open research)
+- Workspace inherits team config, can override at personal or workspace level
+- Mandatory policies at System layer cannot be overridden
+
+### PM2 — Skill Trust Tiers ⏳ Planned
+- `restricted` / `standard` / `elevated` skill permission levels
+- Elevated skills require explicit workspace grant
+- Skill review workflow respects tier (elevated requires senior reviewer)
+
+### PM3 — Persona Memory Isolation ⏳ Planned
+- Each workspace has its own memory space (separate investigation history)
+- Cross-workspace memory sharing (opt-in, with attribution)
+- Memory export/import between workspaces
+
+### PM4 — Team Persona & Shared KB ⏳ Planned
+- Team-level persona: shared external KB + individual investigation memories
+- Team onboarding: new member inherits team KB baseline
+- Contribution model: personal discoveries promoted to team KB after review
+
+---
+
+## Current Sprint Priorities
+
+| Priority | Item | Status | Notes |
+|----------|------|--------|-------|
+| P1 | KR0: Qdrant stand-up + basic ingestion | 🔄 In Progress | Storage: embedded Qdrant |
+| P1 | IM Phase 2: diagnostic path learning | 🔄 In Progress | Depends on IM Phase 1 data accumulation |
+| P2 | PM1: 4-layer config cascade | ⏳ Planned | Research R3 first |
+| P3 | KR1: Source connectors | ⏳ Planned | After KR0 validated |
+
+---
+
+## Open Research Items
+
+| ID | Question | Blocking |
+|----|----------|---------|
+| R1 | Contextual Retrieval vs Late Chunking for technical docs | KR0 |
+| R3 | Config cascade merge strategy: JSON Merge Patch vs Strategic Merge Patch | PM1 |
+| R5 | Agent Memory deep-dive: Mem0 vs Letta vs Zep vs Cognee | IM Phase 3 |
+| T1 | Embedded KG storage: Kuzu vs SQLite relation tables | KR2 |
+
+---
+
+## Competitive Landscape (Reference)
+
+| System | What we learned |
+|--------|----------------|
+| **RCACopilot** (Microsoft) | Handler + embedding vector DB + LLM classification — validated pattern closest to our approach |
+| **HolmesGPT** (Robusta) | Multi-datasource integration (Prometheus/Grafana/ES/Datadog) — reference for KR connectors |
+| **Dynatrace** | Topology + causal engine — commercial standard for KR2 KG direction |
+| **OpenClaw** | Memory architecture (SQLite+FTS5+vector), batch embedding, query expansion — inform IM design |
+| **Glean** | Memory + connectors + knowledge graph + governance — enterprise benchmark for PM4 |
+
+---
+
+## Agent Behavior Principles (North Star)
+
+The six characteristics that define the Siclaw agent experience:
+
+1. **Cognitive humility** — Knows what it doesn't know; checks before answering
+2. **Knowledge provenance** — Labels `[general knowledge]` vs `[team knowledge]` vs `[current finding]`
+3. **Proactive context sensing** — Understands work context, pre-fetches relevant knowledge
+4. **Gap detection** — Finds mismatches between documented architecture and live environment
+5. **Deep discussion** — Doesn't just give answers; thinks through problems together
+6. **Cross-domain association** — Connects knowledge across domains to find non-obvious causes


### PR DESCRIPTION
## Summary

Establishes a shared knowledge layer — architecture invariants, roadmap, and decision records — so every Claude session and human contributor starts from the same ground truth without reverse-engineering constraints from code.

## Problem

Implicit architectural constraints were invisible to reviewers. PR #29 demonstrated this: `skillsHandler.materialize()` was called in local mode code, which would silently wipe `skills/core/` for all users — a critical bug that only surfaces if you know LocalSpawner shares a filesystem across all users. That constraint was buried in code, not documented.

More broadly: each Claude session currently has to spend significant time reading code before it can review accurately. The same invariants keep getting re-discovered.

## Solution

Four new files in `docs/healthy-dev-infrastructure` branch:

**`CLAUDE.md`** (project root, 178 lines)
Auto-loaded by Claude Code on every session start. Concise operating manual: critical invariants summary, current roadmap phase, review checklist, key file map. Designed to be read in under 2 minutes.

**`docs/design/invariants.md`** (320 lines)
Full architectural constraints and component contracts:
- Local mode filesystem sharing (the core invariant behind PR #29)
- Skill bundle contract (team + personal only, never core)
- Shell security model (whitelist-only, explicit exclusions)
- sql.js single-process lock
- Two-database architecture (Gateway DB vs Memory DB)
- Resource sync safety matrix (what's safe where)
- Deep investigation budget constants
- TypeScript/ESM invariants

**`docs/design/roadmap.md`** (193 lines)
Structured roadmap for all three tracks (IM / KR / PM) with current status indicators, open research items, competitive landscape reference, and the six agent behavior principles.

**`docs/design/decisions.md`** (205 lines)
8 Architecture Decision Records covering the non-obvious choices: sql.js selection, LocalSpawner in-process design, skill bundle exclusion of core skills, whitelist-only shell security, hybrid memory search, mTLS scope, dual brain architecture, cron HA coordination. Each ADR includes Context → Decision → Consequences.

## Test Plan

- [x] `CLAUDE.md` line count <200 (actual: 178)
- [x] All cross-references to source files verified against current codebase
- [x] Roadmap status matches git log and project memory
- [x] ADR consequences match observed behavior (e.g., ADR-002 explains the PR #29 bug class)