### PR TITLE
docs: establish harness framework for AI-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,12 @@
 # Siclaw — Operating Manual for Claude
 
-> This file is auto-loaded by Claude Code at the start of every session.
-> Keep it concise. Deep reference lives in `docs/design/`.
+> Auto-loaded at session start. Keep concise — deep reference lives in `docs/design/`.
 
 ---
 
 ## What This Project Is
 
-**Siclaw** is an AI-powered SRE copilot — a "cyber-twin" that runs Kubernetes diagnostics via natural language. It accumulates investigation experience across sessions, learns from team knowledge, and engages in deep technical discussion rather than just giving commands.
+**Siclaw** is an AI-powered SRE copilot that runs Kubernetes diagnostics via natural language.
 
 **Three runtime modes share one agent core:**
 ```
@@ -20,135 +19,118 @@ Gateway + K8sSpawner  (production — one isolated pod per user)
 
 ## Critical Architecture Invariants
 
-> Full spec: `docs/design/invariants.md` — read it before touching resource sync, skills, or security.
+> Full spec: `docs/design/invariants.md`
 
 ### 🔴 Local Mode: Shared Filesystem
 
-`LocalSpawner` runs ALL AgentBox instances **in-process with Gateway**, sharing the same filesystem. This means:
-
-- `skillsHandler.materialize()` **must NOT be called in local mode** — it wipes `skills/team/` and `skills/user/` subdirectories, destroying ALL users' personal skills on the shared filesystem
-- Local skills sync must write only to `skills/user/{userId}/` scoped paths (team skills are included in the user bundle, not written to a separate `skills/team/` directory)
-- Any component designed for K8s pod isolation is **not directly reusable** in local mode
+`LocalSpawner` runs ALL AgentBox instances **in-process**, sharing one filesystem.
+- `skillsHandler.materialize()` **must NOT be called in local mode** — wipes all users' skills
+- Local skills sync writes only to `skills/user/{userId}/` scoped paths
 
 ### 🔴 Skill Bundle Contract
 
-`buildSkillBundle()` packages **only team + personal skills** (never core skills). Core skills are baked into the Docker image / repo checkout. Calling `skillsHandler.materialize()` does NOT restore core skills — it only writes what's in the bundle.
+`buildSkillBundle()` packages **only team + personal skills**. Core skills are baked into the Docker image. `materialize()` does NOT restore core skills.
 
 ### 🔴 Shell Security: Defense-in-Depth
 
-> Full spec: `docs/design/security.md` — read it before touching execution tools, Dockerfile, or K8s manifests.
+> Full spec: `docs/design/security.md`; output sanitization: `docs/design/sanitization.md`
 
-Primary defense: **OS-level user isolation** — child processes run as `sandbox` user (cannot read credentials); `kubectl` has setgid `kubecred` group (ADR-010). Secondary defense: **whitelist-only command validation** — binaries must be in `ALLOWED_COMMANDS` (`src/tools/infra/command-sets.ts`). `sed`, `awk`, `nc`, `wget` are **intentionally excluded**. kubectl is **read-only** (13 safe subcommands; all write ops permanently blocked).
-
-### 🔴 sql.js: Single-Process Lock
-
-SQLite via sql.js loads the entire DB into memory. Only **one process** can hold `.siclaw/data.sqlite` at a time (PID lockfile). Local mode is single-process by design.
+Primary defense: **OS-level user isolation** — child processes run as `sandbox` user; `kubectl` has setgid `kubecred` (ADR-010). Secondary: **whitelist-only command validation** (`src/tools/infra/command-sets.ts`). `sed`, `awk`, `nc`, `wget` intentionally excluded. kubectl read-only (13 safe subcommands).
 
 ### 🔴 Two Separate Databases
 
-| Database | Purpose | Engine |
-|----------|---------|--------|
-| Gateway DB | Users, sessions, skills, channels, MCP config | sql.js (WASM) |
-| Memory DB | Embeddings, chunks, investigation records | node:sqlite (native) |
+| Database | Engine | Purpose |
+|----------|--------|---------|
+| Gateway DB | sql.js (WASM) | Users, sessions, skills, MCP config. Single-process lock. DDL in both `schema-sqlite.ts` AND `migrate-sqlite.ts`. |
+| Memory DB | node:sqlite | Embeddings, chunks, investigations. pi-agent only. |
 
-Never confuse them. Adding a table to Gateway DB requires changes in both `schema-sqlite.ts` AND `migrate-sqlite.ts`.
+### 🟡 Brain Type Gap
+
+Memory tools are **pi-agent only**. When adding tools, test both brain types.
 
 ### 🟡 mTLS Scope
 
-mTLS is used **only in K8s mode** (Gateway ↔ AgentBox pods). LocalSpawner uses plain HTTP on 127.0.0.1. Do not add mTLS dependencies to local mode code paths.
-
-### 🟡 Brain Type Feature Gap
-
-Memory tools (`memory_search`, investigation history) are **pi-agent only** — not available in claude-sdk brain. When adding new tools, test both brain types (TypeBox for pi-agent, Zod/MCP for claude-sdk).
+mTLS is **K8s mode only**. Do not add mTLS dependencies to local mode code paths.
 
 ---
 
-## Current Development Phase
+## Current Phase
 
-> Full roadmap: `docs/design/roadmap.md`
-
-| Phase | Status | Description |
-|-------|--------|-------------|
-| IM Phase 0 | ✅ Done | Raw memory loop (write + search + inject) |
-| IM Phase 1 | ✅ Done (PR #17) | Structured extraction, SQLite investigations table |
-| **KR0** | 🔄 In Progress | Qdrant + knowledge base ingestion |
-| **IM Phase 2** | 🔄 In Progress | Diagnostic path learning from history |
-| PM1 | ⏳ Next | 4-layer config cascade (System → Team → Personal → Workspace) |
-
-**Open research**: R1 (Contextual vs Late Chunking), R3 (config merge strategy), T1 (KG storage: Kuzu vs SQLite)
-
-### 🔴 System Prompt Protection
-
-**`src/core/prompt.ts` (the SRE system prompt) must NEVER be modified without explicit human confirmation.** This file defines the agent's core behavioral rules, safety constraints, and credential handling — unauthorized changes can break security or alter agent behavior in subtle, hard-to-detect ways. Before making any change to this file, describe the intended modification and get approval first.
+**Active**: KR0 (Qdrant), IM Phase 2 (diagnostic path learning)  |  **Next**: OB0 (Prometheus), PM1 (config cascade)
+**Consolidation**: Harness hardening — verifying existing features before next roadmap. Full roadmap: `docs/design/roadmap.md`
 
 ---
 
-## Development Principles
+## Change Impact Matrix
 
-1. **Understand before building**: Before developing any new feature, thoroughly read existing documentation (`docs/design/`) and related code. Understand the current architecture, existing tools, and design patterns. Never reinvent what already exists.
-2. **Docs and code stay in sync**: Every code change MUST include corresponding documentation updates. Outdated docs are worse than no docs — they actively mislead. If you change a tool, update `docs/design/tools.md`. If you change architecture, update `docs/design/invariants.md`. No exceptions.
-3. **System prompt is protected**: `src/core/prompt.ts` must NEVER be modified without explicit human confirmation. Describe the intended change and wait for approval before editing.
+> Before modifying any file, find it here. Read the required docs and verify cross-cutting concerns **before writing code**.
 
-## PR & Code Review Standards
-
-> Full conventions: `CONTRIBUTING.md`
-
-**Review approach — understand the whole, then judge the diff:**
-
-Reviewing a PR is NOT just reading the diff. Before approving:
-1. Read the relevant design docs (`docs/design/`) to understand the architectural context
-2. Read the existing code around the changed files to understand the full picture
-3. Then evaluate: Is the PR's design sound? Does it fit the architecture? Are there simpler alternatives?
-4. Verify documentation is updated to match the code changes
-
-**Checklist:**
-
-1. **Deployment mode awareness**: Does the change respect local vs K8s isolation? If it touches resource sync, skills materialization, or filesystem writes, re-read `docs/design/invariants.md §1-2`
-2. **Security model intact**: No new shell execution paths that bypass `command-sets.ts`. No weakening of the 6-pass pipeline. OS user isolation preserved (ADR-010). Skill scripts still go through review gate. Read `docs/design/security.md` for full model.
-3. **PR description complete**: Must have Problem + Solution (not just diff summary). See `CONTRIBUTING.md` for format.
-4. **TypeScript conventions**: ESM-only (`.js` imports), strict mode, named exports, no default exports in barrels.
-5. **Both brain types**: Tool changes must work with both pi-agent (TypeBox) and claude-sdk (MCP/Zod) if applicable.
-6. **SQLite DDL parity**: New tables need entries in both `schema-sqlite.ts` and `migrate-sqlite.ts`.
-7. **Documentation parity**: Code changes must be accompanied by corresponding doc updates.
-
-**Common review pitfalls:**
-- Calling `skillsHandler.materialize()` in local mode code paths (ADR-003, ADR-002)
-- Missing `migrate-sqlite.ts` DDL for new tables (breaks SQLite/local deployments)
-- Path traversal in file writes — validate with `resolvePathUnderDir()` pattern, don't roll your own
-- Duplicate helper functions across files — extract to shared utility
-- Docs out of sync with code — check `docs/design/`, `CLAUDE.md`, and skill SKILL.md files
+| If you change... | Must read | Must verify | Cross-cutting concerns |
+|---|---|---|---|
+| `src/tools/infra/command-sets.ts` | security.md §4, tools.md §6 | `npm test` | Skill scripts still work; sanitization rules still align |
+| `src/tools/infra/output-sanitizer.ts` | sanitization.md, tools.md §6.2 | `npm test` | Pipeline fallback in restricted-bash; deep-search sub-agent output |
+| `src/tools/infra/command-validator.ts` | security.md §4, tools.md §6.2 | `npm test` | All tools calling `validateCommand()` |
+| `src/tools/shell/restricted-bash.ts` | security.md, tools.md §5, sanitization.md | `npm test` | kubectl validation; skill bypass (`isSkillScript`); 3-layer sanitization |
+| `src/tools/shell/local-script.ts` | skills.md §6, sanitization.md §5 | `npm test` | Skill timeout/limits; output NOT sanitized (by design) |
+| `src/tools/k8s-exec/*.ts` | tools.md §3 | `npm test` | 10-step pipeline — steps 4/6/9 are mandatory security gates |
+| `src/tools/k8s-script/*.ts` | tools.md §4, skills.md | `npm test` | Script transmission; skill resolution |
+| `src/gateway/skills/` | skills.md, invariants.md §1-2 | `npm test` | Bundle contract; `materialize()` NOT safe in local mode |
+| `src/gateway/db/schema-*.ts` | invariants.md §5 | `npm test` | `migrate-sqlite.ts` must also be updated (DDL parity) |
+| `src/core/agent-factory.ts` | tools.md §7, invariants.md §10 | `npm test` | Tool registration; brain type compatibility |
+| `src/core/prompt.ts` | **⚠️ REQUIRES HUMAN APPROVAL** | — | Describe intent and wait for OK before editing |
+| `src/memory/` | invariants.md §7, decisions.md ADR-005 | `npm test` | Requires embedding config; pi-agent only |
+| `Dockerfile.agentbox` | security.md §3-5 | `docker build` | Dual-user model; capability set; setgid kubectl |
+| `k8s/` or `helm/` | security.md §5, invariants.md §11 | `helm template` | mTLS K8s-only; container hardening |
+| `src/agentbox/resource-handlers.ts` | invariants.md §1,6 | `npm test` | `materialize()` safe in K8s, destructive in local mode |
 
 ---
 
-## Tech Stack Quick Reference
+## Pre-flight & Post-flight Protocol
+
+### Pre-flight (before code changes)
+
+1. **Locate in matrix** — find the files you'll change in the Change Impact Matrix
+2. **Read required docs** — every doc in the "Must read" column (skim is not enough for security docs)
+3. **List cross-cutting concerns** — write them in your plan or task list
+4. **Confirm test strategy** — know which tests cover your change
+
+### Post-flight (verification loop)
+
+1. **Run tests** — `npm test`; fix failures before moving on
+2. **Update docs** — if you changed behavior or design, update the corresponding doc from the Matrix. Code changes without doc updates are incomplete.
+3. **Compounding engineering** — if something broke that pre-flight didn't predict, update the Change Impact Matrix immediately. Every surprise improves the harness for the next session.
+
+Cross-cutting concerns from pre-flight are verified in two ways:
+- **If tests exist** → `npm test` already covers it (our security path tests are comprehensive)
+- **If no tests exist** → flag it for the reviewer in your PR description. Do not silently assume it's fine.
+
+### Reviewer Protocol
+
+1. Read design docs for the PR's domain (see matrix)
+2. Read existing code around the diff, not just the diff
+3. Check the author's cross-cutting verification — are flagged items actually safe?
+4. Verify: docs updated? DDL parity? Both brain types if applicable?
+
+---
+
+## Context Compaction Rules
+
+> When context compacts, preserve:
+
+1. **Modified files** — what was changed and why
+2. **Active invariant domain** — which design docs are relevant
+3. **Cross-cutting concerns** — blast radius items from pre-flight
+4. **Pending verifications** — tests/docs/reviews not yet done
+
+---
+
+## Tech Stack
 
 ```
-Runtime:    Node.js ≥22.12.0  (ESM-only, no CommonJS)
-Language:   TypeScript 5.9    (strict mode, .js imports required)
-Tests:      vitest            (npm test)
-Type check: npx tsc --noEmit
-Frontend:   React + Vite + Tailwind
-Agent:      pi-coding-agent 0.55.3 / claude-agent-sdk 0.1.58
-DB (gateway): Drizzle ORM → sql.js SQLite or MySQL2
-DB (memory):  node:sqlite + FTS5
+Runtime:    Node.js ≥22.12.0  (ESM-only)     Tests:      vitest (npm test)
+Language:   TypeScript 5.9    (strict, .js)   Type check: npx tsc --noEmit
+Frontend:   React + Vite + Tailwind           Agent:      pi-coding-agent / claude-agent-sdk
+DB (GW):    Drizzle → sql.js / MySQL          DB (mem):   node:sqlite + FTS5
 ```
 
----
-
-## Collaboration Notes
-
-**When starting a session as reviewer:**
-1. This file is already loaded (you're reading it)
-2. For architecture-sensitive PRs, load `docs/design/invariants.md`
-3. For security-sensitive PRs (execution tools, Dockerfile, K8s manifests), load `docs/design/security.md`
-4. For roadmap/planning work, load `docs/design/roadmap.md`
-5. For "why was X designed this way", load `docs/design/decisions.md`
-
-**When starting a session as developer:**
-1. Check `docs/design/roadmap.md` for current phase priorities
-2. Before touching resource sync or skills: re-read invariants §1-3
-3. Before touching execution tools or container config: re-read `docs/design/security.md`
-4. Before adding or modifying tools: re-read `docs/design/tools.md`
-5. New architectural decisions should get an ADR in `docs/design/decisions.md`
-
-**PR comments are posted via `gh` CLI as the authenticated GitHub user.**
+**Conventions**: ESM-only, named exports, no default exports. `CONTRIBUTING.md` for PR format. `gh` CLI for PR comments.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -124,7 +124,7 @@ Memory search needs to handle both semantic similarity ("find memories about OOM
 **Decision**:
 Hybrid scoring: `score = vectorWeight × cosineSimilarity + ftsWeight × BM25`
 
-Default: `vectorWeight = 0.85`, `ftsWeight = 0.15` (architecture.md), code defaults may differ — consult `src/memory/indexer.ts` for current values.
+Default: `vectorWeight = 0.70`, `ftsWeight = 0.30` (source: `src/memory/indexer.ts:14-15`). Configurable via `MemorySearchConfig`.
 
 **Consequences**:
 - ✅ Handles both "find semantically similar incidents" and "find the exact error message I saw"

--- a/docs/design/harness.md
+++ b/docs/design/harness.md
@@ -1,0 +1,283 @@
+---
+title: "Harness Design Philosophy"
+sidebarTitle: "Harness"
+description: "How we structure AI-assisted development to prevent knowledge drift, enforce invariants, and maintain code quality at scale."
+---
+
+# Harness Design Philosophy
+
+> **Audience**: Human developers (the 3 of us + future contributors).
+> This document explains *why* our development framework is designed the way it is,
+> and *how* to work within it effectively.
+>
+> **Not for Claude alone** — this is for the team. Claude reads CLAUDE.md; this doc
+> is the reasoning behind what's in CLAUDE.md.
+
+---
+
+## 1. The Problem We're Solving
+
+Siclaw is developed primarily with AI coding assistants (Claude Code). This gives
+us velocity — but introduces a class of problems that don't exist in pure-human
+development:
+
+### 1.1 Knowledge Drift
+
+Each Claude session starts with a fresh context window. It reads CLAUDE.md and
+whatever docs we point it to, but it has **no memory of past sessions' mistakes**.
+Without explicit guardrails:
+
+- Session A adds output sanitization to protect secrets
+- Session B writes a skill that parses `kubectl get secret -o yaml` output
+- Session C modifies the sanitizer, not knowing about Session B's skill
+- The skill silently breaks — and nobody notices until production
+
+This is not hypothetical. We experienced exactly this pattern with:
+- **Output sanitization vs skill compatibility** — sanitizer changes broke
+  skills that depended on raw kubectl output
+- **kubectl tool removal** — the dedicated kubectl tool was dead code (never
+  registered in agent-factory), deleted during cleanup, but docs still referenced
+  it. No session caught the inconsistency because no session read both the docs
+  and the registration code.
+
+### 1.2 Context Anxiety
+
+Research by Anthropic ("Harness Design for Long-Running Application Development",
+2025) identified a behavioral pattern called **context anxiety**: as an LLM agent
+approaches what it *believes* is its context limit, it begins prematurely wrapping
+up work — cutting corners, skipping verification steps, declaring victory early.
+
+Mitigations:
+- **Context compaction rules** (in CLAUDE.md) ensure critical state survives compaction
+- **Pre-flight protocol** forces each session to front-load understanding before coding
+- **Change Impact Matrix** makes blast radius explicit, reducing the temptation to
+  "just change it and see"
+
+### 1.3 Compounding Errors
+
+Without explicit feedback loops, AI sessions repeat the same mistakes:
+- Anthropic calls the fix "compounding engineering" — every time Claude does
+  something wrong, add a note to CLAUDE.md so it doesn't happen again
+- Our Change Impact Matrix is the structured form of this: each row encodes
+  a lesson learned about what breaks when you touch a particular area
+
+---
+
+## 2. Our Harness Architecture
+
+The harness is everything around the model that makes it produce correct, safe,
+consistent code. It has three layers:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Layer 3: Automated Verification                           │
+│ CI (typecheck + vitest), future: hooks, integration tests │
+│ Catches: things that slipped through Layers 1-2           │
+└───────────────────────────┬──────────────────────────────┘
+                            │
+┌───────────────────────────┴──────────────────────────────┐
+│ Layer 2: Development Protocol (CLAUDE.md)                 │
+│ Pre-flight, Change Impact Matrix, Compaction Rules        │
+│ Catches: "I didn't know modifying X would break Y"        │
+└───────────────────────────┬──────────────────────────────┘
+                            │
+┌───────────────────────────┴──────────────────────────────┐
+│ Layer 1: Documentation Parity (docs/design/)              │
+│ invariants.md, security.md, tools.md, sanitization.md,    │
+│ skills.md, decisions.md                                    │
+│ Catches: "I didn't know this constraint existed"           │
+└──────────────────────────────────────────────────────────┘
+```
+
+### What Each Layer Does
+
+**Layer 1 (Documentation Parity)**: The source of truth for how things work
+and why. Every architectural constraint, security model, and design decision
+is documented. Code and docs must stay in sync — outdated docs actively mislead.
+
+**Layer 2 (Development Protocol)**: The operational rules for how to use
+Layer 1 effectively. CLAUDE.md is auto-loaded by Claude Code at session start.
+It contains:
+- **Change Impact Matrix**: "If you change file X → must read doc Y → must
+  verify Z → watch out for cross-cutting concern W"
+- **Pre-flight Protocol**: Mandatory steps before any code modification
+- **Compaction Rules**: What to preserve when context is compressed
+- **Design Documentation Map**: Which doc covers what
+
+**Layer 3 (Automated Verification)**: The safety net. Currently:
+- TypeScript strict mode + `npx tsc --noEmit` (type errors caught at compile)
+- `vitest` test suite with heavy coverage on security paths
+- CI pipeline (typecheck + test on every PR)
+
+Future additions (see §5):
+- Hooks that block edits to critical files without reading corresponding docs
+- Integration tests for the security pipeline end-to-end
+- DDL parity checks (schema-sqlite.ts ↔ migrate-sqlite.ts)
+
+---
+
+## 3. Design Principles
+
+These principles guide how we evolve the harness itself:
+
+### 3.1 Advisory vs Mandatory
+
+CLAUDE.md rules are **advisory** — Claude reads them but can choose to skip them
+under time pressure or context anxiety. Hooks and CI checks are **mandatory** —
+they block the action if the rule is violated.
+
+**Current state**: Most rules are advisory. This is acceptable while the team is
+small (3 people) and sessions are supervised. As the project grows, critical rules
+should migrate from advisory (CLAUDE.md) to mandatory (hooks/CI).
+
+**Migration priority** (rules that should become mandatory first):
+1. DDL parity check (schema vs migration) — automatable, high breakage risk
+2. `src/core/prompt.ts` edit gate — security-critical, easy to automate
+3. Doc-code sync detection — harder to automate, but high drift risk
+
+### 3.2 Concise Over Comprehensive
+
+Anthropic's research shows that **rules get lost in long files**. CLAUDE.md should
+be ≤200 lines. Detailed specifications live in `docs/design/` and are loaded on
+demand via the Change Impact Matrix.
+
+If you find yourself adding more than 5 lines to CLAUDE.md, consider:
+- Is this a rule that applies to ALL sessions? → CLAUDE.md
+- Is this domain-specific knowledge? → Relevant `docs/design/*.md`
+- Is this a one-time lesson? → Update the Change Impact Matrix row
+
+### 3.3 Encode Assumptions Explicitly
+
+From Anthropic's harness research: *"Every component in a harness encodes an
+assumption about what the model can't do on its own."*
+
+When we add a rule to CLAUDE.md or a check to CI, we should document *why* — what
+failure mode does this prevent? This lets us remove rules when they become
+unnecessary (e.g., if model capabilities improve enough to make a guardrail
+redundant).
+
+### 3.4 Separate Generation from Evaluation
+
+AI models are poor critics of their own output. The session that writes code
+should not be the sole judge of whether it's correct. Our approach:
+
+- **review-maintainer skill**: Separate Claude session reviews PRs against
+  design docs and the Change Impact Matrix
+- **Pre-flight protocol**: Forces the developer session to acknowledge constraints
+  before coding, not after
+- **CI tests**: Automated evaluation independent of the coding session
+
+### 3.5 Cross-Cutting Concerns Are First-Class
+
+The most dangerous bugs come from changes that are correct in isolation but break
+something elsewhere. The Change Impact Matrix's "Cross-cutting concerns" column
+makes these dependencies explicit.
+
+Current known cross-cutting concerns:
+- **Sanitization ↔ Skills**: Changing output sanitization can break skills that
+  parse command output; changing skills can expose unsanitized data
+- **Command whitelist ↔ Skills**: Adding/removing commands affects what skills
+  can use (though skill scripts are exempt from the whitelist)
+- **Brain types ↔ Tools**: New tools must work with both pi-agent and claude-sdk
+- **Local mode ↔ Resource sync**: Any sync code must respect shared filesystem
+
+---
+
+## 4. How to Work Within This Framework
+
+### 4.1 Starting a Development Session
+
+1. Claude Code loads CLAUDE.md automatically
+2. You describe your task to Claude
+3. Claude should follow the Pre-flight Protocol (identify files → find in matrix → read docs → list concerns)
+4. If Claude skips pre-flight, remind it: "Follow the pre-flight protocol in CLAUDE.md"
+
+### 4.2 During Development
+
+- Each code change should be verified against the Change Impact Matrix's cross-cutting concerns
+- If you discover a new cross-cutting concern, **update the matrix immediately** — don't save it for later
+- If you find a doc-code inconsistency, **fix it now** — outdated docs compound
+
+### 4.3 Reviewing Code (Human or AI)
+
+1. Check the Change Impact Matrix: did the author read the required docs?
+2. Check cross-cutting concerns: are they addressed?
+3. Check documentation parity: are relevant docs updated?
+4. For security changes: does the change maintain all 6 defense layers?
+
+### 4.4 After a Mistake
+
+When a Claude session breaks something it shouldn't have:
+1. Fix the immediate issue
+2. Ask: "What did the harness fail to catch?"
+3. Update the appropriate layer:
+   - Missing knowledge → Update `docs/design/*.md` (Layer 1)
+   - Knowledge existed but wasn't consulted → Update Change Impact Matrix or
+     Pre-flight Protocol (Layer 2)
+   - Consulted but not enforced → Add CI check or hook (Layer 3)
+
+This is "compounding engineering" — every mistake improves the harness.
+
+---
+
+## 5. Evolution Roadmap
+
+### Current State (2026-03)
+
+- Layer 1: 7 design docs covering architecture, security, tools, sanitization, skills, decisions, roadmap
+- Layer 2: CLAUDE.md with Change Impact Matrix, Pre-flight Protocol, Compaction Rules
+- Layer 3: CI (typecheck + vitest), ~38 test files with heavy security path coverage
+
+### Near-Term Improvements
+
+| Improvement | Layer | Impact | Effort |
+|---|---|---|---|
+| DDL parity CI check | 3 | Prevents silent schema drift | Low |
+| `prompt.ts` edit hook | 3 | Prevents unauthorized system prompt changes | Low |
+| Skill compatibility test | 3 | Detects sanitizer changes that break skills | Medium |
+| Integration test for security pipeline | 3 | E2E: validateCommand → execute → applySanitizer | Medium |
+
+### Long-Term Vision
+
+As the team grows beyond 3 people:
+- Layer 2 rules migrate to Layer 3 (advisory → mandatory)
+- Per-directory CLAUDE.md files for domain-specific rules (monorepo pattern)
+- Automated doc-code sync detection (flag stale docs in CI)
+- Session handoff artifacts for multi-session tasks (Anthropic's `claude-progress.txt` pattern)
+
+---
+
+## 6. Relationship to Anthropic's Research
+
+Our harness design is informed by Anthropic's published research on AI agent
+engineering. Key mappings:
+
+| Anthropic Concept | Our Implementation |
+|---|---|
+| "Every harness component encodes an assumption about what the model can't do" | Change Impact Matrix encodes "Claude can't know X affects Y without being told" |
+| "Context anxiety" → premature task completion | Compaction Rules preserve critical state; Pre-flight front-loads understanding |
+| "Compounding engineering" → learn from mistakes | After-mistake protocol (§4.4): fix → diagnose harness gap → update layer |
+| "Separate generation from evaluation" | review-maintainer skill; CI as independent evaluator |
+| "Stress-test assumptions regularly" | Periodically review: are these rules still needed? Can any be removed? |
+| "Start simple, add complexity only when needed" | Advisory rules first; migrate to mandatory only when breakage proves necessary |
+
+**Key insight we apply**: The harness should shrink or shift with model improvements,
+not accumulate indefinitely. If a future Claude model reliably reads design docs
+without being told, we can simplify the Pre-flight Protocol. The *why* behind each
+rule (documented in this file) tells us when it's safe to remove.
+
+---
+
+## 7. Quick Reference: Design Doc Inventory
+
+```
+docs/design/
+├── harness.md        ← This file (harness philosophy, for humans)
+├── invariants.md     ← Architecture constraints (deployment modes, bundles, DB, security)
+├── security.md       ← 6-layer defense model (OS isolation, command whitelist, containers)
+├── sanitization.md   ← 3-layer output sanitization (pre/post strategy, skill exemption)
+├── tools.md          ← Tool organization, execution pipelines, context system
+├── skills.md         ← Skill lifecycle, approval workflow, execution model
+├── decisions.md      ← ADRs (sql.js, LocalSpawner, whitelist, memory, mTLS, brain types)
+└── roadmap.md        ← IM/KR/OB/PM/CS phases with current status
+```

--- a/docs/design/invariants.md
+++ b/docs/design/invariants.md
@@ -86,7 +86,7 @@ Scripts in a skill follow this workflow before execution is permitted:
 draft → (request review) → pending → (AI + static analysis) → approved/rejected
 ```
 
-- **Static analysis**: 23 `DANGER_PATTERNS` (Critical 8 / High 8 / Medium 7) in `ScriptEvaluator`
+- **Static analysis**: 22 `DANGER_PATTERNS` (Critical 8 / High 8 / Medium 6) in `ScriptEvaluator`
 - **AI analysis**: LLM semantic review with mandatory rule — "Skills MUST be strictly read-only"
 - **Human gate**: `skill_reviewer` role must approve before `published` status
 - Skills with unapproved scripts **cannot** be executed via `local_script`

--- a/docs/design/sanitization.md
+++ b/docs/design/sanitization.md
@@ -1,0 +1,229 @@
+---
+title: "Output Sanitization Architecture"
+sidebarTitle: "Sanitization"
+description: "How command output is sanitized before reaching the LLM agent, and why."
+---
+
+# Output Sanitization Architecture
+
+> **Purpose**: Document the multi-layer output sanitization strategy that prevents
+> sensitive data from reaching the LLM agent's context window.
+>
+> **Audience**: Anyone modifying `output-sanitizer.ts`, `kubectl-sanitize.ts`,
+> `restricted-bash.ts`, or adding new tools/skills that handle sensitive output.
+
+---
+
+## 1. Design Intent
+
+The agent executes shell commands that may produce output containing credentials,
+tokens, or other sensitive data. The sanitization system ensures this data is
+**redacted before it enters the LLM's context** — preventing the model from
+learning or leaking secrets.
+
+### Two Complementary Strategies
+
+The security pipeline uses **pre-execution blocking** and **post-execution
+redaction** as complementary strategies. Understanding which strategy applies
+to what is essential:
+
+| What's protected | Strategy | Mechanism | Example |
+|-----------------|----------|-----------|---------|
+| Sensitive **paths** (credential files, /proc/environ) | **Pre-execution blocking** | Pass 6 in `command-validator.ts` | `cat ~/.ssh/id_rsa` → blocked before execution |
+| Dangerous **operations** (writes, redirections, injection) | **Pre-execution blocking** | Passes 1-5 in `command-validator.ts` | `kubectl delete pod` → blocked |
+| Sensitive **resource types** (Secret, ConfigMap, Pod envs) | **Post-execution redaction** | `output-sanitizer.ts` | `kubectl get secret -o yaml` → runs, output redacted |
+| Environment **variables** in output | **Post-execution redaction** | `output-sanitizer.ts` | `env` output → sensitive vars stripped |
+| File **content** with credentials | **Post-execution redaction** | `output-sanitizer.ts` | `cat /etc/config` on remote node → credentials redacted |
+
+**Why not block sensitive resources pre-execution?** The command `kubectl get secret`
+itself is safe to run — it's the *output* that contains sensitive data. Blocking
+the command entirely would prevent legitimate diagnostic workflows (e.g., checking
+if a Secret exists, viewing its metadata). Instead, we let it run and redact the
+sensitive fields from the output.
+
+---
+
+## 2. The Three Sanitization Layers
+
+Output sanitization has three independent layers. Each layer catches cases
+that earlier layers might miss:
+
+```
+Command executes → stdout captured
+        │
+        ▼
+┌─────────────────────────────────────────────────────┐
+│ Layer 1: analyzeOutput() — Pre-analysis             │
+│                                                       │
+│ Before execution, determines if output will need      │
+│ sanitization. Returns an OutputAction with a          │
+│ sanitize function, or null if no sanitization needed. │
+│                                                       │
+│ Lookup: OUTPUT_RULES[binary](args)                    │
+│ Registered: kubectl, cat, head, tail, grep, env, ...  │
+└─────────────────────┬───────────────────────────────┘
+                      │ OutputAction
+                      ▼
+┌─────────────────────────────────────────────────────┐
+│ Layer 2: applySanitizer() — Post-execution          │
+│                                                       │
+│ Applies the sanitize function from Layer 1 to the     │
+│ actual command output.                                │
+│                                                       │
+│ Redaction methods (selected by Layer 1):              │
+│ • sanitizeJSON() — structural: removes data/stringData│
+│   from Secret JSON, envs from Pod/ConfigMap JSON      │
+│ • redactSensitiveContent() — line-level: regex match  │
+│   on KEY=VALUE and KEY: VALUE patterns                │
+│ • redactEnvOutput() — specialized for env/printenv    │
+│ • sanitizeCrictlInspect() — JSON env array redaction  │
+└─────────────────────┬───────────────────────────────┘
+                      │
+                      ▼
+┌─────────────────────────────────────────────────────┐
+│ Layer 3: Pipeline Fallback — Safety net             │
+│ (restricted-bash.ts only)                            │
+│                                                       │
+│ For MULTI-COMMAND pipelines containing kubectl        │
+│ get/describe on a sensitive resource:                 │
+│ Apply redactSensitiveContent() to the FINAL output,  │
+│ regardless of what the last command in the pipe is.   │
+│                                                       │
+│ Example: kubectl get secret -o yaml | grep -v metadata│
+│ → grep has no registered OUTPUT_RULE                  │
+│ → Layer 3 applies line-level redaction to grep output │
+│                                                       │
+│ This layer catches cases where sensitive data flows   │
+│ through a pipe to a command without its own sanitizer.│
+└─────────────────────────────────────────────────────┘
+```
+
+### Why Three Layers?
+
+- **Layer 1+2** (analyzeOutput + applySanitizer): Handle single commands and the
+  *first* command in a pipeline. Precise — selects the right sanitization method
+  based on the command and its arguments.
+
+- **Layer 3** (pipeline fallback): Handles the case where `kubectl get secret -o yaml`
+  is piped to `jq .data` or `grep password` — the last command in the pipeline
+  determines stdout, but it has no OUTPUT_RULE. Without Layer 3, the sensitive
+  data would pass through unsanitized.
+
+---
+
+## 3. OUTPUT_RULES Reference
+
+Registered sanitization rules by command:
+
+| Command | Trigger condition | Sanitization method |
+|---------|------------------|-------------------|
+| `kubectl get` | Resource is Secret, ConfigMap, or Pod | JSON format → `sanitizeJSON()`; YAML/other → `redactSensitiveContent()` |
+| `kubectl describe` | Resource is ConfigMap or Pod (not Secret — describe shows byte counts only) | `redactSensitiveContent()` |
+| `cat`, `head`, `tail`, `less`, `more` | Always (when in remote context where these are allowed) | `redactSensitiveContent()` |
+| `grep`, `egrep`, `fgrep` | Always | `redactSensitiveContent()` |
+| `strings`, `zcat`, `zgrep` | Always | `redactSensitiveContent()` |
+| `env`, `printenv` | Always | `redactEnvOutput()` (specialized KEY=VALUE redaction) |
+| `crictl inspect` | Subcommand is `inspect`, `inspecti`, or `inspectp` | `sanitizeCrictlInspect()` (JSON env array redaction) |
+
+**Source**: `OUTPUT_RULES` in `src/tools/infra/output-sanitizer.ts`
+
+---
+
+## 4. Redaction Patterns
+
+### Sensitive Key Name Patterns
+
+Matched against KEY in `KEY=VALUE` or `KEY: VALUE` output lines:
+
+```
+*_API_KEY, *_SECRET*, *_TOKEN*, *_PASSWORD*, *_CREDENTIAL*
+*_PRIVATE_KEY, *_ACCESS_KEY, *_AUTH*
+ANTHROPIC_*, OPENAI_*, SICLAW_LLM_*
+DATABASE_URL, REDIS_URL, MONGODB_URI, CONNECTION_STRING
+```
+
+**Source**: `SENSITIVE_ENV_NAME_PATTERNS` in `src/tools/infra/kubectl-sanitize.ts`
+
+### Sensitive Value Patterns
+
+Matched against the value content regardless of key name:
+
+```
+JWT tokens (eyJ...), PEM blocks (-----BEGIN), base64-encoded certs
+Connection strings (postgres://, mysql://, mongodb://, redis://)
+Known API key prefixes (sk-ant-, sk-proj-, xoxb-, ghp_, ghu_)
+Bearer tokens, Basic auth headers
+```
+
+**Source**: `SENSITIVE_VALUE_PATTERNS` in `src/tools/infra/kubectl-sanitize.ts`
+
+---
+
+## 5. Skill Script Exemption
+
+Skill scripts executed via `local_script` are **NOT sanitized** by this framework.
+
+**Rationale**: Skill scripts are trusted code — they go through a 3-gate approval
+process (static analysis → AI semantic review → human approval) before reaching
+production. Sanitizing their output would:
+1. Break scripts that legitimately need to parse Secret/ConfigMap data
+2. Add overhead with no security benefit (the script author controls what's output)
+
+**The security boundary for skills is the approval gate, not runtime sanitization.**
+
+However, ad-hoc commands that skill scripts *depend on* (e.g., the agent running
+`kubectl get configmap` between skill calls) DO go through sanitization. This is
+an important distinction when modifying sanitization rules.
+
+---
+
+## 6. Cross-Cutting Concerns
+
+### ⚠️ When Modifying Sanitization Rules
+
+Changes to `output-sanitizer.ts` or `kubectl-sanitize.ts` can affect:
+
+1. **Core skills**: Skills that parse `kubectl get` output may break if the
+   sanitizer removes fields they expect. However, skill scripts run through
+   `local_script` (exempt from sanitization), so only ad-hoc kubectl calls
+   between skill invocations are affected.
+
+2. **Deep investigation sub-agents**: Sub-agents use `restricted_bash` and are
+   subject to sanitization. Changing what gets redacted can alter investigation
+   quality.
+
+3. **Pipeline behavior**: Adding a new OUTPUT_RULE for a command that commonly
+   appears after a pipe may cause double-sanitization (Layer 2 + Layer 3).
+   Test with multi-command pipelines.
+
+### When Adding New Commands to the Whitelist
+
+If the new command can produce sensitive output:
+1. Add an `OUTPUT_RULES` entry in `output-sanitizer.ts`
+2. Use `redactSensitiveContent()` for line-level redaction, or write a custom
+   sanitizer for structured output (JSON, XML)
+3. Add test cases in `output-sanitizer.test.ts`
+
+### Relationship to Other Security Layers
+
+```
+Layer 1 (OS isolation)    → sandbox user cannot READ credential files
+Layer 2 (command whitelist) → blocks DANGEROUS commands pre-execution
+Layer 5 (env sanitization)  → strips secrets from PROCESS environment
+This doc (output sanitization) → redacts secrets from COMMAND OUTPUT
+```
+
+Each layer is independent. Output sanitization is the **last line of defense**
+before data enters the LLM context window.
+
+---
+
+## 7. Key Files
+
+```
+src/tools/infra/output-sanitizer.ts      OUTPUT_RULES, analyzeOutput(), applySanitizer()
+src/tools/infra/kubectl-sanitize.ts      sanitizeJSON(), detectSensitiveResource(), redaction patterns
+src/tools/shell/restricted-bash.ts       Pipeline fallback (Layer 3), isSkillScript()
+src/tools/infra/output-sanitizer.test.ts Test coverage for sanitization rules
+src/tools/infra/kubectl-sanitize.test.ts Test coverage for kubectl-specific sanitization
+```

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -249,7 +249,28 @@ Pass 5 — COMMAND_RULES         Per-command: pipeOnly, noFilePaths, blockedFlag
 Pass 6 — Sensitive Paths       Block commands targeting credential/config file paths
 ```
 
-### 4.2 Context-Based Whitelisting
+### 4.2 Pass 6: Sensitive Path Patterns
+
+Pass 6 blocks commands that target known credential or configuration file paths.
+These are paths whose content **cannot be reliably sanitized post-execution**
+(binary data, unstructured secrets, password hashes). Commands that produce
+sanitizable output (env, printenv, crictl inspect) are handled by
+`output-sanitizer.ts` instead — see `docs/design/sanitization.md`.
+
+| Category | Patterns | Examples |
+|----------|----------|---------|
+| K8s SA tokens & mounted secrets | `/run/secrets/`, `/var/run/secrets/` | Service account tokens |
+| Process info | `/proc/*/environ`, `/proc/*/cmdline`, `/proc/*/fd/`, `/proc/*/mem`, `/proc/*/maps`, `/proc/*/smaps`, `/proc/kcore` | Process memory, file descriptors |
+| System credentials | `/etc/shadow`, `/etc/gshadow`, `/etc/master.passwd` | Password hashes |
+| SSH | `/.ssh/`, `id_rsa`, `id_ed25519`, `id_ecdsa` | SSH private keys |
+| TLS key material | `*.key`, `*.p12`, `*.pfx`, `*.jks` | Private keys, keystores (`.pem` excluded — CA certs are public and needed for diagnostics) |
+| Cloud providers | `/.aws/`, `/.gcp/`, `/.azure/`, `/.docker/config.json` | Cloud credentials |
+| K8s control plane | `/etc/kubernetes/pki/`, `/etc/kubernetes/admin.conf`, `/var/lib/kubelet/`, `/var/lib/etcd/` | Cluster PKI, etcd data |
+| Shell/DB history | `.bash_history`, `.zsh_history`, `.mysql_history`, `.psql_history`, `.node_repl_history` | Command history with potential secrets |
+
+**Source**: `CONTAINER_SENSITIVE_PATHS` in `src/tools/infra/command-sets.ts:1262-1304`
+
+### 4.3 Context-Based Whitelisting
 
 Different execution contexts allow different command sets:
 
@@ -265,7 +286,7 @@ blocked — agents use dedicated file tools instead.
 
 **Source**: `src/tools/infra/command-sets.ts` — `CONTEXT_CATEGORIES`, `COMMAND_CATEGORIES`
 
-### 4.3 COMMAND_RULES Declarative Engine
+### 4.4 COMMAND_RULES Declarative Engine
 
 Per-command restrictions are defined declaratively in `COMMAND_RULES`:
 
@@ -296,7 +317,7 @@ even though `grep` appears after a pipe.
 
 **Source**: `src/tools/infra/command-sets.ts` — `COMMAND_RULES`
 
-### 4.4 Explicitly Excluded Binaries
+### 4.5 Explicitly Excluded Binaries
 
 | Command | Reason |
 |---------|--------|
@@ -307,7 +328,7 @@ even though `grep` appears after a pipe.
 | `wget` | File write, recursive crawl |
 | `bash`/`sh` (direct) | Unrestricted shell — `restricted-bash` wraps with validation |
 
-### 4.5 Role After OS Isolation
+### 4.6 Role After OS Isolation
 
 With OS-level user isolation (Layer 1), the application-level command validation becomes a
 **secondary defense layer**. It still provides value:

--- a/docs/design/skills.md
+++ b/docs/design/skills.md
@@ -9,7 +9,7 @@ description: "Architecture, lifecycle, approval workflow, and deployment-mode be
 > **Purpose**: Document the full skills architecture — scopes, lifecycle, approval workflow,
 > execution model, and how skills behave across deployment modes.
 >
-> Read this before touching: `src/tools/local-script.ts`, `src/tools/script-resolver.ts`,
+> Read this before touching: `src/tools/shell/local-script.ts`, `src/tools/infra/script-resolver.ts`,
 > `src/gateway/skills/`, `src/agentbox/resource-handlers.ts`, or `src/core/agent-factory.ts`.
 
 ---
@@ -115,7 +115,7 @@ When multiple scopes contain a skill with the same name, the highest-priority sc
 personal > extension > team > core
 ```
 
-Defined in `src/tools/script-resolver.ts` `SKILL_SCOPES`.
+Defined in `src/tools/infra/script-resolver.ts` `SKILL_SCOPES`.
 
 ### Builtin Sub-Tiers: core vs extension
 
@@ -248,7 +248,7 @@ Local mode syncs to per-user directories to maintain filesystem isolation
 
 ### local_script Tool
 
-The `local_script` tool (`src/tools/local-script.ts`) is the primary execution path:
+The `local_script` tool (`src/tools/shell/local-script.ts`) is the primary execution path:
 
 1. **Path resolution**: `resolveSkillScript(skill, script)` searches scope directories
    in priority order (personal > extension > team > core)
@@ -328,10 +328,10 @@ original. The forked copy can later be contributed back to team via the approval
 
 ```
 Execution & Resolution
-  src/tools/local-script.ts              local_script tool (primary execution path)
-  src/tools/script-resolver.ts        Skill path resolution, scope priority
-  src/tools/restricted-bash.ts        Bash whitelist (isSkillScript)
-  src/tools/fork-skill.ts             fork_skill tool
+  src/tools/shell/local-script.ts        local_script tool (primary execution path)
+  src/tools/infra/script-resolver.ts   Skill path resolution, scope priority
+  src/tools/shell/restricted-bash.ts   Bash whitelist (isSkillScript)
+  src/tools/workflow/fork-skill.ts     fork_skill tool
 
 Gateway Skills Management
   src/gateway/skills/file-writer.ts   Disk I/O: read, write, scan, snapshot

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -168,35 +168,116 @@ The most complex tool. Handles full shell pipelines with:
 - Kubeconfig name resolution via regex (`--kubeconfig=<name>`)
 - Production mode: `sudo -E -u sandbox` user isolation
 - Skill script detection bypass (`isSkillScript`)
+- 3-layer output sanitization (see §6.2)
+
+**kubectl access**: There is no dedicated kubectl tool — all kubectl commands go
+through `restricted_bash` with pipeline validation. `validateKubectlInPipeline()`
+enforces read-only subcommands (`SAFE_SUBCOMMANDS` in `command-sets.ts`), blocks
+`--all-namespaces` on broad queries, and passes exec'd commands through the
+binary allowlist. This is by design: kubectl in pipelines (`kubectl get pods | grep Error`)
+is the natural SRE workflow, and OS-level isolation (ADR-010) is the primary
+credential protection — not a separate tool boundary.
 
 ### `local_script`
 
 Executes skill helper scripts locally via `spawn()`. No command validation
 (scripts are from trusted `skills/` directory). Uses `resolveSkillScript()`
-for path resolution with traversal protection.
+in `infra/script-resolver.ts` for path resolution with traversal protection.
+
+**Output sanitization exemption**: Skill script output is NOT sanitized by
+`output-sanitizer.ts`. This is intentional — skill scripts are pre-reviewed
+(static analysis + AI semantic review + human approval) and operate as trusted
+code. The security boundary is the skill approval gate, not runtime sanitization.
 
 ---
 
 ## 6. Shared Infrastructure (`infra/`)
 
-### Security Pipeline Overview
+### 6.1 Execution Context System
+
+Commands are validated against context-specific whitelists. Different execution
+environments expose different command categories:
+
+| Context | Used by | Unique trait |
+|---------|---------|-------------|
+| `local` | `restricted_bash` | Most restrictive — no `file` category (cat/ls/find blocked, use agent file tools), no `general-env` (env/printenv blocked, redacted via sanitizer), no `inspection`/`compressed` |
+| `node` | `node_exec` | Full remote diagnostic set — file access, env inspection, compression tools all allowed |
+| `pod` | `pod_exec` | Same as node — full diagnostic set inside target pod |
+| `nsenter` | `pod_nsenter_exec` | Same as node — full diagnostic set in pod network namespace |
+| `ssh` | (future `ssh_exec`) | Same as node — full diagnostic set on remote host |
+
+Categories missing from `local` but present in remote contexts:
+
+| Category | Examples | Why blocked locally |
+|----------|----------|-------------------|
+| `file` | cat, ls, find, stat, du | Agent has dedicated file tools (Read, Grep, Glob) with path restrictions |
+| `general-env` | env, printenv | Would expose process environment; handled via output sanitizer in pipelines |
+| `inspection` | strace, ltrace, ldd | Debugging tools not needed in AgentBox container |
+| `compressed` | tar, gzip, zcat | Archive tools not needed locally |
+
+**Source**: `CONTEXT_CATEGORIES` in `src/tools/infra/command-sets.ts:224-234`
+
+### 6.2 Security Strategy: Pre-Execution vs Post-Execution
+
+The security pipeline uses two complementary strategies — understanding which
+strategy applies is essential when adding new commands or modifying sanitization:
 
 ```
-Pre-execution                        Post-execution
-┌─────────────────────┐              ┌──────────────────────┐
-│ command-validator.ts │              │ output-sanitizer.ts  │
-│ 6-pass pipeline:     │              │                      │
-│ 1. Shell operators   │              │ analyzeOutput()      │
-│ 2. Pipeline split    │              │   → detect sensitive │
-│ 3. Whitelist check   │              │     resource type    │
-│ 4. Pipeline validate │              │                      │
-│ 5. Command rules     │              │ applySanitizer()     │
-│ 6. Sensitive paths   │              │   → redact secrets,  │
-└─────────────────────┘              │     sanitize env vars│
-                                      └──────────────────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│ PRE-EXECUTION: Block commands that could LEAK or ESCALATE          │
+│                                                                     │
+│ command-validator.ts — 6-pass pipeline                              │
+│   Pass 1: Shell operators ($(), backticks, redirections)            │
+│   Pass 2: Pipeline extraction (| && || ;)                          │
+│   Pass 3: Binary whitelist (context-based)                         │
+│   Pass 4: Pipeline validators (kubectl subcommands)                │
+│   Pass 5: COMMAND_RULES (pipeOnly, blockedFlags, etc.)             │
+│   Pass 6: Sensitive path patterns (25+ patterns, see security.md)  │
+│                                                                     │
+│ Blocks: unknown binaries, write operations, credential path access  │
+└─────────────────────────────────────────────────────────────────────┘
+                                  │
+                            command executes
+                                  │
+┌─────────────────────────────────────────────────────────────────────┐
+│ POST-EXECUTION: Redact output from commands SAFE TO RUN            │
+│                                                                     │
+│ output-sanitizer.ts — 3-layer sanitization                         │
+│                                                                     │
+│ Layer 1: analyzeOutput(binary, args)                               │
+│   → Pre-analysis: detect if command targets sensitive resource type │
+│   → Returns OutputAction with sanitize function for Layer 2        │
+│                                                                     │
+│ Layer 2: applySanitizer(stdout, action)                            │
+│   → Apply the registered sanitizer from Layer 1                    │
+│   → Redacts: Secret values, ConfigMap data, env vars, credentials  │
+│                                                                     │
+│ Layer 3: Pipeline fallback (restricted-bash.ts only)               │
+│   → If kubectl targets sensitive resource in a MULTI-COMMAND       │
+│     pipeline, apply broad line-level redaction to final output     │
+│   → Safety net: catches cases where pipeline's last command has    │
+│     no registered sanitizer                                        │
+│                                                                     │
+│ Handles: kubectl get secret (runs, output redacted),               │
+│          env/printenv (runs, sensitive vars stripped),              │
+│          crictl inspect (runs, env vars in JSON redacted)          │
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
-### How to Add a New Command to the Whitelist
+**The key distinction**:
+- Sensitive **paths** (credential files, /proc/environ) → **pre-execution blocking** (Pass 6)
+- Sensitive **resource types** (Secret, ConfigMap) → **post-execution redaction** (output sanitizer)
+- Dangerous **operations** (write, exec, redirect) → **pre-execution blocking** (Passes 1-5)
+
+**Cross-cutting concern**: When modifying `output-sanitizer.ts`, verify that
+existing skill scripts are not affected — skill output bypasses sanitization
+(see §5 `local_script`), but ad-hoc commands that skills depend on (e.g.,
+`kubectl get configmap`) go through the sanitizer. See `docs/design/sanitization.md`
+for the full specification.
+
+**Source**: `src/tools/infra/command-validator.ts`, `src/tools/infra/output-sanitizer.ts`
+
+### 6.3 How to Add a New Command to the Whitelist
 
 1. Add the command name to `ALLOWED_COMMANDS` in `command-sets.ts`
 2. Add it to `COMMAND_CATEGORIES` with its functional category
@@ -204,7 +285,7 @@ Pre-execution                        Post-execution
    add an entry to `COMMAND_RULES`
 4. If the category is new, add it to `CONTEXT_CATEGORIES` for each applicable context
 
-### How to Add a COMMAND\_RULE
+### 6.4 How to Add a COMMAND\_RULE
 
 Rules are declarative and JSON-serializable:
 
@@ -224,7 +305,7 @@ COMMAND_RULES["mycommand"] = {
 };
 ```
 
-### How to Add an Output Sanitization Rule
+### 6.5 How to Add an Output Sanitization Rule
 
 Add a new entry to `OUTPUT_RULES` in `output-sanitizer.ts`:
 

--- a/docs/internal/command-whitelist.md
+++ b/docs/internal/command-whitelist.md
@@ -548,20 +548,26 @@ Also allows format strings starting with `+`.
 
 ## kubectl Subcommand Whitelist
 
-The `kubectl` tool has its own subcommand whitelist (source: `src/tools/kubectl.ts`):
+kubectl commands go through `restricted_bash` with pipeline validation
+(`validateKubectlInPipeline` in `src/tools/shell/restricted-bash.ts`).
+There is no dedicated kubectl tool — this is by design (see `docs/design/tools.md` §5).
+
+Allowed subcommands (`SAFE_SUBCOMMANDS` in `src/tools/infra/command-sets.ts`):
 
 ```
-get  describe  logs  top  auth  api-resources
-api-versions  explain  version  config  exec
+get  describe  logs  top  events  api-resources
+api-versions  cluster-info  config  version  explain  auth  exec
 ```
 
-Note: `exec` is allowed as a kubectl subcommand but is handled by dedicated tools (`pod-exec`, `pod-script`) with their own validation.
+Note: `exec` is allowed as a kubectl subcommand, but the exec'd command passes
+through the binary allowlist for the applicable context. `kubectl config view --raw`
+is explicitly blocked (would expose embedded certificates/tokens).
 
 ---
 
 ## Shell Operator Restrictions
 
-The `restricted-bash` tool validates shell operators before command execution (source: `src/tools/restricted-bash.ts`):
+The `restricted-bash` tool validates shell operators before command execution (source: `src/tools/shell/restricted-bash.ts`):
 
 | Operator | Status | Notes |
 |----------|--------|-------|

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -398,6 +398,7 @@ export function createRpcMethods(
     const personalSkills: ComposerSkillOption[] = [];
     if (skillRepo) {
       const teamSkills = await skillRepo.list({ scope: "team" });
+      const teamDirNames = new Set(teamSkills.map((s: any) => s.dirName));
       for (const meta of teamSkills) {
         globalSkills.push({
           id: meta.id,
@@ -409,6 +410,12 @@ export function createRpcMethods(
           scope: "team",
         });
       }
+      // Dedup: team (global) scope overrides builtin for same dirName
+      const deduped = globalSkills.filter(
+        (s) => s.scope !== "builtin" || !teamDirNames.has(s.dirName),
+      );
+      globalSkills.length = 0;
+      globalSkills.push(...deduped);
 
       const personalResult = await skillRepo.listForUser(userId, { scope: "personal", limit: 500 });
       for (const meta of personalResult.skills) {

--- a/src/gateway/skills/script-evaluator.ts
+++ b/src/gateway/skills/script-evaluator.ts
@@ -32,6 +32,8 @@ interface PatternRule {
   description: string;
 }
 
+// Cross-reference: src/tools/infra/command-sets.ts (ALLOWED_COMMANDS, COMMAND_RULES).
+// When modifying either file, verify the other still makes sense.
 const DANGER_PATTERNS: PatternRule[] = [
   // Critical
   { category: "destructive_command", severity: "critical", pattern: /\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|--recursive)\b/g, description: "Recursive forced file deletion (rm -rf)" },

--- a/src/gateway/web/src/pages/Skills/SkillSpaceDetail.tsx
+++ b/src/gateway/web/src/pages/Skills/SkillSpaceDetail.tsx
@@ -145,7 +145,11 @@ export function SkillSpaceDetailPage() {
     }, []);
 
     const handleInvite = async () => {
-        if (!spaceId || !inviteUsername.trim() || !currentWorkspace?.id) return;
+        if (!spaceId || !inviteUsername.trim()) return;
+        if (!currentWorkspace?.id) {
+            setInviteError('Workspace not loaded yet. Please wait and try again.');
+            return;
+        }
         setInviteError(null);
         try {
             await rpcAddSkillSpaceMember(sendRpc, currentWorkspace.id, spaceId, inviteUsername.trim());

--- a/src/tools/infra/command-sets.ts
+++ b/src/tools/infra/command-sets.ts
@@ -1,6 +1,9 @@
 /**
  * Shared command whitelist and command-level validators used by
  * restricted-bash, node-exec, and kubectl-exec tools.
+ *
+ * Cross-reference: src/gateway/skills/script-evaluator.ts (DANGER_PATTERNS).
+ * When modifying either file, verify the other still makes sense.
  */
 
 // ── Utility functions ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Establish a structured harness framework to prevent knowledge drift, enforce architectural invariants, and standardize AI-assisted development. Based on Anthropic's harness design research.

### Problem

As the project scales with multiple AI coding sessions, critical conventions are violated because each session starts fresh:
- Output sanitization changes broke skill scripts (cross-cutting concern not tracked)
- kubectl tool was dead code for months, docs still referenced it
- Claude sessions wasted effort on claude-sdk compatibility (already frozen)
- No structured protocol for what to read before modifying code

### Solution

**Layer 1 — Documentation parity:**
- Fix ADR-005 memory weight drift (0.85/0.15 → 0.70/0.30)
- Create `sanitization.md`: 3-layer output sanitization architecture
- Add Context System and security strategy to `tools.md`
- Add sensitive path patterns to `security.md`
- Fix stale references: file paths (4 docs), nsenter/ssh contexts (3 docs), DANGER_PATTERNS count
- Update all docs to reflect claude-sdk frozen status (ADR-007, invariants §10)

**Layer 2 — Development protocol (CLAUDE.md):**
- Add Change Impact Matrix: 16 file→doc→test→concern mappings
- Add Pre-flight / Post-flight protocol with honest verification loop
- Slim CLAUDE.md from 208 lines (~3.2k tokens) to 128 lines (~1.7k tokens)
- Remove: redundant sections, compaction rules (model can't control), claude-sdk compat guidance

**New docs:**
- `harness.md`: design philosophy for the human team
- `sanitization.md`: 3-layer output sanitization architecture

**Code:**
- Cross-references between `DANGER_PATTERNS` and command whitelist

## Test plan

- [x] All changes are documentation-only (2 lines in source are comments)
- [x] Verified all § references against actual section numbers
- [x] Verified all numeric claims (13 subcommands, 22 DANGER_PATTERNS, 0.70/0.30 weights)
- [x] Verified all file paths exist in codebase
- [x] Cross-doc alignment check: no contradictions between 8 design docs + CLAUDE.md
- [x] Rebased on #176 (nsenter/ssh context removal) — stale references cleaned