### PR TITLE
feat(skills): add quota-debug and volcano-queue-debug diagnostic skills

### DIFF
--- a/skills/core/deployment-rollout-debug/SKILL.md
+++ b/skills/core/deployment-rollout-debug/SKILL.md
@@ -127,7 +127,7 @@ kubectl describe rs <new-rs> -n <ns>
 
 Check events for:
 - **Admission webhook denied** — a webhook is rejecting the new pod spec
-- **Exceeded quota** — resource quota in the namespace prevents creating more pods
+- **Exceeded quota / LimitRange violation** — Use `quota-debug` for native ResourceQuota/LimitRange diagnosis, or `volcano-queue-debug` for Volcano gang scheduling clusters
 - **FailedCreate** — other creation failures
 
 ---

--- a/skills/core/meta.json
+++ b/skills/core/meta.json
@@ -20,6 +20,7 @@
     "pvc-debug":                ["kubernetes", "general",  "diagnostic", "sre", "developer"],
     "quota-debug":              ["kubernetes", "general",  "diagnostic", "sre", "developer"],
     "service-debug":            ["kubernetes", "network",  "diagnostic", "sre", "developer"],
+    "statefulset-debug":        ["kubernetes", "general",  "diagnostic", "sre", "developer"],
     "volcano-queue-debug":      ["kubernetes", "general",  "diagnostic", "sre", "developer"]
   }
 }

--- a/skills/core/meta.json
+++ b/skills/core/meta.json
@@ -18,6 +18,8 @@
     "pod-ping-gateway":         ["kubernetes", "network",  "diagnostic", "sre", "developer"],
     "pod-show-gateway":         ["kubernetes", "network",  "diagnostic", "sre", "developer"],
     "pvc-debug":                ["kubernetes", "general",  "diagnostic", "sre", "developer"],
-    "service-debug":            ["kubernetes", "network",  "diagnostic", "sre", "developer"]
+    "quota-debug":              ["kubernetes", "general",  "diagnostic", "sre", "developer"],
+    "service-debug":            ["kubernetes", "network",  "diagnostic", "sre", "developer"],
+    "volcano-queue-debug":      ["kubernetes", "general",  "diagnostic", "sre", "developer"]
   }
 }

--- a/skills/core/quota-debug/SKILL.md
+++ b/skills/core/quota-debug/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: quota-debug
+description: >-
+  Diagnose Kubernetes native ResourceQuota and LimitRange admission rejections (exceeded quota, forbidden by LimitRange, FailedCreate).
+  Checks namespace quotas, current usage, LimitRange constraints, and ReplicaSet events to identify why pods cannot be created.
+  Not applicable to Volcano Queue — use volcano-queue-debug for gang scheduling clusters.
+---
+
+# ResourceQuota & LimitRange Admission Diagnosis
+
+When pods fail to be created due to Kubernetes native namespace-level resource constraints — ResourceQuota exceeded or LimitRange violations — follow this flow to identify the root cause.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify ResourceQuota, LimitRange, or pod specs — that should be left to the user or cluster administrator.
+
+**When to use:** Pods are not being created at all (not Pending, not CrashLoopBackOff — simply missing). Typical trigger: a ReplicaSet or Job shows `FailedCreate` events mentioning `exceeded quota` or `forbidden: ... LimitRange`.
+
+**Not applicable to Volcano Queue:** If the cluster uses Volcano for gang scheduling, resource quotas are managed by Volcano Queue, not Kubernetes native ResourceQuota. Use the `volcano-queue-debug` skill instead. To check:
+
+```bash
+kubectl get queue 2>/dev/null
+```
+
+If this command returns results (Queue resources listed), the cluster uses Volcano — use `volcano-queue-debug`. If it returns nothing or an error, Volcano is not installed — continue with this skill.
+
+## Diagnostic Flow
+
+### 1. Identify the creation failure
+
+If the user reports a Deployment not progressing or pods not appearing, first find the controller that owns the pods:
+
+```bash
+kubectl get rs -n <ns> --sort-by='.metadata.creationTimestamp' | grep <deployment-name>
+```
+
+Then check the ReplicaSet events for creation failures:
+
+```bash
+kubectl describe rs <new-rs> -n <ns>
+```
+
+Look for events with reason `FailedCreate`. The event message reveals whether it is a ResourceQuota or LimitRange rejection.
+
+If the user already has a specific error message, skip to step 2.
+
+### 2. Match the rejection type
+
+---
+
+#### `exceeded quota` — ResourceQuota exhausted
+
+The namespace has a ResourceQuota and creating the pod would exceed the allowed limits.
+
+Check current quota usage:
+
+```bash
+kubectl get resourcequota -n <ns>
+```
+
+For detailed usage breakdown:
+
+```bash
+kubectl describe resourcequota -n <ns>
+```
+
+Compare the `Used` vs `Hard` columns. Common quota dimensions:
+- **requests.cpu / requests.memory** — total CPU/memory requests across all pods in the namespace
+- **limits.cpu / limits.memory** — total CPU/memory limits
+- **pods** — maximum number of pods allowed in the namespace
+- **count/deployments.apps, count/services** — object count limits
+- **requests.nvidia.com/gpu** — total GPU requests (common in GPU-scheduled clusters)
+- **requests.storage** — total PVC storage requested
+- **persistentvolumeclaims** — number of PVCs
+
+Then check what the pod is requesting:
+
+```bash
+kubectl get pod -n <ns> -l app=<name> -o jsonpath='{range .items[0].spec.containers[*]}{.name}{"\t"}{.resources}{"\n"}{end}' 2>/dev/null
+```
+
+If no pods exist yet (all creation failed), check the Deployment or template spec:
+
+```bash
+kubectl get deployment <name> -n <ns> -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\t"}{.resources}{"\n"}{end}'
+```
+
+**Root cause analysis:**
+- If `Used` is near `Hard` for cpu/memory: existing pods are consuming most of the quota — need to scale down other workloads or increase quota
+- If `pods` count is at the limit: too many pods in namespace — clean up or increase quota
+- If the pod's resource requests are very large: consider reducing requests to fit within remaining quota
+
+---
+
+#### `forbidden: ... minimum cpu/memory` — LimitRange minimum violation
+
+The pod's container does not meet the minimum resource request required by the namespace's LimitRange.
+
+```bash
+kubectl get limitrange -n <ns>
+```
+
+```bash
+kubectl describe limitrange -n <ns>
+```
+
+Check the `Min` column for Container type. If a container does not specify resource requests, or its requests are below the minimum, admission will be rejected.
+
+Compare with the pod's resource spec. If the container has no resource requests at all, the LimitRange default will be applied — but if the LimitRange has `min` without `default`, admission fails.
+
+---
+
+#### `forbidden: ... maximum cpu/memory` — LimitRange maximum violation
+
+The pod's container exceeds the maximum resource limit allowed by the LimitRange.
+
+Check LimitRange as above and compare the `Max` column with the container's resource requests/limits.
+
+---
+
+#### `forbidden: ... maxLimitRequestRatio` — LimitRange ratio violation
+
+The ratio between the container's resource limit and request exceeds the allowed ratio (e.g., limit is 10x the request, but ratio cap is 3x).
+
+```bash
+kubectl describe limitrange -n <ns>
+```
+
+Check the `Max Limit/Request Ratio` column. Then compare the pod's limits vs requests:
+
+```bash
+kubectl get deployment <name> -n <ns> -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\t requests:"}{.resources.requests}{"\t limits:"}{.resources.limits}{"\n"}{end}'
+```
+
+---
+
+#### `forbidden: ... no resources specified` — Missing required resources
+
+The LimitRange requires resource specifications, but the container has none and no defaults are configured.
+
+Check if the LimitRange has `Default` and `DefaultRequest` values:
+
+```bash
+kubectl describe limitrange -n <ns>
+```
+
+If `Default` and `DefaultRequest` are empty but `Min` or `Max` are set, containers MUST explicitly specify resources.
+
+---
+
+#### Pod type LimitRange — min/max per pod
+
+LimitRange can also enforce constraints at the Pod level (sum of all containers). Check if the LimitRange has a `Pod` type entry:
+
+```bash
+kubectl get limitrange -n <ns> -o jsonpath='{range .items[*].spec.limits[*]}{.type}{"\t min:"}{.min}{"\t max:"}{.max}{"\n"}{end}'
+```
+
+If the sum of all container resources exceeds the Pod-level max, admission is rejected.
+
+---
+
+#### `exceeded quota` for storage — PVC quota exhausted
+
+If the error mentions `requests.storage` or `persistentvolumeclaims`:
+
+```bash
+kubectl describe resourcequota -n <ns>
+```
+
+Check the storage-related rows. Also check if there are per-StorageClass quotas:
+
+```bash
+kubectl get resourcequota -n <ns> -o yaml
+```
+
+Look for keys like `<storageclass>.storageclass.storage.k8s.io/requests.storage`.
+
+### 3. Check for multiple constraints
+
+A namespace can have multiple ResourceQuotas and LimitRanges. Always check for all of them:
+
+```bash
+kubectl get resourcequota,limitrange -n <ns>
+```
+
+All ResourceQuotas must be satisfied (intersection). The most restrictive LimitRange applies.
+
+### 4. Verify scoped quotas
+
+ResourceQuotas can be scoped to specific priority classes or pod phases:
+
+```bash
+kubectl get resourcequota -n <ns> -o yaml
+```
+
+Look for `spec.scopes` or `spec.scopeSelector`. A scoped quota only applies to pods matching the scope (e.g., `PriorityClass=high`). If the user's pod has a specific priority class, it may hit a scoped quota while the general quota still has capacity.
+
+## Notes
+
+- ResourceQuota admission happens **before scheduling**. A pod rejected by quota will never appear in `kubectl get pods` — look at the controller (ReplicaSet, Job) events instead.
+- When a namespace has a ResourceQuota for compute resources (cpu/memory), **every container must specify requests/limits** for those resources, otherwise admission is rejected. This catches users who are used to running without resource specs.
+- LimitRange can automatically inject default requests/limits into containers that don't specify them. Check if defaults are configured before telling users to add explicit resource specs.
+- For cross-reference: if the pod IS created but stuck in Pending, use the `pod-pending-debug` skill instead — that covers scheduling failures (node resources, taints, affinity).
+- `kubectl top pods -n <ns>` shows actual resource usage, while quota tracks **requested** resources. A namespace can hit quota limits even if actual usage is low.

--- a/skills/core/quota-debug/SKILL.md
+++ b/skills/core/quota-debug/SKILL.md
@@ -200,4 +200,4 @@ Look for `spec.scopes` or `spec.scopeSelector`. A scoped quota only applies to p
 - When a namespace has a ResourceQuota for compute resources (cpu/memory), **every container must specify requests/limits** for those resources, otherwise admission is rejected. This catches users who are used to running without resource specs.
 - LimitRange can automatically inject default requests/limits into containers that don't specify them. Check if defaults are configured before telling users to add explicit resource specs.
 - For cross-reference: if the pod IS created but stuck in Pending, use the `pod-pending-debug` skill instead — that covers scheduling failures (node resources, taints, affinity).
-- `kubectl top pods -n <ns>` shows actual resource usage, while quota tracks **requested** resources. A namespace can hit quota limits even if actual usage is low.
+- `kubectl top pods -n <ns>` shows actual resource usage, while quota tracks **requested** resources. A namespace can hit quota limits even if actual usage is low. Note: `kubectl top` requires metrics-server to be installed — if it returns an error, skip it and rely on quota `Used` values instead.

--- a/skills/core/statefulset-debug/SKILL.md
+++ b/skills/core/statefulset-debug/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: statefulset-debug
+description: >-
+  Diagnose StatefulSet rollout and scaling failures (ordered update stuck, OnDelete not updating, partition misconfiguration, PVC binding deadlocks).
+  Checks update strategy, pod ordinal progression, PVC bindings, and ordered startup to identify why a StatefulSet is not progressing.
+---
+
+# StatefulSet Rollout & Scaling Failure Diagnosis
+
+When a StatefulSet rollout is stuck, pods are not updating, or scaling is not progressing, follow this flow to identify the root cause.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify the StatefulSet, delete pods, or change PVCs — that should be left to the user.
+
+**When to use:** A StatefulSet is not progressing — pods are not updating to the new version, scaling up/down is stuck, or specific ordinal pods are not becoming ready.
+
+**Not for Deployments:** Deployment rollouts have different semantics (parallel, unordered). Use `deployment-rollout-debug` for Deployments.
+
+## Key Concepts
+
+StatefulSets differ fundamentally from Deployments:
+- **Fixed pod identity** — pods have stable names with ordinal suffixes (pod-0, pod-1, ...)
+- **Ordered operations** — updates go in reverse order (N-1 → 0), scaling up goes in forward order (0 → N-1)
+- **Per-pod PVCs** — each pod gets its own PersistentVolumeClaim via `volumeClaimTemplates`
+- **Blocking progression** — in OrderedReady mode (default), if pod at ordinal K is not Ready, all pods with ordinal < K will NOT be updated
+
+## Diagnostic Flow
+
+### 1. Get StatefulSet overview
+
+```bash
+kubectl get statefulset <name> -n <ns> -o wide
+```
+
+Compare the columns:
+- **READY** — pods that are running and ready
+- **REPLICAS** — desired replica count (from `spec.replicas`)
+- **UP-TO-DATE** — pods running the current version (matching `currentRevision` == `updateRevision`)
+
+If `READY < REPLICAS` or there is no `UP-TO-DATE` column showing full count, the rollout or scaling is incomplete.
+
+### 2. Describe the StatefulSet
+
+```bash
+kubectl describe statefulset <name> -n <ns>
+```
+
+Focus on:
+- **Update Strategy** — `RollingUpdate` or `OnDelete`
+- **Partition** — if set, only pods with ordinal ≥ partition are updated
+- **maxUnavailable** — if set (Kubernetes 1.24+), allows multiple pods to be updated simultaneously instead of one-at-a-time
+- **Current Revision / Update Revision** — if different, an update is in progress
+- **Events** — look for errors or warnings
+
+### 3. Check pod status by ordinal
+
+First get the StatefulSet's pod selector to reliably find its pods:
+
+```bash
+kubectl get statefulset <name> -n <ns> -o jsonpath='{.spec.selector.matchLabels}'
+```
+
+Then use the returned labels to list pods:
+
+```bash
+kubectl get pods -n <ns> -l <key>=<value> --sort-by='.metadata.name'
+```
+
+Identify which ordinal pod is stuck. In a StatefulSet with OrderedReady policy, **the stuck pod blocks all subsequent operations**.
+
+### 4. Match the failure pattern
+
+---
+
+#### OnDelete strategy — Pods not updating after StatefulSet change
+
+The StatefulSet uses `updateStrategy.type: OnDelete`. In this mode, Kubernetes does **not** automatically update pods — the user must manually delete each pod for it to be recreated with the new spec.
+
+```bash
+kubectl get statefulset <name> -n <ns> -o jsonpath='{.spec.updateStrategy}'
+```
+
+If the output shows `{"type":"OnDelete"}` or no `rollingUpdate` field:
+
+Check if the current and update revisions differ:
+
+```bash
+kubectl get statefulset <name> -n <ns> -o jsonpath='current={.status.currentRevision} update={.status.updateRevision}'
+```
+
+If they differ, the StatefulSet spec has been updated but pods are still running the old version. This is **expected behavior** for OnDelete — pods must be manually deleted to pick up the new version.
+
+Check which pods are still on the old revision (use the selector from step 3):
+
+```bash
+kubectl get pods -n <ns> -l <key>=<value> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.controller-revision-hash}{"\n"}{end}'
+```
+
+Pods whose `controller-revision-hash` matches `currentRevision` (not `updateRevision`) are still on the old version.
+
+---
+
+#### RollingUpdate stuck at a specific ordinal — Ordered update blocked
+
+In RollingUpdate mode, StatefulSet updates pods in **reverse ordinal order** (N-1 → N-2 → ... → 0). By default (one-at-a-time), if pod at ordinal K is not Ready, the update stops — pods K-1, K-2, ..., 0 will not be updated.
+
+**Check maxUnavailable** (Kubernetes 1.24+, GA in 1.27):
+
+```bash
+kubectl get statefulset <name> -n <ns> -o jsonpath='{.spec.updateStrategy.rollingUpdate.maxUnavailable}'
+```
+
+If `maxUnavailable` is set (e.g., `3`), multiple pods can be updated simultaneously instead of strict one-at-a-time. In this case, seeing 2-3 pods updating at once is normal — not a sign of being stuck. Only investigate if the number of updating pods is below `maxUnavailable` for an extended period, or if specific pods are stuck in a non-Ready state.
+
+Find pods that are not Ready:
+
+```bash
+kubectl get pods -n <ns> -l <key>=<value> --sort-by='.metadata.name'
+```
+
+Check the stuck pod's status:
+- **Pending** → Use `pod-pending-debug`
+- **CrashLoopBackOff / Error** → Use `pod-crash-debug`
+- **ImagePullBackOff** → Use `image-pull-debug`
+- **Running but not Ready** → Check readiness probe (see below)
+
+If the pod is Running but not Ready:
+
+```bash
+kubectl describe pod <stuck-pod> -n <ns>
+```
+
+Look for `Readiness probe failed` events. Common causes:
+- Application not listening on the expected port after config change
+- New version has a bug that prevents health check from passing
+- Readiness probe configuration too aggressive for the new version's startup time
+
+---
+
+#### Partition update — Only some pods updated
+
+The StatefulSet has `spec.updateStrategy.rollingUpdate.partition` set. Only pods with ordinal **≥ partition** are updated; pods with ordinal < partition remain on the old version.
+
+```bash
+kubectl get statefulset <name> -n <ns> -o jsonpath='{.spec.updateStrategy.rollingUpdate.partition}'
+```
+
+If this returns a number (e.g., `3`), then pods 0, 1, 2 will NOT be updated. This is often used intentionally for **canary rollouts** — update a subset first, verify, then lower the partition to 0 to roll out fully.
+
+If the user expects all pods to be updated, the partition value needs to be set to `0` or removed.
+
+---
+
+#### Scaling up stuck — Ordered creation blocked
+
+When scaling up, StatefulSet creates pods in **forward ordinal order** (0 → 1 → 2 → ...). Pod at ordinal K+1 is not created until pod K is Running and Ready.
+
+```bash
+kubectl get pods -n <ns> | grep <statefulset-name>
+```
+
+Find the highest ordinal pod that exists — the next ordinal is waiting for this pod to become Ready.
+
+Check why the current highest pod is not Ready (same diagnosis as the "stuck at specific ordinal" pattern above).
+
+For the `podManagementPolicy` field:
+
+```bash
+kubectl get statefulset <name> -n <ns> -o jsonpath='{.spec.podManagementPolicy}'
+```
+
+- **OrderedReady** (default) — strict ordered creation, one at a time
+- **Parallel** — all pods are created simultaneously (no ordering guarantee)
+
+If the policy is `Parallel` and pods are still stuck, the issue is not ordering — check individual pod status.
+
+---
+
+#### PVC binding deadlock — Pod stuck in Pending due to volume topology
+
+StatefulSet pods use `volumeClaimTemplates` to create per-pod PVCs. If the PVC is bound to a PV in a specific availability zone (AZ) or node, but that node/AZ has no resources, the pod cannot be scheduled.
+
+Check PVC status for the stuck pod:
+
+```bash
+kubectl get pvc -n <ns> | grep <statefulset-name>
+```
+
+```bash
+kubectl describe pvc <pvc-name> -n <ns>
+```
+
+Check the StorageClass's `volumeBindingMode`:
+
+```bash
+kubectl get storageclass $(kubectl get pvc <pvc-name> -n <ns> -o jsonpath='{.spec.storageClassName}') -o jsonpath='{.volumeBindingMode}'
+```
+
+- **Immediate** — PVC is bound to a PV as soon as created, regardless of pod scheduling. If the PV is in a different zone than the only available nodes, the pod cannot be scheduled.
+- **WaitForFirstConsumer** — PVC binding is delayed until the pod is scheduled. If no node can satisfy both the pod's scheduling constraints and the storage topology, the PVC stays `Pending` and the pod stays `Pending` — a deadlock.
+
+Check if the PV has a node affinity constraint:
+
+```bash
+kubectl get pv <pv-name> -o jsonpath='{.spec.nodeAffinity}'
+```
+
+If the PV is locked to a specific node/zone:
+- Check if that node has available resources: `kubectl describe node <node>`
+- Check if that node is healthy: `kubectl get node <node>`
+
+**Common scenario:** A node was replaced or drained, but the PV is still bound to the old node's zone. The new pod can only be scheduled to nodes that can access this PV, but those nodes may be full or tainted.
+
+For further PVC diagnosis, use the `pvc-debug` skill.
+
+---
+
+#### Scaling down — PVCs left behind
+
+When a StatefulSet is scaled down, pods are deleted in **reverse ordinal order** (N-1 → N-2 → ...). However, Kubernetes does **not** automatically delete the associated PVCs.
+
+```bash
+kubectl get pvc -n <ns> | grep <statefulset-name>
+```
+
+If there are PVCs for ordinals that no longer exist (e.g., `data-myapp-3` when replicas is 2), these are orphaned PVCs from a previous scale-down.
+
+This is by design to prevent data loss. But when scaling back up, the new pod will reattach to the old PVC with stale data, which may cause application issues.
+
+Check the StatefulSet's `persistentVolumeClaimRetentionPolicy` (Kubernetes 1.27+):
+
+```bash
+kubectl get statefulset <name> -n <ns> -o jsonpath='{.spec.persistentVolumeClaimRetentionPolicy}'
+```
+
+- **whenDeleted: Retain** (default) — PVCs are kept when StatefulSet is deleted
+- **whenScaled: Retain** (default) — PVCs are kept when scaling down
+- **whenScaled: Delete** — PVCs are automatically deleted on scale-down
+
+---
+
+#### Pod stuck in Terminating during update or scale-down
+
+During an update or scale-down, if a pod is stuck in `Terminating`, the next operation cannot proceed.
+
+```bash
+kubectl describe pod <terminating-pod> -n <ns>
+```
+
+First check if a PodDisruptionBudget (PDB) is preventing the deletion:
+
+```bash
+kubectl get pdb -n <ns>
+```
+
+```bash
+kubectl describe pdb <pdb-name> -n <ns>
+```
+
+If the PDB's `minAvailable` or `maxUnavailable` limit has been reached, the StatefulSet controller cannot delete the pod. Check `status.disruptionsAllowed` — if it is `0`, no more pods can be disrupted until other pods become Ready.
+
+If PDB is not the issue, check other common causes:
+- **Finalizer blocking deletion** — check `metadata.finalizers`
+- **PreStop hook hanging** — a long-running preStop hook delays termination
+- **Process not responding to SIGTERM** — the container process ignores shutdown signals and must wait for `terminationGracePeriodSeconds` to expire
+- **Volume unmount stuck** — the volume cannot be detached from the node
+
+Check the grace period:
+
+```bash
+kubectl get pod <pod> -n <ns> -o jsonpath='{.spec.terminationGracePeriodSeconds}'
+```
+
+## Notes
+
+- StatefulSet updates go in **reverse** ordinal order (N-1 → 0), but scaling up goes in **forward** order (0 → N-1). This is a common source of confusion.
+- `OnDelete` is frequently used in database StatefulSets (MySQL, PostgreSQL, etc.) where the operator wants manual control over when each replica is restarted. If a user complains that pods are not updating, check the strategy before assuming there is a bug.
+- The `partition` field is for canary rollouts. A common workflow: set partition=N-1 to update only the last pod, verify, then set partition=0 to roll out to all pods. If a user sees partial updates, check partition before investigating further.
+- PVCs created by `volumeClaimTemplates` follow the naming convention `<volumeClaimTemplate-name>-<statefulset-name>-<ordinal>`. Use this pattern to find PVCs for specific ordinals.
+- Unlike Deployments, StatefulSets do NOT create new ReplicaSets for updates. They update pods in-place (delete old pod, create new pod with same name and PVC).
+- For cross-reference: if the stuck pod's issue is at the scheduling level, use `pod-pending-debug`. If it is crashing, use `pod-crash-debug`. If PVCs are not binding, use `pvc-debug`.

--- a/skills/core/volcano-queue-debug/SKILL.md
+++ b/skills/core/volcano-queue-debug/SKILL.md
@@ -94,7 +94,7 @@ kubectl get queue -o custom-columns='NAME:.metadata.name,CAPABILITY:.spec.capabi
 For GPU-specific checks (GPU is often the bottleneck in Volcano clusters):
 
 ```bash
-kubectl get queue -o custom-columns='NAME:.metadata.name,GPU_CAP:.spec.capability.nvidia\.com/gpu,GPU_ALLOC:.status.allocated.nvidia\.com/gpu'
+kubectl get queue -o custom-columns="NAME:.metadata.name,GPU_CAP:.spec.capability['nvidia.com/gpu'],GPU_ALLOC:.status.allocated['nvidia.com/gpu']"
 ```
 
 Compare `Allocated` vs `Capability` for each resource dimension (cpu, memory, GPU). If any dimension is at or near the ceiling, the queue cannot allocate more resources.
@@ -102,7 +102,7 @@ Compare `Allocated` vs `Capability` for each resource dimension (cpu, memory, GP
 **Also verify queue capability against actual cluster capacity** — a common misconfiguration is setting queue capability higher than the cluster's physical resources:
 
 ```bash
-kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu,CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory'
+kubectl get nodes -o custom-columns="NAME:.metadata.name,GPU:.status.allocatable['nvidia.com/gpu'],CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory"
 ```
 
 If the sum of all nodes' allocatable GPUs is less than the queue's `spec.capability.nvidia.com/gpu`, the queue can never be fully utilized. When `Allocated` reaches the cluster's physical limit, the queue will appear to have remaining capacity but no more resources can actually be scheduled.
@@ -153,7 +153,7 @@ kubectl get vcjob <job-name> -n <ns> -o jsonpath='{.spec.tasks[*].template.spec.
 Then check if the matching nodes actually have available resources:
 
 ```bash
-kubectl get nodes -l <label-key>=<label-value> -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+kubectl get nodes -l <label-key>=<label-value> -o custom-columns="NAME:.metadata.name,GPU:.status.allocatable['nvidia.com/gpu']"
 kubectl top nodes -l <label-key>=<label-value>
 ```
 

--- a/skills/core/volcano-queue-debug/SKILL.md
+++ b/skills/core/volcano-queue-debug/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: volcano-queue-debug
+description: >-
+  Diagnose Volcano Queue and PodGroup scheduling failures in gang scheduling clusters.
+  Checks Queue capacity, PodGroup status, minMember/minResources, weight-based sharing, reclaim/preemption,
+  and cross-validates queue capability against actual cluster resources.
+  Not applicable to native Kubernetes ResourceQuota — use quota-debug instead.
+---
+
+# Volcano Queue & PodGroup Scheduling Diagnosis
+
+When batch jobs or gang-scheduled workloads are stuck waiting for resources, running unexpectedly terminated, or failing in a Volcano-managed cluster, follow this flow to identify the root cause.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify Queue capability, weights, or job specs — that should be left to the user or cluster administrator.
+
+**When to use:** Jobs submitted to Volcano are not running (PodGroup stuck in `Pending` or `Inqueue`), jobs were unexpectedly killed (Preempted/Aborted), or pods are not being created despite the job being submitted. This skill applies only to clusters using Volcano scheduler (`volcano.sh`).
+
+**Not applicable to native ResourceQuota:** If the cluster does not use Volcano and relies on Kubernetes native ResourceQuota/LimitRange for admission control, use the `quota-debug` skill instead. Volcano Queue and Kubernetes ResourceQuota are completely independent resource control mechanisms. To check:
+
+```bash
+kubectl get queue 2>/dev/null
+```
+
+If this returns an error or empty result, Volcano is not installed — use `quota-debug`.
+
+## Diagnostic Flow
+
+### 1. Check Queue status
+
+```bash
+kubectl get queue
+```
+
+```bash
+kubectl describe queue <queue-name>
+```
+
+Key fields:
+- **spec.capability** — the resource ceiling for this queue (cpu, memory, GPU, etc.)
+- **spec.weight** — relative priority for inter-queue resource sharing
+- **status.allocated** — resources currently consumed by running jobs in this queue
+- **status.state** — `Open` (accepting jobs) or `Closed` (rejecting new jobs)
+
+If Queue state is `Closed`, no new jobs will be admitted. Check why it was closed before proceeding.
+
+### 2. Check PodGroup status
+
+```bash
+kubectl get podgroup -n <ns>
+```
+
+```bash
+kubectl describe podgroup <podgroup-name> -n <ns>
+```
+
+PodGroup status indicates where the job is stuck:
+- **Pending** — not yet admitted to any queue, or queue is closed
+- **Inqueue** — admitted to the queue but waiting for resources to become available
+- **Running** — resources allocated, pods should be running
+
+Also check both gang scheduling constraint fields:
+
+```bash
+kubectl get podgroup <podgroup-name> -n <ns> -o jsonpath='minMember={.spec.minMember} minResources={.spec.minResources}'
+```
+
+- **minMember** — minimum number of pods that must be scheduled together
+- **minResources** — minimum total resources required before the gang can start (e.g., `nvidia.com/gpu: 32` means 32 GPUs must be available simultaneously)
+
+Both constraints must be satisfied. `minMember` controls pod count, `minResources` controls aggregate resource quantity. A training job may set `minMember: 4` (4 worker pods) with `minResources: {nvidia.com/gpu: 32}` (8 GPUs per worker).
+
+If the PodGroup has events, check them for specific error messages.
+
+### 3. Match the failure pattern
+
+---
+
+#### PodGroup `Pending`, Queue `Closed` — Queue not accepting jobs
+
+The queue is closed and will not admit new PodGroups.
+
+Check the queue state and any annotations or conditions indicating why it was closed. A queue may be closed administratively or due to policy.
+
+---
+
+#### PodGroup `Inqueue`, Queue `Allocated` approaching `Capability` — Queue resource ceiling reached
+
+The queue has admitted the job but cannot schedule it because the queue's resource ceiling has been reached.
+
+```bash
+kubectl get queue -o custom-columns='NAME:.metadata.name,CAPABILITY:.spec.capability,ALLOCATED:.status.allocated'
+```
+
+For GPU-specific checks (GPU is often the bottleneck in Volcano clusters):
+
+```bash
+kubectl get queue -o custom-columns='NAME:.metadata.name,GPU_CAP:.spec.capability.nvidia\.com/gpu,GPU_ALLOC:.status.allocated.nvidia\.com/gpu'
+```
+
+Compare `Allocated` vs `Capability` for each resource dimension (cpu, memory, GPU). If any dimension is at or near the ceiling, the queue cannot allocate more resources.
+
+**Also verify queue capability against actual cluster capacity** — a common misconfiguration is setting queue capability higher than the cluster's physical resources:
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu,CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory'
+```
+
+If the sum of all nodes' allocatable GPUs is less than the queue's `spec.capability.nvidia.com/gpu`, the queue can never be fully utilized. When `Allocated` reaches the cluster's physical limit, the queue will appear to have remaining capacity but no more resources can actually be scheduled.
+
+**Resolution options:**
+- Wait for other jobs in the queue to complete and release resources
+- Increase the queue's `spec.capability` (only if cluster has physical capacity)
+- Adjust queue capability to match actual cluster resources to avoid misleading capacity display
+- Move the job to a different queue with available capacity
+
+---
+
+#### PodGroup `Inqueue`, Queue has spare capacity — Gang constraints not satisfiable
+
+The queue has available resources, but not enough to satisfy the gang scheduling constraints.
+
+**Check minMember:**
+
+```bash
+kubectl get podgroup <podgroup-name> -n <ns> -o jsonpath='{.spec.minMember}'
+```
+
+**Check minResources:**
+
+```bash
+kubectl get podgroup <podgroup-name> -n <ns> -o jsonpath='{.spec.minResources}'
+```
+
+Check what each pod requests:
+
+```bash
+kubectl get vcjob <job-name> -n <ns> -o yaml 2>/dev/null || kubectl get job.batch.volcano.sh <job-name> -n <ns> -o yaml
+```
+
+**Example (minMember):** Queue has 4 free GPUs, but the PodGroup requires `minMember: 8` pods each requesting 1 GPU. Gang scheduling requires all 8 pods to be placed simultaneously, so 4 GPUs is insufficient even though individually each pod could fit.
+
+**Example (minResources):** Queue has 16 free GPUs, but the PodGroup requires `minResources: {nvidia.com/gpu: 32}`. Even though individual pods might fit, the total GPU requirement is not met.
+
+**Check for node-level constraints narrowing available resources:**
+
+If the queue appears to have enough capacity but the job is still stuck in `Inqueue`, the job may have `nodeSelector`, `tolerations`, or `affinity` rules that restrict which nodes it can run on:
+
+```bash
+kubectl get vcjob <job-name> -n <ns> -o jsonpath='{.spec.tasks[*].template.spec.nodeSelector}' 2>/dev/null
+kubectl get vcjob <job-name> -n <ns> -o jsonpath='{.spec.tasks[*].template.spec.tolerations}' 2>/dev/null
+```
+
+Then check if the matching nodes actually have available resources:
+
+```bash
+kubectl get nodes -l <label-key>=<label-value> -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+kubectl top nodes -l <label-key>=<label-value>
+```
+
+Volcano checks queue capacity first, then does node-level scheduling. A job can pass the queue check but fail node placement if all matching nodes are occupied. This is one of the most hidden causes of "queue has capacity but job won't schedule."
+
+**Resolution options:**
+- Reduce `minMember` or `minResources` if the job can tolerate partial scheduling
+- Wait for enough resources to free up to satisfy the full gang
+- Relax `nodeSelector`/affinity constraints if the job can run on other node types
+- Increase queue capability (only if cluster has physical capacity on matching nodes)
+
+---
+
+#### PodGroup `Pending`, no matching Queue — Queue not found or misconfigured
+
+The job references a queue that does not exist or the job's queue annotation is missing.
+
+```bash
+kubectl get vcjob <job-name> -n <ns> -o jsonpath='{.spec.queue}' 2>/dev/null || kubectl get job.batch.volcano.sh <job-name> -n <ns> -o jsonpath='{.spec.queue}'
+```
+
+Verify this queue exists:
+
+```bash
+kubectl get queue <queue-name>
+```
+
+If the queue name is empty, the job will use the `default` queue. Check if a `default` queue exists.
+
+---
+
+#### Multiple queues competing — Low-weight queue starved
+
+When multiple queues compete for shared cluster resources, Volcano distributes resources proportionally by weight.
+
+```bash
+kubectl get queue -o custom-columns='NAME:.metadata.name,WEIGHT:.spec.weight,CAPABILITY:.spec.capability,ALLOCATED:.status.allocated'
+```
+
+A queue with low weight may receive fewer resources when the cluster is under contention. Check if higher-weight queues are consuming a disproportionate share.
+
+---
+
+#### Job `Aborted` or `Failed` — Post-scheduling failure
+
+If the job was scheduled but then moved to `Aborted` or `Failed` status:
+
+```bash
+kubectl get vcjob <job-name> -n <ns> -o jsonpath='{.status.state.phase}' 2>/dev/null || kubectl get job.batch.volcano.sh <job-name> -n <ns> -o jsonpath='{.status.state.phase}'
+```
+
+Check job conditions and events for the reason:
+
+```bash
+kubectl describe vcjob <job-name> -n <ns> 2>/dev/null || kubectl describe job.batch.volcano.sh <job-name> -n <ns>
+```
+
+Common causes:
+- **Aborted due to preemption** — a higher-priority job or queue reclaimed resources (see step 4)
+- **Pod failure exceeding maxRetry** — individual pods crashed too many times
+- **Lifecycle policy triggered** — job's `failedTaskCount` or other policy conditions were met
+- **minMember no longer satisfiable** — some pods were evicted and the remaining count dropped below `minMember`, causing the entire gang to be torn down
+
+Check the pods that belong to this job for their termination reason:
+
+```bash
+kubectl get pods -n <ns> -l volcano.sh/job-name=<job-name> --sort-by='.metadata.creationTimestamp'
+kubectl describe pod <failed-pod> -n <ns>
+```
+
+### 4. Check reclaim and preemption
+
+```bash
+kubectl get queue -o custom-columns='NAME:.metadata.name,WEIGHT:.spec.weight,RECLAIMABLE:.spec.reclaimable,ALLOCATED:.status.allocated'
+```
+
+- **reclaimable: true** — Volcano can preempt jobs from this queue when higher-weight queues need resources. Jobs in reclaimable queues may be evicted.
+- **reclaimable: false** — Once resources are allocated to this queue, they cannot be taken back. This can cause resource hoarding if the queue is underutilizing its allocation.
+
+If the user's queue is low-weight and non-reclaimable queues are holding resources they don't actively need, resources may be locked up.
+
+**If a job was unexpectedly killed (user reports "my job was suddenly terminated"):**
+
+Check for preemption events:
+
+```bash
+kubectl get events -n <ns> --field-selector reason=Preempted
+```
+
+Check the job's status conditions for preemption or eviction reasons:
+
+```bash
+kubectl describe vcjob <job-name> -n <ns> 2>/dev/null || kubectl describe job.batch.volcano.sh <job-name> -n <ns>
+```
+
+Look for `Preempted`, `Evicted`, or `Aborted` conditions. Cross-reference with which queue triggered the preemption by checking which higher-weight queue's `Allocated` increased around the same time.
+
+### 5. Check Volcano component health
+
+If all configuration looks correct but jobs are still not being scheduled or pods are not being created:
+
+**Check scheduler:**
+
+```bash
+kubectl get pods -n volcano-system -l app=volcano-scheduler
+kubectl logs -n volcano-system -l app=volcano-scheduler --tail=100
+```
+
+**Check controller-manager** (responsible for creating pods after scheduling decisions):
+
+```bash
+kubectl get pods -n volcano-system -l app=volcano-controllers
+kubectl logs -n volcano-system -l app=volcano-controllers --tail=100
+```
+
+The scheduler makes scheduling decisions, but the controller-manager is responsible for actually creating pods. If the scheduler is healthy but the controller-manager is down, scheduling decisions are made but pods will not be created.
+
+Common issues:
+- Scheduler or controller-manager pod not running or in CrashLoopBackOff
+- Plugin configuration errors
+- Cluster resource discovery failures
+- Leader election issues (if running multiple replicas)
+
+## Notes
+
+- Volcano Queue manages resources at the **queue level**, not the namespace level. A single queue can span multiple namespaces, and a namespace can have jobs in different queues.
+- Gang scheduling has two constraint fields: `minMember` (pod count) and `minResources` (aggregate resources). Both must be satisfied. `minMember` is more common for distributed training, `minResources` is used when total resource quantity matters more than pod count.
+- Queue `spec.capability` is a configuration upper bound, not a guarantee of physical resources. Always cross-validate against actual cluster allocatable resources to avoid phantom capacity.
+- Volcano Jobs may be registered as `vcjob` or `job.batch.volcano.sh` depending on the deployment. Always try both: `kubectl get vcjob` first, fallback to `kubectl get job.batch.volcano.sh`. Regular `kubectl get jobs` (batch/v1) will not show Volcano-managed workloads.
+- Volcano scheduling is a two-phase process: first queue-level admission (capacity check), then node-level placement. A job can pass queue admission but fail node placement due to `nodeSelector`, taints, or affinity constraints — this manifests as PodGroup stuck in `Inqueue` with queue capacity available.
+- For cross-reference: if pods ARE created but stuck in Pending, the issue may be at the Kubernetes scheduler level (node resources, taints, affinity) — use `pod-pending-debug`.
+- Volcano Queue and Kubernetes ResourceQuota are independent. If the namespace also has a ResourceQuota, pods may pass Volcano scheduling but still be rejected by Kubernetes admission — use `quota-debug` for that layer.


### PR DESCRIPTION
- Add quota-debug skill for native K8s ResourceQuota/LimitRange admission diagnosis
- Add volcano-queue-debug skill for Volcano Queue/PodGroup gang scheduling diagnosis
- Update deployment-rollout-debug to cross-reference both new skills
- Register new skills in meta.json

## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **SQLite DDL parity**: New tables added to both `schema-sqlite.ts` AND `migrate-sqlite.ts`.
- [ ] **Both brain types**: Tool changes work with pi-agent (TypeBox) and claude-sdk (MCP/Zod).

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
