### PR TITLE
refactor(k8s): replace per-user dynamic PVCs with shared PVC + subPath

### DIFF
--- a/helm/siclaw/templates/NOTES.txt
+++ b/helm/siclaw/templates/NOTES.txt
@@ -1,8 +1,8 @@
 Thank you for installing {{ include "siclaw.fullname" . }}!
 
-{{- if and .Values.agentbox.persistence.enabled (not .Values.agentbox.persistence.storageClass) }}
+{{- if .Values.agentbox.persistence.enabled }}
 
-⚠️  WARNING: agentbox.persistence is enabled but storageClass is empty.
-   The cluster default StorageClass will be used. Set agentbox.persistence.storageClass
-   explicitly for production deployments.
+ℹ️  User data persistence is enabled.
+   Ensure the shared PVC "{{ .Values.agentbox.persistence.claimName }}" exists and supports ReadWriteMany.
+   Gateway will create per-user subdirectories automatically.
 {{- end }}

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -43,12 +43,10 @@ spec:
             {{- if .Values.agentbox.persistence.enabled }}
             - name: SICLAW_PERSISTENCE_ENABLED
               value: "true"
-            - name: SICLAW_PERSISTENCE_STORAGE_CLASS
-              value: {{ .Values.agentbox.persistence.storageClass | quote }}
-            - name: SICLAW_PERSISTENCE_ACCESS_MODE
-              value: {{ .Values.agentbox.persistence.accessMode | quote }}
-            - name: SICLAW_PERSISTENCE_SIZE
-              value: {{ .Values.agentbox.persistence.size | quote }}
+            - name: SICLAW_PERSISTENCE_CLAIM_NAME
+              value: {{ .Values.agentbox.persistence.claimName | quote }}
+            - name: SICLAW_PERSISTENCE_MOUNT_PATH
+              value: {{ .Values.agentbox.persistence.mountPath | quote }}
             {{- end }}
             {{- if .Values.agentbox.debugImage }}
             - name: SICLAW_DEBUG_IMAGE
@@ -80,6 +78,10 @@ spec:
           volumeMounts:
             - name: skills
               mountPath: /app/.siclaw/skills
+            {{- if .Values.agentbox.persistence.enabled }}
+            - name: user-data
+              mountPath: {{ .Values.agentbox.persistence.mountPath }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /api/health
@@ -95,3 +97,8 @@ spec:
       volumes:
         - name: skills
           emptyDir: {}
+        {{- if .Values.agentbox.persistence.enabled }}
+        - name: user-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.agentbox.persistence.claimName }}
+        {{- end }}

--- a/helm/siclaw/templates/gateway-rbac.yaml
+++ b/helm/siclaw/templates/gateway-rbac.yaml
@@ -25,7 +25,7 @@ rules:
     verbs: ["get", "list", "create", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "create"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -33,12 +33,13 @@ agentbox:
     repository: ""      # defaults to "siclaw-agentbox"
     tag: ""             # defaults to image.tag
   debugImage: ""        # Debug pod image for node_exec/node_script (default: "busybox:latest")
-  # User data persistence (memory, investigations, sessions)
+  # User data persistence (memory, investigations, sessions).
+  # Uses a single shared PVC; gateway creates per-user subdirectories,
+  # AgentBox pods mount via subPath. No dynamic provisioning required.
   persistence:
     enabled: false          # set to true to persist user memory across pod restarts
-    storageClass: ""        # required when enabled (e.g. "nfs-client", "efs-sc", "cephfs")
-    accessMode: ReadWriteMany
-    size: "1Gi"             # per-user PVC size
+    claimName: "siclaw-data"  # name of pre-existing shared PVC (must support ReadWriteMany)
+    mountPath: "/app/.siclaw/user-data"  # gateway mount path (env + volumeMount must match)
 
 # -- Database (MySQL — SQLite is not supported in K8s mode)
 database:

--- a/k8s/agentbox-template.yaml
+++ b/k8s/agentbox-template.yaml
@@ -108,7 +108,7 @@ spec:
       readOnly: true
     - name: skills-pv
       mountPath: /app/.siclaw/user-data
-      subPath: user/${USER_ID}/agent-data
+      subPath: users/${USER_ID}/${WORKSPACE_ID}
     - name: skills-pv
       mountPath: /home/agentbox/.credentials
       subPath: user/${USER_ID}/.ws-${WORKSPACE_ID}/.credentials
@@ -139,10 +139,10 @@ spec:
   - name: workspace
     emptyDir:
       sizeLimit: 1Gi
-  # Shared skills PVC
+  # Shared data PVC (skills + user data)
   - name: skills-pv
     persistentVolumeClaim:
-      claimName: siclaw-skills
+      claimName: siclaw-data
 
 ---
 # Service for accessing the AgentBox pod

--- a/k8s/gateway-deployment.yaml
+++ b/k8s/gateway-deployment.yaml
@@ -133,7 +133,7 @@ rules:
   verbs: ["get", "list", "create", "delete"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
-  verbs: ["get", "list", "create"]
+  verbs: ["get", "list"]
 
 ---
 # RoleBinding

--- a/k8s/siclaw-data-pvc.yaml
+++ b/k8s/siclaw-data-pvc.yaml
@@ -1,5 +1,13 @@
-# Data PV — gateway SQLite database + JWT secret + local state
-# Only needed in SQLite mode (default). Not required when using MySQL.
+# Shared data PVC — user memory, investigations, sessions.
+# Also used for gateway SQLite database in non-MySQL deployments.
+#
+# This single PVC is shared by gateway and all AgentBox pods.
+# Gateway creates per-user subdirectories (users/{userId}/{workspaceId}/);
+# AgentBox pods mount via subPath for isolation.
+#
+# Requirements:
+#   - Must support ReadWriteMany (e.g. NFS, CephFS, EFS)
+#   - Must be created before deploying siclaw
 #
 # Deploy: kubectl apply -f k8s/siclaw-data-pvc.yaml -n siclaw
 
@@ -13,8 +21,8 @@ metadata:
     component: data
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   storageClassName: nfs
   resources:
     requests:
-      storage: 1Gi
+      storage: 10Gi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siclaw",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siclaw",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siclaw",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "AI-powered SRE copilot for Kubernetes diagnostics via natural language",
   "type": "module",
   "bin": {

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -27,9 +27,8 @@ const spawner = useK8s
       persistence: process.env.SICLAW_PERSISTENCE_ENABLED === "true"
         ? {
             enabled: true,
-            storageClass: process.env.SICLAW_PERSISTENCE_STORAGE_CLASS || "",
-            accessMode: process.env.SICLAW_PERSISTENCE_ACCESS_MODE || "ReadWriteMany",
-            size: process.env.SICLAW_PERSISTENCE_SIZE || "1Gi",
+            claimName: process.env.SICLAW_PERSISTENCE_CLAIM_NAME || "siclaw-data",
+            mountPath: process.env.SICLAW_PERSISTENCE_MOUNT_PATH || "/app/.siclaw/user-data",
           }
         : undefined,
     })

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -5,6 +5,8 @@
  */
 
 import * as k8s from "@kubernetes/client-node";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import type { BoxSpawner } from "./spawner.js";
 import type { AgentBoxConfig, AgentBoxHandle, AgentBoxInfo, AgentBoxStatus } from "./types.js";
 import { CertificateManager } from "../security/cert-manager.js";
@@ -18,12 +20,14 @@ export interface K8sSpawnerConfig {
   imagePullPolicy?: "Always" | "IfNotPresent" | "Never";
   /** Pod label prefix */
   labelPrefix?: string;
-  /** User data persistence (memory, sessions) */
+  /** Shared PVC for user data persistence (memory, sessions).
+   *  Gateway creates per-user subdirectories; AgentBox pods mount via subPath. */
   persistence?: {
     enabled: boolean;
-    storageClass: string;
-    accessMode: string;  // e.g. "ReadWriteMany"
-    size: string;        // e.g. "1Gi"
+    /** Name of the pre-existing shared PVC (e.g. "siclaw-data") */
+    claimName: string;
+    /** Local mount path of the shared PVC on the gateway (default: "/app/.siclaw/user-data") */
+    mountPath?: string;
   };
 }
 
@@ -102,8 +106,6 @@ export class K8sSpawner implements BoxSpawner {
       // Pod doesn't exist, proceed to create
     }
 
-
-
     // Issue client certificate for mTLS authentication (env encoded in cert)
     if (!this.certManager) throw new Error("CertificateManager not initialized — call setCertManager() first");
     const podEnv: "prod" | "dev" | "test" = boxConfig.podEnv ?? "prod";
@@ -177,12 +179,13 @@ export class K8sSpawner implements BoxSpawner {
       }
     }
 
-    // Ensure per-user PVC if persistence is enabled
+    // Ensure per-user subdirectory on shared PVC
+    const safeUserId = this.sanitizePathSegment(userId);
+    const safeWorkspaceId = this.sanitizePathSegment(workspaceId);
     if (this.config.persistence?.enabled) {
-      if (!workspaceId || (workspaceId === "default" && !boxConfig.workspaceId)) {
-        console.warn(`[k8s-spawner] Persistence enabled but no explicit workspaceId — using "default"`);
-      }
-      await this.ensureUserPvc(userId);
+      const subDir = `users/${safeUserId}/${safeWorkspaceId}`;
+      console.log(`[k8s-spawner] Persistence enabled: shared PVC "${this.config.persistence.claimName}", subPath "${subDir}"`);
+      this.ensureUserDir(safeUserId, safeWorkspaceId);
     }
 
     // Pod definition
@@ -228,7 +231,7 @@ export class K8sSpawner implements BoxSpawner {
           this.config.persistence?.enabled
             ? {
                 name: "user-data",
-                persistentVolumeClaim: { claimName: this.userPvcName(userId) },
+                persistentVolumeClaim: { claimName: this.config.persistence.claimName },
               }
             : {
                 name: "user-data",
@@ -276,9 +279,9 @@ export class K8sSpawner implements BoxSpawner {
               {
                 name: "user-data",
                 mountPath: "/app/.siclaw/user-data",
-                subPath: this.config.persistence?.enabled
-                  ? workspaceId.replace(/[^a-zA-Z0-9-]/g, "_")
-                  : `user/${userId}/agent-data`,
+                ...(this.config.persistence?.enabled
+                  ? { subPath: `users/${safeUserId}/${safeWorkspaceId}` }
+                  : {}),
               },
               {
                 name: "client-cert",
@@ -336,53 +339,24 @@ export class K8sSpawner implements BoxSpawner {
     };
   }
 
-  /**
-   * Generate PVC name for a user
-   */
-  private userPvcName(userId: string): string {
-    return `siclaw-user-${userId.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 50)}`;
+  /** Sanitize a path segment — keep only safe characters for directory names and K8s subPath. */
+  private sanitizePathSegment(segment: string): string {
+    return segment.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 63);
   }
 
   /**
-   * Ensure per-user PVC exists (idempotent)
+   * Ensure per-user subdirectory exists on the shared PVC (synchronous, idempotent).
+   * Expects already-sanitized path segments.
+   * Directory layout: `{mountPath}/users/{safeUserId}/{safeWorkspaceId}/`
    */
-  private async ensureUserPvc(userId: string): Promise<void> {
-    const { namespace } = this.config;
-    const pvcName = this.userPvcName(userId);
-
-    try {
-      await this.coreApi.readNamespacedPersistentVolumeClaim({ name: pvcName, namespace });
-      // PVC already exists
-    } catch (err: any) {
-      if (err.code === 404 || err.statusCode === 404) {
-        console.log(`[k8s-spawner] Creating User PVC: ${pvcName}`);
-        await this.coreApi.createNamespacedPersistentVolumeClaim({
-          namespace,
-          body: {
-            apiVersion: "v1",
-            kind: "PersistentVolumeClaim",
-            metadata: {
-              name: pvcName,
-              namespace,
-              labels: {
-                [`${this.config.labelPrefix}/app`]: "agentbox",
-                [`${this.config.labelPrefix}/user`]: userId,
-                [`${this.config.labelPrefix}/type`]: "user-data",
-              },
-            },
-            spec: {
-              accessModes: [this.config.persistence!.accessMode],
-              storageClassName: this.config.persistence!.storageClass || undefined,
-              resources: {
-                requests: { storage: this.config.persistence!.size },
-              },
-            },
-          },
-        });
-      } else {
-        throw err;
-      }
+  private ensureUserDir(safeUserId: string, safeWorkspaceId: string): void {
+    const mountPath = this.config.persistence?.mountPath || "/app/.siclaw/user-data";
+    const base = path.resolve(mountPath);
+    const userDir = path.join(base, "users", safeUserId, safeWorkspaceId);
+    if (!userDir.startsWith(base)) {
+      throw new Error(`[k8s-spawner] Path traversal detected: ${userDir}`);
     }
+    fs.mkdirSync(userDir, { recursive: true });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace per-user dynamically provisioned PVCs with a single shared PVC (`siclaw-data`)
- Gateway creates per-user subdirectories (`users/{userId}/{workspaceId}/`) on the shared volume
- AgentBox pods mount via `subPath` for isolation — no dynamic provisioning or StorageClass required
- Sanitize userId/workspaceId in path segments to prevent traversal and invalid directory names

## Details

**Before**: Each user got a dedicated PVC (`siclaw-user-{userId}`) created on demand via K8s API, requiring a StorageClass that supports dynamic provisioning.

**After**: Operator pre-creates one shared `ReadWriteMany` PVC. Gateway mounts it and creates subdirectories at spawn time; AgentBox pods mount the user-specific subdirectory via `subPath`.

### Changes

- **k8s-spawner.ts**: Remove `ensureUserPvc()`/`userPvcName()`, add `ensureUserDir()`/`sanitizePathSegment()`, use shared PVC `claimName` + `subPath`
- **gateway-main.ts**: Replace `storageClass/accessMode/size` env vars with `claimName/mountPath`
- **Helm values**: Simplify persistence config to `enabled` + `claimName`
- **Helm gateway-deployment**: Mount shared PVC on gateway, pass `SICLAW_PERSISTENCE_MOUNT_PATH`
- **Helm RBAC**: Remove PVC `create` verb (only `get`/`list` needed)
- **siclaw-data-pvc.yaml**: Update to `ReadWriteMany`, 10Gi, updated comments

## Test plan

- [ ] Deploy with `persistence.enabled=true`, verify gateway creates `users/{userId}/{workspaceId}/` on the shared PVC
- [ ] Spawn AgentBox pod, verify it mounts the correct subPath and user data persists across pod restarts
- [ ] Verify special characters in userId/workspaceId are sanitized (no path traversal)
- [ ] Deploy with `persistence.enabled=false` (default), verify emptyDir fallback still works
- [ ] Verify RBAC: gateway no longer needs PVC create permission