### PR TITLE
chore: sync package-lock.json version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siclaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siclaw",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.58",
         "@anthropic-ai/sdk": "^0.71.2",


### PR DESCRIPTION
Missed in the version bump PR #42.