### PR TITLE
fix(deep-search): catch Phase 1 sub-agent timeout to prevent investigation failure

### DIFF
--- a/src/tools/deep-search/engine.ts
+++ b/src/tools/deep-search/engine.ts
@@ -394,16 +394,25 @@ export async function investigate(
   } else {
     onProgress?.({ type: "phase", phase: "Phase 1/4", detail: "Gathering context..." });
     const contextPrompt = contextGatheringPrompt(question, budget.maxContextCalls, kubeconfigPath);
-    const contextResult = await runSubAgent(
-      contextPrompt,
-      question,
-      budget.maxContextCalls,
-      options,
-      onProgress,
-      forceContextSummaryPrompt(),
-    );
-    globalCallsUsed += contextResult.callsUsed;
-    contextSummary = parseContextSummary(contextResult.textOutput);
+    try {
+      const contextResult = await runSubAgent(
+        contextPrompt,
+        question,
+        budget.maxContextCalls,
+        options,
+        onProgress,
+        forceContextSummaryPrompt(),
+      );
+      globalCallsUsed += contextResult.callsUsed;
+      contextSummary = parseContextSummary(contextResult.textOutput);
+    } catch (err) {
+      // Phase 1 sub-agent timed out or crashed — fall back to question as context
+      // so Phases 2-4 can still proceed with degraded quality.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[deep-search] Phase 1 context gathering failed: ${msg}`);
+      onProgress?.({ type: "phase", phase: "Phase 1/4", detail: `Context gathering failed (${msg}), proceeding with question only` });
+      contextSummary = `Context gathering failed. Original question: ${question}`;
+    }
   }
 
   // --- Prior Investigation Retrieval (3-layer: patterns + similar + validated hypotheses) ---

--- a/src/tools/deep-search/engine.ts
+++ b/src/tools/deep-search/engine.ts
@@ -408,9 +408,12 @@ export async function investigate(
     } catch (err) {
       // Phase 1 sub-agent timed out or crashed — fall back to question as context
       // so Phases 2-4 can still proceed with degraded quality.
+      // Charge the full Phase 1 budget conservatively — the sub-agent may have
+      // consumed calls before throwing, but we can't know the exact count.
+      globalCallsUsed += budget.maxContextCalls;
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[deep-search] Phase 1 context gathering failed: ${msg}`);
-      onProgress?.({ type: "phase", phase: "Phase 1/4", detail: `Context gathering failed (${msg}), proceeding with question only` });
+      onProgress?.({ type: "phase", phase: "Phase 1/4", detail: `Context gathering failed (${msg.slice(0, 120)}), proceeding with question only` });
       contextSummary = `Context gathering failed. Original question: ${question}`;
     }
   }

--- a/src/tools/deep-search/sub-agent.ts
+++ b/src/tools/deep-search/sub-agent.ts
@@ -395,19 +395,21 @@ export async function runSubAgent(
 
   const SUB_AGENT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+  let raceTimer: ReturnType<typeof setTimeout> | undefined;
   try {
     // Run the investigation with a timeout to prevent indefinite hangs
     await Promise.race([
       session.prompt(userMessage),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Sub-agent timed out after 5 minutes")), SUB_AGENT_TIMEOUT_MS),
-      ),
+      new Promise<never>((_, reject) => {
+        raceTimer = setTimeout(() => reject(new Error("Sub-agent timed out after 5 minutes")), SUB_AGENT_TIMEOUT_MS);
+      }),
     ]);
   } finally {
     // Mark finished first — guards against events from abort/dispose
     sessionFinished = true;
 
-    // Clear abort timer if it hasn't fired
+    // Clear timers to prevent leaked rejections after successful completion
+    if (raceTimer) clearTimeout(raceTimer);
     if (abortTimer) clearTimeout(abortTimer);
 
     // Unsubscribe from events before dispose to prevent orphan events

--- a/src/tools/deep-search/sub-agent.ts
+++ b/src/tools/deep-search/sub-agent.ts
@@ -396,12 +396,19 @@ export async function runSubAgent(
   const SUB_AGENT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
   let raceTimer: ReturnType<typeof setTimeout> | undefined;
+  let timedOutByRace = false;
+  let finalText = "";
+  let trace: TraceStep[] = [];
+
   try {
     // Run the investigation with a timeout to prevent indefinite hangs
     await Promise.race([
       session.prompt(userMessage),
       new Promise<never>((_, reject) => {
-        raceTimer = setTimeout(() => reject(new Error("Sub-agent timed out after 5 minutes")), SUB_AGENT_TIMEOUT_MS);
+        raceTimer = setTimeout(() => {
+          timedOutByRace = true;
+          reject(new Error("Sub-agent timed out after 5 minutes"));
+        }, SUB_AGENT_TIMEOUT_MS);
       }),
     ]);
   } finally {
@@ -414,15 +421,21 @@ export async function runSubAgent(
 
     // Unsubscribe from events before dispose to prevent orphan events
     unsubscribe();
+
+    // If timed out, abort the still-running session.prompt() to stop
+    // burning CPU/resources on a result nobody will read
+    if (timedOutByRace) {
+      session.abort().catch(() => {});
+    }
+
+    // Extract output before dispose — session state is cleared on dispose
+    finalText = extractTextFromMessages(session.state.messages);
+    trace = extractTrace(session.state.messages);
+
+    // Dispose session (removes internal listeners, frees resources)
+    // Now guaranteed to run on both success and error/timeout paths
+    session.dispose();
   }
-
-  // Extract final text and full trace from session messages
-  const sessionMessages = session.state.messages;
-  const finalText = extractTextFromMessages(sessionMessages);
-  const trace = extractTrace(sessionMessages);
-
-  // Dispose session (removes internal listeners, frees resources)
-  session.dispose();
 
   return { textOutput: finalText, evidence, callsUsed, trace };
 }


### PR DESCRIPTION
## Problem

When `deep_search` is called without `triageContext` (autonomous mode), Phase 1 launches a sub-agent to gather environment context. If this sub-agent exceeds the 5-minute timeout (`SUB_AGENT_TIMEOUT_MS`), the error bubbles up uncaught through `investigate()` to the tool layer's catch block, returning:

> Deep search failed: Sub-agent timed out after 5 minutes

This kills the entire investigation even though Phases 2-4 could still proceed with degraded context. The user initially sees streaming progress (hypothesis trees, phase events), but the final stored result is the timeout error — so revisiting the session shows a failed investigation.

**Reproduction**: Call `deep_search` with only `question` + `budget` (no `triageContext`), where the cluster has enough complexity that Phase 1 context gathering takes > 5 minutes.

## Root Cause

`engine.ts` L397: `runSubAgent()` for Phase 1 has no `try/catch`, unlike Phase 3 hypothesis validation (which catches sub-agent errors and marks hypotheses as inconclusive).

## Fix

Wrap Phase 1's `runSubAgent` in `try/catch`. On failure, fall back to using the question as minimal context so Phases 2-4 can still run.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 1004/1004 passed
- [ ] Manual: run `deep_search` without triageContext on a complex cluster, verify investigation completes even if Phase 1 times out