### PR TITLE
fix: structured output for propose_hypotheses to fix hypothesis card title bleed-through

### DIFF
--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -587,12 +587,31 @@ export function usePilot() {
                     break;
                 }
 
-                case 'message_end':
+                case 'message_end': {
+                    const endMsg = payload.message as { role?: string; toolName?: string; details?: Record<string, unknown> } | undefined;
+                    if (endMsg?.role === 'toolResult' && endMsg.details && Object.keys(endMsg.details).length > 0) {
+                        // Pi-agent brain: tool result details arrive via message_end (not tool_execution_end).
+                        // Backfill toolDetails onto the matching tool message.
+                        const tName = endMsg.toolName;
+                        setMessages(prev => {
+                            // Walk backwards to find the most recent tool message with this name
+                            for (let i = prev.length - 1; i >= 0; i--) {
+                                const m = prev[i];
+                                if (m.role === 'tool' && (!tName || m.toolName === tName) && !m.toolDetails) {
+                                    const updated = [...prev];
+                                    updated[i] = { ...m, toolDetails: endMsg.details };
+                                    return updated;
+                                }
+                            }
+                            return prev;
+                        });
+                    }
                     // Mark current streaming assistant message as complete
                     setMessages(prev => prev.map(m =>
                         m.isStreaming && m.role === 'assistant' ? { ...m, isStreaming: false } : m
                     ));
                     break;
+                }
 
                 case 'auto_compaction_start':
                     setIsCompacting(true);

--- a/src/gateway/web/src/pages/Pilot/components/HypothesesCard.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/HypothesesCard.tsx
@@ -242,13 +242,13 @@ export function HypothesesCard({ message, sendMessage, abortResponse, onHypothes
     const raw = message.toolDetails?.hypotheses;
     let hypotheses: ParsedHypothesis[];
     if (Array.isArray(raw)) {
-        // Structured path: new propose_hypotheses (array of {id, text, confidence}) or deep_search result
-        hypotheses = (raw as Array<{ id?: string; text?: string; confidence?: number; status?: string; reasoning?: string }>).map((h, i) => ({
+        // Structured path: use schema fields (id, text, confidence, description)
+        hypotheses = (raw as Array<{ text?: string; confidence?: number; description?: string }>).map((h, i) => ({
             index: i + 1,
             title: h.text ?? `Hypothesis ${i + 1}`,
             confidence: h.confidence,
-            description: h.reasoning,
-            detailLines: h.status ? [`Status: ${h.status}`] : [],
+            description: h.description,
+            detailLines: [],
         }));
     } else {
         // Text fallback for historical messages

--- a/src/tools/dp-tools.ts
+++ b/src/tools/dp-tools.ts
@@ -148,11 +148,28 @@ export function createProposeHypothesesTool(dpState: DpState): ToolDefinition {
     parameters: Type.Object({
       hypotheses: Type.Array(
         Type.Object({
-          id: Type.String({ description: "Hypothesis identifier, e.g. H1, H2, H3" }),
-          text: Type.String({ description: "One-line hypothesis statement" }),
+          id: Type.String({ description: "Hypothesis identifier: H1, H2, H3, etc." }),
+          text: Type.String({
+            description:
+              "A specific, testable hypothesis statement (one sentence). " +
+              "NOT a title, category name, or group heading. " +
+              'Good: "Firewall rules blocking inter-node communication on port 6443". ' +
+              'Bad: "Check cluster demo".',
+          }),
           confidence: Type.Number({ description: "Prior confidence 0-100" }),
+          description: Type.Optional(
+            Type.String({
+              description:
+                "Brief explanation: why this hypothesis is plausible and how to validate it. " +
+                "Include relevant technical context, affected components, and key validation commands.",
+            })
+          ),
         }),
-        { description: "Structured list of hypotheses to present to the user" }
+        {
+          description:
+            "Each element is one distinct, independent hypothesis. " +
+            "Do NOT include overall titles or summary items — only concrete hypotheses.",
+        }
       ),
     }),
     async execute(_toolCallId, params) {
@@ -161,7 +178,19 @@ export function createProposeHypothesesTool(dpState: DpState): ToolDefinition {
         // Outside DP mode — don't create a checklist, just present hypotheses
       }
 
-      const { hypotheses } = params as { hypotheses: Array<{ id: string; text: string; confidence: number }> };
+      const { hypotheses: rawHypotheses } = params as {
+        hypotheses: Array<{ id: string; text: string; confidence: number; description?: string }>;
+      };
+
+      // Post-validation: filter out non-hypothesis items the model sometimes includes
+      const hypotheses = rawHypotheses.filter((h) => {
+        const text = h.text.trim();
+        // Markdown table rows / headers
+        if (text.startsWith("|")) return false;
+        // Meta-text about the hypotheses themselves (titles, proposal headings)
+        if (/假设提案|(?:revised|proposed|updated)\s*hypothes[ei]s/i.test(text)) return false;
+        return true;
+      });
 
       const responseText = isDpMode
         ? "Hypotheses presented. In DP mode — consider waiting for user confirmation before proceeding to deep_search."


### PR DESCRIPTION
## Problem

The Hypothesis Review card in the web UI sometimes showed the title line (e.g. \"Revised Hypotheses for 'demo' Check\") as hypothesis item 1, pushing real hypotheses to items 2 and 3. This happened because `propose_hypotheses` accepted `hypotheses: string` (freeform markdown), and the text parser in `HypothesesCard.tsx` misclassified the title as a hypothesis.

A secondary bug: `deep_search` stores `RawHypothesis[]` in `details.hypotheses`, but `HypothesesCard` previously cast it as `string`, rendering `[object Object]` instead of actual hypothesis text.

## Solution

Replace the freeform string input with structured output — the same pattern already used by `generateHypotheses()` in Phase 2.

- **`src/tools/dp-tools.ts`**: Changed `propose_hypotheses` parameter from `hypotheses: string` to `hypotheses: Array<{id, text, confidence}>`. The structured array is stored directly in `details.hypotheses` — no text serialization or parsing.

- **`src/gateway/web/src/pages/Pilot/components/HypothesesCard.tsx`**: Added type-aware branching on `toolDetails.hypotheses`:
  - `Array` → map directly to `ParsedHypothesis` (no regex, no title bleed-through; also fixes `deep_search` result rendering)
  - `string` → fall through to existing `parseHypotheses()` for backward compatibility with historical messages

## Test plan

- [ ] Trigger a deep investigation in WebUI — hypothesis card shows correctly numbered items with no title as item 1
- [ ] Send feedback and re-propose — revised list renders correctly
- [ ] Load a historical session — old text-format cards still render via the string fallback path
- [ ] Check `deep_search` result card — hypotheses show text instead of `[object Object]`