### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siclaw",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siclaw",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siclaw",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AI-powered SRE copilot for Kubernetes diagnostics via natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump package.json version to 0.1.4
- Already published to npm: `siclaw@0.1.4`