### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siclaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AI-powered SRE copilot for Kubernetes diagnostics via natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Published siclaw@0.1.1 to npm. Tag v0.1.1 will be created after merge.