### PR TITLE
feat(cron): add rate limits and resource protection

### DIFF
--- a/src/cron/cron-matcher.test.ts
+++ b/src/cron/cron-matcher.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { parseCronExpression, getMinimumIntervalMs } from "./cron-matcher.js";
+
+const HOUR = 60 * 60 * 1000;
+const MIN = 60 * 1000;
+
+describe("parseCronExpression", () => {
+  it("rejects invalid field count", () => {
+    expect(() => parseCronExpression("* * *")).toThrow("expected 5 fields");
+  });
+
+  it("rejects out-of-range values", () => {
+    expect(() => parseCronExpression("60 * * * *")).toThrow("Invalid cron field value");
+    expect(() => parseCronExpression("* 25 * * *")).toThrow("Invalid cron field value");
+  });
+
+  it("parses standard expressions", () => {
+    const fields = parseCronExpression("0 * * * *");
+    expect(fields.minutes).toEqual([0]);
+    expect(fields.hours).toEqual(Array.from({ length: 24 }, (_, i) => i));
+  });
+
+  it("parses step expressions", () => {
+    const fields = parseCronExpression("*/15 * * * *");
+    expect(fields.minutes).toEqual([0, 15, 30, 45]);
+  });
+
+  it("parses comma-separated values", () => {
+    const fields = parseCronExpression("0 9,17 * * *");
+    expect(fields.hours).toEqual([9, 17]);
+  });
+
+  it("parses ranges", () => {
+    const fields = parseCronExpression("0 9 * * 1-5");
+    expect(fields.daysOfWeek).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("getMinimumIntervalMs", () => {
+  it("every hour → 60 min interval", () => {
+    expect(getMinimumIntervalMs("0 * * * *")).toBe(HOUR);
+  });
+
+  it("every 5 minutes → 5 min interval", () => {
+    expect(getMinimumIntervalMs("*/5 * * * *")).toBe(5 * MIN);
+  });
+
+  it("every minute → 1 min interval", () => {
+    expect(getMinimumIntervalMs("* * * * *")).toBe(MIN);
+  });
+
+  it("daily at 9am → 24h interval", () => {
+    expect(getMinimumIntervalMs("0 9 * * *")).toBe(24 * HOUR);
+  });
+
+  it("every 15 minutes → 15 min interval", () => {
+    expect(getMinimumIntervalMs("*/15 * * * *")).toBe(15 * MIN);
+  });
+
+  it("variable-interval: 9am and 5pm → minimum 8h", () => {
+    // Weekdays 9am and 5pm: gaps are 8h (9→17) and 16h (17→next 9)
+    const interval = getMinimumIntervalMs("0 9,17 * * 1-5");
+    expect(interval).toBe(8 * HOUR);
+  });
+
+  it("monthly 1st at midnight → ~28-31 days", () => {
+    const interval = getMinimumIntervalMs("0 0 1 * *");
+    // Minimum is 28 days (Feb → Mar in non-leap year)
+    expect(interval).toBeGreaterThanOrEqual(28 * 24 * HOUR);
+    expect(interval).toBeLessThanOrEqual(31 * 24 * HOUR);
+  });
+});

--- a/src/cron/cron-matcher.ts
+++ b/src/cron/cron-matcher.ts
@@ -138,3 +138,24 @@ export function getNextCronDelay(expr: string, after?: Date): number {
   const next = getNextCronTime(expr, now);
   return next.getTime() - now.getTime();
 }
+
+/**
+ * Estimate the minimum interval (in ms) between consecutive fires
+ * by sampling `sampleCount` successive trigger times.
+ *
+ * Handles variable-interval expressions like `0 9,17 * * 1-5`
+ * where intervals alternate (e.g. 8h / 16h).
+ */
+export function getMinimumIntervalMs(expr: string, sampleCount = 10): number {
+  let minGap = Infinity;
+
+  let prev = getNextCronTime(expr, new Date());
+  for (let i = 1; i < sampleCount; i++) {
+    const next = getNextCronTime(expr, prev);
+    const gap = next.getTime() - prev.getTime();
+    if (gap < minGap) minGap = gap;
+    prev = next;
+  }
+
+  return minGap;
+}

--- a/src/gateway/cron/cron-limits.ts
+++ b/src/gateway/cron/cron-limits.ts
@@ -1,0 +1,17 @@
+/**
+ * Cron rate-limit constants.
+ * Centralised here so they're easy to tune without touching validation logic.
+ */
+
+export const CRON_LIMITS = {
+  /** Minimum interval between fires — regular users (1 hour) */
+  MIN_INTERVAL_MS: 60 * 60 * 1000,
+  /** Minimum interval between fires — admin users (15 min) */
+  ADMIN_MIN_INTERVAL_MS: 15 * 60 * 1000,
+  /** Maximum active (non-paused) jobs per user */
+  MAX_ACTIVE_JOBS_PER_USER: 20,
+  /** Maximum concurrently executing jobs (soft limit) */
+  MAX_CONCURRENT_EXECUTIONS: 5,
+  /** How many consecutive fires to sample when computing minimum interval */
+  INTERVAL_SAMPLE_COUNT: 10,
+} as const;

--- a/src/gateway/cron/cron-service.ts
+++ b/src/gateway/cron/cron-service.ts
@@ -10,6 +10,7 @@ import crypto from "node:crypto";
 import { CronScheduler, type CronJobRow } from "../../cron/cron-scheduler.js";
 import type { ConfigRepository } from "../db/repositories/config-repo.js";
 import type { NotificationRepository } from "../db/repositories/notification-repo.js";
+import { CRON_LIMITS } from "./cron-limits.js";
 
 const EXECUTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const STALE_LOCK_CLEANUP_MS = 6 * 60 * 1000; // 6 min
@@ -85,6 +86,15 @@ export class CronService {
     const current = await this.configRepo.getCronJobById(job.id);
     if (!current || current.status !== "active") {
       console.log(`[cron-service] Job ${job.id} no longer active, skipping`);
+      return;
+    }
+
+    // Soft concurrent-execution limit — skip this run, retry next cycle
+    const executing = await this.configRepo.countCurrentlyExecutingJobs();
+    if (executing >= CRON_LIMITS.MAX_CONCURRENT_EXECUTIONS) {
+      console.warn(
+        `[cron-service] Job ${job.id} skipped: concurrent limit reached (${executing}/${CRON_LIMITS.MAX_CONCURRENT_EXECUTIONS})`,
+      );
       return;
     }
 

--- a/src/gateway/db/repositories/config-repo.ts
+++ b/src/gateway/db/repositories/config-repo.ts
@@ -337,6 +337,26 @@ export class ConfigRepository {
       );
   }
 
+  // ─── Cron Limits Queries ─────────────────────────
+
+  /** Count active (non-paused) jobs owned by a user */
+  async countActiveJobsByUser(userId: string): Promise<number> {
+    const rows = await this.db
+      .select({ cnt: sql<number>`count(*)` })
+      .from(cronJobs)
+      .where(and(eq(cronJobs.userId, userId), eq(cronJobs.status, "active")));
+    return Number(rows[0]?.cnt ?? 0);
+  }
+
+  /** Count jobs currently locked for execution (lockedBy IS NOT NULL) */
+  async countCurrentlyExecutingJobs(): Promise<number> {
+    const rows = await this.db
+      .select({ cnt: sql<number>`count(*)` })
+      .from(cronJobs)
+      .where(isNotNull(cronJobs.lockedBy));
+    return Number(rows[0]?.cnt ?? 0);
+  }
+
   // ─── Triggers ─────────────────────────────────
 
   async listTriggers(userId: string) {

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -37,6 +37,8 @@ import { SkillVersionRepository } from "./db/repositories/skill-version-repo.js"
 import { createTwoFilesPatch } from "diff";
 import yaml from "js-yaml";
 import type { CronService } from "./cron/cron-service.js";
+import { CRON_LIMITS } from "./cron/cron-limits.js";
+import { parseCronExpression, getMinimumIntervalMs } from "../cron/cron-matcher.js";
 import { buildSkillBundle, type SkillBundle } from "./skills/skill-bundle.js";
 import { buildRedactionConfig, redactText, type RedactionConfig } from "./output-redactor.js";
 import { RESOURCE_DESCRIPTORS } from "../shared/resource-sync.js";
@@ -2594,16 +2596,63 @@ export function createRpcMethods(
     const description = params.description as string | undefined;
     const schedule = params.schedule as string;
     const status = (params.status as "active" | "paused") ?? "active";
+    const skillId = params.skillId as string | undefined;
 
     const existingId = params.id as string | undefined;
     const workspaceId = params.workspaceId as string | null | undefined;
+
+    // ── Validation chain ──────────────────────────
+
+    // 1. Syntax validation
+    parseCronExpression(schedule);
+
+    // 2. Ownership check on update
+    let existingJob: Awaited<ReturnType<ConfigRepository["getCronJobById"]>> | null = null;
+    if (existingId) {
+      existingJob = await configRepo.getCronJobById(existingId);
+      if (!existingJob) throw new Error("Job not found");
+      if (existingJob.userId !== userId) throw new Error("Forbidden");
+    }
+
+    // 3. Minimum interval check (skip if updating without changing schedule)
+    const scheduleChanged = !existingJob || existingJob.schedule !== schedule;
+    if (scheduleChanged) {
+      const minInterval = getMinimumIntervalMs(schedule, CRON_LIMITS.INTERVAL_SAMPLE_COUNT);
+      const limit = isAdminUser(context) ? CRON_LIMITS.ADMIN_MIN_INTERVAL_MS : CRON_LIMITS.MIN_INTERVAL_MS;
+      if (minInterval < limit) {
+        const limitMin = Math.round(limit / 60_000);
+        throw new Error(`Schedule interval too short: minimum ${limitMin} minutes between executions`);
+      }
+    }
+
+    // 4. Active job quota
+    if (status === "active") {
+      const activeCount = await configRepo.countActiveJobsByUser(userId);
+      // If updating an already-active job, it's already counted
+      const alreadyCounted = existingJob?.status === "active" ? 1 : 0;
+      if (activeCount - alreadyCounted >= CRON_LIMITS.MAX_ACTIVE_JOBS_PER_USER) {
+        throw new Error(`Active job limit reached (max ${CRON_LIMITS.MAX_ACTIVE_JOBS_PER_USER})`);
+      }
+    }
+
+    // 5. Skill ownership validation
+    if (skillId && skillRepo) {
+      const skill = await skillRepo.getById(skillId);
+      if (!skill) throw new Error(`Skill not found: ${skillId}`);
+      // Allow builtin + team skills for everyone; personal skills only for the author
+      if (skill.scope === "personal" && skill.authorId !== userId) {
+        throw new Error("Forbidden: cannot use another user's personal skill");
+      }
+    }
+
+    // ── Persist ───────────────────────────────────
 
     const id = await configRepo.saveCronJob(userId, {
       id: existingId,
       name,
       description,
       schedule,
-      skillId: params.skillId as string | undefined,
+      skillId,
       status,
       workspaceId: workspaceId ?? null,
     });
@@ -2614,7 +2663,7 @@ export function createRpcMethods(
       } else {
         cronService.addOrUpdate({
           id, userId, name, description: description ?? null, schedule, status,
-          skillId: (params.skillId as string) ?? null, assignedTo: null,
+          skillId: skillId ?? null, assignedTo: null,
           lastRunAt: null, lastResult: null, lockedBy: null, lockedAt: null,
           workspaceId: workspaceId ?? null,
         });
@@ -2666,6 +2715,23 @@ export function createRpcMethods(
     const job = await configRepo.getCronJobById(id);
     if (!job) throw new Error("Job not found");
     if (job.userId !== userId) throw new Error("Forbidden");
+
+    // ── Rate-limit checks when activating ──────────
+    if (status === "active" && job.status !== "active") {
+      // Interval check (prevents re-activating a high-frequency job)
+      const minInterval = getMinimumIntervalMs(job.schedule, CRON_LIMITS.INTERVAL_SAMPLE_COUNT);
+      const limit = isAdminUser(context) ? CRON_LIMITS.ADMIN_MIN_INTERVAL_MS : CRON_LIMITS.MIN_INTERVAL_MS;
+      if (minInterval < limit) {
+        const limitMin = Math.round(limit / 60_000);
+        throw new Error(`Schedule interval too short: minimum ${limitMin} minutes between executions`);
+      }
+
+      // Active job quota
+      const activeCount = await configRepo.countActiveJobsByUser(userId);
+      if (activeCount >= CRON_LIMITS.MAX_ACTIVE_JOBS_PER_USER) {
+        throw new Error(`Active job limit reached (max ${CRON_LIMITS.MAX_ACTIVE_JOBS_PER_USER})`);
+      }
+    }
 
     // Update status
     await configRepo.saveCronJob(userId, {


### PR DESCRIPTION
## Summary

- Add 5 safeguards to the cron system to prevent resource abuse:
  1. **Cron expression syntax validation** — reject invalid expressions on save
  2. **Minimum execution interval** — 1h for regular users, 15min for admin
  3. **Per-user active job cap** — max 20 active jobs per user
  4. **Global concurrent execution limit** — max 5 simultaneous executions (soft limit)
  5. **Skill ownership validation** — personal skills restricted to their author
- Fix missing ownership check in `cron.save` when updating existing jobs (any user could overwrite any job by ID)
- All checks enforced at RPC layer (`cron.save` + `cron.setStatus`), no changes needed in `manage_schedule` tool
- Existing jobs grandfathered — limits only apply on create, modify schedule, or reactivate

## Changed files

| File | Change |
|------|--------|
| `src/gateway/cron/cron-limits.ts` | New — centralized rate-limit constants |
| `src/cron/cron-matcher.ts` | Add `getMinimumIntervalMs()` function |
| `src/gateway/db/repositories/config-repo.ts` | Add `countActiveJobsByUser()` and `countCurrentlyExecutingJobs()` |
| `src/gateway/rpc-methods.ts` | Add validation chain to `cron.save`, activation checks to `cron.setStatus` |
| `src/gateway/cron/cron-service.ts` | Add concurrent execution check before `lockJobForExecution()` |
| `src/cron/cron-matcher.test.ts` | New — 13 tests for expression parsing and interval calculation |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run src/cron/cron-matcher.test.ts` — 13/13 tests pass
- [ ] Manual: create `*/5 * * * *` job → rejected ("interval too short: minimum 60 minutes")
- [ ] Manual: create `0 * * * *` job → accepted (hourly)
- [ ] Manual: create 21st active job → rejected ("active job limit reached")
- [ ] Manual: admin creates `*/15 * * * *` → accepted
- [ ] Manual: non-admin `cron.setStatus` activates a `*/5` job → rejected
- [ ] Manual: reference another user's personal skill → rejected