### PR TITLE
fix: deep investigation UI — IME conflict, refresh state restoration

### DIFF
--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -421,6 +421,17 @@ export function usePilot() {
                     // Initialize investigation progress for deep_search (preserve optimistic state if present)
                     if (toolName === 'deep_search') {
                         setInvestigationProgress(prev => prev ?? { hypotheses: [] });
+                        // Ensure dpChecklist exists so InvestigationCard is hidden in favor of DpChecklistCard.
+                        // Covers page refresh where restoreDpProgress returned empty (Phase 3 hadn't started yet).
+                        setDpChecklist(prev => {
+                            if (prev) return prev;
+                            const checklist = createDefaultDpChecklist();
+                            checklist[0].status = 'done';         // triage
+                            checklist[1].status = 'done';         // hypotheses
+                            checklist[2].status = 'in_progress';  // deep_search
+                            return checklist;
+                        });
+                        setDpFocus(prev => prev ?? 'deep_search');
                     }
                     // Handle manage_checklist status updates
                     if (toolName === 'manage_checklist') {
@@ -1119,17 +1130,19 @@ export function usePilot() {
             // If the prompt has already finished, restoring the old phase/checklist leaves
             // the UI stuck showing a stale "Present findings" card for completed sessions.
             if (!snap.promptActive) return;
-            if (!snap.events || snap.events.length === 0) return;
+
             // Replay events through the same reducer used for live progress
             let state: InvestigationProgress = { hypotheses: [] };
-            for (const ev of snap.events) {
-                state = reduceInvestigationProgress(state, ev);
+            if (snap.events && snap.events.length > 0) {
+                for (const ev of snap.events) {
+                    state = reduceInvestigationProgress(state, ev);
+                }
+                setInvestigationProgress(state);
             }
-            setInvestigationProgress(state);
 
-            // Derive dpChecklist from restored investigation state so the
-            // DpChecklistCard renders (it gates hypothesis tree visibility).
-            // Phase values from engine: "Phase 1/4" .. "Phase 4/4"
+            // Always create dpChecklist when prompt is active, even without events.
+            // Without this, a page refresh during deep_search shows the bare
+            // InvestigationCard (no progress bars) instead of DpChecklistCard.
             const phase = state.phase;
             const checklist = createDefaultDpChecklist();
             const phaseNum = phase ? parseInt(phase.match(/(\d+)/)?.[1] ?? '0') : 0;
@@ -1142,8 +1155,9 @@ export function usePilot() {
                         checklist[i].status = 'in_progress';
                     }
                 }
-            } else if (state.hypotheses.length > 0) {
-                // Have hypotheses but no phase info — at least in deep_search
+            } else {
+                // No phase info — default to deep_search in_progress so
+                // DpChecklistCard renders instead of bare InvestigationCard.
                 checklist[0].status = 'done';
                 checklist[1].status = 'done';
                 checklist[2].status = 'in_progress';

--- a/src/gateway/web/src/pages/Pilot/components/HypothesesCard.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/HypothesesCard.tsx
@@ -225,9 +225,11 @@ export interface HypothesesCardProps {
     abortResponse?: () => void;
     onHypothesesConfirmed?: (hypotheses: ConfirmedHypothesis[]) => void;
     superseded?: boolean;
+    /** True when a deep_search exists after this card — survives page refresh */
+    alreadyConfirmed?: boolean;
 }
 
-export function HypothesesCard({ message, sendMessage, abortResponse, onHypothesesConfirmed, superseded }: HypothesesCardProps) {
+export function HypothesesCard({ message, sendMessage, abortResponse, onHypothesesConfirmed, superseded, alreadyConfirmed }: HypothesesCardProps) {
     const [feedbackMode, setFeedbackMode] = useState(false);
     const [feedbackText, setFeedbackText] = useState('');
     const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
@@ -239,6 +241,9 @@ export function HypothesesCard({ message, sendMessage, abortResponse, onHypothes
     // Parse hypotheses: prefer toolDetails.hypotheses (gateway mode), fallback to toolInput
     const hypothesesSource = (message.toolDetails?.hypotheses as string) || message.toolInput || '';
     const hypotheses = parseHypotheses(hypothesesSource);
+
+    // Effective confirmed: local state OR derived from history (deep_search exists after this card)
+    const effectiveConfirmed = confirmed || alreadyConfirmed;
 
     // Superseded: a newer propose_hypotheses exists — render collapsed
     if (superseded) {
@@ -258,7 +263,7 @@ export function HypothesesCard({ message, sendMessage, abortResponse, onHypothes
 
     // Check if auto-confirmed (TUI mode) or user-confirmed (web mode)
     const isAutoConfirmed = isDone && (message.toolDetails?.autoConfirmed === true);
-    const showActions = isDone && !isRunning && !feedbackMode && !isAutoConfirmed && !confirmed;
+    const showActions = isDone && !isRunning && !feedbackMode && !isAutoConfirmed && !effectiveConfirmed;
 
     const emitConfirmed = () => {
         if (onHypothesesConfirmed && hypotheses.length > 0) {
@@ -309,13 +314,13 @@ export function HypothesesCard({ message, sendMessage, abortResponse, onHypothes
                     <Search className="w-4 h-4 text-indigo-500 shrink-0" />
                     <span className="text-sm font-semibold text-gray-800">Deep Investigation</span>
                     <span className="text-xs text-gray-500">Hypothesis Review</span>
-                    {isDone && (isAutoConfirmed || confirmed) && (
+                    {isDone && (isAutoConfirmed || effectiveConfirmed) && (
                         <span className="ml-auto text-xs font-medium px-1.5 py-0.5 rounded flex items-center gap-1 bg-indigo-100 text-indigo-700">
                             <CheckCircle2 className="w-3 h-3" />
                             Confirmed
                         </span>
                     )}
-                    {isDone && !isAutoConfirmed && !confirmed && !feedbackMode && (
+                    {isDone && !isAutoConfirmed && !effectiveConfirmed && !feedbackMode && (
                         <span className="ml-auto text-xs text-amber-600 font-medium px-1.5 py-0.5 rounded bg-amber-50">
                             Awaiting review
                         </span>
@@ -401,7 +406,7 @@ export function HypothesesCard({ message, sendMessage, abortResponse, onHypothes
                             type="text"
                             value={feedbackText}
                             onChange={(e) => setFeedbackText(e.target.value)}
-                            onKeyDown={(e) => e.key === 'Enter' && handleSendFeedback()}
+                            onKeyDown={(e) => e.key === 'Enter' && !e.nativeEvent.isComposing && handleSendFeedback()}
                             placeholder="Add/modify hypotheses..."
                             className="flex-1 text-sm border border-indigo-200 rounded-md px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-indigo-400"
                             autoFocus

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -209,6 +209,22 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
         return null;
     }, [messages]);
 
+    // Check if latest hypotheses were already confirmed.
+    // Three signals (any one is sufficient):
+    // 1. deep_search tool message exists after hypotheses (works when complete or in live session)
+    // 2. User confirmation message exists ("confirmed hypotheses") — always persisted immediately
+    // 3. dpChecklist has deep_search in progress/done (works on refresh when deep_search isn't in history yet)
+    const latestHypothesesConfirmed = useMemo(() => {
+        if (!latestHypothesesId) return false;
+        const hypoIdx = messages.findIndex(m => m.id === latestHypothesesId);
+        if (hypoIdx < 0) return false;
+        const afterHypo = messages.slice(hypoIdx + 1);
+        if (afterHypo.some(m => m.toolName === 'deep_search')) return true;
+        if (afterHypo.some(m => m.role === 'user' && m.content.includes('confirmed hypotheses'))) return true;
+        if (dpChecklist?.some(i => i.id === 'deep_search' && (i.status === 'in_progress' || i.status === 'done'))) return true;
+        return false;
+    }, [messages, latestHypothesesId, dpChecklist]);
+
     // Handles three cases:
     // 1. Initial load / session switch (0 → N): force scroll to bottom
     // 2. Prepend (load more): restore scroll position so view doesn't jump
@@ -379,8 +395,10 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                     sendMessage={sendMessage}
                                     abortResponse={abortResponse}
                                     dpFocus={dpFocus}
+                                    dpChecklistActive={dpChecklist != null && dpChecklist.length > 0}
                                     onHypothesesConfirmed={onHypothesesConfirmed}
                                     hypothesesSuperseded={latestHypothesesId != null && msg.toolName === 'propose_hypotheses' && msg.id !== latestHypothesesId}
+                                    hypothesesAlreadyConfirmed={msg.id === latestHypothesesId && latestHypothesesConfirmed}
                                     selectedWorkspaceId={selectedWorkspaceId}
                                 />
                             ))}
@@ -448,7 +466,7 @@ function parseDeepInvestigation(content: string): { isDeepInvestigation: boolean
     return { isDeepInvestigation: false, text: content };
 }
 
-function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, onHypothesesConfirmed, hypothesesSuperseded, selectedWorkspaceId }: {
+function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, dpChecklistActive, onHypothesesConfirmed, hypothesesSuperseded, hypothesesAlreadyConfirmed, selectedWorkspaceId }: {
     message: PilotMessage;
     sendRpc?: RpcSendFn;
     skills?: Skill[];
@@ -465,8 +483,12 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
     sendMessage?: (text: string) => void;
     abortResponse?: () => void;
     dpFocus?: string | null;
+    /** True when DpChecklistCard is active — used to hide InvestigationCard even if dpFocus is transiently null */
+    dpChecklistActive?: boolean;
     onHypothesesConfirmed?: (hypotheses: Array<{ id: string; text: string; confidence: number }>) => void;
     hypothesesSuperseded?: boolean;
+    /** True when a deep_search exists after this propose_hypotheses — survives page refresh */
+    hypothesesAlreadyConfirmed?: boolean;
     selectedWorkspaceId?: string | null;
 }) {
     const isUser = message.role === 'user';
@@ -486,14 +508,16 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
             return <ScheduleCard message={message} status={scheduleStatus ?? 'pending'} onOpenPanel={onOpenSchedulePanel} sendRpc={sendRpc} updateMessageMeta={updateMessageMeta} selectedWorkspaceId={selectedWorkspaceId} />;
         }
         if (message.toolName === 'deep_search') {
-            // In DP mode, DpChecklistCard handles the running display — hide duplicate InvestigationCard
-            if (message.isStreaming && dpFocus) {
+            // In DP mode, DpChecklistCard handles the running display — hide duplicate InvestigationCard.
+            // Use dpChecklistActive (not just dpFocus) to avoid brief flash when dpFocus is transiently null
+            // during checklist phase transitions.
+            if (message.isStreaming && (dpFocus || dpChecklistActive)) {
                 return null;
             }
             return <InvestigationCard message={message} progress={message.isStreaming ? investigationProgress : undefined} />;
         }
         if (message.toolName === 'propose_hypotheses' && !message.isStreaming) {
-            return <HypothesesCard message={message} sendMessage={sendMessage} abortResponse={abortResponse} onHypothesesConfirmed={onHypothesesConfirmed} superseded={hypothesesSuperseded} />;
+            return <HypothesesCard message={message} sendMessage={sendMessage} abortResponse={abortResponse} onHypothesesConfirmed={onHypothesesConfirmed} superseded={hypothesesSuperseded} alreadyConfirmed={hypothesesAlreadyConfirmed} />;
         }
         return <ToolItem message={message} skills={skills} onEditSkill={onEditSkill} />;
     }


### PR DESCRIPTION
## Problem

Three bugs in the deep investigation UI:

1. **IME Enter conflict**: In HypothesesCard "Modify" feedback input, pressing Enter to select an IME candidate (CJK input) triggers message send instead of confirming the character
2. **Phase 2 buttons reappear on refresh**: After confirming hypotheses and starting Phase 3, refreshing the page shows "Confirm / Modify" buttons again because confirmation state is local React state
3. **Bare fallback card on refresh**: Refreshing during deep_search shows InvestigationCard without progress bars instead of DpChecklistCard, because `restoreDpProgress` returns early when events are empty

## Solution

1. Add `!e.nativeEvent.isComposing` guard to the Enter keydown handler
2. Derive confirmation state from message history via three-signal detection (deep_search tool message / user confirm message / dpChecklist status), pass as `alreadyConfirmed` prop
3. In `restoreDpProgress`, always create `dpChecklist` when `promptActive` is true — even without events. Also auto-create dpChecklist on `tool_execution_start` for `deep_search` as safety net
4. Use `dpChecklistActive` (checklist exists) instead of just `dpFocus` to prevent InvestigationCard flash during phase transitions