### PR TITLE
feat: add circuit breaker for deep-search parallel validation

### DIFF
--- a/src/tools/deep-search/circuit-breaker.ts
+++ b/src/tools/deep-search/circuit-breaker.ts
@@ -1,0 +1,34 @@
+/**
+ * Simple circuit breaker for deep-search sub-agent LLM calls.
+ *
+ * Scoped to a single investigation. When consecutive failures reach the
+ * threshold, the circuit "opens" and callers should fail fast instead of
+ * waiting for another timeout.
+ *
+ * No half-open/reset logic — investigations are short-lived (≤5 min),
+ * so once tripped the circuit stays open for the remainder.
+ */
+export class CircuitBreaker {
+  private consecutiveFailures = 0;
+  private _tripped = false;
+
+  constructor(private readonly threshold: number) {}
+
+  /** Whether the circuit is open (callers should skip work and fail fast). */
+  get tripped(): boolean {
+    return this._tripped;
+  }
+
+  /** Record a successful call — resets the consecutive failure count. */
+  recordSuccess(): void {
+    this.consecutiveFailures = 0;
+  }
+
+  /** Record a failed call — may trip the circuit. */
+  recordFailure(): void {
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= this.threshold) {
+      this._tripped = true;
+    }
+  }
+}

--- a/src/tools/deep-search/circuit-breaker.ts
+++ b/src/tools/deep-search/circuit-breaker.ts
@@ -24,11 +24,13 @@ export class CircuitBreaker {
     this.consecutiveFailures = 0;
   }
 
-  /** Record a failed call — may trip the circuit. */
-  recordFailure(): void {
+  /** Record a failed call — may trip the circuit. Returns true if this call caused the trip. */
+  recordFailure(): boolean {
     this.consecutiveFailures++;
-    if (this.consecutiveFailures >= this.threshold) {
+    if (!this._tripped && this.consecutiveFailures >= this.threshold) {
       this._tripped = true;
+      return true;
     }
+    return false;
   }
 }

--- a/src/tools/deep-search/deep-search.test.ts
+++ b/src/tools/deep-search/deep-search.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   NORMAL_BUDGET,
   QUICK_BUDGET,
+  CIRCUIT_BREAKER_THRESHOLD,
   type HypothesisNode,
   type InvestigationResult,
   type Evidence,
 } from "./types.js";
+import { CircuitBreaker } from "./circuit-breaker.js";
 import {
   contextGatheringPrompt,
   hypothesisGenerationPrompt,
@@ -51,6 +53,55 @@ describe("types / budgets", () => {
 
   it("QUICK_BUDGET maxDurationMs is less than NORMAL_BUDGET", () => {
     expect(QUICK_BUDGET.maxDurationMs).toBeLessThan(NORMAL_BUDGET.maxDurationMs);
+  });
+});
+
+// ─── circuit-breaker.ts ───
+
+describe("CircuitBreaker", () => {
+  it("starts in closed state", () => {
+    const breaker = new CircuitBreaker(3);
+    expect(breaker.tripped).toBe(false);
+  });
+
+  it("trips after threshold consecutive failures", () => {
+    const breaker = new CircuitBreaker(3);
+    breaker.recordFailure();
+    expect(breaker.tripped).toBe(false);
+    breaker.recordFailure();
+    expect(breaker.tripped).toBe(false);
+    breaker.recordFailure();
+    expect(breaker.tripped).toBe(true);
+  });
+
+  it("resets consecutive count on success", () => {
+    const breaker = new CircuitBreaker(3);
+    breaker.recordFailure();
+    breaker.recordFailure();
+    breaker.recordSuccess(); // resets count
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.tripped).toBe(false); // only 2 consecutive, not 3
+  });
+
+  it("stays tripped once opened", () => {
+    const breaker = new CircuitBreaker(2);
+    breaker.recordFailure();
+    breaker.recordFailure();
+    expect(breaker.tripped).toBe(true);
+    breaker.recordSuccess(); // doesn't un-trip
+    expect(breaker.tripped).toBe(true);
+  });
+
+  it("works with threshold of 1", () => {
+    const breaker = new CircuitBreaker(1);
+    expect(breaker.tripped).toBe(false);
+    breaker.recordFailure();
+    expect(breaker.tripped).toBe(true);
+  });
+
+  it("CIRCUIT_BREAKER_THRESHOLD matches maxParallel default", () => {
+    expect(CIRCUIT_BREAKER_THRESHOLD).toBe(NORMAL_BUDGET.maxParallel);
   });
 });
 
@@ -382,6 +433,19 @@ describe("formatResult", () => {
     const result = makeResult({ timedOut: false });
     const output = formatResult(result);
     expect(output).not.toContain("timed out");
+  });
+
+  it("shows circuit breaker marker when circuitBroken is true", () => {
+    const result = makeResult({ circuitBroken: true });
+    const output = formatResult(result);
+    expect(output).toContain("circuit breaker");
+    expect(output).toContain("LLM API unavailable");
+  });
+
+  it("does not show circuit breaker marker when circuitBroken is false", () => {
+    const result = makeResult({ circuitBroken: undefined });
+    const output = formatResult(result);
+    expect(output).not.toContain("circuit breaker");
   });
 
   it("does not show skipped count when no hypotheses are skipped", () => {

--- a/src/tools/deep-search/deep-search.test.ts
+++ b/src/tools/deep-search/deep-search.test.ts
@@ -66,11 +66,11 @@ describe("CircuitBreaker", () => {
 
   it("trips after threshold consecutive failures", () => {
     const breaker = new CircuitBreaker(3);
-    breaker.recordFailure();
+    expect(breaker.recordFailure()).toBe(false);
     expect(breaker.tripped).toBe(false);
-    breaker.recordFailure();
+    expect(breaker.recordFailure()).toBe(false);
     expect(breaker.tripped).toBe(false);
-    breaker.recordFailure();
+    expect(breaker.recordFailure()).toBe(true); // this call caused the trip
     expect(breaker.tripped).toBe(true);
   });
 
@@ -84,11 +84,12 @@ describe("CircuitBreaker", () => {
     expect(breaker.tripped).toBe(false); // only 2 consecutive, not 3
   });
 
-  it("stays tripped once opened", () => {
+  it("stays tripped once opened and subsequent failures return false", () => {
     const breaker = new CircuitBreaker(2);
     breaker.recordFailure();
-    breaker.recordFailure();
+    expect(breaker.recordFailure()).toBe(true); // trips here
     expect(breaker.tripped).toBe(true);
+    expect(breaker.recordFailure()).toBe(false); // already tripped, not "just tripped"
     breaker.recordSuccess(); // doesn't un-trip
     expect(breaker.tripped).toBe(true);
   });

--- a/src/tools/deep-search/engine.ts
+++ b/src/tools/deep-search/engine.ts
@@ -24,10 +24,12 @@ import type {
 import {
   NORMAL_BUDGET,
   EARLY_EXIT_CONFIDENCE,
+  CIRCUIT_BREAKER_THRESHOLD,
   TRACE_MAX_OUTPUT,
   TRACE_HEAD_CHARS,
   TRACE_TAIL_CHARS,
 } from "./types.js";
+import { CircuitBreaker } from "./circuit-breaker.js";
 import { HYPOTHESES_SCHEMA, CONCLUSION_SCHEMA } from "./schemas.js";
 
 interface RawHypothesis {
@@ -579,6 +581,7 @@ export async function investigate(
 
   let rootCauseFound = false;
   let timedOut = false;
+  const breaker = new CircuitBreaker(CIRCUIT_BREAKER_THRESHOLD);
 
   // Build a summary of completed hypotheses for sub-agent context
   function buildPriorFindings(): string | undefined {
@@ -621,16 +624,23 @@ export async function investigate(
       hypothesis.toolCallsUsed = result.callsUsed;
       hypothesis.trace = result.trace;
       globalCallsUsed += result.callsUsed;
+      breaker.recordSuccess();
 
       onProgress?.({ type: "hypothesis", id: hypothesis.id, status: hypothesis.status, confidence: hypothesis.confidence });
     } catch (err) {
+      breaker.recordFailure();
+      if (breaker.tripped) {
+        onProgress?.({ type: "phase", phase: "Phase 3/4", detail: "Circuit breaker tripped — LLM API appears unavailable, skipping remaining hypotheses" });
+      }
       if (!isRetry) {
-        // First failure → queue for retry
+        // First failure → queue for retry (unless circuit is broken)
         hypothesis.status = "inconclusive";
         hypothesis.confidence = 0;
         hypothesis.reasoning = `Sub-agent error: ${err instanceof Error ? err.message : String(err)}`;
         onProgress?.({ type: "hypothesis", id: hypothesis.id, status: "inconclusive", confidence: 0 });
-        retryQueue.push(hypothesis);
+        if (!breaker.tripped) {
+          retryQueue.push(hypothesis);
+        }
       }
       // Second failure → leave as inconclusive (already marked)
     }
@@ -643,7 +653,7 @@ export async function investigate(
 
   await new Promise<void>((resolvePool) => {
     function tryStartNext() {
-      while (activeCount < budget.maxParallel && !rootCauseFound) {
+      while (activeCount < budget.maxParallel && !rootCauseFound && !breaker.tripped) {
         // Timeout check
         if (Date.now() - startTime > budget.maxDurationMs) {
           timedOut = true;
@@ -761,6 +771,7 @@ export async function investigate(
     totalToolCalls: globalCallsUsed,
     totalDurationMs,
     timedOut,
+    circuitBroken: breaker.tripped || undefined,
     debugTracePath,
   };
 }

--- a/src/tools/deep-search/engine.ts
+++ b/src/tools/deep-search/engine.ts
@@ -628,8 +628,8 @@ export async function investigate(
 
       onProgress?.({ type: "hypothesis", id: hypothesis.id, status: hypothesis.status, confidence: hypothesis.confidence });
     } catch (err) {
-      breaker.recordFailure();
-      if (breaker.tripped) {
+      const justTripped = breaker.recordFailure();
+      if (justTripped) {
         onProgress?.({ type: "phase", phase: "Phase 3/4", detail: "Circuit breaker tripped — LLM API appears unavailable, skipping remaining hypotheses" });
       }
       if (!isRetry) {

--- a/src/tools/deep-search/format.ts
+++ b/src/tools/deep-search/format.ts
@@ -100,8 +100,10 @@ export function formatSummary(
   const skipped = result.hypotheses.filter(
     (h) => h.status === "skipped",
   ).length;
-  const duration = `${(result.totalDurationMs / 1000).toFixed(1)}s` +
-    (result.timedOut ? " (timed out)" : "");
+  const durationSuffix = result.timedOut ? " (timed out)"
+    : result.circuitBroken ? " (circuit breaker tripped — LLM API unavailable)"
+    : "";
+  const duration = `${(result.totalDurationMs / 1000).toFixed(1)}s${durationSuffix}`;
   const hypoStat = `${validated}/${result.hypotheses.length} validated` +
     (skipped > 0 ? `, ${skipped} skipped` : "");
   sections.push(
@@ -171,7 +173,7 @@ export function formatResult(result: InvestigationResult): string {
     `## Statistics\n` +
     `- Tool calls: ${result.totalToolCalls}\n` +
     `- Duration: ${(result.totalDurationMs / 1000).toFixed(1)}s` +
-    (result.timedOut ? " (timed out)" : "") +
+    (result.timedOut ? " (timed out)" : result.circuitBroken ? " (circuit breaker — LLM API unavailable)" : "") +
     `\n` +
     `- Hypotheses: ${validated}/${result.hypotheses.length} validated` +
     (skipped > 0 ? `, ${skipped} skipped` : "");

--- a/src/tools/deep-search/types.ts
+++ b/src/tools/deep-search/types.ts
@@ -34,6 +34,8 @@ export interface InvestigationResult {
   totalToolCalls: number;
   totalDurationMs: number;
   timedOut: boolean;
+  /** True when the circuit breaker tripped due to consecutive LLM API failures. */
+  circuitBroken?: boolean;
   debugTracePath?: string;
 }
 
@@ -84,6 +86,12 @@ export const EVIDENCE_HEAD_CHARS = 2000;
 export const EVIDENCE_TAIL_CHARS = 1500;
 
 // --- Engine constants ---
+
+/** Circuit breaker: consecutive sub-agent failures before tripping.
+ *  With maxParallel=3, this means the circuit trips after the first full
+ *  batch of parallel sub-agents all fail, preventing subsequent batches
+ *  from wasting time on a down LLM API. */
+export const CIRCUIT_BREAKER_THRESHOLD = 3;
 
 /** Early exit threshold: skip remaining hypotheses if one reaches this confidence.
  *  Set to 101 to effectively disable early exit (validate all hypotheses by default).


### PR DESCRIPTION
## Problem

When the LLM API is down during a deep-search investigation, all parallel sub-agents independently timeout (up to 5 minutes each). With `maxParallel=3` and 5 hypotheses, this means two full batches of timeouts before the investigation gives up — wasting ~10 minutes and returning empty results.

## Solution

Add a circuit breaker that shares failure state across Phase 3 sub-agents:

- `CircuitBreaker` class tracks consecutive failures; trips after threshold (default: 3, matching `maxParallel`)
- On trip: stops launching new sub-agents, skips retry queue, proceeds to Phase 4 conclusion with whatever partial results exist
- `InvestigationResult.circuitBroken` flag lets consumers know the investigation was cut short
- Format functions show "circuit breaker — LLM API unavailable" in statistics

### Behavior with 5 hypotheses, maxParallel=3:

**Before:**
```
H1 → timeout (5min) → fail
H2 → timeout (5min) → fail     (parallel with H1)
H3 → timeout (5min) → fail     (parallel with H1)
H4 → timeout (5min) → fail     ← second batch
H5 → timeout (5min) → fail
Total: ~10 min, empty result
```

**After:**
```
H1 → timeout → fail → breaker(1)
H2 → timeout → fail → breaker(2)     (parallel)
H3 → timeout → fail → breaker(3) → TRIPPED
H4 → skipped (0ms)
H5 → skipped (0ms)
Total: ~5 min, partial result from Phase 4
```

## Files changed

- `src/tools/deep-search/circuit-breaker.ts` — new CircuitBreaker class
- `src/tools/deep-search/types.ts` — CIRCUIT_BREAKER_THRESHOLD constant, circuitBroken field on InvestigationResult
- `src/tools/deep-search/engine.ts` — wire breaker into Phase 3 loop
- `src/tools/deep-search/format.ts` — display circuit breaker status in reports
- `src/tools/deep-search/deep-search.test.ts` — unit tests for CircuitBreaker + format output