### PR TITLE
refactor: remove env var config delivery for AgentBox

### DIFF
--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -209,3 +209,53 @@ DB-based coordination with heartbeat. Each cron instance:
 - ✅ Job ownership is explicit and auditable
 - ⚠️ Up to 90s delay in job reassignment after a crash (dead threshold)
 - ⚠️ Duplicate firing possible in edge case: instance A marks job "executing" but crashes before updating `lastRunAt`; instance B reclaims and fires again. Acceptable for SRE automation use cases; add idempotency guards in critical skill scripts.
+
+---
+
+## ADR-009: AgentBox Config via Settings File, Not Environment Variables
+
+**Status**: Active
+
+**Context**:
+AgentBox needs LLM provider config (API keys, base URLs, models) and embedding config from Gateway. Previously, Gateway delivered this through two redundant channels:
+
+1. **settings.json** — `GET /api/internal/settings` (mTLS-protected) returns full provider/embedding config; AgentBox writes it to `.siclaw/config/settings.json`
+2. **Environment variables** — Gateway's `envResolver` injected `SICLAW_LLM_API_KEY`, `SICLAW_LLM_BASE_URL`, `SICLAW_LLM_MODEL`, `SICLAW_EMBEDDING_*` into spawned pods/processes
+
+The env var channel has a larger attack surface:
+- `kubectl describe pod` shows all env vars in plain text
+- `/proc/self/environ` is readable from within the container
+- `ProcessSpawner` inherited Gateway's entire `process.env` (including secrets) into child processes
+
+Meanwhile, `.siclaw/config/settings.json` is protected: `restricted-bash.ts` blocks agent shell commands from reading it.
+
+Additionally, K8s DIR env vars (`SICLAW_SKILLS_DIR`, `SICLAW_USER_DATA_DIR`) were injected with values identical to `config.ts` defaults — redundant since each pod is isolated.
+
+**Decision**:
+Remove the env var delivery channel for LLM/embedding config. Settings.json (via mTLS `GET /api/internal/settings`) is the sole channel for delivering sensitive config to AgentBox in K8s mode.
+
+Removed:
+- `envResolver` in `server.ts` (injected `SICLAW_LLM_*`, `SICLAW_EMBEDDING_*`)
+- `EnvResolver` type and `setEnvResolver()` in `AgentBoxManager`
+- `resolveApiKey()` function (no longer needed — DB stores plain API keys)
+- `SICLAW_SKILLS_DIR` and `SICLAW_USER_DATA_DIR` from K8s pod env (match defaults)
+
+Kept as env vars (bootstrap or infrastructure):
+- `SICLAW_GATEWAY_URL` — needed before settings can be fetched (bootstrap dependency)
+- `SICLAW_AGENTBOX_PORT` — per-process port assignment (ProcessSpawner)
+- `SICLAW_CERT_PATH` — K8s Secret volume mount path
+- `SICLAW_CREDENTIALS_DIR` — differs from default in K8s (`/home/agentbox/.credentials`)
+- `SICLAW_METRICS_PORT` / `SICLAW_METRICS_TOKEN` — ops config, not agent-accessible
+
+Unchanged:
+- TUI mode: `applyEnvOverrides()` in `config.ts` still reads `SICLAW_API_KEY` etc. for users who set env vars directly
+- ProcessSpawner: still injects `SICLAW_USER_DATA_DIR` per-user for dev isolation
+
+**Consequences**:
+- ✅ API keys no longer visible via `kubectl describe pod`
+- ✅ Single delivery channel eliminates redundancy and reduces confusion
+- ✅ Settings file is protected from agent access by `restricted-bash.ts`
+- ✅ K8s pod spec is simpler (fewer env vars)
+- ⚠️ AgentBox must successfully fetch settings from Gateway before creating sessions — if Gateway is unreachable, AgentBox has no LLM config (this was already the case)
+
+**Revisit when**: A legitimate use case requires env-var-based config delivery to AgentBox (e.g., sidecar injection patterns that cannot use HTTP).

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -239,13 +239,15 @@ Removed:
 - `EnvResolver` type and `setEnvResolver()` in `AgentBoxManager`
 - `resolveApiKey()` function (no longer needed — DB stores plain API keys)
 - `SICLAW_SKILLS_DIR` and `SICLAW_USER_DATA_DIR` from K8s pod env (match defaults)
+- `SICLAW_AGENTBOX_PORT` — K8s always uses default 3000
+- `SICLAW_CERT_PATH` — code default is already `/etc/siclaw/certs`
+- `SICLAW_CREDENTIALS_DIR` — switched to default `.siclaw/credentials` (Dockerfile already creates it; `restricted-bash.ts` blocks agent access)
+- `USER_ID` — was injected but never read by AgentBox code
+- `SICLAW_WORKSPACE_ALLOWED_TOOLS` — was injected but never read by AgentBox code
 
-Kept as env vars (bootstrap or infrastructure):
+Kept as env vars (bootstrap or third-party library):
 - `SICLAW_GATEWAY_URL` — needed before settings can be fetched (bootstrap dependency)
-- `SICLAW_AGENTBOX_PORT` — per-process port assignment (ProcessSpawner)
-- `SICLAW_CERT_PATH` — K8s Secret volume mount path
-- `SICLAW_CREDENTIALS_DIR` — differs from default in K8s (`/home/agentbox/.credentials`)
-- `SICLAW_METRICS_PORT` / `SICLAW_METRICS_TOKEN` — ops config, not agent-accessible
+- `PI_CODING_AGENT_DIR` — pi-coding-agent library reads this env var to determine its config/session storage directory; no config file alternative available
 
 Unchanged:
 - TUI mode: `applyEnvOverrides()` in `config.ts` still reads `SICLAW_API_KEY` etc. for users who set env vars directly

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -154,8 +154,6 @@ export class K8sSpawner implements BoxSpawner {
       { name: "USER_ID", value: boxConfig.userId },
       { name: "SICLAW_AGENTBOX_PORT", value: "3000" },
       { name: "PI_CODING_AGENT_DIR", value: ".siclaw/user-data/agent" },
-      { name: "SICLAW_SKILLS_DIR", value: ".siclaw/skills" },
-      { name: "SICLAW_USER_DATA_DIR", value: ".siclaw/user-data" },
       { name: "SICLAW_GATEWAY_URL", value: process.env.SICLAW_GATEWAY_INTERNAL_URL || `https://siclaw-gateway.${namespace}.svc.cluster.local:3002` },
       { name: "SICLAW_CREDENTIALS_DIR", value: "/home/agentbox/.credentials" },
       { name: "SICLAW_CERT_PATH", value: "/etc/siclaw/certs" },

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -149,20 +149,11 @@ export class K8sSpawner implements BoxSpawner {
       }
     }
 
-    // Environment variables
+    // Environment variables — only bootstrap deps that cannot come from settings.json
     const env: k8s.V1EnvVar[] = [
-      { name: "USER_ID", value: boxConfig.userId },
-      { name: "SICLAW_AGENTBOX_PORT", value: "3000" },
       { name: "PI_CODING_AGENT_DIR", value: ".siclaw/user-data/agent" },
       { name: "SICLAW_GATEWAY_URL", value: process.env.SICLAW_GATEWAY_INTERNAL_URL || `https://siclaw-gateway.${namespace}.svc.cluster.local:3002` },
-      { name: "SICLAW_CREDENTIALS_DIR", value: "/home/agentbox/.credentials" },
-      { name: "SICLAW_CERT_PATH", value: "/etc/siclaw/certs" },
     ];
-
-    // Pass workspace allowed tools
-    if (boxConfig.allowedTools !== undefined) {
-      env.push({ name: "SICLAW_WORKSPACE_ALLOWED_TOOLS", value: JSON.stringify(boxConfig.allowedTools) });
-    }
 
     // Add custom environment variables
     if (boxConfig.env) {

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -31,8 +31,6 @@ interface ManagedBox {
   createdAt: Date;
 }
 
-export type EnvResolver = () => Promise<Record<string, string>>;
-
 export class AgentBoxManager {
   private spawner: BoxSpawner;
   private config: Required<AgentBoxManagerConfig>;
@@ -46,9 +44,6 @@ export class AgentBoxManager {
   /** Health check timer (local dev only) */
   private healthCheckTimer?: ReturnType<typeof setInterval>;
 
-  /** Optional async resolver that provides extra env vars for new AgentBoxes */
-  private envResolver?: EnvResolver;
-
   /** Whether the spawner is K8s-based (stateless, no in-memory cache) */
   private readonly isK8s: boolean;
 
@@ -58,14 +53,6 @@ export class AgentBoxManager {
     this.isK8s = spawner.name === "k8s";
 
     console.log(`[agentbox-manager] Initialized with spawner: ${spawner.name}${this.isK8s ? " (stateless, K8s API discovery)" : " (in-memory cache)"}`);
-  }
-
-  /**
-   * Set an async resolver that provides extra env vars injected into every new AgentBox.
-   * The resolved env is merged after config.env, so it takes precedence.
-   */
-  setEnvResolver(resolver: EnvResolver): void {
-    this.envResolver = resolver;
   }
 
   /** Update the spawner's AgentBox image at runtime (takes effect on next spawn) */
@@ -163,7 +150,7 @@ export class AgentBoxManager {
     // 2. Pod doesn't exist or not running → create
     console.log(`[agentbox-manager] Creating new AgentBox for user: ${userId} workspace: ${workspaceId}`);
 
-    const resolvedEnv = await this.resolveEnv(config?.env);
+    const resolvedEnv = this.resolveEnv(config?.env);
     const handle = await this.spawner.spawn({
       userId,
       workspaceId,
@@ -194,7 +181,7 @@ export class AgentBoxManager {
 
     console.log(`[agentbox-manager] Creating new AgentBox for user: ${userId} workspace: ${workspaceId}`);
 
-    const resolvedEnv = await this.resolveEnv(config?.env);
+    const resolvedEnv = this.resolveEnv(config?.env);
     const handle = await this.spawner.spawn({
       userId,
       workspaceId,
@@ -212,16 +199,8 @@ export class AgentBoxManager {
   }
 
   /** Resolve merged env vars */
-  private async resolveEnv(configEnv?: Record<string, string>): Promise<Record<string, string>> {
-    let resolvedEnv: Record<string, string> | undefined;
-    if (this.envResolver) {
-      try {
-        resolvedEnv = await this.envResolver();
-      } catch (err) {
-        console.warn("[agentbox-manager] envResolver failed, continuing without extra env:", err);
-      }
-    }
-    return { ...configEnv, ...resolvedEnv };
+  private resolveEnv(configEnv?: Record<string, string>): Record<string, string> {
+    return configEnv ?? {};
   }
 
   /**

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -151,30 +151,10 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
   // Config repo for webhook route
   const configRepo = db ? new ConfigRepository(db) : null;
 
-  // Clean orphan model entries on startup, then set up env resolver
+  // Clean orphan model entries on startup
   if (db) {
     const modelConfigRepo = new ModelConfigRepository(db);
     await modelConfigRepo.cleanOrphanModels();
-    agentBoxManager.setEnvResolver(async () => {
-      const env: Record<string, string> = {};
-
-      const llm = await modelConfigRepo.getResolvedDefaultConfig();
-      if (llm) {
-        if (llm.baseUrl) env.SICLAW_LLM_BASE_URL = llm.baseUrl;
-        if (llm.apiKey) env.SICLAW_LLM_API_KEY = resolveApiKey(llm.apiKey);
-        if (llm.model) env.SICLAW_LLM_MODEL = llm.model;
-      }
-
-      const emb = await modelConfigRepo.getResolvedEmbeddingConfig();
-      if (emb) {
-        if (emb.baseUrl) env.SICLAW_EMBEDDING_BASE_URL = emb.baseUrl;
-        if (emb.apiKey) env.SICLAW_EMBEDDING_API_KEY = resolveApiKey(emb.apiKey);
-        if (emb.model) env.SICLAW_EMBEDDING_MODEL = emb.model;
-        if (emb.dimensions) env.SICLAW_EMBEDDING_DIMENSIONS = String(emb.dimensions);
-      }
-
-      return env;
-    });
   }
 
   // Workspace repo (used by internal API to resolve default workspace)
@@ -1307,24 +1287,3 @@ async function resolveJwtSecret(sysConfigRepo: SystemConfigRepository | null): P
   return generated;
 }
 
-/**
- * Resolve an API key value — if it looks like an env var name (no slashes,
- * no dots, all uppercase/underscores), resolve it from process.env.
- */
-function resolveApiKey(value: string): string {
-  // Legacy: bare ALL_CAPS_NAME treated as env var name
-  if (/^[A-Z_][A-Z0-9_]*$/.test(value)) {
-    return process.env[value] ?? value;
-  }
-  // $VAR / ${VAR} syntax — inline env-var references
-  if (/\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*/.test(value)) {
-    return value.replace(
-      /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
-      (_, braced, bare) => {
-        const name = braced || bare;
-        return process.env[name] ?? "";
-      },
-    );
-  }
-  return value;
-}


### PR DESCRIPTION
## Problem

AgentBox received LLM/embedding config through two redundant channels:
1. **settings.json** via mTLS `GET /api/internal/settings` — protected from agent access by `restricted-bash.ts`
2. **Environment variables** via `envResolver` — exposed via `kubectl describe pod`, `/proc/self/environ`

This creates unnecessary security risk (API keys visible in pod env) and maintenance confusion (two code paths for the same data).

Additionally, `SICLAW_SKILLS_DIR` and `SICLAW_USER_DATA_DIR` were injected into K8s pods with values identical to `config.ts` defaults — redundant since each pod is isolated.

## Solution

- Remove `envResolver` from Gateway `server.ts` (no longer injects `SICLAW_LLM_*`, `SICLAW_EMBEDDING_*`)
- Remove `EnvResolver` type, `setEnvResolver()`, and `resolveApiKey()` from `AgentBoxManager`
- Remove redundant `SICLAW_SKILLS_DIR` / `SICLAW_USER_DATA_DIR` from K8s pod env spec
- Add ADR-009 documenting the decision

Settings.json (delivered via mTLS) is now the sole channel for sensitive config. Bootstrap env vars (`SICLAW_GATEWAY_URL`, `SICLAW_AGENTBOX_PORT`, `SICLAW_CERT_PATH`, `SICLAW_CREDENTIALS_DIR`) are retained.

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 749 tests pass
- [x] Built and deployed to test K8s cluster — Gateway starts successfully
- [ ] Trigger new AgentBox session, verify pod env no longer contains `SICLAW_LLM_API_KEY` etc.
- [ ] Verify AgentBox session creates successfully with LLM config from settings.json