### PR TITLE
feat: copy extension skills into Docker images

### DIFF
--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -71,6 +71,7 @@ COPY --from=builder /app/dist/ ./dist/
 
 # Builtin skills baked into image (always available, no Gateway dependency)
 COPY skills/core/ ./skills/core/
+COPY skills/extension/ ./skills/extension/
 
 # ── Directory structure & permissions ────────────────────────────
 # Credentials: agentbox:kubecred 0750 (sandbox: no access, kubectl: read via setgid)

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -45,8 +45,9 @@ COPY --from=builder /app/dist/ ./dist/
 # Copy web frontend from builder
 COPY --from=builder /app/src/gateway/web/dist/ ./dist/gateway/web/dist/
 
-# Copy core skills (baked-in, always available)
+# Copy builtin skills (baked-in, always available)
 COPY skills/core/ ./skills/core/
+COPY skills/extension/ ./skills/extension/
 
 # Create data directory
 RUN mkdir -p .siclaw


### PR DESCRIPTION
## Summary
- Add `COPY skills/extension/ ./skills/extension/` to both `Dockerfile.gateway` and `Dockerfile.agentbox`
- `skills/extension/` already exists in the repo (with `.gitkeep`), and `script-resolver.ts` already iterates both `core` and `extension` via `builtinDirs()` (PR #87) — but the Dockerfiles only copied `skills/core/`
- This allows downstream overlays to place extension skills in `skills/extension/` without needing to override the Dockerfiles

## Test plan
- [ ] `docker build -f Dockerfile.gateway .` succeeds (empty extension dir, no error)
- [ ] `docker build -f Dockerfile.agentbox .` succeeds
- [ ] Skills placed in `skills/extension/` are discoverable inside the container