### PR TITLE
refactor(settings): clean up System Settings — remove unused configs

### DIFF
--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -50,11 +50,6 @@ export class K8sSpawner implements BoxSpawner {
     this.certManager = cm;
   }
 
-  /** Update the AgentBox image at runtime (takes effect on next spawn) */
-  setImage(image: string): void {
-    this.config.image = image;
-  }
-
   /**
    * Generate Pod name
    */

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -55,13 +55,6 @@ export class AgentBoxManager {
     console.log(`[agentbox-manager] Initialized with spawner: ${spawner.name}${this.isK8s ? " (stateless, K8s API discovery)" : " (in-memory cache)"}`);
   }
 
-  /** Update the spawner's AgentBox image at runtime (takes effect on next spawn) */
-  setSpawnerImage(image: string): void {
-    if ('setImage' in this.spawner) {
-      (this.spawner as any).setImage(image);
-    }
-  }
-
   /** Inject CertificateManager into spawner (for mTLS, K8s spawner only) */
   setCertManager(cm: unknown): void {
     if ('setCertManager' in this.spawner) {

--- a/src/gateway/db/repositories/system-config-repo.ts
+++ b/src/gateway/db/repositories/system-config-repo.ts
@@ -2,7 +2,7 @@
  * System Config Repository — key/value config stored in DB.
  *
  * Used for SSO, system URLs, CA certs, etc.
- * Keys follow dotted notation: "sso.issuer", "system.baseUrl", etc.
+ * Keys follow dotted notation: "sso.issuer", "system.agentboxImage", etc.
  */
 
 import { eq, like } from "drizzle-orm";

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -3614,7 +3614,7 @@ export function createRpcMethods(
 
     const ALLOWED_SECTIONS: Record<string, string[]> = {
       sso: ["sso.enabled", "sso.issuer", "sso.clientId", "sso.clientSecret", "sso.redirectUri"],
-      system: ["system.baseUrl", "system.platformUrl", "system.agentboxImage", "system.grafanaUrl"],
+      system: ["system.grafanaUrl"],
       metrics: ["metrics.port", "metrics.token", "metrics.includeUserId"],
     };
 
@@ -3631,11 +3631,6 @@ export function createRpcMethods(
     }
 
     await sysConfigRepo.setMany(entries);
-
-    // Apply agentbox image change at runtime
-    if (section === "system" && entries["system.agentboxImage"]) {
-      agentBoxManager.setSpawnerImage(entries["system.agentboxImage"]);
-    }
 
     return { ok: true };
   });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -216,12 +216,6 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
   }
   if (db) metricsAggregator.setDb(db);
 
-  // Apply DB-stored agentbox image override (takes effect on next pod spawn)
-  if (sysConfigRepo) {
-    const img = await sysConfigRepo.get("system.agentboxImage");
-    if (img) agentBoxManager.setSpawnerImage(img);
-  }
-
   // CSP frame-src cache for Grafana iframe embedding
   let cachedFrameSrc: string | null = null;
   const refreshCspCache = async () => {

--- a/src/gateway/web/package-lock.json
+++ b/src/gateway/web/package-lock.json
@@ -78,7 +78,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1385,7 +1384,6 @@
             "integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -1408,7 +1406,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
             "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -1594,7 +1591,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2430,7 +2426,6 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -3576,7 +3571,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -3765,7 +3759,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -3778,7 +3771,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -3826,7 +3818,6 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -3954,8 +3945,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -4364,7 +4354,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4629,7 +4618,6 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",

--- a/src/gateway/web/src/pages/Settings/SettingsLayout.tsx
+++ b/src/gateway/web/src/pages/Settings/SettingsLayout.tsx
@@ -1,44 +1,5 @@
-import { NavLink, Outlet } from 'react-router-dom';
-import { User, KeyRound, Wrench } from 'lucide-react';
-import { cn } from '@/lib/utils';
-
-const tabs = [
-    { icon: User, label: 'Profile', to: '/settings', end: true },
-    { icon: KeyRound, label: 'Credentials', to: '/settings/credentials', end: false },
-    { icon: Wrench, label: 'System', to: '/settings/system', end: false },
-];
+import { Outlet } from 'react-router-dom';
 
 export function SettingsLayout() {
-    return (
-        <div className="h-full bg-white flex flex-col">
-            {/* Tab bar */}
-            <div className="border-b border-gray-200 px-6 bg-white shrink-0">
-                <nav className="flex gap-1">
-                    {tabs.map((tab) => (
-                        <NavLink
-                            key={tab.to}
-                            to={tab.to}
-                            end={tab.end}
-                            className={({ isActive }) =>
-                                cn(
-                                    "flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors -mb-px",
-                                    isActive
-                                        ? "border-primary-600 text-primary-600"
-                                        : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-                                )
-                            }
-                        >
-                            <tab.icon className="w-4 h-4" />
-                            {tab.label}
-                        </NavLink>
-                    ))}
-                </nav>
-            </div>
-
-            {/* Content */}
-            <div className="flex-1 overflow-hidden">
-                <Outlet />
-            </div>
-        </div>
-    );
+    return <Outlet />;
 }

--- a/src/gateway/web/src/pages/Settings/SystemSettings.tsx
+++ b/src/gateway/web/src/pages/Settings/SystemSettings.tsx
@@ -45,9 +45,6 @@ const SECTIONS: SectionConfig[] = [
         title: 'System Settings',
         icon: Globe,
         fields: [
-            { key: 'baseUrl', label: 'Base URL', type: 'text', placeholder: 'https://your-domain.com' },
-            { key: 'platformUrl', label: 'Platform URL', type: 'text', placeholder: 'https://your-platform-url' },
-            { key: 'agentboxImage', label: 'AgentBox Image', type: 'text', placeholder: 'siclaw-agentbox:latest' },
             { key: 'grafanaUrl', label: 'Grafana URL', type: 'text', placeholder: 'https://grafana.example.com/d/siclaw/overview?kiosk' },
         ],
     },


### PR DESCRIPTION
## Summary

- **Remove SettingsLayout tab bar**: System Settings page had an unnecessary 3-tab bar (Profile / Credentials / System). The Credentials tab even pointed to a non-existent route `/settings/credentials`. Now System renders as a plain page, consistent with other sidebar pages (Credentials, Permissions, Models, etc.)
- **Remove dead config keys**: `system.baseUrl` and `system.platformUrl` were stored in DB but never consumed by any backend code — removed from both frontend UI and RPC whitelist
- **Move agentboxImage to Helm-only**: Container image config belongs in Helm values at deploy time (`agentbox.image.registry/tag` → `SICLAW_AGENTBOX_IMAGE` env var), not in a runtime UI setting. Removed the runtime override path (`setImage`/`setSpawnerImage` methods, DB lookup on startup, RPC apply logic)

## Files changed

| File | Change |
|------|--------|
| `SettingsLayout.tsx` | Strip tab bar, render `<Outlet />` only |
| `SystemSettings.tsx` | Remove `baseUrl`, `platformUrl`, `agentboxImage` fields |
| `rpc-methods.ts` | Remove keys from `ALLOWED_SECTIONS` + runtime apply block |
| `server.ts` | Remove DB-stored image override on startup |
| `manager.ts` | Remove `setSpawnerImage()` |
| `k8s-spawner.ts` | Remove `setImage()` |
| `system-config-repo.ts` | Update doc comment |

## Test plan

- [ ] Verify System Settings page renders without tab bar
- [ ] Verify remaining configs (SSO, Grafana URL, Metrics) still save and load correctly
- [ ] Verify agentbox pods use the image from `SICLAW_AGENTBOX_IMAGE` env var (set by Helm)