### PR TITLE
fix: TUI first-run bugs and kubeconfig management

### DIFF
--- a/siclaw.mjs
+++ b/siclaw.mjs
@@ -20,12 +20,14 @@ Commands:
   local        Start local gateway with web UI
 
 Options:
-  --prompt <text>   Run in non-interactive print mode
-  --continue        Continue the most recent session
-  --debug           Enable debug logging
-  --setup           Force provider setup wizard
-  --help, -h        Show this help
-  --version, -v     Show version
+  --prompt <text>      Run in non-interactive print mode
+  --continue           Continue the most recent session
+  --credentials        Manage cluster credentials (add/remove kubeconfig)
+  --add-kube [path]    Quick-add a kubeconfig (default: ~/.kube/config)
+  --debug              Enable debug logging
+  --setup              Force provider setup wizard
+  --help, -h           Show this help
+  --version, -v        Show version
 `);
 }
 
@@ -43,6 +45,29 @@ if (subcommand === "local") {
   // Remove "local" from argv so gateway-main doesn't see it as an unknown arg
   process.argv.splice(2, 1);
   await import("./dist/gateway-main.js");
+} else if (args.includes("--credentials") || args.includes("--add-kube")) {
+  // Credential management — lightweight path, no agent/config loading
+  const { runCredentialsManager } = await import("./dist/cli-credentials.js");
+  const { registerKubeconfig } = await import("./dist/tools/credential-manager.js");
+  const path = await import("node:path");
+  const os = await import("node:os");
+  const credDir = path.default.resolve(process.cwd(), ".siclaw/credentials");
+
+  const addKubeIndex = args.indexOf("--add-kube");
+  if (addKubeIndex >= 0) {
+    const nextArg = args[addKubeIndex + 1];
+    const kubePath = (nextArg && !nextArg.startsWith("--")) ? nextArg : path.default.join(os.homedir(), ".kube", "config");
+    try {
+      const result = await registerKubeconfig({ sourcePath: path.default.resolve(kubePath), credentialsDir: credDir });
+      console.log(`  ✓ Added "${result.name}" ${result.reachable ? `(${result.serverVersion})` : `(unreachable: ${result.probeError})`}`);
+    } catch (err) {
+      console.error(`  ✗ ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+  } else {
+    await runCredentialsManager(credDir);
+  }
+  process.exit(0);
 } else {
   await import("./dist/cli-main.js");
 }

--- a/src/cli-credentials.ts
+++ b/src/cli-credentials.ts
@@ -1,0 +1,120 @@
+/**
+ * Interactive credentials manager for TUI mode.
+ *
+ * Replaces model-driven credential_add — credential management is a user action,
+ * not a model action. The model can only read credentials via credential_list.
+ *
+ * Supports: kubeconfig (future: SSH keys, API tokens, etc.)
+ */
+import readline from "node:readline";
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+import { registerKubeconfig } from "./tools/credential-manager.js";
+
+interface ManifestEntry {
+  name: string;
+  type: string;
+  files: string[];
+  metadata?: Record<string, unknown>;
+}
+
+function loadManifest(credentialsDir: string): ManifestEntry[] {
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+function saveManifest(credentialsDir: string, entries: ManifestEntry[]): void {
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+  fs.writeFileSync(manifestPath, JSON.stringify(entries, null, 2) + "\n");
+}
+
+export async function runCredentialsManager(credentialsDir: string): Promise<void> {
+  fs.mkdirSync(credentialsDir, { recursive: true });
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const ask = (q: string): Promise<string> =>
+    new Promise((resolve) => rl.question(q, resolve));
+
+  try {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const entries = loadManifest(credentialsDir);
+
+      console.log("\n  Siclaw Credentials\n");
+
+      if (entries.length === 0) {
+        console.log("  (no credentials registered)\n");
+      } else {
+        for (const entry of entries) {
+          const meta = entry.metadata as Record<string, unknown> | undefined;
+          const ctx = (meta?.currentContext as string) || "-";
+          console.log(`  • ${entry.name}  (${entry.type}, context: ${ctx})`);
+        }
+        console.log("");
+      }
+
+      console.log("  [a] Add kubeconfig");
+      if (entries.length > 0) console.log("  [r] Remove credential");
+      console.log("  [q] Quit\n");
+
+      const choice = (await ask("  > ")).trim().toLowerCase();
+
+      if (choice === "q" || choice === "") break;
+
+      if (choice === "a") {
+        const defaultPath = path.join(homedir(), ".kube", "config");
+        const raw = (await ask(`  Kubeconfig path [${defaultPath}]: `)).trim();
+        const filePath = raw || defaultPath;
+
+        // Expand ~ and resolve
+        const resolved = filePath.startsWith("~/")
+          ? path.join(homedir(), filePath.slice(2))
+          : path.resolve(filePath);
+
+        // Let user pick a friendly name (avoids leaking cluster IDs to the model)
+        const customName = (await ask("  Display name (enter to auto-detect): ")).trim() || undefined;
+
+        try {
+          const result = await registerKubeconfig({ sourcePath: resolved, credentialsDir, name: customName });
+          const status = result.reachable
+            ? `(${result.serverVersion})`
+            : `(unreachable: ${result.probeError})`;
+          console.log(`  ✓ Added "${result.name}" ${status}`);
+        } catch (err) {
+          console.error(`  ✗ ${err instanceof Error ? err.message : String(err)}`);
+        }
+      } else if (choice === "r" && entries.length > 0) {
+        console.log("");
+        for (let i = 0; i < entries.length; i++) {
+          console.log(`  [${i + 1}] ${entries[i].name}  (${entries[i].type})`);
+        }
+        console.log("");
+        const idx = parseInt((await ask("  Number to remove (or 0 to cancel): ")).trim(), 10);
+        if (idx >= 1 && idx <= entries.length) {
+          const entry = entries[idx - 1];
+          // Remove credential files (with path traversal check)
+          for (const f of entry.files) {
+            const filePath = path.resolve(path.join(credentialsDir, f));
+            if (!filePath.startsWith(path.resolve(credentialsDir) + path.sep)) continue;
+            try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+          }
+          // Update manifest
+          const updated = entries.filter((_, i) => i !== idx - 1);
+          saveManifest(credentialsDir, updated);
+          console.log(`  ✓ Removed "${entry.name}"`);
+        }
+      }
+    }
+  } finally {
+    rl.close();
+  }
+}

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -26,6 +26,7 @@ const brainType: BrainType | undefined = brainArg === "claude-sdk" ? "claude-sdk
 if (forceSetup) {
   await runInteractiveSetup();
 }
+
 if (needsSetup()) {
   printSetupInstructions();
   process.exit(1);
@@ -44,9 +45,12 @@ const sessionManager = continueSession
   ? SessionManager.continueRecent(process.cwd())
   : SessionManager.create(process.cwd());
 
+// Resolve credentials directory for TUI mode
+const credentialsDir = path.resolve(process.cwd(), loadConfig().paths.credentialsDir);
+
 // Create session via shared factory
 const { brain, session, modelFallbackMessage, customTools, skillsDirs, memoryIndexer, mcpManager } =
-  await createSiclawSession({ sessionManager, mode: "cli", brainType });
+  await createSiclawSession({ sessionManager, mode: "cli", brainType, kubeconfigRef: { credentialsDir } });
 
 // P1-1: Startup status summary
 {
@@ -64,14 +68,24 @@ const { brain, session, modelFallbackMessage, customTools, skillsDirs, memoryInd
     } catch { /* skip */ }
   }
   const memoryActive = fs.existsSync(path.resolve(process.cwd(), loadConfig().paths.userDataDir, "memory"));
+
+  // Count registered kubeconfig credentials
+  let kubeCreds = 0;
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+  try { kubeCreds = JSON.parse(fs.readFileSync(manifestPath, "utf-8")).filter((e: any) => e.type === "kubeconfig").length; } catch {}
+
   const parts = [
     `Siclaw v${pkg.version}`,
     `Model: ${modelName} (${providerName})`,
     `Skills: ${skillCount}`,
     memoryActive ? "Memory: active" : "Memory: off",
+    kubeCreds > 0 ? `kubectl: ${kubeCreds} credential(s)` : "kubectl: no credentials",
   ];
   if (brainType) parts.push(`Brain: ${brainType}`);
   console.log(parts.join(" | "));
+  if (kubeCreds === 0) {
+    console.log("  Tip: siclaw --credentials  to manage cluster access");
+  }
 }
 
 // Debug: subscribe to all session events and write to log file

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -518,7 +518,7 @@ export async function createSiclawSession(
 
   const loader = new DefaultResourceLoader({
     cwd,
-    systemPromptOverride: () => buildSreSystemPrompt(memoryDir),
+    systemPromptOverride: () => buildSreSystemPrompt(memoryDir, mode),
     appendSystemPromptOverride: () => {
       const parts = buildAppendSystemPrompt(skillsBase, getUserSkillDirName, getPlatformSkillDirName, memoryDir);
       if (workspaceSystemPromptAppend) {
@@ -557,7 +557,7 @@ export async function createSiclawSession(
       createEndInvestigationTool(dpState),
     );
 
-    const systemPrompt = buildSreSystemPrompt(memoryDir);
+    const systemPrompt = buildSreSystemPrompt(memoryDir, mode);
 
     // Build the same append content that pi-agent gets via appendSystemPromptOverride
     const appendParts = buildAppendSystemPrompt(skillsBase, getUserSkillDirName, getPlatformSkillDirName, memoryDir);

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -1,4 +1,4 @@
-export function buildSreSystemPrompt(memoryDir?: string): string {
+export function buildSreSystemPrompt(memoryDir?: string, mode?: "cli" | "web" | "channel"): string {
   let prompt = `You are Siclaw, a personal SRE AI assistant. You help your user manage and troubleshoot their infrastructure — Kubernetes clusters, cloud resources, and DevOps workflows. You are competent, direct, and warm. You remember context from previous sessions and grow more helpful over time.
 
 ## Core Behavior
@@ -55,11 +55,16 @@ The main file \`MEMORY.md\` is automatically loaded into every new session conte
 ## Credentials
 
 - **Before your first kubectl command**, call \`credential_list\` to discover available kubeconfigs.
-- If \`credential_list\` returns **no credentials**, inform the user that no kubeconfig is configured.
+- If \`credential_list\` returns **no credentials**:${mode === "cli" ? `
+  - Tell the user to run \`siclaw --credentials\` in another terminal to add a kubeconfig (or \`siclaw --add-kube ~/.kube/config\` for quick add).
+  - You do NOT have credential management tools — credential management is a user action, not a model action.
+  - Once the user confirms they've added credentials, kubectl commands work immediately — no restart needed.` : `
+  - Inform the user that no kubeconfig is configured and they need to add one via the web UI.`}
 - If \`credential_list\` returns **exactly one** kubeconfig, kubectl is pre-configured — just run kubectl commands directly. No --kubeconfig needed.
 - If \`credential_list\` returns **multiple** kubeconfigs, present the list (names only) and ask the user which one to use. Then pass \`--kubeconfig=<name>\` (the credential **name**, NOT a file path).
 - **NEVER output credential details** in your responses — including file paths, server URLs, API keys, tokens, cluster internal IDs, or kubeconfig contents. When discussing credentials, only mention the name and type.
-- **NEVER read credential files** (.kubeconfig, .key, .token, settings.json, etc.) using read or cat commands.`;
+- **NEVER read credential files** (.kubeconfig, .key, .token, settings.json, etc.) using read or cat commands.
+- **If a user pastes credential content** (kubeconfig YAML, certificates, keys) in chat, tell them this is not the right place — direct them to \`siclaw --credentials\` instead. Do NOT write, store, or process pasted credential content.`;
 
   prompt += `\n\n## Language\n\nAlways respond in the same language the user writes in. Match the user's language naturally. Technical terms (kubectl, pod names, error messages, CLI output) can remain in English.`;
 

--- a/src/tools/credential-list.ts
+++ b/src/tools/credential-list.ts
@@ -1,4 +1,3 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { Type } from "@sinclair/typebox";
@@ -7,6 +6,7 @@ import { Text } from "@mariozechner/pi-tui";
 import { renderTextResult } from "./tool-render.js";
 import type { KubeconfigRef } from "../core/agent-factory.js";
 import { loadConfig } from "../core/config.js";
+import { probeKubeconfig } from "./credential-manager.js";
 
 interface CredentialListParams {
   type?: string;
@@ -22,33 +22,6 @@ interface CredentialEntry {
   reachable?: boolean;
   server_version?: string;
   probe_error?: string;
-}
-
-/** Probe a kubeconfig with `kubectl version` (3s timeout, parallel-safe). */
-function probeKubeconfig(kubeconfigPath: string): Promise<{ reachable: boolean; version?: string; error?: string }> {
-  return new Promise((resolve) => {
-    execFile(
-      "kubectl",
-      ["version", "--output=json", `--kubeconfig=${kubeconfigPath}`, "--request-timeout=3s"],
-      { timeout: 5000 },
-      (err, stdout) => {
-        if (err) {
-          const msg = err.message?.includes("timed out")
-            ? "connection timeout"
-            : err.message?.split("\n")[0] ?? "unknown error";
-          resolve({ reachable: false, error: msg });
-          return;
-        }
-        try {
-          const info = JSON.parse(stdout);
-          const ver = info.serverVersion?.gitVersion ?? "unknown";
-          resolve({ reachable: true, version: ver });
-        } catch {
-          resolve({ reachable: true, version: "unknown" });
-        }
-      },
-    );
-  });
 }
 
 /**

--- a/src/tools/credential-manager.ts
+++ b/src/tools/credential-manager.ts
@@ -1,0 +1,165 @@
+/**
+ * Shared credential management utilities.
+ *
+ * - probeKubeconfig(): test connectivity to a cluster via kubectl
+ * - registerKubeconfig(): validate, copy, and register a kubeconfig file
+ *
+ * Used by cli-credentials (TUI) and credential_list tools.
+ */
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+
+// ---------------------------------------------------------------------------
+// Probe
+// ---------------------------------------------------------------------------
+
+/** Probe a kubeconfig with `kubectl version` (3s timeout, parallel-safe). */
+export function probeKubeconfig(kubeconfigPath: string): Promise<{ reachable: boolean; version?: string; error?: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      "kubectl",
+      ["version", "--output=json", `--kubeconfig=${kubeconfigPath}`, "--request-timeout=3s"],
+      { timeout: 5000 },
+      (err, stdout) => {
+        if (err) {
+          const msg = err.message?.includes("timed out")
+            ? "connection timeout"
+            : err.message?.split("\n")[0] ?? "unknown error";
+          resolve({ reachable: false, error: msg });
+          return;
+        }
+        try {
+          const info = JSON.parse(stdout);
+          const ver = info.serverVersion?.gitVersion ?? "unknown";
+          resolve({ reachable: true, version: ver });
+        } catch {
+          resolve({ reachable: true, version: "unknown" });
+        }
+      },
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Register
+// ---------------------------------------------------------------------------
+
+export interface RegisterKubeconfigResult {
+  name: string;
+  reachable: boolean;
+  serverVersion?: string;
+  probeError?: string;
+}
+
+interface ManifestEntry {
+  name: string;
+  type: string;
+  description?: string | null;
+  files: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export async function registerKubeconfig(opts: {
+  sourcePath: string;
+  credentialsDir: string;
+  name?: string;
+}): Promise<RegisterKubeconfigResult> {
+  const { sourcePath, credentialsDir } = opts;
+
+  // 1. Validate source file exists and is reasonable
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`File not found: ${sourcePath}`);
+  }
+  const stat = fs.statSync(sourcePath);
+  if (!stat.isFile()) {
+    throw new Error(`Not a regular file: ${sourcePath}`);
+  }
+  if (stat.size > 1024 * 1024) {
+    throw new Error(`File too large (${Math.round(stat.size / 1024)}KB > 1MB limit)`);
+  }
+
+  // 2. Read and validate
+  const content = fs.readFileSync(sourcePath, "utf-8");
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = yaml.load(content) as Record<string, unknown>;
+  } catch (e) {
+    throw new Error(`Invalid YAML: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Invalid kubeconfig: not a YAML mapping");
+  }
+  if (!parsed.clusters || !parsed.contexts) {
+    throw new Error("Invalid kubeconfig: missing 'clusters' or 'contexts' field");
+  }
+
+  // 3. Derive name
+  const rawName = opts.name || (parsed["current-context"] as string) || path.basename(sourcePath, path.extname(sourcePath));
+  const safeName = rawName.replace(/[^a-zA-Z0-9_-]/g, "_");
+  if (!safeName) {
+    throw new Error("Could not derive a valid credential name");
+  }
+
+  // 4. Copy to credentials directory
+  fs.mkdirSync(credentialsDir, { recursive: true });
+  const destFile = `${safeName}.kubeconfig`;
+  const destPath = path.join(credentialsDir, destFile);
+
+  // Path traversal check
+  const resolvedDest = path.resolve(destPath);
+  const resolvedDir = path.resolve(credentialsDir);
+  if (!resolvedDest.startsWith(resolvedDir + path.sep) && resolvedDest !== resolvedDir) {
+    throw new Error("Invalid credential name (path traversal detected)");
+  }
+
+  fs.writeFileSync(destPath, content, { mode: 0o600 });
+
+  // 5. Extract metadata (same format as Gateway rpc-methods.ts)
+  const clusters = (parsed.clusters as Array<{ name: string; cluster?: { server?: string } }>) ?? [];
+  const contexts = (parsed.contexts as Array<{ name: string; context?: { cluster?: string; namespace?: string } }>) ?? [];
+  const metadata: Record<string, unknown> = {
+    clusters: clusters.map((c) => ({
+      name: c.name,
+      server: c.cluster?.server,
+    })),
+    contexts: contexts.map((c) => ({
+      name: c.name,
+      cluster: c.context?.cluster,
+      namespace: c.context?.namespace,
+    })),
+    currentContext: parsed["current-context"] as string | undefined,
+  };
+
+  // 6. Update manifest.json (upsert by name)
+  const manifestPath = path.join(credentialsDir, "manifest.json");
+  let manifest: ManifestEntry[] = [];
+  try {
+    if (fs.existsSync(manifestPath)) {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    }
+  } catch { /* start fresh */ }
+
+  const newEntry: ManifestEntry = {
+    name: safeName,
+    type: "kubeconfig",
+    files: [destFile],
+    metadata,
+  };
+
+  // Remove existing entry with same name (upsert)
+  manifest = manifest.filter((e) => e.name !== safeName);
+  manifest.push(newEntry);
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+
+  // 7. Probe connectivity
+  const probe = await probeKubeconfig(destPath);
+
+  return {
+    name: safeName,
+    reachable: probe.reachable,
+    ...(probe.version ? { serverVersion: probe.version } : {}),
+    ...(probe.error ? { probeError: probe.error } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

Fixes multiple TUI first-run issues and adds credential management for TUI mode:

- **Embedding crash on first run**: `baseUrl` undefined when no embedding config → skip embedding gracefully
- **SQLite UNIQUE constraint on chunks**: race condition on repeated indexing → use `INSERT OR REPLACE`
- **TUI onboarding UX**: redesign setup flow to match Claude Code patterns (non-interactive by default, `--setup` for wizard)
- **TUI kubeconfig management**: `kubeconfigRef.credentialsDir` was undefined in TUI mode → all kubectl commands failed (`KUBECONFIG=/dev/null`). Added `siclaw --credentials` interactive manager and `siclaw --add-kube` CLI shortcut, following the same user-managed credential model as the web UI.

## Key design decisions

- **Credential management is a user action, not a model action** — the model has no tool to add/modify credentials. It can only read metadata via `credential_list`. This mirrors the web UI pattern.
- **Lightweight entry point**: `--credentials` and `--add-kube` are routed in `siclaw.mjs` before heavy imports to avoid MCP/config side effects.
- **Mode-aware system prompt**: CLI mode tells the model to direct users to `siclaw --credentials`; web mode directs to the web UI.

## Changed files

| File | Change |
|------|--------|
| `src/tools/credential-manager.ts` | **New** — shared `registerKubeconfig()` + `probeKubeconfig()` |
| `src/cli-credentials.ts` | **New** — interactive credential manager (add/remove kubeconfig) |
| `siclaw.mjs` | Route `--credentials` / `--add-kube` to lightweight path |
| `src/cli-main.ts` | Pass `kubeconfigRef` to session, startup status line with kubectl info |
| `src/core/prompt.ts` | Accept `mode` param, mode-aware credential guidance |
| `src/core/agent-factory.ts` | Pass `mode` to prompt builder |
| `src/tools/credential-list.ts` | Import `probeKubeconfig` from shared module |
| `src/cli-setup.ts` | Redesign setup: env-var detection, `--setup` wizard, non-interactive default |
| `src/core/config.ts` | Env-var based provider config (`SICLAW_PROVIDER`, `SICLAW_API_KEY`, etc.) |
| `src/memory/embeddings.ts` | Guard against undefined `baseUrl` |
| `src/memory/indexer.ts` | `INSERT OR REPLACE` for chunks |

## Security

- Model cannot write to credentials directory (no `credential_add` tool)
- `credential_list` strips file paths, server URLs, metadata — returns only name/type/reachability
- Path traversal protection on both register and remove operations
- Kubeconfig files written with `0o600` permissions
- YAML structure validation + 1MB size limit
- `execFile` (not `exec`) for kubectl probe — no shell injection
- Prompt instructs model to reject pasted credential content

## Test plan

- [x] `npm test` — 728/728 passing
- [x] `npx tsc --noEmit` — clean
- [x] `siclaw --credentials` — interactive add/remove works
- [x] `siclaw --add-kube ~/.kube/config` — quick add works
- [x] TUI startup shows `kubectl: N credential(s)` status
- [x] `credential_list` returns registered credentials in conversation
- [x] kubectl commands work after adding credentials
- [x] No credentials → model guides user to `siclaw --credentials`