### PR TITLE
fix: skill AI review — URL, spec coverage, config caching, and UX

### DIFF
--- a/src/gateway/db/repositories/skill-review-repo.ts
+++ b/src/gateway/db/repositories/skill-review-repo.ts
@@ -3,7 +3,7 @@
  */
 
 import crypto from "node:crypto";
-import { eq, desc } from "drizzle-orm";
+import { eq, and, desc } from "drizzle-orm";
 import type { Database } from "../index.js";
 import { skillReviews, type ReviewFinding } from "../schema.js";
 
@@ -53,5 +53,11 @@ export class SkillReviewRepository {
       .from(skillReviews)
       .where(eq(skillReviews.skillId, skillId))
       .orderBy(desc(skillReviews.createdAt));
+  }
+
+  async deleteAiReviewsForSkill(skillId: string) {
+    await this.db.delete(skillReviews).where(
+      and(eq(skillReviews.skillId, skillId), eq(skillReviews.reviewerType, "ai")),
+    );
   }
 }

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -2145,12 +2145,17 @@ export function createRpcMethods(
     }
 
     // 5. AI script review using staged files
+    // Clear old reviews first so the UI shows "in progress" while the new review runs
+    if (skillReviewRepo) {
+      await skillReviewRepo.deleteAiReviewsForSkill(skillId);
+    }
     let stagedFiles: SkillFiles | null = null;
     if (skillContentRepo) {
       stagedFiles = await skillContentRepo.read(skillId, "staging");
     }
-    if (stagedFiles?.scripts?.length) {
-      triggerScriptReview(skillId, meta.name, stagedFiles.scripts, stagedFiles.specs).catch(console.error);
+    if (stagedFiles?.scripts?.length || stagedFiles?.specs) {
+      // Review both scripts and specs — specs contain command templates the agent will follow
+      triggerScriptReview(skillId, meta.name, stagedFiles?.scripts ?? [], stagedFiles?.specs).catch(console.error);
     }
 
     // 6. Notify reviewers (only on first submit to avoid flooding)
@@ -2190,14 +2195,17 @@ export function createRpcMethods(
       throw new Error("This skill is not pending review");
     }
 
-    // Record reviewer decision
+    // Record reviewer decision — inherit riskLevel from the latest AI review if available
     if (skillReviewRepo) {
+      const reviews = await skillReviewRepo.listForSkill(skillId);
+      const aiReview = reviews.find((r) => r.reviewerType === "ai");
+      const riskLevel = (aiReview?.riskLevel as "low" | "medium" | "high" | "critical") ?? "low";
       await skillReviewRepo.create({
         skillId,
         version: meta.version,
         reviewerType: "admin",
         reviewerId,
-        riskLevel: "low",
+        riskLevel,
         summary: reason || (decision === "approve" ? "Approved by reviewer" : "Rejected by reviewer"),
         findings: [],
         decision,

--- a/src/gateway/skills/script-evaluator.ts
+++ b/src/gateway/skills/script-evaluator.ts
@@ -115,12 +115,10 @@ export class ScriptEvaluator {
   }
 
   private async getConfig(): Promise<LlmConfig> {
-    if (this.config === undefined) {
-      if (this.modelConfigRepo) {
-        this.config = await this.modelConfigRepo.getResolvedDefaultConfig();
-      } else {
-        this.config = null;
-      }
+    // Don't cache null results — config may become available after startup
+    if (this.config) return this.config;
+    if (this.modelConfigRepo) {
+      this.config = await this.modelConfigRepo.getResolvedDefaultConfig();
     }
     if (!this.config) throw new Error("No LLM provider configured — add one via WebUI or DB");
     return this.config;
@@ -128,7 +126,12 @@ export class ScriptEvaluator {
 
   /** Run both static and AI analysis on skill scripts */
   async evaluate(req: EvaluateRequest): Promise<ScriptReviewResult> {
-    const staticFindings = this.staticAnalysis(req.scripts);
+    // Static analysis on both scripts and specs (specs contain command templates the agent follows)
+    const allContent = [...req.scripts];
+    if (req.specs) {
+      allContent.push({ name: "skill.md", content: req.specs });
+    }
+    const staticFindings = this.staticAnalysis(allContent);
 
     try {
       return await this.aiAnalysis(req, staticFindings);
@@ -192,7 +195,7 @@ export class ScriptEvaluator {
 
     const userContent = `Review the following scripts for skill "${req.skillName}":\n\n${scriptContents}${req.specs ? `\nSkill specification:\n${req.specs}` : ""}${staticContext}`;
 
-    const resp = await fetch(`${config.baseUrl}/v1/chat/completions`, {
+    const resp = await fetch(`${config.baseUrl.replace(/\/+$/, "")}/chat/completions`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/gateway/web/src/pages/Skills/index.tsx
+++ b/src/gateway/web/src/pages/Skills/index.tsx
@@ -990,6 +990,24 @@ function ScriptReviewApprovalCard({
 
     const aiReview = reviews.find(r => r.reviewerType === 'ai');
 
+    // Poll for AI review while it's in progress (expanded + no AI review yet)
+    useEffect(() => {
+        if (!expanded || aiReview || !skill.id) return;
+        const interval = setInterval(async () => {
+            try {
+                const result = await rpcGetSkillReview(sendRpc, String(skill.id));
+                if (result?.reviews) {
+                    const ai = result.reviews.find((r: any) => r.reviewerType === 'ai');
+                    if (ai) {
+                        setReviews(result.reviews);
+                        clearInterval(interval);
+                    }
+                }
+            } catch { /* ignore */ }
+        }, 3000);
+        return () => clearInterval(interval);
+    }, [expanded, aiReview, skill.id, sendRpc]);
+
     // Scope display config
     const scopeConfig = {
         builtin: { label: 'System Skills', cls: 'bg-gray-100 text-gray-700', icon: Lock },


### PR DESCRIPTION
## Summary

- **Broken API URL**: Remove extra `/v1` prefix in script-evaluator (`baseUrl/v1/chat/completions` → `baseUrl/chat/completions`), matching all other call sites (llm-proxy, sub-agent)
- **Specs not reviewed**: Review `skill.md` content in addition to scripts — specs contain command templates the agent will follow, static analysis now also scans specs for dangerous patterns
- **Config caching bug**: Don't cache null LLM config result so review works after model provider is configured post-startup
- **Stale review on re-submit**: Clear old AI reviews on submit so UI shows "in progress" instead of stale results from previous submission
- **No auto-refresh**: Poll for AI review completion (3s interval) so results appear without manual page refresh
- **Hardcoded riskLevel**: Human review records now inherit AI risk assessment instead of always writing "low"

## Test plan

- [ ] Submit spec-only skill — AI reviews spec content (not "No scripts to review")
- [ ] Submit skill with dangerous command in spec (e.g. `kubectl delete`) — flagged as high risk
- [ ] Re-submit skill — old review clears, "AI review in progress" shown, new result auto-appears without page refresh
- [ ] Approve/reject skill — admin review record inherits AI risk level
- [ ] Configure model provider after Gateway startup, then submit skill — AI review works (no permanent "No LLM provider" failure)