### PR TITLE
chore(ui): hide Brains menu until claude-sdk is ready

### DIFF
--- a/src/gateway/web/src/App.tsx
+++ b/src/gateway/web/src/App.tsx
@@ -15,7 +15,7 @@ import { SettingsLayout } from './pages/Settings/SettingsLayout';
 import { SystemSettings } from './pages/Settings/SystemSettings';
 import { PermissionsPage } from './pages/Permissions';
 import { ModelsPage } from './pages/Models';
-import { BrainsPage } from './pages/Brains';
+// import { BrainsPage } from './pages/Brains';  // hidden until claude-sdk brain is polished
 import { CredentialsPage } from './pages/Credentials';
 import { WorkspacesPage } from './pages/Workspaces';
 import { McpServersPage } from './pages/McpServers';
@@ -69,7 +69,7 @@ const router = createBrowserRouter([
                     { path: 'sessions', element: <ComingSoonPage title="Sessions" /> },
                     { path: 'workspace', element: <WorkspacesPage /> },
                     { path: 'mcp', element: <McpServersPage /> },
-                    { path: 'brains', element: <BrainsPage /> },
+                    // { path: 'brains', element: <BrainsPage /> },  // hidden until claude-sdk brain is polished
                     { path: 'models', element: <ModelsPage /> },
                 ],
             },

--- a/src/gateway/web/src/components/ui/Sidebar.tsx
+++ b/src/gateway/web/src/components/ui/Sidebar.tsx
@@ -14,7 +14,7 @@ import {
     Plug,
     Cpu,
     Compass,
-    BrainCircuit,
+    // BrainCircuit,  // hidden until claude-sdk brain is polished
     KeyRound,
     Wrench,
 } from 'lucide-react';
@@ -63,7 +63,7 @@ const groups: NavGroup[] = [
         key: 'settings',
         items: [
             { icon: Share2, label: 'Channels', to: '/channels', adminOnly: true },
-            { icon: BrainCircuit, label: 'Brains', to: '/brains' },
+            // { icon: BrainCircuit, label: 'Brains', to: '/brains' },  // hidden until claude-sdk brain is polished
             { icon: Cpu, label: 'Models', to: '/models', adminOnly: true },
             { icon: KeyRound, label: 'Credentials', to: '/credentials' },
             { icon: Shield, label: 'Permissions', to: '/permissions', adminOnly: true },


### PR DESCRIPTION
## Summary
- Comment out the **Brains** sidebar menu item, its route, and the `BrainsPage` import
- The Brains page and component code remain intact — just hidden from the UI
- Uncomment when claude agent SDK integration is polished and ready for release

## Test plan
- [ ] Verify the sidebar no longer shows a "Brains" entry
- [ ] Verify navigating to `/brains` shows a 404 / blank instead of the Brains page
- [ ] Verify no TypeScript build errors introduced (unused import cleaned up)