### PR TITLE
fix: improve skill tool descriptions and remove Skill Scripts Reference

### DIFF
--- a/skills/platform/create-skill/SKILL.md
+++ b/skills/platform/create-skill/SKILL.md
@@ -15,6 +15,32 @@ Use this skill when the user asks you to:
 - Create a new skill for a specific operational procedure
 - Save a diagnosis workflow as a skill
 
+## Duplicate / Overlap Check — Do This FIRST
+
+**Before creating any skill, check whether an existing skill already covers the same functionality.** Consult the `<available_skills>` index in your context.
+
+- **Functional overlap found**: If an existing builtin, team, or personal skill solves the same problem (even with a different name), DO NOT silently create a new one. Instead:
+  1. Tell the user which existing skill overlaps and what it does.
+  2. Ask if they want to: (a) use the existing skill as-is, (b) fork it with `fork_skill` to make a customized personal copy, or (c) still create a brand-new separate skill.
+  3. Only proceed with `create_skill` if the user explicitly chooses option (c).
+- **Why this matters**: Duplicate skills with similar functionality confuse the model — it cannot reliably choose between two skills that do the same thing. One well-maintained skill is always better than two overlapping ones.
+- To fork a builtin or team skill into a personal copy, use `fork_skill`.
+
+## Environments and Approval Workflow
+
+Skills go through a review workflow that behaves differently per environment:
+
+| Environment | Behavior |
+|-------------|----------|
+| **Dev / Test** | Newly created skills (draft status) are immediately visible and usable. You can test them right away. |
+| **Production** | Only **approved** skill versions are visible and usable. Draft and pending skills do NOT appear. |
+
+- After creating a skill, it starts in **draft** status.
+- Skills with scripts must be **submitted for review** and **approved by an admin** before they become active in production.
+- Skills without scripts (pure guidance) also start as draft but can be submitted and approved more quickly.
+- **After creating a skill in production context**: inform the user that it is pending review and will not be available in production until approved. Suggest testing in the dev/test environment first.
+- **Do NOT attempt to test or run a newly created skill in production** — it will not be found.
+
 ## Skill Structure
 
 A skill is a directory under `skills/` containing:
@@ -171,9 +197,12 @@ node_script: node="node-1", skill="node-logs", script="get-node-logs.sh", args="
 
 ## How to Create a Skill
 
-### Step 0: Check Completeness — Ask Before You Build
+### Step 0: Check for Duplicates and Completeness
 
-Before calling `create_skill`, review what you know and identify gaps. A good skill needs **all** of the following. If any are missing or vague, ask the user to clarify before proceeding:
+Before calling `create_skill`:
+
+1. **Check for existing skills** — consult the `<available_skills>` index. If an existing skill covers the same functionality, discuss with the user: reuse as-is, fork with `fork_skill`, or create new.
+2. **Verify completeness** — a good skill needs **all** of the following. If any are missing, ask the user:
 
 | Required Info | What to check | Example question to ask |
 |---|---|---|
@@ -205,7 +234,8 @@ create_skill({
   description: "Find OOMKilled pods and analyze memory usage",
   type: "Monitoring",
   specs: "---\nname: check-pod-oom\n...",
-  scripts: [{ name: "check-oom.sh", content: "#!/bin/bash\n..." }]
+  scripts: [{ name: "check-oom.sh", content: "#!/bin/bash\n..." }],
+  labels: ["monitoring", "memory"]
 })
 ```
 
@@ -283,6 +313,8 @@ pod_netns_script: pod="<pod>", namespace="<ns>", skill="pod-ping-gateway", scrip
 - **`## Parameters` table**: list required and optional parameters with descriptions
 - **Actionable examples**: show multiple real tool invocations with realistic parameters
 - **Category selection**: choose from Monitoring, Network, Security, Database, Core, Utility, Automation, Custom
+- **Labels**: add relevant labels (e.g. `['gpu', 'network', 'monitoring']`) for discoverability
 - **Scripts are optional**: simple skills that just guide the bot's kubectl usage don't need scripts
 - **One concern per skill**: keep skills focused on a single task
+- **No duplicates**: always check for existing skills first; fork rather than recreate
 - **User scripts by name**: when referencing uploaded scripts, just pass `{name: "file.sh"}` without content

--- a/skills/platform/manage-skill/SKILL.md
+++ b/skills/platform/manage-skill/SKILL.md
@@ -9,15 +9,22 @@ description: >-
 
 ## When to Use
 
-When the user requests to create, update, edit, enable, or disable a Skill.
+When the user requests to create, update, edit, enable, or disable a Skill in a **Channel** conversation (where skill management tools are not available).
 
 ## Instructions
 
 Skill creation, updates, and management should be done through the Siclaw Web page.
 
 On the Web page, you can:
-- Create and edit Skills
+- Create and edit Skills (with live preview)
+- Fork builtin or team skills into personal copies
+- Submit skills for review and approval
 - Enable or disable Skills
 - View Skill execution history
 
 Inform the user of this directly — no further action is required.
+
+## Environments
+
+- **Dev / Test environment**: newly created or updated skills are immediately usable for testing.
+- **Production environment**: only approved skill versions are available. Skills must go through admin review before they appear in production.

--- a/skills/platform/update-skill/SKILL.md
+++ b/skills/platform/update-skill/SKILL.md
@@ -2,27 +2,37 @@
 name: update-skill
 description: >-
   Procedure for modifying, updating, or fixing an existing Siclaw skill.
-  Skills are on a read-only filesystem — use the update_skill tool,
-  never edit files directly.
+  Use the update_skill tool — never edit skill files directly.
 ---
 
 # Update Skill
 
 ## When to Use
 
-When the user's message contains `[Editing Skill: <name> (id:<id>)]` followed by the current skill content, or when the user asks to modify/update/fix an existing skill.
+When the user's message contains `[Skill: <name>]` (UI skill editing context), or when the user asks to modify/update/fix an existing skill.
+
+## Environments and Approval Workflow
+
+| Environment | Behavior |
+|-------------|----------|
+| **Dev / Test** | Updated content (working copy) is immediately visible and testable. |
+| **Production** | Only the **approved** version is active. Updates enter a staged review state; the old version remains in use until the new version is approved by an admin. |
+
+- When scripts are changed, the update enters a **staged review** state.
+- The **old version** of the skill remains usable in production during review.
+- In dev/test, the working copy is available immediately for testing.
 
 ## How to Update
 
 Call the `update_skill` tool (NOT `create_skill`) with the skill ID and the complete updated definition.
 
-**Do NOT use `read`, `edit`, `write`, or `bash` on files under `/mnt/skills/` — the filesystem is read-only.**
+**Skill directories are read-only. All skill modifications must go through skill management tools (create_skill, update_skill, fork_skill).**
 
 ### Tool Call Format
 
 ```
 update_skill({
-  id: "<skill-id>",                // Required — from [Editing Skill: ... (id:<id>)]
+  id: "<skill-id>",                // From [Skill: ...] context, or the skill's kebab-case name
   name: "skill-name",              // Keep original name unless user wants rename
   description: "What the skill does",
   type: "Monitoring",
@@ -31,7 +41,8 @@ update_skill({
     { name: "run.sh", content: "#!/bin/bash\n..." },   // Changed: provide full content
     { name: "check.sh" }                                // Unchanged: name only
     // Omitted scripts are deleted
-  ]
+  ],
+  labels: ["monitoring", "memory"] // Optional labels/tags
 })
 ```
 

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -135,108 +135,16 @@ function truncateWithBudget(content: string, maxChars: number): string {
 }
 
 /**
- * Build the append system prompt content (skills index + MEMORY.md).
+ * Build the append system prompt content (PROFILE.md + MEMORY.md).
  * Shared between pi-agent (via DefaultResourceLoader) and SDK brain.
+ *
+ * Skills are NOT listed here — pi-agent's DefaultResourceLoader provides a
+ * lazy index (name + description + path) and the model reads SKILL.md on demand.
  */
 function buildAppendSystemPrompt(
-  skillsBase: string,
-  getUserSkillDirName: () => string,
-  getPlatformSkillDirName: () => string,
   memoryDir: string,
 ): string[] {
   const parts: string[] = [];
-
-  const skillSearchDirs: string[] = [];
-  const activeDir = path.join(skillsBase, "user", getUserSkillDirName());
-  if (fs.existsSync(activeDir)) {
-    skillSearchDirs.push(activeDir);
-    // Platform skills (create-skill, update-skill, manage-skill) are excluded —
-    // they are internal agent guides, not user-facing skills.
-  } else {
-    const SKILL_SCOPES = ["user", "team", "core"];
-    for (const scope of SKILL_SCOPES) {
-      const scopeDir = path.join(skillsBase, scope);
-      if (fs.existsSync(scopeDir)) {
-        skillSearchDirs.push(scopeDir);
-      }
-    }
-  }
-
-  const withScripts: string[] = [];
-  const withoutScripts: string[] = [];
-  const seenSkills = new Set<string>();
-
-  for (const searchDir of skillSearchDirs) {
-    try {
-      const entries = fs.readdirSync(searchDir, { withFileTypes: true });
-      for (const entry of entries) {
-        if (entry.name.startsWith("_")) continue;
-        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-        if (seenSkills.has(entry.name)) continue;
-        seenSkills.add(entry.name);
-        const skillName = entry.name;
-        const sDir = path.join(searchDir, skillName, "scripts");
-        let scripts: string[] = [];
-        try {
-          scripts = fs.readdirSync(sDir)
-            .filter((f) => f.endsWith(".sh") || f.endsWith(".py"));
-        } catch { /* no scripts dir */ }
-
-        if (scripts.length > 0) {
-          let execTool = "run_skill";
-          try {
-            const skillMd = fs.readFileSync(
-              path.join(searchDir, skillName, "SKILL.md"),
-              "utf-8",
-            );
-            // If the SKILL.md has an explicit "run_skill: ... skill=<this>" invocation,
-            // honour it and skip the heuristic — avoids misclassification when the
-            // SKILL.md cross-references other skills via node_script/pod_script.
-            const selfRunSkill = skillMd.split("\n").some((line) =>
-              /\brun_skill\s*:/.test(line) && new RegExp(`skill=["']?${skillName}["']?`).test(line),
-            );
-            if (!selfRunSkill) {
-              if (skillMd.includes("node_script")) execTool = "node_script";
-              else if (skillMd.includes("pod_script") || skillMd.includes("pod_netns_script")) execTool = "pod_script";
-            }
-          } catch { /* default to run_skill */ }
-          withScripts.push(
-            `- ${skillName} → ${scripts.map((s) => `\`${s}\``).join(", ")} (via **${execTool}**)`,
-          );
-        } else {
-          withoutScripts.push(skillName);
-        }
-      }
-    } catch { /* ignore */ }
-  }
-
-  if (withScripts.length > 0 || withoutScripts.length > 0) {
-    const lines = [
-      "\n## Skill Scripts Reference",
-      "",
-      `**Skill directories**: ${skillSearchDirs.join(", ")}`,
-      `Example: \`read(path: "${skillSearchDirs[0]}/<skill-name>/SKILL.md")\``,
-      "IMPORTANT: Always use the FULL directory path above — do NOT shorten or guess paths.",
-      "",
-      "Each skill below shows its execution tool. **CRITICAL: use the EXACT tool indicated** — do NOT substitute one tool for another.",
-      "There are only three execution tools: `run_skill`, `node_script`, `pod_script` — do NOT use any other tool name (e.g. `node_exec` does not exist).",
-      "- `run_skill`: runs on agentbox (has kubectl), pass `skill=\"<skill-name>/<script>\"`",
-      "- `node_script`: runs ON a Kubernetes node (host namespaces), needs `node` parameter",
-      "- `pod_script`: runs inside a pod's namespace",
-      "",
-    ];
-    if (withScripts.length > 0) {
-      lines.push("**Skills with scripts:**");
-      lines.push(...withScripts);
-    }
-    if (withoutScripts.length > 0) {
-      lines.push("");
-      lines.push(
-        `**Skills without scripts** (follow SKILL.md instructions, do NOT invent script names): ${withoutScripts.join(", ")}`,
-      );
-    }
-    parts.push(lines.join("\n"));
-  }
 
   // Load PROFILE.md (user profile for personalized interactions)
   const profileFile = path.join(memoryDir, "PROFILE.md");
@@ -470,8 +378,6 @@ export async function createSiclawSession(
 
   // Skills: when userId is set (local mode), use per-user directory for isolation;
   // otherwise "." collapses to skillsBase/user/ (K8s single-user pod).
-  const getUserSkillDirName = opts?.userId ? () => opts.userId! : () => ".";
-  const getPlatformSkillDirName = () => mode === "channel" ? ".platform-channel" : ".platform-web";
 
   // Skill directories (two fixed sources):
   // 1. Builtin: baked into Docker image at /app/skills/core/
@@ -530,7 +436,7 @@ export async function createSiclawSession(
     cwd,
     systemPromptOverride: () => buildSreSystemPrompt(memoryDir, mode),
     appendSystemPromptOverride: () => {
-      const parts = buildAppendSystemPrompt(skillsBase, getUserSkillDirName, getPlatformSkillDirName, memoryDir);
+      const parts = buildAppendSystemPrompt(memoryDir);
       if (workspaceSystemPromptAppend) {
         parts.push("\n\n" + workspaceSystemPromptAppend);
       }
@@ -570,7 +476,7 @@ export async function createSiclawSession(
     const systemPrompt = buildSreSystemPrompt(memoryDir, mode);
 
     // Build the same append content that pi-agent gets via appendSystemPromptOverride
-    const appendParts = buildAppendSystemPrompt(skillsBase, getUserSkillDirName, getPlatformSkillDirName, memoryDir);
+    const appendParts = buildAppendSystemPrompt(memoryDir);
     let systemPromptAppend = appendParts.join("\n") || undefined;
 
     // Inject deep investigation judgment framework

--- a/src/tools/create-skill.ts
+++ b/src/tools/create-skill.ts
@@ -61,7 +61,32 @@ Important:
 - If the user asks to "change", "modify", "update", or "replace" a skill (whether created earlier in this conversation or not), always use \`update_skill\`.
 - Only use \`create_skill\` when the user explicitly wants a brand-new, separate skill.
 
-**Approval required**: Skills with scripts require admin approval before they become active. After creating a skill, do NOT attempt to test or run it — it will not be available until an admin approves it. Inform the user that the skill is pending review.
+## Duplicate / Overlap Check — CRITICAL
+
+**Before calling \`create_skill\`, you MUST check whether an existing skill already covers the same functionality.** Check \`<available_skills>\` in your system prompt and compare the user's request against existing builtin, team, and personal skills.
+
+- **Exact name match**: The tool will reject creation if a skill with the same name exists. But functional overlap with a DIFFERENT name is equally problematic.
+- **Functional overlap found**: If an existing skill solves the same problem (even with a different name), DO NOT silently create a new one. Instead:
+  1. Tell the user which existing skill overlaps and what it does.
+  2. Ask if they want to: (a) use the existing skill as-is, (b) fork it with \`fork_skill\` to make a customized personal copy, or (c) still create a brand-new separate skill.
+  3. Only proceed with \`create_skill\` if the user explicitly chooses option (c).
+- **Why this matters**: Duplicate skills with similar functionality confuse the model — it cannot reliably choose between two skills that do the same thing. One well-maintained skill is always better than two overlapping ones.
+- To fork a builtin or team skill into a personal copy, use \`fork_skill\`.
+
+## Environments and Approval Workflow
+
+Skills go through a review workflow that behaves differently per environment:
+
+| Environment | Behavior |
+|-------------|----------|
+| **Dev / Test** | Newly created skills (draft status) are immediately visible and usable. You can test them right away. |
+| **Production** | Only **approved** skill versions are visible. Draft and pending skills do NOT appear in production. |
+
+- After creating a skill, it starts in **draft** status.
+- Skills with scripts must be **submitted for review** and **approved by an admin** before they become active in production.
+- Skills without scripts (pure guidance) also start as draft but can be submitted and approved more quickly.
+- **After creating a skill in production context**: inform the user that the skill is pending review and will not be available in production until approved. Suggest testing in the dev/test environment first.
+- **Do NOT attempt to test or run a newly created skill in production** — it will not be found.
 
 ## Script Execution Modes
 

--- a/src/tools/fork-skill.ts
+++ b/src/tools/fork-skill.ts
@@ -24,10 +24,22 @@ This tool outputs a structured fork definition that the user can preview and sav
 
 **When to use this tool vs others:**
 - \`fork_skill\`: Fork an existing builtin/team skill to personal (with or without modifications)
-- \`create_skill\`: Create a brand-new skill from scratch
+- \`create_skill\`: Create a brand-new skill from scratch (only when no existing skill covers the same functionality)
 - \`update_skill\`: Update an existing personal skill
 
-**IMPORTANT**: Before calling this tool, check the Skill Scripts Reference in your context and read the source skill's SKILL.md to understand its current content. You need the exact skill name.
+**IMPORTANT**: Before calling this tool, check \`<available_skills>\` in your system prompt and read the source skill's SKILL.md to understand its current content. You need the exact skill name.
+
+**Prefer forking over creating**: If a user wants to create a skill that overlaps with an existing builtin or team skill, recommend forking instead. This avoids duplicate skills that confuse the model. Fork lets them customize while keeping a clear lineage.
+
+## Environments and Approval Workflow
+
+| Environment | Behavior |
+|-------------|----------|
+| **Dev / Test** | Forked skill (draft) is immediately visible and testable. |
+| **Production** | Forked skill must be **approved** before it appears. |
+
+- Forked skills with scripts require admin approval before production use.
+- In dev/test, the forked copy is available immediately for testing.
 
 Parameters:
 - source: The exact name of the builtin or team skill to fork (e.g. "find-node", "roce-perftest-pod")

--- a/src/tools/update-skill.ts
+++ b/src/tools/update-skill.ts
@@ -17,22 +17,33 @@ export function createUpdateSkillTool(): ToolDefinition {
     name: "update_skill",
     label: "Update Skill",
     description: `Update an existing Siclaw skill definition.
+
+**Skill directories are read-only. All skill modifications must go through skill management tools (create_skill, update_skill, fork_skill).**
+
 This tool outputs a structured skill update that the user can preview and confirm. It does NOT persist anything — the user must confirm via the UI.
 
 Use this tool (NOT create_skill) when the user asks to modify, update, change, or fix an existing skill. This includes:
-- When the user message contains [Editing Skill: <name> (id:<id>)] context from the UI
+- When the user message contains \`[Skill: <name>]\` context from the UI (the user selected a skill to edit)
 - When the user asks to change a skill that was created earlier in the conversation
 - When the user asks to modify or replace an existing skill
 
-**IMPORTANT — Identify the target skill FIRST**:
-Before calling this tool, you MUST know the exact name of the skill to update. Check the Skill Scripts Reference in your context for existing skills. If the user's request is ambiguous (e.g. "update that skill", "update it"), ASK the user to clarify which skill they mean. Never guess — a wrong target will corrupt the wrong skill.
+**Identify the target skill FIRST**:
+Before calling this tool, you MUST know the exact name of the skill to update. Check \`<available_skills>\` in your system prompt, or \`read\` the skill's SKILL.md for details. If the user's request is ambiguous, ASK them to clarify which skill they mean.
 
-Do NOT use read, edit, write, or bash on files under .siclaw/skills/ — the filesystem is read-only. Always use this tool instead.
+## Environments and Approval Workflow
 
-**Approval required**: When scripts are changed, the update enters a "staged" review state and requires admin approval before the new version becomes active. The old version of the skill remains usable during review. After updating, do NOT attempt to test the new version — it will not take effect until an admin approves it. Inform the user that the update is pending review.
+| Environment | Behavior |
+|-------------|----------|
+| **Dev / Test** | Updated content (working copy) is immediately visible and testable. |
+| **Production** | Only the **approved** version is active. Updates enter a staged review state and the OLD version remains in use until the new version is approved. |
+
+- When scripts are changed, the update enters a **staged review** state and requires admin approval before the new version becomes active in production.
+- The **old version** of the skill remains usable in production during review.
+- In dev/test, the working copy is immediately available for testing.
+- After updating in production context, inform the user that the update is pending review.
 
 Parameters:
-- id: The skill ID from [Editing Skill: ... (id:<id>)] context, OR the skill's kebab-case name (for name-based lookup).
+- id: The skill ID from the UI context, OR the skill's kebab-case name (for name-based lookup).
 - name: the skill name in kebab-case (cannot be changed after creation).
 - description: one-line summary
 - type: category (Monitoring, Network, Security, Database, Core, Utility, Automation, Custom)


### PR DESCRIPTION
## Summary

- **Remove "Skill Scripts Reference" from append system prompt** — this section eagerly listed all skills with their scripts permanently in the context window. Skills are now fully managed by pi-agent's lazy-loading lifecycle (`<available_skills>` index + on-demand SKILL.md read), so this was redundant context overhead.

- **Clarify skill directory is read-only** — the agent was attempting to `write`/`edit` skill files directly instead of using `update_skill`. Tool descriptions now state upfront that skill directories are read-only and all modifications must go through skill management tools.

- **Add environment/approval workflow docs** to `create_skill`, `update_skill`, and `fork_skill` — explains dev/test (immediate) vs production (needs admin approval) behavior.

- **Add duplicate/overlap check guidance** to `create_skill` — agent must check `<available_skills>` before creating, and recommend `fork_skill` when an existing skill covers the same functionality.

- **Fix stale references** — `[Editing Skill: ...]` → `[Skill: <name>]` in `update_skill`, remove hardcoded `/mnt/skills/` path, replace all "Skill Scripts Reference" mentions with `<available_skills>` index.

## Test plan

- [x] Built and deployed to test cluster (`env-isolation` tag)
- [x] Gateway and cron pods running healthy
- [ ] Verify agent uses `update_skill` tool instead of writing files directly when asked to modify a skill
- [ ] Verify agent checks `<available_skills>` before creating duplicate skills