### PR TITLE
fix: replace obsolete mcp-servers.json fallback with settings.json

### DIFF
--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -924,22 +924,20 @@ export function createRpcMethods(
       };
     }
 
-    // Fallback: read local file (CLI / no-DB mode)
-    const mcpConfigPath = path.resolve(process.cwd(), "config", "mcp-servers.json");
+    // Fallback: read from settings.json mcpServers (CLI / no-DB mode)
     try {
-      const raw = fs.readFileSync(mcpConfigPath, "utf-8");
-      const config = JSON.parse(raw) as {
-        mcpServers: Record<string, { url?: string; command?: string; transport?: string }>;
-      };
+      const { loadConfig } = await import("../core/config.js");
+      const config = loadConfig();
       const servers: Array<Record<string, unknown>> = [];
       for (const [name, serverConfig] of Object.entries(config.mcpServers ?? {})) {
+        const cfg = serverConfig as { url?: string; command?: string; transport?: string };
         servers.push({
           id: name,
           name,
-          url: serverConfig.url,
-          transport: serverConfig.transport ?? (serverConfig.url ? "streamable-http" : "stdio"),
+          url: cfg.url,
+          transport: cfg.transport ?? (cfg.url ? "streamable-http" : "stdio"),
           enabled: true,
-          source: "file",
+          source: "settings",
         });
       }
       return { servers };


### PR DESCRIPTION
## Summary

### Problem

The `mcp.list` RPC method's fallback path still reads from `config/mcp-servers.json`, a file that was already removed from both Dockerfiles and is no longer part of the MCP config strategy. In CLI/no-DB mode, `mcp.list` silently returns an empty list instead of reading the user's configured MCP servers.

### Solution

Replace the file-based fallback with `loadConfig().mcpServers` from `settings.json`, aligning with the unified MCP config source strategy:
- **Gateway mode**: DB (primary) via admin API
- **AgentBox mode**: `SICLAW_MCP_DIR/mcp-servers.json` (synced from Gateway)
- **CLI mode**: `.siclaw/config/settings.json` mcpServers field

This is the remaining piece from the MCP config unification in PR #33, whose command-sets refactoring part was already merged via PR #32.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [ ] Manual verification: `mcp.list` returns servers configured in settings.json when no DB is available

## Architecture Checklist

- [x] **Deployment mode**: No filesystem writes, no resource sync changes
- [x] **Security model**: No new shell execution paths