### PR TITLE
fix: restrict schedule and skill tools to web/channel mode

### DIFF
--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -264,10 +264,13 @@ export async function createSiclawSession(
     createCredentialListTool(kubeconfigRef),
   ];
 
-  // Web/channel-only tools: these require frontend UI for rendering, confirmation,
-  // or workspace binding that TUI (cli) mode does not have.
+  // Schedule tool works in web + channel (no UI rendering needed, just DB ops).
   if (mode !== "cli") {
     customTools.push(createManageScheduleTool(kubeconfigRef));
+  }
+  // Skill management tools are web-only: they produce output designed for
+  // frontend preview card rendering that neither TUI nor channel mode supports.
+  if (mode === "web") {
     customTools.push(createCreateSkillTool());
     customTools.push(createUpdateSkillTool());
     customTools.push(createForkSkillTool());


### PR DESCRIPTION
## Problem

`ManageScheduleTool` and skill management tools (create/update/fork) produce output designed for frontend UI rendering. In TUI/CLI mode there is no UI to render confirmation dialogs or skill previews, making these tools non-functional.

## Solution

Move `ManageScheduleTool` into the `mode !== "cli"` conditional block alongside skill tools. This restricts both tool groups to web and channel modes where the frontend can properly render their output.