### PR TITLE
fix: correct hypothesis parsing in TUI widget for indented and multi-line formats

### DIFF
--- a/src/core/extensions/deep-investigation.ts
+++ b/src/core/extensions/deep-investigation.ts
@@ -99,8 +99,8 @@ function parseHypotheses(text: string): Array<{ title: string; confidence?: numb
   }
   if (results.length > 0) return results;
 
-  // Strategy 2: Numbered lists — 1. ... / 1) ... / (1) ...
-  const numberedPattern = /^(?:\d+[.)]\s*|\(\d+\)\s*)(.+)/gm;
+  // Strategy 2: Numbered lists — 1. ... / 1) ... / (1) ... (allows leading whitespace)
+  const numberedPattern = /^\s*(?:\d+[.)]\s*|\(\d+\)\s*)(.+)/gm;
   while ((m = numberedPattern.exec(text)) !== null) {
     const line = m[1]?.trim();
     if (line && line.length > 5) results.push(extract(line));
@@ -115,14 +115,21 @@ function parseHypotheses(text: string): Array<{ title: string; confidence?: numb
   }
   if (results.length > 0) return results;
 
-  // Strategy 4: Raw fallback — non-empty lines, strip markdown markers
-  const rawLines = text.split("\n")
-    .map((l) => l.replace(/^[#*\->\s]+/, "").trim())
-    .filter((l) => l.length > 5);
-  for (const line of rawLines.slice(0, 8)) {
-    results.push(extract(line));
+  // Strategy 4: Grouped fallback — group bullet/indented lines under their parent
+  // Mirrors HypothesesCard.tsx parseNumberedList logic to avoid splitting sub-items
+  const lines = text.split("\n");
+  let current: string | null = null;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const isSubItem = trimmed.startsWith("-") || trimmed.startsWith("*") || /^\s{2,}/.test(line);
+    if (!isSubItem && trimmed.length > 5) {
+      if (current !== null) results.push(extract(current));
+      current = trimmed;
+    }
   }
-  return results;
+  if (current !== null) results.push(extract(current));
+  return results.slice(0, 8);
 }
 
 /**


### PR DESCRIPTION
## Problem

The TUI hypothesis review widget (`formatHypothesesWidget`) was splitting hypothesis content into individual items — showing the title, description, sub-bullets, and validation notes as separate numbered entries instead of grouped hypotheses.

Root cause: `parseHypotheses()` Strategy 2 used `^(?:\d+[.)])` which doesn't allow leading whitespace, so LLM output with indented numbered lists (common when hypotheses are nested under a header section) fell through to Strategy 4. Strategy 4 was a raw line-by-line fallback that treated every non-empty line as a separate hypothesis.

## Solution

Two targeted fixes in `src/core/extensions/deep-investigation.ts`:

1. **Strategy 2**: Added `\s*` to allow optional leading whitespace before numbered items (`^\s*(?:\d+[.)])`) — covers the majority of indented numbered list cases
2. **Strategy 4**: Replaced raw line splitting with grouped parsing that collects sub-items (lines starting with `-`, `*`, or 2+ spaces of indentation) under their parent hypothesis — mirrors the grouping logic already used in the web UI's `HypothesesCard.tsx`