### PR TITLE
improve(skills): hint about test workspace when skill awaits approval

### DIFF
--- a/src/gateway/web/src/pages/Pilot/components/SkillPanel.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/SkillPanel.tsx
@@ -424,7 +424,15 @@ export function SkillPanel({ message, sendRpc, skills, onSave, onDismiss, onClos
                 <div className="px-4 py-2 bg-gray-50 border-t border-gray-200 flex items-start gap-2 shrink-0">
                     <Info className="w-3.5 h-3.5 text-gray-400 shrink-0 mt-0.5" />
                     <span className="text-xs text-gray-600">
-                        Saved as draft. Available in test environments. Request publish to use in production.
+                        Saved as draft. Available in test workspaces. Request publish to use in production.
+                    </span>
+                </div>
+            )}
+            {saveState === 'saved' && (reviewStatus === 'pending' || reviewStatus === 'staged') && (
+                <div className="px-4 py-2 bg-amber-50 border-t border-amber-200 flex items-start gap-2 shrink-0">
+                    <AlertTriangle className="w-3.5 h-3.5 text-amber-500 shrink-0 mt-0.5" />
+                    <span className="text-xs text-amber-800">
+                        Awaiting admin approval. You can switch to a test workspace to debug this skill immediately.
                     </span>
                 </div>
             )}

--- a/src/tools/create-skill.ts
+++ b/src/tools/create-skill.ts
@@ -205,7 +205,7 @@ pod_netns_script: pod="<pod>", namespace="<ns>", skill="pod-ping-gateway", scrip
         summary: `Created skill definition '${params.name.trim()}'. Please review and click Save.`
           + (hasScripts ? ' This skill has scripts and will require admin approval after saving. Do NOT attempt to test or run it until approved.' : ''),
         reviewNote: hasScripts
-          ? "This skill contains scripts and will enter PENDING review status after saving. It CANNOT be used or tested until an admin approves it. Please inform the user that the skill is awaiting admin approval."
+          ? "This skill contains scripts and will enter PENDING review status after saving. It CANNOT be used or tested in production until an admin approves it. Tip: the user can switch to a test workspace to debug the skill immediately without waiting for approval. Please inform the user about both the approval requirement and the test workspace option."
           : undefined,
       };
 

--- a/src/tools/update-skill.ts
+++ b/src/tools/update-skill.ts
@@ -198,7 +198,7 @@ pod_netns_script: pod="<pod>", namespace="<ns>", skill="pod-ping-gateway", scrip
         summary: `Updated skill definition '${params.name.trim()}'. Please review and click Update.`
           + (hasScripts ? ' Script changes will be staged for admin review. The old version remains active until approved. Do NOT attempt to test the new version until approved.' : ''),
         reviewNote: hasScripts
-          ? "This update contains scripts and will enter STAGED review status. The OLD version of the skill remains active and usable, but the new version will NOT take effect until an admin approves it. Please inform the user that the update is awaiting admin approval."
+          ? "This update contains scripts and will enter STAGED review status. The OLD version of the skill remains active and usable, but the new version will NOT take effect in production until an admin approves it. Tip: the user can switch to a test workspace to debug the updated skill immediately without waiting for approval. Please inform the user about both the approval requirement and the test workspace option."
           : undefined,
       };
 


### PR DESCRIPTION
## Problem

After creating or updating a skill with scripts, users are told it requires admin approval but are not informed they can immediately debug it in a test workspace. This creates a confusing experience where users think they must wait for approval before they can iterate on their skill.

## Solution

Add test workspace hints in two places:

1. **Agent tool responses** (`create_skill` / `update_skill` `reviewNote`): Claude now mentions the test workspace option alongside the approval requirement when relaying the message to the user.

2. **SkillPanel UI banner**: New amber banner for `pending`/`staged` review status states — "Awaiting admin approval. You can switch to a test workspace to debug this skill immediately." (Previously only `draft` status had a banner.)

## Test plan

- [ ] Create a new skill with scripts → agent response mentions test workspace option
- [ ] Update an existing skill's scripts → agent response mentions test workspace option
- [ ] After saving a skill with scripts, SkillPanel shows amber banner with test workspace hint
- [ ] Draft status still shows the existing gray banner
- [ ] Approved skills show no banner