### PR TITLE
fix(db): force UTC timezone for mysql2 to fix audit query offset

### DIFF
--- a/src/gateway/db/index.ts
+++ b/src/gateway/db/index.ts
@@ -84,8 +84,8 @@ export async function createDb(): Promise<Database> {
     // Force MySQL session timezone to UTC so timestamp comparisons match
     // the client-side serialization (timezone: '+00:00' above).
     pool.on("connection", (conn) => {
-      conn.query("SET time_zone = '+00:00'").catch((err) => {
-        console.error("[db] Failed to set session timezone:", err);
+      conn.query("SET time_zone = '+00:00'", (err: unknown) => {
+        if (err) console.error("[db] Failed to set session timezone:", err);
       });
     });
     _db = drizzle(pool, { schema, mode: "default" });


### PR DESCRIPTION
## Summary
- When MySQL server uses a non-UTC timezone (e.g. UTC+8) but Node.js runs in UTC, mysql2 serializes Date objects as UTC strings while MySQL interprets them in its session timezone, causing an 8-hour offset in all timestamp comparisons
- This made **all** audit records from the last 8 hours invisible to **all** users (including admin) on the Audit page
- Production DB had 247 audit records but queries returned empty results

## Root Cause
```
Node.js (UTC) → mysql2 serializes Date as '13:21:06' (UTC)
    → MySQL session (UTC+8) interprets as 13:21:06+08:00 = 05:21 UTC
    → Record at 13:21 UTC > endDate 05:21 UTC → not matched
```

## Fix
- Set `timezone: '+00:00'` on mysql2 pool for client-side Date serialization
- `SET time_zone = '+00:00'` on each MySQL connection for session consistency
- Both sides now use UTC regardless of MySQL server system timezone

## Test plan
- [x] Verified in test env (MySQL UTC): audit works before and after change
- [x] Verified in prod env (MySQL UTC+8): confirmed 8h offset via `NOW()` vs `UTC_TIMESTAMP()`
- [ ] Deploy to prod, confirm audit records visible immediately (not after 8h delay)
- [ ] Verify other timestamp-dependent features (session list, metrics timeseries) unaffected