### PR TITLE
fix(ui): tooltip clipped on skill review cards

### DIFF
--- a/src/gateway/web/src/pages/Skills/index.tsx
+++ b/src/gateway/web/src/pages/Skills/index.tsx
@@ -1016,7 +1016,7 @@ function ScriptReviewApprovalCard({
     }[skill.scope] || { label: skill.scope, cls: 'bg-gray-100 text-gray-600', icon: User };
 
     return (
-        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-sm transition-shadow">
+        <div className="bg-white rounded-xl border border-gray-200 hover:shadow-sm transition-shadow">
             <ConfirmDialog
                 isOpen={confirmDialog.isOpen}
                 onClose={() => setConfirmDialog(prev => ({ ...prev, isOpen: false }))}


### PR DESCRIPTION
Closes #62

## Summary

- Remove `overflow-hidden` from the `ScriptReviewApprovalCard` outer container — it was clipping tooltip popups on the top-right header icons (Eye "View in Editor", expand/collapse chevron)
- Inner elements that need overflow containment (diff viewer, script preview) already have their own `overflow-hidden`, so removing it from the card wrapper has no side effects

## Test plan

- [ ] Open Skill Review page, hover over the icons in the top-right corner of a review card
- [ ] Verify tooltip text is fully visible and not clipped
- [ ] Verify card layout and rounded corners are intact