### PR TITLE
docs: update install commands, add demo GIF, reduce redundancy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -43,13 +43,20 @@ Siclaw:
   </Card>
 </CardGroup>
 
+## See It In Action
+
+<Frame>
+  <img src="/assets/demo.gif" alt="Siclaw Web UI — investigating a CrashLoopBackOff pod" />
+</Frame>
+
 ## Quick Start
 
 ```bash
-npx siclaw
+npm install -g siclaw
+siclaw local        # Web UI at http://localhost:3000
 ```
 
-Then describe your problem. Siclaw handles the rest.
+Or `siclaw` for personal CLI mode.
 
 <CardGroup cols={2}>
   <Card title="Getting Started" icon="rocket" href="/start/getting-started">

--- a/docs/install/cli.mdx
+++ b/docs/install/cli.mdx
@@ -1,25 +1,30 @@
 ---
-title: "CLI Installation"
-sidebarTitle: "CLI"
-description: "Run Siclaw as a terminal application for personal diagnostics."
+title: "CLI & Local Server"
+sidebarTitle: "CLI / Local"
+description: "Install Siclaw globally and run as CLI or local server."
 ---
 
-## Quick Install
-
-```bash
-npx siclaw
-```
-
-That's it. npx downloads and runs the latest version automatically.
-
-## Global Install
-
-If you prefer a permanent installation:
+## Install
 
 ```bash
 npm install -g siclaw
+```
+
+## Local Server (recommended)
+
+```bash
+siclaw local
+```
+
+Launches the Web UI at `http://localhost:3000` with multi-user support, channels (Slack/Lark), cron patrols, and all features.
+
+## CLI (TUI)
+
+```bash
 siclaw
 ```
+
+Personal terminal mode. Same investigation engine, no server.
 
 ## From Source
 

--- a/docs/start/core-concepts.mdx
+++ b/docs/start/core-concepts.mdx
@@ -6,16 +6,9 @@ description: "Key ideas behind Siclaw's investigation approach."
 
 ## How Siclaw Investigates
 
-Siclaw's core is a **4-phase hypothesis-driven investigation engine**:
+Siclaw uses a **4-phase hypothesis-driven investigation engine**: gather context → generate hypotheses → validate in parallel with sub-agents → produce a structured report with root cause and remediation.
 
-```
-Phase 1: Context Gathering    → Collects cluster state, events, logs, metrics
-Phase 2: Hypothesis Generation → Generates 3-5 ranked hypotheses from evidence
-Phase 3: Parallel Validation   → Up to 3 sub-agents independently test hypotheses
-Phase 4: Conclusion            → Structured report with root cause and remediation
-```
-
-Every investigation is **read-only** — Siclaw never modifies your cluster. See [Deep Investigation](/features/deep-investigation) for details.
+Every investigation is **read-only** — Siclaw never modifies your cluster. See [Deep Investigation](/features/deep-investigation) for the full pipeline details and budget controls.
 
 ## Runtime Modes
 
@@ -23,8 +16,9 @@ Siclaw runs in three modes sharing one agent core:
 
 | Mode | Use Case | Start Command |
 |------|----------|---------------|
-| **CLI (TUI)** | Personal terminal diagnostics | `npx siclaw` |
-| **Gateway** | Multi-user with Web UI, Slack, Lark | `siclaw-gateway` |
+| **CLI (TUI)** | Personal terminal diagnostics | `siclaw` |
+| **Local Server** | Team use with Web UI, Slack, Lark | `siclaw local` |
+| **Gateway + K8s** | Production multi-tenant | `siclaw-gateway --k8s` |
 | **Cron** | Scheduled health patrols | `siclaw-cron` |
 
 For team use, Gateway spawns an isolated **AgentBox** per user — either in-process (local dev) or as a Kubernetes pod (production).

--- a/docs/start/first-investigation.mdx
+++ b/docs/start/first-investigation.mdx
@@ -11,7 +11,7 @@ A pod in your production cluster is stuck in `CrashLoopBackOff` after a deployme
 ## Start Siclaw
 
 ```bash
-npx siclaw
+siclaw
 ```
 
 ## Describe the Problem

--- a/docs/start/getting-started.mdx
+++ b/docs/start/getting-started.mdx
@@ -12,22 +12,27 @@ description: "Install Siclaw and run your first investigation in under 5 minutes
 
 ## Install
 
-### Option 1: npx (Fastest)
-
-```bash
-npx siclaw
-```
-
-This downloads and runs Siclaw in TUI (terminal) mode. No installation needed.
-
-### Option 2: npm global install
-
 ```bash
 npm install -g siclaw
+```
+
+### Local Server (recommended for teams)
+
+```bash
+siclaw local
+```
+
+Launches the Web UI at `http://localhost:3000` with multi-user support, Slack/Lark channels, and all features enabled.
+
+### CLI
+
+```bash
 siclaw
 ```
 
-### Option 3: Clone and build
+TUI mode for personal terminal diagnostics.
+
+### From Source
 
 ```bash
 git clone https://github.com/scitix/siclaw.git
@@ -38,11 +43,11 @@ npm run dev
 
 ## Configure Your LLM
 
-On first run, Siclaw will prompt you to configure an LLM provider. You can also override via environment variables:
+On first run, Siclaw prompts you to configure an LLM provider. You can also set it via environment variables:
 
 ```bash
 export SICLAW_LLM_API_KEY="sk-ant-..."
-npx siclaw
+siclaw
 ```
 
 Or configure manually in `~/.siclaw/config/settings.json`:
@@ -66,23 +71,16 @@ Siclaw supports any OpenAI-compatible API. See [LLM Providers](/configuration/pr
 
 ## Run Your First Investigation
 
-Start Siclaw and describe an issue:
+Describe an issue:
 
 ```
-$ npx siclaw
-
 ? What would you like to investigate?
 > Pod CrashLoopBackOff in production cluster after deployment
 ```
 
-Siclaw will:
+Siclaw autonomously runs a [4-phase deep investigation](/features/deep-investigation) — gathering context, forming hypotheses, validating in parallel, and producing a structured report with root cause, confidence score, and remediation steps.
 
-1. **Gather context** — cluster state, events, pod logs, recent deployments
-2. **Generate hypotheses** — ranked list of possible root causes
-3. **Validate in parallel** — up to 3 sub-agents independently test each hypothesis
-4. **Conclude** — structured report with root cause, confidence score, and remediation steps
-
-The full report is saved to `~/.siclaw/reports/`.
+Reports are saved to `~/.siclaw/reports/`.
 
 ## What's Next?
 


### PR DESCRIPTION
## Summary

- Replace all `npx siclaw` references with `npm install -g siclaw` to match the published npm package
- Add `siclaw local` as the primary recommended quick start (Web UI for teams)
- Embed the existing demo GIF on the docs homepage using Mintlify `<Frame>` component
- Condense the 4-phase pipeline description in core-concepts.mdx to a one-liner with link to the authoritative deep-investigation page (eliminates triple repetition)
- Deduplicate install instructions between getting-started.mdx and install/cli.mdx
- Update runtime modes table to include Local Server and Gateway+K8s entries

## Test plan

- [ ] Verify Mintlify preview renders the demo GIF correctly on the homepage
- [ ] Confirm all internal doc links resolve (especially `/features/deep-investigation`)
- [ ] Check that no `npx siclaw` references remain in navigated docs