### PR TITLE
Fix skill diff: baseline tracking + personal fork eye icon

### DIFF
--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -2790,10 +2790,16 @@ export function createRpcMethods(
 
       // Save content
       if (skillContentRepo) {
-        await skillContentRepo.save(id, "working", {
+        const forkedFiles = {
           specs: effectiveSpecs,
           scripts: effectiveScripts,
-        });
+        };
+        await skillContentRepo.save(id, "working", forkedFiles);
+        // Persist the fork source as the initial baseline so later diffs show
+        // what changed inside the Skill Space after the fork.
+        await skillContentRepo.save(id, "published", forkedFiles);
+        await skillRepo.update(id, { publishedVersion: inheritVersion });
+        console.log(`[skill.fork] Initialized Skill Space baseline for ${id} from ${sourceId}`);
       }
 
       // Notify all members to reload
@@ -2852,10 +2858,16 @@ export function createRpcMethods(
 
     // ── 6. Save content ──
     if (skillContentRepo) {
-      await skillContentRepo.save(id, "working", {
+      const forkedFiles = {
         specs: effectiveSpecs,
         scripts: effectiveScripts,
-      });
+      };
+      await skillContentRepo.save(id, "working", forkedFiles);
+      // Persist the fork source as the initial baseline so later diffs show
+      // what changed after the fork (same pattern as skillset forks).
+      await skillContentRepo.save(id, "published", forkedFiles);
+      await skillRepo.update(id, { publishedVersion: inheritVersion });
+      console.log(`[skill.fork] Initialized personal baseline for ${id} from ${sourceId}`);
     }
 
     const hasScripts = effectiveScripts && effectiveScripts.length > 0;
@@ -3152,6 +3164,7 @@ export function createRpcMethods(
       oldPrefix: string,
       newPrefix: string,
     ): string {
+      if (!oldFiles && !newFiles) return "Baseline not found — cannot compute diff.";
       const parts: string[] = [];
 
       // SKILL.md diff
@@ -3187,34 +3200,116 @@ export function createRpcMethods(
     }
 
     if (meta.scope === "skillset") {
-      let globalFiles: SkillFiles | null = null;
+      let baselineFiles: SkillFiles | null = null;
+      let baselineLabel = "Skill Space baseline";
+      let baselinePrefix = "skill-space-baseline";
       if (skillContentRepo) {
-        const globalSkill = await skillRepo.getByDirNameAndScope(meta.dirName, "team");
-        if (globalSkill) {
-          globalFiles = await skillContentRepo.read(globalSkill.id, "published");
-        }
+        baselineFiles = await skillContentRepo.read(skillId, "published");
       }
 
-      if (!globalFiles && meta.forkedFromId) {
+      if (!baselineFiles && meta.forkedFromId) {
+        console.warn(`[skill.diff] Missing Skill Space baseline for ${skillId}; falling back to fork source ${meta.forkedFromId}`);
         if (meta.forkedFromId.startsWith("builtin:") || meta.forkedFromId.startsWith("core:") || meta.forkedFromId.startsWith("extension:")) {
-          const dirName = meta.forkedFromId.includes(":") ? meta.forkedFromId.split(":")[1] : meta.forkedFromId;
-          globalFiles = skillWriter.readSkill("builtin", dirName);
+          const dirName = meta.forkedFromId.includes(":") ? meta.forkedFromId.split(":").slice(1).join(":") : meta.forkedFromId;
+          if (dirName.includes("..")) {
+            console.error(`[skill.diff] Refusing path-traversal dirName: ${dirName}`);
+          } else {
+            baselineFiles = skillWriter.readSkill("builtin", dirName);
+          }
+          baselineLabel = "Builtin source";
+          baselinePrefix = "builtin-source";
         } else if (skillContentRepo) {
           const sourceMeta = await skillRepo.getById(meta.forkedFromId);
           if (sourceMeta) {
             const sourceTag = sourceMeta.scope === "team" ? "published" : "working";
-            globalFiles = await skillContentRepo.read(sourceMeta.id, sourceTag as SkillContentTag);
+            baselineFiles = await skillContentRepo.read(sourceMeta.id, sourceTag as SkillContentTag);
+            if (sourceMeta.scope === "team") {
+              baselineLabel = "Global published";
+              baselinePrefix = "global-published";
+            } else if (sourceMeta.scope === "skillset") {
+              baselineLabel = "Skill Space source";
+              baselinePrefix = "skill-space-source";
+            } else {
+              baselineLabel = "Fork source";
+              baselinePrefix = "fork-source";
+            }
           }
         }
       }
 
       let stagingFiles: SkillFiles | null = null;
       if (skillContentRepo) stagingFiles = await skillContentRepo.read(skillId, "staging");
-      if (!stagingFiles && skillContentRepo) {
-        stagingFiles = await skillContentRepo.read(skillId, "working");
+      let compareFiles = stagingFiles;
+      let compareLabel = "Skill Space staging";
+      let comparePrefix = "skill-space-staging";
+      if (!compareFiles && skillContentRepo) {
+        compareFiles = await skillContentRepo.read(skillId, "working");
+        compareLabel = "Skill Space draft";
+        comparePrefix = "skill-space-draft";
       }
 
-      return { diff: buildFullDiff(globalFiles, stagingFiles, "global", "skill-space") };
+      return {
+        diff: buildFullDiff(baselineFiles, compareFiles, baselinePrefix, comparePrefix),
+        baselineLabel,
+        compareLabel,
+      };
+    }
+
+    // Personal fork diff: fork baseline vs current working/staging
+    if (meta.scope === "personal" && meta.forkedFromId && !teamDiff) {
+      let baselineFiles: SkillFiles | null = null;
+      let baselineLabel = "Fork baseline";
+      let baselinePrefix = "fork-baseline";
+      if (skillContentRepo) {
+        baselineFiles = await skillContentRepo.read(skillId, "published");
+      }
+
+      if (!baselineFiles) {
+        console.warn(`[skill.diff] Missing personal fork baseline for ${skillId}; falling back to fork source ${meta.forkedFromId}`);
+        if (meta.forkedFromId.startsWith("builtin:") || meta.forkedFromId.startsWith("core:") || meta.forkedFromId.startsWith("extension:")) {
+          const dirName = meta.forkedFromId.includes(":") ? meta.forkedFromId.split(":").slice(1).join(":") : meta.forkedFromId;
+          if (dirName.includes("..")) {
+            console.error(`[skill.diff] Refusing path-traversal dirName: ${dirName}`);
+          } else {
+            baselineFiles = skillWriter.readSkill("builtin", dirName);
+          }
+          baselineLabel = "Builtin source";
+          baselinePrefix = "builtin-source";
+        } else if (skillContentRepo) {
+          const sourceMeta = await skillRepo.getById(meta.forkedFromId);
+          if (sourceMeta) {
+            const sourceTag = sourceMeta.scope === "team" ? "published" : "working";
+            baselineFiles = await skillContentRepo.read(sourceMeta.id, sourceTag as SkillContentTag);
+            if (sourceMeta.scope === "team") {
+              baselineLabel = "Global published";
+              baselinePrefix = "global-published";
+            } else if (sourceMeta.scope === "skillset") {
+              baselineLabel = "Skill Space source";
+              baselinePrefix = "skill-space-source";
+            } else {
+              baselineLabel = "Fork source";
+              baselinePrefix = "fork-source";
+            }
+          }
+        }
+      }
+
+      let stagingFiles: SkillFiles | null = null;
+      if (skillContentRepo) stagingFiles = await skillContentRepo.read(skillId, "staging");
+      let compareFiles = stagingFiles;
+      let compareLabel = "Personal staging";
+      let comparePrefix = "personal-staging";
+      if (!compareFiles && skillContentRepo) {
+        compareFiles = await skillContentRepo.read(skillId, "working");
+        compareLabel = "Personal draft";
+        comparePrefix = "personal-draft";
+      }
+
+      return {
+        diff: buildFullDiff(baselineFiles, compareFiles, baselinePrefix, comparePrefix),
+        baselineLabel,
+        compareLabel,
+      };
     }
 
     if (teamDiff) {
@@ -3229,7 +3324,11 @@ export function createRpcMethods(
       let publishedFiles: SkillFiles | null = null;
       if (skillContentRepo) publishedFiles = await skillContentRepo.read(skillId, "published");
 
-      return { diff: buildFullDiff(teamFiles, publishedFiles, "team", "contributed") };
+      return {
+        diff: buildFullDiff(teamFiles, publishedFiles, "team", "contributed"),
+        baselineLabel: "Global published",
+        compareLabel: "Contributed",
+      };
     } else {
       // Publish review: published vs staging
       let publishedFiles: SkillFiles | null = null;
@@ -3240,8 +3339,18 @@ export function createRpcMethods(
 
       // If no staging, fall back to working copy
       let compareFiles = stagingFiles;
-      if (!compareFiles && skillContentRepo) compareFiles = await skillContentRepo.read(skillId, "working");
-      return { diff: buildFullDiff(publishedFiles, compareFiles, "published", "staging") };
+      let compareLabel = "Staging";
+      let comparePrefix = "staging";
+      if (!compareFiles && skillContentRepo) {
+        compareFiles = await skillContentRepo.read(skillId, "working");
+        compareLabel = "Draft";
+        comparePrefix = "draft";
+      }
+      return {
+        diff: buildFullDiff(publishedFiles, compareFiles, "published", comparePrefix),
+        baselineLabel: "Published",
+        compareLabel,
+      };
     }
   });
 

--- a/src/gateway/web/src/pages/Skills/SkillSpaceDetail.tsx
+++ b/src/gateway/web/src/pages/Skills/SkillSpaceDetail.tsx
@@ -230,7 +230,7 @@ export function SkillSpaceDetailPage() {
             setDiffModal({
                 isOpen: true,
                 title: `${skill.name} Diff`,
-                subtitle: 'Global published -> Skill Space staging',
+                subtitle: 'Loading comparison...',
                 diffText: null,
                 isLoading: true,
             });
@@ -238,7 +238,9 @@ export function SkillSpaceDetailPage() {
             setDiffModal({
                 isOpen: true,
                 title: `${skill.name} Diff`,
-                subtitle: 'Global published -> Skill Space staging',
+                subtitle: result.baselineLabel && result.compareLabel
+                    ? `${result.baselineLabel} -> ${result.compareLabel}`
+                    : 'Skill Space diff',
                 diffText: result.diff || 'No changes detected.',
                 isLoading: false,
             });
@@ -246,7 +248,7 @@ export function SkillSpaceDetailPage() {
             setDiffModal({
                 isOpen: true,
                 title: `${skill.name} Diff`,
-                subtitle: 'Global published -> Skill Space staging',
+                subtitle: 'Skill Space diff',
                 diffText: 'Failed to load diff.',
                 isLoading: false,
             });
@@ -576,11 +578,13 @@ export function SkillSpaceDetailPage() {
                                         </div>
                                         {isMaintainer && (
                                             <div className="flex gap-1 ml-2">
+                                                {(skill.forkedFromId || (skill.publishedVersion && skill.publishedVersion > 0)) && (
                                                 <Tooltip content="Open Diff">
                                                     <button onClick={() => handleViewDiff(skill)} className="p-1 text-gray-300 hover:text-gray-600 rounded">
                                                         <Eye className="w-3.5 h-3.5" />
                                                     </button>
                                                 </Tooltip>
+                                                )}
                                                 <Tooltip content="Delete">
                                                     <button onClick={() => handleDeleteSkill(skill)} className="p-1 text-gray-300 hover:text-red-500 rounded">
                                                         <Trash2 className="w-3.5 h-3.5" />

--- a/src/gateway/web/src/pages/Skills/index.tsx
+++ b/src/gateway/web/src/pages/Skills/index.tsx
@@ -55,6 +55,44 @@ export function SkillsPage() {
     const labelDropdownRef = useRef<HTMLDivElement>(null);
     const searchTimerRef = useRef<ReturnType<typeof setTimeout>>();
     const contentRef = useRef<HTMLDivElement>(null);
+    const [personalDiffModal, setPersonalDiffModal] = useState<{
+        isOpen: boolean;
+        title: string;
+        subtitle: string;
+        diffText: string | null;
+        isLoading: boolean;
+    }>({ isOpen: false, title: '', subtitle: '', diffText: null, isLoading: false });
+
+    const handlePersonalDiff = async (skill: Skill) => {
+        setPersonalDiffModal({
+            isOpen: true,
+            title: `${skill.name} Diff`,
+            subtitle: 'Loading comparison...',
+            diffText: null,
+            isLoading: true,
+        });
+        try {
+            const result = await rpcGetSkillDiff(sendRpc, String(skill.id));
+            setPersonalDiffModal({
+                isOpen: true,
+                title: `${skill.name} Diff`,
+                subtitle: result.baselineLabel && result.compareLabel
+                    ? `${result.baselineLabel} -> ${result.compareLabel}`
+                    : 'Personal diff',
+                diffText: result.diff || 'No changes detected.',
+                isLoading: false,
+            });
+        } catch (err: any) {
+            setPersonalDiffModal({
+                isOpen: true,
+                title: `${skill.name} Diff`,
+                subtitle: 'Personal diff',
+                diffText: 'Failed to load diff.',
+                isLoading: false,
+            });
+            console.error('[Skills] Failed to load personal fork diff:', err);
+        }
+    };
 
     // Label color mapping by category
     const labelColors: Record<string, string> = {
@@ -318,8 +356,8 @@ export function SkillsPage() {
         e.stopPropagation();
         setDialogState({
             isOpen: true,
-            title: 'Contribute to Team',
-            description: `Contribute "${skill.name}" to the team? An admin will review before it becomes a shared team skill.`,
+            title: 'Contribute to Global',
+            description: `Contribute "${skill.name}" to global? An admin will review before it becomes a shared global skill.`,
             variant: 'primary',
             confirmText: 'Contribute',
             onConfirm: () => { publishSkill(skill, true).catch((err: any) => showError(err?.message || String(err))); }
@@ -331,7 +369,7 @@ export function SkillsPage() {
         setDialogState({
             isOpen: true,
             title: 'Fork to Personal',
-            description: `This will fork "${skill.name}" into your personal skills. You can edit and customize the fork, and optionally contribute changes back to the team.`,
+            description: `This will fork "${skill.name}" into your personal skills. You can edit and customize the fork, and optionally contribute changes back to global.`,
             variant: 'primary',
             confirmText: 'Fork Skill',
             onConfirm: () => { copyToPersonal(skill); }
@@ -888,7 +926,7 @@ export function SkillsPage() {
                                         )}
 
                                         {skill.scope === 'personal' && skill.reviewStatus === 'approved' && skill.contributionStatus !== 'pending' && (
-                                            <Tooltip content="Contribute to Team">
+                                            <Tooltip content="Contribute to Global">
                                                 <button
                                                     onClick={(e) => handleContribute(e, skill)}
                                                     className="p-1.5 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
@@ -939,6 +977,17 @@ export function SkillsPage() {
                                                     className="p-1.5 text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
                                                 >
                                                     <GitCommitHorizontal className="w-4 h-4" />
+                                                </button>
+                                            </Tooltip>
+                                        )}
+
+                                        {skill.scope === 'personal' && (skill.forkedFromId || (skill.publishedVersion && skill.publishedVersion > 0)) && (
+                                            <Tooltip content="View Diff">
+                                                <button
+                                                    onClick={(e) => { e.stopPropagation(); handlePersonalDiff(skill); }}
+                                                    className="p-1.5 text-gray-400 hover:text-cyan-600 hover:bg-cyan-50 rounded-lg transition-colors"
+                                                >
+                                                    <Eye className="w-4 h-4" />
                                                 </button>
                                             </Tooltip>
                                         )}
@@ -1032,6 +1081,15 @@ export function SkillsPage() {
                     </div>
                 </div>
             )}
+
+            <DiffViewerModal
+                isOpen={personalDiffModal.isOpen}
+                onClose={() => setPersonalDiffModal(prev => ({ ...prev, isOpen: false }))}
+                title={personalDiffModal.title}
+                subtitle={personalDiffModal.subtitle}
+                diffText={personalDiffModal.diffText}
+                isLoading={personalDiffModal.isLoading}
+            />
         </div>
     );
 }
@@ -1176,7 +1234,7 @@ function ScriptReviewApprovalCard({
                 variant: 'primary',
                 confirmText: skill.scope === 'skillset'
                     ? 'Approve & Merge to Global'
-                    : (isContributionReview ? 'Approve & Publish to Team' : 'Approve'),
+                    : (isContributionReview ? 'Approve & Publish to Global' : 'Approve'),
                 onConfirm: () => executeDecision('approve'),
             });
         } else {
@@ -1497,7 +1555,7 @@ function ScriptReviewApprovalCard({
                                             className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-green-700 bg-green-50 border border-green-200 hover:bg-green-100 rounded-lg transition-all disabled:opacity-50"
                                         >
                                             <Check className="w-4 h-4" />
-                                            {skill.scope === 'skillset' ? 'Approve & Merge to Global' : (isContributionReview ? 'Approve & Publish to Team' : 'Approve')}
+                                            {skill.scope === 'skillset' ? 'Approve & Merge to Global' : (isContributionReview ? 'Approve & Publish to Global' : 'Approve')}
                                         </button>
                                     </div>
                                 </div>

--- a/src/gateway/web/src/pages/Skills/skillsData.ts
+++ b/src/gateway/web/src/pages/Skills/skillsData.ts
@@ -232,7 +232,7 @@ export async function rpcGetSkillDiff(
     id: string,
     teamDiff?: boolean,
     workspaceId?: string,
-): Promise<{ diff: string }> {
+): Promise<{ diff: string; baselineLabel?: string; compareLabel?: string }> {
     return sendRpc('skill.diff', { id, teamDiff, workspaceId });
 }
 


### PR DESCRIPTION
## Problem

1. **Skill space diff showed full file as additions** instead of incremental diff. The old logic looked up a team skill by `dirName` for the baseline — failed for builtin forks, and the fallback hit a path traversal bug (`resolveUnderDir` with relative `skillsDir`).

2. **Personal forked skills had no diff viewer.** No eye icon existed on the skills list page, and no fork baseline was persisted at fork time.

3. **Eye icon showed unconditionally** in skill spaces, even for newly created skills with no meaningful baseline.

## Solution

**Fork-time baseline persistence** (both skillset and personal):
- Save fork source content as `published` tag at fork time, creating an immutable baseline snapshot
- Set `publishedVersion` atomically with the baseline write

**Improved `skill.diff` RPC**:
- Skillset: read own `published` tag first (not team skill by dirName), with fallback chain for pre-fix forks (builtin → team → skillset → personal source)
- Personal fork: new branch mirrors skillset logic — own `published` baseline, same fallback chain
- All branches return `baselineLabel` + `compareLabel` for dynamic frontend subtitles
- Existing publish-review path (non-fork approved skills) now also returns labels

**Frontend**:
- Eye icon visibility unified: `forkedFromId || publishedVersion > 0` (both skill space and personal list)
- Dynamic subtitle from backend labels instead of hardcoded strings
- Personal skills list: new diff modal + handler reusing `DiffViewerModal`

## Test plan

- [ ] Fork a global/builtin skill to skill space → diff shows "No changes detected"
- [ ] Edit the forked skill → diff shows only the delta
- [ ] Fork a global skill to personal → eye icon appears, diff shows "No changes detected"
- [ ] Edit the personal fork → diff shows incremental changes
- [ ] Approve a skill space skill → baseline advances, next diff is incremental from approved version
- [ ] Newly created (non-fork) skill in skill space → no eye icon until first approve
- [ ] Non-fork personal skill → no eye icon until first approve; after approve shows "Published → Draft"
- [ ] Pre-fix forks (no published tag) → fallback to fork source, no errors