### PR TITLE
fix(ui): workspace switch & notification z-index

### DIFF
--- a/src/gateway/web/src/components/NotificationBell.tsx
+++ b/src/gateway/web/src/components/NotificationBell.tsx
@@ -61,7 +61,7 @@ export function NotificationBell() {
             </button>
 
             {isOpen && (
-                <div className="absolute top-full left-0 mt-2 w-[28rem] bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden z-50">
+                <div className="absolute top-full left-0 mt-2 w-[28rem] bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden z-[60]">
                     {/* Header */}
                     <div className="px-4 py-3 border-b border-gray-100 flex items-center justify-between">
                         <h3 className="text-sm font-semibold text-gray-900">Notifications</h3>

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -153,6 +153,7 @@ function reduceInvestigationProgress(
 }
 
 const SESSION_KEY_STORAGE = 'siclaw_current_session';
+const SESSION_WORKSPACE_STORAGE = 'siclaw_session_workspace';
 const SELECTED_BRAIN_STORAGE = 'siclaw_selected_brain';
 
 export type BrainType = "pi-agent" | "claude-sdk";
@@ -281,7 +282,12 @@ export function usePilot() {
     });
     const [sessions, setSessions] = useState<Session[]>([]);
     const [currentSessionKey, setCurrentSessionKey] = useState<string | null>(() => {
-        return sessionStorage.getItem(SESSION_KEY_STORAGE);
+        const storedKey = sessionStorage.getItem(SESSION_KEY_STORAGE);
+        if (!storedKey) return null;
+        // If workspace changed while Pilot was unmounted, discard stale session key
+        const storedWs = sessionStorage.getItem(SESSION_WORKSPACE_STORAGE);
+        if (storedWs !== (workspaceId ?? '')) return null;
+        return storedKey;
     });
     const [isLoading, setIsLoading] = useState(false);
     const [pendingMessages, setPendingMessages] = useState<string[]>([]);
@@ -346,14 +352,16 @@ export function usePilot() {
         setInvestigationProgress(null);
     };
 
-    // Persist currentSessionKey to sessionStorage (per-tab isolation)
+    // Persist currentSessionKey + workspace to sessionStorage (per-tab isolation)
     useEffect(() => {
         if (currentSessionKey) {
             sessionStorage.setItem(SESSION_KEY_STORAGE, currentSessionKey);
+            sessionStorage.setItem(SESSION_WORKSPACE_STORAGE, workspaceId ?? '');
         } else {
             sessionStorage.removeItem(SESSION_KEY_STORAGE);
+            sessionStorage.removeItem(SESSION_WORKSPACE_STORAGE);
         }
-    }, [currentSessionKey]);
+    }, [currentSessionKey, workspaceId]);
 
     // Persist dpActive to localStorage
     useEffect(() => {
@@ -1187,13 +1195,26 @@ export function usePilot() {
     // Load sessions, skills, and models on connect; reload history for persisted session
     useEffect(() => {
         if (isConnected) {
-            loadSessions();
+            // Load sessions and auto-select most recent if no persisted session key
+            (async () => {
+                try {
+                    const params: Record<string, unknown> = {};
+                    if (workspaceId) params.workspaceId = workspaceId;
+                    const result = await sendRpc<{ sessions: Session[] }>('session.list', params);
+                    const newSessions = result.sessions ?? [];
+                    setSessions(newSessions);
+                    if (currentSessionKey) {
+                        loadHistory(currentSessionKey);
+                    } else if (newSessions.length > 0) {
+                        loadHistory(newSessions[0].key);
+                    }
+                } catch (err) {
+                    console.error('Failed to load sessions:', err);
+                }
+            })();
             loadSkills();
             loadModels();
             loadSystemStatus();
-            if (currentSessionKey) {
-                loadHistory(currentSessionKey);
-            }
         }
     }, [isConnected]); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## Problem

1. **Workspace switch not reflected on Pilot page**: Switching workspace from a non-Pilot page (e.g. Models, Credentials), then navigating back to Pilot, still shows the old workspace's conversation. This happens because `currentSessionKey` persisted in sessionStorage belongs to the previous workspace, and the workspace-change effect in `usePilot` doesn't fire (prev === current on fresh mount).

2. **Notification dropdown hidden behind Recent Sessions drawer**: Both use `z-50`, but the drawer is inside `<main>` (painted after Sidebar in DOM order), so it overlaps the notification panel.

## Solution

1. Store workspace ID alongside session key in sessionStorage (`siclaw_session_workspace`). On `usePilot` init, if the stored workspace doesn't match the current one, discard the stale session key. The initial-load effect then auto-selects the most recent session from the correct workspace.

2. Raise notification dropdown z-index from `z-50` to `z-[60]`.

## Test plan

- [ ] Switch workspace from a non-Pilot page, navigate back to Pilot — should show correct workspace's sessions
- [ ] Open both notification dropdown and Recent Sessions drawer — notification should render on top
- [ ] Normal workspace switch while on Pilot page still works as before
- [ ] Refresh page — persisted session key should restore correctly within the same workspace