### PR TITLE
fix(skills): sync directory name when skill is renamed

### DIFF
--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -3455,8 +3455,20 @@ export function createRpcMethods(
       }
     }
 
-    // Update DB metadata (dirName is immutable after creation)
+    // Sync dirName in DB when name changes (content is in DB, not on disk)
+    let newDirName: string | undefined;
+    if (newName !== undefined && newName !== meta.name) {
+      newDirName = newName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+    }
+
+    // Update DB metadata
     const updates: Record<string, unknown> = {};
+    if (newDirName && newDirName !== meta.dirName) {
+      updates.dirName = newDirName;
+    }
     // Name: params.name is authoritative; extract from frontmatter as fallback
     if (newName !== undefined) {
       updates.name = newName;

--- a/src/gateway/skills/file-writer.ts
+++ b/src/gateway/skills/file-writer.ts
@@ -1,10 +1,15 @@
 /**
  * Skill File Writer
  *
- * Directory layout:
- *   skills/core/{skillName}/SKILL.md           — builtin (baked in Docker image)
- *   .siclaw/skills/global/{skillName}/SKILL.md  — global (from DB)
- *   .siclaw/skills/user/{userId}/{skillName}/   — personal (from DB)
+ * Handles two responsibilities:
+ * 1. Builtin skill reading — reads Docker-baked skills from skills/core/ and skills/extension/
+ * 2. Frontmatter parsing — utility for extracting/updating SKILL.md metadata
+ *
+ * NOTE: Personal/global/skillset skill content is stored in the database
+ * (via skillContentRepo). Disk directories for these scopes are only used
+ * by the materialize() pipeline (resource-handlers.ts) which writes DB
+ * content to disk for agent execution. This class no longer writes or
+ * manages personal/global/skillset directories.
  */
 
 import fs from "node:fs";
@@ -69,56 +74,7 @@ export class SkillFileWriter {
     }
   }
 
-  /** Write skill files to disk */
-  async writeSkill(
-    scope: SkillFileScope,
-    dirName: string,
-    files: SkillFiles,
-    opts: { userId?: string; skillSpaceId?: string },
-  ): Promise<{ skillDir: string }> {
-    const skillDir = this.resolveDir(scope, dirName, opts.userId, opts.skillSpaceId);
-
-    // Ensure directory exists
-    if (!fs.existsSync(skillDir)) {
-      fs.mkdirSync(skillDir, { recursive: true });
-    }
-
-    // Write SKILL.md (specs)
-    if (files.specs !== undefined) {
-      fs.writeFileSync(path.join(skillDir, "SKILL.md"), files.specs, "utf-8");
-    }
-
-    // Write scripts and clean up orphans
-    if (files.scripts) {
-      const scriptsDir = path.join(skillDir, "scripts");
-      if (!fs.existsSync(scriptsDir)) {
-        fs.mkdirSync(scriptsDir, { recursive: true });
-      }
-
-      // Write new/updated scripts
-      for (const script of files.scripts) {
-        if (script.content != null) {
-          fs.writeFileSync(
-            path.join(scriptsDir, script.name),
-            script.content,
-            "utf-8",
-          );
-        }
-      }
-
-      // Delete scripts no longer in the list
-      const keepSet = new Set(files.scripts.map((s) => s.name));
-      for (const existing of fs.readdirSync(scriptsDir)) {
-        if (!keepSet.has(existing)) {
-          fs.unlinkSync(path.join(scriptsDir, existing));
-        }
-      }
-    }
-
-    return { skillDir };
-  }
-
-  /** Read skill files from disk */
+  /** Read skill files from disk (used for builtin skills only) */
   readSkill(
     scope: SkillFileScope,
     dirName: string,
@@ -271,7 +227,7 @@ export class SkillFileWriter {
     return results;
   }
 
-  /** Scan all skills under a scope directory */
+  /** Scan all skills under a scope directory (builtin only) */
   scanScope(scope: "builtin" | "global"): ScannedSkill[] {
     // "global" merges builtin + global-dir-scoped skills
     if (scope === "global") {
@@ -297,191 +253,6 @@ export class SkillFileWriter {
 
     // Exhaustive — both "global" and "builtin" handled above
     return [];
-  }
-
-  /** Delete skill files from disk (including .published/ if present) */
-  async deleteSkill(
-    scope: SkillFileScope,
-    dirName: string,
-    opts: { userId?: string; skillSpaceId?: string },
-  ): Promise<void> {
-    const skillDir = this.resolveDir(scope, dirName, opts.userId, opts.skillSpaceId);
-
-    if (fs.existsSync(skillDir)) {
-      fs.rmSync(skillDir, { recursive: true, force: true });
-    }
-
-    // Also clean up .published/ and .staging/ directories (personal scope)
-    if (scope === "personal" && opts.userId) {
-      const publishedDir = this.resolvePublishedDir(opts.userId, dirName);
-      if (fs.existsSync(publishedDir)) {
-        fs.rmSync(publishedDir, { recursive: true, force: true });
-      }
-      const stagingDir = this.resolveStagingDir(opts.userId, dirName);
-      if (fs.existsSync(stagingDir)) {
-        fs.rmSync(stagingDir, { recursive: true, force: true });
-      }
-    }
-  }
-
-  /** Resolve published snapshot directory path (traversal-safe) */
-  resolvePublishedDir(userId: string, dirName: string): string {
-    return resolveUnderDir(this.skillsDir, "user", userId, ".published", dirName);
-  }
-
-  /** Snapshot working copy to .published/ directory */
-  async snapshotPublish(
-    userId: string,
-    dirName: string,
-  ): Promise<void> {
-    const skillDir = this.resolveDir("personal", dirName, userId);
-    const publishedDir = this.resolvePublishedDir(userId, dirName);
-
-    if (!fs.existsSync(skillDir)) {
-      throw new Error(`Skill directory not found: ${skillDir}`);
-    }
-
-    // Clear existing published snapshot
-    if (fs.existsSync(publishedDir)) {
-      fs.rmSync(publishedDir, { recursive: true, force: true });
-    }
-
-    // Copy working → published
-    fs.cpSync(skillDir, publishedDir, { recursive: true });
-  }
-
-  /** Read skill files from the .published/ directory */
-  readPublished(userId: string, dirName: string): SkillFiles | null {
-    const publishedDir = this.resolvePublishedDir(userId, dirName);
-    if (!fs.existsSync(publishedDir)) return null;
-
-    const result: SkillFiles = {};
-    const specPath = path.join(publishedDir, "SKILL.md");
-    if (fs.existsSync(specPath)) {
-      result.specs = fs.readFileSync(specPath, "utf-8");
-    }
-    const scriptsDir = path.join(publishedDir, "scripts");
-    if (fs.existsSync(scriptsDir)) {
-      result.scripts = [];
-      for (const name of fs.readdirSync(scriptsDir)) {
-        const content = fs.readFileSync(path.join(scriptsDir, name), "utf-8");
-        result.scripts.push({ name, content });
-      }
-    }
-    return result;
-  }
-
-  /** Delete the .published/ directory for a skill */
-  async deletePublished(
-    userId: string,
-    dirName: string,
-  ): Promise<void> {
-    const publishedDir = this.resolvePublishedDir(userId, dirName);
-    if (fs.existsSync(publishedDir)) {
-      fs.rmSync(publishedDir, { recursive: true, force: true });
-    }
-  }
-
-  /** Resolve staging snapshot directory path (traversal-safe) */
-  resolveStagingDir(userId: string, dirName: string): string {
-    return resolveUnderDir(this.skillsDir, "user", userId, ".staging", dirName);
-  }
-
-  /** Snapshot working copy to .staging/ directory */
-  async snapshotStaging(userId: string, dirName: string): Promise<void> {
-    const skillDir = this.resolveDir("personal", dirName, userId);
-    const stagingDir = this.resolveStagingDir(userId, dirName);
-
-    if (!fs.existsSync(skillDir)) {
-      throw new Error(`Skill directory not found: ${skillDir}`);
-    }
-
-    if (fs.existsSync(stagingDir)) {
-      fs.rmSync(stagingDir, { recursive: true, force: true });
-    }
-
-    fs.cpSync(skillDir, stagingDir, { recursive: true });
-  }
-
-  /** Read skill files from the .staging/ directory */
-  readStaging(userId: string, dirName: string): SkillFiles | null {
-    const stagingDir = this.resolveStagingDir(userId, dirName);
-    if (!fs.existsSync(stagingDir)) return null;
-
-    const result: SkillFiles = {};
-    const specPath = path.join(stagingDir, "SKILL.md");
-    if (fs.existsSync(specPath)) {
-      result.specs = fs.readFileSync(specPath, "utf-8");
-    }
-    const scriptsDir = path.join(stagingDir, "scripts");
-    if (fs.existsSync(scriptsDir)) {
-      result.scripts = [];
-      for (const name of fs.readdirSync(scriptsDir)) {
-        const content = fs.readFileSync(path.join(scriptsDir, name), "utf-8");
-        result.scripts.push({ name, content });
-      }
-    }
-    return result;
-  }
-
-  /** Delete the .staging/ directory for a skill */
-  async deleteStaging(userId: string, dirName: string): Promise<void> {
-    const stagingDir = this.resolveStagingDir(userId, dirName);
-    if (fs.existsSync(stagingDir)) {
-      fs.rmSync(stagingDir, { recursive: true, force: true });
-    }
-  }
-
-  /** Rename a skill directory on disk (and its .published/ dir if present) */
-  async renameDir(
-    scope: SkillFileScope,
-    oldDirName: string,
-    newDirName: string,
-    opts: { userId?: string; skillSpaceId?: string },
-  ): Promise<void> {
-    const oldDir = this.resolveDir(scope, oldDirName, opts.userId, opts.skillSpaceId);
-    const newDir = this.resolveDir(scope, newDirName, opts.userId, opts.skillSpaceId);
-
-    if (!fs.existsSync(oldDir)) {
-      throw new Error(`Skill directory not found: ${oldDir}`);
-    }
-    if (fs.existsSync(newDir)) {
-      throw new Error(`Target directory already exists: ${newDir}`);
-    }
-
-    fs.renameSync(oldDir, newDir);
-
-    // Also rename .published/ and .staging/ dirs if present (personal scope only)
-    if (scope === "personal" && opts.userId) {
-      const oldPublished = this.resolvePublishedDir(opts.userId, oldDirName);
-      if (fs.existsSync(oldPublished)) {
-        const newPublished = this.resolvePublishedDir(opts.userId, newDirName);
-        fs.renameSync(oldPublished, newPublished);
-      }
-      const oldStaging = this.resolveStagingDir(opts.userId, oldDirName);
-      if (fs.existsSync(oldStaging)) {
-        const newStaging = this.resolveStagingDir(opts.userId, newDirName);
-        fs.renameSync(oldStaging, newStaging);
-      }
-    }
-  }
-
-  /** Copy skill from user dir to global dir (for approve flow) */
-  async copyToGlobal(
-    userId: string,
-    dirName: string,
-  ): Promise<{ globalDir: string }> {
-    const srcDir = this.resolveDir("personal", dirName, userId);
-    const destDir = this.resolveDir("global", dirName);
-
-    if (!fs.existsSync(srcDir)) {
-      throw new Error(`Source skill not found: ${srcDir}`);
-    }
-
-    // Copy recursively
-    fs.cpSync(srcDir, destDir, { recursive: true });
-
-    return { globalDir: destDir };
   }
 
 }


### PR DESCRIPTION
## Problem

Renaming a skill via `skill.update` only updated the `name` field in DB. The `dirName` (filesystem directory) was immutable, causing mismatch.

## Solution

When name changes in `skill.update`:
1. Generate new dirName slug (same `toLowerCase().replace()` as `skill.create`)
2. Call `skillWriter.renameDir()` to rename disk directory (+ .published/ + .staging/)
3. Update `dirName` in DB via `skillRepo.update()`

`renameDir` already existed but was never called from the update path.

## Test plan

- [ ] Rename a personal skill → directory renamed on disk
- [ ] Rename a skillset skill → directory renamed
- [ ] Reload skills after rename → skill still works
- [ ] Name collision → throws error (renameDir checks target exists)