### PR TITLE
fix(gateway): use dedicated NFS mount path and remove skills emptyDir

### DIFF
--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -76,10 +76,8 @@ spec:
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
           volumeMounts:
-            - name: skills
-              mountPath: /app/.siclaw/skills
             {{- if .Values.agentbox.persistence.enabled }}
-            - name: user-data
+            - name: agentbox-user-data
               mountPath: {{ .Values.agentbox.persistence.mountPath }}
             {{- end }}
           livenessProbe:
@@ -95,10 +93,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
       volumes:
-        - name: skills
-          emptyDir: {}
         {{- if .Values.agentbox.persistence.enabled }}
-        - name: user-data
+        - name: agentbox-user-data
           persistentVolumeClaim:
             claimName: {{ .Values.agentbox.persistence.claimName }}
         {{- end }}

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -39,7 +39,7 @@ agentbox:
   persistence:
     enabled: false          # set to true to persist user memory across pod restarts
     claimName: "siclaw-data"  # name of pre-existing shared PVC (must support ReadWriteMany)
-    mountPath: "/app/.siclaw/user-data"  # gateway mount path (env + volumeMount must match)
+    mountPath: "/app/.siclaw/agentbox-user-data"  # gateway mount path for ensureUserDir (env + volumeMount must match)
 
 # -- Database (MySQL — SQLite is not supported in K8s mode)
 database:

--- a/k8s/gateway-deployment.yaml
+++ b/k8s/gateway-deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: SICLAW_PERSISTENCE_CLAIM_NAME
           value: "siclaw-data"
         - name: SICLAW_PERSISTENCE_MOUNT_PATH
-          value: "/app/.siclaw/user-data"
+          value: "/app/.siclaw/agentbox-user-data"
         - name: SICLAW_DATABASE_URL
           valueFrom:
             secretKeyRef:
@@ -86,13 +86,9 @@ spec:
           initialDelaySeconds: 2
           periodSeconds: 2
         volumeMounts:
-        - name: skills-local
-          mountPath: /app/.siclaw/skills
         - name: user-data
-          mountPath: /app/.siclaw/user-data
+          mountPath: /app/.siclaw/agentbox-user-data
       volumes:
-      - name: skills-local
-        emptyDir: {}
       - name: user-data
         persistentVolumeClaim:
           claimName: siclaw-data

--- a/src/gateway-main.ts
+++ b/src/gateway-main.ts
@@ -28,7 +28,7 @@ const spawner = useK8s
         ? {
             enabled: true,
             claimName: process.env.SICLAW_PERSISTENCE_CLAIM_NAME || "siclaw-data",
-            mountPath: process.env.SICLAW_PERSISTENCE_MOUNT_PATH || "/app/.siclaw/user-data",
+            mountPath: process.env.SICLAW_PERSISTENCE_MOUNT_PATH || "/app/.siclaw/agentbox-user-data",
           }
         : undefined,
     })

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -26,7 +26,7 @@ export interface K8sSpawnerConfig {
     enabled: boolean;
     /** Name of the pre-existing shared PVC (e.g. "siclaw-data") */
     claimName: string;
-    /** Local mount path of the shared PVC on the gateway (default: "/app/.siclaw/user-data") */
+    /** Local mount path of the shared PVC on the gateway (default: "/app/.siclaw/agentbox-user-data") */
     mountPath?: string;
   };
 }
@@ -278,7 +278,7 @@ export class K8sSpawner implements BoxSpawner {
               },
               {
                 name: "user-data",
-                mountPath: "/app/.siclaw/user-data",
+                mountPath: "/app/.siclaw/agentbox-user-data",
                 ...(this.config.persistence?.enabled
                   ? { subPath: `users/${safeUserId}/${safeWorkspaceId}` }
                   : {}),
@@ -350,7 +350,7 @@ export class K8sSpawner implements BoxSpawner {
    * Directory layout: `{mountPath}/users/{safeUserId}/{safeWorkspaceId}/`
    */
   private ensureUserDir(safeUserId: string, safeWorkspaceId: string): void {
-    const mountPath = this.config.persistence?.mountPath || "/app/.siclaw/user-data";
+    const mountPath = this.config.persistence?.mountPath || "/app/.siclaw/agentbox-user-data";
     const base = path.resolve(mountPath);
     const userDir = path.join(base, "users", safeUserId, safeWorkspaceId);
     if (!userDir.startsWith(base)) {


### PR DESCRIPTION
## Problem

1. Gateway mounts the NFS PVC at `/app/.siclaw/user-data` — same name as agentbox's internal user-data path, causing confusion. The NFS root contains MySQL, Prometheus, Grafana data alongside siclaw data.
2. Gateway has an unnecessary skills emptyDir volume — root filesystem is already writable, `SkillFileWriter` can write directly.

## Solution

- Change gateway NFS mount path to `/app/.siclaw/agentbox-user-data` — dedicated path that won't collide with agentbox internals
- Remove skills emptyDir volume and mount from gateway deployments
- Update defaults in `k8s-spawner.ts`, `gateway-main.ts`, Helm values/templates, and `k8s/gateway-deployment.yaml`

## Test plan

- [ ] Gateway starts and `ensureUserDir()` creates directories at `/app/.siclaw/agentbox-user-data/users/{userId}/{wsId}`
- [ ] AgentBox pods start correctly (no change to agentbox mounts)
- [ ] `SkillFileWriter` still writes skills to `/app/.siclaw/skills` on container filesystem