### PR TITLE
docs: expand roadmap with OB, CS tracks and trim speculative phases

### DIFF
--- a/docs/design/roadmap.md
+++ b/docs/design/roadmap.md
@@ -10,29 +10,31 @@
 
 ## Architecture Layers
 
-Siclaw is built in four interconnected layers:
+Siclaw is built in five interconnected layers. **Depth** (IM/KR) and **breadth** (OB/CS) must grow together — a knowledgeable agent with short arms cannot do real SRE work.
 
 ```
-┌─────────────────────────────────────────────────────┐
-│  Persona & Workspace System  (PM roadmap)            │
-│  4-layer patch: System → Team → Personal → Workspace │
-└─────────────────────┬───────────────────────────────┘
-                      │
-┌─────────────────────┴───────────────────────────────┐
-│  Knowledge Streams (KR roadmap)                      │
-│  Stream A: Team KB (Qdrant)  Stream B: Investigation │
-│            external docs         Memory (SQLite)     │
-└─────────────────────┬───────────────────────────────┘
-                      │
-┌─────────────────────┴───────────────────────────────┐
-│  Investigation Engine (IM roadmap)                   │
-│  Deep search · Hypothesis validation · Memory loop   │
-└─────────────────────┬───────────────────────────────┘
-                      │
-┌─────────────────────┴───────────────────────────────┐
-│  Agent Runtime (current foundation)                  │
-│  TUI · Gateway · AgentBox · Skills · Tools · MCP     │
-└─────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│  Persona & Workspace System  (PM roadmap)                         │
+│  Config cascade · Skill trust tiers                               │
+│  System → Team → Personal → Workspace (mandatory → optional)      │
+└───────────────────────────┬──────────────────────────────────────┘
+                            │
+┌───────────────────────────┴──────────────────────────────────────┐
+│  Knowledge Streams  (IM + KR roadmaps)                            │
+│  Stream A: Team KB (Qdrant, external docs)                        │
+│  Stream B: Investigation Memory (SQLite, learned patterns)        │
+└───────────────────────────┬──────────────────────────────────────┘
+                            │
+┌───────────────────────────┴──────────────────────────────────────┐
+│  Observability Integration  (OB roadmap)                          │
+│  Metrics · Logs · Events — the agent's sensory layer              │
+└───────────────────────────┬──────────────────────────────────────┘
+                            │
+┌───────────────────────────┴──────────────────────────────────────┐
+│  Agent Runtime  (current foundation)                              │
+│  TUI · Gateway · AgentBox · Skills · MCP · Brain types            │
+│  Command surface (CS roadmap) · Credential model · DB layer       │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -58,103 +60,142 @@ The knowledge feedback loop: every investigation produces structured experience 
 - Feed patterns into Phase 2 (hypothesis generation) of deep investigation engine
 - Automatic pattern confidence scoring based on historical outcomes
 
-### IM Phase 3 — Cross-Investigation Correlation ⏳ Planned
-- Detect recurring failures across multiple investigations
-- Build causal graphs: environment change → failure pattern → root cause
-- Surface "this looks like the incident from 2 weeks ago" proactively
-- Temporal decay for outdated patterns
-
-### IM Phase 4 — Active Learning ⏳ Planned
-- Agent identifies gaps in its own knowledge ("I've seen this symptom but never found the cause")
-- Proactively asks questions or suggests follow-up investigations
-- Knowledge completeness scoring per failure category
-
-### IM Phase 5 — Team Knowledge Merge ⏳ Planned
-- Merge investigation memories across team members (with consent model)
-- Conflict resolution for contradictory findings
-- Attribution tracking (who discovered what)
-
 ---
 
 ## Roadmap B — Knowledge Base & Retrieval (KR)
 
 External knowledge ingestion: team docs, runbooks, architecture diagrams → searchable by the agent.
 
-### KR0 — Qdrant + Basic Ingestion 🔄 Next Priority
-- Stand up Qdrant vector store (embedded or self-hosted)
+### KR0 — Qdrant + Basic Ingestion 🔄 In Progress
+- Stand up Qdrant vector store (embedded first, self-hosted for production)
 - Ingest: team docs (Confluence/Notion/markdown), runbooks, architecture diagrams
 - Chunking strategy: heading-aware hierarchical chunking (Anthropic Contextual Retrieval pattern)
 - Basic semantic search for agent via `knowledge_search` tool
-- Evaluate: Contextual Retrieval vs Late Chunking for technical docs
+- Evaluate: Contextual Retrieval vs Late Chunking for technical docs (R1)
 
 ### KR1 — Source Connectors ⏳ Planned
 - Connectors: GitHub (issues, PRs, wikis), Confluence, Notion, local filesystem
 - Incremental sync (only re-ingest changed content)
 - Source attribution in search results
 
-### KR2 — Knowledge Graph Overlay ⏳ Planned
-- Entity extraction: services, nodes, deployments, configs
-- Relationship graph: "service A depends on service B via env var X"
-- Graph-augmented retrieval: entity → related docs → context
-- Storage options: Kuzu (embedded KG) vs SQLite relation tables (T1 open research)
+---
 
-### KR3 — Knowledge Quality & Trust ⏳ Planned
-- Content freshness scoring (docs older than 90 days get staleness warning)
-- Conflict detection: runbook says X, investigation found Y
-- Trust levels: verified (admin-reviewed), contributed (team), auto-ingested
+## Roadmap C — Observability Integration (OB)
 
-### KR4 — Proactive Knowledge Surfacing ⏳ Planned
-- Agent detects "current environment differs from documented architecture"
-- Surfaces relevant runbooks before user asks
-- "What changed since last deployment" cross-references knowledge base
+**Currently the largest capability gap.** Real SRE diagnosis without metrics and logs is like diagnosing a patient without vital signs. This is the agent's sensory layer — without it, knowledge accumulation has no raw data to reason from.
 
-### KR5 — Multi-Team Knowledge Federation ⏳ Planned
-- Team A shares runbooks with Team B (with ACL)
-- Federated search across multiple Qdrant collections
-- Knowledge licensing and access control model
+Reference: HolmesGPT integrates Prometheus/Grafana/ES/Datadog — that is the minimum viable observability surface.
+
+### OB0 — Metrics Query (Prometheus/Thanos) ⏳ Next Priority
+- `metrics_query` tool: PromQL execution against configured Prometheus/Thanos endpoint
+- Range queries: "show me CPU usage for this pod over the last 2 hours"
+- Instant queries: current value lookups for health checks
+- Result formatting: table output for LLM consumption without token explosion (R2)
+- Endpoint auth uses existing `api_token` credential type — no new credential infrastructure needed
+- Workspace-level endpoint configuration (each workspace points to its own Prometheus)
+
+### OB1 — Log Query (Loki / Elasticsearch / Datadog Logs) ⏳ Planned
+- `log_query` tool: unified interface over multiple log backends
+- Backend adapters: Loki (LogQL), Elasticsearch (Lucene/KQL), Datadog
+- Time-range + label/field filtering
+- Endpoint auth via existing `api_token` / `api_basic_auth` credential types
+- Backend abstraction: single tool with backend param vs separate tools per backend (T2)
+
+### OB2 — Event Correlation ⏳ Planned
+- Correlate K8s events + metrics spikes + log error bursts on a shared timeline
+- `correlate_events` tool: given a time window, surface co-occurring anomalies across OB sources
+- Feed correlated event sets into IM causal pattern building
+- "At 14:32 the deployment rolled out, at 14:34 error rate spiked, at 14:35 OOMKill started"
 
 ---
 
-## Roadmap C — Persona & Workspace System (PM)
+## Roadmap D — Persona & Workspace System (PM)
 
-The "cyber-twin" model: one person, multiple workspaces (personas), each accumulating context independently.
+The "cyber-twin" model: one person, multiple workspaces (personas), each with its own config and skills. Config flows downward; lower layers override higher layers except for mandatory System policies.
 
-### PM0 — Workspace Foundation ✅ Complete (in Agent Runtime)
+```
+System (mandatory baselines, security, compliance)
+  └─ Team (conventions, shared tools, approved skills)
+       └─ Personal (individual preferences, personal skills)
+            └─ Workspace (context-specific overrides — highest priority)
+```
+
+### PM0 — Workspace Foundation ✅ Complete
 - Workspace CRUD via WebUI
 - Per-workspace: skills, tools, environments, credentials, allowed models
 - `{userId}:{workspaceId}` as fundamental isolation unit
+- Schema: `workspaces`, `workspaceSkills`, `workspaceTools`, `workspaceEnvironments`, `workspaceCredentials`
 
 ### PM1 — 4-Layer Config Cascade ⏳ Planned
-- Full implementation of: System → Team → Personal → Workspace patch model
-- JSON Merge Patch vs Strategic Merge Patch evaluation (R3 open research)
-- Workspace inherits team config, can override at personal or workspace level
-- Mandatory policies at System layer cannot be overridden
+- Full merge semantics: System → Team → Personal → Workspace (R3: JSON Merge Patch vs Strategic Merge Patch)
+- Mandatory policies at System layer: cannot be overridden by any lower layer, enforced at agent startup
+- Team layer: shared tool configs, approved skill lists, default models
+- Workspace layer: context-specific tool endpoints (which Prometheus, which kubeconfig)
+- Config validation at each layer boundary (reject invalid overrides at write time, not runtime)
 
 ### PM2 — Skill Trust Tiers ⏳ Planned
-- `restricted` / `standard` / `elevated` skill permission levels
-- Elevated skills require explicit workspace grant
-- Skill review workflow respects tier (elevated requires senior reviewer)
+- Three tiers: `restricted` (read-only, no exec) / `standard` (normal tools) / `elevated` (write ops, external calls)
+- Elevated skills require explicit workspace grant + senior reviewer approval
+- System layer defines maximum allowed tier per workspace type
+- Runtime enforcement: agent refuses to load elevated skills without workspace grant in config
 
-### PM3 — Persona Memory Isolation ⏳ Planned
-- Each workspace has its own memory space (separate investigation history)
-- Cross-workspace memory sharing (opt-in, with attribution)
-- Memory export/import between workspaces
+---
 
-### PM4 — Team Persona & Shared KB ⏳ Planned
-- Team-level persona: shared external KB + individual investigation memories
-- Team onboarding: new member inherits team KB baseline
-- Contribution model: personal discoveries promoted to team KB after review
+## Roadmap E — Command & Environment Surface (CS)
+
+The agent's reach: what it can run, and where it can connect. Two dimensions that must grow together.
+
+**Security invariant**: whitelist-only model (ADR-004) must not be weakened. Every addition requires use case justification + flag restrictions + test coverage.
+
+**Credential infrastructure note**: the credential model already supports `ssh_key`, `ssh_password`, `kubeconfig`, `api_token`, `api_basic_auth` — all stored, materialized, and discoverable via the `credential_list` tool. CS work is about the execution layer (tools + whitelist), not re-doing credential storage.
+
+### CS0 — K8s Ecosystem Tools ⏳ Next Priority
+- `helm`: read-only subcommands (`get`, `list`, `status`, `history`, `show`) — no `install`/`upgrade`/`delete`
+- `istioctl`: `analyze`, `proxy-status`, `proxy-config` — no config mutations
+- `argocd`: `app get`, `app list`, `app history`, `app diff` — no sync/rollback
+- Add per-tool flag allowlists following the existing `command-sets.ts` declarative pattern
+
+### CS1 — Network & TLS Diagnostic Tools ⏳ Planned
+- `curl`: expand allowed flags — add `--resolve`, `--connect-to` for service endpoint testing
+- `openssl s_client`: TLS handshake and certificate inspection (read-only)
+- `dig` / `nslookup`: DNS resolution diagnostics
+
+### CS2 — SSH & Remote Host Access ⏳ Planned
+- `ssh_exec` tool: executes commands on remote hosts using workspace `ssh_key` / `ssh_password` credentials; target must be in environment `allowedServers` list
+- `ssh` added to command whitelist with strict flag restrictions (no tunneling, no agent forwarding)
+- Host diagnostic skills: memory/CPU/NUMA topology, disk I/O, process state, kernel logs
+- InfiniBand diagnostic skills: link state, routing, congestion — commands already whitelisted (`ibaddr`, `iblinkinfo`, `ibswitches`, `ibroute`), only skill wrappers missing
+- Switch/network device access: separate evaluation needed (SNMP read-only or vendor REST API via `api_token`)
+
+---
+
+## Agent Behavior Engineering Map
+
+The six agent behavior principles must map to concrete engineering work, not remain as aspirations.
+
+| Principle | Engineering Feature | Roadmap Item | Status |
+|-----------|--------------------|-----------|----|
+| **Cognitive humility** | `knowledge_search` called before answering; KB miss triggers explicit "I don't know" | KR0 | ⏳ |
+| **Knowledge provenance** | Tool responses tagged: `[team-kb]` / `[investigation-memory]` / `[live-cluster]` / `[general]` | KR0 + IM2 | ⏳ |
+| **Proactive context sensing** | Workspace context (namespace, recent alerts) injected at session start; triggers OB + KB pre-fetch | OB0 + PM1 | ⏳ |
+| **Gap detection** | Compare KB-documented architecture vs. live cluster state; flag discrepancies | KR1 + OB2 | ⏳ |
+| **Deep discussion** | Multi-turn hypothesis refinement; agent presents competing hypotheses and asks before concluding | IM2 | 🔄 |
+| **Cross-domain association** | Connect a service's runbook, alert history, recent deployments, and investigation records | KR1 + IM2 | ⏳ |
 
 ---
 
 ## Current Sprint Priorities
 
-| Priority | Item | Status | Notes |
-|----------|------|--------|-------|
-| P1 | KR0: Qdrant stand-up + basic ingestion | 🔄 In Progress | Storage: embedded Qdrant |
-| P1 | IM Phase 2: diagnostic path learning | 🔄 In Progress | Depends on IM Phase 1 data accumulation |
-| P2 | PM1: 4-layer config cascade | ⏳ Planned | Research R3 first |
-| P3 | KR1: Source connectors | ⏳ Planned | After KR0 validated |
+| Priority | Item | Roadmap | Status | Notes |
+|----------|------|---------|--------|-------|
+| P1 | OB0: Prometheus metrics query tool | OB | ⏳ Planned | Largest capability gap; unblocks real SRE diagnosis |
+| P1 | KR0: Qdrant stand-up + basic ingestion | KR | 🔄 In Progress | Embedded Qdrant first |
+| P1 | IM Phase 2: diagnostic path learning | IM | 🔄 In Progress | Needs IM Phase 1 data accumulation |
+| P2 | CS0: Helm + Istioctl + ArgoCD read-only | CS | ⏳ Planned | Expands command surface for real SRE workflows |
+| P2 | PM1: 4-layer config cascade | PM | ⏳ Planned | Research R3 first |
+| P3 | OB1: Log query (Loki/ES) | OB | ⏳ Planned | After OB0 pattern validated |
+| P3 | KR1: Source connectors | KR | ⏳ Planned | After KR0 validated |
+| P3 | CS2: SSH & remote host access | CS | ⏳ Planned | Credential layer ready; needs ssh_exec tool + skills |
 
 ---
 
@@ -163,9 +204,9 @@ The "cyber-twin" model: one person, multiple workspaces (personas), each accumul
 | ID | Question | Blocking |
 |----|----------|---------|
 | R1 | Contextual Retrieval vs Late Chunking for technical docs | KR0 |
+| R2 | OB tool output format: summarize metrics/logs for LLM without token explosion | OB0 |
 | R3 | Config cascade merge strategy: JSON Merge Patch vs Strategic Merge Patch | PM1 |
-| R5 | Agent Memory deep-dive: Mem0 vs Letta vs Zep vs Cognee | IM Phase 3 |
-| T1 | Embedded KG storage: Kuzu vs SQLite relation tables | KR2 |
+| T2 | OB backend abstraction: single tool with backend param vs separate tools per backend | OB1 |
 
 ---
 
@@ -174,16 +215,17 @@ The "cyber-twin" model: one person, multiple workspaces (personas), each accumul
 | System | What we learned |
 |--------|----------------|
 | **RCACopilot** (Microsoft) | Handler + embedding vector DB + LLM classification — validated pattern closest to our approach |
-| **HolmesGPT** (Robusta) | Multi-datasource integration (Prometheus/Grafana/ES/Datadog) — reference for KR connectors |
-| **Dynatrace** | Topology + causal engine — commercial standard for KR2 KG direction |
+| **HolmesGPT** (Robusta) | Multi-datasource OB integration (Prometheus/Grafana/ES/Datadog) — direct reference for OB roadmap |
+| **Dynatrace** | Topology + causal engine — commercial standard for future KG direction |
 | **OpenClaw** | Memory architecture (SQLite+FTS5+vector), batch embedding, query expansion — inform IM design |
-| **Glean** | Memory + connectors + knowledge graph + governance — enterprise benchmark for PM4 |
+| **OpenOcta** | Tool Profile mechanism, Exec Security tiers — inform CS and future workspace agent design |
+| **Glean** | Memory + connectors + knowledge graph + governance — enterprise benchmark for long-term PM direction |
 
 ---
 
 ## Agent Behavior Principles (North Star)
 
-The six characteristics that define the Siclaw agent experience:
+The six characteristics that define the Siclaw agent experience. See "Agent Behavior Engineering Map" above for how each maps to concrete roadmap items.
 
 1. **Cognitive humility** — Knows what it doesn't know; checks before answering
 2. **Knowledge provenance** — Labels `[general knowledge]` vs `[team knowledge]` vs `[current finding]`


### PR DESCRIPTION
## Problem

The previous roadmap was heavily skewed toward knowledge accumulation (IM/KR), missing two critical dimensions:

1. **Observability gap**: The agent has no access to metrics, logs, or events. Without this sensory layer, even the best knowledge base can't do real SRE diagnosis.
2. **Command surface gap**: Only kubectl (read-only) and basic tools are available. Real SRE workflows need helm, istioctl, argocd, and remote host access.
3. **Speculative phases**: IM Phase 3-5 and KR Phase 2-5 were planned well beyond current execution capacity, adding noise without near-term value.

## Changes

**Architecture diagram**: Updated from 4 to 5 layers — Observability Integration added as a distinct layer between the runtime and knowledge streams.

**New: Roadmap C — Observability Integration (OB)**
- OB0: Prometheus/Thanos metrics query tool (P1 — largest current gap)
- OB1: Log query unified interface (Loki/ES/Datadog)
- OB2: Event correlation across metrics + logs + K8s events
- Notes that OB endpoint auth reuses existing `api_token` / `api_basic_auth` credential types — no new infrastructure needed

**New: Roadmap E — Command & Environment Surface (CS)**
- CS0: Helm, Istioctl, ArgoCD read-only subcommands (P2)
- CS1: Network & TLS diagnostic tools (curl expansion, openssl, dig)
- CS2: SSH & remote host access — clarifies that `ssh_key` / `ssh_password` credential types already exist in the credential model; gap is the `ssh_exec` tool + whitelist entry + host/IB diagnostic skills

**Trimmed**:
- IM Phase 3-5 removed (cross-investigation correlation, active learning, team merge) — too far ahead of Phase 2
- KR Phase 2-5 removed (knowledge graph, quality scoring, proactive surfacing, federation)
- PM Phase 3-5 removed (persona memory isolation, team persona) — PM3 "workspace sub-agents" was also confusing given the existing deep-search internal sub-agent

**Added**: Agent Behavior Engineering Map — maps each of the 6 north-star principles to a concrete roadmap item and status, so they are commitments not aspirations.

**Updated**: Sprint priorities, open research items, competitive landscape references.