### PR TITLE
fix: survive WS disconnect during deep investigation

### DIFF
--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -1101,12 +1101,14 @@ export function createRpcMethods(
     const userId = requireAuth(context);
     const sessionId = params.sessionId as string | undefined;
     const snapKey = sessionId ? `${userId}:${sessionId}` : userId;
+    const streamKey = sessionId ? `${userId}:${sessionId}` : undefined;
+    const promptActive = streamKey ? activeStreams.has(streamKey) : false;
     const snap = dpProgressSnapshots.get(snapKey);
     if (!snap || Date.now() - snap.updatedAt > 600_000) {
       dpProgressSnapshots.delete(snapKey);
-      return { events: null };
+      return { events: null, promptActive };
     }
-    return { sessionId: snap.sessionId, events: snap.events };
+    return { sessionId: snap.sessionId, events: snap.events, promptActive };
   });
 
   methods.set("chat.history", async (params, context: RpcContext) => {
@@ -3634,13 +3636,13 @@ export function createRpcMethods(
     return buildSkillBundle(userId, env, skillWriter, skillRepo, skillContentRepo, disabled);
   }
 
-  /** Abort all SSE streams associated with a specific WebSocket connection */
+  /** Detach WebSocket from SSE streams — SSE continues so DB persistence and
+   *  dpProgressSnapshots keep updating. User reconnect resumes live events. */
   function cleanupForWs(ws: WebSocket): void {
     for (const [key, stream] of activeStreams.entries()) {
       if (stream.ws === ws) {
-        console.log(`[rpc] Cleaning up SSE stream ${key} (WS closed)`);
-        stream.abort();
-        activeStreams.delete(key);
+        console.log(`[rpc] WS detached from SSE stream ${key} — SSE continues`);
+        stream.ws = undefined;
       }
     }
   }

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -993,32 +993,42 @@ export function usePilot() {
         }
     }, [isConnected, sendRpc, currentSessionKey, loadSessions]);
 
-    // Reset loading state when WebSocket disconnects mid-generation
-    // (e.g. model API error, backend crash, network drop)
+    // Reset loading state when WebSocket disconnects mid-generation.
+    // Give a 15s grace window for WS to auto-reconnect (SSH tunnel flaps,
+    // browser sleep, network blips). Backend SSE continues independently.
+    const disconnectTimerRef = useRef<ReturnType<typeof setTimeout>>();
     useEffect(() => {
         if (!isConnected && isLoading) {
-            setIsLoading(false);
-            isAbortingRef.current = false;
-            setPendingMessages([]);
-            setMessages(prev => prev.map(m =>
-                m.isStreaming
-                    ? { ...m, isStreaming: false, ...(m.role === 'tool' ? { toolStatus: 'error' as const } : {}) }
-                    : m
-            ));
-            clearDpTimers();
-            setDpChecklist(prev => {
-                if (!prev) return null;
-                return prev.map(item =>
-                    item.status === 'in_progress' || item.status === 'pending'
-                        ? { ...item, status: 'error' as const, summary: 'Connection lost' }
-                        : item
-                );
-            });
-            setDpFocus(null);
-            setInvestigationProgress(null);
-            dpTimeout(() => resetDpState(), 10_000);
+            disconnectTimerRef.current = setTimeout(() => {
+                setIsLoading(false);
+                isAbortingRef.current = false;
+                setPendingMessages([]);
+                setMessages(prev => prev.map(m =>
+                    m.isStreaming
+                        ? { ...m, isStreaming: false, ...(m.role === 'tool' ? { toolStatus: 'error' as const } : {}) }
+                        : m
+                ));
+                clearDpTimers();
+                setDpChecklist(prev => {
+                    if (!prev) return null;
+                    return prev.map(item =>
+                        item.status === 'in_progress' || item.status === 'pending'
+                            ? { ...item, status: 'error' as const, summary: 'Connection lost' }
+                            : item
+                    );
+                });
+                setDpFocus(null);
+                setInvestigationProgress(null);
+                dpTimeout(() => resetDpState(), 10_000);
+            }, 15_000);
         }
-    }, [isConnected]); // eslint-disable-line react-hooks/exhaustive-deps
+        return () => {
+            if (disconnectTimerRef.current) {
+                clearTimeout(disconnectTimerRef.current);
+                disconnectTimerRef.current = undefined;
+            }
+        };
+    }, [isConnected, isLoading]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Stale-loading watchdog: if isLoading but no agent events for too long,
     // the backend likely died silently — reset UI so user isn't stuck.
@@ -1062,11 +1072,19 @@ export function usePilot() {
         }
     }, [isLoading, staleTimeoutMs]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    /** Restore deep_search progress from gateway snapshot after WS reconnect */
+    /** Restore deep_search progress from gateway snapshot after WS reconnect / page refresh */
     const restoreDpProgress = useCallback(async () => {
         if (!isConnected) return;
         try {
-            const snap = await sendRpc<{ sessionId?: string; events: Array<Record<string, unknown>> | null }>('chat.dpProgress', { sessionId: currentSessionKeyRef.current });
+            const snap = await sendRpc<{
+                sessionId?: string;
+                events: Array<Record<string, unknown>> | null;
+                promptActive?: boolean;
+            }>('chat.dpProgress', { sessionId: currentSessionKeyRef.current });
+            // If prompt is still running on the backend, restore loading state
+            if (snap.promptActive) {
+                setIsLoading(true);
+            }
             if (!snap.events || snap.events.length === 0) return;
             // Replay events through the same reducer used for live progress
             let state: InvestigationProgress = { hypotheses: [] };
@@ -1074,6 +1092,31 @@ export function usePilot() {
                 state = reduceInvestigationProgress(state, ev);
             }
             setInvestigationProgress(state);
+
+            // Derive dpChecklist from restored investigation state so the
+            // DpChecklistCard renders (it gates hypothesis tree visibility).
+            // Phase values from engine: "Phase 1/4" .. "Phase 4/4"
+            const phase = state.phase;
+            const checklist = createDefaultDpChecklist();
+            const phaseNum = phase ? parseInt(phase.match(/(\d+)/)?.[1] ?? '0') : 0;
+            if (phaseNum >= 1) {
+                // Map engine phases to checklist items: 1→triage, 2→hypotheses, 3→deep_search, 4→conclusion
+                for (let i = 0; i < checklist.length; i++) {
+                    if (i < phaseNum - 1) {
+                        checklist[i].status = 'done';
+                    } else if (i === phaseNum - 1) {
+                        checklist[i].status = 'in_progress';
+                    }
+                }
+            } else if (state.hypotheses.length > 0) {
+                // Have hypotheses but no phase info — at least in deep_search
+                checklist[0].status = 'done';
+                checklist[1].status = 'done';
+                checklist[2].status = 'in_progress';
+            }
+            setDpChecklist(checklist);
+            const focus = checklist.find(i => i.status === 'in_progress');
+            setDpFocus(focus ? focus.id : null);
         } catch {
             // Ignore — gateway may not support this RPC yet
         }

--- a/src/gateway/web/src/pages/Pilot/components/HypothesesCard.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/HypothesesCard.tsx
@@ -233,7 +233,8 @@ export function HypothesesCard({ message, sendMessage, abortResponse, onHypothes
     const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
     const [confirmed, setConfirmed] = useState(false);
     const isRunning = message.toolStatus === 'running';
-    const isDone = message.toolStatus === 'success';
+    // toolStatus is undefined for messages loaded from DB history (not persisted)
+    const isDone = message.toolStatus === 'success' || (!message.toolStatus && !message.isStreaming);
 
     // Parse hypotheses: prefer toolDetails.hypotheses (gateway mode), fallback to toolInput
     const hypothesesSource = (message.toolDetails?.hypotheses as string) || message.toolInput || '';


### PR DESCRIPTION
## Problem

WebSocket disconnects (SSH tunnel flaps, browser sleep, network blips) during deep investigation kill the SSE event stream and immediately destroy all DP progress on the frontend. The AgentBox agent continues running independently, but Gateway stops receiving events — investigation progress and results are lost.

**Bug chain:**
```
WS close → cleanupForWs() aborts SSE stream + deletes activeStream entry
  → DB persistence stops (messages during disconnect lost)
  → dpProgressSnapshots stops updating
  → prompt_done sent to nobody
  → Frontend immediately destroys all DP state
```

## Solution

### Backend (`rpc-methods.ts`)
- **`cleanupForWs`**: Detach WS (`stream.ws = undefined`) instead of aborting SSE. The SSE loop continues running so DB persistence and `dpProgressSnapshots` keep updating.
- **`chat.dpProgress`**: Return `promptActive` flag (true if SSE stream is still alive) so frontend can restore loading state on reconnect.

### Frontend (`usePilot.ts`)
- **15s grace window**: WS disconnect no longer immediately destroys DP state. A 15s timer gives WS auto-reconnect time to recover (typically <5s). Reconnect cancels the timer.
- **`restoreDpProgress`**: Restore `isLoading` when `promptActive` is true. Derive `dpChecklist` from investigation phase data so the DpChecklistCard (which gates hypothesis tree visibility) renders after page refresh.

### Frontend (`HypothesesCard.tsx`)
- **`isDone` fallback**: Treat `undefined` toolStatus (DB-loaded messages) as done, so Confirm/Modify/Cancel buttons render after page refresh.

## Recovery flow
```
WS reconnect → 15s timer cancelled (no state destruction)
  → loadHistory() → DB has all messages (SSE kept persisting)
  → restoreDpProgress() → promptActive: true → isLoading restored
  → replay cached events → investigation progress + checklist restored
  → sendToUser resumes → live events flow into new WS
```

## Test plan
- [ ] Start deep investigation → Phase 3 → Chrome DevTools Network → Offline 5s → back online → DP progress resumes
- [ ] Disconnect >15s → "Connection lost" shown → reconnect → loadHistory + restoreDpProgress recovers
- [ ] Agent completes during disconnect → reconnect → `promptActive: false` + full conversation in history
- [ ] Page refresh during Phase 3 → checklist + hypothesis tree restored
- [ ] Page refresh at Phase 2 (hypothesis confirmation) → Confirm buttons visible
- [ ] `npx tsc --noEmit` passes (backend + frontend)