### PR TITLE
feat: support custom debugImage in Helm chart

### DIFF
--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -50,6 +50,10 @@ spec:
             - name: SICLAW_PERSISTENCE_SIZE
               value: {{ .Values.agentbox.persistence.size | quote }}
             {{- end }}
+            {{- if .Values.agentbox.debugImage }}
+            - name: SICLAW_DEBUG_IMAGE
+              value: {{ .Values.agentbox.debugImage | quote }}
+            {{- end }}
             - name: SICLAW_SKILLS_DIR
               value: ".siclaw/skills"
             - name: SICLAW_CRON_SERVICE_URL

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -32,6 +32,7 @@ agentbox:
     registry: ""        # defaults to image.registry
     repository: ""      # defaults to "siclaw-agentbox"
     tag: ""             # defaults to image.tag
+  debugImage: ""        # Debug pod image for node_exec/node_script (default: "busybox:latest")
   # User data persistence (memory, investigations, sessions)
   persistence:
     enabled: false          # set to true to persist user memory across pod restarts

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1284,6 +1284,10 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
               try {
                 const modelConfigRepo = new ModelConfigRepository(db);
                 const settings: Record<string, unknown> = await modelConfigRepo.exportSettingsConfig();
+                // Append debugImage if configured via env
+                if (process.env.SICLAW_DEBUG_IMAGE) {
+                  settings.debugImage = process.env.SICLAW_DEBUG_IMAGE;
+                }
                 // Append metrics config from system_config table
                 if (sysConfigRepo) {
                   const metricsPort = await sysConfigRepo.get("metrics.port");


### PR DESCRIPTION
## Summary

- Add `agentbox.debugImage` to Helm `values.yaml` for specifying a private registry image used by `node_exec`/`node_script` debug pods
- Gateway deployment template injects `SICLAW_DEBUG_IMAGE` env when set
- Gateway `/api/internal/settings` endpoint includes `debugImage` in the exported config so AgentBox picks it up via `settings.json`

Without this, debug pods always pull `busybox:latest` from Docker Hub, which fails in air-gapped or private-registry environments.

**Config flow:** `Helm values` → `Gateway env` → `/api/internal/settings` → `AgentBox settings.json` → `loadConfig().debugImage`

**Usage:**
```yaml
agentbox:
  debugImage: "my-registry.example.com/debug-image:latest"
```

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 864 tests pass
- [ ] Deploy with `agentbox.debugImage` set, verify `node_script` uses the configured image
- [ ] Deploy without `agentbox.debugImage`, verify fallback to `busybox:latest`