### PR TITLE
Fix non-admin users accessing admin-only Models page

### DIFF
--- a/src/gateway/web/src/pages/Models/index.tsx
+++ b/src/gateway/web/src/pages/Models/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Settings, Layers, Globe, Key, Save, Trash2, Plus } from 'lucide-react';
+import { Settings, Layers, Globe, Key, Save, Trash2, Plus, ShieldX } from 'lucide-react';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { usePermissions } from '@/hooks/usePermissions';
 import { SettingsDialog } from './SettingsDialog';
@@ -33,7 +33,7 @@ interface EmbeddingConfig {
 
 export function ModelsPage() {
     const { sendRpc, isConnected } = useWebSocket();
-    const { isAdmin } = usePermissions(sendRpc, isConnected);
+    const { isAdmin, loaded } = usePermissions(sendRpc, isConnected);
 
     const [providers, setProviders] = useState<ProviderInfo[]>([]);
     const [allModels, setAllModels] = useState<ModelEntry[]>([]);
@@ -180,6 +180,18 @@ export function ModelsPage() {
             setEmbeddingModel(modelsForProv[0].id);
         }
     };
+
+    if (loaded && !isAdmin) {
+        return (
+            <div className="h-full flex items-center justify-center">
+                <div className="text-center">
+                    <ShieldX className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+                    <h2 className="text-lg font-semibold text-gray-900 mb-1">Admin access required</h2>
+                    <p className="text-sm text-gray-500">Only administrators can manage models.</p>
+                </div>
+            </div>
+        );
+    }
 
     const defaultChanged = savedDefault
         ? defaultProvider !== savedDefault.provider || defaultModelId !== savedDefault.modelId

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -50,6 +50,7 @@ export interface PilotAreaProps {
     systemStatus?: SystemStatus | null;
     onNavigateModels?: () => void;
     onNavigateCredentials?: () => void;
+    isAdmin?: boolean;
 }
 
 /** Compute superseded status for skill messages */
@@ -149,7 +150,7 @@ function computeScheduleStatuses(messages: PilotMessage[]): Map<string, Schedule
     return statuses;
 }
 
-export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, skills, editingSkill, onEditSkill, onClearEditSkill, onSkillSaved, onOpenSkillPanel, onOpenSchedulePanel, panelMessage, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials }: PilotAreaProps) {
+export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, skills, editingSkill, onEditSkill, onClearEditSkill, onSkillSaved, onOpenSkillPanel, onOpenSchedulePanel, panelMessage, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials, isAdmin }: PilotAreaProps) {
     const scrollRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const prevScrollHeightRef = useRef(0);
@@ -267,6 +268,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                             onSendPrompt={sendMessage}
                             onNavigateModels={onNavigateModels ?? (() => {})}
                             onNavigateCredentials={onNavigateCredentials ?? (() => {})}
+                            isAdmin={isAdmin}
                         />
                     ) : (
                         <>

--- a/src/gateway/web/src/pages/Pilot/components/WelcomeArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/WelcomeArea.tsx
@@ -6,6 +6,7 @@ export interface WelcomeAreaProps {
     onSendPrompt: (text: string) => void;
     onNavigateModels: () => void;
     onNavigateCredentials: () => void;
+    isAdmin?: boolean;
 }
 
 const CAPABILITIES = [
@@ -49,18 +50,22 @@ const CREDENTIAL_LABELS: Record<string, string> = {
     api_basic_auth: 'API Auth',
 };
 
-export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNavigateCredentials }: WelcomeAreaProps) {
-    const isFirstTime = systemStatus?.hasProfile === false;
+export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNavigateCredentials, isAdmin }: WelcomeAreaProps) {
     const hasModels = systemStatus?.hasModels ?? false;
     const credentials = systemStatus?.credentials ?? {};
     const hasCredentials = Object.keys(credentials).length > 0;
     const sessionCount = systemStatus?.sessionCount ?? 0;
+    const isFirstTime = sessionCount === 0;
 
-    const allChecklistDone = hasModels && hasCredentials && sessionCount > 0;
+    const allChecklistDone = isAdmin
+        ? hasModels && hasCredentials && sessionCount > 0
+        : hasCredentials && sessionCount > 0;
 
     const handlePromptClick = (text: string) => {
         if (!hasModels) {
-            onNavigateModels();
+            if (isAdmin) {
+                onNavigateModels();
+            }
             return;
         }
         onSendPrompt(text);
@@ -85,25 +90,27 @@ export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNa
                         <div className="w-full bg-white border border-gray-200 rounded-2xl shadow-sm p-5 space-y-3">
                             <h2 className="text-sm font-semibold text-gray-700">Getting Started</h2>
                             <div className="space-y-2">
-                                {/* Step 1: Configure AI Model */}
+                                {/* Step: Configure AI Model (admin only) */}
+                                {isAdmin && (
+                                    <ChecklistStep
+                                        step={1}
+                                        done={hasModels}
+                                        label="Configure AI Model"
+                                        subtitle="Add a model provider to start chatting"
+                                        onClick={onNavigateModels}
+                                    />
+                                )}
+                                {/* Step: Add Credentials */}
                                 <ChecklistStep
-                                    step={1}
-                                    done={hasModels}
-                                    label="Configure AI Model"
-                                    subtitle="Add a model provider to start chatting"
-                                    onClick={onNavigateModels}
-                                />
-                                {/* Step 2: Add Credentials */}
-                                <ChecklistStep
-                                    step={2}
+                                    step={isAdmin ? 2 : 1}
                                     done={hasCredentials}
                                     label="Add Credentials"
                                     subtitle="Connect to your clusters and servers via SSH or Kubeconfig"
                                     onClick={onNavigateCredentials}
                                 />
-                                {/* Step 3: Start a conversation */}
+                                {/* Step: Start a conversation */}
                                 <ChecklistStep
-                                    step={3}
+                                    step={isAdmin ? 3 : 2}
                                     done={sessionCount > 0}
                                     label="Start your first conversation"
                                     subtitle="Ask Siclaw to diagnose an issue or run a skill"
@@ -164,7 +171,7 @@ export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNa
                     </div>
                     {!hasModels && (
                         <p className="text-xs text-center text-amber-600">
-                            Configure a model first to start chatting
+                            {isAdmin ? 'Configure a model first to start chatting' : 'Waiting for an admin to configure a model'}
                         </p>
                     )}
                 </div>

--- a/src/gateway/web/src/pages/Pilot/index.tsx
+++ b/src/gateway/web/src/pages/Pilot/index.tsx
@@ -7,6 +7,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { usePilot, type PilotMessage } from '@/hooks/usePilot';
+import { usePermissions } from '@/hooks/usePermissions';
 
 
 export function PilotPage() {
@@ -14,6 +15,7 @@ export function PilotPage() {
     const [panelMessage, setPanelMessage] = useState<PilotMessage | null>(null);
     const navigate = useNavigate();
     const pilot = usePilot();
+    const { isAdmin } = usePermissions(pilot.sendRpc, pilot.isConnected);
 
     // Track which tool content we've already auto-opened the panel for
     // Uses content hash instead of message ID (IDs change when DB ID replaces temp ID)
@@ -206,6 +208,7 @@ export function PilotPage() {
                         systemStatus={pilot.systemStatus}
                         onNavigateModels={() => navigate('/models')}
                         onNavigateCredentials={() => navigate('/credentials')}
+                        isAdmin={isAdmin}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Block direct URL access to `/models` for non-admin users — renders "Admin access required" page (same pattern as Permissions page)
- Hide "Configure AI Model" onboarding checklist step for non-admin users, renumber remaining steps
- Fix `isFirstTime` detection: use per-user `sessionCount === 0` instead of global `hasProfile` (PROFILE.md) check
- Non-admin prompt click no longer redirects to `/models`; warning text shows "Waiting for an admin to configure a model"

## Test plan
- [ ] Login as admin — full onboarding checklist with "Configure AI Model" step visible, Models page works normally
- [ ] Login as non-admin — onboarding shows 2 steps (Credentials + First conversation), no model config step
- [ ] Non-admin clicks prompt when no model configured — no redirect to `/models`
- [ ] Non-admin navigates to `localhost:3000/models` directly — sees "Admin access required"
- [ ] New user (0 sessions) sees onboarding; returning user (>=1 session) does not