### PR TITLE
docs: align invariants/decisions/CLAUDE.md with implementation reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Gateway + K8sSpawner  (production — one isolated pod per user)
 
 `LocalSpawner` runs ALL AgentBox instances **in-process with Gateway**, sharing the same filesystem. This means:
 
-- `skillsHandler.materialize()` **must NOT be called in local mode** — it wipes `skillsDir` entirely, destroying `skills/core/` and other users' data
+- `skillsHandler.materialize()` **must NOT be called in local mode** — it wipes `skills/team/` and `skills/user/` subdirectories, destroying ALL users' personal skills on the shared filesystem
 - Local skills sync must write only to `skills/user/{userId}/` scoped paths (team skills are included in the user bundle, not written to a separate `skills/team/` directory)
 - Any component designed for K8s pod isolation is **not directly reusable** in local mode
 
@@ -130,8 +130,13 @@ Resource Sync (read before touching)
   src/shared/resource-sync.ts  Types, contracts, RESOURCE_DESCRIPTORS
   src/agentbox/resource-handlers.ts  mcpHandler + skillsHandler
   src/agentbox/resource-sync.ts      syncAllResources() for K8s startup
-  src/gateway/agentbox/local-spawner.ts  Local mode (in-process)
   src/gateway/resource-notifier.ts   Gateway → AgentBox reload notifications
+
+Spawner Implementations
+  src/gateway/agentbox/spawner.ts          BoxSpawner interface
+  src/gateway/agentbox/local-spawner.ts    In-process, dev mode (shared filesystem)
+  src/gateway/agentbox/k8s-spawner.ts      K8s pod spawner (production)
+  src/gateway/agentbox/process-spawner.ts  Child process spawner (--process flag)
 
 Database
   src/gateway/db/index.ts          createDb() — SQLite vs MySQL selection
@@ -150,6 +155,14 @@ Investigation
   src/tools/deep-search/types.ts    Budget constants (Normal/Quick)
   src/tools/deep-search/engine.ts   4-phase workflow engine
   src/tools/deep-search/sub-agent.ts Sub-agent factory (minimal tool set)
+  src/tools/investigation-feedback.ts  User feedback on diagnoses (IM Phase 2, pi-agent only)
+
+Platform Tools
+  src/tools/manage-schedule.ts     Cron job management (language-aware)
+  src/tools/credential-list.ts     Credential discovery for AgentBox
+
+Cron (merged into Gateway)
+  src/gateway/cron/cron-service.ts In-process scheduler, DB-based coordination (ADR-008)
 ```
 
 ---

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -82,7 +82,7 @@ Bundles contain **only team + personal skills**. Core skills are baked into the 
 - ✅ Bundle requests are small and fast (no large static skill content)
 - ✅ Core skills are versioned with the code, not the database
 - ⚠️ `skillsHandler.materialize()` does NOT restore core skills — it only writes what's in the bundle
-- ⚠️ In local mode, `materialize()` would wipe core skills from disk — see ADR-002 for why local mode cannot safely call `materialize()`
+- ⚠️ In local mode, `materialize()` wipes `skills/team/` and `skills/user/` subdirectories, destroying ALL users' personal skills on the shared filesystem — see ADR-002 for why local mode cannot safely call `materialize()`
 - ⚠️ If a user disables a core skill, the `disabledBuiltins` list in the bundle tells AgentBox which core skills to skip
 
 ---

--- a/docs/design/invariants.md
+++ b/docs/design/invariants.md
@@ -34,19 +34,19 @@ Siclaw runs in three modes that differ fundamentally in process and filesystem t
 
 **Consequences**:
 - Any code that writes/deletes files in `./skills/` affects ALL users simultaneously
-- `skillsHandler.materialize()` is **NOT safe** in local mode — it wipes `skillsDir` before writing. This is designed for K8s pods with isolated filesystems
+- `skillsHandler.materialize()` is **NOT safe** in local mode — it wipes `skills/team/` and `skills/user/` subdirectories (not `core/`), which in a shared filesystem destroys ALL users' personal skills. This is designed for K8s pods with isolated filesystems.
 - Per-user skill sync in local mode must write only to `skills/user/<userId>/` without touching `skills/core/` (team + personal skills from the bundle are both written into the user's directory)
 - The sql.js SQLite lockfile prevents multi-process access; local mode is single-process by design
 
-**Source**: `src/gateway/agentbox/local-spawner.ts`, `src/agentbox/resource-handlers.ts:90-129`
+**Source**: `src/gateway/agentbox/local-spawner.ts`, `src/agentbox/resource-handlers.ts:82-97`
 
 ### 1.3 K8s Pod Isolation
 
 **Invariant**: Each K8s AgentBox pod is fully isolated: its own emptyDir volume for skills, its own mTLS client certificate, its own process. Skills sync via `skillsHandler.materialize()` is safe here because there is no shared filesystem.
 
 **Consequences**:
-- The skills directory in a pod is fully managed by resource sync — it is wiped and rebuilt on every sync
-- Core skills are NOT in the pod's initial image; they arrive via the skill bundle
+- The `team/` and `user/` skill subdirectories in a pod are managed by resource sync — wiped and rebuilt on every sync. `core/` and `extension/` are baked into the image.
+- Core skills ARE baked into the Docker image (`COPY skills/core/ ./skills/core/` in Dockerfile.agentbox). They are NOT delivered via the skill bundle — see §2.1.
 - Pod self-destructs after 5 minutes of idle (no SSE connections, no sessions)
 
 **Source**: `src/gateway/agentbox/k8s-spawner.ts`, `src/agentbox/http-server.ts` (IDLE_TIMEOUT_MS)
@@ -86,7 +86,7 @@ Scripts in a skill follow this workflow before execution is permitted:
 draft → (request review) → pending → (AI + static analysis) → approved/rejected
 ```
 
-- **Static analysis**: 27 `DANGER_PATTERNS` (Critical/High/Medium severity) in `ScriptEvaluator`
+- **Static analysis**: 23 `DANGER_PATTERNS` (Critical 8 / High 8 / Medium 7) in `ScriptEvaluator`
 - **AI analysis**: LLM semantic review with mandatory rule — "Skills MUST be strictly read-only"
 - **Human gate**: `skill_reviewer` role must approve before `published` status
 - Skills with unapproved scripts **cannot** be executed via `run_skill`
@@ -234,7 +234,7 @@ postReload(context)  Notify active sessions to pick up changes
 ```
 
 - `fetch` is network I/O with retry (3 attempts, exponential backoff: 1s, 2s, 4s)
-- `materialize` is local filesystem write — **idempotent but destructive for skills** (wipes then rebuilds)
+- `materialize` is local filesystem write — **idempotent but destructive for skills** (wipes `team/` + `user/` subdirs then rebuilds)
 - `postReload` calls `brain.reload()` on active sessions
 
 ### 6.2 When to Use Each Handler
@@ -242,7 +242,7 @@ postReload(context)  Notify active sessions to pick up changes
 | Handler | Safe in LocalSpawner? | Safe in K8s pod? | Notes |
 |---------|----------------------|------------------|-------|
 | `mcpHandler.materialize()` | ✅ Yes | ✅ Yes | Merges, does not wipe |
-| `skillsHandler.materialize()` | ❌ No | ✅ Yes | Wipes entire skillsDir first |
+| `skillsHandler.materialize()` | ❌ No | ✅ Yes | Wipes `team/` + `user/` subdirs (not `core/`) |
 
 For local mode skills sync, write directly to `skills/user/<userId>/` without delegating to `skillsHandler.materialize()`. Team and personal skills from the bundle are both placed under the user's directory.
 
@@ -256,7 +256,7 @@ For local mode skills sync, write directly to `skills/user/<userId>/` without de
 finalScore = (vectorWeight × cosineSimilarity) + (ftsWeight × bm25Score)
 ```
 
-Default weights: `vectorWeight = 0.85`, `ftsWeight = 0.15` (architecture.md reference; code default may differ — check `src/memory/indexer.ts`)
+Default weights: `vectorWeight = 0.70`, `ftsWeight = 0.30` (see `src/memory/indexer.ts:14-15`; configurable via `searchConfig`)
 
 - Minimum score threshold: `0.35` (results below this are filtered)
 - Default top-K: `10` results
@@ -348,43 +348,14 @@ Memory-dependent features (investigations, `memory_search`) only work with pi-ag
 
 ## 12. Production/Test Environment Isolation (ADR-011)
 
-**Invariant**: Environment isolation is enforced at the **workspace level via credential scoping**, not at the tool level or via LLM prompts.
+> **Status: Data model only — enforcement not yet implemented.**
 
-### 12.1 Workspace envType
+The data model supports workspace-level environment isolation:
+- `workspaces.envType` (`"prod"` | `"test"`) — exists in schema, default `"prod"`
+- `environments.apiServer` — exists in schema, required field
 
-Every workspace has an `envType` (`"prod"` or `"test"`) set at creation time. This determines the credential visibility boundary for the workspace's AgentBox.
+**Not yet implemented**: credential scoping enforcement, environment binding constraints,
+kubeconfig upload validation, investigation memory isolation.
+Until enforcement lands, treat all workspaces as having full credential visibility.
 
-### 12.2 Credential Visibility Rules
-
-```
-Prod workspace  → sees all kubeconfigs (prod + test envs) + all non-kubeconfig credentials
-Test workspace  → sees only test kubeconfigs; no SSH keys, API tokens, or prod kubeconfigs
-```
-
-Production can see test credentials (for comparison/debugging). Test cannot see production credentials.
-
-### 12.3 Environment Governance
-
-- **Admin-only**: Only admins can create/modify/delete environments. Users cannot.
-- **apiServer required**: Every environment must have an `apiServer` address. Kubeconfig uploads are validated against this anchor — the kubeconfig's `clusters[].cluster.server` must match.
-- **isTest immutable by users**: The `isTest` flag is set by admin and determines credential routing.
-
-### 12.4 Binding Constraints
-
-```
-workspace.envType === "test" → can only bind environments where isTest=true
-workspace.envType === "prod" → can bind any environment
-user.testOnly === true       → can only create workspaces with envType="test"
-```
-
-### 12.5 Investigation Memory Isolation
-
-**Planned (not yet implemented):** Each workspace will have its own memory database (`<userDataDir>/<workspaceId>/.memory.db`). Investigations will not cross workspace boundaries.
-
-### 12.6 What NOT to Do
-
-- Do NOT add per-tool environment guards in `restricted-bash.ts` or other tools — credential scoping is the isolation mechanism
-- Do NOT inject environment info into LLM system prompts as a security measure — models forget
-- Do NOT allow users to create environments or change `isTest`/`apiServer`
-
-**Source**: `docs/design/decisions.md` ADR-011
+→ Full target design: `docs/design/decisions.md` ADR-011


### PR DESCRIPTION
## Summary

- **invariants.md §12 (ADR-011)**: Trimmed 6 unimplemented subsections down to a single paragraph. Only data model facts remain (`envType`, `apiServer` columns exist); unimplemented enforcement details moved to ADR-011 reference. This prevents the Invariant Reviewer from flagging code that correctly ignores not-yet-built features.
- **invariants.md accuracy fixes**: Corrected `materialize()` wipe scope (team/+user/ subdirs, not entire skillsDir), core skills baked-into-image fact, DANGER_PATTERNS count (27→23), hybrid search weights (0.85/0.15→0.70/0.30), source line references.
- **decisions.md ADR-003**: Fixed materialize() description to match actual behavior.
- **CLAUDE.md**: Fixed materialize() description; added missing file map entries (spawner implementations, investigation-feedback, platform tools, cron).

## Test plan

- [ ] Read through updated §12 — confirms only implemented facts remain
- [ ] Verify `docs/design/decisions.md` ADR-011 is unchanged (full target design preserved there)
- [ ] Spot-check corrected numbers against source (`src/memory/indexer.ts:14-15` weights, `src/gateway/skills/script-evaluator.ts` pattern count)