### PR TITLE
Fix non-admin users accessing admin-only pages and onboarding route leaks

### DIFF
--- a/src/gateway/web/src/pages/Channels/index.tsx
+++ b/src/gateway/web/src/pages/Channels/index.tsx
@@ -1,12 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
+import { ShieldX } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWebSocket } from '@/hooks/useWebSocket';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useChannels } from '@/hooks/useChannels';
 import { mergeChannels, type Channel } from './channelsData';
 import { ChannelDrawer } from './components/ChannelDrawer';
 
 export function ChannelsPage() {
     const { sendRpc, isConnected } = useWebSocket();
+    const { isAdmin, loaded } = usePermissions(sendRpc, isConnected);
     const { channels: views, loading, loadChannels, saveChannel } = useChannels(sendRpc);
     const [selectedChannel, setSelectedChannel] = useState<Channel | null>(null);
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -32,6 +35,18 @@ export function ChannelsPage() {
         await saveChannel(id, enabled, config);
         setIsDrawerOpen(false);
     };
+
+    if (loaded && !isAdmin) {
+        return (
+            <div className="h-full flex items-center justify-center">
+                <div className="text-center">
+                    <ShieldX className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+                    <h2 className="text-lg font-semibold text-gray-900 mb-1">Admin access required</h2>
+                    <p className="text-sm text-gray-500">Only administrators can manage channels.</p>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="h-full bg-white flex flex-col">

--- a/src/gateway/web/src/pages/Models/index.tsx
+++ b/src/gateway/web/src/pages/Models/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Settings, Layers, Globe, Key, Save, Trash2, Plus } from 'lucide-react';
+import { Settings, Layers, Globe, Key, Save, Trash2, Plus, ShieldX } from 'lucide-react';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { usePermissions } from '@/hooks/usePermissions';
 import { ModelsDialog } from './ModelsDialog';
@@ -34,7 +34,7 @@ interface EmbeddingConfig {
 
 export function ModelsPage() {
     const { sendRpc, isConnected } = useWebSocket();
-    const { isAdmin } = usePermissions(sendRpc, isConnected);
+    const { isAdmin, loaded } = usePermissions(sendRpc, isConnected);
 
     const [providers, setProviders] = useState<ProviderInfo[]>([]);
     const [allModels, setAllModels] = useState<ModelEntry[]>([]);
@@ -193,6 +193,18 @@ export function ModelsPage() {
 
     const llmGroups = groupByProvider(llmModels);
     const embeddingGroups = groupByProvider(embeddingModels);
+
+    if (loaded && !isAdmin) {
+        return (
+            <div className="h-full flex items-center justify-center">
+                <div className="text-center">
+                    <ShieldX className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+                    <h2 className="text-lg font-semibold text-gray-900 mb-1">Admin access required</h2>
+                    <p className="text-sm text-gray-500">Only administrators can manage models.</p>
+                </div>
+            </div>
+        );
+    }
 
     const defaultChanged = defaultValue !== savedDefault;
     const embeddingChanged = savedEmbedding

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -54,6 +54,7 @@ export interface PilotAreaProps {
     sessionKey?: string | null;
     /** Current workspace ID for cron job operations */
     selectedWorkspaceId?: string | null;
+    isAdmin?: boolean;
 }
 
 /** Compute superseded status for skill messages */
@@ -153,7 +154,7 @@ function computeScheduleStatuses(messages: PilotMessage[]): Map<string, Schedule
     return statuses;
 }
 
-export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, skills, editingSkill, onEditSkill, onClearEditSkill, onSkillSaved, onOpenSkillPanel, onOpenSchedulePanel, panelMessage, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials, sessionKey, selectedWorkspaceId }: PilotAreaProps) {
+export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, skills, editingSkill, onEditSkill, onClearEditSkill, onSkillSaved, onOpenSkillPanel, onOpenSchedulePanel, panelMessage, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials, sessionKey, selectedWorkspaceId, isAdmin }: PilotAreaProps) {
     const scrollRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const prevScrollHeightRef = useRef(0);
@@ -361,6 +362,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                             onSendPrompt={sendMessage}
                             onNavigateModels={onNavigateModels ?? (() => {})}
                             onNavigateCredentials={onNavigateCredentials ?? (() => {})}
+                            isAdmin={isAdmin}
                         />
                     ) : (
                         <>

--- a/src/gateway/web/src/pages/Pilot/components/WelcomeArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/WelcomeArea.tsx
@@ -6,6 +6,7 @@ export interface WelcomeAreaProps {
     onSendPrompt: (text: string) => void;
     onNavigateModels: () => void;
     onNavigateCredentials: () => void;
+    isAdmin?: boolean;
 }
 
 const CAPABILITIES = [
@@ -49,22 +50,56 @@ const CREDENTIAL_LABELS: Record<string, string> = {
     api_basic_auth: 'API Auth',
 };
 
-export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNavigateCredentials }: WelcomeAreaProps) {
-    const isFirstTime = systemStatus?.hasProfile === false;
+export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNavigateCredentials, isAdmin }: WelcomeAreaProps) {
+    const isFirstTime = systemStatus ? (systemStatus.sessionCount ?? 0) === 0 : false;
     const hasModels = systemStatus?.hasModels ?? false;
     const credentials = systemStatus?.credentials ?? {};
     const hasCredentials = Object.keys(credentials).length > 0;
     const sessionCount = systemStatus?.sessionCount ?? 0;
 
-    const allChecklistDone = hasModels && hasCredentials && sessionCount > 0;
+    const allChecklistDone = isAdmin
+        ? hasModels && hasCredentials && sessionCount > 0
+        : hasCredentials && sessionCount > 0;
 
     const handlePromptClick = (text: string) => {
         if (!hasModels) {
-            onNavigateModels();
+            if (isAdmin) {
+                onNavigateModels();
+            }
             return;
         }
         onSendPrompt(text);
     };
+
+    // Build checklist steps dynamically based on role
+    const checklistSteps: Array<{
+        done: boolean;
+        label: string;
+        subtitle: string;
+        onClick?: () => void;
+    }> = [];
+
+    if (isAdmin) {
+        checklistSteps.push({
+            done: hasModels,
+            label: 'Configure AI Model',
+            subtitle: 'Add a model provider to start chatting',
+            onClick: onNavigateModels,
+        });
+    }
+
+    checklistSteps.push({
+        done: hasCredentials,
+        label: 'Add Credentials',
+        subtitle: 'Connect to your clusters and servers via SSH or Kubeconfig',
+        onClick: onNavigateCredentials,
+    });
+
+    checklistSteps.push({
+        done: sessionCount > 0,
+        label: 'Start your first conversation',
+        subtitle: 'Ask Siclaw to diagnose an issue or run a skill',
+    });
 
     return (
         <div className="flex flex-col items-center justify-center py-12 px-4 max-w-2xl mx-auto space-y-8">
@@ -84,26 +119,16 @@ export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNa
                 <div className="w-full bg-white border border-gray-200 rounded-2xl shadow-sm p-5 space-y-3">
                     <h2 className="text-sm font-semibold text-gray-700">Getting Started</h2>
                     <div className="space-y-2">
-                        <ChecklistStep
-                            step={1}
-                            done={hasModels}
-                            label="Configure AI Model"
-                            subtitle="Add a model provider to start chatting"
-                            onClick={onNavigateModels}
-                        />
-                        <ChecklistStep
-                            step={2}
-                            done={hasCredentials}
-                            label="Add Credentials"
-                            subtitle="Connect to your clusters and servers via SSH or Kubeconfig"
-                            onClick={onNavigateCredentials}
-                        />
-                        <ChecklistStep
-                            step={3}
-                            done={sessionCount > 0}
-                            label="Start your first conversation"
-                            subtitle="Ask Siclaw to diagnose an issue or run a skill"
-                        />
+                        {checklistSteps.map((step, idx) => (
+                            <ChecklistStep
+                                key={step.label}
+                                step={idx + 1}
+                                done={step.done}
+                                label={step.label}
+                                subtitle={step.subtitle}
+                                onClick={step.onClick}
+                            />
+                        ))}
                     </div>
                 </div>
             )}
@@ -155,7 +180,9 @@ export function WelcomeArea({ systemStatus, onSendPrompt, onNavigateModels, onNa
                     </div>
                     {!hasModels && (
                         <p className="text-xs text-center text-amber-600">
-                            Configure a model first to start chatting
+                            {isAdmin
+                                ? 'Configure a model first to start chatting'
+                                : 'Waiting for an admin to configure a model'}
                         </p>
                     )}
                 </div>

--- a/src/gateway/web/src/pages/Pilot/index.tsx
+++ b/src/gateway/web/src/pages/Pilot/index.tsx
@@ -7,6 +7,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { usePilot, type PilotMessage } from '@/hooks/usePilot';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useWorkspace } from '@/contexts/WorkspaceContext';
 
 
@@ -16,6 +17,7 @@ export function PilotPage() {
     const navigate = useNavigate();
     const location = useLocation();
     const pilot = usePilot();
+    const { isAdmin } = usePermissions(pilot.sendRpc, pilot.isConnected);
     const { currentWorkspace } = useWorkspace();
 
     // Track which tool content we've already auto-opened the panel for
@@ -216,6 +218,7 @@ export function PilotPage() {
                         onNavigateModels={() => navigate('/models')}
                         onNavigateCredentials={() => navigate('/credentials')}
                         sessionKey={pilot.currentSessionKey}
+                        isAdmin={isAdmin}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **Route protection**: Non-admin users navigating to `/models` or `/channels` (via direct URL) now see an "Admin access required" page instead of the full admin UI
- **Onboarding fix**: `isFirstTime` now uses per-user `sessionCount === 0` instead of the global `hasProfile` check, which was shared across all users
- **Checklist scoping**: Non-admin users see 2 onboarding steps (Credentials + First conversation) instead of 3 — the "Configure AI Model" step is hidden since they can't access it
- **Redirect guard**: Clicking suggested prompts when no model is configured no longer redirects non-admin users to `/models`
- **Warning text**: Non-admin users see "Waiting for an admin to configure a model" instead of "Configure a model first"

## Test plan

- [ ] Login as admin → Models page, Channels page, and full 3-step onboarding checklist work normally
- [ ] Login as non-admin → Pilot shows 2-step onboarding (no "Configure AI Model")
- [ ] Non-admin clicking prompts when no model configured → no redirect to `/models`
- [ ] Non-admin direct URL `/models` → "Admin access required" with ShieldX icon
- [ ] Non-admin direct URL `/channels` → "Admin access required" with ShieldX icon
- [ ] Non-admin warning text shows "Waiting for an admin to configure a model"