### PR TITLE
fix(skills): sync skill name between DB and SKILL.md frontmatter

### DIFF
--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -2516,7 +2516,7 @@ export function createRpcMethods(
     const userId = requireAuth(context);
     const username = context.auth!.username;
 
-    const name = params.name as string;
+    const name = (params.name as string)?.trim();
     const type = params.type as string | undefined;
     const specs = params.specs as string | undefined;
     const rawScripts = params.scripts as
@@ -2525,10 +2525,19 @@ export function createRpcMethods(
 
     if (!name) throw new Error("Missing required param: name");
 
+    // Sync name into specs frontmatter so DB name and frontmatter name stay consistent
+    let syncedSpecs = specs;
+    let fmDescription: string | undefined;
+    if (syncedSpecs) {
+      const fm = skillWriter.parseFrontmatter(syncedSpecs);
+      fmDescription = fm.description || undefined;
+      if (fm.name !== name) {
+        syncedSpecs = skillWriter.setFrontmatterName(syncedSpecs, name);
+      }
+    }
+
     // Auto-extract description from specs frontmatter; fall back to explicit param
-    const description = specs
-      ? skillWriter.parseFrontmatter(specs).description || (params.description as string | undefined)
-      : (params.description as string | undefined);
+    const description = fmDescription || (params.description as string | undefined);
 
     // Resolve scripts: if content is missing, copy from user uploads directory
     let scripts: Array<{ name: string; content: string }> | undefined;
@@ -2545,8 +2554,8 @@ export function createRpcMethods(
       });
     }
 
-    // Generate dirName from skill name
-    const dirName = name
+    // Generate dirName from skill name, auto-deduplicate on collision
+    const baseDirName = name
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "");
@@ -2576,24 +2585,36 @@ export function createRpcMethods(
       if (!isMaintainer) throw new Error("Forbidden: only skill space maintainers can create skills");
     }
 
+    // Check display name uniqueness, then auto-deduplicate dirName on collision
+    let dirName = baseDirName;
     if (targetScope === "personal") {
-      // Check for duplicate personal skill with same dirName
       const existingResult = await skillRepo.listForUser(userId, { scope: "personal" });
-      const duplicate = existingResult.skills.find(
-        (s: any) => s.dirName === dirName && s.scope === "personal" && s.authorId === userId,
+      const personalSkills = existingResult.skills.filter(
+        (s: any) => s.scope === "personal" && s.authorId === userId,
       );
-      if (duplicate) {
-        throw new Error(
-          `A personal skill named "${name}" already exists (id: ${duplicate.id}). ` +
-          `Delete it first if you want to re-fork.`,
-        );
+      // Block same display name
+      const nameDup = personalSkills.find((s: any) => s.name === name);
+      if (nameDup) {
+        throw new Error(`A personal skill named "${name}" already exists. Rename or delete it first.`);
+      }
+      // Auto-dedup dirName (e.g. after a rename left a stale dirName)
+      const existingDirNames = new Set(personalSkills.map((s: any) => s.dirName));
+      let suffix = 1;
+      while (existingDirNames.has(dirName)) {
+        suffix++;
+        dirName = `${baseDirName}-${suffix}`;
       }
     } else {
-      // Check for duplicate in skill space
       const spaceSkills = await skillRepo.listBySkillSpaceId(skillSpaceId!);
-      const dupInSpace = spaceSkills.find((s: any) => s.dirName === dirName);
-      if (dupInSpace) {
-        throw new Error(`A skill named "${name}" already exists in this skill space`);
+      const nameDup = spaceSkills.find((s: any) => s.name === name);
+      if (nameDup) {
+        throw new Error(`A skill named "${name}" already exists in this skill space.`);
+      }
+      const existingDirNames = new Set(spaceSkills.map((s: any) => s.dirName));
+      let suffix = 1;
+      while (existingDirNames.has(dirName)) {
+        suffix++;
+        dirName = `${baseDirName}-${suffix}`;
       }
     }
 
@@ -2646,9 +2667,9 @@ export function createRpcMethods(
       skillSpaceId: skillSpaceId ?? undefined,
     });
 
-    // Save content to DB
+    // Save content to DB (use syncedSpecs so frontmatter name matches DB name)
     if (skillContentRepo) {
-      await skillContentRepo.save(id, "working", { specs, scripts });
+      await skillContentRepo.save(id, "working", { specs: syncedSpecs, scripts });
     }
 
     // Notify reload
@@ -2969,10 +2990,41 @@ export function createRpcMethods(
     }
 
     // Update files
-    const specs = params.specs as string | undefined;
+    const rawSpecs = params.specs as string | undefined;
     const rawScripts = params.scripts as
       | Array<{ name: string; content?: string }>
       | undefined;
+
+    // Resolve the canonical name: params.name (UI input) is authoritative
+    const newName = (params.name as string | undefined)?.trim() || undefined;
+
+    // Check name uniqueness on rename
+    if (newName !== undefined && newName !== meta.name) {
+      if (meta.scope === "personal") {
+        const existingResult = await skillRepo.listForUser(userId, { scope: "personal" });
+        const nameDup = existingResult.skills.find(
+          (s: any) => s.scope === "personal" && s.authorId === userId && s.name === newName && s.id !== skillId,
+        );
+        if (nameDup) {
+          throw new Error(`A personal skill named "${newName}" already exists. Rename or delete it first.`);
+        }
+      } else if (meta.scope === "skillset" && meta.skillSpaceId) {
+        const spaceSkills = await skillRepo.listBySkillSpaceId(meta.skillSpaceId);
+        const nameDup = spaceSkills.find((s: any) => s.name === newName && s.id !== skillId);
+        if (nameDup) {
+          throw new Error(`A skill named "${newName}" already exists in this skill space.`);
+        }
+      }
+    }
+
+    // Sync name into specs frontmatter so DB name and frontmatter name stay consistent
+    let specs = rawSpecs;
+    if (newName !== undefined && specs) {
+      const fmName = skillWriter.parseFrontmatter(specs).name;
+      if (fmName !== newName) {
+        specs = skillWriter.setFrontmatterName(specs, newName);
+      }
+    }
 
     // Resolve scripts: if content is missing, try DB then uploads dir then existing skill files
     // NOTE: an explicit empty array means "delete all scripts" — do NOT fall back to existing
@@ -3012,15 +3064,29 @@ export function createRpcMethods(
         specs: specs ?? existing?.specs,
         scripts: scripts ?? existing?.scripts,
       };
+      // If name changed but no new specs provided, sync name into existing specs
+      if (newName !== undefined && !specs && mergedFiles.specs) {
+        const fmName = skillWriter.parseFrontmatter(mergedFiles.specs).name;
+        if (fmName !== newName) {
+          mergedFiles.specs = skillWriter.setFrontmatterName(mergedFiles.specs, newName);
+        }
+      }
       await skillContentRepo.save(skillId, "working", mergedFiles);
     }
 
-    // Update DB metadata (name and dirName are immutable after creation)
+    // Update DB metadata (dirName is immutable after creation)
     const updates: Record<string, unknown> = {};
-    // Auto-extract description from specs frontmatter
+    // Name: params.name is authoritative; extract from frontmatter as fallback
+    if (newName !== undefined) {
+      updates.name = newName;
+    } else if (specs) {
+      const extractedName = skillWriter.parseFrontmatter(specs).name;
+      if (extractedName) updates.name = extractedName;
+    }
+    // Description: prefer frontmatter extraction, fall back to explicit param
     if (specs) {
-      const extracted = skillWriter.parseFrontmatter(specs).description;
-      if (extracted) updates.description = extracted;
+      const extractedDesc = skillWriter.parseFrontmatter(specs).description;
+      if (extractedDesc) updates.description = extractedDesc;
     } else if (params.description !== undefined) {
       updates.description = params.description;
     }

--- a/src/gateway/skills/file-writer.ts
+++ b/src/gateway/skills/file-writer.ts
@@ -161,15 +161,30 @@ export class SkillFileWriter {
     return result;
   }
 
+  /** Split specs into { before, yaml, after } around the frontmatter block */
+  private splitFrontmatter(specs: string): { before: string; yaml: string; after: string } | null {
+    const match = specs.match(/^(---\n)([\s\S]*?)(\n---)([\s\S]*)$/);
+    if (!match) return null;
+    return { before: match[1], yaml: match[2], after: match[3] + match[4] };
+  }
+
+  /** Strip YAML quotes from a raw value string */
+  private unquoteYaml(raw: string): string {
+    const v = raw.trim();
+    if (v.startsWith("'") && v.endsWith("'")) return v.slice(1, -1).replace(/''/g, "'");
+    if (v.startsWith('"') && v.endsWith('"')) return v.slice(1, -1);
+    return v;
+  }
+
   /** Parse YAML frontmatter from SKILL.md content */
   parseFrontmatter(specs: string): { name: string; description: string } {
-    const match = specs.match(/^---\n([\s\S]*?)\n---/);
-    if (!match) return { name: "", description: "" };
-    const yaml = match[1];
+    const fm = this.splitFrontmatter(specs);
+    if (!fm) return { name: "", description: "" };
+    const { yaml } = fm;
 
-    // Extract name (always a simple string)
+    // Extract name (may be quoted with single or double quotes)
     const nameMatch = yaml.match(/^name:\s*(.+)$/m);
-    const name = nameMatch ? nameMatch[1].trim() : "";
+    const name = nameMatch ? this.unquoteYaml(nameMatch[1]) : "";
 
     // Extract description — handles both inline and block scalar (>- / >)
     let description = "";
@@ -192,6 +207,29 @@ export class SkillFileWriter {
     }
 
     return { name, description };
+  }
+
+  /** Replace the `name:` field inside YAML frontmatter, preserving everything else */
+  setFrontmatterName(specs: string, newName: string): string {
+    // Sanitize: strip newlines to prevent YAML injection
+    const safeName = newName.replace(/[\r\n]/g, "").trim();
+    if (!safeName) return specs;
+    // Single-quote to prevent YAML special char issues (: # { } ' etc.)
+    const quoted = `'${safeName.replace(/'/g, "''")}'`;
+    const fm = this.splitFrontmatter(specs);
+    if (!fm) {
+      // No frontmatter — prepend one
+      return `---\nname: ${quoted}\n---\n${specs}`;
+    }
+    const { before, yaml, after } = fm;
+    const nameMatch = yaml.match(/^name:\s*.+$/m);
+    if (nameMatch) {
+      // Replace existing name field
+      const updatedYaml = yaml.replace(/^name:\s*.+$/m, `name: ${quoted}`);
+      return `${before}${updatedYaml}${after}`;
+    }
+    // No name field — add it as the first field
+    return `${before}name: ${quoted}\n${yaml}${after}`;
   }
 
   /** Scan a single directory for skills */

--- a/src/gateway/web/src/pages/Skills/SkillEditor.tsx
+++ b/src/gateway/web/src/pages/Skills/SkillEditor.tsx
@@ -126,6 +126,7 @@ export function SkillEditor() {
     const [formData, setFormData] = useState<Skill | null>(null);
     const [activeScriptId, setActiveScriptId] = useState<string | null>(null);
     const [isSaving, setIsSaving] = useState(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
     const [showAddMenu, setShowAddMenu] = useState(false);
     const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -228,7 +229,7 @@ export function SkillEditor() {
                 icon: Code2,
                 status: 'not_installed',
                 version: '0.0.1',
-                specs: DEFAULT_SPEC_TEMPLATE,
+                specs: DEFAULT_SPEC_TEMPLATE.replace(/^name:\s*.+$/m, 'name: New Custom Skill'),
                 scripts: [],
                 scope: 'personal',
                 author: 'Current User',
@@ -315,13 +316,15 @@ export function SkillEditor() {
         if (!formData) return;
         try {
             setIsSaving(true);
+            setSaveError(null);
             await rpcSaveSkill(sendRpc, formData, isNew, currentWorkspace?.id);
             if (id) clearDraft(id);
             setServerData(formData); // Mark current state as "saved" so isDirty becomes false
             isSaveNavigatingRef.current = true;
             navigate(backTarget);
-        } catch (err) {
+        } catch (err: any) {
             console.error('[SkillEditor] Save failed:', err);
+            setSaveError(err?.message || 'Save failed');
         } finally {
             setIsSaving(false);
         }
@@ -404,7 +407,18 @@ export function SkillEditor() {
 
     const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (formData) {
-            setFormData({ ...formData, name: e.target.value });
+            const newName = e.target.value;
+            // Sync name into specs frontmatter
+            let specs = formData.specs || '';
+            const fmMatch = specs.match(/^(---\n)([\s\S]*?)(\n---)/);
+            if (fmMatch) {
+                const yaml = fmMatch[2];
+                const updatedYaml = yaml.match(/^name:\s*.+$/m)
+                    ? yaml.replace(/^name:\s*.+$/m, `name: ${newName}`)
+                    : `name: ${newName}\n${yaml}`;
+                specs = `${fmMatch[1]}${updatedYaml}${fmMatch[3]}${specs.slice(fmMatch[0].length)}`;
+            }
+            setFormData({ ...formData, name: newName, specs });
         }
     };
 
@@ -554,6 +568,14 @@ export function SkillEditor() {
                     )}
                 </div>
             </header>
+
+            {/* Save error banner */}
+            {saveError && (
+                <div className="px-6 py-2.5 bg-red-50 border-b border-red-200 flex items-center gap-2 shrink-0">
+                    <span className="text-sm text-red-800">{saveError}</span>
+                    <button onClick={() => setSaveError(null)} className="ml-auto text-red-400 hover:text-red-600"><X className="w-4 h-4" /></button>
+                </div>
+            )}
 
             {/* Draft restore banner */}
             {draftRestored && (
@@ -723,7 +745,15 @@ export function SkillEditor() {
                             <div className="relative flex-1 group/editor">
                                 <textarea
                                     value={formData.specs}
-                                    onChange={(e) => !isReadOnly && setFormData({ ...formData, specs: e.target.value })}
+                                    onChange={(e) => {
+                                        if (isReadOnly) return;
+                                        const newSpecs = e.target.value;
+                                        // Sync frontmatter name → UI name
+                                        const fmMatch = newSpecs.match(/^---\n([\s\S]*?)\n---/);
+                                        const nameMatch = fmMatch?.[1]?.match(/^name:\s*(.+)$/m);
+                                        const fmName = nameMatch ? nameMatch[1].trim() : undefined;
+                                        setFormData({ ...formData, specs: newSpecs, ...(fmName !== undefined ? { name: fmName } : {}) });
+                                    }}
                                     readOnly={isReadOnly}
                                     className={cn(
                                         "w-full h-full px-4 py-3 border border-gray-200 rounded-lg text-xs font-mono text-gray-700 outline-none resize-none leading-relaxed transition-all",


### PR DESCRIPTION
## Problem

Skill rename was broken: the `skill.update` handler treated `name` as immutable, silently ignoring UI renames. Additionally, DB `name` and SKILL.md frontmatter `name:` were never synchronized — they diverged from creation time (DB stored "New Custom Skill" while frontmatter had the template default "new-skill").

This caused:
- Renaming a skill bumped version but didn't change the displayed name
- Creating a new skill after renaming an old one with the same original name failed silently (dirName collision)
- Save errors in the SkillEditor were swallowed (`console.error` only)

## Solution

**Establish DB `name` as authoritative, frontmatter `name:` as a sync target:**

### Backend (`rpc-methods.ts`, `file-writer.ts`)
- Add `setFrontmatterName()` helper to `SkillFileWriter` with newline sanitization to prevent YAML injection
- `skill.create`: sync `params.name` into specs frontmatter before persisting
- `skill.update`: `params.name` is authoritative → synced into specs frontmatter; if no explicit name, extract from frontmatter as fallback for DB name. Handles the case where specs is not provided (patches existing specs in DB)
- `skill.create`: add display name uniqueness check (separate from dirName check) + auto-dedup dirName on collision to handle stale dirNames left after renames

### Frontend (`SkillEditor.tsx`)
- Bidirectional sync: name input change → updates frontmatter `name:` in specs textarea; editing frontmatter `name:` in textarea → updates name input
- New skill template uses `"New Custom Skill"` in frontmatter (was hardcoded `"new-skill"`)
- Save errors shown in a red banner instead of silently swallowed

## Test plan

- [ ] Create a new skill → verify YAML frontmatter shows `name: New Custom Skill` (not `name: new-skill`)
- [ ] Rename skill via name input → verify frontmatter `name:` updates in real-time
- [ ] Edit frontmatter `name:` in YAML editor → verify top name input updates
- [ ] Save renamed skill → refresh page → verify name persists
- [ ] Rename skill A, then create new skill with A's original name → should succeed
- [ ] Try creating a skill with a duplicate display name → should show error banner