### PR TITLE
feat(skills): add Volcano scheduling diagnostic skills for SRE

### DIFF
--- a/skills/core/cluster-events/SKILL.md
+++ b/skills/core/cluster-events/SKILL.md
@@ -61,7 +61,7 @@ Match the Warning events against the patterns below. For each matched pattern, r
 
 The scheduler cannot place a pod on any node.
 
-**Next step:** Use the `pod-pending-debug` skill to diagnose the specific pod.
+**Next step:** Use the `pod-pending-debug` skill to diagnose the specific pod. If the pod has a `scheduling.volcano.sh/pod-group` annotation (managed by Volcano scheduler), use `volcano-diagnose-pod` skill instead for Volcano-specific issues (PodGroup, Queue, Gang scheduling).
 
 ---
 

--- a/skills/core/meta.json
+++ b/skills/core/meta.json
@@ -18,6 +18,14 @@
     "pod-ping-gateway":         ["kubernetes", "network",  "diagnostic", "sre", "developer"],
     "pod-show-gateway":         ["kubernetes", "network",  "diagnostic", "sre", "developer"],
     "pvc-debug":                ["kubernetes", "general",  "diagnostic", "sre", "developer"],
-    "service-debug":            ["kubernetes", "network",  "diagnostic", "sre", "developer"]
+    "service-debug":            ["kubernetes", "network",  "diagnostic", "sre", "developer"],
+    "volcano-diagnose-pod":       ["volcano", "scheduling", "diagnostic", "sre", "developer"],
+    "volcano-gang-scheduling":    ["volcano", "scheduling", "diagnostic", "sre", "developer"],
+    "volcano-resource-insufficient": ["volcano", "scheduling", "diagnostic", "sre", "developer"],
+    "volcano-queue-diagnose":     ["volcano", "scheduling", "diagnostic", "sre", "developer"],
+    "volcano-scheduler-logs":     ["volcano", "scheduling", "diagnostic", "sre", "developer"],
+    "volcano-node-resources":     ["volcano", "scheduling", "diagnostic", "sre", "developer"],
+    "volcano-job-diagnose":       ["volcano", "scheduling", "diagnostic", "sre", "developer"],
+    "volcano-scheduler-config":   ["volcano", "scheduling", "diagnostic", "sre", "developer"]
   }
 }

--- a/skills/core/pod-pending-debug/SKILL.md
+++ b/skills/core/pod-pending-debug/SKILL.md
@@ -144,3 +144,4 @@ The scheduler is attempting to evict lower-priority pods to make room. This is n
 
 - If no `FailedScheduling` event exists, the pod may not have been processed by the scheduler yet — check if the scheduler pod itself is healthy: `kubectl get pods -n kube-system -l component=kube-scheduler`.
 - For pods created by controllers (Deployment, StatefulSet), the pending pod name may change as the controller recreates it — use label selectors to find the current pending pod.
+- If the pod has a `scheduling.volcano.sh/pod-group` annotation, it is managed by Volcano scheduler — use `volcano-diagnose-pod` skill instead for Volcano-specific issues (PodGroup, Queue, Gang scheduling).

--- a/skills/core/volcano-diagnose-pod/SKILL.md
+++ b/skills/core/volcano-diagnose-pod/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: volcano-diagnose-pod
+description: >-
+  Diagnose Volcano-managed Pod scheduling issues.
+  Checks Pod status, PodGroup, events, and Queue to identify scheduling failures.
+---
+
+# Volcano Pod Diagnosis
+
+Diagnose Volcano-managed Pod scheduling issues. This skill checks Pod status, associated PodGroup, scheduling events, and Queue configuration to identify why a Pod cannot be scheduled.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify pod specs, PodGroups, or Queues — that should be left to the user.
+
+## Usage
+
+```bash
+bash skills/core/volcano-diagnose-pod/scripts/diagnose-pod.sh --pod <pod-name> --namespace <namespace>
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--pod POD` | yes | Pod name to diagnose |
+| `--namespace NS` | no | Namespace (default: `default`) |
+| `--verbose` | no | Show detailed output including node resources |
+
+## Examples
+
+Diagnose a pending pod in default namespace:
+```bash
+bash skills/core/volcano-diagnose-pod/scripts/diagnose-pod.sh --pod my-job-0
+```
+
+Diagnose a pod in specific namespace:
+```bash
+bash skills/core/volcano-diagnose-pod/scripts/diagnose-pod.sh --pod my-job-0 --namespace training
+```
+
+Verbose mode with node resource information:
+```bash
+bash skills/core/volcano-diagnose-pod/scripts/diagnose-pod.sh --pod my-job-0 --namespace training --verbose
+```
+
+## Diagnostic Flow
+
+The script performs the following checks in order:
+
+### 1. Pod Status
+Check the Pod's current phase and conditions.
+
+```bash
+kubectl get pod <pod> -n <ns> -o wide
+kubectl describe pod <pod> -n <ns>
+```
+
+### 2. PodGroup Status
+Check if the Pod is associated with a PodGroup and its scheduling status.
+
+```bash
+kubectl get pod <pod> -n <ns> -o jsonpath='{.metadata.annotations.scheduling.volcano.sh/pod-group}'
+kubectl get podgroup <podgroup> -n <ns>
+```
+
+Key fields to check:
+- `spec.minMember`: Minimum members required for Gang scheduling
+- `status.phase`: Pending, Inqueue, Running, Unknown
+- `status.running`: Number of running pods
+- `status.pending`: Number of pending pods
+
+### 3. Events Analysis
+Check scheduling events for failure reasons.
+
+```bash
+kubectl get events -n <ns> --field-selector involvedObject.name=<pod> --sort-by='.lastTimestamp'
+```
+
+Look for these event patterns:
+
+#### `FailedScheduling` - General scheduling failure
+The scheduler attempted but failed to schedule the pod. Check the message for specific reasons.
+
+**Volcano-specific sub-patterns:**
+
+| Event Message | Meaning | Next Step |
+|---------------|---------|-----------|
+| `0/N nodes are available` + `minMember` | Gang constraint not satisfied | Use `volcano-gang-scheduling` |
+| `exceeded quota` / `queue resource exceeded` | Queue deserved resources exhausted | Use `volcano-queue-diagnose` |
+| `Insufficient cpu/memory` + Gang mention | Resource shortage blocking Gang | Use `volcano-resource-insufficient` |
+| `pod group is not ready` | PodGroup not in Inqueue phase | Check PodGroup status |
+| `task <name> is not ready` | Task dependencies not met | Check dependent tasks |
+
+> **Quick Reference vs Detailed Analysis:** The table above provides a quick lookup for common patterns. The sections below provide detailed analysis, additional context, and more diagnostic commands for each pattern.
+
+#### `Insufficient cpu` / `Insufficient memory` - Resource shortage
+No node has enough allocatable resources. Check:
+- Node resources: `kubectl top nodes`
+- Pod resource requests: `kubectl get pod <pod> -n <ns> -o jsonpath='{.spec.containers[*].resources.requests}'`
+
+**Volcano context:** If this is a Gang-scheduled pod, even if total cluster resources are sufficient, you need enough resources **simultaneously** on enough nodes. Use `volcano-resource-insufficient` to check fragmentation.
+
+#### `minMember` not satisfied - Gang constraint
+The PodGroup requires `minMember` pods to be scheduled simultaneously, but the cluster cannot satisfy this. Use `volcano-gang-scheduling` skill for detailed diagnosis.
+
+**Key insight:** Even if `kubectl top nodes` shows enough total resources, Gang requires **simultaneous** availability on **different nodes**.
+
+#### `queue resource exceeded` - Queue quota limit
+The Queue associated with this Pod has exceeded its deserved resources. Check Queue status with `volcano-queue-diagnose` skill.
+
+**Volcano-specific terms you might see:**
+- `overused` - Queue has exceeded its fair share
+- `deserved resources` - Calculated from queue weight proportion
+- `allocated resources` - Currently used by jobs in this queue
+
+#### `reclaim` events - Resource reclamation triggered
+If you see events mentioning `reclaim`:
+- Another queue is trying to reclaim resources from your pod's queue
+- Your queue may be `over-allocated` (allocated > deserved)
+- Check queue status: `volcano-queue-diagnose --queue <queue>`
+
+#### `preempt` events - Priority preemption
+Higher priority workload is evicting this pod. Check:
+- Pod priority class: `kubectl get pod <pod> -o jsonpath='{.spec.priorityClassName}'`
+- Preemptor details in scheduler logs: `volcano-scheduler-logs --keyword preempt`
+
+#### `enqueue` related events
+- `PodGroup is enqueued` - PodGroup admitted to queue, ready for scheduling
+- `PodGroup is pending` - Waiting for queue admission (capacity or resource check)
+- `enqueue failed` - Failed admission check (overcommit, queue closed, etc.)
+
+### 4. Queue Status
+Check the Queue configuration and resource allocation.
+
+```bash
+kubectl get podgroup <podgroup> -n <ns> -o jsonpath='{.spec.queue}'
+kubectl get queue <queue>
+kubectl describe queue <queue>
+```
+
+Key fields:
+- `spec.weight`: Queue weight for resource sharing
+- `spec.capability`: Maximum resources the queue can use
+- `status.state`: Open, Closed, or Closing
+- `status.deserved`: Resources deserved by this queue
+- `status.allocated`: Resources currently allocated
+
+### 5. Node Resources (verbose mode)
+When `--verbose` is specified, also check node allocatable resources.
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory'
+```
+
+## Common Issues and Solutions
+
+### Pod stuck in Pending, no events
+- Check if Volcano scheduler is running: `kubectl get pods -n volcano-system -l app=volcano-scheduler`
+- Check if Volcano controller-manager is running: `kubectl get pods -n volcano-system -l app=volcano-controller-manager`
+  - The controller-manager is responsible for Job lifecycle, PodGroup creation, and queue management — if it's down, jobs won't transition states even if the scheduler is healthy
+- Check scheduler logs: `volcano-scheduler-logs` skill
+
+### PodGroup phase is Pending
+- The PodGroup is waiting for enqueue action to admit it
+- **Verify the queue actually exists** — a typo in queue name causes the PodGroup to stay Pending silently:
+  ```bash
+  kubectl get podgroup <pg> -n <ns> -o jsonpath='{.spec.queue}'
+  kubectl get queue <queue-name>
+  ```
+  If the queue name is empty, the job uses the `default` queue — verify it exists and is Open
+- Check Queue capacity and deserved resources
+- Check if cluster has sufficient resources
+
+### PodGroup phase is Inqueue but Pod is Pending
+- Check if `minMember` constraint is not satisfied
+- Check if there are affinity/anti-affinity conflicts
+- Check if taints prevent scheduling
+
+### Queue status shows insufficient deserved resources
+- The queue may have insufficient weight or capability configured
+- Other queues may be reclaiming resources
+- Use `volcano-queue-diagnose` for detailed analysis
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VOLCANO_NAMESPACE` | `default` | Default namespace for Pod lookup |
+| `VOLCANO_SCHEDULER_NS` | `volcano-system` | Namespace where volcano scheduler runs |
+
+## See Also
+
+- `volcano-gang-scheduling` - Detailed Gang scheduling diagnosis
+- `volcano-queue-diagnose` - Queue status and quota analysis
+- `volcano-scheduler-logs` - Scheduler log analysis
+- `volcano-resource-insufficient` - Resource shortage diagnosis

--- a/skills/core/volcano-diagnose-pod/scripts/diagnose-pod.sh
+++ b/skills/core/volcano-diagnose-pod/scripts/diagnose-pod.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Diagnose Volcano-managed Pod scheduling issues.
+# This script performs read-only operations using kubectl.
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: $0 --pod <pod> [options]
+
+Diagnose Volcano-managed Pod scheduling issues.
+Checks Pod status, PodGroup, events, and Queue configuration.
+
+Options:
+  --pod POD         Pod name to diagnose (required)
+  --namespace NS    Namespace (default: default)
+  --verbose         Show detailed output including node resources
+  -h, --help        Show this help message
+
+Environment:
+  VOLCANO_NAMESPACE     Override default namespace
+  VOLCANO_SCHEDULER_NS  Scheduler namespace (default: volcano-system)
+
+Examples:
+  $0 --pod my-job-0
+  $0 --pod my-job-0 --namespace training
+  $0 --pod my-job-0 --namespace training --verbose
+EOF
+  exit 0
+}
+
+# Parse arguments
+POD=""
+NS="${VOLCANO_NAMESPACE:-default}"
+SCHEDULER_NS="${VOLCANO_SCHEDULER_NS:-volcano-system}"
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help) show_help ;;
+    --pod) POD="$2"; shift 2 ;;
+    --namespace) NS="$2"; shift 2 ;;
+    --verbose) VERBOSE=true; shift ;;
+    *) echo "Unknown option: $1. Use --help for usage." >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$POD" ]] && { echo "Error: --pod is required. Use --help for usage." >&2; exit 1; }
+
+echo "=== Volcano Pod Diagnosis: $NS/$POD ==="
+echo
+
+# 1. Pod Status
+echo "[1/5] Pod Status"
+echo "----------------"
+if ! kubectl get pod "$POD" -n "$NS" -o wide 2>/dev/null; then
+  echo "Error: Pod '$POD' not found in namespace '$NS'" >&2
+  exit 1
+fi
+echo
+
+# Get Pod phase
+POD_PHASE=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+echo "Pod Phase: $POD_PHASE"
+echo
+
+# 2. PodGroup Information
+echo "[2/5] PodGroup Information"
+echo "--------------------------"
+PG=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.metadata.annotations.scheduling\.volcano\.sh/pod-group}' 2>/dev/null || true)
+
+if [[ -n "$PG" ]]; then
+  echo "PodGroup: $PG"
+  echo
+  if kubectl get podgroup "$PG" -n "$NS" 2>/dev/null; then
+    echo
+    PG_PHASE=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+    PG_MINMEMBER=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.spec.minMember}' 2>/dev/null || echo "0")
+    PG_RUNNING=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.status.running}' 2>/dev/null || echo "0")
+    PG_PENDING=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.status.pending}' 2>/dev/null || echo "0")
+    PG_QUEUE=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.spec.queue}' 2>/dev/null || echo "default")
+
+    echo "PodGroup Phase: $PG_PHASE"
+    echo "MinMember: $PG_MINMEMBER"
+    echo "Running: $PG_RUNNING"
+    echo "Pending: $PG_PENDING"
+    echo "Queue: $PG_QUEUE"
+  else
+    echo "Warning: PodGroup '$PG' not found"
+  fi
+else
+  echo "⚠️  No PodGroup annotation found — this Pod is NOT managed by Volcano scheduler."
+  echo "   Recommended: Use 'pod-pending-debug' skill for standard kube-scheduler issues."
+  echo ""
+  echo "   Continuing with basic event analysis..."
+fi
+echo
+
+# 3. Events Analysis
+echo "[3/5] Recent Events"
+echo "-------------------"
+kubectl get events -n "$NS" --field-selector "involvedObject.name=$POD" --sort-by='.lastTimestamp' 2>/dev/null | tail -15 || echo "No events found"
+echo
+
+# 4. Queue Status (if PodGroup exists and has a queue)
+if [[ -n "$PG" ]]; then
+  PG_QUEUE=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.spec.queue}' 2>/dev/null || echo "")
+  if [[ -n "$PG_QUEUE" ]]; then
+    echo "[4/5] Queue Status: $PG_QUEUE"
+    echo "------------------------------"
+    if kubectl get queue "$PG_QUEUE" 2>/dev/null; then
+      echo
+      QUEUE_STATE=$(kubectl get queue "$PG_QUEUE" -o jsonpath='{.status.state}' 2>/dev/null || echo "Unknown")
+      QUEUE_WEIGHT=$(kubectl get queue "$PG_QUEUE" -o jsonpath='{.spec.weight}' 2>/dev/null || echo "N/A")
+      echo "Queue State: $QUEUE_STATE"
+      echo "Queue Weight: $QUEUE_WEIGHT"
+      echo
+      echo "Deserved Resources:"
+      kubectl get queue "$PG_QUEUE" -o jsonpath='{.status.deserved}' 2>/dev/null || echo "  N/A"
+      echo
+      echo "Allocated Resources:"
+      kubectl get queue "$PG_QUEUE" -o jsonpath='{.status.allocated}' 2>/dev/null || echo "  N/A"
+    else
+      echo "Warning: Queue '$PG_QUEUE' not found"
+    fi
+    echo
+  else
+    echo "[4/5] Queue Status"
+    echo "------------------"
+    echo "No queue specified in PodGroup"
+    echo
+  fi
+else
+  echo "[4/5] Queue Status"
+  echo "------------------"
+  echo "Skipping (no PodGroup found)"
+  echo
+fi
+
+# 5. Node Resources (verbose mode)
+if [[ "$VERBOSE" == "true" ]]; then
+  echo "[5/5] Node Resources"
+  echo "--------------------"
+  echo "Node Allocatable Resources:"
+  kubectl get nodes -o custom-columns='NAME:.metadata.name,CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory,GPU:.status.allocatable.nvidia\.com/gpu' 2>/dev/null | head -10
+  echo
+
+  echo "Node Resource Usage (if metrics available):"
+  kubectl top nodes 2>/dev/null | head -10 || echo "Metrics not available (requires metrics-server)"
+  echo
+fi
+
+# Summary
+echo "=== Diagnosis Summary ==="
+echo "Pod: $NS/$POD"
+echo "Phase: $POD_PHASE"
+if [[ -n "$PG" ]]; then
+  echo "PodGroup: $PG (Phase: ${PG_PHASE:-Unknown})"
+  if [[ -n "${PG_QUEUE:-}" ]]; then
+    echo "Queue: $PG_QUEUE (State: ${QUEUE_STATE:-Unknown})"
+  fi
+else
+  echo "PodGroup: Not found"
+fi
+
+if [[ "$POD_PHASE" == "Pending" ]]; then
+  echo
+  echo "Recommendations:"
+  echo "1. Check events above for 'FailedScheduling' reasons"
+  echo "2. If PodGroup phase is 'Pending', check Queue capacity"
+  echo "3. If minMember is not satisfied, use volcano-gang-scheduling skill"
+  echo "4. Check scheduler logs with volcano-scheduler-logs skill"
+fi
+
+echo
+echo "=== Diagnosis Complete ==="

--- a/skills/core/volcano-gang-scheduling/SKILL.md
+++ b/skills/core/volcano-gang-scheduling/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: volcano-gang-scheduling
+description: >-
+  Gang Scheduling diagnostic guide for Volcano.
+  Use when PodGroup cannot schedule completely, member Pods remain Pending,
+  or minAvailable/minMember constraints are not satisfied.
+---
+
+# Gang Scheduling Diagnosis
+
+This is a diagnostic guide for Gang scheduling issues in Volcano. Gang scheduling requires that all members of a PodGroup be scheduled simultaneously. If the cluster cannot satisfy the `minMember` requirement, none of the pods will be scheduled.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify PodGroups or resource configurations.
+
+## When to Use This Guide
+
+Use this skill when:
+- PodGroup status is `Inqueue` but member Pods remain `Pending`
+- Events contain `minMember` related errors
+- Volcano Job has `minAvailable` or `minMember` that cannot be satisfied
+- Some member Pods are running, others are Pending, and the entire group won't start
+- You see `FailedScheduling` events mentioning Gang constraints
+
+## Understanding Gang Scheduling
+
+Gang scheduling in Volcano ensures that either all members of a workload are scheduled, or none are. This is crucial for distributed workloads like MPI, TensorFlow, PyTorch where partial scheduling is wasteful.
+
+**Key Concepts:**
+- `minMember` (in PodGroup spec): Minimum number of pods that must be scheduled simultaneously
+- `minResources` (in PodGroup spec): Aggregate resource floor (e.g., total GPUs) that must be available — **both** `minMember` and `minResources` must be satisfied if set
+- `minAvailable` (in Job spec): Similar concept at Job level
+- The scheduler checks if there are **simultaneous** resources for all minMember pods before allocating
+
+## Diagnostic Steps
+
+### Step 1: Identify the PodGroup
+
+Find the PodGroup associated with the pending pods:
+
+```bash
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.metadata.annotations.scheduling.volcano.sh/pod-group}'
+```
+
+### Step 2: Check PodGroup Status
+
+Get detailed PodGroup information:
+
+```bash
+kubectl get podgroup <podgroup-name> -n <namespace> -o yaml
+```
+
+**Key fields to examine:**
+
+| Field | Meaning | What to Look For |
+|-------|---------|------------------|
+| `spec.minMember` | Minimum pods required | Is this number achievable? |
+| `spec.minResources` | Aggregate resource floor | Is total cluster capacity sufficient? |
+| `status.phase` | Current scheduling phase | Should be `Inqueue` for ready-to-schedule |
+| `status.running` | Currently running pods | Compare to minMember |
+| `status.pending` | Pending pods | These are waiting for Gang constraint |
+| `spec.queue` | Queue name | Check if queue has sufficient resources |
+
+**Common scenarios:**
+
+- `status.phase: Pending` - PodGroup is waiting to be enqueued
+- `status.phase: Inqueue` - Ready for scheduling but constraint not met
+- `status.running < spec.minMember` - Gang constraint not satisfied
+
+### Step 3: Calculate Resource Requirements
+
+Calculate the total resources needed for the Gang:
+
+```
+Total CPU = minMember × single Pod CPU request
+Total Memory = minMember × single Pod Memory request
+Total GPU = minMember × single Pod GPU request (if applicable)
+```
+
+Get a pod's resource requests:
+
+```bash
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[*].resources.requests}'
+```
+
+### Step 4: Check Cluster Resources
+
+#### Option A: Check Node Resources
+
+View available resources across nodes:
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory,GPU:.status.allocatable.nvidia\.com/gpu'
+```
+
+Check current resource usage:
+
+```bash
+kubectl top nodes
+```
+
+#### Option B: Check by Node Labels (if pods have node affinity)
+
+If pods target specific nodes:
+
+```bash
+kubectl get nodes -l <label-key>=<label-value> -o wide
+```
+
+### Step 5: Check Events for Gang Errors
+
+Look for Gang-specific scheduling errors:
+
+```bash
+kubectl get events -n <namespace> --field-selector involvedObject.name=<pod-name> --sort-by='.lastTimestamp'
+```
+
+**Common Gang-related event messages:**
+
+| Message | Meaning | Investigation |
+|---------|---------|---------------|
+| `minMember not satisfied` | Gang constraint preventing scheduling | Check if total resources >= minMember requirements |
+| `gang member not ready` | Some pods in the gang are not ready | Check individual pod status |
+| `resource insufficient` | Not enough resources for all members | Use `volcano-resource-insufficient` skill |
+
+### Step 6: Verify Queue Resources
+
+If the PodGroup is in a Queue, check if the queue has sufficient deserved resources:
+
+```bash
+kubectl get queue <queue-name>
+kubectl describe queue <queue-name>
+```
+
+Look for:
+- `status.deserved` vs `status.allocated`
+- If allocated >= deserved, the queue is at capacity
+- Check `status.state` is `Open` (not `Closing` or `Closed`)
+
+## Common Causes and Solutions
+
+### Cause 1: minMember Too Large
+
+**Symptom:** `minMember` is larger than the number of available nodes, or requires more resources than any single node can provide.
+
+**Example:**
+- minMember = 10
+- Each pod requests 8 GPUs
+- Only 5 nodes have 8 GPUs each
+- **Result:** Gang can never be satisfied
+
+**Solution:**
+- Reduce `minMember` in PodGroup spec
+- Increase cluster capacity (add nodes)
+- Reduce per-pod resource requests
+
+### Cause 2: Resource Fragmentation
+
+**Symptom:** Total cluster resources are sufficient, but not concentrated on enough nodes to satisfy simultaneous scheduling.
+
+**Example:**
+- minMember = 4, each needs 4 CPUs
+- Total cluster: 20 CPUs available
+- But distributed across 10 nodes with 2 CPUs each
+- **Result:** Cannot find 4 nodes with 4 CPUs simultaneously
+
+**Solution:**
+- Configure `binpack` plugin to concentrate pods on fewer nodes
+- Defragment cluster by rescheduling or draining nodes
+- Adjust resource requests to fit node sizes
+
+### Cause 3: Priority Preemption
+
+**Symptom:** Resources exist but are being used by lower-priority workloads that should be preempted.
+
+**Check:**
+- Compare PodGroup priority vs running PodGroups
+- Check if higher priority exists in the same queue
+
+**Solution:**
+- Ensure correct PriorityClass is assigned
+- Check `priority` plugin is enabled in scheduler config
+
+### Cause 4: Queue Resource Exhaustion
+
+**Symptom:** The PodGroup's queue has used all its deserved resources.
+
+**Check:**
+```bash
+kubectl get queue <queue-name> -o jsonpath='{.status.allocated}'
+kubectl get queue <queue-name> -o jsonpath='{.status.deserved}'
+```
+
+**Solution:**
+- Increase queue weight or capability
+- Wait for other jobs to complete
+- Use `volcano-queue-diagnose` for detailed analysis
+
+### Cause 5: Affinity/Anti-Affinity Conflicts (Effective Node Pool Narrowing)
+
+**Symptom:** Queue shows available capacity, but Gang still blocks. Pod scheduling constraints narrow the effective node pool below what Gang requires.
+
+**Diagnosis — compute the effective node pool:**
+```bash
+# 1. Check pod's nodeSelector
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.nodeSelector}'
+
+# 2. Check matching nodes
+kubectl get nodes -l <selector-key>=<selector-value> -o custom-columns="NAME:.metadata.name,CPU:.status.allocatable.cpu,GPU:.status.allocatable['nvidia.com/gpu']"
+
+# 3. Check tolerations (tainted nodes require matching tolerations)
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.tolerations}'
+kubectl get nodes -o custom-columns="NAME:.metadata.name,TAINTS:.spec.taints[*].key"
+```
+
+Volcano scheduling is **two-phase**: first queue-level admission (capacity check), then node-level placement. A job can pass the queue check but fail node placement if all matching nodes are occupied.
+
+**Solution:**
+- Relax affinity constraints if possible
+- Ensure sufficient nodes match the constraints
+- Verify toleration matches for tainted nodes
+
+### Cause 6: Queue Has Capacity but Gang Still Blocks
+
+**Symptom:** Queue `allocated < deserved`, PodGroup is `Inqueue`, but pods remain Pending.
+
+**Check — verify remaining capacity vs Gang requirement:**
+```bash
+# Queue remaining capacity
+kubectl get queue <queue> -o jsonpath='{"deserved: "}{.status.deserved}{"\nallocated: "}{.status.allocated}'
+
+# PodGroup minMember and minResources
+kubectl get podgroup <pg> -n <ns> -o jsonpath='{"minMember: "}{.spec.minMember}{"\nminResources: "}{.spec.minResources}'
+```
+
+Calculate: `remaining = deserved - allocated`. If `remaining < minMember × per-pod-resources`, the Gang cannot be satisfied even though the queue is not fully used.
+
+If `minResources` is set, also verify: `remaining >= minResources` for each resource dimension.
+
+**Solution:**
+- Wait for enough resources to free up in the queue
+- Reduce `minMember` or `minResources` if the job can tolerate partial scheduling
+
+### Cause 7: Post-Scheduling Gang Breakage
+
+**Symptom:** Job was Running, then moves to Aborted. Running pod count dropped below `minMember`.
+
+This happens when pods are evicted (preemption, node failure, OOM) and the remaining count falls below the Gang constraint, causing the entire group to be torn down.
+
+**Check:**
+```bash
+# Current running vs required
+kubectl get podgroup <pg> -n <ns> -o jsonpath='{"running: "}{.status.running}{"\nminMember: "}{.spec.minMember}'
+
+# Check for eviction/preemption events
+kubectl get events -n <ns> --field-selector reason=Preempted
+kubectl get events -n <ns> --field-selector reason=Evicted
+```
+
+**Solution:**
+- Investigate why pods were evicted (resource pressure, preemption, node failure)
+- Consider setting `reclaimable: false` on the queue to prevent preemption
+- Increase cluster capacity to reduce eviction pressure
+
+## Verification Steps
+
+After identifying the issue, verify your analysis:
+
+1. **Check if issue is Gang-specific:**
+   - Try scheduling a single pod with same resources
+   - If single pod schedules, it's a Gang constraint issue
+   - If single pod doesn't schedule, it's a resource/affinity issue
+
+2. **Calculate minimum requirements:**
+   - Confirm minMember × per-pod-resources ≤ available resources
+   - Confirm enough nodes can accommodate the pods
+
+3. **Check scheduler logs:**
+   ```bash
+   # Use volcano-scheduler-logs skill
+   bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --keyword gang
+   ```
+
+## Key Insight
+
+Gang Scheduling constraint: **Must have enough resources to schedule minMember Pods simultaneously on different nodes.**
+
+Even if total cluster resources are sufficient, if resources are released gradually over time (as other pods complete), the "simultaneous" requirement may not be met.
+
+**Distinguish between:**
+1. **Total shortage** - Entire cluster lacks resources
+2. **Cannot satisfy simultaneously** - Resources exist but not on enough nodes at the same time
+3. **Queue limit** - Queue deserved resources are exhausted
+
+## See Also
+
+- `volcano-diagnose-pod` - General Pod scheduling diagnosis
+- `volcano-queue-diagnose` - Queue status and resource analysis
+- `volcano-resource-insufficient` - Resource shortage diagnosis
+- `volcano-scheduler-logs` - Scheduler log analysis

--- a/skills/core/volcano-job-diagnose/SKILL.md
+++ b/skills/core/volcano-job-diagnose/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: volcano-job-diagnose
+description: >-
+  Diagnose Volcano Job status and issues.
+  Check Job phases, task statuses, PodGroup associations, and overall job health.
+---
+
+# Volcano Job Diagnosis
+
+Diagnose Volcano Job (batch.volcano.sh/v1beta1) status and issues. This skill checks Job phases, task statuses, PodGroup associations, and overall job health.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify job specs or restart jobs — that should be left to the user.
+
+## Usage
+
+```bash
+bash skills/core/volcano-job-diagnose/scripts/diagnose-job.sh --job <job-name> --namespace <namespace>
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--job JOB` | yes | Job name to diagnose |
+| `--namespace NS` | no | Namespace (default: `default`) |
+| `--verbose` | no | Show detailed task and pod information |
+
+## Examples
+
+Diagnose a Volcano Job:
+```bash
+bash skills/core/volcano-job-diagnose/scripts/diagnose-job.sh --job my-training-job --namespace training
+```
+
+Verbose mode with task details:
+```bash
+bash skills/core/volcano-job-diagnose/scripts/diagnose-job.sh --job my-training-job --namespace training --verbose
+```
+
+## Understanding Volcano Jobs
+
+### Job Structure
+
+```yaml
+apiVersion: batch.volcano.sh/v1beta1
+kind: Job
+spec:
+  schedulerName: volcano
+  tasks:
+    - name: worker
+      replicas: 4
+      template:
+        spec:
+          containers:
+            - name: worker
+              resources:
+                requests:
+                  cpu: "4"
+                  memory: "8Gi"
+  maxRetry: 3              # Max retries before job is Aborted
+  policies:
+    - event: PodFailed
+      action: RestartJob
+```
+
+> **Note:** Volcano Jobs can also be queried using the short name `vcjob` (e.g., `kubectl get vcjob`). This is an alias for `job.batch.volcano.sh`. Be careful not to confuse with native Kubernetes `batch/v1 Job` — always use `job.batch.volcano.sh` or `vcjob` for Volcano Jobs.
+
+### Job Phases
+
+| Phase | Meaning |
+|-------|---------|
+| `Pending` | Job is waiting for resources or admission |
+| `Running` | Job is executing |
+| `Completing` | Job tasks are completing |
+| `Completed` | Job finished successfully |
+| `Failed` | Job failed |
+| `Restarting` | Job is being restarted due to policy |
+| `Terminating` | Job is being terminated |
+| `Aborted` | Job was aborted |
+
+### Task Statuses
+
+Each task within a job has its own status:
+- `Pending` - Task pods not yet scheduled
+- `Running` - Task pods are running
+- `Completed` - Task finished
+- `Failed` - Task failed
+
+## Diagnostic Flow
+
+### Step 1: Job Overview
+
+Get the Job status:
+
+```bash
+kubectl get job.batch.volcano.sh <job-name> -n <namespace> -o yaml
+```
+
+**Key fields to check:**
+- `status.state.phase` - Current job phase
+- `status.failed` - Number of failed tasks
+- `status.succeeded` - Number of succeeded tasks
+- `status.running` - Number of running tasks
+- `status.pending` - Number of pending tasks
+
+### Step 2: Check Tasks
+
+List all tasks and their statuses:
+
+```bash
+kubectl get pods -n <namespace> -l volcano.sh/job-name=<job-name> -o wide
+```
+
+**What to look for:**
+- Pod phases (Pending, Running, Completed, Failed)
+- Pod restart counts
+- Node assignments
+
+### Step 3: Check PodGroup Association
+
+Find the PodGroup created for this Job:
+
+```bash
+kubectl get podgroups -n <namespace> -l volcano.sh/job-name=<job-name>
+```
+
+Or check the Job's tasks for PodGroup annotations:
+
+```bash
+kubectl get pods -n <namespace> -l volcano.sh/job-name=<job-name> \
+  -o jsonpath='{.items[0].metadata.annotations.scheduling\.volcano\.sh/pod-group}'
+```
+
+**Next step:** If PodGroup status is problematic, use `volcano-diagnose-pod` for detailed PodGroup analysis.
+
+### Step 4: Check Policies
+
+Review job policies that may affect behavior:
+
+```bash
+kubectl get job.batch.volcano.sh <job-name> -n <namespace> -o jsonpath='{.spec.policies}'
+```
+
+**Common policies:**
+- `PodFailed` → `RestartJob` - Restart entire job on any pod failure
+- `PodFailed` → `RestartTask` - Restart only the failed task
+- `PodEvicted` → `RestartTask` - Restart evicted tasks
+- `PodEvicted` → `AbortJob` - Abort entire job when a pod is evicted (can cause unexpected aborts during preemption)
+- `TaskCompleted` → `CompleteJob` - Complete job when task finishes
+
+Also check `maxRetry` — when retries are exhausted the job moves to `Aborted`:
+```bash
+kubectl get job.batch.volcano.sh <job-name> -n <namespace> -o jsonpath='{.spec.maxRetry}'
+```
+
+### Step 5: Events Analysis
+
+Check job-related events:
+
+```bash
+kubectl get events -n <namespace> --field-selector involvedObject.name=<job-name>
+```
+
+**Common event patterns:**
+
+#### `JobFailed` - Job has failed
+Check the reason and message for failure details.
+
+#### `JobRestarting` - Job is being restarted
+Check the restart policy and previous failure reason.
+
+#### `TaskFailed` - Individual task failed
+May or may not cause entire job to fail depending on policy.
+
+## Common Issues
+
+### Issue 1: Job Stuck in Pending
+
+**Symptom:** Job phase is `Pending`, no pods created.
+
+**Check:**
+1. PodGroup status: `kubectl get podgroups -n <ns>`
+2. Queue state: `kubectl get queue <queue>`
+3. Events: `kubectl get events -n <ns> | grep <job-name>`
+
+**Likely causes:**
+- Queue is Closed
+- PodGroup cannot be enqueued (resource shortage)
+- Admission webhook rejection
+
+### Issue 2: Some Tasks Running, Others Pending
+
+**Symptom:** Partial task scheduling (e.g., 2/4 tasks running).
+
+**Check:**
+1. PodGroup minMember vs actual pod count
+2. Gang scheduling constraints
+3. Resource availability
+
+**Likely causes:**
+- Gang constraint not satisfied (use `volcano-gang-scheduling`)
+- Resource fragmentation
+- Queue quota exhausted
+
+### Issue 3: Job Restarting Repeatedly
+
+**Symptom:** Job keeps restarting, never completes.
+
+**Check:**
+1. Restart policy: `kubectl get job.batch.volcano.sh -o jsonpath='{.spec.policies}'`
+2. Pod failure reasons: `kubectl describe pod <pod>`
+3. Container logs: `kubectl logs <pod>`
+
+**Likely causes:**
+- Application crashing (check container logs)
+- Resource pressure causing evictions
+- Misconfigured restart policy
+
+### Issue 4: Job Failed After Some Tasks Completed
+
+**Symptom:** Some tasks succeeded, but job marked as Failed.
+
+**Check:**
+1. Failed task details
+2. Job completion policy
+3. Task lifecycle policies
+
+**Likely causes:**
+- One critical task failed
+- Completion policy is strict (all tasks must succeed)
+- Lifecycle policy triggered premature job failure
+
+### Issue 5: Job Aborted Unexpectedly
+
+**Symptom:** Job was Running, then moved to `Aborted`.
+
+**Check:**
+```bash
+# Check maxRetry
+kubectl get job.batch.volcano.sh <job> -n <ns> -o jsonpath='{.spec.maxRetry}'
+
+# Check for preemption/eviction events
+kubectl get events -n <ns> --field-selector reason=Preempted
+kubectl get events -n <ns> --field-selector reason=Evicted
+
+# Check if running pod count dropped below minMember (Gang breakage)
+kubectl get podgroup -n <ns> -l volcano.sh/job-name=<job> -o jsonpath='{"running: "}{.items[0].status.running}{"\nminMember: "}{.items[0].spec.minMember}'
+```
+
+**Likely causes:**
+- `maxRetry` exhausted — job restarted too many times
+- Preemption by higher-priority job — pods evicted, triggering `PodEvicted → AbortJob` policy
+- Gang breakage — pod eviction caused running count to drop below `minMember`, tearing down the entire group
+- Lifecycle policy mismatch — e.g., `PodEvicted → AbortJob` when `RestartTask` would be more appropriate
+
+## Task Lifecycle Policies
+
+Volcano controls task coordination through lifecycle policies, not explicit task dependencies.
+
+```yaml
+spec:
+  tasks:
+    - name: master
+      replicas: 1
+      policies:
+        - event: TaskCompleted
+          action: CompleteJob
+    - name: worker
+      replicas: 4
+      policies:
+        - event: PodFailed
+          action: RestartTask
+```
+
+**Diagnosis:**
+```bash
+# Check per-task status counts
+kubectl get job.batch.volcano.sh <job> -o jsonpath='{.status.taskStatusCount}'
+
+# Check configured policies
+kubectl get job.batch.volcano.sh <job> -o jsonpath='{.spec.tasks[*].policies}'
+```
+
+Look for mismatched events/actions that could cause unexpected restarts or premature completion.
+
+## Integration with Other Skills
+
+Use this skill in combination with others:
+
+```bash
+# 1. Job-level diagnosis
+bash skills/core/volcano-job-diagnose/scripts/diagnose-job.sh --job my-job --namespace training
+
+# 2. If PodGroup issues found → Pod-level diagnosis
+bash skills/core/volcano-diagnose-pod/scripts/diagnose-pod.sh --pod my-job-worker-0 --namespace training
+
+# 3. If Gang issues → Gang scheduling analysis
+# (refer to volcano-gang-scheduling skill)
+
+# 4. If Queue issues → Queue diagnosis
+bash skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh --queue training-queue
+
+# 5. Check scheduler logs for decisions
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --pod my-job-worker-0 --since 1h
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VOLCANO_NAMESPACE` | `default` | Default namespace for job lookup |
+
+## See Also
+
+- `volcano-diagnose-pod` - Pod-level scheduling diagnosis
+- `volcano-gang-scheduling` - Gang scheduling constraint analysis
+- `volcano-queue-diagnose` - Queue resource analysis
+- `volcano-scheduler-logs` - Scheduler decision logs
+- `deployment-rollout-debug` - (Similar concept for Deployments)

--- a/skills/core/volcano-job-diagnose/scripts/diagnose-job.sh
+++ b/skills/core/volcano-job-diagnose/scripts/diagnose-job.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+# Diagnose Volcano Job status and issues.
+# This script performs read-only operations using kubectl.
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: $0 --job <job-name> [options]
+
+Diagnose Volcano Job (batch.volcano.sh/v1beta1) status and issues.
+Checks Job phases, task statuses, PodGroup associations, and overall job health.
+
+Options:
+  --job JOB         Job name to diagnose (required)
+  --namespace NS    Namespace (default: default)
+  --verbose         Show detailed task and pod information
+  -h, --help        Show this help message
+
+Environment:
+  VOLCANO_NAMESPACE     Override default namespace
+
+Examples:
+  $0 --job my-training-job --namespace training
+  $0 --job my-training-job --namespace training --verbose
+EOF
+  exit 0
+}
+
+# Parse arguments
+JOB=""
+NS="${VOLCANO_NAMESPACE:-default}"
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help) show_help ;;
+    --job) JOB="$2"; shift 2 ;;
+    --namespace) NS="$2"; shift 2 ;;
+    --verbose) VERBOSE=true; shift ;;
+    *) echo "Unknown option: $1. Use --help for usage." >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$JOB" ]] && { echo "Error: --job is required. Use --help for usage." >&2; exit 1; }
+
+echo "=== Volcano Job Diagnosis: $NS/$JOB ==="
+echo
+
+# 1. Job Overview
+echo "[1/5] Job Overview"
+echo "------------------"
+if ! kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o wide 2>/dev/null; then
+  echo "Error: Job '$JOB' not found in namespace '$NS'" >&2
+  exit 1
+fi
+echo
+
+# Get job details
+JOB_PHASE=$(kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.status.state.phase}' 2>/dev/null || echo "Unknown")
+JOB_FAILED=$(kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.status.failed}' 2>/dev/null || echo "0")
+JOB_SUCCEEDED=$(kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.status.succeeded}' 2>/dev/null || echo "0")
+JOB_RUNNING=$(kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.status.running}' 2>/dev/null || echo "0")
+JOB_PENDING=$(kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.status.pending}' 2>/dev/null || echo "0")
+
+echo "Job Phase: $JOB_PHASE"
+echo "Tasks - Failed: $JOB_FAILED, Succeeded: $JOB_SUCCEEDED, Running: $JOB_RUNNING, Pending: $JOB_PENDING"
+echo
+
+# Warning for problematic states
+case "$JOB_PHASE" in
+  Failed)
+    echo "⚠️  WARNING: Job has FAILED"
+    ;;
+  Pending)
+    echo "ℹ️  Job is PENDING - waiting for resources or admission"
+    ;;
+  Restarting)
+    echo "⚠️  WARNING: Job is RESTARTING - check previous failure reasons"
+    ;;
+  Aborted)
+    echo "⚠️  WARNING: Job was ABORTED"
+    ;;
+esac
+
+# Check minAvailable if set
+MIN_AVAILABLE=$(kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.spec.minAvailable}' 2>/dev/null || echo "")
+if [[ -n "$MIN_AVAILABLE" ]]; then
+  echo "MinAvailable: $MIN_AVAILABLE (Gang constraint)"
+fi
+echo
+
+# 2. Check Policies
+echo "[2/5] Job Policies"
+echo "------------------"
+POLICIES=$(kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.spec.policies}' 2>/dev/null || echo "")
+if [[ -n "$POLICIES" && "$POLICIES" != "[]" && "$POLICIES" != "null" ]]; then
+  echo "Configured Policies:"
+  kubectl get job.batch.volcano.sh "$JOB" -n "$NS" -o jsonpath='{.spec.policies}' 2>/dev/null | jq -r '.[] | "  - Event: \(.event), Action: \(.action)"' 2>/dev/null || echo "  (Failed to parse policies)"
+else
+  echo "No policies configured"
+fi
+echo
+
+# 3. Task Status
+echo "[3/5] Task Status"
+echo "-----------------"
+
+# Initialize counters with defaults (in case PODS is empty)
+PENDING_PODS=0
+RUNNING_PODS=0
+COMPLETED_PODS=0
+FAILED_PODS=0
+TOTAL_PODS=0
+
+# Get all pods for this job
+PODS=$(kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+if [[ -z "$PODS" ]]; then
+  echo "⚠️  No pods found for this job"
+  echo "   Job may be in Pending state or pods may have been cleaned up"
+else
+  # Count pods by phase (--no-headers avoids header line in count)
+  PENDING_PODS=$(kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" --field-selector status.phase=Pending --no-headers 2>/dev/null | grep -c . || echo "0")
+  RUNNING_PODS=$(kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" --field-selector status.phase=Running --no-headers 2>/dev/null | grep -c . || echo "0")
+  COMPLETED_PODS=$(kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" --field-selector status.phase=Succeeded --no-headers 2>/dev/null | grep -c . || echo "0")
+  FAILED_PODS=$(kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" --field-selector status.phase=Failed --no-headers 2>/dev/null | grep -c . || echo "0")
+  
+  TOTAL_PODS=$((PENDING_PODS + RUNNING_PODS + COMPLETED_PODS + FAILED_PODS))
+  
+  echo "Total Pods: $TOTAL_PODS"
+  echo "  Pending: $PENDING_PODS"
+  echo "  Running: $RUNNING_PODS"
+  echo "  Completed: $COMPLETED_PODS"
+  echo "  Failed: $FAILED_PODS"
+  echo
+  
+  if [[ "$FAILED_PODS" -gt 0 ]]; then
+    echo "⚠️  Failed pods detected - check pod logs and events"
+  fi
+  
+  if [[ "$PENDING_PODS" -gt 0 && "$JOB_RUNNING" -gt 0 ]]; then
+    echo "⚠️  Partial scheduling - some pods pending while others running"
+    echo "   Possible Gang scheduling issue - use volcano-gang-scheduling skill"
+  fi
+  
+  # Show pod details in verbose mode
+  if [[ "$VERBOSE" == "true" ]]; then
+    echo
+    echo "Pod Details:"
+    kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" -o custom-columns='NAME:.metadata.name,STATUS:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount,NODE:.spec.nodeName,AGE:.metadata.creationTimestamp' 2>/dev/null || echo "  (Failed to get pod details)"
+  fi
+fi
+echo
+
+# 4. PodGroup Association
+echo "[4/5] PodGroup Association"
+echo "----------------------------"
+
+# Try to find PodGroup
+PG=$(kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" -o jsonpath='{.items[0].metadata.annotations.scheduling\.volcano\.sh/pod-group}' 2>/dev/null || echo "")
+
+if [[ -n "$PG" ]]; then
+  echo "PodGroup: $PG"
+  
+  if kubectl get podgroup "$PG" -n "$NS" &>/dev/null; then
+    PG_PHASE=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+    PG_MINMEMBER=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.spec.minMember}' 2>/dev/null || echo "N/A")
+    PG_RUNNING=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.status.running}' 2>/dev/null || echo "0")
+    PG_PENDING=$(kubectl get podgroup "$PG" -n "$NS" -o jsonpath='{.status.pending}' 2>/dev/null || echo "0")
+    
+    echo "PodGroup Phase: $PG_PHASE"
+    echo "MinMember: $PG_MINMEMBER | Running: $PG_RUNNING | Pending: $PG_PENDING"
+    
+    if [[ "$PG_PHASE" == "Pending" ]]; then
+      echo "⚠️  PodGroup is Pending - check Queue capacity and resource availability"
+    fi
+    
+    if [[ "$PG_PHASE" == "Inqueue" && "$PENDING_PODS" -gt 0 ]]; then
+      echo "⚠️  PodGroup Inqueue but pods Pending - Gang constraint may not be satisfied"
+    fi
+  else
+    echo "Warning: PodGroup '$PG' not found"
+  fi
+else
+  echo "No PodGroup annotation found on job pods"
+  echo "This may indicate the job is not using Gang scheduling"
+fi
+echo
+
+# 5. Events Analysis
+echo "[5/5] Recent Events"
+echo "-------------------"
+kubectl get events -n "$NS" --field-selector "involvedObject.name=$JOB" --sort-by='.lastTimestamp' 2>/dev/null | tail -10 || echo "No events found for job"
+echo
+
+# Also check pod events if verbose
+if [[ "$VERBOSE" == "true" && -n "$PODS" ]]; then
+  echo "Pod Events (first failed/running pod):"
+  # Find a failed or running pod to check events
+  SAMPLE_POD=$(kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" --field-selector status.phase=Failed -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || \
+               kubectl get pods -n "$NS" -l "volcano.sh/job-name=$JOB" --field-selector status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+  if [[ -n "$SAMPLE_POD" ]]; then
+    kubectl get events -n "$NS" --field-selector "involvedObject.name=$SAMPLE_POD" --sort-by='.lastTimestamp' 2>/dev/null | tail -5 || echo "No events found"
+  fi
+  echo
+fi
+
+# Summary
+echo "=== Diagnosis Summary ==="
+echo "Job: $NS/$JOB"
+echo "Phase: $JOB_PHASE"
+echo "Tasks: $JOB_PENDING pending, $JOB_RUNNING running, $JOB_SUCCEEDED succeeded, $JOB_FAILED failed"
+
+if [[ -n "$PG" ]]; then
+  echo "PodGroup: $PG (Phase: ${PG_PHASE:-Unknown})"
+fi
+
+# Recommendations
+echo
+echo "Recommendations:"
+case "$JOB_PHASE" in
+  Pending)
+    echo "1. Check PodGroup status (if associated)"
+    echo "2. Check Queue capacity with volcano-queue-diagnose"
+    echo "3. Check scheduler logs with volcano-scheduler-logs"
+    ;;
+  Running)
+    if [[ "$PENDING_PODS" -gt 0 ]]; then
+      echo "1. Partial scheduling detected - use volcano-gang-scheduling for Gang analysis"
+      echo "2. Check node resources with volcano-node-resources"
+    else
+      echo "1. Job is running normally - monitor progress"
+    fi
+    ;;
+  Failed)
+    echo "1. Check failed pod logs: kubectl logs <pod> -n $NS"
+    echo "2. Check pod events for failure reasons"
+    echo "3. Review job policies and restart configuration"
+    ;;
+  Restarting)
+    echo "1. Check previous failure reason in events"
+    echo "2. Review container logs for crash reasons"
+    echo "3. Verify restart policy is appropriate"
+    ;;
+esac
+
+echo
+echo "=== Diagnosis Complete ==="

--- a/skills/core/volcano-node-resources/SKILL.md
+++ b/skills/core/volcano-node-resources/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: volcano-node-resources
+description: >-
+  Query cluster node resources for Volcano scheduling.
+  Check allocatable CPU, memory, GPU, and current usage.
+---
+
+# Volcano Node Resources
+
+Query cluster node resources to understand capacity and availability for Volcano scheduling. This skill helps identify resource bottlenecks at the node level.
+
+**Scope:** This skill is for **diagnosis only**. It retrieves resource information but does not modify any cluster state.
+
+## Usage
+
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh [options]
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--node NODE` | no | Query specific node only |
+| `--label LABEL` | no | Filter nodes by label (e.g., gpu=true) |
+| `--show-usage` | no | Show current resource usage (requires metrics-server) |
+| `--show-pods` | no | Show pods running on each node |
+| `--format FORMAT` | no | Output format: table (default), json, wide |
+
+## Examples
+
+Get overview of all nodes:
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh
+```
+
+Check specific node:
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --node worker-1
+```
+
+Check GPU nodes:
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --label nvidia.com/gpu.present=true
+```
+
+Show resource usage:
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --show-usage
+```
+
+Show with pod information:
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --show-pods
+```
+
+JSON output for parsing:
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --format json
+```
+
+## Understanding Node Resources
+
+### Resource Types
+
+| Resource | Description | Scheduling Impact |
+|----------|-------------|-------------------|
+| `cpu` | CPU cores (millicores) | Primary scheduling constraint |
+| `memory` | RAM (bytes) | Primary scheduling constraint |
+| `nvidia.com/gpu` | GPU devices | Hardware-specific scheduling |
+| `pods` | Max pods per node | Density limit |
+| `ephemeral-storage` | Disk space | Secondary constraint |
+
+### Capacity vs Allocatable
+
+- **Capacity**: Total physical resources on the node
+- **Allocatable**: Resources available for pods (capacity minus system reservations)
+
+**Reservations include:**
+- kubelet overhead
+- System daemons (kube-proxy, node-exporter)
+- Kernel reserved memory
+- Eviction threshold
+
+### Resource Usage
+
+When `--show-usage` is enabled and metrics-server is available:
+
+- **Requests**: Sum of all pod resource requests on the node
+- **Limits**: Sum of all pod resource limits
+- **Usage**: Actual resource consumption
+
+**Key insights:**
+- Allocatable - Requests = Available for new pods
+- Usage < Requests = Over-provisioning
+- Usage > Requests = Over-committing (risky)
+
+## Resource Calculation
+
+### Available Resources
+
+```
+Available = Allocatable - Allocated (sum of all requests)
+```
+
+Nodes with zero or negative available resources cannot accept new pods.
+
+### Gang Scheduling Calculation
+
+For Gang scheduling, you need:
+```
+Number of nodes with Available >= Pod Request >= minMember
+```
+
+Example:
+- minMember = 4
+- Pod requests 4 CPUs each
+- Need at least 4 nodes with 4+ CPUs available
+
+## Diagnostic Use Cases
+
+### Case 1: Identify Nodes with Available Resources
+
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh
+```
+
+Look for nodes with positive Available CPU/Memory. Nodes with zero or near-zero availability cannot schedule new pods.
+
+### Case 2: Find GPU-Equipped Nodes
+
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --label nvidia.com/gpu.present=true --show-usage
+```
+
+Check:
+- Which nodes have GPUs
+- How many GPUs are allocatable
+- How many are currently allocated/used
+- GPU utilization patterns
+
+### Case 3: Detect Resource Fragmentation
+
+```bash
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --show-usage
+```
+
+Fragmentation indicators:
+- Many nodes with small amounts of available resources
+- High node count but low available resources per node
+- Allocated resources spread thinly across many nodes
+
+### Case 4: Node Affinity Troubleshooting
+
+If pods require specific labels:
+
+```bash
+# Check nodes with required labels
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --label <required-label>
+
+# Verify sufficient resources
+kubectl describe node <node-name> | grep -A 10 "Allocated resources"
+```
+
+### Case 5: Capacity Planning
+
+Monitor trends over time:
+
+```bash
+# Current capacity
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh --format json
+
+# Check usage trends (if metrics available)
+for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+  echo "=== $node ==="
+  kubectl top node $node 2>/dev/null || echo "Metrics not available"
+done
+```
+
+## Node Status Indicators
+
+### Ready Status
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `Ready` | Node healthy and schedulable | Normal |
+| `NotReady` | Node unhealthy | Check node conditions |
+| `SchedulingDisabled` | Node cordoned | May need uncordon |
+
+Check node conditions:
+```bash
+kubectl get nodes -o json | jq '.items[].status.conditions'
+```
+
+### Node Taints
+
+Taints prevent pod scheduling:
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,TAINTS:.spec.taints[*].key'
+```
+
+Common taints:
+- `node.kubernetes.io/not-ready`
+- `node.kubernetes.io/unreachable`
+- `node.kubernetes.io/disk-pressure`
+- `node.kubernetes.io/memory-pressure`
+- `node.kubernetes.io/pid-pressure`
+
+## Common Issues
+
+### Issue 1: Node at Capacity
+
+**Symptom:** Available resources near zero, new pods stuck pending
+
+**Check:**
+```bash
+kubectl describe node <node-name> | grep -A 5 "Allocated resources"
+```
+
+**Solution:**
+- Scale cluster (add nodes)
+- Drain and consolidate workloads
+- Review resource requests (may be over-provisioned)
+
+### Issue 2: GPU Not Allocatable
+
+**Symptom:** Node has GPUs but not showing as allocatable
+
+**Check:**
+```bash
+kubectl get node <node> -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
+```
+
+**Solution:**
+- Verify GPU device plugin is running
+- Check nvidia-driver installation
+- Review node labels
+
+### Issue 3: Memory Pressure
+
+**Symptom:** Node has `node.kubernetes.io/memory-pressure` taint
+
+**Check:**
+```bash
+kubectl describe node <node-name> | grep -A 3 "MemoryPressure"
+```
+
+**Solution:**
+- Evict or reschedule memory-intensive pods
+- Increase node memory
+- Adjust pod memory limits
+
+### Issue 4: Disk Pressure
+
+**Symptom:** Node has `node.kubernetes.io/disk-pressure` taint
+
+**Check:**
+```bash
+kubectl describe node <node-name> | grep -A 3 "DiskPressure"
+```
+
+**Solution:**
+- Clean up unused images/containers
+- Increase node disk capacity
+- Review log rotation policies
+
+## Output Formats
+
+### Table Format (default)
+
+Human-readable table:
+```
+NAME        CPU_ALLOC   MEM_ALLOC   GPU_ALLOC   CPU_AVAIL   MEM_AVAIL
+node-1      32          64Gi        4           8           16Gi
+node-2      16          32Gi        0           2           4Gi
+```
+
+### Wide Format
+
+Additional columns:
+```
+NAME    CPU    MEM    GPU    CPU_AVAIL    MEM_AVAIL    STATUS    AGE
+```
+
+### JSON Format
+
+Machine-parseable output:
+```json
+{
+  "nodes": [
+    {
+      "name": "node-1",
+      "allocatable": {
+        "cpu": "32",
+        "memory": "64Gi",
+        "nvidia.com/gpu": "4"
+      },
+      "available": {
+        "cpu": "8",
+        "memory": "16Gi"
+      }
+    }
+  ]
+}
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NODE_LABEL` | "" | Default label selector for nodes |
+
+## Integration with Other Skills
+
+Combine with other skills for comprehensive analysis:
+
+```bash
+# 1. Check node resources
+bash skills/core/volcano-node-resources/scripts/get-node-resources.sh
+
+# 2. Check queue resources
+bash skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh
+
+# 3. If insufficient resources, refer to volcano-resource-insufficient skill guide
+#    (This is a documentation skill - follow the diagnostic steps in the SKILL.md)
+```
+
+## See Also
+
+- `volcano-resource-insufficient` - Resource shortage diagnosis
+- `volcano-diagnose-pod` - Pod-specific scheduling issues
+- `volcano-gang-scheduling` - Gang constraint analysis
+- `volcano-queue-diagnose` - Queue resource distribution

--- a/skills/core/volcano-node-resources/scripts/get-node-resources.sh
+++ b/skills/core/volcano-node-resources/scripts/get-node-resources.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# Query cluster node resources for Volcano scheduling.
+# This script performs read-only operations using kubectl.
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: $0 [options]
+
+Query cluster node resources to understand capacity and availability.
+Checks allocatable CPU, memory, GPU, and current usage.
+
+Options:
+  --node NODE       Query specific node only
+  --label LABEL     Filter nodes by label (e.g., gpu=true)
+  --show-usage      Show current resource usage (requires metrics-server)
+  --show-pods       Show pods running on each node
+  --format FORMAT   Output format: table (default), json, wide
+  -h, --help        Show this help message
+
+Examples:
+  $0                                  # All nodes
+  $0 --node worker-1                  # Specific node
+  $0 --label nvidia.com/gpu.present=true  # GPU nodes
+  $0 --show-usage --show-pods         # With usage and pods
+  $0 --format json                    # JSON output
+EOF
+  exit 0
+}
+
+# Parse arguments
+NODE=""
+LABEL=""
+SHOW_USAGE=false
+SHOW_PODS=false
+FORMAT="table"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help) show_help ;;
+    --node) NODE="$2"; shift 2 ;;
+    --label) LABEL="$2"; shift 2 ;;
+    --show-usage) SHOW_USAGE=true; shift ;;
+    --show-pods) SHOW_PODS=true; shift ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    *) echo "Unknown option: $1. Use --help for usage." >&2; exit 1 ;;
+  esac
+done
+
+# Validate format
+if [[ "$FORMAT" != "table" && "$FORMAT" != "json" && "$FORMAT" != "wide" ]]; then
+  echo "Error: Invalid format '$FORMAT'. Use: table, json, or wide" >&2
+  exit 1
+fi
+
+echo "=== Volcano Node Resources ==="
+[[ -n "$NODE" ]] && echo "Node: $NODE"
+[[ -n "$LABEL" ]] && echo "Label filter: $LABEL"
+echo "Show usage: $SHOW_USAGE"
+echo "Show pods: $SHOW_PODS"
+echo "Format: $FORMAT"
+echo
+
+# Build kubectl get nodes command
+NODE_CMD="kubectl get nodes"
+[[ -n "$LABEL" ]] && NODE_CMD="$NODE_CMD -l $LABEL"
+[[ -n "$NODE" ]] && NODE_CMD="$NODE_CMD $NODE"
+
+# Check if nodes exist
+if ! $NODE_CMD -o name &>/dev/null; then
+  echo "Error: No nodes found matching criteria" >&2
+  exit 1
+fi
+
+# Function to get node resources
+get_node_resources() {
+  local node="$1"
+
+  # Get allocatable resources
+  local cpu_alloc mem_alloc gpu_alloc pods_alloc
+  cpu_alloc=$(kubectl get node "$node" -o jsonpath='{.status.allocatable.cpu}' 2>/dev/null || echo "N/A")
+  mem_alloc=$(kubectl get node "$node" -o jsonpath='{.status.allocatable.memory}' 2>/dev/null || echo "N/A")
+  gpu_alloc=$(kubectl get node "$node" -o jsonpath='{.status.allocatable.nvidia\.com/gpu}' 2>/dev/null || echo "0")
+  pods_alloc=$(kubectl get node "$node" -o jsonpath='{.status.allocatable.pods}' 2>/dev/null || echo "N/A")
+
+  # Get capacity
+  local cpu_cap mem_cap
+  cpu_cap=$(kubectl get node "$node" -o jsonpath='{.status.capacity.cpu}' 2>/dev/null || echo "N/A")
+  mem_cap=$(kubectl get node "$node" -o jsonpath='{.status.capacity.memory}' 2>/dev/null || echo "N/A")
+
+  # Get status and age
+  local status age
+  status=$(kubectl get node "$node" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+  # Calculate age in days (cross-platform: GNU date on Linux, BSD date on macOS)
+  age=$(kubectl get node "$node" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null | {
+    IFS= read -r timestamp
+    if [[ -n "$timestamp" ]]; then
+      if date -d "$timestamp" +%s &>/dev/null 2>&1; then
+        # GNU date (Linux)
+        created=$(date -d "$timestamp" +%s 2>/dev/null)
+      else
+        # BSD date (macOS)
+        created=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$timestamp" +%s 2>/dev/null)
+      fi
+      now=$(date +%s)
+      if [[ -n "$created" && -n "$now" ]]; then
+        echo $(( (now - created) / 86400 ))
+      else
+        echo "N/A"
+      fi
+    else
+      echo "N/A"
+    fi
+  })
+
+  # Get taints
+  local taints
+  taints=$(kubectl get node "$node" -o jsonpath='{.spec.taints[*].key}' 2>/dev/null || echo "")
+
+  # Get allocated resources (from describe)
+  local cpu_req mem_req
+  if describe_output=$(kubectl describe node "$node" 2>/dev/null); then
+    cpu_req=$(echo "$describe_output" | grep -A 5 "Allocated resources" | grep "cpu-requests" | awk '{print $2}' || echo "N/A")
+    mem_req=$(echo "$describe_output" | grep -A 5 "Allocated resources" | grep "memory-requests" | awk '{print $2}' || echo "N/A")
+  else
+    cpu_req="N/A"
+    mem_req="N/A"
+  fi
+
+  # Calculate available (rough estimate)
+  local cpu_avail="N/A"
+  local mem_avail="N/A"
+
+  # Try to calculate if we have numeric values
+  if [[ "$cpu_alloc" =~ ^[0-9]+$ && "$cpu_req" =~ ^[0-9]+m?$ ]]; then
+    # Convert millicores to cores if needed
+    local alloc_val req_val
+    alloc_val=$cpu_alloc
+    if [[ "$cpu_req" =~ m$ ]]; then
+      req_val=$(echo "${cpu_req%m}" | awk '{print $1/1000}')
+    else
+      req_val=$cpu_req
+    fi
+    cpu_avail=$(awk "BEGIN {printf \"%.0f\", $alloc_val - $req_val}")
+  fi
+
+  # Output based on format
+  case "$FORMAT" in
+    table)
+      echo "Node: $node"
+      echo "  Status: $status"
+      echo "  Age: ${age}d"
+      [[ -n "$taints" ]] && echo "  Taints: $taints"
+      echo "  Resources:"
+      echo "    CPU:        Allocatable=$cpu_alloc | Requested=$cpu_req | Available=$cpu_avail"
+      echo "    Memory:     Allocatable=$mem_alloc | Requested=$mem_req | Available=$mem_avail"
+      [[ "$gpu_alloc" != "0" ]] && echo "    GPU:        Allocatable=$gpu_alloc"
+      [[ "$SHOW_USAGE" == "true" ]] && echo "    Usage:      (see metrics below)"
+
+      if [[ "$SHOW_USAGE" == "true" ]]; then
+        echo
+        echo "  Resource Usage (requires metrics-server):"
+        if kubectl top node "$node" 2>/dev/null; then
+          : # success
+        else
+          echo "    (Metrics not available)"
+        fi
+      fi
+
+      if [[ "$SHOW_PODS" == "true" ]]; then
+        echo
+        echo "  Running Pods:"
+        kubectl get pods --all-namespaces --field-selector spec.nodeName="$node" -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.phase,CPU_REQ:.spec.containers[*].resources.requests.cpu,MEM_REQ:.spec.containers[*].resources.requests.memory' 2>/dev/null | head -20 || echo "    (Failed to list pods)"
+      fi
+      echo
+      ;;
+
+    wide)
+      echo "$node $cpu_alloc $mem_alloc $gpu_alloc $status ${age}d"
+      ;;
+
+    json)
+      echo "  {"
+      echo "    \"name\": \"$node\","
+      echo "    \"status\": \"$status\","
+      echo "    \"age_days\": $age,"
+      [[ -n "$taints" ]] && echo "    \"taints\": \"$taints\","
+      echo "    \"allocatable\": {"
+      echo "      \"cpu\": \"$cpu_alloc\","
+      echo "      \"memory\": \"$mem_alloc\","
+      echo "      \"gpu\": \"$gpu_alloc\","
+      echo "      \"pods\": \"$pods_alloc\""
+      echo "    },"
+      echo "    \"requested\": {"
+      echo "      \"cpu\": \"$cpu_req\","
+      echo "      \"memory\": \"$mem_req\""
+      echo "    },"
+      echo "    \"available\": {"
+      echo "      \"cpu\": \"$cpu_avail\","
+      echo "      \"memory\": \"$mem_avail\""
+      echo "    }"
+      echo "  }"
+      ;;
+  esac
+}
+
+# Main logic
+case "$FORMAT" in
+  table|wide)
+    if [[ "$FORMAT" == "wide" ]]; then
+      echo "NAME CPU_ALLOC MEM_ALLOC GPU_ALLOC STATUS AGE"
+      echo "==== ========= ========= ========= ====== ===="
+    fi
+
+    if [[ -n "$NODE" ]]; then
+      get_node_resources "$NODE"
+    else
+      # Use process substitution instead of pipe to avoid subshell
+      while read -r n; do
+        [[ -n "$n" ]] && get_node_resources "$n"
+      done < <(kubectl get nodes ${LABEL:+-l $LABEL} -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n')
+    fi
+    ;;
+
+  json)
+    echo "{"
+    echo "  \"nodes\": ["
+
+    # Use process substitution to avoid subshell issue with 'first' variable
+    first=true
+    if [[ -n "$NODE" ]]; then
+      get_node_resources "$NODE"
+    else
+      while read -r n; do
+        if [[ -n "$n" ]]; then
+          [[ "$first" == "false" ]] && echo ","
+          get_node_resources "$n"
+          first=false
+        fi
+      done < <(kubectl get nodes ${LABEL:+-l $LABEL} -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n')
+    fi
+
+    echo
+    echo "  ]"
+    echo "}"
+    ;;
+esac
+
+# Summary for table format
+if [[ "$FORMAT" == "table" ]]; then
+  echo "=== Summary ==="
+
+  # Count nodes by status
+  total=$(kubectl get nodes ${LABEL:+-l $LABEL} 2>/dev/null | wc -l)
+  total=$((total - 1))  # Subtract header
+  ready=$(kubectl get nodes ${LABEL:+-l $LABEL} 2>/dev/null | grep -c " Ready " || echo "0")
+  not_ready=$((total - ready))
+
+  echo "Total Nodes: $total"
+  echo "  Ready: $ready"
+  echo "  NotReady: $not_ready"
+
+  # Check for GPU nodes
+  gpu_nodes=$(kubectl get nodes ${LABEL:+-l $LABEL} -o jsonpath='{.items[*].status.allocatable.nvidia\.com/gpu}' 2>/dev/null | tr ' ' '\n' | grep -v "^0$" | grep -v "^$" | wc -l)
+  if [[ "$gpu_nodes" -gt 0 ]]; then
+    echo "  GPU Nodes: $gpu_nodes"
+  fi
+
+  # Check metrics availability
+  if [[ "$SHOW_USAGE" == "true" ]]; then
+    echo
+    if kubectl top nodes &>/dev/null; then
+      echo "Metrics-server: Available"
+    else
+      echo "Metrics-server: Not Available (kubectl top nodes failed)"
+    fi
+  fi
+fi
+
+echo
+echo "=== Query Complete ==="

--- a/skills/core/volcano-queue-diagnose/SKILL.md
+++ b/skills/core/volcano-queue-diagnose/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: volcano-queue-diagnose
+description: >-
+  Diagnose Volcano Queue status and resource allocation.
+  Check queue weights, deserved resources, allocated resources,
+  and identify queue-related scheduling bottlenecks.
+---
+
+# Volcano Queue Diagnosis
+
+Diagnose Volcano Queue status, resource allocation, and scheduling bottlenecks. This skill helps understand how resources are distributed across queues and why workloads may be pending due to queue constraints.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify queue configurations or delete queues.
+
+## Usage
+
+```bash
+bash skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh [options]
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--queue QUEUE` | no | Queue name to diagnose (default: all queues) |
+| `--show-pods` | no | Show pods associated with each queue |
+| `--verbose` | no | Show detailed resource breakdown |
+
+## Examples
+
+Diagnose all queues:
+```bash
+bash skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh
+```
+
+Diagnose specific queue:
+```bash
+bash skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh --queue training-queue
+```
+
+Show verbose output with pod information:
+```bash
+bash skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh --queue training-queue --show-pods --verbose
+```
+
+## Understanding Volcano Queues
+
+### Queue Concept
+
+In Volcano, a Queue is a cluster-level resource allocation unit. Jobs and PodGroups are submitted to queues, and the scheduler distributes resources among queues based on:
+
+1. **Weight** - Relative share of cluster resources (proportional: weight 10 vs weight 2 = 83% vs 17%)
+2. **Capability** - Maximum resources a queue can use (ceiling, not guarantee — actual allocation depends on cluster capacity and competition)
+3. **Parent** - Hierarchical queue relationships (if enabled)
+
+**Important:** A Queue is a **cluster-scoped** resource. PodGroups from **any namespace** can reference the same queue, so cross-namespace resource competition within a queue is expected.
+
+### Queue Status Fields
+
+| Field | Meaning |
+|-------|---------|
+| `state` | Queue state: Open, Closed, Closing |
+| `deserved` | Resources the queue should receive based on weight |
+| `allocated` | Resources currently allocated to jobs in this queue |
+| `used` | Resources actually used by running pods (≤ allocated) |
+| `pending` | Number of PodGroups waiting in the queue |
+| `running` | Number of running PodGroups |
+
+## Diagnostic Flow
+
+### Step 1: List All Queues
+
+Get an overview of all queues:
+
+```bash
+kubectl get queue
+```
+
+**Output columns:**
+- NAME: Queue name
+- WEIGHT: Queue weight (higher = more resources)
+- STATE: Open, Closed, or Closing
+- PARENT: Parent queue (for hierarchical queues)
+
+### Step 2: Check Queue Details
+
+Get detailed information about a specific queue:
+
+```bash
+kubectl get queue <queue-name> -o yaml
+kubectl describe queue <queue-name>
+```
+
+**Key sections to examine:**
+
+#### Spec (Configuration)
+```yaml
+spec:
+  weight: 10              # Relative weight (default: 1)
+  capability:             # Max resources allowed
+    cpu: "100"
+    memory: "200Gi"
+  reclaimable: true       # Allow resource reclamation
+```
+
+#### Status (Runtime State)
+```yaml
+status:
+  state: Open             # Open, Closed, or Closing
+  pending: 5              # PodGroups waiting
+  running: 10             # Running PodGroups
+  deserved:               # Resources this queue should get
+    cpu: "40"
+    memory: "80Gi"
+  allocated:              # Resources actually allocated
+    cpu: "35"
+    memory: "70Gi"
+```
+
+### Step 3: Check Queue Resource Utilization
+
+Calculate utilization ratios:
+
+```
+Allocation Ratio = allocated / deserved
+Utilization Ratio = used / allocated
+```
+
+**Interpretation:**
+- `allocated >= deserved`: Queue is at or over its fair share
+- `allocated < deserved`: Queue has room to grow
+- `used << allocated`: Jobs have reserved resources but not using them
+
+### Step 4: Identify PodGroups in Queue
+
+Find workloads associated with a queue:
+
+```bash
+# Find all PodGroups in a queue
+kubectl get podgroups --all-namespaces -o json | \
+  jq -r '.items[] | select(.spec.queue=="<queue-name>") | "\(.metadata.namespace)/\(.metadata.name)"'
+
+# Check pending PodGroups
+kubectl get podgroups --all-namespaces -o json | \
+  jq -r '.items[] | select(.spec.queue=="<queue-name>" and .status.phase=="Pending") | \
+  "\(.metadata.namespace)/\(.metadata.name): \(.status.phase)"'
+```
+
+### Step 5: Check Queue Events
+
+Look for queue-related events:
+
+```bash
+kubectl get events --all-namespaces --field-selector reason=FailedScheduling | grep -i queue
+```
+
+## Common Queue Issues
+
+### Issue 1: Queue Resource Exhaustion
+
+**Symptom:** `allocated >= deserved`, new PodGroups stay in Pending
+
+**Check:**
+```bash
+kubectl get queue <queue> -o jsonpath='{"
+  Deserved: "}{.status.deserved}{"
+  Allocated: "}{.status.allocated}{"
+  Ratio: "}{.status.allocated.cpu}{"/"}{.status.deserved.cpu}{"
+"}'
+```
+
+For GPU-specific checks (GPU is often the bottleneck):
+```bash
+kubectl get queue -o custom-columns="NAME:.metadata.name,GPU_CAP:.spec.capability['nvidia.com/gpu'],GPU_ALLOC:.status.allocated['nvidia.com/gpu']"
+```
+
+**Also cross-validate capability against actual cluster capacity** — a common misconfiguration is setting `spec.capability` higher than the cluster's physical resources:
+```bash
+kubectl get nodes -o custom-columns="NAME:.metadata.name,GPU:.status.allocatable['nvidia.com/gpu'],CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory"
+```
+If the sum of all nodes' allocatable GPUs is less than the queue's `spec.capability`, the queue can never be fully utilized. When allocation reaches the cluster's physical limit, the queue appears to have remaining capacity but no more resources can actually be scheduled.
+
+**Solution:**
+- Increase queue weight (requires scheduler config change)
+- Increase queue capability (only if cluster has physical capacity)
+- Wait for other jobs to complete
+- Check if other queues are over-allocated (reclaim may help)
+
+### Issue 2: Queue is Closed
+
+**Symptom:** `status.state: Closed`, new PodGroups rejected
+
+**Check:**
+```bash
+kubectl get queue <queue> -o jsonpath='{.status.state}'
+```
+
+**Solution:**
+- Queue must be reopened by admin
+- Use a different queue
+
+### Issue 3: Weight Imbalance
+
+**Symptom:** One queue gets all resources, others starve
+
+**Check:**
+```bash
+kubectl get queue -o custom-columns='NAME:.metadata.name,WEIGHT:.spec.weight,STATE:.status.state,CPU_DESERVED:.status.deserved.cpu,CPU_ALLOC:.status.allocated.cpu,MEM_DESERVED:.status.deserved.memory,MEM_ALLOC:.status.allocated.memory'
+```
+
+**Analysis:** Volcano distributes resources proportionally by weight. For example:
+- Queue A (weight=10) + Queue B (weight=2): A gets 10/12 ≈ 83%, B gets 2/12 ≈ 17% of total cluster resources
+- If Queue B has many pending jobs but low deserved resources, its weight is too low relative to others
+
+**Solution:**
+- Adjust queue weights proportionally
+- Check if high-weight queues have capability limits preventing allocation
+
+### Issue 4: Resource Reclaim Not Working
+
+**Symptom:** Queue is over-allocated but reclaim is not triggered
+
+**Check:**
+```bash
+# Check reclaim is enabled in scheduler config
+kubectl get cm volcano-scheduler-configmap -n volcano-system -o yaml | grep reclaim
+```
+
+**Reclaim troubleshooting checklist (all must be true):**
+1. `reclaim` action must be in scheduler actions
+2. `proportion` plugin must be enabled
+3. Source queue must be under-utilized (allocated < deserved)
+4. Target queue must have over-allocated resources (allocated > deserved)
+5. Target queue must have `reclaimable: true`
+
+Check the reclaimable flag on the specific queue:
+```bash
+kubectl get queue <queue> -o jsonpath='{.spec.reclaimable}'
+```
+If `reclaimable` is `false` (or unset), the queue's resources **cannot be reclaimed** even if it's over-allocated.
+
+**Solution:**
+- Verify all 5 prerequisites above
+- Check scheduler logs for reclaim attempts: use `volcano-scheduler-logs --keyword reclaim`
+
+## Queue Hierarchy (Advanced)
+
+If using hierarchical queues:
+
+```bash
+# Check parent-child relationships
+kubectl get queue -o custom-columns='NAME:.metadata.name,PARENT:.spec.parent,WEIGHT:.spec.weight'
+```
+
+**Key points:**
+- Child queues share parent's deserved resources
+- Weight is relative to siblings, not absolute
+- Parent queue's deserved = sum of children's usage
+
+## Script Output Interpretation
+
+The diagnose-queue.sh script provides:
+
+1. **Queue Summary Table**
+   - Name, State, Weight
+   - Pending/Running counts
+   - Resource allocation summary
+
+2. **Resource Breakdown (with --verbose)**
+   - CPU: deserved, allocated, usage ratio
+   - Memory: deserved, allocated, usage ratio
+   - GPU: if available
+
+3. **Warning Flags**
+   - `[OVER]` - Queue allocated > deserved
+   - `[FULL]` - Queue at capacity
+   - `[CLOSED]` - Queue not accepting new jobs
+   - `[HIGH_PEND]` - Many pending PodGroups
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VOLCANO_NAMESPACE` | `default` | Default namespace for pod lookup |
+
+## See Also
+
+- `volcano-diagnose-pod` - Diagnose individual pod scheduling
+- `volcano-gang-scheduling` - Gang constraint issues
+- `volcano-resource-insufficient` - Resource shortage diagnosis
+- `volcano-scheduler-logs` - Check scheduler decisions

--- a/skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh
+++ b/skills/core/volcano-queue-diagnose/scripts/diagnose-queue.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+# Diagnose Volcano Queue status and resource allocation.
+# This script performs read-only operations using kubectl.
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: $0 [options]
+
+Diagnose Volcano Queue status, resource allocation, and scheduling bottlenecks.
+Checks queue weights, deserved resources, allocated resources, and state.
+
+Options:
+  --queue QUEUE     Queue name to diagnose (default: all queues)
+  --show-pods       Show PodGroups associated with each queue
+  --verbose         Show detailed resource breakdown
+  -h, --help        Show this help message
+
+Examples:
+  $0                              # Diagnose all queues
+  $0 --queue training-queue       # Diagnose specific queue
+  $0 --queue training-queue --verbose --show-pods
+EOF
+  exit 0
+}
+
+# Parse arguments
+QUEUE=""
+SHOW_PODS=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help) show_help ;;
+    --queue) QUEUE="$2"; shift 2 ;;
+    --show-pods) SHOW_PODS=true; shift ;;
+    --verbose) VERBOSE=true; shift ;;
+    *) echo "Unknown option: $1. Use --help for usage." >&2; exit 1 ;;
+  esac
+done
+
+echo "=== Volcano Queue Diagnosis ==="
+[[ -n "$QUEUE" ]] && echo "Queue: $QUEUE"
+echo
+
+# Function to diagnose a single queue
+diagnose_queue() {
+  local q="$1"
+
+  echo "Queue: $q"
+  echo "=================="
+
+  # Get queue details
+  local weight state pending running deserved allocated
+  weight=$(kubectl get queue "$q" -o jsonpath='{.spec.weight}' 2>/dev/null || echo "N/A")
+  state=$(kubectl get queue "$q" -o jsonpath='{.status.state}' 2>/dev/null || echo "Unknown")
+  pending=$(kubectl get queue "$q" -o jsonpath='{.status.pending}' 2>/dev/null || echo "0")
+  running=$(kubectl get queue "$q" -o jsonpath='{.status.running}' 2>/dev/null || echo "0")
+
+  echo "  Weight: $weight"
+  echo "  State: $state"
+  echo "  Pending PodGroups: $pending"
+  echo "  Running PodGroups: $running"
+
+  # State warnings
+  if [[ "$state" == "Closed" ]]; then
+    echo "  ⚠️  WARNING: Queue is CLOSED - new jobs will be rejected"
+  elif [[ "$state" == "Closing" ]]; then
+    echo "  ⚠️  WARNING: Queue is CLOSING - will not accept new jobs soon"
+  fi
+
+  # Get resource info
+  local deserved_cpu deserved_mem allocated_cpu allocated_mem
+  deserved_cpu=$(kubectl get queue "$q" -o jsonpath='{.status.deserved.cpu}' 2>/dev/null || echo "")
+  deserved_mem=$(kubectl get queue "$q" -o jsonpath='{.status.deserved.memory}' 2>/dev/null || echo "")
+  allocated_cpu=$(kubectl get queue "$q" -o jsonpath='{.status.allocated.cpu}' 2>/dev/null || echo "")
+  allocated_mem=$(kubectl get queue "$q" -o jsonpath='{.status.allocated.memory}' 2>/dev/null || echo "")
+
+  # Handle empty values
+  [[ -z "$deserved_cpu" ]] && deserved_cpu="0"
+  [[ -z "$deserved_mem" ]] && deserved_mem="0"
+  [[ -z "$allocated_cpu" ]] && allocated_cpu="0"
+  [[ -z "$allocated_mem" ]] && allocated_mem="0"
+
+  echo
+  echo "  Resources:"
+  echo "    CPU:"
+  echo "      Deserved:   $deserved_cpu"
+  echo "      Allocated:  $allocated_cpu"
+
+  # Calculate CPU ratio if possible
+  if [[ "$deserved_cpu" =~ ^[0-9]+\.?[0-9]*$ && "$allocated_cpu" =~ ^[0-9]+\.?[0-9]*$ ]]; then
+    if awk "BEGIN {exit !($deserved_cpu > 0)}" 2>/dev/null; then
+      local cpu_ratio
+      cpu_ratio=$(awk "BEGIN {printf \"%.1f\", $allocated_cpu * 100 / $deserved_cpu}" 2>/dev/null || echo "N/A")
+      echo "      Ratio:      ${cpu_ratio}%"
+
+      if awk "BEGIN {exit !($allocated_cpu > $deserved_cpu)}" 2>/dev/null; then
+        echo "      ⚠️  OVER-ALLOCATED: Queue using more than deserved"
+      elif [[ "$cpu_ratio" != "N/A" ]] && awk "BEGIN {exit !($cpu_ratio >= 90)}" 2>/dev/null; then
+        echo "      ⚠️  NEAR CAPACITY: ${cpu_ratio}% of deserved resources used"
+      fi
+    fi
+  fi
+
+  echo "    Memory:"
+  echo "      Deserved:   $deserved_mem"
+  echo "      Allocated:  $allocated_mem"
+
+  # Check capability if set
+  local cap_cpu cap_mem
+  cap_cpu=$(kubectl get queue "$q" -o jsonpath='{.spec.capability.cpu}' 2>/dev/null || echo "")
+  cap_mem=$(kubectl get queue "$q" -o jsonpath='{.spec.capability.memory}' 2>/dev/null || echo "")
+
+  if [[ -n "$cap_cpu" || -n "$cap_mem" ]]; then
+    echo "    Capability (max allowed):"
+    [[ -n "$cap_cpu" ]] && echo "      CPU: $cap_cpu"
+    [[ -n "$cap_mem" ]] && echo "      Memory: $cap_mem"
+  fi
+
+  # Check reclaimable
+  local reclaimable
+  reclaimable=$(kubectl get queue "$q" -o jsonpath='{.spec.reclaimable}' 2>/dev/null || echo "true")
+  [[ "$reclaimable" != "false" ]] && reclaimable="true"
+  echo "    Reclaimable: $reclaimable"
+  [[ "$reclaimable" == "false" ]] && echo "      ℹ️  Resources cannot be reclaimed from this queue"
+
+  # Show PodGroups if requested
+  if [[ "$SHOW_PODS" == "true" ]]; then
+    echo
+    echo "  PodGroups in this Queue:"
+    local pgs
+    pgs=$(kubectl get podgroups --all-namespaces -o json 2>/dev/null | \
+      jq -r --arg q "$q" '.items[] | select(.spec.queue==$q) | "    \(.metadata.namespace)/\(.metadata.name): \(.status.phase // \"Unknown\")"' 2>/dev/null || echo "")
+
+    if [[ -n "$pgs" ]]; then
+      echo "$pgs"
+    else
+      echo "    No PodGroups found"
+    fi
+
+    # Show pending count specifically
+    local pending_pgs
+    pending_pgs=$(kubectl get podgroups --all-namespaces -o json 2>/dev/null | \
+      jq -r --arg q "$q" '.items[] | select(.spec.queue==$q and .status.phase=="Pending") | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null || echo "")
+
+    if [[ -n "$pending_pgs" ]]; then
+      echo
+      echo "  ⚠️  Pending PodGroups:"
+      echo "$pending_pgs" | while read -r pg; do
+        echo "    - $pg"
+      done
+    fi
+  fi
+
+  # Verbose output
+  if [[ "$VERBOSE" == "true" ]]; then
+    echo
+    echo "  Raw Queue YAML:"
+    kubectl get queue "$q" -o yaml 2>/dev/null | sed 's/^/    /'
+  fi
+
+  echo
+}
+
+# Main logic
+if [[ -n "$QUEUE" ]]; then
+  # Diagnose specific queue
+  if ! kubectl get queue "$QUEUE" &>/dev/null; then
+    echo "Error: Queue '$QUEUE' not found" >&2
+    exit 1
+  fi
+  diagnose_queue "$QUEUE"
+else
+  # Diagnose all queues
+  echo "[1] Listing all queues"
+  echo "---------------------"
+  kubectl get queue -o custom-columns='NAME:.metadata.name,STATE:.status.state,WEIGHT:.spec.weight,PENDING:.status.pending,RUNNING:.status.running' 2>/dev/null || {
+    echo "Error: Failed to list queues" >&2
+    exit 1
+  }
+  echo
+
+  echo "[2] Resource Allocation Summary"
+  echo "--------------------------------"
+  # Print table header
+  printf "%-20s %-8s %-10s %-12s %-15s %-12s\n" "QUEUE" "STATE" "WEIGHT" "CPU_RATIO" "MEM_ALLOC" "PODS(P/R)"
+  printf "%-20s %-8s %-10s %-12s %-15s %-12s\n" "--------------------" "--------" "----------" "------------" "---------------" "-----------"
+  
+  # Helper: convert K8s CPU value (e.g. "500m", "2", "1.5") to millicores
+  cpu_to_milli() {
+    local v="$1"
+    if [[ "$v" =~ ^([0-9]+)m$ ]]; then
+      echo "${BASH_REMATCH[1]}"
+    elif [[ "$v" =~ ^[0-9]+\.?[0-9]*$ ]]; then
+      awk "BEGIN {printf \"%.0f\", $v * 1000}" 2>/dev/null || echo "0"
+    else
+      echo "0"
+    fi
+  }
+
+  # Get all queue names and print resource summary
+  kubectl get queue -o json 2>/dev/null | jq -r '.items[] |
+    [.metadata.name,
+     (.status.state // "Unknown"),
+     (.spec.weight // 1),
+     (.status.deserved.cpu // "0"),
+     (.status.allocated.cpu // "0"),
+     (.status.allocated.memory // "N/A"),
+     (.status.pending // 0),
+     (.status.running // 0)] | @tsv' 2>/dev/null | \
+  while IFS=$'\t' read -r name state weight deserved_cpu_raw alloc_cpu_raw mem_alloc pending running; do
+    ratio=0
+    deserved_m=$(cpu_to_milli "$deserved_cpu_raw")
+    alloc_m=$(cpu_to_milli "$alloc_cpu_raw")
+    if [[ "$deserved_m" -gt 0 ]]; then
+      ratio=$((alloc_m * 100 / deserved_m))
+    fi
+
+    status_indicator=""
+    if [[ "$state" == "Closed" ]]; then
+      status_indicator="🚫"
+    elif [[ "$state" == "Closing" ]]; then
+      status_indicator="⚠️"
+    elif [[ "$ratio" -ge 90 ]]; then
+      status_indicator="🔴"
+    elif [[ "$ratio" -ge 75 ]]; then
+      status_indicator="🟡"
+    fi
+
+    printf "%-20s %-8s %-10s %-12s %-15s %-12s %s\n" \
+      "$name" "$state" "${weight:-1}" "${ratio}%" "${mem_alloc:-N/A}" "${pending:-0}/${running:-0}" "$status_indicator"
+  done
+  echo
+  echo "Legend: 🚫=Closed ⚠️=Closing 🔴=>=90% 🟡=>=75%"
+  echo
+
+  echo "[3] Detailed Queue Analysis"
+  echo "--------------------------"
+  # Get all queue names
+  kubectl get queue -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n' | while read -r q; do
+    [[ -n "$q" ]] && diagnose_queue "$q"
+  done
+fi
+
+# Summary
+echo "=== Diagnosis Summary ==="
+
+# Count queues by state
+total=0
+open_count=0
+closed_count=0
+closing_count=0
+
+while read -r q; do
+  [[ -z "$q" ]] && continue
+  total=$((total + 1))
+  state=$(kubectl get queue "$q" -o jsonpath='{.status.state}' 2>/dev/null || echo "Unknown")
+  [[ "$state" == "Open" ]] && open_count=$((open_count + 1))
+  [[ "$state" == "Closed" ]] && closed_count=$((closed_count + 1))
+  [[ "$state" == "Closing" ]] && closing_count=$((closing_count + 1))
+done < <(kubectl get queue -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n')
+
+echo "Total Queues: $total"
+echo "  Open: $open_count"
+echo "  Closed: $closed_count"
+echo "  Closing: $closing_count"
+
+# Find queues with high pending
+high_pending=$(kubectl get queue -o json 2>/dev/null | jq -r '.items[] | select(.status.pending > 5) | "\(.metadata.name) (\(.status.pending) pending)"' 2>/dev/null || echo "")
+if [[ -n "$high_pending" ]]; then
+  echo
+  echo "⚠️  Queues with high pending (>5):"
+  echo "$high_pending" | sed 's/^/  - /'
+fi
+
+echo
+echo "=== Diagnosis Complete ==="

--- a/skills/core/volcano-resource-insufficient/SKILL.md
+++ b/skills/core/volcano-resource-insufficient/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: volcano-resource-insufficient
+description: >-
+  Resource shortage diagnostic guide for Volcano.
+  Use when seeing Insufficient cpu/memory events, OOMKilled pods,
+  or nodes with zero allocatable resources.
+---
+
+# Resource Insufficiency Diagnosis
+
+This guide helps diagnose resource shortage issues in Volcano-scheduled workloads. Resource insufficiency is one of the most common causes of scheduling failures.
+
+**Scope:** This skill is for **diagnosis only**. Once you identify the root cause, report it to the user and stop. Do NOT attempt to modify resource quotas or delete workloads.
+
+## When to Use This Guide
+
+Use this skill when:
+- Events show `Insufficient cpu` or `Insufficient memory`
+- Pods are stuck in `Pending` with resource-related events
+- Nodes show zero allocatable resources
+- Pods are being `OOMKilled` (Out of Memory)
+- `FailedScheduling` events mention resource constraints
+
+## Types of Resource Issues
+
+### 1. Cluster-Wide Resource Exhaustion
+The entire cluster lacks sufficient resources to meet the workload demands.
+
+### 2. Resource Fragmentation
+Total resources exist but are distributed across too many nodes to satisfy specific scheduling constraints (like Gang scheduling).
+
+### 3. Per-Node Resource Shortage
+Individual nodes lack enough resources, even though the cluster as a whole has capacity.
+
+### 4. Queue Resource Limits
+The Queue has reached its deserved resource limit, preventing new pods from being scheduled.
+
+## Diagnostic Steps
+
+### Step 1: Identify Resource Shortage Type
+
+Check the specific error message in events:
+
+```bash
+kubectl get events -n <namespace> --field-selector involvedObject.name=<pod-name> --sort-by='.lastTimestamp'
+```
+
+**Common error patterns:**
+
+| Error Message | Resource Type | Scope |
+|--------------|---------------|-------|
+| `Insufficient cpu` | CPU | Node-level |
+| `Insufficient memory` | Memory | Node-level |
+| `Insufficient nvidia.com/gpu` | GPU | Node-level |
+| `0/N nodes are available` | General | Cluster-level |
+| `exceeded quota` | Queue-level | Queue limit |
+
+### Step 2: Check Pod Resource Requests
+
+Determine how much resources the pod is requesting:
+
+```bash
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[*].resources.requests}'
+```
+
+For detailed breakdown:
+```bash
+kubectl get pod <pod-name> -n <namespace> -o yaml | grep -A 10 "resources:"
+```
+
+**Key fields:**
+- `resources.requests.cpu` - CPU cores requested (e.g., "100m" = 0.1 core, "2" = 2 cores)
+- `resources.requests.memory` - Memory requested (e.g., "1Gi", "512Mi")
+- `resources.requests.nvidia.com/gpu` - GPUs requested
+- `resources.limits` - Maximum allowed (may be different from requests)
+
+### Step 3: Check Node Allocatable Resources
+
+View total allocatable resources per node:
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,CPU:.status.allocatable.cpu,MEM:.status.allocatable.memory,GPU:.status.allocatable.nvidia\.com/gpu,PODS:.status.allocatable.pods'
+```
+
+For detailed node information:
+```bash
+kubectl describe node <node-name>
+```
+
+**Key concepts:**
+- `allocatable` = Total capacity - System reserved - Kubelet reserved
+- `capacity` = Total hardware capacity
+- The difference is reserved for system/Kubernetes daemons
+
+### Step 4: Check Current Resource Usage
+
+If metrics-server is available:
+
+```bash
+kubectl top nodes
+```
+
+For per-node pod usage:
+```bash
+kubectl top pods --all-namespaces --sort-by=cpu | head -20
+kubectl top pods --all-namespaces --sort-by=memory | head -20
+```
+
+**Note:** If metrics-server is not available, you can still see resource allocation (requests) but not actual usage.
+
+### Step 5: Calculate Resource Availability
+
+For each node, calculate available resources:
+
+```
+Available CPU = allocatable.cpu - sum(all pod requests on node)
+Available Memory = allocatable.memory - sum(all pod requests on node)
+```
+
+Quick check with:
+```bash
+kubectl describe node <node-name> | grep -A 20 "Allocated resources"
+```
+
+**Look for:**
+- `cpu-requests` vs `cpu-capacity`
+- `memory-requests` vs `memory-capacity`
+- Percentage of allocation (high % = resource pressure)
+
+### Step 6: Check for Resource Fragmentation
+
+For Gang scheduling or affinity constraints, fragmentation is critical:
+
+```bash
+# Count nodes that can fit a single pod
+NODE_CPU_REQ="4"
+NODE_MEM_REQ="8Gi"
+
+kubectl get nodes -o json | jq -r '
+  .items[] |
+  select(.status.allocatable.cpu | tonumber >= '"$NODE_CPU_REQ"') |
+  select(.status.allocatable.memory | ascii_downcase | gsub("[gimk]"; "") | tonumber >= 8) |
+  .metadata.name'
+```
+
+**Fragmentation indicators:**
+- Many nodes with small amounts of free resources
+- No single node can satisfy the pod's resource needs
+- Total cluster resources sufficient but poorly distributed
+
+## Common Scenarios
+
+### Scenario 1: Pod Requests Exceed Any Single Node
+
+**Symptom:** `Insufficient cpu` or `Insufficient memory` on all nodes
+
+**Diagnosis:**
+```bash
+# Check pod request
+kubectl get pod <pod> -o jsonpath='{.spec.containers[0].resources.requests.cpu}'
+# Output: 32
+
+# Check largest node's allocatable
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.allocatable.cpu}{"\n"}{end}' | sort -k2 -n | tail -1
+# Output: node-1    16
+```
+
+**Analysis:** Pod requests 32 CPUs, but largest node only has 16 allocatable.
+
+**Solution:**
+- Reduce pod resource requests (if actual usage is lower)
+- Add larger nodes to cluster
+- Use node pool with bigger instances
+
+### Scenario 2: Cluster at Capacity
+
+**Symptom:** Most nodes show high allocation percentage
+
+**Diagnosis:**
+```bash
+kubectl describe node <node-name> | grep "Allocated resources"
+# cpu-requests:  14900m (93%)
+# memory-requests:  55000Mi (85%)
+```
+
+**Analysis:** Nodes are 85-93% allocated, leaving little room for new pods.
+
+**Solution:**
+- Scale cluster (add more nodes)
+- Review and optimize resource requests (may be over-provisioned)
+- Consider cluster autoscaler for dynamic scaling
+
+### Scenario 3: Resource Fragmentation
+
+**Symptom:** Gang scheduling fails despite total resources being sufficient
+
+**Diagnosis:**
+```bash
+# Total cluster CPU
+kubectl get nodes -o jsonpath='{range .items[*]}{.status.allocatable.cpu}{"\n"}{end}' | awk '{sum+=$1} END {print sum}'
+# Output: 64
+
+# Available nodes for 4-CPU pods
+kubectl get nodes -o custom-columns='NAME:.metadata.name,CPU:.status.allocatable.cpu' | awk '$2 >= 4 {count++} END {print count " nodes can fit the pod"}'
+# Output: 2 nodes can fit the pod
+
+# But we need 8 pods for Gang
+# 2 < 8, so Gang fails
+```
+
+**Analysis:** Total cluster has 64 CPUs, but only 2 nodes have 4+ CPUs. Gang needs 8 pods.
+
+**Solution:**
+- Enable `binpack` plugin to concentrate pods
+- Defragment by draining and rebalancing nodes
+- Use larger nodes to reduce fragmentation
+
+### Scenario 4: Queue Resource Exhaustion
+
+**Symptom:** Events mention queue limits, PodGroup stays in Pending
+
+**Diagnosis:**
+```bash
+# Check queue status
+kubectl get queue <queue-name> -o yaml
+```
+
+**Look for:**
+- `status.allocated` >= `status.deserved`
+- `state` is `Open` but no capacity available
+
+**Analysis:** Queue has used all its deserved resources.
+
+**Solution:**
+- Increase queue weight or capability
+- Wait for other jobs to complete
+- Use `volcano-queue-diagnose` for detailed analysis
+
+### Scenario 5: GPU Resource Shortage
+
+**Symptom:** `Insufficient nvidia.com/gpu` in events
+
+**Diagnosis:**
+```bash
+# Check GPU allocatable
+kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu'
+
+# Check GPU usage (if metrics available)
+kubectl top nodes --show-capacity 2>/dev/null || echo "GPU metrics not available"
+```
+
+**Analysis:** GPU resources are fully allocated or fragmented across nodes.
+
+**Solution:**
+- Verify GPU device plugin is running
+- Check if GPUs are properly allocatable on nodes
+- Consider GPU sharing if workload supports it
+
+## Resource Calculation Examples
+
+### Example 1: Calculate Total Cluster Capacity
+
+```bash
+kubectl get nodes -o json | jq -r '
+  .items |
+  map(.status.allocatable) |
+  reduce .[] as $item ({}; 
+    . + {cpu: ((.cpu // 0 | tonumber) + ($item.cpu | tonumber)),
+         memory: ((.memory // 0) + ($item.memory | tonumber))})'
+```
+
+### Example 2: Find Pods with High Resource Requests
+
+```bash
+kubectl get pods --all-namespaces -o json | jq -r '
+  .items[] |
+  select(.spec.containers[].resources.requests.cpu | tonumber > 4) |
+  "\(.metadata.namespace)/\(.metadata.name): \(.spec.containers[].resources.requests)"'
+```
+
+### Example 3: Check Resource Utilization vs Request
+
+```bash
+# High-level view
+kubectl get nodes -o custom-columns='NAME:.metadata.name,CPU_ALLOC:.status.allocatable.cpu,MEM_ALLOC:.status.allocatable.memory'
+```
+
+## Prevention and Best Practices
+
+1. **Right-size resource requests**
+   - Set requests based on actual usage, not maximum possible
+   - Use Vertical Pod Autoscaler (VPA) for recommendations
+
+2. **Use cluster autoscaler**
+   - Automatically scale nodes based on pending pod demands
+   - Configure appropriate node pools for different workloads
+
+3. **Enable binpack plugin**
+   - Reduces fragmentation by concentrating pods
+   - Better for batch workloads
+
+4. **Monitor resource quotas**
+   - Set up alerts for queue resource exhaustion
+   - Use `volcano-queue-diagnose` proactively
+
+5. **Regular capacity planning**
+   - Track resource growth trends
+   - Plan cluster expansion before hitting capacity
+
+## See Also
+
+- `volcano-diagnose-pod` - General Pod scheduling diagnosis
+- `volcano-gang-scheduling` - Gang scheduling constraint issues
+- `volcano-queue-diagnose` - Queue resource analysis
+- `volcano-node-resources` - Node resource querying

--- a/skills/core/volcano-scheduler-config/SKILL.md
+++ b/skills/core/volcano-scheduler-config/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: volcano-scheduler-config
+description: >-
+  View Volcano scheduler configuration.
+  Check scheduler ConfigMap, actions, plugins, and tier settings.
+---
+
+# Volcano Scheduler Configuration
+
+View Volcano scheduler configuration to understand scheduling policies, enabled plugins, and actions. This skill helps diagnose configuration-related scheduling behaviors.
+
+**Scope:** This skill is for **diagnosis only**. It retrieves configuration for analysis but does not modify any cluster state.
+
+## Usage
+
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh [options]
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--section SECTION` | no | Show specific section: actions, plugins, tiers, all (default: all) |
+| `--format FORMAT` | no | Output format: yaml, json, summary (default: summary) |
+| `--raw` | no | Show raw ConfigMap data without parsing |
+
+## Examples
+
+Get summary of scheduler configuration:
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh
+```
+
+View actions configuration only:
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section actions
+```
+
+View plugins configuration:
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section plugins
+```
+
+Show full YAML configuration:
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --format yaml
+```
+
+Get raw ConfigMap:
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --raw
+```
+
+## Understanding Scheduler Configuration
+
+### Configuration Location
+
+The Volcano scheduler configuration is stored in:
+- **Namespace:** `volcano-system`
+- **ConfigMap:** `volcano-scheduler-configmap`
+- **Key:** `volcano-scheduler.conf`
+
+### Configuration Structure
+
+```yaml
+actions: "enqueue, allocate, backfill"  # Pipeline order
+tiers:
+- plugins:
+  - name: priority
+  - name: gang
+  - name: conformance
+- plugins:
+  - name: overcommit
+  - name: drf
+  - name: predicates
+  - name: proportion
+  - name: nodeorder
+  - name: binpack
+```
+
+### Actions
+
+Actions define the **two-phase scheduling pipeline**:
+1. **Enqueue phase** — PodGroup is admitted to the queue based on queue capacity (does the queue have enough deserved resources?)
+2. **Allocate phase** — Individual pods are placed on nodes based on node resources, affinity, taints, etc.
+
+A job can pass enqueue (PodGroup moves to `Inqueue`) but fail allocation (pods stay `Pending`) if node-level constraints block placement. This two-phase model explains the common scenario: "queue has capacity but pods won't schedule."
+
+Actions in order:
+
+| Action | Required | Purpose |
+|--------|----------|---------|
+| `enqueue` | Yes | Admit pod groups to queue |
+| `allocate` | Yes | Allocate resources to pods |
+| `backfill` | No | Fill idle resources with best-effort pods |
+| `preempt` | No | Evict low-priority pods for high-priority |
+| `reclaim` | No | Reclaim resources from over-allocated queues |
+| `elect` | No | Select target workload (removed in v1.6+) |
+
+### Tiers
+
+Tiers divide plugins into priority levels:
+- **Tier 1:** First to evaluate, results cannot be overridden
+- **Tier 2:** Second to evaluate, lower priority
+
+Common tier organization:
+- **Tier 1:** Critical plugins (priority, gang, conformance)
+- **Tier 2:** Resource and optimization plugins
+
+### Plugins
+
+#### Critical Plugins
+
+| Plugin | Function | Critical For |
+|--------|----------|--------------|
+| `gang` | Gang scheduling | Batch jobs, ML training |
+| `priority` | Priority sorting | Workload prioritization |
+| `conformance` | Protect critical pods | System stability |
+
+#### Resource Plugins
+
+| Plugin | Function | Use Case |
+|--------|----------|----------|
+| `proportion` | Fair share allocation | Multi-tenant clusters |
+| `drf` | Dominant Resource Fairness | Fair GPU/CPU sharing |
+| `overcommit` | Allow overcommit | Resource efficiency |
+
+#### Node Plugins
+
+| Plugin | Function | Use Case |
+|--------|----------|----------|
+| `predicates` | Node filtering | Resource/affinity matching |
+| `nodeorder` | Node ranking | Node selection optimization |
+| `binpack` | Dense packing | Reduce fragmentation |
+| `numaaware` | NUMA topology | HPC workloads |
+
+#### Queue Plugins
+
+| Plugin | Function | Use Case |
+|--------|----------|----------|
+| `priority` | Queue ordering | Queue prioritization |
+| `proportion` | Proportional share | Fair queue allocation |
+
+## Diagnostic Use Cases
+
+### Case 1: Check If Gang Scheduling is Enabled
+
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section plugins
+```
+
+Look for `name: gang` in the plugin list. If missing, Gang scheduling will not work.
+
+### Case 2: Verify Reclaim is Enabled
+
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section actions
+```
+
+Look for `reclaim` in the actions list. If missing, queues cannot reclaim resources.
+
+### Case 3: Check Proportion Plugin Configuration
+
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section plugins
+```
+
+Look for `name: proportion`. If missing, queue fair-share allocation is disabled.
+
+### Case 4: Compare with Default Configuration
+
+Default configuration:
+```yaml
+actions: "enqueue, allocate, backfill"
+tiers:
+- plugins:
+  - name: priority
+  - name: gang
+    enablePreemptable: false
+  - name: conformance
+- plugins:
+  - name: overcommit
+  - name: drf
+    enablePreemptable: false
+  - name: predicates
+  - name: proportion
+  - name: nodeorder
+  - name: binpack
+```
+
+If your configuration differs significantly, it may explain scheduling behaviors.
+
+### Case 5: Check Plugin Arguments
+
+Some plugins accept arguments:
+
+```yaml
+- name: overcommit
+  arguments:
+    overcommit-factor: "1.2"
+```
+
+Use `--format yaml` or `--raw` to see full plugin configurations including arguments.
+
+## Common Configuration Issues
+
+### Issue 1: Missing Gang Plugin
+
+**Symptom:** PodGroups stay Pending, minMember never satisfied
+
+**Check:**
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section plugins | grep gang
+```
+
+**Solution:** Add `gang` plugin to configuration
+
+### Issue 2: Missing Reclaim Action
+
+**Symptom:** Queues cannot reclaim resources from over-allocated queues
+
+**Check:**
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section actions | grep reclaim
+```
+
+**Solution:** Add `reclaim` to actions list
+
+### Issue 3: Wrong Action Order
+
+**Symptom:** Unexpected scheduling behavior
+
+**Check:**
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section actions
+```
+
+**Common orders:**
+- Default: `enqueue, allocate, backfill`
+- With preemption: `enqueue, allocate, backfill, preempt`
+- With reclaim: `enqueue, allocate, backfill, reclaim`
+- Full: `enqueue, allocate, backfill, preempt, reclaim`
+
+**Important:** `enqueue` must come before `allocate`. `allocate` must be present.
+
+### Issue 4: Plugin Tier Misconfiguration
+
+**Symptom:** Priority/preemption not working as expected
+
+**Check:**
+```bash
+bash skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh --section tiers
+```
+
+**Guideline:**
+- Tier 1: Plugins that should not be overridden (priority, gang)
+- Tier 2: Resource optimization plugins (proportion, binpack)
+
+## Configuration Options Reference
+
+### Plugin Arguments
+
+| Plugin | Argument | Default | Description |
+|--------|----------|---------|-------------|
+| `gang` | `enablePreemptable` | `true` | Allow Gang pods to be preempted |
+| `overcommit` | `overcommit-factor` | `1.2` | Multiplier for allocatable resources |
+| `drf` | `enablePreemptable` | `true` | Allow DRF pods to be preempted |
+| `nodeorder` | various weights | `0` | Node scoring weights |
+| `proportion` | (none) | - | No arguments |
+| `predicates` | `GPUSharingEnable` | `false` | Enable GPU sharing |
+
+### Action-Specific Notes
+
+#### Enqueue
+- Evaluates `jobEnqueueableFn` from plugins
+- Default `overcommit-factor` of 1.2 means 20% overcommit
+
+#### Allocate
+- Main allocation logic
+- Calls `allocate` action for each tier
+
+#### Backfill
+- Only schedules best-effort pods (no resource requests)
+- Ignores queue deserved resources
+
+#### Preempt
+- Requires `priority` plugin for comparison
+- Requires `preemptableFn` from plugins
+
+#### Reclaim
+- Requires `proportion` plugin
+- Requires `reclaimableFn` from plugins
+- Reclaims from over-allocated queues
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VOLCANO_SCHEDULER_NS` | `volcano-system` | Scheduler namespace |
+| `VOLCANO_SCHEDULER_CONFIG` | `volcano-scheduler-configmap` | ConfigMap name |
+
+## Output Formats
+
+### Summary Format (default)
+
+Human-readable summary:
+```
+Scheduler Configuration
+=======================
+Actions: enqueue, allocate, backfill
+
+Tier 1 Plugins:
+  - priority
+  - gang
+  - conformance
+
+Tier 2 Plugins:
+  - overcommit
+  - drf
+  - predicates
+  - proportion
+  - nodeorder
+  - binpack
+```
+
+### YAML Format
+
+Parsed YAML structure:
+```yaml
+actions: "enqueue, allocate, backfill"
+tiers:
+  - plugins:
+      - name: priority
+      - name: gang
+```
+
+### JSON Format
+
+Machine-parseable:
+```json
+{
+  "actions": "enqueue, allocate, backfill",
+  "tiers": [
+    {
+      "plugins": [
+        {"name": "priority"},
+        {"name": "gang"}
+      ]
+    }
+  ]
+}
+```
+
+### Raw Format
+
+ConfigMap raw output:
+```
+volcano-scheduler.conf:
+---
+actions: "enqueue, allocate, backfill"
+tiers:
+...
+```
+
+## See Also
+
+- `volcano-queue-diagnose` - Queue resource analysis
+- `volcano-gang-scheduling` - Gang scheduling issues
+- `volcano-diagnose-pod` - Pod scheduling diagnosis
+- `volcano-scheduler-logs` - Scheduler decision logs

--- a/skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh
+++ b/skills/core/volcano-scheduler-config/scripts/get-scheduler-config.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+# View Volcano scheduler configuration.
+# This script performs read-only operations using kubectl.
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: $0 [options]
+
+View Volcano scheduler configuration.
+Check scheduler ConfigMap, actions, plugins, and tier settings.
+
+Options:
+  --section SECTION   Show specific section: actions, plugins, tiers, all (default: all)
+  --format FORMAT     Output format: yaml, json, summary (default: summary)
+  --raw               Show raw ConfigMap data without parsing
+  -h, --help          Show this help message
+
+Environment:
+  VOLCANO_SCHEDULER_NS      Scheduler namespace (default: volcano-system)
+  VOLCANO_SCHEDULER_CONFIG  ConfigMap name (default: volcano-scheduler-configmap)
+
+Examples:
+  $0                              # Summary of all config
+  $0 --section actions            # Actions only
+  $0 --section plugins            # Plugins only
+  $0 --format yaml                # Full YAML output
+  $0 --raw                        # Raw ConfigMap data
+EOF
+  exit 0
+}
+
+# Parse arguments
+SECTION="all"
+FORMAT="summary"
+RAW=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help) show_help ;;
+    --section) SECTION="$2"; shift 2 ;;
+    --format) FORMAT="$2"; shift 2 ;;
+    --raw) RAW=true; shift ;;
+    *) echo "Unknown option: $1. Use --help for usage." >&2; exit 1 ;;
+  esac
+done
+
+# Validate arguments
+if [[ "$SECTION" != "all" && "$SECTION" != "actions" && "$SECTION" != "plugins" && "$SECTION" != "tiers" ]]; then
+  echo "Error: Invalid section '$SECTION'. Use: all, actions, plugins, or tiers" >&2
+  exit 1
+fi
+
+if [[ "$FORMAT" != "summary" && "$FORMAT" != "yaml" && "$FORMAT" != "json" ]]; then
+  echo "Error: Invalid format '$FORMAT'. Use: summary, yaml, or json" >&2
+  exit 1
+fi
+
+# Environment settings
+SCHEDULER_NS="${VOLCANO_SCHEDULER_NS:-volcano-system}"
+CONFIG_NAME="${VOLCANO_SCHEDULER_CONFIG:-volcano-scheduler-configmap}"
+
+echo "=== Volcano Scheduler Configuration ==="
+echo "Namespace: $SCHEDULER_NS"
+echo "ConfigMap: $CONFIG_NAME"
+echo "Section: $SECTION"
+echo "Format: $FORMAT"
+echo
+
+# Check if ConfigMap exists
+if ! kubectl get cm "$CONFIG_NAME" -n "$SCHEDULER_NS" &>/dev/null; then
+  echo "Error: ConfigMap '$CONFIG_NAME' not found in namespace '$SCHEDULER_NS'" >&2
+  echo "Available ConfigMaps in $SCHEDULER_NS:" >&2
+  kubectl get cm -n "$SCHEDULER_NS" 2>/dev/null | head -10 >&2 || echo "  (failed to list ConfigMaps)" >&2
+  exit 1
+fi
+
+# Get raw configuration
+CONFIG_DATA=$(kubectl get cm "$CONFIG_NAME" -n "$SCHEDULER_NS" -o jsonpath='{.data.volcano-scheduler\.conf}' 2>/dev/null || echo "")
+
+if [[ -z "$CONFIG_DATA" ]]; then
+  echo "Error: Config key 'volcano-scheduler.conf' not found in ConfigMap" >&2
+  echo "Available keys:" >&2
+  kubectl get cm "$CONFIG_NAME" -n "$SCHEDULER_NS" -o jsonpath='{.data}' 2>/dev/null | jq 'keys' 2>/dev/null || echo "  (could not list keys)" >&2
+  exit 1
+fi
+
+# If raw mode, just output the raw data
+if [[ "$RAW" == "true" ]]; then
+  echo "Raw ConfigMap Data:"
+  echo "===================="
+  echo "$CONFIG_DATA"
+  echo
+  echo "=== Query Complete ==="
+  exit 0
+fi
+
+# Parse configuration
+# Extract actions line
+ACTIONS_LINE=$(echo "$CONFIG_DATA" | grep "^actions:" | head -1 || echo "")
+ACTIONS=$(echo "$ACTIONS_LINE" | sed 's/^actions:[[:space:]]*//' | sed 's/^"//;s/"$//')
+
+# Extract tier and plugin information
+# This is a simple parser - for complex YAML, we'd need yq
+parse_plugins() {
+  local tier_num=$1
+  local in_tier=false
+  local tier_count=0
+  local plugins=""
+
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*plugins: ]]; then
+      if [[ "$in_tier" == "true" ]]; then
+        break
+      fi
+      tier_count=$((tier_count + 1))
+      if [[ $tier_count -eq $tier_num ]]; then
+        in_tier=true
+      fi
+      continue
+    fi
+
+    if [[ "$in_tier" == "true" && "$line" =~ "name:" ]]; then
+      local plugin_name
+      plugin_name=$(echo "$line" | grep -o 'name:[[:space:]]*[^[:space:]]*' | sed 's/name:[[:space:]]*//' || echo "")
+      if [[ -n "$plugin_name" ]]; then
+        plugins="$plugins$plugin_name "
+      fi
+    fi
+  done <<< "$CONFIG_DATA"
+
+  echo "$plugins"
+}
+
+# Count number of tiers
+TIER_COUNT=$(echo "$CONFIG_DATA" | grep -c "^[[:space:]]*- plugins:" || echo "0")
+
+# Output based on format and section
+case "$FORMAT" in
+  summary)
+    echo "Scheduler Configuration Summary"
+    echo "================================"
+    echo
+
+    if [[ "$SECTION" == "all" || "$SECTION" == "actions" ]]; then
+      echo "Actions:"
+      echo "--------"
+      if [[ -n "$ACTIONS" ]]; then
+        echo "  $ACTIONS"
+        echo
+
+        # Explain each action
+        IFS=',' read -ra action_list <<< "$ACTIONS"
+        for action in "${action_list[@]}"; do
+          action=$(echo "$action" | tr -d ' ')  # Remove spaces
+          case "$action" in
+            enqueue)
+              echo "  - enqueue: Admit pod groups to queue"
+              ;;
+            allocate)
+              echo "  - allocate: Allocate resources to pods"
+              ;;
+            backfill)
+              echo "  - backfill: Fill idle resources (best-effort pods)"
+              ;;
+            preempt)
+              echo "  - preempt: Evict low-priority pods"
+              ;;
+            reclaim)
+              echo "  - reclaim: Reclaim over-allocated queue resources"
+              ;;
+            elect)
+              echo "  - elect: Select target workload (removed in v1.6+)"
+              ;;
+          esac
+        done
+      else
+        echo "  (Actions not found in configuration)"
+      fi
+      echo
+    fi
+
+    if [[ "$SECTION" == "all" || "$SECTION" == "plugins" || "$SECTION" == "tiers" ]]; then
+      echo "Tiers and Plugins:"
+      echo "------------------"
+      echo "Total Tiers: $TIER_COUNT"
+      echo
+
+      for ((i=1; i<=TIER_COUNT; i++)); do
+        tier_plugins=$(parse_plugins $i)
+        echo "Tier $i Plugins:"
+        if [[ -n "$tier_plugins" ]]; then
+          for plugin in $tier_plugins; do
+            echo "  - $plugin"
+          done
+        else
+          echo "  (No plugins found)"
+        fi
+        echo
+      done
+    fi
+
+    # Plugin explanations
+    if [[ "$SECTION" == "all" || "$SECTION" == "plugins" ]]; then
+      echo "Critical Plugins:"
+      echo "-----------------"
+      echo "  - gang: Gang scheduling (required for batch workloads)"
+      echo "  - priority: Priority handling"
+      echo "  - conformance: Protect critical pods"
+      echo "  - proportion: Fair queue resource allocation"
+      echo "  - drf: Dominant Resource Fairness"
+      echo "  - predicates: Node filtering"
+      echo
+
+      # Check for missing critical plugins
+      all_plugins=$(parse_plugins 1)$(parse_plugins 2)
+      echo "Configuration Check:"
+      echo "-------------------"
+
+      if [[ "$all_plugins" =~ "gang" ]]; then
+        echo "  ✓ Gang plugin: enabled"
+      else
+        echo "  ⚠ Gang plugin: NOT FOUND (Gang scheduling will not work)"
+      fi
+
+      if [[ "$all_plugins" =~ "proportion" ]]; then
+        echo "  ✓ Proportion plugin: enabled"
+      else
+        echo "  ⚠ Proportion plugin: NOT FOUND (Queue fair-share disabled)"
+      fi
+
+      if [[ "$ACTIONS" =~ "reclaim" ]]; then
+        echo "  ✓ Reclaim action: enabled"
+      else
+        echo "  ℹ Reclaim action: not enabled (resource reclaim disabled)"
+      fi
+
+      if [[ "$ACTIONS" =~ "preempt" ]]; then
+        echo "  ✓ Preempt action: enabled"
+      else
+        echo "  ℹ Preempt action: not enabled (priority preemption disabled)"
+      fi
+    fi
+    ;;
+
+  yaml)
+    echo "Scheduler Configuration (YAML):"
+    echo "=============================="
+    echo
+    echo "$CONFIG_DATA"
+    ;;
+
+  json)
+    # Simple JSON conversion (basic structure)
+    echo "{"
+    echo "  \"namespace\": \"$SCHEDULER_NS\","
+    echo "  \"configmap\": \"$CONFIG_NAME\","
+
+    if [[ -n "$ACTIONS" ]]; then
+      echo "  \"actions\": ["
+      IFS=',' read -ra action_list <<< "$ACTIONS"
+      first=true
+      for action in "${action_list[@]}"; do
+        action=$(echo "$action" | tr -d ' ')
+        [[ "$first" == "false" ]] && echo ","
+        echo -n "    \"$action\""
+        first=false
+      done
+      echo
+      echo "  ],"
+    fi
+
+    echo "  \"tiers\": ["
+    for ((i=1; i<=TIER_COUNT; i++)); do
+      [[ $i -gt 1 ]] && echo ","
+      tier_plugins=$(parse_plugins $i)
+      echo "    {"
+      echo "      \"tier\": $i,"
+      echo "      \"plugins\": ["
+      pfirst=true
+      for plugin in $tier_plugins; do
+        [[ "$pfirst" == "false" ]] && echo ","
+        echo -n "        \"$plugin\""
+        pfirst=false
+      done
+      echo
+      echo "      ]"
+      echo -n "    }"
+    done
+    echo
+    echo "  ]"
+    echo "}"
+    ;;
+esac
+
+echo
+echo "=== Query Complete ==="

--- a/skills/core/volcano-scheduler-logs/SKILL.md
+++ b/skills/core/volcano-scheduler-logs/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: volcano-scheduler-logs
+description: >-
+  Retrieve and analyze Volcano scheduler logs.
+  Filter by keyword, time range, or pod name to debug scheduling decisions.
+---
+
+# Volcano Scheduler Logs
+
+Retrieve and analyze Volcano scheduler logs to understand scheduling decisions, failures, and performance issues.
+
+**Scope:** This skill is for **diagnosis only**. It retrieves logs for analysis but does not modify any cluster state.
+
+## Usage
+
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh [options]
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--keyword KEYWORD` | no | Filter logs by keyword (case-insensitive) |
+| `--pod POD` | no | Filter logs related to specific pod name |
+| `--since TIME` | no | Show logs newer than relative time (e.g., 10m, 1h) |
+| `--lines N` | no | Number of lines to show (default: 100) |
+| `--follow` | no | Stream logs in real-time (Ctrl+C to stop) |
+| `--previous` | no | Show logs from previous container instance (after restart) |
+
+## Examples
+
+Get recent scheduler logs:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh
+```
+
+Search for error messages:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --keyword error
+```
+
+Get logs for a specific pod:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --pod my-job-0
+```
+
+Get last 500 lines from the past hour:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --since 1h --lines 500
+```
+
+Stream logs for gang scheduling issues:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --keyword gang --follow
+```
+
+Check logs from previous scheduler instance (after crash/restart):
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --previous --lines 200
+```
+
+## Common Keywords for Filtering
+
+| Keyword | Use Case |
+|---------|----------|
+| `error` | Find error messages and failures |
+| `FailedScheduling` | Scheduling failures |
+| `allocate` | Resource allocation attempts |
+| `gang` | Gang scheduling decisions |
+| `minMember` | MinMember constraint issues |
+| `preempt` | Preemption events |
+| `reclaim` | Resource reclamation |
+| `enqueue` | Queue admission decisions |
+| `bind` | Pod binding attempts |
+| `queue` | Queue-related decisions |
+| `proportion` | Proportion plugin decisions |
+| `priority` | Priority-related decisions |
+
+## Understanding Scheduler Logs
+
+### Log Format
+
+Volcano scheduler logs typically follow this format:
+```
+I0102 15:04:05.123456       1 scheduler.go:123] Starting scheduling session
+I0102 15:04:05.234567       1 allocate.go:456] Try to allocate resources for Job <namespace>/<job-name>
+E0102 15:04:05.345678       1 gang.go:789] Failed to schedule pod <pod-name>: minMember not satisfied
+```
+
+**Log levels:**
+- `I` - Info: Normal operation information
+- `W` - Warning: Unusual but non-fatal conditions
+- `E` - Error: Failures and errors
+- `F` - Fatal: Critical errors causing shutdown
+
+### Common Log Patterns
+
+#### Session Start
+```
+Starting scheduling session
+Starting scheduling loop
+```
+- Indicates scheduler is processing a new batch of pending pods
+
+#### Enqueue Decisions
+```
+Try to enqueue pod group
+PodGroup <name> is enqueued
+PodGroup <name> is pending
+```
+- Shows whether pod groups are admitted to the queue
+
+#### Allocation Attempts
+```
+Try to allocate resources for Job
+Try to allocate for task
+```
+- Shows scheduling attempts for specific jobs/pods
+
+#### Gang Scheduling
+```
+minMember not satisfied
+gang member not ready
+Waiting for gang members
+```
+- Indicates Gang constraint preventing scheduling
+
+#### Resource Shortage
+```
+Insufficient cpu
+Insufficient memory
+0 nodes are available
+```
+- Indicates resource constraint preventing scheduling
+
+#### Preemption
+```
+Preempting pods
+Found victim pods
+```
+- Shows preemption decisions for high-priority workloads
+
+#### Reclaim
+```
+Try to reclaim resources
+Reclaiming resources from queue
+```
+- Shows resource reclamation between queues
+
+## Diagnostic Use Cases
+
+### Case 1: Pod Stuck in Pending
+
+Find relevant scheduler decisions:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --pod <pod-name> --since 30m
+```
+
+Look for:
+- `FailedScheduling` events
+- `minMember not satisfied`
+- `Insufficient` resource messages
+- `enqueue` decisions (is the PodGroup being admitted?)
+
+### Case 2: Gang Scheduling Issues
+
+Check Gang plugin behavior:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --keyword gang --since 1h
+```
+
+Look for:
+- `minMember` related messages
+- Gang constraint validation
+- Comparison of running vs required members
+
+### Case 3: Queue Resource Issues
+
+Check proportion and reclaim decisions:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --keyword "reclaim\|proportion" --since 30m
+```
+
+Look for:
+- Queue resource calculations
+- Reclaim triggers
+- Over-commit handling
+
+### Case 4: Scheduler Performance
+
+Check for scheduling delays:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --lines 500 | grep -E "(Starting|Finished) scheduling"
+```
+
+Look for:
+- Long gaps between "Starting" and "Finished"
+- High frequency of scheduling loops
+- Errors causing retries
+
+### Case 5: Preemption Analysis
+
+Check preemption decisions:
+```bash
+bash skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh --keyword preempt --since 1h
+```
+
+Look for:
+- Which pods are being preempted
+- Priority comparisons
+- Preemption success/failure
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VOLCANO_SCHEDULER_NS` | `volcano-system` | Scheduler namespace |
+| `VOLCANO_SCHEDULER_LABEL` | `app=volcano-scheduler` | Label selector for scheduler pods |
+
+## Limitations
+
+1. **Log retention:** Logs may be rotated based on cluster configuration
+2. **Multi-scheduler:** If running multiple schedulers, logs will be interleaved
+3. **Log level:** Default log level may not show all debug information
+4. **Previous logs:** `--previous` only works if the container has restarted
+
+## Tips for Effective Log Analysis
+
+1. **Use time ranges:** Narrow down with `--since` to focus on recent issues
+2. **Combine keywords:** Search for `error\|Failed\|failed` to catch all failures
+3. **Check pod context:** Always include `--pod` when investigating specific pods
+4. **Look for patterns:** Repeating errors may indicate systemic issues
+5. **Correlate with events:** Compare with `kubectl get events` timestamps
+
+## See Also
+
+- `volcano-diagnose-pod` - Diagnose individual pod issues
+- `volcano-gang-scheduling` - Gang scheduling specific diagnosis
+- `volcano-queue-diagnose` - Queue resource analysis
+- `volcano-resource-insufficient` - Resource shortage diagnosis

--- a/skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh
+++ b/skills/core/volcano-scheduler-logs/scripts/get-scheduler-logs.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Retrieve and analyze Volcano scheduler logs.
+# This script performs read-only operations using kubectl.
+set -euo pipefail
+
+show_help() {
+  cat <<EOF
+Usage: $0 [options]
+
+Retrieve and analyze Volcano scheduler logs.
+Filter by keyword, time range, or pod name to debug scheduling decisions.
+
+Options:
+  --keyword KEYWORD   Filter logs by keyword (case-insensitive)
+  --pod POD           Filter logs related to specific pod name
+  --since TIME        Show logs newer than relative time (e.g., 10m, 1h, 1d)
+  --lines N           Number of lines to show (default: 100)
+  --follow            Stream logs in real-time (Ctrl+C to stop)
+  --previous          Show logs from previous container instance
+  -h, --help          Show this help message
+
+Environment:
+  VOLCANO_SCHEDULER_NS      Scheduler namespace (default: volcano-system)
+  VOLCANO_SCHEDULER_LABEL   Pod label selector (default: app=volcano-scheduler)
+
+Examples:
+  $0 --keyword error                    # Search for errors
+  $0 --pod my-job-0 --since 30m        # Logs for pod in last 30 min
+  $0 --lines 500 --since 1h            # Last 500 lines from past hour
+  $0 --keyword gang --follow           # Stream gang scheduling logs
+  $0 --previous --lines 200            # Logs from previous scheduler instance
+EOF
+  exit 0
+}
+
+# Parse arguments
+KEYWORD=""
+POD=""
+SINCE=""
+LINES=100
+FOLLOW=false
+PREVIOUS=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help) show_help ;;
+    --keyword) KEYWORD="$2"; shift 2 ;;
+    --pod) POD="$2"; shift 2 ;;
+    --since) SINCE="$2"; shift 2 ;;
+    --lines) LINES="$2"; shift 2 ;;
+    --follow) FOLLOW=true; shift ;;
+    --previous) PREVIOUS=true; shift ;;
+    *) echo "Unknown option: $1. Use --help for usage." >&2; exit 1 ;;
+  esac
+done
+
+# Validate arguments
+if [[ "$FOLLOW" == "true" && -n "$SINCE" ]]; then
+  echo "Error: --follow and --since cannot be used together" >&2
+  exit 1
+fi
+
+if [[ "$FOLLOW" == "true" && -n "$SINCE" && "$LINES" != "100" ]]; then
+  echo "Warning: --follow ignores --lines, streaming from now" >&2
+fi
+
+# Environment settings
+SCHEDULER_NS="${VOLCANO_SCHEDULER_NS:-volcano-system}"
+SCHEDULER_LABEL="${VOLCANO_SCHEDULER_LABEL:-app=volcano-scheduler}"
+
+echo "=== Volcano Scheduler Logs ==="
+echo "Namespace: $SCHEDULER_NS"
+echo "Label: $SCHEDULER_LABEL"
+[[ -n "$KEYWORD" ]] && echo "Keyword filter: $KEYWORD"
+[[ -n "$POD" ]] && echo "Pod filter: $POD"
+[[ -n "$SINCE" ]] && echo "Time range: $SINCE"
+echo "Lines: $LINES"
+[[ "$PREVIOUS" == "true" ]] && echo "Previous instance: yes"
+echo
+
+# Check if scheduler pod exists
+if ! kubectl get pods -n "$SCHEDULER_NS" -l "$SCHEDULER_LABEL" &>/dev/null; then
+  echo "Error: No scheduler pods found in namespace '$SCHEDULER_NS' with label '$SCHEDULER_LABEL'" >&2
+  echo "Available pods in $SCHEDULER_NS:" >&2
+  kubectl get pods -n "$SCHEDULER_NS" 2>/dev/null | head -10 >&2 || echo "  (failed to list pods)" >&2
+  exit 1
+fi
+
+# Get scheduler pod name
+SCHEDULER_POD=$(kubectl get pods -n "$SCHEDULER_NS" -l "$SCHEDULER_LABEL" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+if [[ -z "$SCHEDULER_POD" ]]; then
+  echo "Error: Could not determine scheduler pod name" >&2
+  exit 1
+fi
+
+echo "Scheduler Pod: $SCHEDULER_POD"
+echo
+
+# Build kubectl logs command
+LOG_CMD="kubectl logs -n $SCHEDULER_NS $SCHEDULER_POD"
+
+# Add options
+[[ "$FOLLOW" == "true" ]] && LOG_CMD="$LOG_CMD --follow"
+[[ "$PREVIOUS" == "true" ]] && LOG_CMD="$LOG_CMD --previous"
+[[ -n "$SINCE" ]] && LOG_CMD="$LOG_CMD --since=$SINCE"
+[[ "$FOLLOW" == "false" ]] && LOG_CMD="$LOG_CMD --tail=$LINES"
+
+# Execute command with optional filtering
+echo "Executing: $LOG_CMD"
+echo "----------------------------------------"
+echo
+
+# Build filter pattern
+FILTER_PATTERN=""
+
+# If both keyword and pod are specified, combine them
+if [[ -n "$KEYWORD" && -n "$POD" ]]; then
+  FILTER_PATTERN="$KEYWORD|$POD"
+elif [[ -n "$KEYWORD" ]]; then
+  FILTER_PATTERN="$KEYWORD"
+elif [[ -n "$POD" ]]; then
+  FILTER_PATTERN="$POD"
+fi
+
+# Execute and filter
+if [[ -n "$FILTER_PATTERN" ]]; then
+  # Use case-insensitive grep for filtering
+  if [[ "$FOLLOW" == "true" ]]; then
+    # For follow mode, we need to filter in real-time
+    $LOG_CMD 2>&1 | grep -iE "$FILTER_PATTERN" || true
+  else
+    # For non-follow mode, filter after getting logs
+    $LOG_CMD 2>&1 | grep -iE "$FILTER_PATTERN" || {
+      echo "(No log lines matched the filter pattern: $FILTER_PATTERN)"
+    }
+  fi
+else
+  # No filtering, show all logs
+  $LOG_CMD 2>&1 || {
+    echo "Error: Failed to retrieve logs" >&2
+    exit 1
+  }
+fi
+
+echo
+
+# If not following, show some helpful hints
+if [[ "$FOLLOW" == "false" ]]; then
+  echo "----------------------------------------"
+  echo "Hints:"
+  echo "  - Use --follow to stream logs in real-time"
+  echo "  - Use --since 30m for recent logs only"
+  echo "  - Use --previous if scheduler recently restarted"
+  echo "  - Common keywords: error, FailedScheduling, gang, preempt, reclaim"
+fi
+
+echo
+echo "=== Log Retrieval Complete ==="


### PR DESCRIPTION
Closes #81

## Summary

Add 8 core diagnostic skills for open-source Volcano scheduling system, enabling SREs to quickly diagnose scheduling issues without leaving Siclaw.

### New skills

| Skill | Type | Description |
|-------|------|-------------|
| `volcano-diagnose-pod` | script | Pod-level diagnosis — PodGroup status, scheduling events, Volcano error patterns |
| `volcano-gang-scheduling` | doc | Gang scheduling analysis — minMember constraints, partial scheduling |
| `volcano-queue-diagnose` | script | Queue state, resource allocation ratio, over-allocation detection |
| `volcano-node-resources` | script | Cluster capacity, GPU nodes, resource fragmentation |
| `volcano-job-diagnose` | script | Volcano Job phases, task statuses, lifecycle policy review |
| `volcano-scheduler-config` | script | Scheduler ConfigMap parsing, action/plugin/tier validation |
| `volcano-scheduler-logs` | script | Filtered log retrieval with keyword/pod-name search |
| `volcano-resource-insufficient` | doc | Resource shortage diagnosis patterns and resolution guide |

### Other changes

- Register all 8 skills in `meta.json` with `["volcano", "scheduling", "diagnostic", "sre", "developer"]` labels
- Add Volcano cross-references in `pod-pending-debug` and `cluster-events` SKILL.md

### Design decisions

- **Read-only**: All scripts use only safe kubectl subcommands (get, describe, logs, top) per security model
- **Portable**: Avoided `bc` dependency (use `awk` for float math), no `mapfile` (Bash 3 compat), cross-platform `date` handling
- **Robust**: `set -euo pipefail` with safe arithmetic (`$((x+1))` not `((x++))`) and proper `--no-headers` counting

## Test Plan

- [ ] `npx tsc --noEmit` passes (no TS changes)
- [ ] All scripts pass `bash -n` syntax check
- [ ] Manual verification on cluster with Volcano installed:
  - [ ] `diagnose-pod.sh` correctly identifies PodGroup and events
  - [ ] `diagnose-queue.sh` handles milliCPU values ("500m") without crash
  - [ ] `get-scheduler-config.sh` parses multi-tier plugin config correctly
  - [ ] `diagnose-job.sh` uses `job.batch.volcano.sh` (not native Job)
- [ ] Cross-references in `pod-pending-debug` and `cluster-events` point to correct skills

## Architecture Checklist

- [x] **Security model**: All scripts read-only, no new shell execution paths — kubectl restricted to safe subcommands
- [ ] **Deployment mode**: Skills are static files, no runtime behavior differences
- [x] **Both brain types**: No tool changes, skills loaded via existing `buildAppendSystemPrompt` path