### PR TITLE
Align public docs with current product behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Siclaw
 
-**AI Agent platform for SRE — the collaborative AI foundation for your team**
+**Read-only investigation copilot for SRE teams**
 
 [![npm](https://img.shields.io/npm/v/siclaw?logo=npm)](https://www.npmjs.com/package/siclaw)
 [![CI](https://github.com/scitix/siclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/scitix/siclaw/actions/workflows/ci.yml)
@@ -19,7 +19,7 @@
 
 ---
 
-Siclaw is an AI Agent platform for DevOps / SRE, inspired by [OpenClaw](https://github.com/openclaw) and designed to be the collaborative AI foundation for engineering teams. Unlike general-purpose coding agents, Siclaw is built for **read-only infrastructure diagnostics** — the agent observes, analyzes, and reports, but never mutates your environment directly. When remediation is needed, Siclaw integrates with your existing change management systems to execute changes through established, auditable workflows. Describe a problem in plain language and the agent runs kubectl, reads logs, traces network paths, and delivers a root-cause analysis — from a terminal, a web UI, or your team's IM workspace.
+Siclaw is an open-source AI agent for DevOps and SRE teams. It is built for **read-only infrastructure diagnostics**: gather evidence, form hypotheses, validate them, and return a clear root-cause analysis without changing your environment directly. Describe a problem in plain language and Siclaw investigates it from the terminal, the web UI, or your team's chat channels.
 
 <div align="center">
 <img src="docs/assets/demo.gif" alt="Siclaw Demo" width="800" />
@@ -28,16 +28,13 @@ Siclaw is an AI Agent platform for DevOps / SRE, inspired by [OpenClaw](https://
 
 ## Features
 
-- **Deep Investigation** — Hypothesis-driven 4-phase diagnostic engine (context gathering → hypothesis generation → parallel validation → root-cause conclusion), bringing Deep Research to SRE with cross-system, multi-dimensional fault analysis
-- **Investigation Memory** — Accumulates structured knowledge from every deep investigation into a local hybrid store (vector + full-text); surfaces relevant past experience during hypothesis generation so the agent gets smarter with every incident resolved
-- **Security Governance** — Strict permission layer between agent and infrastructure: read-only by default, command whitelist, write operations require per-item approval, credentials isolated by workspace — zero accidental mutations in production
-- **Team Collaboration** — Multi-workspace, multi-user management (SSO/OAuth2), isolated AgentBox sandboxes per user, designed for multi-team, multi-environment enterprise scenarios
-- **Alert-Driven Operations** — Webhook triggers connect to your existing monitoring stack (Prometheus, PagerDuty, custom), automatically launching agent investigations when alerts fire
-- **Scheduled Tasks** — Cron-based recurring jobs for routine health checks, periodic diagnostics, or any agent task — manageable via Web UI or natural language
-- **Skill System** — AI-generated diagnostic skills with automated risk-level review, supporting creation, forking, and hot-reload via Web UI or natural language — organize across core / team / personal tiers to codify your team's operational expertise into reusable, shareable runbooks
-- **Extensible** — [MCP](https://modelcontextprotocol.io) tool servers for custom data source integrations
-- **Built-in Metrics** — Zero-dependency monitoring dashboard for token usage, cost, latency, and sessions — no Prometheus required; optional Grafana iframe embedding for teams with existing observability stacks
-- **Multi-Channel Access** — Terminal TUI, Web UI, or IM bots (Slack, Discord, Telegram, Lark)
+- **Deep Investigation** — A 4-phase workflow for evidence gathering, hypothesis testing, and root-cause analysis
+- **Investigation Memory** — Learns from past incidents to improve future investigations
+- **Read-Only by Default** — Investigates and recommends next steps without changing your environment directly
+- **Team Workflows** — Shared web UI, credentials, channels, triggers, and scheduled patrols
+- **Reusable Skills** — Turn repeated diagnostic playbooks into reviewable runbooks
+- **Extensible** — Connect external tools and data sources through [MCP](https://modelcontextprotocol.io)
+- **Multi-Channel Access** — Use Siclaw from the terminal, web UI, or chat channels
 
 ## Architecture
 
@@ -52,11 +49,16 @@ Siclaw is an AI Agent platform for DevOps / SRE, inspired by [OpenClaw](https://
 
 - **Node.js >= 22.12.0** — [Download](https://nodejs.org/)
 - **npm** — Comes with Node.js
-- **kubectl** + **kubeconfig** — Required for Kubernetes diagnostics only ([Install guide](https://kubernetes.io/docs/tasks/tools/)); not needed for TUI or Local Server mode without K8s access
+- **kubectl** — Optional, only needed if you want Siclaw to investigate Kubernetes clusters
 
 ## Quick Start
 
-Siclaw supports three deployment profiles. Pick the one that fits your use case.
+Siclaw supports three deployment profiles. For local usage, start from a dedicated working directory because Siclaw stores most runtime data in `.siclaw/` relative to where you launch it.
+
+```bash
+mkdir -p ~/siclaw-work
+cd ~/siclaw-work
+```
 
 ### 1. TUI Mode — Personal, local, lowest barrier
 
@@ -81,7 +83,7 @@ siclaw --continue
 
 ```bash
 git clone https://github.com/scitix/siclaw.git && cd siclaw
-npm ci && npm run build
+npm ci && npm run build:web && npm run build
 npm link                 # register `siclaw` command globally
 
 siclaw                   # TUI mode
@@ -96,17 +98,18 @@ siclaw --prompt "..."    # single-shot mode
 
 ### 2. Local Server — VM or laptop, recommended for daily use
 
-A lightweight web UI backed by SQLite. No MySQL, no Docker required — just start the server and configure everything in the browser. Siclaw enforces strict read-only access by default (command whitelist, no write operations without approval), so you can safely deploy it on your own workstation without worrying about unintended changes to your clusters.
+A lightweight web UI backed by SQLite. No MySQL, no Docker required.
 
 ```bash
 npm install -g siclaw
 
-# Start the server (SQLite database is created automatically)
+# Start the server
 siclaw local
 
 # Open http://localhost:3000
 # Login: admin / admin (default credentials)
-# Go to Settings to configure your LLM provider
+# Configure providers in Models
+# Import kubeconfigs in Credentials
 ```
 
 <details>
@@ -114,7 +117,7 @@ siclaw local
 
 ```bash
 git clone https://github.com/scitix/siclaw.git && cd siclaw
-npm ci && npm run build && npm run build:web
+npm ci && npm run build:web && npm run build
 npm link                 # register `siclaw` command globally
 
 siclaw local             # start local server
@@ -124,43 +127,47 @@ siclaw local             # start local server
 
 </details>
 
-The server uses SQLite by default and auto-generates a JWT secret on first run. All configuration — LLM providers, models, credentials — is done through the **Settings** page in the web UI.
+On first startup, Siclaw creates a local admin account:
+
+- Username: `admin`
+- Password: `admin`
+
+Set `SICLAW_ADMIN_PASSWORD` before first launch if you want a different bootstrap password.
 
 ### 3. Kubernetes — Team / enterprise
 
-Full multi-user deployment with isolated AgentBox pods, SSO, and IM channels. Just prepare a MySQL database and deploy with Helm:
+Production deployment uses Helm plus three container images: `gateway`, `agentbox`, and `cron`.
+
+Build and push images if you are using your own registry:
 
 ```bash
-helm install siclaw oci://ghcr.io/scitix/siclaw/helm/siclaw \
-  --namespace siclaw --create-namespace \
-  --set database.url="mysql://user:pass@host:3306/siclaw"
+make docker REGISTRY=registry.example.com/myteam TAG=latest
+make push REGISTRY=registry.example.com/myteam TAG=latest
 ```
 
-<details>
-<summary><b>Using a custom image registry</b></summary>
-
-If you need to build and push images to your own registry:
+Then deploy the chart with a MySQL URL:
 
 ```bash
-# Build and push images
-make docker push REGISTRY=registry.example.com/myteam
-
-# Deploy with custom registry
 helm upgrade --install siclaw ./helm/siclaw \
-  --namespace siclaw --create-namespace \
-  --set image.registry="registry.example.com/myteam" \
+  --namespace siclaw \
+  --create-namespace \
+  --set image.registry=registry.example.com/myteam \
+  --set image.tag=latest \
   --set database.url="mysql://user:pass@host:3306/siclaw"
 ```
 
-</details>
-
-See [`helm/siclaw/`](helm/siclaw/) for values reference, and [`k8s/README.md`](k8s/README.md) for the full deployment guide.
+The default chart exposes the Gateway Service on service port `80` and NodePort `31000`.
 
 ## Configuration
 
-### settings.json (TUI mode)
+### TUI / CLI
 
-Minimal example — copy `settings.example.json` to `.siclaw/config/settings.json`:
+- TUI reads `.siclaw/config/settings.json`
+- The first-run wizard can generate this file for you
+- Kubernetes credentials should be imported through `/setup`
+- Investigation reports are written to `~/.siclaw/reports/`
+
+Minimal example:
 
 ```json
 {
@@ -168,82 +175,28 @@ Minimal example — copy `settings.example.json` to `.siclaw/config/settings.jso
     "default": {
       "baseUrl": "https://api.openai.com/v1",
       "apiKey": "sk-YOUR-KEY",
+      "api": "openai-completions",
       "models": [{ "id": "gpt-4o", "name": "GPT-4o" }]
     }
   }
 }
 ```
 
-<details>
-<summary><b>Full settings.json reference</b></summary>
+### Local Server / Kubernetes
 
-```json
-{
-  "providers": {
-    "provider-name": {
-      "baseUrl": "https://api.example.com/v1",
-      "apiKey": "your-key",
-      "api": "openai-completions",
-      "authHeader": true,
-      "models": [
-        {
-          "id": "model-id",
-          "name": "Display Name",
-          "reasoning": false,
-          "contextWindow": 128000,
-          "maxTokens": 16384,
-          "cost": { "input": 2.5, "output": 10.0, "cacheRead": 0.5, "cacheWrite": 3.0 }
-        }
-      ]
-    }
-  },
-  "default": { "provider": "provider-name", "modelId": "model-id" },
-  "embedding": {
-    "baseUrl": "https://api.example.com/v1",
-    "apiKey": "your-key",
-    "model": "BAAI/bge-m3",
-    "dimensions": 1024
-  },
-  "mcpServers": {
-    "server-name": {
-      "command": "npx",
-      "args": ["-y", "@some/mcp-server"]
-    }
-  },
-  "debugImage": "busybox:latest",
-  "debug": false
-}
-```
+- Configure providers in the **Models** page
+- Import kubeconfigs, API tokens, and SSH credentials in **Credentials**
+- Configure Slack, Lark, Discord, and Telegram in **Channels**
+- Create inbound webhook endpoints in **Triggers**
+- Configure MCP servers in **MCP Servers**
 
-</details>
+## Documentation
 
-<details>
-<summary><b>IM Channels — Slack / Discord / Telegram / Lark</b></summary>
-
-### Slack
-
-Configure a Slack bot in **Settings > Channels**. You'll need:
-- Bot token and signing secret from the [Slack API](https://api.slack.com/apps)
-
-### Discord
-
-Configure a Discord bot in **Settings > Channels**. You'll need:
-- Bot token from the [Discord Developer Portal](https://discord.com/developers/applications)
-- Scopes: `bot`, `messages.read`
-
-### Telegram
-
-Configure a Telegram bot in **Settings > Channels**. You'll need:
-- Bot token from [@BotFather](https://t.me/BotFather)
-
-### Lark
-
-Configure a Lark bot in **Settings > Channels** of the web UI. You'll need:
-- App ID and App Secret from the [Lark Open Platform](https://open.larksuite.com/)
-- Event subscription URL: `https://your-domain/api/channels/feishu/event`
-- Scopes: `im:message`, `im:message.group_at_msg`, `im:resource`
-
-</details>
+- [Getting Started](https://docs.siclaw.ai/start/getting-started)
+- [CLI & Local Server](https://docs.siclaw.ai/install/cli)
+- [Kubernetes Deployment](https://docs.siclaw.ai/install/kubernetes)
+- [LLM Providers](https://docs.siclaw.ai/configuration/providers)
+- [MCP Servers](https://docs.siclaw.ai/configuration/mcp)
 
 ## Tech Stack
 

--- a/docs/configuration/mcp.mdx
+++ b/docs/configuration/mcp.mdx
@@ -35,7 +35,7 @@ Creating and managing MCP servers requires **admin** role. All users can use the
 
 ### Via settings.json (CLI mode)
 
-For TUI / single-user mode, add MCP servers to `~/.siclaw/config/settings.json`:
+For TUI / single-user mode, add MCP servers to `.siclaw/config/settings.json`:
 
 ```json
 {
@@ -52,36 +52,20 @@ For TUI / single-user mode, add MCP servers to `~/.siclaw/config/settings.json`:
 }
 ```
 
-### Environment Variable Substitution
-
-Use `${VAR_NAME}` in env values — Siclaw resolves them from the process environment at spawn time:
-
-```json
-{
-  "mcpServers": {
-    "github": {
-      "transport": "streamable-http",
-      "url": "http://localhost:8000/mcp",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_TOKEN}"
-      }
-    }
-  }
-}
-```
-
 ## Examples
 
 ### Prometheus Metrics
 
 ```json
 {
-  "prometheus": {
-    "transport": "stdio",
-    "command": "npx",
-    "args": ["-y", "@prom-mcp/server"],
-    "env": {
-      "PROMETHEUS_URL": "http://prometheus.monitoring:9090"
+  "mcpServers": {
+    "prometheus": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@prom-mcp/server"],
+      "env": {
+        "PROMETHEUS_URL": "http://prometheus.monitoring:9090"
+      }
     }
   }
 }
@@ -99,10 +83,12 @@ Phase 1: Context Gathering
 
 ```json
 {
-  "filesystem": {
-    "transport": "stdio",
-    "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
+  "mcpServers": {
+    "filesystem": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
+    }
   }
 }
 ```
@@ -111,12 +97,14 @@ Phase 1: Context Gathering
 
 ```json
 {
-  "github": {
-    "transport": "stdio",
-    "command": "npx",
-    "args": ["-y", "@github/mcp-server"],
-    "env": {
-      "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+  "mcpServers": {
+    "github": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@github/mcp-server"],
+      "env": {
+        "GITHUB_TOKEN": "your-token"
+      }
     }
   }
 }
@@ -128,11 +116,13 @@ Any service implementing the MCP protocol can be connected:
 
 ```json
 {
-  "my-service": {
-    "transport": "streamable-http",
-    "url": "https://mcp.internal.example.com/v1",
-    "headers": {
-      "Authorization": "Bearer ${MY_SERVICE_TOKEN}"
+  "mcpServers": {
+    "my-service": {
+      "transport": "streamable-http",
+      "url": "https://mcp.internal.example.com/v1",
+      "headers": {
+        "Authorization": "Bearer your-token"
+      }
     }
   }
 }
@@ -169,7 +159,7 @@ The merge strategy: DB entries (managed via Web UI) override local seed entries 
 ### Kubernetes Considerations
 
 <Warning>
-In Kubernetes mode, MCP server binaries must be available in the AgentBox container image. For `stdio` transport servers that use `npx`, ensure the package can be installed inside the pod (network access required) or pre-install it in the image.
+In Kubernetes mode, `stdio` MCP servers run inside AgentBox pods. Make sure the required binaries or packages are available in that runtime image, or use HTTP-based MCP transports instead.
 </Warning>
 
 For HTTP-based transports (`sse`, `streamable-http`), the MCP server runs externally — the AgentBox pod only needs network access to the URL.

--- a/docs/configuration/providers.mdx
+++ b/docs/configuration/providers.mdx
@@ -4,7 +4,10 @@ sidebarTitle: "LLM Providers"
 description: "Configure Siclaw to use Anthropic, OpenAI, Ollama, or any compatible LLM."
 ---
 
-Siclaw needs an LLM to power its investigation engine. Configure via `~/.siclaw/config/settings.json` or environment variable overrides.
+Siclaw needs an LLM to power its investigation engine.
+
+- **TUI mode** reads `.siclaw/config/settings.json`
+- **Local Server / Gateway** is typically configured through the **Models** page in the Web UI
 
 ## Anthropic (Recommended)
 
@@ -90,22 +93,7 @@ See [`settings.example.json`](https://github.com/scitix/siclaw/blob/main/setting
 ## Configuration Methods
 
 - **TUI mode**: First-run wizard or `/setup` command inside a session
-- **Gateway/Docker mode**: Edit `settings.json` directly or via the web UI
-
-API keys support `$VAR` / `${VAR}` references in `settings.json`:
-
-```json
-{
-  "providers": {
-    "default": {
-      "apiKey": "${MY_API_KEY}",
-      "baseUrl": "https://api.openai.com/v1",
-      "api": "openai-completions",
-      "models": [{ "id": "gpt-4o", "name": "GPT-4o" }]
-    }
-  }
-}
-```
+- **Local Server / Gateway**: Configure providers and models in the Web UI
 
 ## Embedding Provider
 
@@ -125,6 +113,8 @@ Embedding is used for memory search — matching current symptoms against past i
   }
 }
 ```
+
+If `embedding.apiKey` is omitted, Siclaw falls back to the default provider API key.
 
 | Provider | Model | Dimensions | Notes |
 |----------|-------|------------|-------|

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,17 +98,6 @@
             ]
           }
         ]
-      },
-      {
-        "tab": "Roadmap",
-        "groups": [
-          {
-            "group": "Project",
-            "pages": [
-              "design/roadmap"
-            ]
-          }
-        ]
       }
     ]
   },

--- a/docs/features/channels.mdx
+++ b/docs/features/channels.mdx
@@ -14,15 +14,17 @@ All channels share the same investigation engine — the interface differs but t
 | **Web UI** | Gateway | Stable |
 | **Slack** | Gateway | Stable |
 | **Lark (Feishu)** | Gateway | Stable |
+| **Discord** | Gateway | Stable |
+| **Telegram** | Gateway | Stable |
 | **Webhooks** | Gateway | Stable |
 
 ## Web UI
 
-Available in Gateway mode (`siclaw-gateway` or Docker deployment):
+Available in Local Server mode (`siclaw local`) and Kubernetes deployments:
 
 ```bash
 npm run dev:gateway
-# Open http://localhost:3001
+# Open http://localhost:3000
 ```
 
 The Web UI provides:
@@ -41,12 +43,10 @@ The Web UI provides:
 2. Enable **Socket Mode** and **Event Subscriptions**
 3. Subscribe to events: `app_mention`, `message.im`
 4. Add bot scopes: `chat:write`, `app_mentions:read`, `im:history`
-5. Set environment variables:
+5. In Siclaw Web UI, open **Channels** and save the bot credentials for Slack:
 
-```bash
-SLACK_BOT_TOKEN=xoxb-...
-SLACK_APP_TOKEN=xapp-...
-```
+   - `botToken`
+   - `appToken`
 
 ### Usage
 
@@ -60,19 +60,35 @@ Or send a direct message for private investigations.
 
 ## Lark (Feishu) Integration
 
-```bash
-LARK_APP_ID=cli_...
-LARK_APP_SECRET=...
-```
+Create a Lark bot app, enable message event subscriptions, then configure it in **Channels** with:
 
-Create a Lark bot app, enable message event subscriptions, and set the environment variables above.
+- `appId`
+- `appSecret`
+
+## Discord Integration
+
+Configure a Discord bot in **Channels** with:
+
+- `token`
+
+## Telegram Integration
+
+Configure a Telegram bot in **Channels** with:
+
+- `botToken`
 
 ## Alert Webhooks
 
-Siclaw accepts alert webhooks from monitoring systems and automatically starts an investigation:
+Create a Trigger in the **Triggers** page. Siclaw will generate:
+
+- a unique webhook URL
+- a bearer secret
+
+Requests should be sent to the generated endpoint:
 
 ```bash
-curl -X POST https://siclaw.example.com/api/webhook/alert \
+curl -X POST https://siclaw.example.com/hooks/v1/<trigger-id> \
+  -H "Authorization: Bearer <trigger-secret>" \
   -H "Content-Type: application/json" \
   -d '{
     "title": "High error rate on payment-service",
@@ -96,18 +112,6 @@ Schedule recurring health checks using natural language:
 ### Creating a Patrol
 
 **Via Web UI**: Go to **Cron** in the sidebar, click **New Patrol**, describe what to check and how often.
-
-**Via API**:
-
-```bash
-curl -X POST https://siclaw.example.com/api/cron \
-  -H "Content-Type: application/json" \
-  -d '{
-    "description": "Check GPU utilization every 6 hours",
-    "schedule": "0 */6 * * *",
-    "skills": ["gpu-health-check"]
-  }'
-```
 
 Each patrol run produces a status (success / warning / failure), output summary, and timestamp — all visible in the Web UI.
 

--- a/docs/features/deep-investigation.mdx
+++ b/docs/features/deep-investigation.mdx
@@ -6,7 +6,7 @@ description: "How Siclaw's 4-phase hypothesis-driven investigation engine works.
 
 ## Overview
 
-Deep Investigation is Siclaw's core diagnostic engine. Instead of running a fixed playbook, it **thinks like an SRE**: gathers evidence, forms hypotheses, tests them independently, and synthesizes a conclusion.
+Deep Investigation is Siclaw's core diagnostic engine. Instead of running a fixed playbook, it follows a structured investigation process: gather evidence, form hypotheses, test them independently, and synthesize a conclusion.
 
 ## The 4-Phase Pipeline
 
@@ -18,8 +18,6 @@ A sub-agent with tool access collects the current state of the environment:
 - Node conditions and resource utilization
 - Recent deployments and config changes
 - Relevant metrics from Prometheus/monitoring
-
-**Budget**: Up to 8 tool calls (5 in Quick mode)
 
 ### Phase 2: Hypothesis Generation
 
@@ -37,10 +35,8 @@ If [Investigation Memory](/features/memory) has data, past investigations with s
 
 Up to 3 sub-agents run simultaneously, each validating one hypothesis:
 
-- Each sub-agent has its own **independent tool budget** (up to 10 calls each)
 - Sub-agents don't share information — this prevents confirmation bias
 - Each agent produces a verdict: `validated`, `invalidated`, or `inconclusive`
-- Tool set is minimal: `read`, `restricted-bash`, `node_exec` only
 
 ### Phase 4: Conclusion
 
@@ -52,22 +48,11 @@ All evidence is synthesized into a structured report containing:
 - **Remediation steps** (actionable next steps)
 - **Structured extraction** (category, affected entities, environment tags) → stored in Investigation Memory
 
-## Budget Controls
-
-| Metric | Normal | Quick |
-|--------|--------|-------|
-| Context tool calls | 8 | 5 |
-| Max hypotheses | 5 | 3 |
-| Calls per hypothesis | 10 | 8 |
-| Total tool calls | 60 | 30 |
-| Parallel sub-agents | 3 | 3 |
-| Max duration | 5 min | 3 min |
-
 ## Triggering Deep Investigation
 
 ### Automatic (via triage)
 
-The main agent triages the user's question. If it determines a deep investigation is needed, it calls `deep_search` with pre-gathered context and hypotheses, skipping Phases 1-2.
+The main agent decides when a deeper investigation is needed and expands into the full workflow automatically.
 
 ### Manual
 
@@ -78,7 +63,8 @@ The main agent triages the user's question. If it determines a deep investigatio
 ### Via Alert Webhook
 
 ```bash
-curl -X POST https://siclaw.example.com/api/webhook/alert \
+curl -X POST https://siclaw.example.com/hooks/v1/<trigger-id> \
+  -H "Authorization: Bearer <trigger-secret>" \
   -H "Content-Type: application/json" \
   -d '{"title": "High error rate on payment-service", "severity": "critical"}'
 ```
@@ -91,4 +77,4 @@ Every investigation produces a report saved to `~/.siclaw/reports/`:
 ~/.siclaw/reports/deep-search-2026-03-06T14-30-00.md
 ```
 
-Reports include the full investigation trace: every tool call, its output, and the reasoning chain.
+Reports include the investigation summary, evidence, and recommended next steps.

--- a/docs/features/memory.mdx
+++ b/docs/features/memory.mdx
@@ -6,81 +6,31 @@ description: "How Siclaw learns from past investigations to improve future diagn
 
 ## Overview
 
-Every deep investigation automatically produces two outputs:
+Every deep investigation helps Siclaw get better at future investigations.
 
-1. **Raw markdown** — human-readable report saved to `~/.siclaw/reports/`
-2. **Structured record** — root cause category, causal chain, affected entities → SQLite
+Siclaw stores:
 
-This dual-output system means Siclaw **accumulates diagnostic experience** across sessions.
+- a human-readable investigation report
+- a structured summary of the incident
+- searchable memory used to improve future hypothesis generation
 
 ## How It Works
 
 ### Writing Memory
 
-After Phase 4 (Conclusion), the investigation engine extracts structured data:
+After an investigation finishes, Siclaw saves key facts such as:
 
-```json
-{
-  "root_cause_category": "resource_exhaustion",
-  "affected_entities": ["pod/payment-service", "node/worker-03"],
-  "environment_tags": ["cluster-prod", "namespace-payments"],
-  "causal_chain": [
-    "v2.3 added caching layer",
-    "Memory usage increased to 310Mi",
-    "Exceeded 256Mi limit",
-    "OOMKilled → CrashLoopBackOff"
-  ],
-  "confidence": 92
-}
-```
+- likely root cause
+- affected services or resources
+- important evidence
+- recommended next steps
 
 ### Reading Memory
 
-When a new investigation starts, Phase 2 (Hypothesis Generation) retrieves relevant past investigations using **hybrid search**:
+When a new investigation starts, Siclaw can look up similar past incidents and use them to improve hypothesis quality.
 
-1. **Structured query** — matches on root cause category, affected entities, environment tags
-2. **Semantic search** — vector similarity over investigation chunks (cosine similarity with BM25 boost)
-
-```
-finalScore = 0.70 × cosineSimilarity + 0.30 × bm25Score
-```
-
-Results above `0.35` threshold are injected into the hypothesis generation prompt.
-
-## Root Cause Categories
-
-Structured records use a fixed category taxonomy:
-
-| Category | Examples |
-|----------|---------|
-| `resource_exhaustion` | OOMKilled, CPU throttling, disk full |
-| `config_error` | Missing configmap, wrong env var, bad YAML |
-| `network_partition` | DNS failure, CNI issues, firewall rules |
-| `hardware_failure` | Disk failure, GPU error, NIC flap |
-| `pcie_error` | PCIe bus error, GPU fallen off bus |
-| `driver_issue` | NVIDIA driver mismatch, kernel module missing |
-| `software_bug` | Application crash, deadlock, race condition |
-| `permission_denied` | RBAC, PodSecurityPolicy, filesystem permissions |
-| `scheduling_failure` | Insufficient resources, affinity conflicts |
-| `unknown` | No clear root cause identified |
-
-## Storage
-
-| Component | Engine | Location |
-|-----------|--------|----------|
-| Structured records | node:sqlite (native) | `~/.siclaw/memory/.memory.db` |
-| Embeddings | node:sqlite + FTS5 | Same database |
-| Raw reports | Markdown files | `~/.siclaw/reports/` |
+This makes repeated incident patterns easier to recognize over time.
 
 <Warning>
-Memory search requires an [embedding provider](/configuration/providers#embedding) to be configured. Without it, structured field matching still works but semantic similarity search is disabled.
+Memory search works best with an [embedding provider](/configuration/providers#embedding). Without one, Siclaw still saves investigation history, but semantic recall is reduced.
 </Warning>
-
-## Chunking
-
-Memory files are split on heading boundaries for optimal retrieval:
-
-- Max chunk size: ~400 tokens (~1600 bytes)
-- Overlap: ~80 tokens between adjacent chunks
-- Each chunk tracks: file path, heading breadcrumb, start/end line
-- CJK queries use OR for bigrams; Latin queries use AND

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -6,30 +6,24 @@ description: "Extend Siclaw with reusable diagnostic playbooks and custom script
 
 ## What Are Skills?
 
-Skills are reusable diagnostic playbooks that extend Siclaw's capabilities. Each skill is a directory containing a description and optional executable scripts.
+Skills are reusable diagnostic playbooks. They let your team package recurring investigation steps into a named capability that Siclaw can run on demand.
 
-```
-skills/core/k8s-pod-diagnostics/
-├── SKILL.md        ← Description, parameters, usage
-└── scripts/
-    └── check-pod.sh  ← Executable diagnostic script
-```
+Typical examples:
 
-## Skill Tiers
+- Check why a deployment rollout is stuck
+- Review GPU health across training nodes
+- Validate a service's DNS and network path
+- Collect the same evidence bundle every time an alert fires
 
-```
-skills/
-├── core/             ← Built-in, read-only, ships with Siclaw
-├── team/             ← Team-managed via Web UI, admin-published
-├── user/&lt;userId&gt;/    ← Personal skills, per-user
-└── extension/        ← Optional overlay builds
-```
+## How Teams Use Skills
 
-**Loading priority** (highest wins): personal > `team` > `core`
+Siclaw ships with built-in skills, and teams can add their own through the Web UI.
+
+- **Core skills**: built-in and maintained by Siclaw
+- **Team skills**: shared across your organization after review
+- **Personal skills**: private to one user unless promoted later
 
 ## Creating a Skill
-
-### 1. Write the SKILL.md
 
 ```markdown
 # GPU Health Check
@@ -47,53 +41,36 @@ Check all GPUs: `run_skill gpu-health-check`
 Check specific node: `run_skill gpu-health-check --node gpu-worker-01`
 ```
 
-### 2. Add Scripts (Optional)
+You can create and edit skills in the Web UI, then describe:
 
-```bash
-#!/bin/bash
-# scripts/check-gpu.sh
-# Arguments passed as positional parameters
+- what the skill is for
+- which parameters it accepts
+- how Siclaw should use it during an investigation
+- optional scripts when a structured workflow needs custom execution
 
-kubectl get nodes -l nvidia.com/gpu.present=true -o wide
-kubectl exec -n gpu-operator -- nvidia-smi --query-gpu=gpu_name,temperature.gpu,utilization.gpu,memory.used --format=csv
-```
+## Review and Approval
 
-## Security Review Gate
-
-Scripts follow a mandatory review workflow before execution:
+Skills with scripts go through a mandatory review workflow before they become available:
 
 ```
 draft → request review → pending → AI + static analysis → approved/rejected
 ```
 
-### Static Analysis
+The review process checks for risky behavior such as destructive shell commands, unsafe script patterns, or actions that would violate Siclaw's read-only model.
 
-Danger patterns are checked automatically:
-
-| Severity | Examples |
-|----------|---------|
-| Critical | `rm -rf`, `mkfs`, `dd if=`, fork bomb |
-| High | `chmod 777`, `curl | sh`, `eval`, `> /dev/sda` |
-| Medium | `kill -9`, `pkill`, `reboot`, `shutdown` |
-
-### AI Review
-
-An LLM reviews the script semantics with a mandatory rule: **"Skills MUST be strictly read-only."**
-
-### Human Approval
-
-A user with `skill_reviewer` role must approve before the skill can be executed.
-
-## Script Execution
-
-When a skill script is approved and executed via `run_skill`:
-
-- **Interpreter**: `bash` for `.sh`, `python3` for `.py` (detected automatically)
-- **Timeout**: Default 180s, max 300s
-- **Arguments**: Passed as array to `spawn()` — no shell interpolation (injection-safe)
-- **Max output**: 10 MB combined stdout + stderr
-- **Injected environment**: `KUBECONFIG`, `SICLAW_DEBUG_IMAGE`, `SICLAW_CREDENTIALS_DIR`
+Only approved skills can be used in shared environments.
 
 <Note>
-Skill scripts are **exempt from the binary allowlist**. This is the only way to run otherwise-blocked binaries (like `sed` or `awk`) — the security review gate is the safety mechanism.
+Siclaw is designed for read-only diagnostics. Team skills should follow the same model: investigate, summarize, and recommend actions rather than change production systems directly.
 </Note>
+
+## Running Skills
+
+Skills can be used in several ways:
+
+- directly during a conversation
+- as part of a deeper investigation
+- from scheduled patrols
+- from webhook-triggered workflows
+
+This makes them a good fit for turning repeated incident response habits into reusable, reviewable runbooks.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,7 +12,7 @@ An open-source AI agent that diagnoses Kubernetes infrastructure issues the way 
 
 ## What Makes Siclaw Different
 
-Most AI ops tools are glorified chatbots — they run one command, show the output, and ask "what next?" Siclaw runs a **complete investigation autonomously**:
+Siclaw runs a **complete investigation workflow**, not just a single command followed by another prompt:
 
 ```
 You: "Pod payment-service is CrashLoopBackOff after deploying v2.3"
@@ -30,7 +30,7 @@ Siclaw:
 
 <CardGroup cols={2}>
   <Card title="Deep Investigation" icon="magnifying-glass" href="/features/deep-investigation">
-    4-phase pipeline with parallel sub-agents. Not just Q&A — full root cause analysis with confidence scoring.
+    4-phase workflow for evidence gathering, hypothesis testing, and root-cause analysis.
   </Card>
   <Card title="Investigation Memory" icon="brain" href="/features/memory">
     Learns from every investigation. Past diagnoses improve future hypotheses automatically.
@@ -39,7 +39,7 @@ Siclaw:
     Custom diagnostic playbooks with mandatory security review. Your team's runbooks, executable by AI.
   </Card>
   <Card title="Multi-Channel" icon="comments" href="/features/channels">
-    Terminal, Web UI, Slack, Lark. Same investigation engine, any interface.
+    Terminal, Web UI, Slack, Lark, Discord, Telegram. Same investigation engine, any interface.
   </Card>
 </CardGroup>
 
@@ -52,6 +52,7 @@ Siclaw:
 ## Quick Start
 
 ```bash
+mkdir -p ~/siclaw-work && cd ~/siclaw-work
 npm install -g siclaw
 siclaw local        # Web UI at http://localhost:3000
 ```

--- a/docs/install/cli.mdx
+++ b/docs/install/cli.mdx
@@ -4,6 +4,15 @@ sidebarTitle: "CLI / Local"
 description: "Install Siclaw globally and run as CLI or local server."
 ---
 
+## Recommended Working Directory
+
+Siclaw stores most runtime data in a `.siclaw/` folder **relative to the directory where you start it**. Create a dedicated working directory and reuse it:
+
+```bash
+mkdir -p ~/siclaw-work
+cd ~/siclaw-work
+```
+
 ## Install
 
 ```bash
@@ -16,7 +25,14 @@ npm install -g siclaw
 siclaw local
 ```
 
-Launches the Web UI at `http://localhost:3000` with multi-user support, channels (Slack/Lark), cron patrols, and all features.
+Launches the Web UI at `http://localhost:3000`.
+
+On first startup, the local server creates a default admin account:
+
+- Username: `admin`
+- Password: `admin`
+
+Change it after logging in, or set `SICLAW_ADMIN_PASSWORD` before the first start.
 
 ## CLI (TUI)
 
@@ -32,34 +48,48 @@ Personal terminal mode. Same investigation engine, no server.
 git clone https://github.com/scitix/siclaw.git
 cd siclaw
 npm ci
+npm run build:web
 npm run build
-npm run dev
+
+# TUI
+node siclaw.mjs
+
+# Local server
+node siclaw.mjs local
 ```
 
 ## Configuration
 
-Siclaw stores its configuration and data in `~/.siclaw/`:
+By default, Siclaw reads and writes these paths relative to your current working directory:
 
 ```
-~/.siclaw/
+.siclaw/
 ├── config/
 │   └── settings.json     ← LLM provider, model, API key
-├── data.sqlite            ← Session data (Gateway mode, sql.js)
-├── memory/
-│   ├── .memory.db         ← Investigation memory (node:sqlite)
-│   └── *.md               ← Raw memory files
-└── reports/
-    └── deep-search-*.md   ← Investigation reports
+├── credentials/           ← Imported kubeconfigs, SSH keys, API tokens
+├── skills/
+└── user-data/
+    ├── memory/
+    │   └── .memory.db
+    └── ...
 ```
 
 ### LLM Configuration
 
-Edit `~/.siclaw/config/settings.json` (see [`settings.example.json`](https://github.com/scitix/siclaw/blob/main/settings.example.json) for full format):
+TUI mode reads `.siclaw/config/settings.json`. The easiest path is to let the first-run wizard create it for you.
+
+Minimal example:
 
 ```json
 {
   "providers": {
-    "default": {
+    "openai": {
+      "baseUrl": "https://api.openai.com/v1",
+      "apiKey": "sk-...",
+      "api": "openai-completions",
+      "models": [{ "id": "gpt-4o", "name": "GPT-4o" }]
+    },
+    "anthropic": {
       "baseUrl": "https://api.anthropic.com/v1",
       "apiKey": "sk-ant-...",
       "api": "anthropic",
@@ -71,15 +101,18 @@ Edit `~/.siclaw/config/settings.json` (see [`settings.example.json`](https://git
 
 Once inside the TUI session, use `/setup` to manage providers, models, and credentials.
 
-See [LLM Providers](/configuration/providers) for Ollama, vLLM, and other setups.
+In Local Server mode, configure providers and models in the **Models** page of the Web UI.
 
-### Kubeconfig
+See [LLM Providers](/configuration/providers) for provider examples.
 
-Siclaw uses your default kubeconfig (`~/.kube/config`). To use a specific context:
+### Kubernetes Credentials
 
-```bash
-KUBECONFIG=/path/to/kubeconfig siclaw
-```
+Siclaw tools resolve kubeconfig from its own credential store, not from your shell's `KUBECONFIG`.
+
+- In TUI mode, use `/setup` to import a kubeconfig
+- In Local Server mode, add it in **Credentials**
+
+After import, Siclaw can route `kubectl` calls through that stored credential.
 
 ## Embedding (Optional)
 
@@ -96,4 +129,12 @@ To enable Investigation Memory with semantic search, add an embedding config:
 }
 ```
 
-Without embedding, memory features are disabled but all other functionality works normally.
+If `embedding.apiKey` is omitted, Siclaw falls back to the default LLM provider key.
+
+## Reports
+
+Deep investigation reports are written to:
+
+```text
+~/.siclaw/reports/
+```

--- a/docs/install/docker.mdx
+++ b/docs/install/docker.mdx
@@ -1,78 +1,62 @@
 ---
-title: "Docker Deployment"
-sidebarTitle: "Docker"
-description: "Run Siclaw as a multi-user server with Web UI using Docker Compose."
+title: "Container Images"
+sidebarTitle: "Images"
+description: "Build and publish Siclaw container images for Kubernetes deployment."
 ---
 
-## Quick Start
+## What Docker Supports Today
+
+Siclaw currently ships Dockerfiles for **building runtime images**:
+
+- `gateway` — Web UI + API server
+- `agentbox` — per-user execution runtime
+- `cron` — scheduled job runner
+
+For a single-machine setup, use [CLI & Local Server](/install/cli). The repository does **not** include a supported `docker compose` deployment.
+
+## Build Images
+
+From the repo root:
 
 ```bash
-git clone https://github.com/scitix/siclaw.git
-cd siclaw
-docker compose up -d
+make docker REGISTRY=registry.example.com/myteam TAG=latest
 ```
 
-The Web UI is available at `http://localhost:3001`.
+That builds:
 
-## Docker Compose Configuration
+- `registry.example.com/myteam/siclaw-gateway:latest`
+- `registry.example.com/myteam/siclaw-agentbox:latest`
+- `registry.example.com/myteam/siclaw-cron:latest`
 
-```yaml
-# docker-compose.yml
-services:
-  siclaw-gateway:
-    build:
-      context: .
-      dockerfile: Dockerfile.gateway
-    ports:
-      - "3001:3001"    # Web UI + API
-    volumes:
-      - siclaw-data:/app/.siclaw
-      - ~/.kube/config:/app/.kube/config:ro
-    restart: unless-stopped
-
-volumes:
-  siclaw-data:
-```
-
-## Architecture
-
-In Docker mode, Siclaw runs with `LocalSpawner`:
-
-- **Gateway** serves the Web UI, API, and WebSocket connections
-- **AgentBox** instances run in-process (same container)
-- **SQLite** (sql.js) for session data, **node:sqlite** for memory
-
-<Warning>
-All users share the same filesystem in Docker mode. This is a development/small-team deployment model, not a production multi-tenant solution. Use [Kubernetes](/install/kubernetes) for production.
-</Warning>
-
-## Channels
-
-Connect messaging platforms by setting environment variables:
+To build one image only:
 
 ```bash
-# Slack (Socket Mode)
-SLACK_BOT_TOKEN=xoxb-...
-SLACK_APP_TOKEN=xapp-...
-
-# Lark
-LARK_APP_ID=...
-LARK_APP_SECRET=...
+make docker-gateway REGISTRY=registry.example.com/myteam TAG=latest
+make docker-agentbox REGISTRY=registry.example.com/myteam TAG=latest
+make docker-cron REGISTRY=registry.example.com/myteam TAG=latest
 ```
 
-See [Channels](/features/channels) for full configuration.
-
-## Persistence
-
-Mount a volume to `/app/.siclaw` to persist:
-- Session history
-- Investigation memory
-- Skill configurations
-- Cron job definitions
-
-## Updating
+## Push Images
 
 ```bash
-docker compose pull
-docker compose up -d
+make push REGISTRY=registry.example.com/myteam TAG=latest
 ```
+
+Or push individually:
+
+```bash
+make push-gateway REGISTRY=registry.example.com/myteam TAG=latest
+make push-agentbox REGISTRY=registry.example.com/myteam TAG=latest
+make push-cron REGISTRY=registry.example.com/myteam TAG=latest
+```
+
+## Runtime Notes
+
+- The Gateway image listens on container port `3000`.
+- The Gateway image starts in Kubernetes mode by default.
+- The AgentBox image is designed to be spawned by the Gateway inside Kubernetes.
+- Core skills are baked into the images; dynamic skills and credentials are synced at runtime.
+
+## Next Step
+
+After publishing images, continue with [Kubernetes Deployment](/install/kubernetes).

--- a/docs/install/kubernetes.mdx
+++ b/docs/install/kubernetes.mdx
@@ -4,217 +4,135 @@ sidebarTitle: "Kubernetes"
 description: "Deploy Siclaw on Kubernetes with full tenant isolation using Helm."
 ---
 
-## Quick Start
-
-```bash
-helm install siclaw oci://ghcr.io/scitix/siclaw/helm/siclaw \
-  --set llm.provider=anthropic \
-  --set llm.apiKey=sk-ant-... \
-  --set llm.model=claude-sonnet-4-20250514
-```
-
 ## Architecture
 
-In Kubernetes mode, Siclaw uses `K8sSpawner` for full tenant isolation:
+Kubernetes is the production deployment model for Siclaw:
 
 ```
-Gateway Pod (Deployment)
-  ├── API server (port 3001)
-  ├── HTTPS/mTLS server (port 3002)
-  ├── K8sSpawner → creates AgentBox pods on demand
-  └── MySQL connection (required for K8s mode)
+Gateway Deployment
+  ├── Web UI + API
+  ├── K8sSpawner
+  ├── Cron coordination
+  └── MySQL connection
 
-AgentBox Pod (per user)
-  ├── Isolated filesystem (emptyDir volume)
-  ├── mTLS client certificate (identity: userId + workspaceId)
-  ├── Skills synced via bundle API (team + personal only)
-  └── Auto-terminates after 5 minutes idle
+Cron Deployment
+  └── Executes scheduled jobs
+
+AgentBox Pod (spawned per user / workspace)
+  ├── Isolated runtime
+  ├── Synced skills and credentials
+  └── Internal mTLS back to Gateway
 ```
 
-## Helm Values
+## Prerequisites
 
-Key configuration options:
+- A Kubernetes cluster
+- A MySQL database reachable from the cluster
+- Published Siclaw images for `gateway`, `agentbox`, and `cron`
 
-```yaml
-# values.yaml
-replicaCount: 1
-
-llm:
-  provider: anthropic
-  apiKey: sk-ant-...
-  model: claude-sonnet-4-20250514
-
-database:
-  type: mysql
-  host: mysql.default.svc.cluster.local
-  port: 3306
-  name: siclaw
-  user: siclaw
-  password: ...
-
-gateway:
-  image:
-    repository: siclaw/siclaw-gateway
-    tag: latest
-  service:
-    type: ClusterIP
-    port: 3001
-
-agentbox:
-  image:
-    repository: siclaw/siclaw-agentbox
-    tag: latest
-  resources:
-    limits:
-      memory: 512Mi
-      cpu: 500m
-```
-
-## mTLS Security
-
-Gateway and AgentBox communicate over mutual TLS:
-
-- **CA certificate**: Auto-generated (10-year), stored in database, auto-renewed at 30-day threshold
-- **Client certificates**: Issued per-pod at spawn time, encode `userId` + `workspaceId` in CN/OU
-- **Protected endpoints**: `/api/internal/*` on Gateway port 3002
-
-No API keys in pod environment variables — identity is cryptographically bound to the certificate.
-
-## Database
-
-Kubernetes mode **requires MySQL** (SQLite is single-process only):
+Build and push images first if you are using your own registry:
 
 ```bash
-helm install siclaw ... \
-  --set database.type=mysql \
-  --set database.host=mysql.svc.cluster.local \
-  --set database.name=siclaw \
-  --set database.user=siclaw \
-  --set database.password=secret
+make docker REGISTRY=registry.example.com/myteam TAG=latest
+make push REGISTRY=registry.example.com/myteam TAG=latest
 ```
 
-<Warning>
-Common gotcha: use `--set-string` for numeric Helm values like image tags (e.g., `--set-string gateway.image.tag=20260301`). Also ensure `--set namespace=` matches the actual Kubernetes namespace.
-</Warning>
+## Quick Start
 
-## Ingress
+Install from the chart in this repository:
 
-Example with nginx-ingress:
+```bash
+helm upgrade --install siclaw ./helm/siclaw \
+  --namespace siclaw \
+  --create-namespace \
+  --set image.registry=registry.example.com/myteam \
+  --set image.tag=latest \
+  --set database.url="mysql://user:pass@mysql.svc.cluster.local:3306/siclaw"
+```
+
+The chart expects all three images to share the same registry and tag unless you explicitly override `agentbox.image.*`.
+
+## Important Values
+
+Current top-level values look like this:
 
 ```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: siclaw
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-spec:
-  rules:
-    - host: siclaw.example.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: siclaw-gateway
-                port:
-                  number: 3001
+image:
+  registry: registry.example.com/myteam
+  tag: latest
+
+gateway:
+  replicas: 1
+  service:
+    type: NodePort
+    port: 80
+    nodePort: 31000
+
+cron:
+  replicas: 2
+
+database:
+  url: mysql://user:pass@mysql.svc.cluster.local:3306/siclaw
+```
+
+Use `database.existingSecret.name` if you do not want to pass the connection string on the command line.
+
+## Accessing the UI
+
+By default the chart exposes the Gateway Service on port `80` inside the cluster.
+
+- If you keep the default `NodePort`, the UI is available on node port `31000`
+- If you add an Ingress, route it to the Gateway Service on service port `80`
+
+Example Ingress backend:
+
+```yaml
+backend:
+  service:
+    name: siclaw-gateway
+    port:
+      number: 80
 ```
 
 <Note>
-WebSocket support is required for real-time investigation updates. Set appropriate proxy timeouts for long-running investigations (up to 5 minutes).
+WebSocket support is required for live investigation updates. Keep proxy read/send timeouts high enough for multi-minute investigations.
 </Note>
 
-## Metrics & Observability
+## Authentication
 
-Siclaw exposes Prometheus metrics out of the box. The Helm chart can automatically create monitoring resources for [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator).
+On first startup, Siclaw creates a default local admin account:
 
-### Endpoints
+- Username: `admin`
+- Password: `admin`
 
-| Component | Port | Path | Protocol |
-|-----------|------|------|----------|
-| Gateway | 3000 | `/metrics` | HTTP |
-| AgentBox | 9090 | `/metrics` | HTTP (dedicated sidecar port, bypasses mTLS) |
-
-### Helm Configuration
+To change the bootstrap password, set:
 
 ```yaml
-# values.yaml
-metrics:
-  enabled: true                # master switch for all monitoring resources
-
-  serviceMonitor:
-    enabled: true              # ServiceMonitor for Gateway
-    interval: 15s
-
-  podMonitor:
-    enabled: true              # PodMonitor for AgentBox (cross-namespace discovery)
-    interval: 15s
-
-  grafanaDashboard:
-    enabled: true              # auto-import dashboard via Grafana sidecar
-
-  prometheusRule:
-    enabled: false             # opt-in: preset alert rules
-    costThresholdPerHour: 10   # USD — alert when hourly LLM cost exceeds this
+gateway:
+  env:
+    SICLAW_ADMIN_PASSWORD: "change-me"
 ```
 
-All monitoring resources are created by default when `metrics.enabled: true` (except `prometheusRule`, which is opt-in).
+## Metrics
 
-### Grafana Dashboard
+The Gateway exposes Prometheus metrics at `/metrics`. The chart can create ServiceMonitor, PodMonitor, Grafana dashboard, and PrometheusRule resources under the `metrics.*` values block.
 
-When `grafanaDashboard.enabled: true`, the chart creates a ConfigMap with the `grafana_dashboard: "1"` label. If your Grafana is deployed via [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack), the sidecar will auto-discover and import the **Siclaw Overview** dashboard.
+Common settings:
 
-The dashboard includes five sections:
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+  podMonitor:
+    enabled: true
+  grafanaDashboard:
+    enabled: true
+  prometheusRule:
+    enabled: false
+```
 
-- **Overview** — active sessions, WebSocket connections, prompt rate, error rate, cost, stuck sessions
-- **Cost & Tokens** — cost over time by provider, token consumption rate by type (input/output/cache)
-- **Latency** — prompt duration percentiles (p50/p95/p99), prompt rate by outcome
-- **Tools** — top 10 tool calls per minute, tool error rate by name
-- **Health** — sessions over time, WebSocket connections over time, context window usage
-
-### Alert Rules
-
-Enable with `metrics.prometheusRule.enabled: true`. Three preset alerts:
-
-| Alert | Condition | Severity |
-|-------|-----------|----------|
-| `SiclawSessionStuck` | >3 stuck sessions in 10 min | warning |
-| `SiclawHighErrorRate` | Prompt error rate >10% for 10 min | warning |
-| `SiclawHighCost` | Hourly LLM cost exceeds threshold | warning |
-
-### Metrics Reference
-
-<Expandable title="All Siclaw metrics (11)">
-
-**Core metrics:**
-
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `siclaw_tokens_total` | Counter | `type`, `provider`, `model`, `user_id` | Cumulative token consumption (delta per prompt) |
-| `siclaw_cost_usd_total` | Counter | `provider`, `model`, `user_id` | Cumulative LLM cost in USD |
-| `siclaw_prompt_duration_ms` | Histogram | `provider`, `model`, `outcome` | Prompt end-to-end latency (ms) |
-| `siclaw_prompts_total` | Counter | `provider`, `model`, `outcome` | Total prompts processed |
-| `siclaw_sessions_active` | Gauge | — | Current active sessions |
-| `siclaw_tool_calls_total` | Counter | `tool_name`, `outcome` | Tool invocation count |
-| `siclaw_ws_connections` | Gauge | — | Current WebSocket connections |
-
-**Health metrics:**
-
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `siclaw_context_tokens_used` | Gauge | `provider`, `model` | Context window tokens used |
-| `siclaw_context_tokens_limit` | Gauge | `provider`, `model` | Context window token limit |
-| `siclaw_session_stuck_total` | Counter | — | Stuck sessions detected |
-| `siclaw_session_stuck_age_ms` | Histogram | — | Duration of stuck sessions (ms) |
-
-</Expandable>
-
-### Authentication
-
-Both Gateway and AgentBox `/metrics` endpoints support optional bearer token authentication via the `SICLAW_METRICS_TOKEN` environment variable:
+If you want bearer-token protection for `/metrics`, add:
 
 ```yaml
 gateway:
@@ -222,35 +140,17 @@ gateway:
     SICLAW_METRICS_TOKEN: "your-secret-token"
 ```
 
-When set, Prometheus must include the token in scrape config:
+To remove the `user_id` label from token and cost metrics:
 
 ```yaml
-# prometheus scrape config
-authorization:
-  credentials: your-secret-token
+gateway:
+  env:
+    SICLAW_METRICS_USER_ID: "false"
 ```
 
-<Warning>
-If `SICLAW_METRICS_TOKEN` is not set, the `/metrics` endpoint is unauthenticated. A warning is logged at startup. For production deployments with sensitive data in metric labels (e.g., `user_id`), setting a token is recommended.
-</Warning>
+## Operational Notes
 
-### Privacy: User ID in Metrics
-
-By default, `user_id` is included as a label on token and cost metrics for per-user cost tracking. To disable:
-
-```bash
-helm install siclaw ... --set gateway.env.SICLAW_METRICS_USER_ID=false
-```
-
-<Warning>
-**Cardinality warning**: With `user_id` enabled (default), `siclaw_tokens_total` and `siclaw_cost_usd_total` create one time series per user × provider × model × type. For deployments with more than 500 active users, this can increase Prometheus storage and memory usage significantly. Consider setting `SICLAW_METRICS_USER_ID=false` in large-scale environments and using application-level cost reporting instead.
-</Warning>
-
-### Monitoring Resource Deployment
-
-The Helm chart and the `k8s/` directory both include PodMonitor and ServiceMonitor definitions. These are **alternative deployment methods** — use one or the other, not both:
-
-- **Helm chart** (`helm install`): Monitoring resources are created automatically when `metrics.enabled: true`
-- **Raw manifests** (`k8s/*.yaml`): Apply manually with `kubectl apply -f` for non-Helm deployments
-
-Deploying both simultaneously will result in duplicate scrape targets in Prometheus.
+- Kubernetes mode requires MySQL. SQLite is only for single-process local use.
+- AgentBox pods are created on demand by the Gateway.
+- Internal service-to-service communication is secured automatically.
+- If you deploy monitoring resources from the chart, do not also apply duplicate monitor manifests manually.

--- a/docs/start/core-concepts.mdx
+++ b/docs/start/core-concepts.mdx
@@ -6,9 +6,9 @@ description: "Key ideas behind Siclaw's investigation approach."
 
 ## How Siclaw Investigates
 
-Siclaw uses a **4-phase hypothesis-driven investigation engine**: gather context → generate hypotheses → validate in parallel with sub-agents → produce a structured report with root cause and remediation.
+Siclaw uses a **4-phase hypothesis-driven investigation engine**: gather context → generate hypotheses → validate in parallel → produce a structured report with root cause and remediation.
 
-Every investigation is **read-only** — Siclaw never modifies your cluster. See [Deep Investigation](/features/deep-investigation) for the full pipeline details and budget controls.
+Every investigation is **read-only** — Siclaw never modifies your cluster. See [Deep Investigation](/features/deep-investigation) for the full workflow.
 
 ## Runtime Modes
 
@@ -17,46 +17,23 @@ Siclaw runs in three modes sharing one agent core:
 | Mode | Use Case | Start Command |
 |------|----------|---------------|
 | **CLI (TUI)** | Personal terminal diagnostics | `siclaw` |
-| **Local Server** | Team use with Web UI, Slack, Lark | `siclaw local` |
-| **Gateway + K8s** | Production multi-tenant | `siclaw-gateway --k8s` |
-| **Cron** | Scheduled health patrols | `siclaw-cron` |
+| **Local Server** | Team use with Web UI and shared configuration | `siclaw local` |
+| **Kubernetes** | Production multi-tenant deployment | `helm upgrade --install siclaw ./helm/siclaw ...` |
 
-For team use, Gateway spawns an isolated **AgentBox** per user — either in-process (local dev) or as a Kubernetes pod (production).
+Use `siclaw` for personal terminal workflows, `siclaw local` for a browser-based local setup, and Kubernetes for team deployments.
 
 ## Skills
 
-Skills are reusable diagnostic playbooks your team can create and share:
-
-```
-skills/
-├── core/              Built-in (kubectl checks, log analysis, etc.)
-├── team/              Team-managed via Web UI
-└── user/<userId>/     Personal skills
-```
-
-Each skill contains a `SKILL.md` description and optional scripts (`.sh`, `.py`). Scripts go through **mandatory security review** (static analysis + AI review + human approval) before they can execute.
-
-See [Skills](/features/skills) for details.
+Skills are reusable diagnostic playbooks your team can create, review, and share. See [Skills](/features/skills) for details.
 
 ## Investigation Memory
 
-Siclaw **learns from every investigation**:
-
-- Stores structured records (root cause, causal chain, confidence) in a local database
-- **Hybrid search** (vector similarity + keyword matching) retrieves relevant past incidents
-- Past findings feed into Phase 2 to improve hypothesis generation
-
-Requires an [embedding provider](/configuration/providers#embedding) to be configured. See [Memory](/features/memory) for details.
+Siclaw can reuse findings from previous incidents so recurring problems are recognized faster. See [Memory](/features/memory) for details.
 
 ## Security Model
 
-Siclaw uses a **whitelist-only** security model — commands must be explicitly approved to run:
-
-- **Shell**: ~80 approved binaries only. `sed`, `awk`, `nc` are intentionally excluded.
-- **kubectl**: Read-only (13 safe subcommands). All write operations permanently blocked.
-- **Skills**: Scripts exempt from the binary allowlist, but require the security review gate.
-- **Files**: Agent can only write to its own data directory.
+Siclaw is designed for read-only diagnostics. It investigates, explains, and recommends next steps without changing your environment directly.
 
 ## MCP Integration
 
-Siclaw supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) for extending capabilities with external tools — Prometheus metrics, GitHub issues, custom data sources. See [MCP Servers](/configuration/mcp) for setup and examples.
+Siclaw supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) for connecting external tools and data sources. See [MCP Servers](/configuration/mcp) for setup and examples.

--- a/docs/start/first-investigation.mdx
+++ b/docs/start/first-investigation.mdx
@@ -14,6 +14,8 @@ A pod in your production cluster is stuck in `CrashLoopBackOff` after a deployme
 siclaw
 ```
 
+If you want Siclaw to inspect a Kubernetes cluster, import a kubeconfig first with `/setup`.
+
 ## Describe the Problem
 
 ```
@@ -80,9 +82,9 @@ Siclaw synthesizes all evidence into a structured report:
     3. Pod exceeded 256Mi memory limit
     4. Kernel OOMKilled the process → container restart → CrashLoopBackOff
 
-  Remediation:
-    - Increase memory limit to 512Mi: kubectl set resources deploy/payment-service -n prod --limits=memory=512Mi
-    - Consider adding memory requests to match expected usage
+  Recommended next steps:
+    - Increase the deployment memory limit to 512Mi
+    - Add memory requests to match expected usage
 ```
 
 The full report is saved to `~/.siclaw/reports/deep-search-{timestamp}.md`.
@@ -127,6 +129,6 @@ Using `/deep` triggers a full investigation with maximum budget — useful for c
 
 ## What's Next?
 
-- [Deep Investigation](/features/deep-investigation) — budget controls, sub-agent architecture
-- [Skills](/features/skills) — create custom diagnostic playbooks
+- [Deep Investigation](/features/deep-investigation) — how the investigation workflow works
+- [Skills](/features/skills) — create reusable diagnostic playbooks
 - [Memory](/features/memory) — how investigation history improves future diagnoses

--- a/docs/start/getting-started.mdx
+++ b/docs/start/getting-started.mdx
@@ -7,12 +7,13 @@ description: "Install Siclaw and run your first investigation in under 5 minutes
 ## Prerequisites
 
 - **Node.js** >= 22.12.0
-- **kubectl** configured with access to a Kubernetes cluster
 - An **LLM API key** (Anthropic, OpenAI, or any OpenAI-compatible provider)
 
 ## Install
 
 ```bash
+mkdir -p ~/siclaw-work
+cd ~/siclaw-work
 npm install -g siclaw
 ```
 
@@ -22,7 +23,12 @@ npm install -g siclaw
 siclaw local
 ```
 
-Launches the Web UI at `http://localhost:3000` with multi-user support, Slack/Lark channels, and all features enabled.
+Launches the Web UI at `http://localhost:3000`.
+
+Default local login:
+
+- Username: `admin`
+- Password: `admin`
 
 ### CLI
 
@@ -37,14 +43,17 @@ TUI mode for personal terminal diagnostics.
 ```bash
 git clone https://github.com/scitix/siclaw.git
 cd siclaw
-npm ci && npm run build
-npm run dev
+npm ci
+npm run build:web
+npm run build
+node siclaw.mjs
 ```
 
 ## Configure Your LLM
 
 On first run, Siclaw launches a setup wizard to configure your LLM provider.
-You can also configure manually in `.siclaw/config/settings.json`, or use the `/setup` command inside a session:
+
+If you prefer, you can also edit `.siclaw/config/settings.json` manually:
 
 ```json
 {
@@ -76,9 +85,18 @@ Siclaw autonomously runs a [4-phase deep investigation](/features/deep-investiga
 
 Reports are saved to `~/.siclaw/reports/`.
 
+## Add Cluster Access
+
+To investigate Kubernetes issues, import a kubeconfig into Siclaw:
+
+- **TUI**: `/setup`
+- **Local Server**: **Credentials** page in the Web UI
+
+Siclaw uses its stored credentials when running diagnostic tools.
+
 ## What's Next?
 
 - [Core Concepts](/start/core-concepts) — understand the investigation engine
 - [Your First Investigation](/start/first-investigation) — walk through a complete diagnosis
 - [LLM Providers](/configuration/providers) — detailed provider configuration
-- [Deploy for your team](/install/docker) — multi-user setup with Web UI
+- [Deploy for your team](/install/kubernetes) — production multi-user deployment

--- a/docs/start/troubleshooting.mdx
+++ b/docs/start/troubleshooting.mdx
@@ -25,34 +25,43 @@ nvm use 22
 **Symptom**: "Failed to connect to LLM provider" or empty responses.
 
 **Check**:
-1. Verify your API key is set correctly:
+1. Open the active config file:
    ```bash
-   echo $ANTHROPIC_API_KEY  # or $OPENAI_API_KEY
+   ls .siclaw/config/settings.json
    ```
-2. Test the API directly:
+2. Verify `baseUrl`, `api`, `apiKey`, and model ID are correct.
+3. Test the provider directly:
    ```bash
    curl https://api.anthropic.com/v1/messages \
-     -H "x-api-key: $ANTHROPIC_API_KEY" \
+     -H "x-api-key: YOUR_API_KEY" \
      -H "content-type: application/json" \
      -d '{"model":"claude-sonnet-4-20250514","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}'
    ```
-3. For OpenAI-compatible providers, confirm `baseUrl` is correct and accessible from your machine.
+4. For OpenAI-compatible providers, confirm `baseUrl` is correct and reachable from the machine running Siclaw.
 
 ## kubectl Permission Denied
 
 **Symptom**: "Error from server (Forbidden)" during investigation.
 
-Siclaw uses your local kubeconfig. Verify:
+Siclaw uses a kubeconfig imported into its credential store. Verify:
 
 ```bash
-# Check current context
-kubectl config current-context
-
-# Test basic read access
-kubectl get pods --all-namespaces
+# See whether Siclaw has imported credentials
+ls .siclaw/credentials/manifest.json
 ```
 
-Siclaw needs **read-only** access. Minimum RBAC:
+If no kubeconfig has been imported yet:
+
+- TUI: run `/setup`
+- Local Server: open **Credentials** in the Web UI
+
+Then verify the same kubeconfig can read your cluster:
+
+```bash
+kubectl --kubeconfig /path/to/imported.kubeconfig get pods --all-namespaces
+```
+
+Siclaw needs read-oriented access. A typical minimum RBAC baseline is:
 ```yaml
 rules:
   - apiGroups: ["", "apps", "batch", "events.k8s.io"]
@@ -67,7 +76,7 @@ rules:
 
 **Symptom**: `memory_search` tool not available, or "embedding provider not configured".
 
-Investigation Memory requires an embedding provider. Add to `~/.siclaw/config/settings.json`:
+Investigation Memory semantic search requires an embedding provider. Add to `.siclaw/config/settings.json`:
 
 ```json
 {
@@ -88,10 +97,10 @@ Without this, all other features work normally — only semantic memory search i
 
 ```bash
 # Check what's using the port
-lsof -i :3001
-# Kill the process or use a different port
-PORT=3005 npm run dev:gateway
+lsof -i :3000
 ```
+
+Current Gateway builds listen on `3000` by default. Stop the conflicting process, then start Siclaw again.
 
 ## SQLite Lock Error
 
@@ -104,7 +113,13 @@ ps aux | grep siclaw
 # Kill stale processes if needed
 ```
 
-The lockfile is at `~/.siclaw/data.sqlite.lock` — if the previous process crashed, you may need to delete it manually.
+The default lockfile is:
+
+```text
+.siclaw/data.sqlite.lock
+```
+
+This path is relative to the directory where you started Siclaw.
 
 ## Skill Script Rejected
 


### PR DESCRIPTION
## Summary
- Rewrite public-facing docs to match current product: read-only framing, credential store model, updated ports/paths/webhook URLs
- Remove internal implementation details (budget constants, scoring formulas, metrics reference) from user docs
- Remove unused metrics aggregator, local-collector, and Metrics dashboard code that was never shipped publicly

## Test plan
- [ ] Verify docs site builds cleanly (`mintlify dev`)
- [ ] Spot-check key pages: install/cli, install/kubernetes, features/deep-investigation
- [ ] Confirm removed code has no remaining import references (`npm run build`)