### PR TITLE
feat(metrics): add skill call metrics across full stack

### DIFF
--- a/src/agentbox/resource-handlers.ts
+++ b/src/agentbox/resource-handlers.ts
@@ -72,6 +72,7 @@ interface SkillBundlePayload {
   version: string;
   skills: Array<{
     dirName: string;
+    scope: "team" | "personal";
     specs: string;
     scripts: Array<{ name: string; content: string }>;
   }>;
@@ -91,18 +92,23 @@ export const skillsHandler: AgentBoxResourceHandler<SkillBundlePayload> = {
     const config = loadConfig();
     const skillsDir = path.resolve(process.cwd(), config.paths.skillsDir);
 
-    // Clear existing skill dirs (but not hidden files like .gitkeep)
+    // Clear only bundle-managed scope subdirectories (team/ and user/)
+    // Never wipe the entire skillsDir — that would destroy core/ and other dirs
     if (fs.existsSync(skillsDir)) {
-      for (const entry of fs.readdirSync(skillsDir)) {
-        if (entry.startsWith(".")) continue;
-        fs.rmSync(path.join(skillsDir, entry), { recursive: true });
+      for (const scopeDir of ["team", "user"]) {
+        const scopePath = path.join(skillsDir, scopeDir);
+        if (fs.existsSync(scopePath)) {
+          fs.rmSync(scopePath, { recursive: true });
+        }
       }
     } else {
       fs.mkdirSync(skillsDir, { recursive: true });
     }
 
     for (const skill of payload.skills) {
-      const skillDir = path.join(skillsDir, skill.dirName);
+      // Write into scope subdirectory so getSkillScriptDirs() layer 2 matches naturally
+      const scopeDir = skill.scope === "personal" ? "user" : "team";
+      const skillDir = path.join(skillsDir, scopeDir, skill.dirName);
       fs.mkdirSync(skillDir, { recursive: true });
 
       if (skill.specs) {

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -204,6 +204,9 @@ export class AgentBoxSessionManager {
       userId: this.userId,
     });
 
+    // Populate sessionIdRef so skill_call events can associate with this session
+    result.sessionIdRef.current = id;
+
     // New session: re-sync memory index to pick up files from previous sessions
     if (isNewSession && this._sharedMemoryIndexer) {
       this._sharedMemoryIndexer.sync().catch((err) => {

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -103,6 +103,9 @@ export interface SiclawSessionResult {
   memoryIndexer?: MemoryIndexer;
   /** Mutable DP state — only set for SDK brain (pi-agent uses extension state) */
   dpState?: DpState;
+  /** Mutable ref — populated when session ID is assigned (for skill_call events) */
+  sessionIdRef: { current: string };
+
 }
 
 /**
@@ -338,6 +341,7 @@ export async function createSiclawSession(
 
   const kubeconfigRef: KubeconfigRef = opts?.kubeconfigRef ?? {};
   const llmConfigRef: LlmConfigRef = {};
+  const sessionIdRef: { current: string } = { current: "" };
   const mode = opts?.mode ?? "web";
   // Mutable ref — populated after memoryIndexer is created (below), so deep_search
   // can retrieve past investigations and persist new ones.
@@ -351,7 +355,7 @@ export async function createSiclawSession(
     createNetnsScriptTool(kubeconfigRef),
     createPodExecTool(kubeconfigRef),
     createPodNsenterExecTool(kubeconfigRef),
-    createRunSkillTool(kubeconfigRef),
+    createRunSkillTool(kubeconfigRef, sessionIdRef),
     createManageScheduleTool(kubeconfigRef),
     createDeepSearchTool(kubeconfigRef, llmConfigRef, memoryRef),
     createCredentialListTool(kubeconfigRef),
@@ -628,6 +632,7 @@ Follow the structured workflow described in the deep-investigation skill guide.`
       mode,
       mcpManager,
       dpState,
+      sessionIdRef,
     };
   }
 
@@ -686,5 +691,5 @@ Follow the structured workflow described in the deep-investigation skill guide.`
   });
 
   const brain: BrainSession = new PiAgentBrain(session);
-  return { brain, session, modelFallbackMessage, customTools, kubeconfigRef, llmConfigRef, skillsDirs, mode, mcpManager, memoryIndexer };
+  return { brain, session, modelFallbackMessage, customTools, kubeconfigRef, llmConfigRef, skillsDirs, mode, mcpManager, memoryIndexer, sessionIdRef };
 }

--- a/src/gateway/db/init-schema.ts
+++ b/src/gateway/db/init-schema.ts
@@ -348,6 +348,23 @@ const DDL_STATEMENTS = [
     FOREIGN KEY (created_by) REFERENCES users(id)
   )`,
 
+  `CREATE TABLE IF NOT EXISTS session_stats (
+    id VARCHAR(64) PRIMARY KEY,
+    session_id VARCHAR(64) NOT NULL,
+    user_id VARCHAR(32) NOT NULL,
+    provider VARCHAR(64),
+    model VARCHAR(128),
+    input_tokens INT DEFAULT 0,
+    output_tokens INT DEFAULT 0,
+    cache_read_tokens INT DEFAULT 0,
+    cache_write_tokens INT DEFAULT 0,
+    duration_ms INT DEFAULT 0,
+    prompt_count INT DEFAULT 0,
+    tool_call_count INT DEFAULT 0,
+    skill_call_count INT DEFAULT 0,
+    created_at BIGINT NOT NULL
+  )`,
+
 ];
 
 // Indexes — handled separately since MySQL lacks CREATE INDEX IF NOT EXISTS
@@ -366,6 +383,8 @@ const INDEX_STATEMENTS = [
   `ALTER TABLE skill_versions ADD INDEX idx_skill_versions_skill (skill_id, version)`,
   `ALTER TABLE skill_contents ADD INDEX idx_skill_contents_skill (skill_id)`,
   `ALTER TABLE credentials ADD INDEX idx_credentials_user (user_id, type)`,
+  `ALTER TABLE session_stats ADD INDEX idx_session_stats_created (created_at)`,
+  `ALTER TABLE session_stats ADD INDEX idx_session_stats_user (user_id, created_at)`,
 ];
 
 export async function initSchema(db: Database): Promise<void> {

--- a/src/gateway/db/migrate-sqlite.ts
+++ b/src/gateway/db/migrate-sqlite.ts
@@ -316,6 +316,7 @@ const DDL_STATEMENTS = [
     duration_ms       INTEGER DEFAULT 0,
     prompt_count      INTEGER DEFAULT 0,
     tool_call_count   INTEGER DEFAULT 0,
+    skill_call_count  INTEGER DEFAULT 0,
     created_at        INTEGER NOT NULL
   )`,
 
@@ -369,6 +370,13 @@ export async function runSqliteMigrations(db: Database): Promise<void> {
 
   for (const ddl of INDEX_STATEMENTS) {
     sdb.run(sql.raw(ddl));
+  }
+
+  // Column migrations (idempotent — ignore if column already exists)
+  try {
+    sdb.run(sql.raw("ALTER TABLE session_stats ADD COLUMN skill_call_count INTEGER DEFAULT 0"));
+  } catch {
+    // Column already exists (re-run of migration)
   }
 
   // Trigger: auto-update updated_at on mcp_servers UPDATE (mirrors MySQL ON UPDATE CURRENT_TIMESTAMP)

--- a/src/gateway/db/migrate-sqlite.ts
+++ b/src/gateway/db/migrate-sqlite.ts
@@ -372,13 +372,6 @@ export async function runSqliteMigrations(db: Database): Promise<void> {
     sdb.run(sql.raw(ddl));
   }
 
-  // Column migrations (idempotent — ignore if column already exists)
-  try {
-    sdb.run(sql.raw("ALTER TABLE session_stats ADD COLUMN skill_call_count INTEGER DEFAULT 0"));
-  } catch {
-    // Column already exists (re-run of migration)
-  }
-
   // Trigger: auto-update updated_at on mcp_servers UPDATE (mirrors MySQL ON UPDATE CURRENT_TIMESTAMP)
   sdb.run(sql.raw(`
     CREATE TRIGGER IF NOT EXISTS trg_mcp_servers_updated_at

--- a/src/gateway/db/schema-mysql.ts
+++ b/src/gateway/db/schema-mysql.ts
@@ -424,6 +424,7 @@ export const sessionStats = mysqlTable("session_stats", {
   durationMs: int("duration_ms").default(0),
   promptCount: int("prompt_count").default(0),
   toolCallCount: int("tool_call_count").default(0),
+  skillCallCount: int("skill_call_count").default(0),
   createdAt: bigint("created_at", { mode: "number" }).notNull(),
 });
 

--- a/src/gateway/db/schema-sqlite.ts
+++ b/src/gateway/db/schema-sqlite.ts
@@ -410,6 +410,7 @@ export const sessionStats = sqliteTable("session_stats", {
   durationMs: integer("duration_ms").default(0),
   promptCount: integer("prompt_count").default(0),
   toolCallCount: integer("tool_call_count").default(0),
+  skillCallCount: integer("skill_call_count").default(0),
   createdAt: integer("created_at").notNull(),
 });
 

--- a/src/gateway/metrics-aggregator.ts
+++ b/src/gateway/metrics-aggregator.ts
@@ -16,6 +16,7 @@ import { onDiagnostic } from "../shared/diagnostic-events.js";
 import {
   type MetricsBucket,
   type ToolCallStats,
+  type SkillCallStats,
   type SessionStatsRecord,
   type MetricsSnapshot,
   createEmptyBucket,
@@ -30,6 +31,7 @@ export interface LocalCollectorRef {
   query(range: "1h" | "6h" | "24h"): MetricsBucket[];
   snapshot(): { activeSessions: number; wsConnections: number };
   topTools(n: number): ToolCallStats[];
+  topSkills(n: number): SkillCallStats[];
   drainSessionStats(): SessionStatsRecord[];
 }
 
@@ -46,6 +48,12 @@ export interface SnapshotFetcher {
 export class MetricsAggregator {
   private ringBuffer = new Map<number, MetricsBucket>();
   private toolCallMap = new Map<string, { success: number; error: number }>();
+  private skillCallMap = new Map<string, {
+    scope: "builtin" | "team" | "personal";
+    success: number;
+    error: number;
+    totalDurationMs: number;
+  }>();
   private wsConnections = 0;
   private pullTimer?: ReturnType<typeof setInterval>;
   private db?: Database;
@@ -138,6 +146,27 @@ export class MetricsAggregator {
     return result.slice(0, n);
   }
 
+  topSkills(n: number): SkillCallStats[] {
+    if (this.mode === "local" && this.localRef) {
+      return this.localRef.topSkills(n);
+    }
+
+    return [...this.skillCallMap.entries()]
+      .map(([skillName, v]) => {
+        const total = v.success + v.error;
+        return {
+          skillName,
+          scope: v.scope,
+          success: v.success,
+          error: v.error,
+          total,
+          avgDurationMs: total > 0 ? Math.round(v.totalDurationMs / total) : 0,
+        };
+      })
+      .sort((a, b) => b.total - a.total)
+      .slice(0, n);
+  }
+
   // ── K8s pull loop ──
 
   private startPullLoop(): void {
@@ -181,6 +210,8 @@ export class MetricsAggregator {
         existing.activeSessions += bucket.activeSessions;
         existing.toolCalls += bucket.toolCalls;
         existing.toolErrors += bucket.toolErrors;
+        existing.skillSuccesses += bucket.skillSuccesses;
+        existing.skillErrors += bucket.skillErrors;
       } else {
         this.ringBuffer.set(bucket.timestamp, { ...bucket });
       }
@@ -203,6 +234,24 @@ export class MetricsAggregator {
         existing.error += delta.error;
       } else {
         this.toolCallMap.set(delta.toolName, { success: delta.success, error: delta.error });
+      }
+    }
+
+    // Merge skill call deltas
+    for (const delta of snapshot.skillCallDeltas) {
+      const totalDelta = delta.success + delta.error;
+      const existing = this.skillCallMap.get(delta.skillName);
+      if (existing) {
+        existing.success += delta.success;
+        existing.error += delta.error;
+        existing.totalDurationMs += delta.avgDurationMs * totalDelta;
+      } else {
+        this.skillCallMap.set(delta.skillName, {
+          scope: delta.scope,
+          success: delta.success,
+          error: delta.error,
+          totalDurationMs: delta.avgDurationMs * totalDelta,
+        });
       }
     }
 
@@ -230,6 +279,7 @@ export class MetricsAggregator {
         durationMs: record.durationMs,
         promptCount: record.promptCount,
         toolCallCount: record.toolCallCount,
+        skillCallCount: record.skillCallCount,
         createdAt: record.createdAt,
       });
     } catch (err) {

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -3654,7 +3654,7 @@ export function createRpcMethods(
 
   methods.set("metrics.timeseries", async (params, context: RpcContext) => {
     requireAuth(context);
-    if (!metricsAggregator) return { buckets: [], snapshot: { activeSessions: 0, wsConnections: 0 }, topTools: [] };
+    if (!metricsAggregator) return { buckets: [], snapshot: { activeSessions: 0, wsConnections: 0 }, topTools: [], topSkills: [] };
 
     const range = (params.range as string) || "1h";
     if (range !== "1h" && range !== "6h" && range !== "24h") {
@@ -3678,12 +3678,15 @@ export function createRpcMethods(
       wsConnections: b.wsConnections,
       toolCalls: b.toolCalls,
       toolErrors: b.toolErrors,
+      skillSuccesses: b.skillSuccesses,
+      skillErrors: b.skillErrors,
     }));
 
     return {
       buckets,
       snapshot: metricsAggregator.snapshot(),
       topTools: metricsAggregator.topTools(10),
+      topSkills: metricsAggregator.topSkills(10),
     };
   });
 

--- a/src/gateway/web/src/pages/Metrics/DashboardTab.tsx
+++ b/src/gateway/web/src/pages/Metrics/DashboardTab.tsx
@@ -4,6 +4,7 @@ import { TokenChart } from './TokenChart';
 import { LatencyChart } from './LatencyChart';
 import { SessionsChart } from './SessionsChart';
 import { ToolCallsPanel } from './ToolCallsPanel';
+import { SkillCallsPanel } from './SkillCallsPanel';
 import { CumulativePanel } from './CumulativePanel';
 
 interface DashboardTabProps {
@@ -24,6 +25,7 @@ export function DashboardTab({ data, range, loading }: DashboardTabProps) {
     const buckets = data?.buckets ?? [];
     const snapshot = data?.snapshot ?? { activeSessions: 0, wsConnections: 0 };
     const topTools = data?.topTools ?? [];
+    const topSkills = data?.topSkills ?? [];
 
     return (
         <div className="flex-1 overflow-y-auto">
@@ -37,13 +39,16 @@ export function DashboardTab({ data, range, loading }: DashboardTabProps) {
                     <LatencyChart buckets={buckets} />
                 </div>
 
-                {/* Row 3: Sessions & Connections + Tool Calls Top 10 */}
+                {/* Row 3: Tool Calls + Skill Calls (side by side) */}
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <SessionsChart buckets={buckets} />
                     <ToolCallsPanel topTools={topTools} />
+                    <SkillCallsPanel topSkills={topSkills} />
                 </div>
 
-                {/* Row 4: Cumulative Statistics (full width) */}
+                {/* Row 4: Sessions & Connections (full width) */}
+                <SessionsChart buckets={buckets} />
+
+                {/* Row 5: Cumulative Statistics (full width) */}
                 <CumulativePanel />
             </div>
         </div>

--- a/src/gateway/web/src/pages/Metrics/KpiCards.tsx
+++ b/src/gateway/web/src/pages/Metrics/KpiCards.tsx
@@ -1,4 +1,4 @@
-import { Zap, MessageSquare, Wrench, Users } from 'lucide-react';
+import { Zap, MessageSquare, Wrench, LayoutGrid, Users } from 'lucide-react';
 import type { TimeseriesBucket, TimeRange } from './hooks/useMetrics';
 
 interface KpiCardsProps {
@@ -41,8 +41,12 @@ export function KpiCards({ buckets, snapshot, range }: KpiCardsProps) {
     const toolErrors = buckets.reduce((s, b) => s + b.toolErrors, 0);
     const toolTrend = getTrend(buckets, (b) => b.toolCalls + b.toolErrors);
 
+    const totalSkillCalls = buckets.reduce((s, b) => s + b.skillSuccesses + b.skillErrors, 0);
+    const skillErrors = buckets.reduce((s, b) => s + b.skillErrors, 0);
+    const skillErrorRate = totalSkillCalls > 0 ? ((skillErrors / totalSkillCalls) * 100).toFixed(1) : '0';
+
     return (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
             {/* Total Tokens */}
             <div className="rounded-2xl border border-gray-200 bg-white p-5">
                 <div className="flex items-center justify-between mb-3">
@@ -97,6 +101,29 @@ export function KpiCards({ buckets, snapshot, range }: KpiCardsProps) {
                         <span className="text-xs text-red-500 font-medium">{toolErrors} errors</span>
                     ) : toolTrend ? (
                         <span className={`text-xs font-medium ${toolTrend.color}`}>{toolTrend.label}</span>
+                    ) : (
+                        <span className="text-xs text-gray-400">No data</span>
+                    )}
+                </div>
+            </div>
+
+            {/* Skill Calls */}
+            <div className="rounded-2xl border border-gray-200 bg-white p-5">
+                <div className="flex items-center justify-between mb-3">
+                    <span className="text-sm text-gray-500">Skill Calls</span>
+                    <div className="w-8 h-8 rounded-lg bg-purple-50 flex items-center justify-center">
+                        <LayoutGrid className="w-4 h-4 text-purple-600" />
+                    </div>
+                </div>
+                <div className="text-2xl font-bold text-gray-900">{totalSkillCalls}</div>
+                <div className="flex items-center gap-1 mt-1">
+                    {skillErrors > 0 ? (
+                        <>
+                            <span className="text-xs text-red-500 font-medium">{skillErrors} errors</span>
+                            <span className="text-xs text-gray-400 ml-1">({skillErrorRate}%)</span>
+                        </>
+                    ) : totalSkillCalls > 0 ? (
+                        <span className="text-xs text-green-600 font-medium">No errors</span>
                     ) : (
                         <span className="text-xs text-gray-400">No data</span>
                     )}

--- a/src/gateway/web/src/pages/Metrics/SkillCallsPanel.tsx
+++ b/src/gateway/web/src/pages/Metrics/SkillCallsPanel.tsx
@@ -32,7 +32,9 @@ export function SkillCallsPanel({ topSkills }: SkillCallsPanelProps) {
 
     // Scope aggregation for distribution bar
     const byScope = { builtin: 0, team: 0, personal: 0 };
-    for (const s of topSkills) byScope[s.scope] += s.total;
+    for (const s of topSkills) {
+        if (s.scope in byScope) byScope[s.scope as keyof typeof byScope] += s.total;
+    }
 
     return (
         <div className="rounded-2xl border border-gray-200 bg-white p-5">

--- a/src/gateway/web/src/pages/Metrics/SkillCallsPanel.tsx
+++ b/src/gateway/web/src/pages/Metrics/SkillCallsPanel.tsx
@@ -1,0 +1,117 @@
+import type { SkillCallStats } from './hooks/useMetrics';
+
+interface SkillCallsPanelProps {
+    topSkills: SkillCallStats[];
+}
+
+const SCOPE_STYLES: Record<string, string> = {
+    builtin: 'bg-blue-100 text-blue-800',
+    team: 'bg-amber-100 text-amber-800',
+    personal: 'bg-purple-100 text-purple-800',
+};
+
+const SCOPE_LABELS: Record<string, string> = {
+    builtin: 'core',
+    team: 'team',
+    personal: 'personal',
+};
+
+function ScopeBadge({ scope }: { scope: string }) {
+    return (
+        <span
+            className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${SCOPE_STYLES[scope] ?? 'bg-gray-100 text-gray-600'}`}
+        >
+            {SCOPE_LABELS[scope] ?? scope}
+        </span>
+    );
+}
+
+export function SkillCallsPanel({ topSkills }: SkillCallsPanelProps) {
+    const totalCalls = topSkills.reduce((s, t) => s + t.total, 0);
+    const maxTotal = topSkills.length > 0 ? topSkills[0].total : 0;
+
+    // Scope aggregation for distribution bar
+    const byScope = { builtin: 0, team: 0, personal: 0 };
+    for (const s of topSkills) byScope[s.scope] += s.total;
+
+    return (
+        <div className="rounded-2xl border border-gray-200 bg-white p-5">
+            <div className="flex items-center justify-between mb-4">
+                <div className="text-sm font-semibold text-gray-900">Skill Calls Top 10</div>
+                <div className="text-xs text-gray-400">{totalCalls} total</div>
+            </div>
+
+            {topSkills.length === 0 ? (
+                <div className="text-sm text-gray-400 text-center py-8">No skill calls yet</div>
+            ) : (
+                <>
+                    <div className="space-y-2">
+                        {topSkills.map((skill) => {
+                            const pct = maxTotal > 0 ? (skill.total / maxTotal) * 100 : 0;
+                            return (
+                                <div key={skill.skillName} className="flex items-center gap-3">
+                                    <div className="w-32 truncate font-mono text-xs text-gray-600" title={skill.skillName}>
+                                        {skill.skillName}
+                                    </div>
+                                    <div className="flex-1 bg-gray-100 rounded-md h-6 relative overflow-hidden">
+                                        <div
+                                            className="absolute inset-y-0 left-0 bg-purple-100 rounded-md"
+                                            style={{ width: `${pct}%` }}
+                                        />
+                                        <div className="absolute inset-0 flex items-center px-2">
+                                            <span className="text-xs font-medium text-purple-700">{skill.total}</span>
+                                            {skill.error > 0 && (
+                                                <span className="text-xs text-red-400 ml-1">{skill.error} err</span>
+                                            )}
+                                            <span className="ml-auto">
+                                                <ScopeBadge scope={skill.scope} />
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    {/* Scope distribution bar */}
+                    <div className="mt-4 pt-3 border-t border-gray-100">
+                        <div className="flex items-center gap-3 text-xs">
+                            <span className="text-gray-400">By scope:</span>
+                            {byScope.builtin > 0 && (
+                                <span className="flex items-center gap-1">
+                                    <span className="w-2 h-2 rounded-full bg-blue-300" />
+                                    core <span className="font-medium text-gray-700">{byScope.builtin}</span>
+                                </span>
+                            )}
+                            {byScope.team > 0 && (
+                                <span className="flex items-center gap-1">
+                                    <span className="w-2 h-2 rounded-full bg-amber-300" />
+                                    team <span className="font-medium text-gray-700">{byScope.team}</span>
+                                </span>
+                            )}
+                            {byScope.personal > 0 && (
+                                <span className="flex items-center gap-1">
+                                    <span className="w-2 h-2 rounded-full bg-purple-300" />
+                                    personal <span className="font-medium text-gray-700">{byScope.personal}</span>
+                                </span>
+                            )}
+                        </div>
+                        {totalCalls > 0 && (
+                            <div className="flex h-1.5 mt-2 rounded-full overflow-hidden bg-gray-100">
+                                {byScope.builtin > 0 && (
+                                    <div className="bg-blue-300" style={{ width: `${(byScope.builtin / totalCalls) * 100}%` }} />
+                                )}
+                                {byScope.team > 0 && (
+                                    <div className="bg-amber-300" style={{ width: `${(byScope.team / totalCalls) * 100}%` }} />
+                                )}
+                                {byScope.personal > 0 && (
+                                    <div className="bg-purple-300" style={{ width: `${(byScope.personal / totalCalls) * 100}%` }} />
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/gateway/web/src/pages/Metrics/hooks/useMetrics.ts
+++ b/src/gateway/web/src/pages/Metrics/hooks/useMetrics.ts
@@ -15,6 +15,8 @@ export interface TimeseriesBucket {
     wsConnections: number;
     toolCalls: number;
     toolErrors: number;
+    skillSuccesses: number;
+    skillErrors: number;
 }
 
 export interface ToolCallStats {
@@ -24,10 +26,20 @@ export interface ToolCallStats {
     total: number;
 }
 
+export interface SkillCallStats {
+    skillName: string;
+    scope: 'builtin' | 'team' | 'personal';
+    success: number;
+    error: number;
+    total: number;
+    avgDurationMs: number;
+}
+
 export interface TimeseriesResponse {
     buckets: TimeseriesBucket[];
     snapshot: { activeSessions: number; wsConnections: number };
     topTools: ToolCallStats[];
+    topSkills: SkillCallStats[];
 }
 
 export interface SummaryResponse {

--- a/src/shared/__tests__/local-collector.test.ts
+++ b/src/shared/__tests__/local-collector.test.ts
@@ -98,6 +98,134 @@ describe("LocalCollector", () => {
     expect(localCollector.snapshot().wsConnections).toBe(before);
   });
 
+  it("should track skill calls", () => {
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "k8s-diagnostics",
+      scriptName: "check-pods",
+      scope: "builtin",
+      outcome: "success",
+      durationMs: 1500,
+      sessionId: "s-skill-1",
+    });
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "k8s-diagnostics",
+      scriptName: "check-pods",
+      scope: "builtin",
+      outcome: "error",
+      durationMs: 500,
+      sessionId: "s-skill-1",
+    });
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "my-custom-skill",
+      scriptName: "run",
+      scope: "personal",
+      outcome: "success",
+      durationMs: 300,
+    });
+
+    const skills = localCollector.topSkills(10);
+    const k8s = skills.find((s) => s.skillName === "k8s-diagnostics");
+    expect(k8s).toBeDefined();
+    expect(k8s!.success).toBeGreaterThanOrEqual(1);
+    expect(k8s!.error).toBeGreaterThanOrEqual(1);
+    expect(k8s!.scope).toBe("builtin");
+    expect(k8s!.avgDurationMs).toBeGreaterThan(0);
+
+    const custom = skills.find((s) => s.skillName === "my-custom-skill");
+    expect(custom).toBeDefined();
+    expect(custom!.scope).toBe("personal");
+    expect(custom!.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should accumulate skill calls into buckets", () => {
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "test-skill",
+      scriptName: "run",
+      scope: "team",
+      outcome: "success",
+      durationMs: 100,
+    });
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "test-skill",
+      scriptName: "run",
+      scope: "team",
+      outcome: "error",
+      durationMs: 200,
+    });
+
+    const buckets = localCollector.query("1h");
+    expect(buckets.length).toBeGreaterThanOrEqual(1);
+    const last = buckets[buckets.length - 1];
+    expect(last.skillSuccesses).toBeGreaterThanOrEqual(1);
+    expect(last.skillErrors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should include skillCallCount in session stats", () => {
+    const sid = "s-skill-session-1";
+    emitDiagnostic({ type: "session_created", sessionId: sid });
+
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "some-skill",
+      scriptName: "run",
+      scope: "builtin",
+      outcome: "success",
+      durationMs: 100,
+      sessionId: sid,
+    });
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "some-skill",
+      scriptName: "run",
+      scope: "builtin",
+      outcome: "success",
+      durationMs: 100,
+      sessionId: sid,
+    });
+
+    emitDiagnostic({
+      type: "session_released",
+      sessionId: sid,
+      stats: makeStats(100, 50, 0.01),
+      userId: "user1",
+      model: testModel,
+      createdAt: Date.now() - 30000,
+    });
+
+    const records = localCollector.drainSessionStats();
+    const record = records.find((r) => r.sessionId === sid);
+    expect(record).toBeDefined();
+    expect(record!.skillCallCount).toBe(2);
+  });
+
+  it("should include skillCallDeltas in exported snapshot", () => {
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "snapshot-skill",
+      scriptName: "run",
+      scope: "team",
+      outcome: "success",
+      durationMs: 250,
+    });
+
+    const snapshot = localCollector.exportSnapshot();
+    expect(snapshot.skillCallDeltas).toBeDefined();
+    const entry = snapshot.skillCallDeltas.find((s) => s.skillName === "snapshot-skill");
+    expect(entry).toBeDefined();
+    expect(entry!.total).toBe(1);
+    expect(entry!.avgDurationMs).toBe(250);
+
+    // After export, skillCallMap should be cleared — next export should not contain it
+    const snapshot2 = localCollector.exportSnapshot();
+    const entry2 = snapshot2.skillCallDeltas.find((s) => s.skillName === "snapshot-skill");
+    expect(entry2).toBeUndefined();
+  });
+
   it("should export snapshot with only completed minute buckets", () => {
     // Emit an event to ensure current minute has data
     emitDiagnostic({

--- a/src/shared/__tests__/metrics.test.ts
+++ b/src/shared/__tests__/metrics.test.ts
@@ -98,6 +98,44 @@ describe("metrics subscriber", () => {
     expect(output).toContain("siclaw_ws_connections 1");
   });
 
+  it("should track skill calls by name, scope, and outcome", async () => {
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "k8s-diagnostics",
+      scriptName: "check-pods",
+      scope: "builtin",
+      outcome: "success",
+      durationMs: 1200,
+    });
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "k8s-diagnostics",
+      scriptName: "check-pods",
+      scope: "builtin",
+      outcome: "error",
+      durationMs: 500,
+    });
+    emitDiagnostic({
+      type: "skill_call",
+      skillName: "custom-tool",
+      scriptName: "run",
+      scope: "personal",
+      outcome: "success",
+      durationMs: 300,
+    });
+
+    const output = await metricsRegistry.metrics();
+    // Full-label counter
+    expect(output).toContain('siclaw_skill_calls_total{skill_name="k8s-diagnostics",scope="builtin",outcome="success"} 1');
+    expect(output).toContain('siclaw_skill_calls_total{skill_name="k8s-diagnostics",scope="builtin",outcome="error"} 1');
+    expect(output).toContain('siclaw_skill_calls_total{skill_name="custom-tool",scope="personal",outcome="success"} 1');
+
+    // Low-cardinality scope counter
+    expect(output).toContain('siclaw_skill_calls_by_scope_total{scope="builtin",outcome="success"} 1');
+    expect(output).toContain('siclaw_skill_calls_by_scope_total{scope="builtin",outcome="error"} 1');
+    expect(output).toContain('siclaw_skill_calls_by_scope_total{scope="personal",outcome="success"} 1');
+  });
+
   it("should track context usage (Phase 2)", async () => {
     emitDiagnostic({
       type: "context_usage",

--- a/src/shared/diagnostic-events.ts
+++ b/src/shared/diagnostic-events.ts
@@ -54,6 +54,16 @@ export type DiagnosticEvent =
       tokensUsed: number;
       tokensLimit: number;
     }
+  // Skill execution (Skill Metrics)
+  | {
+      type: "skill_call";
+      skillName: string;
+      scriptName: string;
+      scope: "builtin" | "team" | "personal";
+      outcome: "success" | "error";
+      durationMs: number;
+      sessionId?: string;
+    }
   // Stuck session detection (Phase 2)
   | { type: "session_stuck"; sessionId: string; idleMs: number };
 

--- a/src/shared/local-collector.ts
+++ b/src/shared/local-collector.ts
@@ -15,6 +15,7 @@ import { onDiagnostic, type DiagnosticEvent } from "./diagnostic-events.js";
 import {
   type MetricsBucket,
   type ToolCallStats,
+  type SkillCallStats,
   type SessionStatsRecord,
   type MetricsSnapshot,
   createEmptyBucket,
@@ -29,7 +30,13 @@ function minuteTs(now?: number): number {
 class LocalCollector {
   private ringBuffer = new Map<number, MetricsBucket>();
   private toolCallMap = new Map<string, { success: number; error: number }>();
-  private perSessionCounters = new Map<string, { prompts: number; tools: number }>();
+  private skillCallMap = new Map<string, {
+    scope: "builtin" | "team" | "personal";
+    success: number;
+    error: number;
+    totalDurationMs: number;
+  }>();
+  private perSessionCounters = new Map<string, { prompts: number; tools: number; skills: number }>();
   private sessionStatsQueue: SessionStatsRecord[] = [];
 
   private currentSessions = 0;
@@ -76,7 +83,7 @@ class LocalCollector {
         this.currentSessions++;
         const bucket = this.getOrCreateBucket();
         bucket.activeSessions = this.currentSessions;
-        this.perSessionCounters.set(event.sessionId, { prompts: 0, tools: 0 });
+        this.perSessionCounters.set(event.sessionId, { prompts: 0, tools: 0, skills: 0 });
         break;
       }
 
@@ -101,6 +108,7 @@ class LocalCollector {
           durationMs: Date.now() - event.createdAt,
           promptCount: counters?.prompts ?? 0,
           toolCallCount: counters?.tools ?? 0,
+          skillCallCount: counters?.skills ?? 0,
           createdAt: event.createdAt,
         };
         this.sessionStatsQueue.push(record);
@@ -133,6 +141,36 @@ class LocalCollector {
         for (const sc of this.perSessionCounters.values()) {
           sc.tools++;
           break; // increment first (most recent) only
+        }
+        break;
+      }
+
+      case "skill_call": {
+        const bucket = this.getOrCreateBucket();
+        if (event.outcome === "error") {
+          bucket.skillErrors++;
+        } else {
+          bucket.skillSuccesses++;
+        }
+
+        // Per-skill cumulative
+        const key = event.skillName;
+        let skillEntry = this.skillCallMap.get(key);
+        if (!skillEntry) {
+          skillEntry = { scope: event.scope, success: 0, error: 0, totalDurationMs: 0 };
+          this.skillCallMap.set(key, skillEntry);
+        }
+        if (event.outcome === "error") {
+          skillEntry.error++;
+        } else {
+          skillEntry.success++;
+        }
+        skillEntry.totalDurationMs += event.durationMs;
+
+        // Per-session counter (skill_call carries sessionId for precise matching)
+        if (event.sessionId) {
+          const sc = this.perSessionCounters.get(event.sessionId);
+          if (sc) sc.skills++;
         }
         break;
       }
@@ -216,6 +254,24 @@ class LocalCollector {
     return result.slice(0, n);
   }
 
+  /** Return skill call rankings, sorted by total descending, top N */
+  topSkills(n: number): SkillCallStats[] {
+    return [...this.skillCallMap.entries()]
+      .map(([skillName, v]) => {
+        const total = v.success + v.error;
+        return {
+          skillName,
+          scope: v.scope,
+          success: v.success,
+          error: v.error,
+          total,
+          avgDurationMs: total > 0 ? Math.round(v.totalDurationMs / total) : 0,
+        };
+      })
+      .sort((a, b) => b.total - a.total)
+      .slice(0, n);
+  }
+
   /**
    * Drain the session stats queue — returns all pending records and clears the queue.
    * Used by MetricsAggregator in Local mode to consume and write to DB.
@@ -253,6 +309,10 @@ class LocalCollector {
     const toolCallDeltas = this.topTools(Infinity);
     this.toolCallMap.clear();
 
+    // Skill call deltas: export current totals, then reset for next interval
+    const skillCallDeltas = this.topSkills(Infinity);
+    this.skillCallMap.clear();
+
     const sessionStats = this.sessionStatsQueue.splice(0);
 
     return {
@@ -260,6 +320,7 @@ class LocalCollector {
       activeSessions: this.currentSessions,
       sessionStats,
       toolCallDeltas,
+      skillCallDeltas,
     };
   }
 }

--- a/src/shared/metrics-types.ts
+++ b/src/shared/metrics-types.ts
@@ -19,6 +19,8 @@ export interface MetricsBucket {
   wsConnections: number;      // last sampled value (only meaningful on Gateway side)
   toolCalls: number;
   toolErrors: number;
+  skillSuccesses: number;
+  skillErrors: number;
 }
 
 /** Tool call ranking entry */
@@ -27,6 +29,16 @@ export interface ToolCallStats {
   success: number;
   error: number;
   total: number;
+}
+
+/** Skill call ranking entry */
+export interface SkillCallStats {
+  skillName: string;
+  scope: "builtin" | "team" | "personal";
+  success: number;
+  error: number;
+  total: number;
+  avgDurationMs: number;
 }
 
 /** Session stats record — written to Gateway DB when a session is released */
@@ -42,6 +54,7 @@ export interface SessionStatsRecord {
   durationMs: number;         // wall-clock time (created → released)
   promptCount: number;
   toolCallCount: number;
+  skillCallCount: number;
   createdAt: number;          // session creation timestamp (Unix ms)
 }
 
@@ -51,6 +64,7 @@ export interface MetricsSnapshot {
   activeSessions: number;
   sessionStats: SessionStatsRecord[];
   toolCallDeltas: ToolCallStats[];
+  skillCallDeltas: SkillCallStats[];
 }
 
 export function createEmptyBucket(timestamp: number): MetricsBucket {
@@ -68,5 +82,7 @@ export function createEmptyBucket(timestamp: number): MetricsBucket {
     wsConnections: 0,
     toolCalls: 0,
     toolErrors: 0,
+    skillSuccesses: 0,
+    skillErrors: 0,
   };
 }

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -86,6 +86,22 @@ const wsConnections = new Gauge({
   registers: [metricsRegistry],
 });
 
+// ── Skill metrics ──
+
+const skillCallsTotal = new Counter({
+  name: "siclaw_skill_calls_total",
+  help: "Total skill invocations",
+  labelNames: ["skill_name", "scope", "outcome"] as const,
+  registers: [metricsRegistry],
+});
+
+const skillCallsByScopeTotal = new Counter({
+  name: "siclaw_skill_calls_by_scope_total",
+  help: "Total skill invocations aggregated by scope (low-cardinality fallback)",
+  labelNames: ["scope", "outcome"] as const,
+  registers: [metricsRegistry],
+});
+
 // ── Phase 2: Session health metrics (4) ──
 
 const contextTokensUsed = new Gauge({
@@ -160,6 +176,18 @@ function handleDiagnostic(event: DiagnosticEvent): void {
 
     case "tool_call":
       toolCallsTotal.inc({ tool_name: event.toolName, outcome: event.outcome });
+      break;
+
+    case "skill_call":
+      skillCallsTotal.inc({
+        skill_name: event.skillName,
+        scope: event.scope,
+        outcome: event.outcome,
+      });
+      skillCallsByScopeTotal.inc({
+        scope: event.scope,
+        outcome: event.outcome,
+      });
       break;
 
     case "ws_connected":

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -87,6 +87,9 @@ const wsConnections = new Gauge({
 });
 
 // ── Skill metrics ──
+// NOTE: siclaw_skill_calls_total uses skill_name label which is unbounded.
+// If personal skill count grows large, consider dropping this counter and
+// relying solely on the low-cardinality siclaw_skill_calls_by_scope_total.
 
 const skillCallsTotal = new Counter({
   name: "siclaw_skill_calls_total",

--- a/src/tools/run-skill.ts
+++ b/src/tools/run-skill.ts
@@ -13,6 +13,7 @@ import {
   listSkillScripts,
   listAllSkillsWithScripts,
 } from "./script-resolver.js";
+import { emitDiagnostic } from "../shared/diagnostic-events.js";
 
 interface RunSkillParams {
   skill: string;
@@ -21,7 +22,10 @@ interface RunSkillParams {
   timeout_seconds?: number;
 }
 
-export function createRunSkillTool(kubeconfigRef?: KubeconfigRef): ToolDefinition {
+export function createRunSkillTool(
+  kubeconfigRef?: KubeconfigRef,
+  sessionIdRef?: { current: string },
+): ToolDefinition {
   return {
     name: "run_skill",
     label: "Run Skill",
@@ -116,6 +120,7 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
       const cmdArgs = args ? parseArgs(args) : [];
 
       const timeout = Math.min(params.timeout_seconds ?? 180, 300) * 1000;
+      const startMs = Date.now();
 
       try {
         const child = spawn(resolved.interpreter, [resolved.path, ...cmdArgs], {
@@ -167,12 +172,30 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
 
         const output = stdout.trim() +
           (stderr.trim() ? `\n\nSTDERR:\n${stderr.trim()}` : "");
+        emitDiagnostic({
+          type: "skill_call",
+          skillName: skill,
+          scriptName: script,
+          scope: resolved.scope,
+          outcome: "success",
+          durationMs: Date.now() - startMs,
+          sessionId: sessionIdRef?.current,
+        });
         return {
           content: [{ type: "text", text: processToolOutput(output) }],
           details: { exitCode: 0 },
         };
       } catch (err: any) {
         const output = `Exit code: ${err.code ?? "unknown"}\n${err.stdout?.trim() ?? ""}\n${err.stderr?.trim() ?? err.message}`;
+        emitDiagnostic({
+          type: "skill_call",
+          skillName: skill,
+          scriptName: script,
+          scope: resolved.scope,
+          outcome: "error",
+          durationMs: Date.now() - startMs,
+          sessionId: sessionIdRef?.current,
+        });
         return {
           content: [{ type: "text", text: processToolOutput(output) }],
           details: { exitCode: err.code, error: true },

--- a/src/tools/script-resolver.ts
+++ b/src/tools/script-resolver.ts
@@ -116,7 +116,7 @@ export function skillExistsInBundle(skillName: string): boolean {
   const directDir = path.join(base, skillName);
   if (fs.existsSync(directDir) && fs.statSync(directDir).isDirectory()) return true;
   // Scope subdirectory layout
-  for (const scopeDir of ["user", "team"]) {
+  for (const scopeDir of ["user", "extension", "team"]) {
     const dir = path.join(base, scopeDir, skillName);
     if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) return true;
   }

--- a/src/tools/script-resolver.ts
+++ b/src/tools/script-resolver.ts
@@ -29,26 +29,40 @@ function loadDisabledBuiltins(): Set<string> {
  */
 const SKILL_SCOPES = ["user", "extension", "team", "core"];
 
+/** Directory entry with associated scope */
+interface ScopeDir {
+  dir: string;
+  scope: SkillScope;
+}
+
+/** Map scope directory names to SkillScope values */
+const SCOPE_MAP: Record<string, SkillScope> = {
+  user: "personal",
+  extension: "team",
+  team: "team",
+  core: "builtin",
+};
+
 /**
  * Build the list of directories to search for a specific skill's scripts.
  *
  * Priority: personal/team (bundle) > builtin (Docker image).
- * 1. Bundle-materialized (skillsBase/<skill>/) — contains personal or team
- * 2. CLI fallback: scope subdirectories (user > team > core)
+ * 1. Bundle-materialized (skillsBase/<skill>/) — legacy flat layout
+ * 2. Scope subdirectories (user > extension > team > core)
  * 3. Builtin fallback (skills/core/) — unless disabled
  */
-function getSkillScriptDirs(skill: string): string[] {
+function getSkillScriptDirs(skill: string): ScopeDir[] {
   const base = skillsBase();
 
-  // 1. Bundle-materialized skills (personal/team override builtins)
+  // 1. Legacy flat layout (bundle-materialized without scope subdirs)
   const directPath = path.join(base, skill, "scripts");
-  if (fs.existsSync(directPath)) return [directPath];
+  if (fs.existsSync(directPath)) return [{ dir: directPath, scope: "team" }];
 
-  // 2. CLI fallback: search all scope directories (user > team > core)
-  const dirs: string[] = [];
-  for (const scope of SKILL_SCOPES) {
-    const dir = path.join(base, scope, skill, "scripts");
-    if (fs.existsSync(dir)) dirs.push(dir);
+  // 2. Scope subdirectories (user > extension > team > core)
+  const dirs: ScopeDir[] = [];
+  for (const scopeName of SKILL_SCOPES) {
+    const dir = path.join(base, scopeName, skill, "scripts");
+    if (fs.existsSync(dir)) dirs.push({ dir, scope: SCOPE_MAP[scopeName] });
   }
   if (dirs.length > 0) return dirs;
 
@@ -56,7 +70,7 @@ function getSkillScriptDirs(skill: string): string[] {
   const disabled = loadDisabledBuiltins();
   if (!disabled.has(skill)) {
     const builtinPath = path.join(builtinCoreDir(), skill, "scripts");
-    if (fs.existsSync(builtinPath)) return [builtinPath];
+    if (fs.existsSync(builtinPath)) return [{ dir: builtinPath, scope: "builtin" }];
   }
 
   return [];
@@ -71,29 +85,42 @@ function getSkillScriptDirs(skill: string): string[] {
 function getSkillBaseDirs(): string[] {
   const base = skillsBase();
 
-  // 1. Bundle-materialized skills (personal/team first)
+  // 1. Legacy flat layout (bundle-materialized without scope subdirs)
   const hasDirectSkills = fs.existsSync(base) && fs.readdirSync(base).some(
     (entry) => !entry.startsWith(".") && !SKILL_SCOPES.includes(entry) &&
       fs.statSync(path.join(base, entry)).isDirectory(),
   );
   if (hasDirectSkills) {
     const dirs = [base];
-    // Builtin as fallback for skills not in the bundle
     const coreDir = builtinCoreDir();
     if (fs.existsSync(coreDir)) dirs.push(coreDir);
     return dirs;
   }
 
-  // 2. CLI fallback: search all scope directories (user > team > core)
-  return SKILL_SCOPES
+  // 2. Scope subdirectories (user > extension > team > core)
+  const dirs = SKILL_SCOPES
     .map((scope) => path.join(base, scope))
     .filter((dir) => fs.existsSync(dir));
+
+  // 3. Builtin fallback (skills/core/ from Docker image)
+  const coreDir = builtinCoreDir();
+  if (fs.existsSync(coreDir) && !dirs.includes(coreDir)) dirs.push(coreDir);
+
+  return dirs;
 }
 
 /** Check if a skill exists in the materialized bundle (personal/team) */
 export function skillExistsInBundle(skillName: string): boolean {
-  const dir = path.join(skillsBase(), skillName);
-  return fs.existsSync(dir) && fs.statSync(dir).isDirectory();
+  const base = skillsBase();
+  // Legacy flat layout
+  const directDir = path.join(base, skillName);
+  if (fs.existsSync(directDir) && fs.statSync(directDir).isDirectory()) return true;
+  // Scope subdirectory layout
+  for (const scopeDir of ["user", "team"]) {
+    const dir = path.join(base, scopeDir, skillName);
+    if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) return true;
+  }
+  return false;
 }
 
 /** Check if a skill exists as a non-disabled builtin (skills/core/) */
@@ -104,10 +131,13 @@ export function skillExistsAsBuiltin(skillName: string): boolean {
   return fs.existsSync(dir) && fs.statSync(dir).isDirectory();
 }
 
+export type SkillScope = "builtin" | "team" | "personal";
+
 export interface ResolvedScript {
   path: string;
   content: string;
   interpreter: "bash" | "python3";
+  scope: SkillScope;
 }
 
 /**
@@ -118,13 +148,14 @@ export function resolveSkillScript(
   skill: string,
   script: string,
 ): ResolvedScript | null {
-  for (const dir of getSkillScriptDirs(skill)) {
+  for (const { dir, scope } of getSkillScriptDirs(skill)) {
     const scriptPath = path.join(dir, script);
     if (fs.existsSync(scriptPath)) {
       return {
         path: scriptPath,
         content: fs.readFileSync(scriptPath, "utf-8"),
         interpreter: script.endsWith(".py") ? "python3" : "bash",
+        scope,
       };
     }
   }
@@ -136,7 +167,7 @@ export function resolveSkillScript(
  */
 export function listSkillScripts(skill: string): string[] {
   const scripts = new Set<string>();
-  for (const dir of getSkillScriptDirs(skill)) {
+  for (const { dir } of getSkillScriptDirs(skill)) {
     try {
       for (const f of fs.readdirSync(dir)) {
         if (f.endsWith(".sh") || f.endsWith(".py")) scripts.add(f);


### PR DESCRIPTION
## Summary
- Add `skill_call` diagnostic event type with scope resolution (builtin/team/personal), symmetric with existing `tool_call` metrics
- Emit skill metrics from `run-skill` tool → LocalCollector → MetricsAggregator → RPC → Frontend, plus two Prometheus counters (`siclaw_skill_calls_total` + low-cardinality `siclaw_skill_calls_by_scope_total`)
- New `SkillCallsPanel` frontend component with ranked list, scope badges, and scope distribution bar; dashboard layout updated to show Tool + Skill panels side-by-side
- Refactor `materialize()` to write scope subdirectories (`team/`, `user/`) instead of flat layout, protecting `core/` from accidental deletion
- Extend DB schema (`skill_call_count` in `session_stats`) with idempotent migration for both SQLite and MySQL
- Fix: add missing `session_stats` table DDL for MySQL (`init-schema.ts`)

## Test plan
- [x] 5 new test cases in `local-collector.test.ts` and `metrics.test.ts` — all 21 tests pass
- [x] `tsc --noEmit` passes with zero errors
- [x] Vite production build succeeds
- [ ] Manual: verify Skill Calls KPI card and SkillCallsPanel render correctly on dashboard
- [ ] Manual: trigger skill calls and confirm metrics update in real-time