### PR TITLE
feat(feedback): add interactive session feedback system

### DIFF
--- a/skills/core/session-feedback/SKILL.md
+++ b/skills/core/session-feedback/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: session-feedback
+description: Interactive session feedback — reviews the diagnostic process with the user, identifies decision points, and saves structured feedback to improve diagnostic capabilities.
+tags: [feedback, meta, improvement]
+---
+
+# Session Feedback Protocol
+
+You are now conducting an interactive feedback review of the current diagnostic session. Follow these phases strictly.
+
+## Phase 1 — Review
+
+Based on the Session Diagnostic Timeline provided, summarize the diagnostic process:
+
+1. List key steps in chronological order
+2. For each step, note:
+   - What was decided / what action was taken
+   - Which tool or skill was used
+   - The outcome (success/error/partial)
+3. Present as a numbered list in the user's language
+
+Keep it concise — focus on decision points, not every single tool call.
+
+## Phase 2 — Interactive Evaluation
+
+Present these options to the user (numbered for easy selection):
+
+1. **Overall direction** — Was the investigation heading in the right direction?
+2. **A specific step** — Was a particular step wrong or suboptimal?
+3. **Missing checks** — Were important diagnostics skipped?
+4. **Conclusion accuracy** — Was the final diagnosis correct?
+5. **All good** — Satisfied with the session, nothing to change
+6. **Free input** — Other feedback
+
+After the user selects an option, drill deeper:
+- What specifically was wrong?
+- What would the ideal action have been?
+- How would you rate it (1-5)?
+
+The user can provide feedback on **multiple aspects** — after finishing one, ask if they want to discuss another.
+
+## Phase 3 — Report Generation
+
+Once the user is done providing feedback, synthesize a structured report:
+
+- **Strengths**: What the agent did well
+- **Improvements**: What should be done differently next time
+- **Decision Points**: Each evaluated step with `wasCorrect`, `comment`, `idealAction`
+- **Tags**: Categorize issues (e.g., `wrong-skill`, `slow-path`, `missing-check`, `correct-diagnosis`, `wrong-order`)
+- **Overall Rating**: 1-5 based on discussion
+
+Present the report to the user for confirmation. If they want changes, adjust accordingly.
+
+## Phase 4 — Save
+
+After user confirms the report, call the `save_feedback` tool with the structured data:
+
+```
+save_feedback({
+  overallRating: <1-5>,
+  summary: "<brief summary>",
+  decisionPoints: "<JSON array>",
+  strengths: "<JSON array>",
+  improvements: "<JSON array>",
+  tags: "<JSON array>",
+  feedbackConversation: "<JSON summary of this dialogue>"
+})
+```
+
+After saving, thank the user and confirm the feedback has been recorded.

--- a/skills/core/session-feedback/SKILL.md
+++ b/skills/core/session-feedback/SKILL.md
@@ -10,9 +10,24 @@ You are conducting an interactive feedback review of the current diagnostic sess
 
 **Language: Always follow the user's language (from their profile or recent messages). All output — phase titles, timeline, options, report — must be in the user's language.**
 
+## Phase 0 — Scope Selection
+
+Scan the conversation history and identify distinct tasks or investigations performed in this session. Summarize each as a one-liner with what was done and the outcome.
+
+- If **1 task**: state what will be reviewed and proceed directly to Phase 1.
+- If **2+ tasks**: present them as numbered options using `- **1.** label` format, most recent first. Let user pick which to review.
+
+Example (3 tasks in session):
+
+- **1.** Node NotReady diagnosis on roce-test — found 3 nodes down, RDMA config mismatch suspected
+- **2.** Pod crash loop analysis on envoy-gateway — identified OOM, suggested resource limits
+- **3.** Review entire session
+
+After user selects (or if only 1 task), proceed to Phase 1 scoped to that task only.
+
 ## Phase 1 — Compressed Timeline with Self-Reflection
 
-Analyze the Session Diagnostic Timeline and present a **compressed timeline** as a regular markdown numbered list (NOT a code block):
+Analyze the selected task's diagnostic steps and present a **compressed timeline** as a regular markdown numbered list (NOT a code block):
 
 **Compression rules:**
 - Group consecutive same-purpose tool calls into one line, marked with `(N steps)`
@@ -20,39 +35,67 @@ Analyze the Session Diagnostic Timeline and present a **compressed timeline** as
 - Decision points or anomalies get a `⚠️` with a brief self-reflection on what might be questionable
 - Target: **5-8 lines max**, regardless of how many raw steps exist
 
-Example (adapt to user's language, output as plain markdown list — never use code fences):
+Example (output as plain markdown list — never use code fences):
 
-1. 集群连接 — credential_list → 连接 roce-test ✓
-2. 组件扫描 (6 步) — pods/nodes/daemonsets → 发现 3 节点 NotReady ✓
-3. ⚠️ 网卡识别 — 从 ConfigMap tag 推断厂商，未在节点上验证
-4. 节点诊断 (4 步) — node_exec 尝试 → debug 镜像拉取失败
-5. ⚠️ 日志分析转向 — exporter 无设备 vs rdma-qos 60+ VF，数据矛盾
-6. 报告生成 ✓
+1. Cluster connect — credential_list → connected to roce-test ✓
+2. Component scan (6 steps) — pods/nodes/daemonsets → found 3 nodes NotReady ✓
+3. ⚠️ NIC detection — inferred vendor from ConfigMap tag, not verified on node
+4. Node diagnostics (4 steps) — node_exec attempt → debug image pull failed
+5. ⚠️ Log analysis pivot — exporter shows no devices vs rdma-qos 60+ VFs, data contradiction
+6. Report generation ✓
 
 After presenting, tell the user they can ask to expand any step by its number.
 
 ## Phase 2 — Interactive Evaluation
 
-Present options using **letters**, each on its own line:
+Present feedback categories using **letters**, each on its own line:
 
-- **A.** 整体方向 — 调查路径是否正确？
-- **B.** 具体步骤 — 指出上面时间线的编号，或描述
-- **C.** 遗漏检查 — 有重要诊断被跳过？
-- **D.** 结论准确性 — 最终诊断是否正确？
-- **E.** 全部满意 — 直接生成报告
-- **F.** 其他意见
+- **A.** Overall direction — was the investigation path correct?
+- **B.** Specific steps — a particular step was problematic
+- **C.** Missing checks — important diagnostics were skipped
+- **D.** Conclusion accuracy — the final diagnosis was wrong or incomplete
+- **E.** All good — skip to report
+- **F.** Other comments
 
-(The above is a Chinese example. Translate to match the user's language.)
+**Funnel interaction — narrow step by step with structured choices:**
 
-**Rules:**
-- User selects a letter → ask ONE follow-up to get the details (what was wrong + what should have been done). Do NOT ask multiple questions one by one — let the user explain in their own words.
-- If user references a timeline number (e.g. "B 3"), expand that step's details from the raw timeline and discuss it.
-- After each feedback item, show a brief **running tally** (e.g. "已记录 2 项") and ask: **"继续 (选字母) 还是生成报告 (R)？"**
+When user selects a category (A–D), do NOT ask an open-ended question. Follow a 3-step funnel where every level presents clickable options.
+
+**Step 1 — Narrow the area:** Present 2-5 sub-options using `- **1.** label` numbered format, generated from the actual session content. Each sub-option should surface a specific **tension or trade-off** — frame it as a self-critical question worth examining, not a neutral label. Connect to ⚠️ self-reflection points from Phase 1 where possible. Always end with an "Other — describe" escape hatch.
+
+| Category | How to generate sub-options |
+|----------|----------------------------|
+| **A** | List major pivots from the timeline. Frame each as a tension: "did X but maybe should have Y" — e.g. "3 nodes NotReady but investigated RDMA config first — should node recovery have been the priority?" |
+| **B** | List timeline steps that had decisions or anomalies (⚠️ items first). Include what made each step questionable |
+| **C** | Infer 2-4 standard checks NOT performed, relevant to this diagnosis type. Frame as "didn't do X — could that have caught the issue earlier?" |
+| **D** | Offer: root cause completely wrong, partially right but missed key factor, right cause but wrong severity, conclusion was accurate |
+| **F** | Skip sub-options — ask user to describe freely |
+
+**Step 2 — What should have been done:** Present 2-4 concrete alternatives the agent could have taken (same `- **1.** label` format), plus "Other". If the sub-option is already an assessment (e.g. "direction was correct" or "conclusion was accurate"), record directly and skip to Step 3.
+
+**Step 3 — Record & continue:** Show a running tally (e.g. "Noted 2 items"), then re-list remaining categories (exclude already-discussed and E) plus report option, using `- **X.** label` format.
+
+Example — full funnel for category B:
+
+> Step 1 — user selected B, agent presents sub-options with tension:
+>
+> - **1.** Step 3 — inferred NIC vendor from ConfigMap tag alone — should have verified on node before building on that assumption?
+> - **2.** Step 5 — exporter said "no devices" but rdma-qos showed 60+ VFs — contradiction was noted but not resolved
+> - **3.** Other — describe the step
+>
+> Step 2 — user picked 1, agent presents alternatives:
+>
+> - **1.** Should have verified NIC model on node directly (SSH / node_exec)
+> - **2.** Should have cross-checked with lspci or driver logs
+> - **3.** This step was unnecessary — skip and check driver logs instead
+> - **4.** Other
+
+**Other rules:**
 - If user selects **E**, skip directly to Phase 3.
 - After **3 feedback items**, proactively suggest generating the report. Don't keep looping.
-- When user says anything like "没了", "done", "就这些", "R", or similar → move to Phase 3 immediately.
+- When user says "没了", "done", "就这些", "R", or similar → move to Phase 3 immediately.
 
-**Rating:** Do NOT ask per-item ratings. You will infer the overall rating in Phase 3 based on the severity of issues discussed.
+**Rating:** Do NOT ask per-item ratings. Infer the overall rating in Phase 3 based on severity of issues discussed.
 
 ## Phase 3 — Report Generation
 
@@ -64,7 +107,10 @@ Synthesize a structured report. Present it to the user for confirmation:
 - **Tags**: Categorize issues (e.g. `wrong-inference`, `missing-check`, `slow-path`, `wrong-order`, `correct-diagnosis`)
 - **Overall Rating**: Infer 1-5 based on the discussion (1=mostly wrong, 3=ok with gaps, 5=excellent)
 
-Ask user to confirm or request adjustments.
+Present two options using the same `- **X.** label` bullet format:
+
+- **Y.** Confirm & save
+- **N.** Request adjustments
 
 ## Phase 4 — Save
 

--- a/skills/core/session-feedback/SKILL.md
+++ b/skills/core/session-feedback/SKILL.md
@@ -8,20 +8,34 @@ tags: [feedback, meta, improvement]
 
 You are conducting an interactive feedback review of the current diagnostic session. Follow these phases. Be concise — don't over-ask.
 
-## Phase 1 — Review
+## Phase 1 — Compressed Timeline with Self-Reflection
 
-Summarize the diagnostic process based on the Session Diagnostic Timeline:
+Analyze the Session Diagnostic Timeline and present a **compressed timeline**:
 
-1. List key decision points in chronological order (not every tool call — focus on decisions)
-2. For each, note: what was decided, what tool/skill was used, the outcome
-3. Present as a numbered list in the user's language
+**Compression rules:**
+- Group consecutive same-purpose tool calls into one line, marked with `(N steps)`
+- Routine successful steps get `✓` and stay as one-liners
+- Decision points or anomalies get `⚠️` with a brief self-reflection on what might be questionable
+- Target: **5-8 lines max**, regardless of how many raw steps exist
+
+**Example format:**
+```
+1. Cluster connection — credential_list → connected to roce-test ✓
+2. Component scan (6 steps) — pods/nodes/daemonsets → found 3 nodes NotReady ✓
+3. ⚠️ NIC identification — inferred Broadcom from ConfigMap tag, did not verify on node
+4. Node diagnostics (4 steps) — node_exec attempts → debug image pull failed
+5. ⚠️ Log analysis pivot — exporter shows no devices vs rdma-qos shows 60+ VFs, contradictory
+6. Report generation ✓
+```
+
+After presenting, tell the user: **"If you want details on any compressed step, just mention its number."**
 
 ## Phase 2 — Interactive Evaluation
 
 Present options using **letters** (to avoid confusion with numeric ratings):
 
 > **A.** Overall direction — right track?
-> **B.** A specific step — wrong or suboptimal?
+> **B.** A specific step — pick a number from the timeline above, or describe it
 > **C.** Missing checks — important diagnostics skipped?
 > **D.** Conclusion accuracy — was the diagnosis correct?
 > **E.** All good — satisfied, nothing to change
@@ -29,6 +43,7 @@ Present options using **letters** (to avoid confusion with numeric ratings):
 
 **Rules:**
 - User selects a letter → ask ONE follow-up to get the details (what was wrong + what should have been done). Do NOT ask multiple questions one by one — let the user explain in their own words.
+- If user references a timeline number (e.g. "B 3"), expand that step's details from the raw timeline and discuss it.
 - After each feedback item, show a brief **running tally** (e.g. "Noted: 2 items so far") and ask: **"Continue (letter) or generate report (R)?"**
 - If user selects **E**, skip directly to Phase 3.
 - After **3 feedback items**, proactively suggest generating the report. Don't keep looping.

--- a/skills/core/session-feedback/SKILL.md
+++ b/skills/core/session-feedback/SKILL.md
@@ -10,18 +10,24 @@ You are conducting an interactive feedback review of the current diagnostic sess
 
 **Language: Always follow the user's language (from their profile or recent messages). All output — phase titles, timeline, options, report — must be in the user's language.**
 
+**Clickable options:** Whenever you present choices for the user, append this comment at the end of the message — it enables clickable chips in the web UI:
+`<!-- suggested-replies: KEY|Label, KEY|Label -->`
+The visible list format is flexible — write naturally. The comment is the machine contract.
+
 ## Phase 0 — Scope Selection
 
 Scan the conversation history and identify distinct tasks or investigations performed in this session. Summarize each as a one-liner with what was done and the outcome.
 
 - If **1 task**: state what will be reviewed and proceed directly to Phase 1.
-- If **2+ tasks**: present them as numbered options using `- **1.** label` format, most recent first. Let user pick which to review.
+- If **2+ tasks**: present them as numbered options, most recent first. Let user pick which to review.
 
 Example (3 tasks in session):
 
-- **1.** Node NotReady diagnosis on roce-test — found 3 nodes down, RDMA config mismatch suspected
-- **2.** Pod crash loop analysis on envoy-gateway — identified OOM, suggested resource limits
-- **3.** Review entire session
+1. Node NotReady diagnosis on roce-test — found 3 nodes down, RDMA config mismatch suspected
+2. Pod crash loop analysis on envoy-gateway — identified OOM, suggested resource limits
+3. Review entire session
+
+<!-- suggested-replies: 1|Node NotReady diagnosis, 2|Pod crash loop, 3|Entire session -->
 
 After user selects (or if only 1 task), proceed to Phase 1 scoped to that task only.
 
@@ -44,55 +50,62 @@ Example (output as plain markdown list — never use code fences):
 5. ⚠️ Log analysis pivot — exporter shows no devices vs rdma-qos 60+ VFs, data contradiction
 6. Report generation ✓
 
-After presenting, tell the user they can ask to expand any step by its number.
+After presenting, tell the user they can ask to expand any step by its number. Then immediately present Phase 2.
 
 ## Phase 2 — Interactive Evaluation
 
-Present feedback categories using **letters**, each on its own line:
+Present a top-level menu mixing "Specific steps" (a single entry) with cross-cutting observations generated from the session. Use **letters** for top-level, **numbers** for sub-levels, **0** to go back.
 
-- **A.** Overall direction — was the investigation path correct?
-- **B.** Specific steps — a particular step was problematic
-- **C.** Missing checks — important diagnostics were skipped
-- **D.** Conclusion accuracy — the final diagnosis was wrong or incomplete
-- **E.** All good — skip to report
-- **F.** Other comments
+Top-level structure:
+- **A** — Specific steps (review a step from the timeline)
+- **B, C, D...** — 1-3 cross-cutting observations: concrete, session-grounded issues about overall direction, missing checks, or conclusion accuracy. Frame each with self-critical tension.
+- **E** — All good (skip to report)
+- **O** — Other
 
-**Funnel interaction — narrow step by step with structured choices:**
+Example top-level:
 
-When user selects a category (A–D), do NOT ask an open-ended question. Follow a 3-step funnel where every level presents clickable options.
+A. Specific steps — review a step from the timeline
+B. Overall priority — 3 nodes NotReady but RDMA config investigated first, was this the right call?
+C. Missing check — no hardware-level diagnostics (lspci/dmesg) attempted on NotReady nodes
+E. All good — generate report
+O. Other
 
-**Step 1 — Narrow the area:** Present 2-5 sub-options using `- **1.** label` numbered format, generated from the actual session content. Each sub-option should surface a specific **tension or trade-off** — frame it as a self-critical question worth examining, not a neutral label. Connect to ⚠️ self-reflection points from Phase 1 where possible. Always end with an "Other — describe" escape hatch.
+<!-- suggested-replies: A|Specific steps, B|Overall priority, C|Missing check, E|All good, O|Other -->
 
-| Category | How to generate sub-options |
-|----------|----------------------------|
-| **A** | List major pivots from the timeline. Frame each as a tension: "did X but maybe should have Y" — e.g. "3 nodes NotReady but investigated RDMA config first — should node recovery have been the priority?" |
-| **B** | List timeline steps that had decisions or anomalies (⚠️ items first). Include what made each step questionable |
-| **C** | Infer 2-4 standard checks NOT performed, relevant to this diagnosis type. Frame as "didn't do X — could that have caught the issue earlier?" |
-| **D** | Offer: root cause completely wrong, partially right but missed key factor, right cause but wrong severity, conclusion was accurate |
-| **F** | Skip sub-options — ask user to describe freely |
+**Navigation:**
 
-**Step 2 — What should have been done:** Present 2-4 concrete alternatives the agent could have taken (same `- **1.** label` format), plus "Other". If the sub-option is already an assessment (e.g. "direction was correct" or "conclusion was accurate"), record directly and skip to Step 3.
+**Selecting A (Specific steps):** Present timeline steps as numbered sub-options. Highlight ⚠️ items:
 
-**Step 3 — Record & continue:** Show a running tally (e.g. "Noted 2 items"), then re-list remaining categories (exclude already-discussed and E) plus report option, using `- **X.** label` format.
+1. Cluster connect ✓
+2. Component scan (6 steps) ✓
+3. ⚠️ NIC detection — inferred vendor from ConfigMap, not verified
+4. Node diagnostics (4 steps) — image pull failed
+5. ⚠️ Log analysis pivot — contradictory data not resolved
+0. Back
 
-Example — full funnel for category B:
+<!-- suggested-replies: 1|Cluster connect, 2|Component scan, 3|NIC detection, 4|Node diagnostics, 5|Log analysis, 0|Back -->
 
-> Step 1 — user selected B, agent presents sub-options with tension:
->
-> - **1.** Step 3 — inferred NIC vendor from ConfigMap tag alone — should have verified on node before building on that assumption?
-> - **2.** Step 5 — exporter said "no devices" but rdma-qos showed 60+ VFs — contradiction was noted but not resolved
-> - **3.** Other — describe the step
->
-> Step 2 — user picked 1, agent presents alternatives:
->
-> - **1.** Should have verified NIC model on node directly (SSH / node_exec)
-> - **2.** Should have cross-checked with lspci or driver logs
-> - **3.** This step was unnecessary — skip and check driver logs instead
-> - **4.** Other
+**Selecting a specific step or cross-cutting observation:** Present 2-4 concrete alternatives the agent could have taken, plus "Other" and "Back":
+
+1. Should have verified NIC model on node directly (SSH / node_exec)
+2. Should have cross-checked with lspci or driver logs
+3. Other
+0. Back
+
+<!-- suggested-replies: 1|Verify on node, 2|Cross-check lspci, 3|Other, 0|Back -->
+
+If the selection is already a positive assessment (e.g. a ✓ step or "direction was correct"), confirm and record directly.
+
+**After recording:** Show running tally (e.g. "Noted 2 items"), return to top-level menu with discussed items removed. Add R (Generate report) after the first recorded item.
+
+**User input handling:**
+- Any selection can include supplementary text — e.g. `1 and also the annotation source was wrong`. Capture both the selection AND the extra context when recording.
+- "Other" means the user will type their own feedback. Do NOT ask a follow-up question — just wait for their input and record it directly.
 
 **Other rules:**
+- 0 (Back) appears at every sub-level — user can always return.
 - If user selects **E**, skip directly to Phase 3.
-- After **3 feedback items**, proactively suggest generating the report. Don't keep looping.
+- After **3 feedback items**, proactively suggest generating the report.
 - When user says "没了", "done", "就这些", "R", or similar → move to Phase 3 immediately.
 
 **Rating:** Do NOT ask per-item ratings. Infer the overall rating in Phase 3 based on severity of issues discussed.
@@ -107,10 +120,12 @@ Synthesize a structured report. Present it to the user for confirmation:
 - **Tags**: Categorize issues (e.g. `wrong-inference`, `missing-check`, `slow-path`, `wrong-order`, `correct-diagnosis`)
 - **Overall Rating**: Infer 1-5 based on the discussion (1=mostly wrong, 3=ok with gaps, 5=excellent)
 
-Present two options using the same `- **X.** label` bullet format:
+Present two options:
 
-- **Y.** Confirm & save
-- **N.** Request adjustments
+Y. Confirm & save
+N. Request adjustments
+
+<!-- suggested-replies: Y|Confirm & save, N|Request adjustments -->
 
 ## Phase 4 — Save
 

--- a/skills/core/session-feedback/SKILL.md
+++ b/skills/core/session-feedback/SKILL.md
@@ -6,54 +6,51 @@ tags: [feedback, meta, improvement]
 
 # Session Feedback Protocol
 
-You are now conducting an interactive feedback review of the current diagnostic session. Follow these phases strictly.
+You are conducting an interactive feedback review of the current diagnostic session. Follow these phases. Be concise — don't over-ask.
 
 ## Phase 1 — Review
 
-Based on the Session Diagnostic Timeline provided, summarize the diagnostic process:
+Summarize the diagnostic process based on the Session Diagnostic Timeline:
 
-1. List key steps in chronological order
-2. For each step, note:
-   - What was decided / what action was taken
-   - Which tool or skill was used
-   - The outcome (success/error/partial)
+1. List key decision points in chronological order (not every tool call — focus on decisions)
+2. For each, note: what was decided, what tool/skill was used, the outcome
 3. Present as a numbered list in the user's language
-
-Keep it concise — focus on decision points, not every single tool call.
 
 ## Phase 2 — Interactive Evaluation
 
-Present these options to the user (numbered for easy selection):
+Present options using **letters** (to avoid confusion with numeric ratings):
 
-1. **Overall direction** — Was the investigation heading in the right direction?
-2. **A specific step** — Was a particular step wrong or suboptimal?
-3. **Missing checks** — Were important diagnostics skipped?
-4. **Conclusion accuracy** — Was the final diagnosis correct?
-5. **All good** — Satisfied with the session, nothing to change
-6. **Free input** — Other feedback
+> **A.** Overall direction — right track?
+> **B.** A specific step — wrong or suboptimal?
+> **C.** Missing checks — important diagnostics skipped?
+> **D.** Conclusion accuracy — was the diagnosis correct?
+> **E.** All good — satisfied, nothing to change
+> **F.** Free input
 
-After the user selects an option, drill deeper:
-- What specifically was wrong?
-- What would the ideal action have been?
-- How would you rate it (1-5)?
+**Rules:**
+- User selects a letter → ask ONE follow-up to get the details (what was wrong + what should have been done). Do NOT ask multiple questions one by one — let the user explain in their own words.
+- After each feedback item, show a brief **running tally** (e.g. "Noted: 2 items so far") and ask: **"Continue (letter) or generate report (R)?"**
+- If user selects **E**, skip directly to Phase 3.
+- After **3 feedback items**, proactively suggest generating the report. Don't keep looping.
+- When user says anything like "没了", "done", "就这些", "R", or similar → move to Phase 3 immediately.
 
-The user can provide feedback on **multiple aspects** — after finishing one, ask if they want to discuss another.
+**Rating:** Do NOT ask per-item ratings. You will infer the overall rating in Phase 3 based on the severity of issues discussed.
 
 ## Phase 3 — Report Generation
 
-Once the user is done providing feedback, synthesize a structured report:
+Synthesize a structured report. Present it to the user for confirmation:
 
-- **Strengths**: What the agent did well
-- **Improvements**: What should be done differently next time
+- **Strengths**: What the agent did well (2-4 bullet points)
+- **Improvements**: What should change (2-4 bullet points)
 - **Decision Points**: Each evaluated step with `wasCorrect`, `comment`, `idealAction`
-- **Tags**: Categorize issues (e.g., `wrong-skill`, `slow-path`, `missing-check`, `correct-diagnosis`, `wrong-order`)
-- **Overall Rating**: 1-5 based on discussion
+- **Tags**: Categorize issues (e.g. `wrong-inference`, `missing-check`, `slow-path`, `wrong-order`, `correct-diagnosis`)
+- **Overall Rating**: Infer 1-5 based on the discussion (1=mostly wrong, 3=ok with gaps, 5=excellent)
 
-Present the report to the user for confirmation. If they want changes, adjust accordingly.
+Ask user: **"Confirm to save, or any adjustments?"**
 
 ## Phase 4 — Save
 
-After user confirms the report, call the `save_feedback` tool with the structured data:
+After user confirms (or says ok/好/确认/save), call `save_feedback` immediately:
 
 ```
 save_feedback({
@@ -67,4 +64,4 @@ save_feedback({
 })
 ```
 
-After saving, thank the user and confirm the feedback has been recorded.
+After saving, thank the user briefly. Done — do not continue the feedback loop.

--- a/skills/core/session-feedback/SKILL.md
+++ b/skills/core/session-feedback/SKILL.md
@@ -8,43 +8,46 @@ tags: [feedback, meta, improvement]
 
 You are conducting an interactive feedback review of the current diagnostic session. Follow these phases. Be concise — don't over-ask.
 
+**Language: Always follow the user's language (from their profile or recent messages). All output — phase titles, timeline, options, report — must be in the user's language.**
+
 ## Phase 1 — Compressed Timeline with Self-Reflection
 
-Analyze the Session Diagnostic Timeline and present a **compressed timeline**:
+Analyze the Session Diagnostic Timeline and present a **compressed timeline** as a regular markdown numbered list (NOT a code block):
 
 **Compression rules:**
 - Group consecutive same-purpose tool calls into one line, marked with `(N steps)`
-- Routine successful steps get `✓` and stay as one-liners
-- Decision points or anomalies get `⚠️` with a brief self-reflection on what might be questionable
+- Routine successful steps get a `✓` and stay as one-liners
+- Decision points or anomalies get a `⚠️` with a brief self-reflection on what might be questionable
 - Target: **5-8 lines max**, regardless of how many raw steps exist
 
-**Example format:**
-```
-1. Cluster connection — credential_list → connected to roce-test ✓
-2. Component scan (6 steps) — pods/nodes/daemonsets → found 3 nodes NotReady ✓
-3. ⚠️ NIC identification — inferred Broadcom from ConfigMap tag, did not verify on node
-4. Node diagnostics (4 steps) — node_exec attempts → debug image pull failed
-5. ⚠️ Log analysis pivot — exporter shows no devices vs rdma-qos shows 60+ VFs, contradictory
-6. Report generation ✓
-```
+Example (adapt to user's language, output as plain markdown list — never use code fences):
 
-After presenting, tell the user: **"If you want details on any compressed step, just mention its number."**
+1. 集群连接 — credential_list → 连接 roce-test ✓
+2. 组件扫描 (6 步) — pods/nodes/daemonsets → 发现 3 节点 NotReady ✓
+3. ⚠️ 网卡识别 — 从 ConfigMap tag 推断厂商，未在节点上验证
+4. 节点诊断 (4 步) — node_exec 尝试 → debug 镜像拉取失败
+5. ⚠️ 日志分析转向 — exporter 无设备 vs rdma-qos 60+ VF，数据矛盾
+6. 报告生成 ✓
+
+After presenting, tell the user they can ask to expand any step by its number.
 
 ## Phase 2 — Interactive Evaluation
 
-Present options using **letters** (to avoid confusion with numeric ratings):
+Present options using **letters**, each on its own line:
 
-> **A.** Overall direction — right track?
-> **B.** A specific step — pick a number from the timeline above, or describe it
-> **C.** Missing checks — important diagnostics skipped?
-> **D.** Conclusion accuracy — was the diagnosis correct?
-> **E.** All good — satisfied, nothing to change
-> **F.** Free input
+- **A.** 整体方向 — 调查路径是否正确？
+- **B.** 具体步骤 — 指出上面时间线的编号，或描述
+- **C.** 遗漏检查 — 有重要诊断被跳过？
+- **D.** 结论准确性 — 最终诊断是否正确？
+- **E.** 全部满意 — 直接生成报告
+- **F.** 其他意见
+
+(The above is a Chinese example. Translate to match the user's language.)
 
 **Rules:**
 - User selects a letter → ask ONE follow-up to get the details (what was wrong + what should have been done). Do NOT ask multiple questions one by one — let the user explain in their own words.
 - If user references a timeline number (e.g. "B 3"), expand that step's details from the raw timeline and discuss it.
-- After each feedback item, show a brief **running tally** (e.g. "Noted: 2 items so far") and ask: **"Continue (letter) or generate report (R)?"**
+- After each feedback item, show a brief **running tally** (e.g. "已记录 2 项") and ask: **"继续 (选字母) 还是生成报告 (R)？"**
 - If user selects **E**, skip directly to Phase 3.
 - After **3 feedback items**, proactively suggest generating the report. Don't keep looping.
 - When user says anything like "没了", "done", "就这些", "R", or similar → move to Phase 3 immediately.
@@ -61,7 +64,7 @@ Synthesize a structured report. Present it to the user for confirmation:
 - **Tags**: Categorize issues (e.g. `wrong-inference`, `missing-check`, `slow-path`, `wrong-order`, `correct-diagnosis`)
 - **Overall Rating**: Infer 1-5 based on the discussion (1=mostly wrong, 3=ok with gaps, 5=excellent)
 
-Ask user: **"Confirm to save, or any adjustments?"**
+Ask user to confirm or request adjustments.
 
 ## Phase 4 — Save
 

--- a/src/agentbox/gateway-client.ts
+++ b/src/agentbox/gateway-client.ts
@@ -5,6 +5,7 @@
  * Used by AgentBox to query metadata (settings, cron jobs, etc.)
  */
 
+import http from "node:http";
 import https from "node:https";
 import fs from "node:fs";
 import path from "node:path";
@@ -101,7 +102,7 @@ export class GatewayClient {
         ...(isHttps && this.tlsOptions ? this.tlsOptions : {}),
       };
 
-      const client = isHttps ? https : require("http");
+      const client = isHttps ? https : http;
       const req = client.request(requestOptions, (res: any) => {
         let data = "";
 

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -33,6 +33,7 @@ import { createForkSkillTool } from "../tools/fork-skill.js";
 import { createManageScheduleTool } from "../tools/manage-schedule.js";
 import { createDeepSearchTool, type MemoryRef } from "../tools/deep-search/tool.js";
 import { createInvestigationFeedbackTool } from "../tools/investigation-feedback.js";
+import { createSaveFeedbackTool } from "../tools/save-feedback.js";
 import {
   type DpState,
   createProposeHypothesesTool,
@@ -287,6 +288,7 @@ export async function createSiclawSession(
     createRunSkillTool(kubeconfigRef, sessionIdRef),
     createDeepSearchTool(kubeconfigRef, llmConfigRef, memoryRef),
     createInvestigationFeedbackTool(memoryRef),
+    createSaveFeedbackTool(sessionIdRef),
     createCredentialListTool(kubeconfigRef),
     createClusterInfoTool(kubeconfigRef),
   ];

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -335,7 +335,7 @@ export async function createSiclawSession(
 
   // Filter custom tools by workspace allow-list
   // Platform tools are exempt — they must always be available regardless of workspace config
-  const PLATFORM_TOOLS = new Set(["manage_schedule", "credential_list", "cluster_info"]);
+  const PLATFORM_TOOLS = new Set(["manage_schedule", "credential_list", "cluster_info", "save_feedback"]);
   const allowedTools = opts?.allowedTools ?? config.allowedTools;
   if (Array.isArray(allowedTools)) {
     const allowed = new Set(allowedTools);

--- a/src/gateway/db/migrate-sqlite.ts
+++ b/src/gateway/db/migrate-sqlite.ts
@@ -352,6 +352,20 @@ const DDL_STATEMENTS = [
     created_at INTEGER NOT NULL DEFAULT (unixepoch()),
     updated_at INTEGER NOT NULL DEFAULT (unixepoch())
   )`,
+
+  `CREATE TABLE IF NOT EXISTS feedback_reports (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    overall_rating INTEGER CHECK(overall_rating BETWEEN 1 AND 5),
+    summary TEXT NOT NULL,
+    decision_points TEXT,
+    strengths TEXT,
+    improvements TEXT,
+    tags TEXT,
+    feedback_conversation TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
 ];
 
 const INDEX_STATEMENTS = [
@@ -376,6 +390,8 @@ const INDEX_STATEMENTS = [
   `CREATE INDEX IF NOT EXISTS idx_cron_job_runs_job ON cron_job_runs(job_id, created_at)`,
   `CREATE INDEX IF NOT EXISTS idx_cron_jobs_status_assigned ON cron_jobs(status, assigned_to)`,
   `CREATE INDEX IF NOT EXISTS idx_cron_instances_heartbeat ON cron_instances(heartbeat_at)`,
+  `CREATE INDEX IF NOT EXISTS idx_feedback_reports_user ON feedback_reports(user_id, created_at)`,
+  `CREATE INDEX IF NOT EXISTS idx_feedback_reports_session ON feedback_reports(session_id)`,
 ];
 
 export async function runSqliteMigrations(db: Database): Promise<void> {

--- a/src/gateway/db/migrate-sqlite.ts
+++ b/src/gateway/db/migrate-sqlite.ts
@@ -357,6 +357,7 @@ const DDL_STATEMENTS = [
     id TEXT PRIMARY KEY,
     session_id TEXT NOT NULL,
     user_id TEXT NOT NULL,
+    workspace_id TEXT,
     overall_rating INTEGER CHECK(overall_rating BETWEEN 1 AND 5),
     summary TEXT NOT NULL,
     decision_points TEXT,

--- a/src/gateway/db/repositories/feedback-repo.ts
+++ b/src/gateway/db/repositories/feedback-repo.ts
@@ -1,0 +1,76 @@
+/**
+ * Feedback Repository — session feedback report CRUD
+ */
+
+import crypto from "node:crypto";
+import { eq, desc, and } from "drizzle-orm";
+import type { Database } from "../index.js";
+import { feedbackReports } from "../schema.js";
+
+export interface FeedbackReportInput {
+  sessionId: string;
+  userId: string;
+  overallRating?: number;
+  summary: string;
+  decisionPoints?: Array<{
+    step: number;
+    description: string;
+    wasCorrect: boolean;
+    comment?: string;
+    idealAction?: string;
+  }>;
+  strengths?: string[];
+  improvements?: string[];
+  tags?: string[];
+  feedbackConversation?: unknown;
+}
+
+export class FeedbackRepository {
+  constructor(private db: Database) {}
+
+  async saveFeedbackReport(report: FeedbackReportInput): Promise<string> {
+    const id = crypto.randomUUID();
+    await this.db.insert(feedbackReports).values({
+      id,
+      sessionId: report.sessionId,
+      userId: report.userId,
+      overallRating: report.overallRating ?? null,
+      summary: report.summary,
+      decisionPoints: report.decisionPoints ?? null,
+      strengths: report.strengths ?? null,
+      improvements: report.improvements ?? null,
+      tags: report.tags ?? null,
+      feedbackConversation: report.feedbackConversation ?? null,
+    });
+    return id;
+  }
+
+  async listFeedbackReports(opts: {
+    userId?: string;
+    limit?: number;
+    offset?: number;
+  }) {
+    const limit = opts.limit ?? 20;
+    const offset = opts.offset ?? 0;
+    const conditions = opts.userId
+      ? [eq(feedbackReports.userId, opts.userId)]
+      : [];
+
+    return this.db
+      .select()
+      .from(feedbackReports)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(feedbackReports.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  async getFeedbackReport(id: string) {
+    const rows = await this.db
+      .select()
+      .from(feedbackReports)
+      .where(eq(feedbackReports.id, id))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+}

--- a/src/gateway/db/repositories/feedback-repo.ts
+++ b/src/gateway/db/repositories/feedback-repo.ts
@@ -10,6 +10,7 @@ import { feedbackReports } from "../schema.js";
 export interface FeedbackReportInput {
   sessionId: string;
   userId: string;
+  workspaceId?: string;
   overallRating?: number;
   summary: string;
   decisionPoints?: Array<{
@@ -34,6 +35,7 @@ export class FeedbackRepository {
       id,
       sessionId: report.sessionId,
       userId: report.userId,
+      workspaceId: report.workspaceId ?? null,
       overallRating: report.overallRating ?? null,
       summary: report.summary,
       decisionPoints: report.decisionPoints ?? null,

--- a/src/gateway/db/schema-mysql.ts
+++ b/src/gateway/db/schema-mysql.ts
@@ -452,6 +452,28 @@ export const systemConfig = mysqlTable("system_config", {
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });
 
+// ─── Feedback Reports ─────────────────────────────
+
+export const feedbackReports = mysqlTable("feedback_reports", {
+  id: varchar("id", { length: 64 }).primaryKey(),
+  sessionId: varchar("session_id", { length: 64 }).notNull(),
+  userId: varchar("user_id", { length: 32 }).notNull(),
+  overallRating: int("overall_rating"),
+  summary: text("summary").notNull(),
+  decisionPoints: json("decision_points").$type<Array<{
+    step: number;
+    description: string;
+    wasCorrect: boolean;
+    comment?: string;
+    idealAction?: string;
+  }>>(),
+  strengths: json("strengths").$type<string[]>(),
+  improvements: json("improvements").$type<string[]>(),
+  tags: json("tags").$type<string[]>(),
+  feedbackConversation: json("feedback_conversation").$type<unknown>(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
 export const skillReviews = mysqlTable("skill_reviews", {
   id: varchar("id", { length: 64 }).primaryKey(),
   skillId: varchar("skill_id", { length: 64 })

--- a/src/gateway/db/schema-mysql.ts
+++ b/src/gateway/db/schema-mysql.ts
@@ -458,6 +458,7 @@ export const feedbackReports = mysqlTable("feedback_reports", {
   id: varchar("id", { length: 64 }).primaryKey(),
   sessionId: varchar("session_id", { length: 64 }).notNull(),
   userId: varchar("user_id", { length: 32 }).notNull(),
+  workspaceId: varchar("workspace_id", { length: 64 }),
   overallRating: int("overall_rating"),
   summary: text("summary").notNull(),
   decisionPoints: json("decision_points").$type<Array<{

--- a/src/gateway/db/schema-sqlite.ts
+++ b/src/gateway/db/schema-sqlite.ts
@@ -445,6 +445,7 @@ export const feedbackReports = sqliteTable("feedback_reports", {
   id: text("id").primaryKey(),
   sessionId: text("session_id").notNull(),
   userId: text("user_id").notNull(),
+  workspaceId: text("workspace_id"),
   overallRating: integer("overall_rating"),
   summary: text("summary").notNull(),
   decisionPoints: text("decision_points", { mode: "json" }).$type<Array<{

--- a/src/gateway/db/schema-sqlite.ts
+++ b/src/gateway/db/schema-sqlite.ts
@@ -439,6 +439,28 @@ export const systemConfig = sqliteTable("system_config", {
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull().default(sql`(unixepoch())`),
 });
 
+// ─── Feedback Reports ─────────────────────────────
+
+export const feedbackReports = sqliteTable("feedback_reports", {
+  id: text("id").primaryKey(),
+  sessionId: text("session_id").notNull(),
+  userId: text("user_id").notNull(),
+  overallRating: integer("overall_rating"),
+  summary: text("summary").notNull(),
+  decisionPoints: text("decision_points", { mode: "json" }).$type<Array<{
+    step: number;
+    description: string;
+    wasCorrect: boolean;
+    comment?: string;
+    idealAction?: string;
+  }>>(),
+  strengths: text("strengths", { mode: "json" }).$type<string[]>(),
+  improvements: text("improvements", { mode: "json" }).$type<string[]>(),
+  tags: text("tags", { mode: "json" }).$type<string[]>(),
+  feedbackConversation: text("feedback_conversation", { mode: "json" }).$type<unknown>(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().default(sql`(unixepoch())`),
+});
+
 export const skillReviews = sqliteTable("skill_reviews", {
   id: text("id").primaryKey(),
   skillId: text("skill_id")

--- a/src/gateway/db/schema.ts
+++ b/src/gateway/db/schema.ts
@@ -51,6 +51,7 @@ export const {
   sessionStats,
   systemConfig,
   mcpServers,
+  feedbackReports,
   skillReviews,
 } = _mod;
 

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -483,13 +483,15 @@ export function createRpcMethods(
         content: message,
       });
       await chatRepo.incrementMessageCount(sessionId);
-      // Update session metadata (title/preview)
-      const title =
-        message.length > 40 ? message.slice(0, 40) + "..." : message;
-      await chatRepo.updateSessionMeta(sessionId, {
-        title,
-        preview: message.slice(0, 100),
-      });
+      // Update session metadata (title/preview) — skip for feedback sentinel
+      if (!message.startsWith("[Feedback]")) {
+        const title =
+          message.length > 40 ? message.slice(0, 40) + "..." : message;
+        await chatRepo.updateSessionMeta(sessionId, {
+          title,
+          preview: message.slice(0, 100),
+        });
+      }
     }
 
     if (!sessionId) throw new Error("Failed to create session");

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -84,6 +84,51 @@ function apiServerHostMatch(kubeconfigServer: string, envApiServer: string): boo
 }
 
 
+// ── Feedback enrichment helpers ──────────────────────
+
+/**
+ * Read the session-feedback SKILL.md content, stripping YAML frontmatter.
+ */
+async function readFeedbackSkillContent(): Promise<string> {
+  const skillPath = path.join(process.cwd(), "skills", "core", "session-feedback", "SKILL.md");
+  const raw = await fs.promises.readFile(skillPath, "utf-8");
+  // Strip YAML frontmatter (between --- delimiters)
+  const stripped = raw.replace(/^---[\s\S]*?---\s*/, "");
+  return stripped.trim();
+}
+
+/**
+ * Build a markdown timeline of the session's diagnostic activity.
+ */
+async function buildSessionTimeline(
+  chatRepo: ChatRepository,
+  sessionId: string,
+): Promise<string> {
+  const msgs = await chatRepo.getMessages(sessionId, { limit: 200 });
+  if (msgs.length === 0) return "_No messages in this session._";
+
+  const lines: string[] = [];
+  let stepNum = 0;
+  for (const msg of msgs) {
+    if (msg.role === "user") {
+      stepNum++;
+      const preview = msg.content.length > 100 ? msg.content.slice(0, 100) + "..." : msg.content;
+      lines.push(`${stepNum}. **User**: ${preview}`);
+    } else if (msg.role === "tool" && msg.toolName) {
+      stepNum++;
+      const outcome = msg.outcome ?? "unknown";
+      const duration = msg.durationMs != null ? ` (${msg.durationMs}ms)` : "";
+      lines.push(`${stepNum}. **Tool** \`${msg.toolName}\`: ${outcome}${duration}`);
+    } else if (msg.role === "assistant") {
+      // Summarize assistant messages briefly
+      const preview = msg.content.length > 100 ? msg.content.slice(0, 100) + "..." : msg.content;
+      stepNum++;
+      lines.push(`${stepNum}. **Assistant**: ${preview}`);
+    }
+  }
+  return lines.join("\n");
+}
+
 export function createRpcMethods(
   agentBoxManager: AgentBoxManager,
   broadcast: BroadcastFn,
@@ -487,8 +532,26 @@ export function createRpcMethods(
     });
     const client = new AgentBoxClient(handle.endpoint, 30000, agentBoxTlsOptions);
 
+    // === Feedback enrichment (system-level) ===
+    let promptText = message;
+    if (message.startsWith("[Feedback]") && chatRepo) {
+      try {
+        const skillContent = await readFeedbackSkillContent();
+        const timeline = await buildSessionTimeline(chatRepo, sessionId);
+        promptText = [
+          "## Session Feedback Instructions\n",
+          skillContent,
+          "\n## Current Session Diagnostic Timeline\n",
+          timeline,
+          "\n---\nThe user has requested a feedback session. Begin the interactive review now.",
+        ].join("\n");
+      } catch (err) {
+        console.warn("[rpc] feedback enrichment failed, sending raw message:", err);
+      }
+    }
+
     // Send prompt
-    const result = await client.prompt({ sessionId, text: message, modelProvider, modelId, brainType, modelConfig, credentials });
+    const result = await client.prompt({ sessionId, text: promptText, modelProvider, modelId, brainType, modelConfig, credentials });
     console.log(`[rpc] prompt sent → sessionId=${result.sessionId}`);
 
     // Build redaction config from credential payload + model secrets (sanitize outbound WS stream)

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -88,9 +88,13 @@ function apiServerHostMatch(kubeconfigServer: string, envApiServer: string): boo
 
 /**
  * Read the session-feedback SKILL.md content, stripping YAML frontmatter.
+ * Uses import.meta.url to resolve the package root (works in both dev and K8s).
  */
+const _feedbackModDir = path.dirname(fileURLToPath(import.meta.url));
+const _feedbackPkgRoot = path.resolve(_feedbackModDir, "..", "..");
+
 async function readFeedbackSkillContent(): Promise<string> {
-  const skillPath = path.join(process.cwd(), "skills", "core", "session-feedback", "SKILL.md");
+  const skillPath = path.join(_feedbackPkgRoot, "skills", "core", "session-feedback", "SKILL.md");
   const raw = await fs.promises.readFile(skillPath, "utf-8");
   // Strip YAML frontmatter (between --- delimiters)
   const stripped = raw.replace(/^---[\s\S]*?---\s*/, "");

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -93,12 +93,16 @@ function apiServerHostMatch(kubeconfigServer: string, envApiServer: string): boo
 const _feedbackModDir = path.dirname(fileURLToPath(import.meta.url));
 const _feedbackPkgRoot = path.resolve(_feedbackModDir, "..", "..");
 
+let _feedbackSkillCache: string | null = null;
+
 async function readFeedbackSkillContent(): Promise<string> {
+  if (_feedbackSkillCache) return _feedbackSkillCache;
   const skillPath = path.join(_feedbackPkgRoot, "skills", "core", "session-feedback", "SKILL.md");
   const raw = await fs.promises.readFile(skillPath, "utf-8");
   // Strip YAML frontmatter (between --- delimiters)
-  const stripped = raw.replace(/^---[\s\S]*?---\s*/, "");
-  return stripped.trim();
+  const stripped = raw.replace(/^---[\s\S]*?---\s*/, "").trim();
+  _feedbackSkillCache = stripped;
+  return stripped;
 }
 
 /**
@@ -115,6 +119,8 @@ async function buildSessionTimeline(
   let stepNum = 0;
   for (const msg of msgs) {
     if (msg.role === "user") {
+      // Skip feedback sentinel messages from timeline
+      if (msg.content.startsWith("[Feedback]")) continue;
       stepNum++;
       const preview = msg.content.length > 100 ? msg.content.slice(0, 100) + "..." : msg.content;
       lines.push(`${stepNum}. **User**: ${preview}`);
@@ -550,7 +556,8 @@ export function createRpcMethods(
           "\n---\nThe user has requested a feedback session. Begin the interactive review now.",
         ].join("\n");
       } catch (err) {
-        console.warn("[rpc] feedback enrichment failed, sending raw message:", err);
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`Feedback system unavailable: ${reason}`);
       }
     }
 

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -546,6 +546,9 @@ export function createRpcMethods(
 
     // === Feedback enrichment (system-level) ===
     let promptText = message;
+    if (message.startsWith("[Feedback]") && !chatRepo) {
+      throw new Error("Feedback requires a database connection (not available in TUI mode).");
+    }
     if (message.startsWith("[Feedback]") && chatRepo) {
       try {
         const skillContent = await readFeedbackSkillContent();

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -827,6 +827,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
           const id = await feedbackRepo.saveFeedbackReport({
             sessionId: data.sessionId,
             userId: data.userId,
+            workspaceId: data.workspaceId,
             overallRating: data.overallRating,
             summary: data.summary,
             decisionPoints: data.decisionPoints,
@@ -1224,6 +1225,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
                 const id = await feedbackRepo.saveFeedbackReport({
                   sessionId: data.sessionId,
                   userId,
+                  workspaceId: identity?.workspaceId || data.workspaceId,
                   overallRating: data.overallRating,
                   summary: data.summary,
                   decisionPoints: data.decisionPoints,

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -77,10 +77,17 @@ function handleFeedbackPost(
     if (bodySize > MAX_FEEDBACK_BODY) return; // already responded
     try {
       const data = JSON.parse(body);
+      // In local mode (HTTP, no certIdentity), userId comes from the request body.
+      // This is a local-trust assumption — loopback only, no external access.
       const userId = certIdentity?.userId || data.userId;
       if (!data.sessionId || !userId || !data.summary) {
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "sessionId, userId, and summary are required" }));
+        return;
+      }
+      if (data.overallRating != null && (data.overallRating < 1 || data.overallRating > 5)) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "overallRating must be between 1 and 5" }));
         return;
       }
       const feedbackRepo = new FeedbackRepository(db);

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -52,6 +52,60 @@ const MIME_TYPES: Record<string, string> = {
   ".ico": "image/x-icon",
 };
 
+const MAX_FEEDBACK_BODY = 512 * 1024; // 512KB
+
+/** Shared handler for POST /api/internal/feedback — used by both HTTP and HTTPS servers */
+function handleFeedbackPost(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  db: Database,
+  certIdentity?: { userId?: string; workspaceId?: string },
+): void {
+  let body = "";
+  let bodySize = 0;
+  req.on("data", (chunk: Buffer) => {
+    bodySize += chunk.length;
+    if (bodySize > MAX_FEEDBACK_BODY) {
+      res.writeHead(413, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Request body too large" }));
+      req.destroy();
+      return;
+    }
+    body += chunk.toString();
+  });
+  req.on("end", async () => {
+    if (bodySize > MAX_FEEDBACK_BODY) return; // already responded
+    try {
+      const data = JSON.parse(body);
+      const userId = certIdentity?.userId || data.userId;
+      if (!data.sessionId || !userId || !data.summary) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "sessionId, userId, and summary are required" }));
+        return;
+      }
+      const feedbackRepo = new FeedbackRepository(db);
+      const id = await feedbackRepo.saveFeedbackReport({
+        sessionId: data.sessionId,
+        userId,
+        workspaceId: certIdentity?.workspaceId || data.workspaceId,
+        overallRating: data.overallRating,
+        summary: data.summary,
+        decisionPoints: data.decisionPoints,
+        strengths: data.strengths,
+        improvements: data.improvements,
+        tags: data.tags,
+        feedbackConversation: data.feedbackConversation,
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, id }));
+    } catch (err) {
+      console.error("[gateway] feedback save error:", err);
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal server error" }));
+    }
+  });
+}
+
 function serveStatic(res: http.ServerResponse, urlPath: string, frameSrc?: string | null): void {
   const withoutQuery = urlPath.split("?")[0];
   const safePath = path.normalize(withoutQuery).replace(/^(\.\.(\/|\\|$))+/, "");
@@ -813,37 +867,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
         res.end(JSON.stringify({ error: "Database not available" }));
         return;
       }
-      let body = "";
-      req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
-      req.on("end", async () => {
-        try {
-          const data = JSON.parse(body);
-          if (!data.sessionId || !data.userId || !data.summary) {
-            res.writeHead(400, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "sessionId, userId, and summary are required" }));
-            return;
-          }
-          const feedbackRepo = new FeedbackRepository(db);
-          const id = await feedbackRepo.saveFeedbackReport({
-            sessionId: data.sessionId,
-            userId: data.userId,
-            workspaceId: data.workspaceId,
-            overallRating: data.overallRating,
-            summary: data.summary,
-            decisionPoints: data.decisionPoints,
-            strengths: data.strengths,
-            improvements: data.improvements,
-            tags: data.tags,
-            feedbackConversation: data.feedbackConversation,
-          });
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ ok: true, id }));
-        } catch (err) {
-          console.error("[gateway] feedback save error:", err);
-          res.writeHead(500, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Internal server error" }));
-        }
-      });
+      handleFeedbackPost(req, res, db);
       return;
     }
 
@@ -1208,40 +1232,8 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
               res.end(JSON.stringify({ error: "Database not available" }));
               return;
             }
-            let body = "";
-            req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
-            req.on("end", async () => {
-              try {
-                const identity = (req as any).certIdentity;
-                const data = JSON.parse(body);
-                // Use userId from mTLS identity when available (authoritative)
-                const userId = identity?.userId || data.userId;
-                if (!data.sessionId || !userId || !data.summary) {
-                  res.writeHead(400, { "Content-Type": "application/json" });
-                  res.end(JSON.stringify({ error: "sessionId, userId, and summary are required" }));
-                  return;
-                }
-                const feedbackRepo = new FeedbackRepository(db);
-                const id = await feedbackRepo.saveFeedbackReport({
-                  sessionId: data.sessionId,
-                  userId,
-                  workspaceId: identity?.workspaceId || data.workspaceId,
-                  overallRating: data.overallRating,
-                  summary: data.summary,
-                  decisionPoints: data.decisionPoints,
-                  strengths: data.strengths,
-                  improvements: data.improvements,
-                  tags: data.tags,
-                  feedbackConversation: data.feedbackConversation,
-                });
-                res.writeHead(200, { "Content-Type": "application/json" });
-                res.end(JSON.stringify({ ok: true, id }));
-              } catch (err) {
-                console.error("[gateway] feedback save error:", err);
-                res.writeHead(500, { "Content-Type": "application/json" });
-                res.end(JSON.stringify({ error: "Internal server error" }));
-              }
-            });
+            const identity = (req as any).certIdentity;
+            handleFeedbackPost(req, res, db, identity);
             return;
           }
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -24,6 +24,7 @@ import { ModelConfigRepository } from "./db/repositories/model-config-repo.js";
 import { SystemConfigRepository } from "./db/repositories/system-config-repo.js";
 import { WorkspaceRepository } from "./db/repositories/workspace-repo.js";
 import { McpServerRepository } from "./db/repositories/mcp-server-repo.js";
+import { FeedbackRepository } from "./db/repositories/feedback-repo.js";
 import { loadConfig } from "../core/config.js";
 import { buildMergedMcpConfig } from "./mcp-config-builder.js";
 import { CertificateManager } from "./security/cert-manager.js";
@@ -805,6 +806,46 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
       return;
     }
 
+    // Internal feedback endpoint: POST /api/internal/feedback
+    if (url === "/api/internal/feedback" && method === "POST") {
+      if (!db) {
+        res.writeHead(503, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Database not available" }));
+        return;
+      }
+      let body = "";
+      req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+      req.on("end", async () => {
+        try {
+          const data = JSON.parse(body);
+          if (!data.sessionId || !data.userId || !data.summary) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "sessionId, userId, and summary are required" }));
+            return;
+          }
+          const feedbackRepo = new FeedbackRepository(db);
+          const id = await feedbackRepo.saveFeedbackReport({
+            sessionId: data.sessionId,
+            userId: data.userId,
+            overallRating: data.overallRating,
+            summary: data.summary,
+            decisionPoints: data.decisionPoints,
+            strengths: data.strengths,
+            improvements: data.improvements,
+            tags: data.tags,
+            feedbackConversation: data.feedbackConversation,
+          });
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, id }));
+        } catch (err) {
+          console.error("[gateway] feedback save error:", err);
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+      });
+      return;
+    }
+
     // Webhook endpoint: POST /hooks/v1/:triggerId
     if (url.startsWith("/hooks/v1/") && method === "POST") {
       const triggerId = url.split("/hooks/v1/")[1]?.split("?")[0];
@@ -1156,6 +1197,49 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
                 res.end(JSON.stringify({ error: "Internal server error" }));
               }
             })();
+            return;
+          }
+
+          // Internal feedback endpoint: POST /api/internal/feedback
+          if (url === "/api/internal/feedback" && method === "POST") {
+            if (!db) {
+              res.writeHead(503, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "Database not available" }));
+              return;
+            }
+            let body = "";
+            req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+            req.on("end", async () => {
+              try {
+                const identity = (req as any).certIdentity;
+                const data = JSON.parse(body);
+                // Use userId from mTLS identity when available (authoritative)
+                const userId = identity?.userId || data.userId;
+                if (!data.sessionId || !userId || !data.summary) {
+                  res.writeHead(400, { "Content-Type": "application/json" });
+                  res.end(JSON.stringify({ error: "sessionId, userId, and summary are required" }));
+                  return;
+                }
+                const feedbackRepo = new FeedbackRepository(db);
+                const id = await feedbackRepo.saveFeedbackReport({
+                  sessionId: data.sessionId,
+                  userId,
+                  overallRating: data.overallRating,
+                  summary: data.summary,
+                  decisionPoints: data.decisionPoints,
+                  strengths: data.strengths,
+                  improvements: data.improvements,
+                  tags: data.tags,
+                  feedbackConversation: data.feedbackConversation,
+                });
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ ok: true, id }));
+              } catch (err) {
+                console.error("[gateway] feedback save error:", err);
+                res.writeHead(500, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ error: "Internal server error" }));
+              }
+            });
             return;
           }
 

--- a/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Square, X, Loader2, BookOpen, Search, SearchCode } from 'lucide-react';
+import { ArrowUp, Square, X, Loader2, BookOpen, Search, SearchCode, MessageSquareHeart } from 'lucide-react';
 import type { ContextUsage } from '@/hooks/usePilot';
 import type { Skill } from '@/pages/Skills/skillsData';
 import { useState, useCallback, useRef, KeyboardEvent } from 'react';
@@ -34,9 +34,10 @@ interface InputAreaProps {
     dpFocus?: string | null;
     dpActive?: boolean;
     onSetDpActive?: (active: boolean) => void;
+    hasMessages?: boolean;
 }
 
-export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, skills, onEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive }: InputAreaProps) {
+export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, skills, onEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive, hasMessages }: InputAreaProps) {
     const [value, setValue] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const isComposingRef = useRef(false);
@@ -221,6 +222,18 @@ export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, 
                                     title={deepInvestigation ? "Deep Investigation enabled — click to disable" : "Enable Deep Investigation"}
                                 >
                                     <SearchCode className="w-4 h-4" />
+                                </button>
+                            )}
+
+                            {/* Session Feedback */}
+                            {!isLoading && !disabled && hasMessages && (
+                                <button
+                                    type="button"
+                                    onClick={() => onSend("[Feedback]")}
+                                    className="p-1.5 rounded-lg transition-colors text-gray-400 hover:text-emerald-600 hover:bg-emerald-50"
+                                    title="Session Feedback"
+                                >
+                                    <MessageSquareHeart className="w-4 h-4" />
                                 </button>
                             )}
 

--- a/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
@@ -31,13 +31,15 @@ interface InputAreaProps {
     dpFocus?: string | null;
     dpActive?: boolean;
     onSetDpActive?: (active: boolean) => void;
+    /** Whether the session has messages — gates feedback button visibility */
+    hasMessages?: boolean;
     /** External draft text — when changed, populates the input and focuses it */
     draft?: string | null;
     /** Sequence counter — ensures useEffect fires even for repeated same-value drafts */
     draftSeq?: number;
 }
 
-export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive, draft, draftSeq }: InputAreaProps) {
+export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive, hasMessages, draft, draftSeq }: InputAreaProps) {
     const [value, setValue] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const isComposingRef = useRef(false);
@@ -144,8 +146,8 @@ export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, 
                                                     {deepInvestigation && <Check className="w-4 h-4 text-blue-500 shrink-0" />}
                                                 </button>
 
-                                                {/* Session Feedback */}
-                                                {!isLoading && (
+                                                {/* Session Feedback — only visible when session has messages */}
+                                                {!isLoading && hasMessages && (
                                                     <button
                                                         type="button"
                                                         onClick={() => { onSend("[Feedback]"); setShowActionMenu(false); }}

--- a/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
@@ -1,6 +1,6 @@
 import { ArrowUp, Square, X, Loader2, BookOpen, SearchCode, MessageSquareHeart, Plus, Check } from 'lucide-react';
 import type { ContextUsage } from '@/hooks/usePilot';
-import { useState, useCallback, useRef, KeyboardEvent } from 'react';
+import { useState, useCallback, useRef, useEffect, KeyboardEvent } from 'react';
 import { cn } from '@/lib/utils';
 
 /** Format token count: 0 → "0", 1234 → "1.2k", 12345 → "12.3k", 123456 → "123k" */
@@ -31,12 +31,32 @@ interface InputAreaProps {
     dpFocus?: string | null;
     dpActive?: boolean;
     onSetDpActive?: (active: boolean) => void;
+    /** External draft text — when changed, populates the input and focuses it */
+    draft?: string | null;
+    /** Sequence counter — ensures useEffect fires even for repeated same-value drafts */
+    draftSeq?: number;
 }
 
-export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive }: InputAreaProps) {
+export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive, draft, draftSeq }: InputAreaProps) {
     const [value, setValue] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const isComposingRef = useRef(false);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    // When external draft changes, populate input and focus
+    useEffect(() => {
+        if (draft) {
+            setValue(draft);
+            setTimeout(() => {
+                const el = textareaRef.current;
+                if (el) {
+                    el.focus();
+                    el.setSelectionRange(draft.length, draft.length);
+                }
+            }, 0);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draft, draftSeq]);
 
     // Deep investigation toggle — controlled by parent (usePilot manages state)
     const deepInvestigation = dpActive ?? false;
@@ -206,20 +226,29 @@ export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, 
                             </div>
                         )}
 
-                        <textarea
-                            value={value}
-                            onFocus={() => setIsFocused(true)}
-                            onBlur={() => setIsFocused(false)}
-                            onChange={(e) => setValue(e.target.value)}
-                            onKeyDown={handleKeyDown}
-                            onCompositionStart={() => { isComposingRef.current = true; }}
-                            onCompositionEnd={() => { isComposingRef.current = false; }}
-                            placeholder={disabled ? "Connecting..." : "Reply..."}
-                            disabled={disabled}
-                            className="w-full bg-transparent border-none outline-none px-6 py-3 pr-14 text-[15px] text-gray-900 placeholder:text-gray-400 focus:ring-0 focus:outline-none resize-none min-h-[48px] max-h-[200px] disabled:cursor-not-allowed"
-                            rows={1}
-                            style={{ height: 'auto' }}
-                        />
+                        <div className="relative w-full">
+                            <textarea
+                                ref={textareaRef}
+                                value={value}
+                                onFocus={() => setIsFocused(true)}
+                                onBlur={() => setIsFocused(false)}
+                                onChange={(e) => setValue(e.target.value)}
+                                onKeyDown={handleKeyDown}
+                                onCompositionStart={() => { isComposingRef.current = true; }}
+                                onCompositionEnd={() => { isComposingRef.current = false; }}
+                                placeholder={disabled ? "Connecting..." : "Reply..."}
+                                disabled={disabled}
+                                className="w-full bg-transparent border-none outline-none px-6 py-3 pr-14 text-[15px] text-gray-900 placeholder:text-gray-400 focus:ring-0 focus:outline-none resize-none min-h-[48px] max-h-[200px] disabled:cursor-not-allowed"
+                                rows={1}
+                                style={{ height: 'auto' }}
+                            />
+                            {draft && value.trim() === draft.trim() && (
+                                <span className="absolute left-6 top-3 pointer-events-none text-[15px]">
+                                    <span className="invisible">{value}</span>
+                                    <span className="text-gray-400">add details or press Enter ↵</span>
+                                </span>
+                            )}
+                        </div>
 
                         {isLoading && value.trim() ? (
                             <button

--- a/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
@@ -1,6 +1,5 @@
-import { ArrowUp, Square, X, Loader2, BookOpen, Search, SearchCode, MessageSquareHeart } from 'lucide-react';
+import { ArrowUp, Square, X, Loader2, BookOpen, SearchCode, MessageSquareHeart, Plus, Check } from 'lucide-react';
 import type { ContextUsage } from '@/hooks/usePilot';
-import type { Skill } from '@/pages/Skills/skillsData';
 import { useState, useCallback, useRef, KeyboardEvent } from 'react';
 import { cn } from '@/lib/utils';
 
@@ -27,17 +26,14 @@ interface InputAreaProps {
     isCompacting?: boolean;
     editingSkill?: { id: string; name: string } | null;
     onClearEditSkill?: () => void;
-    skills?: Skill[];
-    onEditSkill?: (id: string, name: string) => void;
     pendingMessages?: string[];
     onRemovePending?: (index: number) => void;
     dpFocus?: string | null;
     dpActive?: boolean;
     onSetDpActive?: (active: boolean) => void;
-    hasMessages?: boolean;
 }
 
-export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, skills, onEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive, hasMessages }: InputAreaProps) {
+export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, editingSkill, onClearEditSkill, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive }: InputAreaProps) {
     const [value, setValue] = useState('');
     const [isFocused, setIsFocused] = useState(false);
     const isComposingRef = useRef(false);
@@ -46,10 +42,8 @@ export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, 
     const deepInvestigation = dpActive ?? false;
     const setDeepInvestigation = onSetDpActive ?? (() => {});
 
-    // Skill picker state
-    const [showSkillPicker, setShowSkillPicker] = useState(false);
-    const [skillSearch, setSkillSearch] = useState('');
-    const skillSearchRef = useRef<HTMLInputElement>(null);
+    // Action menu state
+    const [showActionMenu, setShowActionMenu] = useState(false);
 
     const handleSend = useCallback(async () => {
         const text = value.trim();
@@ -98,147 +92,55 @@ export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, 
                     >
                         {/* Toolbar */}
                         <div className="flex items-center gap-1 px-4 pt-3 pb-1 min-w-0">
-                            {/* Skill Picker */}
-                            {skills && skills.length > 0 && onEditSkill && (
-                                <div className="relative">
-                                    <button
-                                        type="button"
-                                        onClick={() => { setShowSkillPicker(!showSkillPicker); setSkillSearch(''); }}
-                                        disabled={disabled}
-                                        className={cn(
-                                            "p-1.5 rounded-lg transition-colors disabled:opacity-50",
-                                            showSkillPicker
-                                                ? "text-indigo-600 bg-indigo-50"
-                                                : "text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-                                        )}
-                                        title="Select skill to edit"
-                                    >
-                                        <BookOpen className="w-4 h-4" />
-                                    </button>
-
-                                    {showSkillPicker && (
-                                        <>
-                                            <div className="fixed inset-0 z-10" onClick={() => setShowSkillPicker(false)} />
-                                            <div className="absolute bottom-full left-0 mb-1 bg-white rounded-xl shadow-xl border border-gray-200 z-20 w-[280px] max-h-[360px] flex flex-col">
-                                                {/* Search */}
-                                                <div className="px-3 pt-3 pb-2">
-                                                    <div className="relative">
-                                                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
-                                                        <input
-                                                            ref={skillSearchRef}
-                                                            type="text"
-                                                            value={skillSearch}
-                                                            onChange={(e) => setSkillSearch(e.target.value)}
-                                                            placeholder="Search skills..."
-                                                            className="w-full pl-8 pr-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-indigo-300 focus:border-indigo-300"
-                                                            autoFocus
-                                                        />
-                                                    </div>
-                                                </div>
-
-                                                {/* Skill list */}
-                                                <div className="overflow-y-auto flex-1 pb-2">
-                                                    {(() => {
-                                                        const query = skillSearch.toLowerCase();
-                                                        const filtered = skills.filter(s =>
-                                                            s.name.toLowerCase().includes(query) ||
-                                                            s.description.toLowerCase().includes(query)
-                                                        );
-                                                        const groups: { label: string; scope: Skill['scope'] }[] = [
-                                                            { label: 'Personal', scope: 'personal' },
-                                                            { label: 'Team Skills', scope: 'team' },
-                                                            { label: 'System Skills', scope: 'builtin' },
-                                                        ];
-                                                        const hasResults = filtered.length > 0;
-
-                                                        if (!hasResults) {
-                                                            return (
-                                                                <div className="px-3 py-4 text-center text-sm text-gray-400">
-                                                                    No skills found
-                                                                </div>
-                                                            );
-                                                        }
-
-                                                        return groups.map(({ label, scope }) => {
-                                                            const items = filtered.filter(s => s.scope === scope);
-                                                            if (items.length === 0) return null;
-                                                            return (
-                                                                <div key={scope}>
-                                                                    <div className="px-3 pt-2 pb-1">
-                                                                        <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-400">{label}</span>
-                                                                    </div>
-                                                                    {items.map(skill => {
-                                                                        const isSelected = editingSkill?.id === String(skill.id);
-                                                                        return (
-                                                                            <button
-                                                                                key={skill.id}
-                                                                                type="button"
-                                                                                className={cn(
-                                                                                    "flex flex-col w-full px-3 py-1.5 text-left transition-colors",
-                                                                                    isSelected
-                                                                                        ? "bg-indigo-50 border-l-2 border-indigo-500"
-                                                                                        : "hover:bg-gray-50 border-l-2 border-transparent"
-                                                                                )}
-                                                                                onClick={() => {
-                                                                                    onEditSkill(String(skill.id), skill.name);
-                                                                                    setShowSkillPicker(false);
-                                                                                }}
-                                                                            >
-                                                                                <span className={cn(
-                                                                                    "text-sm font-medium truncate",
-                                                                                    isSelected ? "text-indigo-700" : "text-gray-700"
-                                                                                )}>
-                                                                                    {skill.name}
-                                                                                </span>
-                                                                                {skill.description && (
-                                                                                    <span className="text-xs text-gray-400 truncate">{skill.description}</span>
-                                                                                )}
-                                                                            </button>
-                                                                        );
-                                                                    })}
-                                                                </div>
-                                                            );
-                                                        });
-                                                    })()}
-                                                </div>
-                                            </div>
-                                        </>
-                                    )}
-                                </div>
-                            )}
-
-                            {/* Deep Investigation Toggle */}
-                            {(
+                            <div className="relative">
                                 <button
                                     type="button"
-                                    onClick={() => setDeepInvestigation(!deepInvestigation)}
+                                    onClick={() => setShowActionMenu(!showActionMenu)}
                                     disabled={disabled}
                                     className={cn(
                                         "p-1.5 rounded-lg transition-colors disabled:opacity-50",
-                                        deepInvestigation
-                                            ? "text-blue-600 bg-blue-50"
+                                        showActionMenu
+                                            ? "text-gray-600 bg-gray-100"
                                             : "text-gray-400 hover:text-gray-600 hover:bg-gray-100"
                                     )}
-                                    title={deepInvestigation ? "Deep Investigation enabled — click to disable" : "Enable Deep Investigation"}
+                                    title="Actions"
                                 >
-                                    <SearchCode className="w-4 h-4" />
+                                    <Plus className="w-4 h-4" />
                                 </button>
-                            )}
 
-                            {/* Session Feedback */}
-                            {!isLoading && !disabled && hasMessages && (
-                                <button
-                                    type="button"
-                                    onClick={() => onSend("[Feedback]")}
-                                    className="p-1.5 rounded-lg transition-colors text-gray-400 hover:text-emerald-600 hover:bg-emerald-50"
-                                    title="Session Feedback"
-                                >
-                                    <MessageSquareHeart className="w-4 h-4" />
-                                </button>
-                            )}
+                                {showActionMenu && (
+                                    <>
+                                        <div className="fixed inset-0 z-10" onClick={() => setShowActionMenu(false)} />
+                                        <div className="absolute bottom-full left-0 mb-1 bg-white rounded-xl shadow-xl border border-gray-200 z-20 w-[220px]">
+                                            <div className="py-1">
+                                                {/* Deep Investigation */}
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setDeepInvestigation(!deepInvestigation)}
+                                                    className="flex items-center gap-3 w-full px-3 py-2.5 text-left hover:bg-gray-50 transition-colors"
+                                                >
+                                                    <SearchCode className="w-4 h-4 text-blue-500 shrink-0" />
+                                                    <span className="flex-1 text-sm text-gray-700">Deep Investigation</span>
+                                                    {deepInvestigation && <Check className="w-4 h-4 text-blue-500 shrink-0" />}
+                                                </button>
 
-                            <div className="ml-auto flex items-center gap-3 shrink-0">
+                                                {/* Session Feedback */}
+                                                {!isLoading && (
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => { onSend("[Feedback]"); setShowActionMenu(false); }}
+                                                        className="flex items-center gap-3 w-full px-3 py-2.5 text-left hover:bg-gray-50 transition-colors"
+                                                    >
+                                                        <MessageSquareHeart className="w-4 h-4 text-emerald-500 shrink-0" />
+                                                        <span className="flex-1 text-sm text-gray-700">Session Feedback</span>
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </>
+                                )}
                             </div>
+                            <div className="ml-auto flex items-center gap-3 shrink-0" />
                         </div>
 
                         {/* Mode chips */}

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -15,7 +15,7 @@ const THINKING_TIPS = [
     'Tip: Siclaw remembers findings across sessions \u2014 ask about past investigations',
     'Analyzing the situation...',
     'Tip: Use Skills to run reusable diagnostic scripts',
-    'Tip: You can steer the AI mid-response by typing in the input box',
+    'Tip: You can queue your next message while the AI is responding',
     'Working on it...',
 ];
 import { DpChecklistCard, type DpChecklistItem } from './DpChecklistCard';
@@ -196,7 +196,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
     }, [sessionKey]);
 
     // Suggested reply draft — chip click populates input instead of sending immediately
-    const chipSeq = useRef(0);
+    const [chipSeq, setChipSeq] = useState(0);
     const [chipDraft, setChipDraft] = useState<string | null>(null);
 
     // Feedback hint: show once per session after agent finishes first response
@@ -447,7 +447,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                     hypothesesAlreadyConfirmed={msg.id === latestHypothesesId && latestHypothesesConfirmed}
                                     selectedWorkspaceId={selectedWorkspaceId}
                                     showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
-                                    onChipClick={(key) => { chipSeq.current++; setChipDraft(key + ' '); }}
+                                    onChipClick={(key) => { setChipSeq(s => s + 1); setChipDraft(key + ' '); }}
                                 />
                             ))}
 
@@ -471,7 +471,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                     <div ref={scrollRef} />
                 </div>
             </div>
-            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} hasMessages={messages.length > 0} draft={chipDraft} draftSeq={chipSeq.current} />
+            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} hasMessages={messages.length > 0} draft={chipDraft} draftSeq={chipSeq} />
         </div>
     );
 }

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -240,6 +240,16 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
         return null;
     }, [messages]);
 
+    // Find last assistant message id — used to show suggested reply chips only on the latest reply
+    const lastAssistantMsgId = useMemo(() => {
+        const visible = messages.filter(m => !m.hidden);
+        for (let i = visible.length - 1; i >= 0; i--) {
+            if (visible[i].role === 'assistant') return visible[i].id;
+            if (visible[i].role === 'user') return null;
+        }
+        return null;
+    }, [messages]);
+
     // Check if latest hypotheses were already confirmed.
     // Three signals (any one is sufficient):
     // 1. deep_search tool message exists after hypotheses (works when complete or in live session)
@@ -432,6 +442,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                     hypothesesSuperseded={latestHypothesesId != null && msg.toolName === 'propose_hypotheses' && msg.id !== latestHypothesesId}
                                     hypothesesAlreadyConfirmed={msg.id === latestHypothesesId && latestHypothesesConfirmed}
                                     selectedWorkspaceId={selectedWorkspaceId}
+                                    showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
                                 />
                             ))}
 
@@ -530,7 +541,48 @@ function parseDeepInvestigation(content: string): { isDeepInvestigation: boolean
     return { isDeepInvestigation: false, text: content };
 }
 
-function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, dpChecklistActive, onHypothesesConfirmed, hypothesesSuperseded, hypothesesAlreadyConfirmed, selectedWorkspaceId }: {
+/** Parse <!-- suggested-replies: A|Label A, B|Label B --> from assistant messages */
+interface SuggestedReply { key: string; label: string; }
+
+/** Auto-detect `- **X.** Label — description` option patterns from agent output */
+function detectOptionReplies(content: string): SuggestedReply[] {
+    const replies: SuggestedReply[] = [];
+    const regex = /[-*]\s+\*\*([A-Za-z\d]+)\.\*\*\s+(.+?)(?:\s+[—\-–]\s+.*)?$/gm;
+    for (const match of content.matchAll(regex)) {
+        replies.push({ key: match[1], label: match[2].trim() });
+    }
+    return replies.length >= 2 && replies.length <= 8 ? replies : [];
+}
+
+function parseSuggestedReplies(content: string): { replies: SuggestedReply[]; text: string } {
+    // Priority 1: Explicit HTML comment (escape hatch for custom cases)
+    const commentMatch = content.match(/<!--\s*suggested-replies:\s*(.*?)\s*-->/);
+    if (commentMatch) {
+        const replies: SuggestedReply[] = [];
+        for (const part of commentMatch[1].split(',')) {
+            const trimmed = part.trim();
+            if (!trimmed) continue;
+            const pipeIdx = trimmed.indexOf('|');
+            if (pipeIdx > 0) {
+                replies.push({ key: trimmed.slice(0, pipeIdx).trim(), label: trimmed.slice(pipeIdx + 1).trim() });
+            } else {
+                replies.push({ key: trimmed, label: trimmed });
+            }
+        }
+        const text = content.replace(/<!--\s*suggested-replies:\s*.*?\s*-->/, '').trimEnd();
+        return { replies, text };
+    }
+
+    // Priority 2: Auto-detect **X.** option patterns — zero agent burden
+    const detected = detectOptionReplies(content);
+    if (detected.length > 0) {
+        return { replies: detected, text: content };
+    }
+
+    return { replies: [], text: content };
+}
+
+function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, dpChecklistActive, onHypothesesConfirmed, hypothesesSuperseded, hypothesesAlreadyConfirmed, selectedWorkspaceId, showSuggestedReplies }: {
     message: PilotMessage;
     sendRpc?: RpcSendFn;
     skills?: Skill[];
@@ -554,6 +606,7 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
     /** True when a deep_search exists after this propose_hypotheses — survives page refresh */
     hypothesesAlreadyConfirmed?: boolean;
     selectedWorkspaceId?: string | null;
+    showSuggestedReplies?: boolean;
 }) {
     const isUser = message.role === 'user';
     const isTool = message.role === 'tool';
@@ -593,9 +646,14 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
     const { scripts, text: afterScripts } = isUser
         ? parseScriptRefs(afterDeepInv)
         : { scripts: [] as ScriptRef[], text: afterDeepInv };
-    const { skillName, text: textContent } = isUser
+    const { skillName, text: afterSkillRef } = isUser
         ? parseSkillRef(afterScripts)
         : { skillName: null, text: afterScripts };
+
+    // Parse suggested replies from the last non-streaming assistant message
+    const { replies: suggestedReplies, text: textContent } = !isUser && !isTool && showSuggestedReplies && !message.isStreaming
+        ? parseSuggestedReplies(afterSkillRef)
+        : { replies: [] as SuggestedReply[], text: afterSkillRef };
 
     return (
         <div className={cn(
@@ -672,6 +730,21 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
                             : "bg-white border border-gray-200 text-gray-800 rounded-tl-sm"
                     )}>
                         <Markdown>{textContent}</Markdown>
+                    </div>
+                )}
+
+                {suggestedReplies.length > 0 && sendMessage && (
+                    <div className="flex flex-wrap gap-2 mt-2">
+                        {suggestedReplies.map((reply) => (
+                            <button
+                                key={reply.key}
+                                type="button"
+                                onClick={() => sendMessage(reply.key)}
+                                className="rounded-full px-3 py-1.5 text-sm border border-gray-200 bg-white hover:bg-gray-50 text-gray-700 transition-colors cursor-pointer"
+                            >
+                                {reply.label}
+                            </button>
+                        ))}
                     </div>
                 )}
             </div>

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -427,7 +427,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                     <div ref={scrollRef} />
                 </div>
             </div>
-            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} skills={skills} onEditSkill={onEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} />
+            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} skills={skills} onEditSkill={onEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} hasMessages={messages.length > 0} />
         </div>
     );
 }

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -195,6 +195,10 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
         }
     }, [sessionKey]);
 
+    // Suggested reply draft — chip click populates input instead of sending immediately
+    const chipSeq = useRef(0);
+    const [chipDraft, setChipDraft] = useState<string | null>(null);
+
     // Feedback hint: show once per session after agent finishes first response
     const hasShownFeedbackHintRef = useRef(false);
     const prevIsLoadingRef = useRef(isLoading);
@@ -443,6 +447,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                     hypothesesAlreadyConfirmed={msg.id === latestHypothesesId && latestHypothesesConfirmed}
                                     selectedWorkspaceId={selectedWorkspaceId}
                                     showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
+                                    onChipClick={(key) => { chipSeq.current++; setChipDraft(key + ' '); }}
                                 />
                             ))}
 
@@ -466,7 +471,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                     <div ref={scrollRef} />
                 </div>
             </div>
-            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} />
+            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} draft={chipDraft} draftSeq={chipSeq.current} />
         </div>
     );
 }
@@ -544,14 +549,25 @@ function parseDeepInvestigation(content: string): { isDeepInvestigation: boolean
 /** Parse <!-- suggested-replies: A|Label A, B|Label B --> from assistant messages */
 interface SuggestedReply { key: string; label: string; }
 
-/** Auto-detect `- **X.** Label — description` option patterns from agent output */
+/** Auto-detect option patterns from agent output.
+ *  Primary:  `- **X.** Label` (bullet + bold)
+ *  Fallback: `X. Label` (plain, letter-only keys — catches agent format drift) */
 function detectOptionReplies(content: string): SuggestedReply[] {
-    const replies: SuggestedReply[] = [];
+    // Primary: - **X.** label (bullet + bold)
+    const primary: SuggestedReply[] = [];
     const regex = /[-*]\s+\*\*([A-Za-z\d]+)\.\*\*\s+(.+?)(?:\s+[—\-–]\s+.*)?$/gm;
     for (const match of content.matchAll(regex)) {
-        replies.push({ key: match[1], label: match[2].trim() });
+        primary.push({ key: match[1], label: match[2].trim() });
     }
-    return replies.length >= 2 && replies.length <= 8 ? replies : [];
+    if (primary.length >= 2 && primary.length <= 8) return primary;
+
+    // Fallback: X. label (uppercase letter keys only, avoids matching numbered lists)
+    const fallback: SuggestedReply[] = [];
+    const fallbackRegex = /^([A-Z])\.\s+(.+?)(?:\s+[—\-–]\s+.*)?$/gm;
+    for (const match of content.matchAll(fallbackRegex)) {
+        fallback.push({ key: match[1], label: match[2].trim() });
+    }
+    return fallback.length >= 2 && fallback.length <= 8 ? fallback : [];
 }
 
 function parseSuggestedReplies(content: string): { replies: SuggestedReply[]; text: string } {
@@ -582,7 +598,7 @@ function parseSuggestedReplies(content: string): { replies: SuggestedReply[]; te
     return { replies: [], text: content };
 }
 
-function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, dpChecklistActive, onHypothesesConfirmed, hypothesesSuperseded, hypothesesAlreadyConfirmed, selectedWorkspaceId, showSuggestedReplies }: {
+function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus, onOpenSkillPanel, onOpenSchedulePanel, sendRpc, updateMessageMeta, investigationProgress, sendMessage, abortResponse, dpFocus, dpChecklistActive, onHypothesesConfirmed, hypothesesSuperseded, hypothesesAlreadyConfirmed, selectedWorkspaceId, showSuggestedReplies, onChipClick }: {
     message: PilotMessage;
     sendRpc?: RpcSendFn;
     skills?: Skill[];
@@ -607,6 +623,8 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
     hypothesesAlreadyConfirmed?: boolean;
     selectedWorkspaceId?: string | null;
     showSuggestedReplies?: boolean;
+    /** Chip click populates input instead of sending immediately */
+    onChipClick?: (key: string) => void;
 }) {
     const isUser = message.role === 'user';
     const isTool = message.role === 'tool';
@@ -650,10 +668,14 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
         ? parseSkillRef(afterScripts)
         : { skillName: null, text: afterScripts };
 
-    // Parse suggested replies from the last non-streaming assistant message
+    // Always strip <!-- suggested-replies --> comments from assistant messages (they should never be visible)
+    // Only parse replies into chips for the last non-streaming assistant message
+    const strippedContent = !isUser && !isTool
+        ? afterSkillRef.replace(/<!--\s*suggested-replies:\s*.*?\s*-->/g, '').trimEnd()
+        : afterSkillRef;
     const { replies: suggestedReplies, text: textContent } = !isUser && !isTool && showSuggestedReplies && !message.isStreaming
         ? parseSuggestedReplies(afterSkillRef)
-        : { replies: [] as SuggestedReply[], text: afterSkillRef };
+        : { replies: [] as SuggestedReply[], text: strippedContent };
 
     return (
         <div className={cn(
@@ -733,16 +755,16 @@ function MessageItem({ message, skills, onEditSkill, skillStatus, scheduleStatus
                     </div>
                 )}
 
-                {suggestedReplies.length > 0 && sendMessage && (
+                {suggestedReplies.length > 0 && onChipClick && (
                     <div className="flex flex-wrap gap-2 mt-2">
                         {suggestedReplies.map((reply) => (
                             <button
                                 key={reply.key}
                                 type="button"
-                                onClick={() => sendMessage(reply.key)}
+                                onClick={() => onChipClick(reply.key)}
                                 className="rounded-full px-3 py-1.5 text-sm border border-gray-200 bg-white hover:bg-gray-50 text-gray-700 transition-colors cursor-pointer"
                             >
-                                {reply.label}
+                                <span className="font-medium text-gray-500">{reply.key}.</span> {reply.label}
                             </button>
                         ))}
                     </div>

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -471,7 +471,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                     <div ref={scrollRef} />
                 </div>
             </div>
-            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} draft={chipDraft} draftSeq={chipSeq.current} />
+            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} hasMessages={messages.length > 0} draft={chipDraft} draftSeq={chipSeq.current} />
         </div>
     );
 }

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -7,6 +7,17 @@ import { SkillCard, type SkillRefStatus } from './SkillCard';
 import { ScheduleCard, type ScheduleCardStatus } from './ScheduleCard';
 import { InvestigationCard } from './InvestigationCard';
 import { HypothesesCard } from './HypothesesCard';
+
+const THINKING_TIPS = [
+    'Thinking...',
+    'Tip: Use + to provide session feedback and help the AI improve',
+    'Tip: Enable Deep Investigation for hypothesis-driven root cause analysis',
+    'Tip: Siclaw remembers findings across sessions \u2014 ask about past investigations',
+    'Analyzing the situation...',
+    'Tip: Use Skills to run reusable diagnostic scripts',
+    'Tip: You can steer the AI mid-response by typing in the input box',
+    'Working on it...',
+];
 import { DpChecklistCard, type DpChecklistItem } from './DpChecklistCard';
 import { WelcomeArea } from './WelcomeArea';
 import type { PilotMessage, ContextUsage, InvestigationProgress, SystemStatus } from '@/hooks/usePilot';
@@ -175,6 +186,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
             userScrolledAwayRef.current = false;
             prevMsgCountRef.current = 0;
             needsScrollOnLoadRef.current = true;
+            hasShownFeedbackHintRef.current = false;
             pendingRestoreScrollRef.current = true;
             if (restoreScrollTimerRef.current) {
                 clearTimeout(restoreScrollTimerRef.current);
@@ -182,6 +194,23 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
             }
         }
     }, [sessionKey]);
+
+    // Feedback hint: show once per session after agent finishes first response
+    const hasShownFeedbackHintRef = useRef(false);
+    const prevIsLoadingRef = useRef(isLoading);
+    const [showFeedbackHint, setShowFeedbackHint] = useState(false);
+
+    useEffect(() => {
+        const wasLoading = prevIsLoadingRef.current;
+        prevIsLoadingRef.current = isLoading;
+
+        if (wasLoading && !isLoading && !hasShownFeedbackHintRef.current && messages.length > 0) {
+            hasShownFeedbackHintRef.current = true;
+            setShowFeedbackHint(true);
+            const timer = setTimeout(() => setShowFeedbackHint(false), 7000);
+            return () => clearTimeout(timer);
+        }
+    }, [isLoading, messages.length]);
 
     useEffect(() => {
         return () => {
@@ -411,15 +440,14 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                 <DpChecklistCard items={dpChecklist} investigationProgress={investigationProgress} onDismiss={onExitDp} />
                             )}
 
-                            {isLoading && (
-                                <div className="flex gap-4">
-                                    <div className="w-8 h-8 rounded-full bg-white border border-gray-200 flex items-center justify-center text-primary-600 shadow-sm">
-                                        <Cpu className="w-5 h-5" />
-                                    </div>
-                                    <div className="flex items-center gap-2 text-gray-400">
-                                        <Loader2 className="w-4 h-4 animate-spin" />
-                                        <span className="text-sm">Thinking...</span>
-                                    </div>
+                            {isLoading && <ThinkingIndicator />}
+
+                            {showFeedbackHint && (
+                                <div className={cn(
+                                    "text-center text-xs text-gray-400 py-2 transition-opacity duration-500",
+                                    showFeedbackHint ? "opacity-100" : "opacity-0"
+                                )}>
+                                    Was this helpful? Tap <span className="font-medium text-gray-500">+</span> below to share feedback
                                 </div>
                             )}
                         </>
@@ -427,7 +455,40 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                     <div ref={scrollRef} />
                 </div>
             </div>
-            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} skills={skills} onEditSkill={onEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} hasMessages={messages.length > 0} />
+            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} editingSkill={editingSkill} onClearEditSkill={onClearEditSkill} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} />
+        </div>
+    );
+}
+
+function ThinkingIndicator() {
+    const [tipIndex, setTipIndex] = useState(0);
+    const [visible, setVisible] = useState(true);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setVisible(false);
+            setTimeout(() => {
+                setTipIndex(i => (i + 1) % THINKING_TIPS.length);
+                setVisible(true);
+            }, 300);
+        }, 8000);
+        return () => clearInterval(interval);
+    }, []);
+
+    return (
+        <div className="flex gap-4">
+            <div className="w-8 h-8 rounded-full bg-white border border-gray-200 flex items-center justify-center text-primary-600 shadow-sm">
+                <Cpu className="w-5 h-5" />
+            </div>
+            <div className="flex items-center gap-2 text-gray-400">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className={cn(
+                    "text-sm transition-opacity duration-300",
+                    visible ? "opacity-100" : "opacity-0"
+                )}>
+                    {THINKING_TIPS[tipIndex]}
+                </span>
+            </div>
         </div>
     );
 }

--- a/src/tools/manage-schedule.ts
+++ b/src/tools/manage-schedule.ts
@@ -107,7 +107,7 @@ Common cron patterns:
       // List action: query Gateway for current schedules
       if (params.action === "list") {
         const cfg = loadConfig();
-        const gatewayUrl = cfg.server.gatewayUrl || "http://siclaw-gateway";
+        const gatewayUrl = cfg.server.gatewayUrl || `http://localhost:${cfg.server.port}`;
         const userId = cfg.userId;
         const workspaceId = process.env.SICLAW_WORKSPACE_ID;
         try {

--- a/src/tools/save-feedback.ts
+++ b/src/tools/save-feedback.ts
@@ -1,0 +1,133 @@
+/**
+ * save_feedback tool — persists structured session feedback to Gateway DB
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { loadConfig } from "../core/config.js";
+import { GatewayClient } from "../agentbox/gateway-client.js";
+
+const MAX_CONVERSATION_BYTES = 100 * 1024; // 100KB
+
+interface SaveFeedbackParams {
+  overallRating: number;
+  summary: string;
+  decisionPoints?: string;
+  strengths?: string;
+  improvements?: string;
+  tags?: string;
+  feedbackConversation?: string;
+}
+
+export function createSaveFeedbackTool(
+  sessionIdRef: { current: string },
+): ToolDefinition {
+  return {
+    name: "save_feedback",
+    label: "Save Session Feedback",
+    description: `Save a structured feedback report for the current diagnostic session.
+Call this after completing the interactive feedback review with the user.
+The report includes overall rating, decision point evaluations, strengths, improvements, and tags.`,
+    parameters: Type.Object({
+      overallRating: Type.Integer({
+        minimum: 1,
+        maximum: 5,
+        description: "Overall session rating (1=poor, 5=excellent)",
+      }),
+      summary: Type.String({
+        description: "Brief summary of the feedback (1-3 sentences)",
+      }),
+      decisionPoints: Type.Optional(Type.String({
+        description: "JSON array of decision point evaluations: [{ step: number, description: string, wasCorrect: boolean, comment?: string, idealAction?: string }]",
+      })),
+      strengths: Type.Optional(Type.String({
+        description: "JSON array of strengths identified: string[]",
+      })),
+      improvements: Type.Optional(Type.String({
+        description: "JSON array of improvements suggested: string[]",
+      })),
+      tags: Type.Optional(Type.String({
+        description: 'JSON array of category tags: string[] (e.g. "wrong-skill", "slow-path", "missing-check")',
+      })),
+      feedbackConversation: Type.Optional(Type.String({
+        description: "JSON summary of the feedback dialogue (optional)",
+      })),
+    }),
+    async execute(_toolCallId, rawParams) {
+      const params = rawParams as SaveFeedbackParams;
+
+      const cfg = loadConfig();
+      const gatewayUrl = cfg.server.gatewayUrl || "http://siclaw-gateway";
+      const userId = cfg.userId;
+      const sessionId = sessionIdRef.current;
+
+      if (!userId) {
+        return {
+          content: [{ type: "text", text: "Cannot save feedback: userId not configured." }],
+          details: { error: true },
+        };
+      }
+      if (!sessionId) {
+        return {
+          content: [{ type: "text", text: "Cannot save feedback: session ID not available." }],
+          details: { error: true },
+        };
+      }
+
+      // Parse JSON string fields
+      let decisionPoints: unknown;
+      let strengths: unknown;
+      let improvements: unknown;
+      let tags: unknown;
+      let feedbackConversation: unknown;
+
+      try {
+        if (params.decisionPoints) decisionPoints = JSON.parse(params.decisionPoints);
+        if (params.strengths) strengths = JSON.parse(params.strengths);
+        if (params.improvements) improvements = JSON.parse(params.improvements);
+        if (params.tags) tags = JSON.parse(params.tags);
+        if (params.feedbackConversation) {
+          let conv = params.feedbackConversation;
+          if (conv.length > MAX_CONVERSATION_BYTES) {
+            conv = conv.slice(0, MAX_CONVERSATION_BYTES);
+          }
+          feedbackConversation = JSON.parse(conv);
+        }
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Invalid JSON in feedback fields: ${err instanceof Error ? err.message : String(err)}` }],
+          details: { error: true },
+        };
+      }
+
+      try {
+        const gatewayClient = new GatewayClient({ gatewayUrl });
+        const result = await gatewayClient.toClientLike().request(
+          "/api/internal/feedback",
+          "POST",
+          {
+            sessionId,
+            userId,
+            overallRating: params.overallRating,
+            summary: params.summary,
+            decisionPoints,
+            strengths,
+            improvements,
+            tags,
+            feedbackConversation,
+          },
+        ) as { ok: boolean; id: string };
+
+        return {
+          content: [{ type: "text", text: `Feedback saved successfully (id: ${result.id}).` }],
+          details: { id: result.id, sessionId },
+        };
+      } catch (err) {
+        return {
+          content: [{ type: "text", text: `Failed to save feedback: ${err instanceof Error ? err.message : String(err)}` }],
+          details: { error: true },
+        };
+      }
+    },
+  };
+}

--- a/src/tools/save-feedback.ts
+++ b/src/tools/save-feedback.ts
@@ -75,34 +75,38 @@ The report includes overall rating, decision point evaluations, strengths, impro
         };
       }
 
-      // Parse JSON string fields
+      // Parse JSON string fields independently — valid fields are saved even if one fails
       let decisionPoints: unknown;
       let strengths: unknown;
       let improvements: unknown;
       let tags: unknown;
       let feedbackConversation: unknown;
       let conversationOmitted = false;
+      const parseErrors: string[] = [];
 
-      try {
-        if (params.decisionPoints) decisionPoints = JSON.parse(params.decisionPoints);
-        if (params.strengths) strengths = JSON.parse(params.strengths);
-        if (params.improvements) improvements = JSON.parse(params.improvements);
-        if (params.tags) tags = JSON.parse(params.tags);
-        if (params.feedbackConversation) {
+      const tryParse = (name: string, value: string | undefined): unknown => {
+        if (!value) return undefined;
+        try { return JSON.parse(value); }
+        catch { parseErrors.push(name); return undefined; }
+      };
+
+      decisionPoints = tryParse("decisionPoints", params.decisionPoints);
+      strengths = tryParse("strengths", params.strengths);
+      improvements = tryParse("improvements", params.improvements);
+      tags = tryParse("tags", params.tags);
+
+      if (params.feedbackConversation) {
+        try {
           const parsed = JSON.parse(params.feedbackConversation);
           const serialized = JSON.stringify(parsed);
-          // Drop entirely if serialized size exceeds limit (truncating JSON is unsafe)
           if (serialized.length <= MAX_CONVERSATION_BYTES) {
             feedbackConversation = parsed;
           } else {
             conversationOmitted = true;
           }
+        } catch {
+          parseErrors.push("feedbackConversation");
         }
-      } catch (err) {
-        return {
-          content: [{ type: "text", text: `Invalid JSON in feedback fields: ${err instanceof Error ? err.message : String(err)}` }],
-          details: { error: true },
-        };
       }
 
       try {
@@ -125,7 +129,7 @@ The report includes overall rating, decision point evaluations, strengths, impro
         ) as { ok: boolean; id: string };
 
         return {
-          content: [{ type: "text", text: `Feedback saved successfully (id: ${result.id}).${conversationOmitted ? " Note: conversation transcript omitted (exceeded size limit)." : ""}` }],
+          content: [{ type: "text", text: `Feedback saved successfully (id: ${result.id}).${conversationOmitted ? " Note: conversation transcript omitted (exceeded size limit)." : ""}${parseErrors.length > 0 ? ` Warning: failed to parse ${parseErrors.join(", ")} (saved without these fields).` : ""}` }],
           details: { id: result.id, sessionId },
         };
       } catch (err) {

--- a/src/tools/save-feedback.ts
+++ b/src/tools/save-feedback.ts
@@ -81,6 +81,7 @@ The report includes overall rating, decision point evaluations, strengths, impro
       let improvements: unknown;
       let tags: unknown;
       let feedbackConversation: unknown;
+      let conversationOmitted = false;
 
       try {
         if (params.decisionPoints) decisionPoints = JSON.parse(params.decisionPoints);
@@ -91,7 +92,11 @@ The report includes overall rating, decision point evaluations, strengths, impro
           const parsed = JSON.parse(params.feedbackConversation);
           const serialized = JSON.stringify(parsed);
           // Drop entirely if serialized size exceeds limit (truncating JSON is unsafe)
-          feedbackConversation = serialized.length <= MAX_CONVERSATION_BYTES ? parsed : undefined;
+          if (serialized.length <= MAX_CONVERSATION_BYTES) {
+            feedbackConversation = parsed;
+          } else {
+            conversationOmitted = true;
+          }
         }
       } catch (err) {
         return {
@@ -120,7 +125,7 @@ The report includes overall rating, decision point evaluations, strengths, impro
         ) as { ok: boolean; id: string };
 
         return {
-          content: [{ type: "text", text: `Feedback saved successfully (id: ${result.id}).` }],
+          content: [{ type: "text", text: `Feedback saved successfully (id: ${result.id}).${conversationOmitted ? " Note: conversation transcript omitted (exceeded size limit)." : ""}` }],
           details: { id: result.id, sessionId },
         };
       } catch (err) {

--- a/src/tools/save-feedback.ts
+++ b/src/tools/save-feedback.ts
@@ -57,7 +57,7 @@ The report includes overall rating, decision point evaluations, strengths, impro
       const params = rawParams as SaveFeedbackParams;
 
       const cfg = loadConfig();
-      const gatewayUrl = cfg.server.gatewayUrl || "http://siclaw-gateway";
+      const gatewayUrl = cfg.server.gatewayUrl || `http://localhost:${cfg.server.port}`;
       const userId = cfg.userId;
       const sessionId = sessionIdRef.current;
       const workspaceId = process.env.SICLAW_WORKSPACE_ID;

--- a/src/tools/save-feedback.ts
+++ b/src/tools/save-feedback.ts
@@ -60,6 +60,7 @@ The report includes overall rating, decision point evaluations, strengths, impro
       const gatewayUrl = cfg.server.gatewayUrl || "http://siclaw-gateway";
       const userId = cfg.userId;
       const sessionId = sessionIdRef.current;
+      const workspaceId = process.env.SICLAW_WORKSPACE_ID;
 
       if (!userId) {
         return {
@@ -87,11 +88,10 @@ The report includes overall rating, decision point evaluations, strengths, impro
         if (params.improvements) improvements = JSON.parse(params.improvements);
         if (params.tags) tags = JSON.parse(params.tags);
         if (params.feedbackConversation) {
-          let conv = params.feedbackConversation;
-          if (conv.length > MAX_CONVERSATION_BYTES) {
-            conv = conv.slice(0, MAX_CONVERSATION_BYTES);
-          }
-          feedbackConversation = JSON.parse(conv);
+          const parsed = JSON.parse(params.feedbackConversation);
+          const serialized = JSON.stringify(parsed);
+          // Drop entirely if serialized size exceeds limit (truncating JSON is unsafe)
+          feedbackConversation = serialized.length <= MAX_CONVERSATION_BYTES ? parsed : undefined;
         }
       } catch (err) {
         return {
@@ -108,6 +108,7 @@ The report includes overall rating, decision point evaluations, strengths, impro
           {
             sessionId,
             userId,
+            workspaceId,
             overallRating: params.overallRating,
             summary: params.summary,
             decisionPoints,


### PR DESCRIPTION
## Summary

- Adds a system-level interactive feedback mechanism: users click a button in WebUI, Gateway enriches the message with session timeline + feedback protocol instructions, agent guides multi-turn review, structured report saved to DB
- New `feedback_reports` table with full schema parity (SQLite + MySQL + migration + indexes)
- `save_feedback` tool registered for both pi-agent and claude-sdk brain paths
- Feedback API endpoint on both HTTP server (local mode) and HTTPS/mTLS server (K8s mode)
- Frontend feedback button only visible when session has messages (no empty-session feedback)

## Design Decisions

- **System-level UI trigger** — Gateway intercepts `[Feedback]` prefix and enriches with SKILL.md + diagnostic timeline, no changes to `prompt.ts`
- **sessionIdRef closure** — follows existing `run_skill` pattern instead of env vars
- **Dual server registration** — HTTP (local) + HTTPS/mTLS (K8s) for the feedback endpoint
- **Gateway DB storage** — `feedback_reports` table, independent from agent memory system (`userdata/memory/`)

## Data Flow

```
User clicks feedback button → chat.send("[Feedback]")
  → Gateway saves raw message to DB
  → Detects [Feedback] prefix → enriches with SKILL.md + session timeline
  → Agent receives full context, runs 4-phase feedback protocol
  → Agent calls save_feedback → POST /api/internal/feedback → feedback_reports table
```

## Test plan

- [x] `npx tsc --noEmit` passes (backend + frontend)
- [x] `npm test` — all 1004 tests pass
- [ ] Local Gateway startup → feedback button visible in WebUI after sending a message
- [ ] Click feedback button → agent starts review (timeline summary → numbered options)
- [ ] Complete feedback flow → verify `feedback_reports` row in DB
- [ ] Verify button hidden on empty/new sessions