### PR TITLE
fix(cron): pass workspace envId to schedule card and panel

### DIFF
--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -52,6 +52,8 @@ export interface PilotAreaProps {
     onNavigateCredentials?: () => void;
     /** Current session key — used to reset scroll position on session switch */
     sessionKey?: string | null;
+    /** Current workspace/environment ID for cron job operations */
+    selectedEnvId?: string | null;
 }
 
 /** Compute superseded status for skill messages */
@@ -151,7 +153,7 @@ function computeScheduleStatuses(messages: PilotMessage[]): Map<string, Schedule
     return statuses;
 }
 
-export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, skills, editingSkill, onEditSkill, onClearEditSkill, onSkillSaved, onOpenSkillPanel, onOpenSchedulePanel, panelMessage, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials, sessionKey }: PilotAreaProps) {
+export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, skills, editingSkill, onEditSkill, onClearEditSkill, onSkillSaved, onOpenSkillPanel, onOpenSchedulePanel, panelMessage, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials, sessionKey, selectedEnvId }: PilotAreaProps) {
     const scrollRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const prevScrollHeightRef = useRef(0);
@@ -379,6 +381,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                     dpFocus={dpFocus}
                                     onHypothesesConfirmed={onHypothesesConfirmed}
                                     hypothesesSuperseded={latestHypothesesId != null && msg.toolName === 'propose_hypotheses' && msg.id !== latestHypothesesId}
+                                    selectedEnvId={selectedEnvId}
                                 />
                             ))}
 
@@ -445,7 +448,7 @@ function parseDeepInvestigation(content: string): { isDeepInvestigation: boolean
     return { isDeepInvestigation: false, text: content };
 }
 
-function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, onHypothesesConfirmed, hypothesesSuperseded }: {
+function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, onHypothesesConfirmed, hypothesesSuperseded, selectedEnvId }: {
     message: PilotMessage;
     sendRpc?: RpcSendFn;
     skills?: Skill[];
@@ -464,6 +467,7 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
     dpFocus?: string | null;
     onHypothesesConfirmed?: (hypotheses: Array<{ id: string; text: string; confidence: number }>) => void;
     hypothesesSuperseded?: boolean;
+    selectedEnvId?: string | null;
 }) {
     const isUser = message.role === 'user';
     const isTool = message.role === 'tool';
@@ -479,7 +483,7 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
             );
         }
         if (message.toolName === 'manage_schedule' && !message.isStreaming) {
-            return <ScheduleCard message={message} status={scheduleStatus ?? 'pending'} onOpenPanel={onOpenSchedulePanel} sendRpc={sendRpc} updateMessageMeta={updateMessageMeta} />;
+            return <ScheduleCard message={message} status={scheduleStatus ?? 'pending'} onOpenPanel={onOpenSchedulePanel} sendRpc={sendRpc} updateMessageMeta={updateMessageMeta} selectedEnvId={selectedEnvId} />;
         }
         if (message.toolName === 'deep_search') {
             // In DP mode, DpChecklistCard handles the running display — hide duplicate InvestigationCard

--- a/src/gateway/web/src/pages/Pilot/components/ScheduleCard.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/ScheduleCard.tsx
@@ -79,16 +79,18 @@ export function ScheduleCard({ message, status, onOpenPanel, sendRpc, updateMess
         // ignore
     }
 
-    // Auto-execute on mount
+    // Auto-execute on mount — only for pause/resume (other actions require manual confirmation via View panel)
+    const isPauseResume = parsed?.action === 'pause' || parsed?.action === 'resume';
     useEffect(() => {
         if (!parsed || parsed.error || !sendRpc || !updateMessageMeta) return;
         if (autoExecRef.current) return;
         if (status === 'saved' || status === 'dismissed' || status === 'superseded') return;
+        if (!isPauseResume) return;
 
         autoExecRef.current = true;
         autoExecute();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [status]);
+    }, [status, isPauseResume]);
 
     const autoExecute = async () => {
         if (!parsed || !sendRpc || !updateMessageMeta) return;

--- a/src/gateway/web/src/pages/Pilot/index.tsx
+++ b/src/gateway/web/src/pages/Pilot/index.tsx
@@ -7,6 +7,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { usePilot, type PilotMessage } from '@/hooks/usePilot';
+import { useWorkspace } from '@/contexts/WorkspaceContext';
 
 
 export function PilotPage() {
@@ -14,6 +15,7 @@ export function PilotPage() {
     const [panelMessage, setPanelMessage] = useState<PilotMessage | null>(null);
     const navigate = useNavigate();
     const pilot = usePilot();
+    const { currentWorkspace } = useWorkspace();
 
     // Track which tool content we've already auto-opened the panel for
     // Uses content hash instead of message ID (IDs change when DB ID replaces temp ID)
@@ -192,6 +194,7 @@ export function PilotPage() {
                         onSkillSaved={handleSkillSaved}
                         onOpenSkillPanel={handleOpenSkillPanel}
                         onOpenSchedulePanel={handleOpenSkillPanel}
+                        selectedEnvId={currentWorkspace?.id ?? null}
                         panelMessage={panelMessage}
                         updateMessageMeta={pilot.updateMessageMeta}
                         pendingMessages={pilot.pendingMessages}
@@ -235,7 +238,7 @@ export function PilotPage() {
                             onDismiss={handlePanelDismiss}
                             onClose={() => setPanelMessage(null)}
                             updateMessageMeta={pilot.updateMessageMeta}
-                            selectedEnvId={undefined}
+                            selectedEnvId={currentWorkspace?.id ?? null}
                         />
                     );
                 }


### PR DESCRIPTION
- Pass currentWorkspace.id as selectedEnvId from WorkspaceContext to SchedulePanel and ScheduleCard, fixing "Please select an environment" error when saving cron jobs from Pilot page
- Restrict ScheduleCard auto-execute to pause/resume only, so create/update/delete/rename require manual confirmation via View panel

## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **SQLite DDL parity**: New tables added to both `schema-sqlite.ts` AND `migrate-sqlite.ts`.
- [ ] **Both brain types**: Tool changes work with pi-agent (TypeBox) and claude-sdk (MCP/Zod).

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
