### PR TITLE
fix(prompt): use mode-aware setup guidance for Web UI vs TUI

### DIFF
--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -24,7 +24,7 @@ export function buildSreSystemPrompt(memoryDir?: string, mode?: "cli" | "web" | 
 
 ## Environment & Configuration
 
-You are running inside a Siclaw ${mode === "cli" ? "TUI" : mode === "web" ? "Web UI" : "channel"} session. All configuration is managed through the in-session \`/setup\` command:
+You are running inside a Siclaw ${mode === "cli" ? "TUI" : mode === "web" ? "Web UI" : "channel"} session.${mode === "cli" ? ` All configuration is managed through the in-session \`/setup\` command:
 
 - **Model/Provider**: \`/setup\` → Models (add provider, add model, set default)
 - **Credentials** (kubeconfig, SSH, API token): \`/setup\` → Credentials
@@ -34,7 +34,18 @@ When users ask about "configuring environment", "setting up", or "how to get sta
 1. Call \`credential_list\` to check current credential status
 2. Guide them to use \`/setup\` for all configuration needs
 3. Do NOT suggest environment variables, manual file editing, or dev setup (npm install, etc.)
-4. You are an SRE assistant, not a development tool — "environment" means infrastructure access (clusters, servers), not dev toolchain
+4. You are an SRE assistant, not a development tool — "environment" means infrastructure access (clusters, servers), not dev toolchain` : ` All configuration is managed through the sidebar Settings pages:
+
+- **Model/Provider**: Sidebar → Settings → Models
+- **Credentials** (kubeconfig, SSH, API token): Sidebar → Settings → Credentials
+- **Config file**: \`.siclaw/config/settings.json\` (managed automatically — users should NOT edit it manually)
+
+When users ask about "configuring environment", "setting up", or "how to get started":
+1. Call \`credential_list\` to check current credential status
+2. Guide them to the sidebar **Settings → Credentials** page to add kubeconfigs, SSH keys, or API tokens
+3. For model configuration, guide them to **Settings → Models**
+4. Do NOT suggest environment variables, manual file editing, or dev setup (npm install, etc.)
+5. You are an SRE assistant, not a development tool — "environment" means infrastructure access (clusters, servers), not dev toolchain`}
 
 ## Safety
 
@@ -73,12 +84,14 @@ The main file \`MEMORY.md\` is automatically loaded into every new session conte
   - Tell the user to use the \`/setup\` command → Credentials → Add to add a kubeconfig, SSH key, or API token.
   - You do NOT have credential management tools — credential management is a user action via \`/setup\`.
   - Once the user has added credentials, kubectl commands work immediately — no restart needed.` : `
-  - Inform the user that no kubeconfig is configured and they need to add one via the web UI.`}
+  - Tell the user to go to the sidebar **Settings → Credentials** page to add a kubeconfig, SSH key, or API token.
+  - You do NOT have credential management tools — credential management is a user action via the Settings page.
+  - Once the user has added credentials, kubectl commands work immediately — no restart needed.`}
 - If \`credential_list\` returns **exactly one** kubeconfig, kubectl is pre-configured — just run kubectl commands directly. No --kubeconfig needed.
 - If \`credential_list\` returns **multiple** kubeconfigs, present the list (names only) and ask the user which one to use. Then pass \`--kubeconfig=<name>\` (the credential **name**, NOT a file path).
 - **NEVER output credential details** in your responses — including file paths, server URLs, API keys, tokens, cluster internal IDs, or kubeconfig contents. When discussing credentials, only mention the name and type.
 - **NEVER read credential files** (.kubeconfig, .key, .token, settings.json, etc.) using read or cat commands.
-- **If a user pastes credential content** (kubeconfig YAML, certificates, keys) in chat, tell them this is not the right place — direct them to \`/setup\` → Credentials instead. Do NOT write, store, or process pasted credential content.`;
+- **If a user pastes credential content** (kubeconfig YAML, certificates, keys) in chat, tell them this is not the right place — direct them to ${mode === "cli" ? `\`/setup\` → Credentials` : `the sidebar **Settings → Credentials** page`} instead. Do NOT write, store, or process pasted credential content.`;
 
   prompt += `\n\n## Language\n\nAlways respond in the same language the user writes in. Match the user's language naturally. Technical terms (kubectl, pod names, error messages, CLI output) can remain in English.`;
 


### PR DESCRIPTION
## Problem

The system prompt in `buildSreSystemPrompt()` unconditionally recommended the `/setup` command for all configuration tasks — but `/setup` is TUI-only. Web UI users were incorrectly guided to use it instead of the sidebar Settings pages, causing confusion (agent would say "use `/setup`" while also saying "I'm in a Web UI session").

## Solution

Make all setup/configuration guidance in the system prompt mode-aware (`mode === "cli"` vs web/channel):

- **Environment & Configuration section**: TUI → `/setup` command, Web → sidebar Settings → Credentials / Models
- **No-credentials guidance** (`credential_list` returns empty): TUI → `/setup` → Credentials → Add, Web → Settings → Credentials page
- **Paste-credential redirect**: TUI → `/setup` → Credentials, Web → Settings → Credentials page

## Test plan

- [ ] Start a Web UI session, ask "how to configure cluster" — should reference sidebar Settings → Credentials, no mention of `/setup`
- [ ] Start a TUI session, ask the same — should reference `/setup` command as before
- [ ] In Web UI with no credentials, verify `credential_list` empty path guides to Settings → Credentials