### PR TITLE
chore: update default docker registry to siclaw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GIT_DIRTY  := $(shell test -n "$$(git status --porcelain)" && echo "-dirty" || e
 VERSION    := $(shell node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")
 
 # ── Configurable variables ──
-REGISTRY  ?= scitix
+REGISTRY  ?= siclaw
 NAMESPACE ?= siclaw
 TAG       ?= $(if $(GIT_TAG),$(GIT_TAG),$(VERSION)-$(GIT_COMMIT)$(GIT_DIRTY))
 

--- a/docs/install/kubernetes.mdx
+++ b/docs/install/kubernetes.mdx
@@ -54,7 +54,7 @@ database:
 
 gateway:
   image:
-    repository: ghcr.io/scitix/siclaw-gateway
+    repository: siclaw/siclaw-gateway
     tag: latest
   service:
     type: ClusterIP
@@ -62,7 +62,7 @@ gateway:
 
 agentbox:
   image:
-    repository: ghcr.io/scitix/siclaw-agentbox
+    repository: siclaw/siclaw-agentbox
     tag: latest
   resources:
     limits:

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -5,7 +5,7 @@ namespace: siclaw
 
 # -- Container images
 image:
-  registry: ""          # e.g. "scitix" -> scitix/siclaw-gateway:latest; empty -> siclaw-gateway:latest
+  registry: ""          # e.g. "siclaw" -> siclaw/siclaw-gateway:latest; empty -> siclaw-gateway:latest
   pullPolicy: Always
   tag: "latest"
 

--- a/package.json
+++ b/package.json
@@ -98,9 +98,9 @@
     "start:gateway": "node siclaw-gateway.mjs",
     "start:agentbox": "node dist/agentbox-main.js",
     "test": "vitest run",
-    "docker:build:gateway": "docker build -f Dockerfile.gateway -t siclaw-gateway:latest .",
-    "docker:build:agentbox": "docker build -f Dockerfile.agentbox -t siclaw-agentbox:latest .",
-    "docker:push:gateway": "docker push siclaw-gateway:latest",
-    "docker:push:agentbox": "docker push siclaw-agentbox:latest"
+    "docker:build:gateway": "docker build -f Dockerfile.gateway -t siclaw/siclaw-gateway:latest .",
+    "docker:build:agentbox": "docker build -f Dockerfile.agentbox -t siclaw/siclaw-agentbox:latest .",
+    "docker:push:gateway": "docker push siclaw/siclaw-gateway:latest",
+    "docker:push:agentbox": "docker push siclaw/siclaw-agentbox:latest"
   }
 }


### PR DESCRIPTION
## Summary
- Update default Docker registry from `scitix` to `siclaw` across all config files
- Images will now push to `siclaw/siclaw-gateway`, `siclaw/siclaw-agentbox`, `siclaw/siclaw-cron` on Docker Hub

## Test plan
- [ ] `make info` shows correct image names
- [ ] `make docker push` pushes to siclaw/ org on Docker Hub