### PR TITLE
refactor(dp): replace manage_checklist tool with system-event-driven checklist

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -195,7 +195,7 @@ For claude-sdk brain: raw server config is passed to the SDK's native MCP suppor
 4. Loads MCP tools from external servers
 5. Initializes the chosen brain (pi-agent or claude-sdk) with the assembled tools and system prompt
 6. For pi-agent: initializes memory indexer, loads extensions (context pruning, memory flush, deep investigation)
-7. For claude-sdk: adds deep investigation tools (manage_checklist, propose_hypotheses, end_investigation), starts LLM proxy if needed
+7. For claude-sdk: adds deep investigation tools (propose_hypotheses, end_investigation), starts LLM proxy if needed
 
 ## 4. Tool System
 
@@ -233,7 +233,6 @@ All tools are TypeBox `ToolDefinition` objects with structured input schemas and
 | Tool | File | Description |
 |------|------|-------------|
 | `deep_search` | `deep-search/tool.ts` | Structured hypothesis-driven investigation (see Section 5) |
-| `manage_checklist` | `dp-tools.ts` | Update deep investigation phase statuses (claude-sdk only) |
 | `propose_hypotheses` | `dp-tools.ts` | Present hypotheses to user for confirmation (claude-sdk only) |
 | `end_investigation` | `dp-tools.ts` | Early termination of investigation (claude-sdk only) |
 | `manage_schedule` | `manage-schedule.ts` | CRUD for cron schedules. Queries Gateway's internal API |

--- a/skills/core/deep-investigation/SKILL.md
+++ b/skills/core/deep-investigation/SKILL.md
@@ -30,21 +30,23 @@ The following phases are a recommended structure. You may skip or merge phases
 when the situation calls for it — e.g., skip straight to deep_search if the user
 gives a clear direction, or end after triage if the answer is already apparent.
 
+Phase progress is tracked automatically by the system — you do not need to
+manage checklist state manually. The UI updates as the engine progresses
+through each phase.
+
 ### Phase 1: Quick Triage
 
 Gather environment context and confirm the problem exists.
 
-1. Call `manage_checklist` to mark `triage` as `in_progress`.
-2. Run targeted kubectl / diagnostic commands to confirm the symptom.
-3. Call `manage_checklist` to mark `triage` as `done` with a brief summary.
+1. Run targeted kubectl / diagnostic commands to confirm the symptom.
+2. Summarize findings.
 
 ### Phase 2: Propose Hypotheses
 
 Formulate 3-5 ranked hypotheses based on triage findings.
 
-1. Call `manage_checklist` to mark `hypotheses` as `in_progress`.
-2. Call `propose_hypotheses` tool with your formatted hypothesis list.
-3. In DP mode, this is a good point to pause for user input — the user may want
+1. Call `propose_hypotheses` tool with your formatted hypothesis list.
+2. In DP mode, this is a good point to pause for user input — the user may want
    to adjust hypotheses before committing to an expensive deep_search.
    If the user is actively engaged, wait for their confirmation.
    If the user gave a clear directive, you may proceed directly.
@@ -53,17 +55,14 @@ Formulate 3-5 ranked hypotheses based on triage findings.
 
 Validate hypotheses using parallel sub-agents.
 
-1. Call `manage_checklist` to mark `deep_search` as `in_progress`.
-2. Call `deep_search` tool with triageContext and the hypotheses.
-3. When deep_search completes, call `manage_checklist` to mark `deep_search` as `done`.
+1. Call `deep_search` tool with triageContext and the hypotheses.
+2. The system automatically tracks phase progress in the UI.
 
 ### Phase 4: Present Findings
 
 Synthesize the deep_search results into a conclusion.
 
-1. Call `manage_checklist` to mark `conclusion` as `in_progress`.
-2. Write a clear conclusion with root cause analysis and recommendations.
-3. Call `manage_checklist` to mark `conclusion` as `done`.
+1. Write a clear conclusion with root cause analysis and recommendations.
 
 ### Phase 5: Feedback (optional)
 
@@ -79,7 +78,6 @@ If the user confirms, corrects, or rejects the diagnosis:
 
 | Tool | Purpose |
 |------|---------|
-| `manage_checklist` | Update checklist progress (items: triage, hypotheses, deep_search, conclusion) |
 | `propose_hypotheses` | Present hypotheses to the user — a communication tool for aligning investigation direction |
 | `deep_search` | Launch parallel sub-agent validation of hypotheses |
 | `end_investigation` | End early — auto-skips remaining phases |
@@ -90,7 +88,6 @@ If the user confirms, corrects, or rejects the diagnosis:
 1. **Use propose_hypotheses for communication**: Always use the tool (not plain text) to present hypotheses — it renders a proper UI card. Think of it as a way to align with the user on investigation direction, not as a mandatory gate.
 2. **Be cost-aware with deep_search**: It launches parallel sub-agents consuming 30-60 tool calls. When the investigation direction is uncertain, use propose_hypotheses to get alignment first.
 3. **Avoid redundant validation**: Let deep_search handle hypothesis validation with its parallel sub-agents. Running the same checks manually is inefficient.
-4. **Use DP-specific tools during DP mode**: Prefer `manage_checklist` over `task_plan` during deep investigation to keep the checklist UI consistent.
 
 ## Early Exit
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -326,6 +326,26 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
           progress: event,
         });
       }
+      // Sync phase events to SDK brain's dpState so the auto-continue loop
+      // sees correct phase progression without relying on LLM tool calls.
+      if (managed.dpState?.checklist) {
+        const ev = event as Record<string, unknown>;
+        if (ev.type === "phase") {
+          const phaseStr = ev.phase as string;
+          const m = phaseStr.match(/(\d+)/);
+          const phaseNum = m ? parseInt(m[1], 10) : 0;
+          if (phaseNum >= 1) {
+            const items = managed.dpState.checklist.items;
+            for (let i = 0; i < items.length; i++) {
+              if (i < phaseNum - 1 && items[i].status !== "done" && items[i].status !== "skipped") {
+                items[i].status = "done";
+              } else if (i === phaseNum - 1 && items[i].status !== "done" && items[i].status !== "skipped") {
+                items[i].status = "in_progress";
+              }
+            }
+          }
+        }
+      }
     };
     deepSearchEvents.on("progress", deepProgressBufHandler);
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -339,10 +339,12 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       }
       // Sync phase events to SDK brain's dpState so the auto-continue loop
       // sees correct phase progression without relying on LLM tool calls.
-      if (managed.dpState?.checklist) {
+      // Guard with _promptDone to avoid stale events mutating state after completion.
+      if (!managed._promptDone && managed.dpState?.checklist) {
         const ev = event as Record<string, unknown>;
         if (ev.type === "phase") {
-          const phaseNum = parsePhaseNum(ev.phase as string);
+          const phaseStr = typeof ev.phase === "string" ? ev.phase : "";
+          const phaseNum = parsePhaseNum(phaseStr);
           if (phaseNum >= 1) {
             applyPhaseToChecklist(managed.dpState.checklist.items, phaseNum);
           }

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -14,7 +14,7 @@ import type { SessionMode } from "../core/agent-factory.js";
 import type { BrainType } from "../core/brain-session.js";
 import { hasOpenAIProvider, ensureProxy } from "../core/llm-proxy.js";
 import { deepSearchEvents } from "../tools/deep-search/events.js";
-import { createChecklist, buildActivationMessage } from "../tools/dp-tools.js";
+import { createChecklist, buildActivationMessage, applyPhaseToChecklist, parsePhaseNum } from "../tools/dp-tools.js";
 import { loadConfig } from "../core/config.js";
 import { emitDiagnostic } from "../shared/diagnostic-events.js";
 import { checkMetricsAuth } from "../shared/metrics.js"; // also registers metrics subscriber (side-effect)
@@ -315,6 +315,17 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       if (!managed._promptDone) {
         managed._eventBuffer.push(event);
       }
+      // Null dpState.checklist when deep_search completes — this is the exit signal
+      // for the SDK brain's auto-continue loop in claude-sdk-brain.ts.
+      const ev = event as Record<string, unknown>;
+      if (ev.type === "tool_execution_end" && managed.dpState?.checklist) {
+        // Find the matching tool_execution_start to get toolName
+        // (tool_execution_end doesn't carry toolName directly in all brain types)
+        const toolName = (ev.toolName as string) ?? "";
+        if (toolName === "deep_search") {
+          managed.dpState.checklist = null;
+        }
+      }
     });
 
     // Also buffer deep_search progress events (same stream as session events)
@@ -331,18 +342,9 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       if (managed.dpState?.checklist) {
         const ev = event as Record<string, unknown>;
         if (ev.type === "phase") {
-          const phaseStr = ev.phase as string;
-          const m = phaseStr.match(/(\d+)/);
-          const phaseNum = m ? parseInt(m[1], 10) : 0;
+          const phaseNum = parsePhaseNum(ev.phase as string);
           if (phaseNum >= 1) {
-            const items = managed.dpState.checklist.items;
-            for (let i = 0; i < items.length; i++) {
-              if (i < phaseNum - 1 && items[i].status !== "done" && items[i].status !== "skipped") {
-                items[i].status = "done";
-              } else if (i === phaseNum - 1 && items[i].status !== "done" && items[i].status !== "skipped") {
-                items[i].status = "in_progress";
-              }
-            }
+            applyPhaseToChecklist(managed.dpState.checklist.items, phaseNum);
           }
         }
       }

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -35,7 +35,6 @@ import { createDeepSearchTool, type MemoryRef } from "../tools/deep-search/tool.
 import { createInvestigationFeedbackTool } from "../tools/investigation-feedback.js";
 import {
   type DpState,
-  createManageChecklistTool,
   createProposeHypothesesTool,
   createEndInvestigationTool,
   getDpWorkflow,
@@ -513,7 +512,6 @@ export async function createSiclawSession(
     // DP tools for SDK brain — mutable state shared with http-server via dpState ref
     const dpState: DpState = { checklist: null };
     sdkTools.push(
-      createManageChecklistTool(dpState),
       createProposeHypothesesTool(dpState),
       createEndInvestigationTool(dpState),
     );

--- a/src/core/extensions/deep-investigation.ts
+++ b/src/core/extensions/deep-investigation.ts
@@ -13,11 +13,11 @@ import { FEEDBACK_SIGNALS, type FeedbackStatus } from "../../memory/types.js";
 
 
 /**
- * Deep Investigation extension — externalized checklist mode.
+ * Deep Investigation extension — system-event-driven checklist.
  *
- * Replaces the former Phase A→B→C→D state machine with an Azure-style
- * externalized checklist. The model manages its own progress via the
- * `manage_checklist` tool; there are no phase gates or structural signals.
+ * Phase progress is driven by deterministic engine events (Phase 1/4 ~ 4/4)
+ * from the deep_search tool, not by LLM tool calls. The frontend maps these
+ * phase events to checklist item statuses.
  *
  * Entry points:
  * - `/dp [question]` command
@@ -342,72 +342,6 @@ export default function deepInvestigationExtension(api: ExtensionAPI, memoryRef?
     },
   });
 
-  // --- manage_checklist tool: model manages its own progress (batch add/update/remove) ---
-
-  function executeManageChecklist(
-    params: {
-      updates?: Array<{ id: string; status?: string; summary?: string }>;
-    },
-    ctx: ExtensionContext,
-  ): { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> } {
-    if (!checklist) {
-      checklist = createChecklist("");
-    }
-
-    const results: string[] = [];
-
-    if (params.updates && params.updates.length > 0) {
-      for (const upd of params.updates) {
-        const found = checklist.items.find((i) => i.id === upd.id);
-        if (!found) {
-          results.push(`update ${upd.id}: not found`);
-          continue;
-        }
-        if (upd.status) found.status = upd.status as ChecklistItemStatus;
-        if (upd.summary) found.summary = upd.summary;
-        results.push(`update ${upd.id}: ${upd.status ?? "ok"}`);
-      }
-    }
-
-    persistState();
-    if (ctx.hasUI) updateStatus(ctx);
-
-    // Auto-exit DP mode when conclusion is marked done (workflow complete)
-    const conclusionItem = checklist.items.find((i) => i.id === "conclusion");
-    if (conclusionItem?.status === "done") {
-      disableDpMode(ctx);
-    }
-
-    return {
-      content: [{ type: "text" as const, text: results.length > 0 ? results.join("; ") : "No operations specified." }],
-      details: {},
-    };
-  }
-
-  api.registerTool({
-    name: "manage_checklist",
-    label: "Manage Investigation Checklist",
-    description:
-      "Update checklist item status during deep investigation. " +
-      "Supports batch updates in one call. Items: triage, hypotheses, deep_search, conclusion.",
-    parameters: Type.Object({
-      updates: Type.Array(Type.Object({
-        id: Type.String({ description: "Checklist item id: triage | hypotheses | deep_search | conclusion" }),
-        status: Type.Optional(Type.Union([
-          Type.Literal("pending"),
-          Type.Literal("in_progress"),
-          Type.Literal("done"),
-          Type.Literal("skipped"),
-        ], { description: "New status" })),
-        summary: Type.Optional(Type.String({ description: "Brief summary (1-2 sentences)" })),
-      })),
-    }),
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      return executeManageChecklist(params as any, ctx);
-    },
-  });
-
-
   // --- end_investigation tool: early termination ---
 
   api.registerTool({
@@ -415,8 +349,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI, memoryRef?
     label: "End Investigation",
     description:
       "End the current deep investigation early with a single call. " +
-      "Automatically marks ALL remaining pending phases as skipped and exits DP mode. " +
-      "Do NOT manually skip phases via manage_checklist — use this tool instead.\n" +
+      "Automatically marks ALL remaining pending phases as skipped and exits DP mode.\n" +
       "Use when: 1) User confirms triage is sufficient (MUST ask first) " +
       "2) User explicitly requests to stop/terminate.",
     parameters: Type.Object({
@@ -639,9 +572,8 @@ export default function deepInvestigationExtension(api: ExtensionAPI, memoryRef?
   });
 
   // --- agent_end: no backend safety-net ---
-  // The model owns checklist state via manage_checklist. If it forgets to mark
-  // items done, that's accurately reflected. Tool guards (gate, dpActive) protect
-  // against harmful actions. Frontend handles visual cleanup on prompt_done.
+  // Checklist state is driven by system events (phase progress from deep_search engine).
+  // Frontend handles visual cleanup on prompt_done.
 
   // --- tool_call: progress rendering setup (no auto-mark) ---
 
@@ -674,9 +606,13 @@ export default function deepInvestigationExtension(api: ExtensionAPI, memoryRef?
       const details = event.details as Record<string, unknown> | undefined;
       pendingFeedbackId = (details?.investigationId as string) ?? null;
 
-      // Standalone deep_search (no DP mode): show feedback immediately since
-      // disableDpMode() won't fire. Guard with !checklist to avoid double-prompting.
-      if (!checklist) {
+      // Auto-exit DP mode when deep_search completes (replaces old manage_checklist conclusion trigger).
+      // The agent will present findings as its next assistant message; DP mode is no longer needed.
+      if (checklist) {
+        disableDpMode(ctx);
+      } else {
+        // Standalone deep_search (no DP mode): show feedback immediately since
+        // disableDpMode() won't fire.
         showFeedbackIfNeeded(ctx);
       }
     }

--- a/src/core/extensions/deep-investigation.ts
+++ b/src/core/extensions/deep-investigation.ts
@@ -165,6 +165,7 @@ export default function deepInvestigationExtension(api: ExtensionAPI, memoryRef?
   let pendingFeedbackId: string | null = null;
   let deepSearchRan = false;
   let feedbackCleanup: (() => void) | null = null;
+  let pendingDpExit = false; // deferred exit: set on deep_search completion, consumed on agent_end
 
   // --- Progress rendering state ---
   let activeUI: ExtensionUIContext | null = null;
@@ -571,9 +572,15 @@ export default function deepInvestigationExtension(api: ExtensionAPI, memoryRef?
     updateStatus(ctx);
   });
 
-  // --- agent_end: no backend safety-net ---
-  // Checklist state is driven by system events (phase progress from deep_search engine).
-  // Frontend handles visual cleanup on prompt_done.
+  // --- agent_end: consume deferred DP exit ---
+  // deep_search sets pendingDpExit; we wait until agent_end so the model can
+  // present its conclusion before disableDpMode triggers the feedback prompt.
+  api.on("agent_end", (_event, ctx) => {
+    if (pendingDpExit) {
+      pendingDpExit = false;
+      disableDpMode(ctx);
+    }
+  });
 
   // --- tool_call: progress rendering setup (no auto-mark) ---
 
@@ -606,10 +613,11 @@ export default function deepInvestigationExtension(api: ExtensionAPI, memoryRef?
       const details = event.details as Record<string, unknown> | undefined;
       pendingFeedbackId = (details?.investigationId as string) ?? null;
 
-      // Auto-exit DP mode when deep_search completes (replaces old manage_checklist conclusion trigger).
-      // The agent will present findings as its next assistant message; DP mode is no longer needed.
+      // Defer DP exit to agent_end so the agent can present its conclusion first.
+      // disableDpMode triggers showFeedbackIfNeeded — firing it here would flash
+      // the feedback prompt before the conclusion message appears.
       if (checklist) {
-        disableDpMode(ctx);
+        pendingDpExit = true;
       } else {
         // Standalone deep_search (no DP mode): show feedback immediately since
         // disableDpMode() won't fire.

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -461,34 +461,37 @@ export function usePilot() {
                     const isError = payload.isError as boolean | undefined;
                     // Use real DB message ID if available (enables metadata persistence)
                     const dbMessageId = payload.dbMessageId as string | undefined;
+                    // Check toolName before entering setMessages to avoid side effects
+                    // inside the state updater (React StrictMode calls updaters twice).
+                    const endedToolName = payload.toolName as string | undefined;
+                    // When deep_search completes, mark all remaining checklist items
+                    // as done and auto-clear after 3s. This replaces the old
+                    // manage_checklist(conclusion=done) trigger.
+                    if (endedToolName === 'deep_search') {
+                        setDpChecklist(prev => {
+                            if (!prev) return prev;
+                            return prev.map(i =>
+                                i.status === 'pending' || i.status === 'in_progress'
+                                    ? { ...i, status: 'done' as const }
+                                    : i
+                            );
+                        });
+                        setDpFocus(null);
+                        dpTimeout(() => resetDpState(), 3000);
+                        dpTimeout(() => {
+                            setInvestigationProgress(prev => {
+                                if (prev && prev.hypotheses.every(h =>
+                                    h.status !== 'validating' && h.status !== 'pending'
+                                )) {
+                                    return null;
+                                }
+                                return prev;
+                            });
+                        }, 5000);
+                    }
                     setMessages(prev => {
                         const last = prev[prev.length - 1];
                         if (last?.role === 'tool' && last.isStreaming) {
-                            // When deep_search completes, mark all remaining checklist items
-                            // as done and auto-clear after 3s. This replaces the old
-                            // manage_checklist(conclusion=done) trigger.
-                            if (last.toolName === 'deep_search') {
-                                setDpChecklist(prev => {
-                                    if (!prev) return prev;
-                                    return prev.map(i =>
-                                        i.status === 'pending' || i.status === 'in_progress'
-                                            ? { ...i, status: 'done' as const }
-                                            : i
-                                    );
-                                });
-                                setDpFocus(null);
-                                dpTimeout(() => resetDpState(), 3000);
-                                dpTimeout(() => {
-                                    setInvestigationProgress(prev => {
-                                        if (prev && prev.hypotheses.every(h =>
-                                            h.status !== 'validating' && h.status !== 'pending'
-                                        )) {
-                                            return null;
-                                        }
-                                        return prev;
-                                    });
-                                }, 5000);
-                            }
                             return [
                                 ...prev.slice(0, -1),
                                 {
@@ -517,14 +520,15 @@ export function usePilot() {
                         // Phase mapping logic mirrors applyPhaseToChecklist() in dp-tools.ts
                         // and restoreDpProgress below. Keep all three in sync.
                         if (progress.type === 'phase') {
-                            const phaseStr = progress.phase as string;
+                            const phaseStr = typeof progress.phase === 'string' ? progress.phase : '';
                             const m = phaseStr.match(/(\d+)/);
                             const phaseNum = m ? parseInt(m[1], 10) : 0;
                             if (phaseNum >= 1) {
                                 setDpChecklist(prev => {
-                                    const items: DpChecklistItem[] = prev
-                                        ? prev.map(i => ({ ...i }))
-                                        : createDefaultDpChecklist();
+                                    // Only update existing checklist — don't create one for
+                                    // standalone deep_search (no DP mode active).
+                                    if (!prev) return prev;
+                                    const items: DpChecklistItem[] = prev.map(i => ({ ...i }));
                                     for (let i = 0; i < items.length; i++) {
                                         if (i < phaseNum - 1) {
                                             // Forward-only: don't regress already-done items

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -417,7 +417,7 @@ export function usePilot() {
                     const toolName = payload.toolName as string | undefined;
                     const args = payload.args as Record<string, unknown> | undefined;
                     const toolInput = formatToolInput(toolName ?? '', args);
-                    const hidden = toolName === 'update_plan' || toolName === 'manage_checklist' || toolName === 'end_investigation';
+                    const hidden = toolName === 'update_plan' || toolName === 'end_investigation';
                     // Initialize investigation progress for deep_search (preserve optimistic state if present)
                     if (toolName === 'deep_search') {
                         setInvestigationProgress(prev => prev ?? { hypotheses: [] });
@@ -432,37 +432,6 @@ export function usePilot() {
                             return checklist;
                         });
                         setDpFocus(prev => prev ?? 'deep_search');
-                    }
-                    // Handle manage_checklist status updates
-                    if (toolName === 'manage_checklist') {
-                        const updates: Array<{ id: string; status?: string; summary?: string }> =
-                            (args?.updates as any[]) || [];
-
-                        setDpChecklist(prev => {
-                            const items: DpChecklistItem[] = prev
-                                ? prev.map(i => ({ ...i }))
-                                : createDefaultDpChecklist();
-
-                            for (const upd of updates) {
-                                const item = items.find(i => i.id === upd.id);
-                                if (!item) continue;
-                                if (upd.status && (upd.status === 'done' || upd.status === 'skipped' || upd.status === 'in_progress' || upd.status === 'pending')) {
-                                    item.status = upd.status;
-                                }
-                                if (upd.summary) item.summary = upd.summary;
-                            }
-
-                            // Derive dpFocus: first in_progress item
-                            const focus = items.find(i => i.status === 'in_progress');
-                            setDpFocus(focus ? focus.id : null);
-
-                            // Auto-clear checklist when all steps are done
-                            const allDone = items.every(i => i.status === 'done' || i.status === 'skipped');
-                            if (allDone) {
-                                dpTimeout(() => resetDpState(), 3000);
-                            }
-                            return items;
-                        });
                     }
                     // Handle end_investigation: immediately reset all DP state
                     if (toolName === 'end_investigation') {
@@ -495,9 +464,21 @@ export function usePilot() {
                     setMessages(prev => {
                         const last = prev[prev.length - 1];
                         if (last?.role === 'tool' && last.isStreaming) {
-                            // Delayed clear of investigation progress — let DpChecklistCard show final state.
-                            // Definitive clear happens on manage_checklist(deep_search, done).
+                            // When deep_search completes, mark all remaining checklist items
+                            // as done and auto-clear after 3s. This replaces the old
+                            // manage_checklist(conclusion=done) trigger.
                             if (last.toolName === 'deep_search') {
+                                setDpChecklist(prev => {
+                                    if (!prev) return prev;
+                                    const items = prev.map(i =>
+                                        i.status === 'pending' || i.status === 'in_progress'
+                                            ? { ...i, status: 'done' as const }
+                                            : i
+                                    );
+                                    dpTimeout(() => resetDpState(), 3000);
+                                    return items;
+                                });
+                                setDpFocus(null);
                                 dpTimeout(() => {
                                     setInvestigationProgress(prev => {
                                         if (prev && prev.hypotheses.every(h =>
@@ -533,6 +514,34 @@ export function usePilot() {
                             const state = prev ?? { hypotheses: [] };
                             return reduceInvestigationProgress(state, progress);
                         });
+                        // Map engine phase events to dpChecklist (system-driven, not LLM-driven)
+                        if (progress.type === 'phase') {
+                            const phaseStr = progress.phase as string;
+                            const m = phaseStr.match(/(\d+)/);
+                            const phaseNum = m ? parseInt(m[1], 10) : 0;
+                            if (phaseNum >= 1) {
+                                setDpChecklist(prev => {
+                                    const items: DpChecklistItem[] = prev
+                                        ? prev.map(i => ({ ...i }))
+                                        : createDefaultDpChecklist();
+                                    for (let i = 0; i < items.length; i++) {
+                                        if (i < phaseNum - 1) {
+                                            // Forward-only: don't regress already-done items
+                                            if (items[i].status !== 'done' && items[i].status !== 'skipped') {
+                                                items[i].status = 'done';
+                                            }
+                                        } else if (i === phaseNum - 1) {
+                                            if (items[i].status !== 'done' && items[i].status !== 'skipped') {
+                                                items[i].status = 'in_progress';
+                                            }
+                                        }
+                                    }
+                                    const focus = items.find(i => i.status === 'in_progress');
+                                    setDpFocus(focus ? focus.id : null);
+                                    return items;
+                                });
+                            }
+                        }
                     }
                     break;
                 }

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -470,15 +470,14 @@ export function usePilot() {
                             if (last.toolName === 'deep_search') {
                                 setDpChecklist(prev => {
                                     if (!prev) return prev;
-                                    const items = prev.map(i =>
+                                    return prev.map(i =>
                                         i.status === 'pending' || i.status === 'in_progress'
                                             ? { ...i, status: 'done' as const }
                                             : i
                                     );
-                                    dpTimeout(() => resetDpState(), 3000);
-                                    return items;
                                 });
                                 setDpFocus(null);
+                                dpTimeout(() => resetDpState(), 3000);
                                 dpTimeout(() => {
                                     setInvestigationProgress(prev => {
                                         if (prev && prev.hypotheses.every(h =>
@@ -514,7 +513,9 @@ export function usePilot() {
                             const state = prev ?? { hypotheses: [] };
                             return reduceInvestigationProgress(state, progress);
                         });
-                        // Map engine phase events to dpChecklist (system-driven, not LLM-driven)
+                        // Map engine phase events to dpChecklist (system-driven, not LLM-driven).
+                        // Phase mapping logic mirrors applyPhaseToChecklist() in dp-tools.ts
+                        // and restoreDpProgress below. Keep all three in sync.
                         if (progress.type === 'phase') {
                             const phaseStr = progress.phase as string;
                             const m = phaseStr.match(/(\d+)/);
@@ -1171,6 +1172,8 @@ export function usePilot() {
             // Always create dpChecklist when prompt is active, even without events.
             // Without this, a page refresh during deep_search shows the bare
             // InvestigationCard (no progress bars) instead of DpChecklistCard.
+            // Phase mapping mirrors applyPhaseToChecklist() in dp-tools.ts
+            // and the tool_progress handler above. Keep all three in sync.
             const phase = state.phase;
             const checklist = createDefaultDpChecklist();
             const phaseNum = phase ? parseInt(phase.match(/(\d+)/)?.[1] ?? '0') : 0;

--- a/src/tools/dp-tools.ts
+++ b/src/tools/dp-tools.ts
@@ -51,6 +51,32 @@ export function createChecklist(question: string): DpChecklist {
   };
 }
 
+/**
+ * Apply a phase number (1-4) to checklist items.
+ * Forward-only: items already done/skipped are not regressed.
+ * Phase mapping: 1→triage, 2→hypotheses, 3→deep_search, 4→conclusion
+ * (coupled to createChecklist() item order at indices 0-3).
+ */
+export function applyPhaseToChecklist(items: ChecklistItem[], phaseNum: number): void {
+  for (let i = 0; i < items.length; i++) {
+    if (i < phaseNum - 1) {
+      if (items[i].status !== "done" && items[i].status !== "skipped") {
+        items[i].status = "done";
+      }
+    } else if (i === phaseNum - 1) {
+      if (items[i].status !== "done" && items[i].status !== "skipped") {
+        items[i].status = "in_progress";
+      }
+    }
+  }
+}
+
+/** Parse phase number from engine phase string (e.g. "Phase 3/4" → 3). Returns 0 if unparseable. */
+export function parsePhaseNum(phaseStr: string): number {
+  const m = phaseStr.match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
 // --- Load SKILL.md workflow (one-time, at module init) ---
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/src/tools/dp-tools.ts
+++ b/src/tools/dp-tools.ts
@@ -76,63 +76,6 @@ export function buildActivationMessage(question: string): string {
 // --- Tool factories (for SDK brain) ---
 
 /**
- * Create the manage_checklist tool.
- * Updates checklist item statuses. When conclusion is marked done,
- * automatically disables DP mode.
- */
-export function createManageChecklistTool(dpState: DpState): ToolDefinition {
-  return {
-    name: "manage_checklist",
-    label: "Manage Investigation Checklist",
-    description:
-      "Update checklist item status during deep investigation. " +
-      "Supports batch updates in one call. Items: triage, hypotheses, deep_search, conclusion.",
-    parameters: Type.Object({
-      updates: Type.Array(Type.Object({
-        id: Type.String({ description: "Checklist item id: triage | hypotheses | deep_search | conclusion" }),
-        status: Type.Optional(Type.Union([
-          Type.Literal("pending"),
-          Type.Literal("in_progress"),
-          Type.Literal("done"),
-          Type.Literal("skipped"),
-        ], { description: "New status" })),
-        summary: Type.Optional(Type.String({ description: "Brief summary (1-2 sentences)" })),
-      })),
-    }),
-    async execute(_toolCallId, params) {
-      if (!dpState.checklist) {
-        dpState.checklist = createChecklist("");
-      }
-
-      const { updates } = params as { updates: Array<{ id: string; status?: string; summary?: string }> };
-      const results: string[] = [];
-
-      for (const upd of updates) {
-        const found = dpState.checklist.items.find((i) => i.id === upd.id);
-        if (!found) {
-          results.push(`update ${upd.id}: not found`);
-          continue;
-        }
-        if (upd.status) found.status = upd.status as ChecklistItemStatus;
-        if (upd.summary) found.summary = upd.summary;
-        results.push(`update ${upd.id}: ${upd.status ?? "ok"}`);
-      }
-
-      // Auto-cleanup when conclusion is marked done
-      const conclusionItem = dpState.checklist.items.find((i) => i.id === "conclusion");
-      if (conclusionItem?.status === "done") {
-        dpState.checklist = null;
-      }
-
-      return {
-        content: [{ type: "text" as const, text: results.length > 0 ? results.join("; ") : "No operations specified." }],
-        details: {},
-      };
-    },
-  };
-}
-
-/**
  * Create the propose_hypotheses tool.
  * Non-blocking: shows hypotheses to user and immediately proceeds to deep_search.
  */
@@ -214,8 +157,7 @@ export function createEndInvestigationTool(dpState: DpState): ToolDefinition {
     label: "End Investigation",
     description:
       "End the current deep investigation early with a single call. " +
-      "Automatically marks ALL remaining pending phases as skipped and exits DP mode. " +
-      "Do NOT manually skip phases via manage_checklist — use this tool instead.\n" +
+      "Automatically marks ALL remaining pending phases as skipped and exits DP mode.\n" +
       "Use when: 1) User confirms triage is sufficient (MUST ask first) " +
       "2) User explicitly requests to stop/terminate.",
     parameters: Type.Object({


### PR DESCRIPTION
## Problem

The DP checklist UI was driven by LLM `manage_checklist` tool calls. This is fundamentally fragile:
- **K8s production failure**: Kimi-K2.5 sent `"completed"` instead of `"done"`, schema validation failed 3 times, checklist never updated
- Different models have different tool-calling behavior — UI reliability depended on LLM correctness
- The `deep_search` engine already emits deterministic phase events (`Phase 1/4` ~ `Phase 4/4`), but the frontend wasn't using them to drive the checklist

## Solution

Remove `manage_checklist` tool entirely. Frontend checklist is now driven by the engine's `tool_progress` phase events.

**Backend (3 files):**
- `dp-tools.ts`: Remove `createManageChecklistTool` function, keep all shared types
- `agent-factory.ts`: Remove import and registration
- `deep-investigation.ts` (pi-agent extension): Remove tool registration + `executeManageChecklist` helper, add auto-exit DP mode when `deep_search` completes

**Frontend (1 file):**
- `usePilot.ts`: Delete `manage_checklist` handler, add phase→checklist mapping in `tool_progress` handler (forward-only guard), auto-complete all items + 3s auto-clear when `deep_search` ends

**SDK brain bridge (1 file):**
- `http-server.ts`: Sync phase events to `dpState.checklist` so the auto-continue loop sees correct phase state

**Docs (2 files):**
- `SKILL.md`: Remove all `manage_checklist` references, simplify phase instructions
- `architecture.md`: Remove from tool table

**Backward compat:** Old session history with `manage_checklist` messages are still hidden via `mapMessages` check.

**Net: -99 lines** (90 insertions, 189 deletions)

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 970/970 passed
- [x] `grep -r manage_checklist` — only backward compat + comments remain
- [x] Local E2E: Kimi-K2.5 deep investigation completed without manage_checklist calls, agent finished normally
- [ ] Manual E2E: verify 4 phases update in real-time in Web UI (no page refresh needed)
- [ ] Manual E2E: verify page refresh during Phase 3 restores checklist correctly