### PR TITLE
fix: ensure positive X.509 serial number in mTLS certificates

### DIFF
--- a/src/gateway/security/cert-manager.ts
+++ b/src/gateway/security/cert-manager.ts
@@ -284,7 +284,9 @@ export class CertificateManager {
 
     const cert = forge.pki.createCertificate();
     cert.publicKey = publicKeyForge;
-    cert.serialNumber = forge.util.bytesToHex(forge.random.getBytesSync(16));
+    // Ensure positive serial number: clear the high bit to avoid negative ASN.1 INTEGER
+    const serialBytes = forge.random.getBytesSync(16);
+    cert.serialNumber = "00" + forge.util.bytesToHex(serialBytes);
 
     const notBefore = new Date();
     const notAfter = new Date();


### PR DESCRIPTION
## Summary
- AgentBox pods fail readiness/liveness probes in K8s with: `x509: negative serial number`
- Root cause: `forge.random.getBytesSync(16)` can produce bytes where the high bit is 1, making the ASN.1 INTEGER negative
- Fix: prepend `00` to the hex serial to guarantee a positive value

## Test plan
- [ ] Deploy to K8s, agentbox pods pass health checks
- [ ] After deploy, delete `ca.cert` and `ca.key` from `system_config` table to force CA regeneration