### PR TITLE
feat(cron): persist tool call traces for cron job executions

### DIFF
--- a/src/gateway/cron/cron-service.ts
+++ b/src/gateway/cron/cron-service.ts
@@ -113,15 +113,16 @@ export class CronService {
     const workspaceId = current.workspaceId ?? undefined;
     console.log(`[cron-service] Executing job ${job.id} (${job.name}) for user ${job.userId}${workspaceId ? ` ws=${workspaceId}` : ""}`);
 
+    // Fresh session per execution — avoids compaction edge cases and JSONL growth
+    let sessionId: string | undefined;
     try {
-      // Fresh session per execution — avoids compaction edge cases and JSONL growth
       const cronSession = await this.chatRepo.createSession(
         current.userId,
         `Cron: ${current.name}`,
         workspaceId,
         "cron",
       );
-      const sessionId = cronSession.id;
+      sessionId = cronSession.id;
 
       const prompt = buildCronPrompt(current);
 
@@ -171,7 +172,7 @@ export class CronService {
       try { await this.configRepo.updateCronJobRun(job.id, "failure"); } catch (e) {
         console.warn(`[cron-service] updateCronJobRun failed for ${job.id}:`, e instanceof Error ? e.message : e);
       }
-      await this.recordResult(job, "failure", "", err instanceof Error ? err.message : String(err));
+      await this.recordResult(job, "failure", "", err instanceof Error ? err.message : String(err), undefined, sessionId);
     } finally {
       try {
         await this.configRepo.unlockJob(job.id, executionId);

--- a/src/gateway/cron/cron-service.ts
+++ b/src/gateway/cron/cron-service.ts
@@ -10,6 +10,7 @@ import crypto from "node:crypto";
 import { CronScheduler, type CronJobRow } from "../../cron/cron-scheduler.js";
 import type { ConfigRepository } from "../db/repositories/config-repo.js";
 import type { NotificationRepository } from "../db/repositories/notification-repo.js";
+import { ChatRepository } from "../db/repositories/chat-repo.js";
 import { CRON_LIMITS } from "../../cron/cron-limits.js";
 
 const EXECUTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -29,6 +30,7 @@ export class CronService {
 
   private configRepo: ConfigRepository;
   private notifRepo: NotificationRepository;
+  private chatRepo: ChatRepository;
   private sendToUser: SendToUserFn;
   private gatewayPort: number;
   private staleLockTimer: NodeJS.Timeout | null = null;
@@ -38,11 +40,13 @@ export class CronService {
   constructor(opts: {
     configRepo: ConfigRepository;
     notifRepo: NotificationRepository;
+    chatRepo: ChatRepository;
     sendToUser: SendToUserFn;
     gatewayPort: number;
   }) {
     this.configRepo = opts.configRepo;
     this.notifRepo = opts.notifRepo;
+    this.chatRepo = opts.chatRepo;
     this.sendToUser = opts.sendToUser;
     this.gatewayPort = opts.gatewayPort;
     this.scheduler = new CronScheduler((job) => this.execute(job));
@@ -110,8 +114,24 @@ export class CronService {
     console.log(`[cron-service] Executing job ${job.id} (${job.name}) for user ${job.userId}${workspaceId ? ` ws=${workspaceId}` : ""}`);
 
     try {
-      const sessionId = `cron-${job.id}-${Date.now()}`;
+      // Fresh session per execution — avoids compaction edge cases and JSONL growth
+      const cronSession = await this.chatRepo.createSession(
+        current.userId,
+        `Cron: ${current.name}`,
+        workspaceId,
+        "cron",
+      );
+      const sessionId = cronSession.id;
+
       const prompt = buildCronPrompt(current);
+
+      // Persist user message
+      await this.chatRepo.appendMessage({
+        sessionId,
+        role: "user",
+        content: prompt,
+      });
+      await this.chatRepo.incrementMessageCount(sessionId);
 
       const resp = await fetch(`http://localhost:${this.gatewayPort}/api/internal/agent-prompt`, {
         method: "POST",
@@ -123,6 +143,7 @@ export class CronService {
           timeoutMs: EXECUTION_TIMEOUT_MS,
           caller: "cron",
           workspaceId,
+          persistToDb: true,
         }),
         signal: AbortSignal.timeout(EXECUTION_TIMEOUT_MS + 10_000),
       });
@@ -144,7 +165,7 @@ export class CronService {
       console.log(`[cron-service] Job ${job.id} completed in ${data.durationMs}ms, resultText length=${resultText.length}`);
 
       // Write run record + notification
-      await this.recordResult(job, "success", resultText, undefined, data.durationMs);
+      await this.recordResult(job, "success", resultText, undefined, data.durationMs, sessionId);
     } catch (err) {
       console.error(`[cron-service] Job ${job.id} failed:`, err);
       try { await this.configRepo.updateCronJobRun(job.id, "failure"); } catch (e) {
@@ -167,6 +188,7 @@ export class CronService {
     resultText: string,
     error?: string,
     durationMs?: number,
+    sessionId?: string,
   ): Promise<void> {
     // Persist run record
     try {
@@ -176,6 +198,7 @@ export class CronService {
         resultText: resultText || undefined,
         error,
         durationMs,
+        sessionId,
       });
     } catch (runErr) {
       console.warn("[cron-service] Failed to insert cron run:", runErr instanceof Error ? runErr.message : runErr);

--- a/src/gateway/cron/cron-service.ts
+++ b/src/gateway/cron/cron-service.ts
@@ -10,7 +10,7 @@ import crypto from "node:crypto";
 import { CronScheduler, type CronJobRow } from "../../cron/cron-scheduler.js";
 import type { ConfigRepository } from "../db/repositories/config-repo.js";
 import type { NotificationRepository } from "../db/repositories/notification-repo.js";
-import { ChatRepository } from "../db/repositories/chat-repo.js";
+import type { ChatRepository } from "../db/repositories/chat-repo.js";
 import { CRON_LIMITS } from "../../cron/cron-limits.js";
 
 const EXECUTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -202,7 +202,7 @@ export class CronService {
         sessionId,
       });
     } catch (runErr) {
-      console.warn("[cron-service] Failed to insert cron run:", runErr instanceof Error ? runErr.message : runErr);
+      console.warn(`[cron-service] Failed to insert cron run (sessionId=${sessionId}):`, runErr instanceof Error ? runErr.message : runErr);
     }
 
     // Create notification

--- a/src/gateway/db/init-schema.ts
+++ b/src/gateway/db/init-schema.ts
@@ -42,6 +42,7 @@ const DDL_STATEMENTS = [
     message_count INT NOT NULL DEFAULT 0,
     deleted_at TIMESTAMP NULL,
     s3_key VARCHAR(500),
+    source VARCHAR(20) NOT NULL DEFAULT 'pilot',
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
   )`,
 
@@ -145,6 +146,7 @@ const DDL_STATEMENTS = [
     result_text TEXT,
     error TEXT,
     duration_ms INT,
+    session_id VARCHAR(64),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (job_id) REFERENCES cron_jobs(id) ON DELETE CASCADE
   )`,
@@ -560,6 +562,9 @@ export async function initSchema(db: Database): Promise<void> {
       FOREIGN KEY (user_id) REFERENCES users(id),
       FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
     )`,
+    // ── Cron session reuse ──
+    `ALTER TABLE sessions ADD COLUMN source VARCHAR(20) NOT NULL DEFAULT 'pilot'`,
+    `ALTER TABLE cron_job_runs ADD COLUMN session_id VARCHAR(64)`,
   ];
   for (const stmt of MIGRATIONS) {
     try {

--- a/src/gateway/db/migrate-sqlite.ts
+++ b/src/gateway/db/migrate-sqlite.ts
@@ -39,7 +39,8 @@ const DDL_STATEMENTS = [
     last_active_at INTEGER NOT NULL DEFAULT (unixepoch()),
     message_count INTEGER NOT NULL DEFAULT 0,
     deleted_at INTEGER,
-    s3_key TEXT
+    s3_key TEXT,
+    source TEXT NOT NULL DEFAULT 'pilot'
   )`,
 
   `CREATE TABLE IF NOT EXISTS messages (
@@ -133,6 +134,7 @@ const DDL_STATEMENTS = [
     result_text TEXT,
     error TEXT,
     duration_ms INTEGER,
+    session_id TEXT,
     created_at INTEGER NOT NULL DEFAULT (unixepoch())
   )`,
 
@@ -535,6 +537,9 @@ export async function runSqliteMigrations(db: Database): Promise<void> {
       SELECT o.user_id, s.id FROM user_disabled_skills_old o
       JOIN skills s ON s.name = o.skill_name`,
     `DROP TABLE IF EXISTS user_disabled_skills_old`,
+    // ── Cron session reuse ──
+    `ALTER TABLE sessions ADD COLUMN source TEXT NOT NULL DEFAULT 'pilot'`,
+    `ALTER TABLE cron_job_runs ADD COLUMN session_id TEXT`,
   ];
   for (const stmt of MIGRATIONS) {
     try {

--- a/src/gateway/db/repositories/chat-repo.ts
+++ b/src/gateway/db/repositories/chat-repo.ts
@@ -3,7 +3,7 @@
  */
 
 import crypto from "node:crypto";
-import { eq, ne, desc, and, lt, lte, gte, isNull, isNotNull, or, like, inArray, sql } from "drizzle-orm";
+import { eq, desc, and, lt, lte, gte, isNull, isNotNull, or, like, inArray, sql } from "drizzle-orm";
 import type { Database } from "../index.js";
 import { sessions, messages, users, sessionStats } from "../schema.js";
 
@@ -11,7 +11,7 @@ export class ChatRepository {
   constructor(private db: Database) {}
 
   async listSessions(userId: string, limit = 20, workspaceId?: string) {
-    const conditions = [eq(sessions.userId, userId), isNull(sessions.deletedAt), ne(sessions.source, "cron")];
+    const conditions = [eq(sessions.userId, userId), isNull(sessions.deletedAt), eq(sessions.source, "pilot")];
     if (workspaceId) {
       conditions.push(eq(sessions.workspaceId, workspaceId));
     }

--- a/src/gateway/db/repositories/chat-repo.ts
+++ b/src/gateway/db/repositories/chat-repo.ts
@@ -3,7 +3,7 @@
  */
 
 import crypto from "node:crypto";
-import { eq, desc, and, lt, lte, gte, isNull, isNotNull, or, like, inArray, sql } from "drizzle-orm";
+import { eq, ne, desc, and, lt, lte, gte, isNull, isNotNull, or, like, inArray, sql } from "drizzle-orm";
 import type { Database } from "../index.js";
 import { sessions, messages, users, sessionStats } from "../schema.js";
 
@@ -11,7 +11,7 @@ export class ChatRepository {
   constructor(private db: Database) {}
 
   async listSessions(userId: string, limit = 20, workspaceId?: string) {
-    const conditions = [eq(sessions.userId, userId), isNull(sessions.deletedAt)];
+    const conditions = [eq(sessions.userId, userId), isNull(sessions.deletedAt), ne(sessions.source, "cron")];
     if (workspaceId) {
       conditions.push(eq(sessions.workspaceId, workspaceId));
     }
@@ -32,7 +32,7 @@ export class ChatRepository {
     return rows[0] ?? null;
   }
 
-  async createSession(userId: string, title?: string, workspaceId?: string) {
+  async createSession(userId: string, title?: string, workspaceId?: string, source: "pilot" | "cron" = "pilot") {
     const id = crypto.randomUUID();
     await this.db.insert(sessions).values({
       id,
@@ -41,6 +41,7 @@ export class ChatRepository {
       title: title ?? "New Chat",
       preview: "",
       messageCount: 0,
+      source,
     });
     return { id, title: title ?? "New Chat" };
   }

--- a/src/gateway/db/repositories/config-repo.ts
+++ b/src/gateway/db/repositories/config-repo.ts
@@ -159,6 +159,7 @@ export class ConfigRepository {
     resultText?: string;
     error?: string;
     durationMs?: number;
+    sessionId?: string;
   }): Promise<string> {
     const id = crypto.randomUUID();
     await this.db.insert(cronJobRuns).values({
@@ -168,6 +169,7 @@ export class ConfigRepository {
       resultText: params.resultText ?? null,
       error: params.error ?? null,
       durationMs: params.durationMs ?? null,
+      sessionId: params.sessionId ?? null,
     });
     return id;
   }

--- a/src/gateway/db/schema-mysql.ts
+++ b/src/gateway/db/schema-mysql.ts
@@ -56,6 +56,7 @@ export const sessions = mysqlTable("sessions", {
   lastActiveAt: timestamp("last_active_at").notNull().defaultNow(),
   messageCount: int("message_count").notNull().default(0),
   deletedAt: timestamp("deleted_at"),
+  source: varchar("source", { length: 20 }).notNull().default("pilot"), // "pilot" | "cron"
 });
 
 // ─── Messages ────────────────────────────────────────
@@ -216,6 +217,7 @@ export const cronJobRuns = mysqlTable("cron_job_runs", {
   resultText: text("result_text"),
   error: text("error"),
   durationMs: int("duration_ms"),
+  sessionId: varchar("session_id", { length: 64 }),
   createdAt: timestamp("created_at").notNull().defaultNow(),
 });
 

--- a/src/gateway/db/schema-sqlite.ts
+++ b/src/gateway/db/schema-sqlite.ts
@@ -52,6 +52,7 @@ export const sessions = sqliteTable("sessions", {
   lastActiveAt: integer("last_active_at", { mode: "timestamp" }).notNull().default(sql`(unixepoch())`),
   messageCount: integer("message_count").notNull().default(0),
   deletedAt: integer("deleted_at", { mode: "timestamp" }),
+  source: text("source").notNull().default("pilot"), // "pilot" | "cron"
 });
 
 // ─── Messages ────────────────────────────────────────
@@ -204,6 +205,7 @@ export const cronJobRuns = sqliteTable("cron_job_runs", {
   resultText: text("result_text"),
   error: text("error"),
   durationMs: integer("duration_ms"),
+  sessionId: text("session_id"),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull().default(sql`(unixepoch())`),
 });
 

--- a/src/gateway/rpc-methods.ts
+++ b/src/gateway/rpc-methods.ts
@@ -49,6 +49,7 @@ import { CRON_LIMITS } from "../cron/cron-limits.js";
 import { parseCronExpression, getAverageIntervalMs } from "../cron/cron-matcher.js";
 import { buildSkillBundle, type SkillBundle } from "./skills/skill-bundle.js";
 import { buildRedactionConfig, redactText, type RedactionConfig } from "./output-redactor.js";
+import { consumeAgentSse, type SseEvent, type SseEventExtras } from "./sse-consumer.js";
 import { RESOURCE_DESCRIPTORS } from "../shared/resource-sync.js";
 import type { ResourceNotifier } from "../shared/resource-sync.js";
 import { sql, gte, sum, count } from "drizzle-orm";
@@ -1479,166 +1480,80 @@ export function createRpcMethods(
       ws: context.ws,
     });
 
-    // Async SSE processing
+    // Async SSE processing — DB persistence delegated to shared consumeAgentSse,
+    // pilot-specific logic (WS forwarding, DP tracking) in the onEvent callback.
+    activePromptUsers?.add(userId);
     (async () => {
-      let assistantContent = "";
-      // Map keyed by toolName to handle parallel tool calls correctly
-      const pendingToolInputs = new Map<string, string>();
-      const pendingToolStartTimes = new Map<string, number>();
-      let sseEventCount = 0;
-      const sseStartTime = Date.now();
-      // Mark user as having an active prompt so WS teardown won't kill the pod
-      activePromptUsers?.add(userId);
       try {
-        for await (const event of client.streamEvents(result.sessionId)) {
-          if (abortController.signal.aborted) break;
-
-          const eventData = event as Record<string, unknown>;
-          const eventType = eventData.type as string;
-          sseEventCount++;
-
-          // Only log key lifecycle events to avoid flooding
-          if (eventType === "agent_start" || eventType === "agent_end" || eventType === "message_end" || eventType === "message_start" || eventType.includes("error")) {
-            console.log(`[rpc] SSE event for ${userId}: ${eventType}`, JSON.stringify(event).slice(0, 300));
-          }
-
-          // For tool_execution_end: save to DB first so we can include the real
-          // message ID in the forwarded event (frontend needs it for metadata updates).
-          let dbMessageId: string | undefined;
-          if (chatRepo && eventType === "tool_execution_end") {
-            const toolResult = eventData.result as {
-              content?: Array<{ type: string; text?: string }>;
-              details?: { blocked?: boolean; error?: boolean };
-            } | undefined;
-            const text =
-              toolResult?.content
-                ?.filter((c) => c.type === "text")
-                .map((c) => c.text ?? "")
-                .join("") ?? "";
-            const toolName = (eventData.toolName as string) || "tool";
-
-            // Audit: determine outcome
-            let outcome: "success" | "error" | "blocked" = "success";
-            if (toolResult?.details?.blocked) {
-              outcome = "blocked";
-            } else if (toolResult?.details?.error) {
-              outcome = "error";
-            }
-            const startTime = pendingToolStartTimes.get(toolName);
-            const durationMs = startTime != null
-              ? Date.now() - startTime
-              : undefined;
-            const toolInput = pendingToolInputs.get(toolName) || "";
-
-            dbMessageId = await chatRepo.appendMessage({
-              sessionId: result.sessionId,
-              role: "tool",
-              content: redactText(text, redactionConfig),
-              toolName,
-              toolInput: toolInput ? redactText(toolInput, redactionConfig) : undefined,
+        await consumeAgentSse({
+          client,
+          sessionId: result.sessionId,
+          userId,
+          chatRepo,
+          redactionConfig,
+          signal: abortController.signal,
+          onEvent(evt: SseEvent, eventType: string, extras: SseEventExtras) {
+            // ── Forward event to frontend via WebSocket ──
+            const eventPayload: Record<string, unknown> = {
               userId,
-              outcome,
-              durationMs,
-            });
-            await chatRepo.incrementMessageCount(result.sessionId);
-            pendingToolInputs.delete(toolName);
-            pendingToolStartTimes.delete(toolName);
-          }
-
-          // Forward event to frontend via sendToUser (targets all WS connections
-          // for this user, so reconnected sessions also receive live events)
-          const eventPayload = {
-            userId,
-            sessionId: result.sessionId,
-            ...eventData,
-            ...(dbMessageId ? { dbMessageId } : {}),
-          };
-          // Redact sensitive credential info from outbound WS stream
-          if (redactionConfig.patterns.length > 0) {
-            const ep = eventPayload as Record<string, unknown>;
-            if (eventType === "message_update") {
-              const ame = ep.assistantMessageEvent as { type?: string; delta?: string } | undefined;
-              if (ame?.type === "text_delta" && ame.delta) {
-                ame.delta = redactText(ame.delta, redactionConfig);
-              }
-            } else if (eventType === "tool_execution_end") {
-              const toolResult = ep.result as { content?: Array<{ type: string; text?: string }> } | undefined;
-              if (toolResult?.content) {
-                for (const block of toolResult.content) {
-                  if (block.type === "text" && block.text) {
-                    block.text = redactText(block.text, redactionConfig);
+              sessionId: result.sessionId,
+              ...evt,
+              ...(extras.dbMessageId ? { dbMessageId: extras.dbMessageId } : {}),
+            };
+            // Redact sensitive info in outbound WS stream
+            if (redactionConfig.patterns.length > 0) {
+              if (eventType === "message_update") {
+                const ame = eventPayload.assistantMessageEvent as { type?: string; delta?: string } | undefined;
+                if (ame?.type === "text_delta" && ame.delta) {
+                  ame.delta = redactText(ame.delta, redactionConfig);
+                }
+              } else if (eventType === "tool_execution_end") {
+                const toolResult = eventPayload.result as { content?: Array<{ type: string; text?: string }> } | undefined;
+                if (toolResult?.content) {
+                  for (const block of toolResult.content) {
+                    if (block.type === "text" && block.text) {
+                      block.text = redactText(block.text, redactionConfig);
+                    }
                   }
                 }
               }
             }
-          }
+            if (sendToUser) {
+              sendToUser(userId, "agent_event", eventPayload);
+            } else {
+              context.sendEvent("agent_event", eventPayload);
+            }
 
-          if (sendToUser) {
-            sendToUser(userId, "agent_event", eventPayload);
-          } else {
-            context.sendEvent("agent_event", eventPayload);
-          }
-
-          // Cache deep_search tool_progress events for WS reconnect recovery
-          if (eventType === "tool_progress" && eventData.toolName === "deep_search") {
-            const progress = eventData.progress as Record<string, unknown> | undefined;
-            if (progress) {
-              let snap = dpProgressSnapshots.get(streamKey);
-              if (!snap) {
-                snap = { sessionId: result.sessionId, events: [], updatedAt: Date.now() };
-                dpProgressSnapshots.set(streamKey, snap);
+            // ── Cache deep_search progress for WS reconnect recovery ──
+            if (eventType === "tool_progress" && evt.toolName === "deep_search") {
+              const progress = evt.progress as Record<string, unknown> | undefined;
+              if (progress) {
+                let snap = dpProgressSnapshots.get(streamKey);
+                if (!snap) {
+                  snap = { sessionId: result.sessionId, events: [], updatedAt: Date.now() };
+                  dpProgressSnapshots.set(streamKey, snap);
+                }
+                snap.events.push(progress);
+                snap.updatedAt = Date.now();
               }
-              snap.events.push(progress);
-              snap.updatedAt = Date.now();
             }
-          }
 
-          // Track DP status from tool events (reads dpStatus from tool result details)
-          if (eventType === "tool_execution_end") {
-            const details = (eventData.result as { details?: { dpStatus?: string } } | undefined)?.details;
-            if (details?.dpStatus) {
-              transitionDpStatus(streamKey, details.dpStatus as DpStatus);
-              emitDpStatus(streamKey, userId, result.sessionId);
-            }
-          } else if (eventType === "agent_end") {
-            const cache = dpStatusCache.get(streamKey);
-            if (cache?.dpStatus === "concluding") {
-              transitionDpStatus(streamKey, "completed");
-              emitDpStatus(streamKey, userId, result.sessionId);
-            }
-          }
-
-          // DB persistence for other event types
-          if (chatRepo) {
-            if (eventType === "message_update") {
-              const ame = eventData.assistantMessageEvent as {
-                type: string;
-                delta?: string;
-              } | undefined;
-              if (ame?.type === "text_delta" && ame.delta) {
-                assistantContent += ame.delta;
+            // ── Track DP status from tool events ──
+            if (eventType === "tool_execution_end") {
+              const details = (evt.result as { details?: { dpStatus?: string } } | undefined)?.details;
+              if (details?.dpStatus) {
+                transitionDpStatus(streamKey, details.dpStatus as DpStatus);
+                emitDpStatus(streamKey, userId, result.sessionId);
               }
-            } else if (eventType === "message_end") {
-              // Save complete assistant message (redacted)
-              if (assistantContent) {
-                await chatRepo.appendMessage({
-                  sessionId: result.sessionId,
-                  role: "assistant",
-                  content: redactText(assistantContent, redactionConfig),
-                });
-                await chatRepo.incrementMessageCount(result.sessionId);
-                assistantContent = "";
+            } else if (eventType === "agent_end") {
+              const cache = dpStatusCache.get(streamKey);
+              if (cache?.dpStatus === "concluding") {
+                transitionDpStatus(streamKey, "completed");
+                emitDpStatus(streamKey, userId, result.sessionId);
               }
-            } else if (eventType === "tool_execution_start") {
-              // Capture tool input and start time for DB persistence (keyed by toolName for parallel calls)
-              const startToolName = (eventData.toolName as string) || "tool";
-              const args = eventData.args as Record<string, unknown> | undefined;
-              pendingToolInputs.set(startToolName, args ? JSON.stringify(args) : "");
-              pendingToolStartTimes.set(startToolName, Date.now());
             }
-            // tool_execution_end already handled above
-          }
-        }
+          },
+        });
       } catch (err) {
         if (!abortController.signal.aborted) {
           const msg = err instanceof Error ? err.message : String(err);
@@ -1646,8 +1561,6 @@ export function createRpcMethods(
           broadcast("error", { userId, message: msg });
         }
       } finally {
-        const sseDurationMs = Date.now() - sseStartTime;
-        console.log(`[rpc] SSE stream ended for userId=${userId} sessionId=${result.sessionId} (${sseEventCount} events, ${sseDurationMs}ms)`);
         activeStreams.delete(streamKey);
         activePromptUsers?.delete(userId);
         // Signal frontend that agent prompt is truly done

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -863,6 +863,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
                 credentials?.manifest?.length ? path.resolve(process.cwd(), ".siclaw/credentials") : undefined,
                 sensitiveStrings.length > 0 ? sensitiveStrings : undefined,
               );
+              const abortCtrl = new AbortController();
               const sseResult = await Promise.race([
                 consumeAgentSse({
                   client,
@@ -870,8 +871,9 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
                   userId,
                   chatRepo: chatRepoLocal,
                   redactionConfig: redactionCfg,
+                  signal: abortCtrl.signal,
                 }),
-                timeout.promise,
+                timeout.promise.catch((err) => { abortCtrl.abort(); throw err; }),
               ]);
               resultText = (sseResult as { resultText: string }).resultText;
             } else {

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -23,6 +23,8 @@ import { UserRepository } from "./db/repositories/user-repo.js";
 import { ModelConfigRepository } from "./db/repositories/model-config-repo.js";
 import { SystemConfigRepository } from "./db/repositories/system-config-repo.js";
 import { WorkspaceRepository } from "./db/repositories/workspace-repo.js";
+import { consumeAgentSse } from "./sse-consumer.js";
+import { buildRedactionConfig } from "./output-redactor.js";
 import { McpServerRepository } from "./db/repositories/mcp-server-repo.js";
 import { FeedbackRepository } from "./db/repositories/feedback-repo.js";
 import { loadConfig } from "../core/config.js";
@@ -260,8 +262,9 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
   const notifRepo = db ? new NotificationRepository(db) : null;
 
   // In-process cron service (replaces standalone cron process)
-  const cronService = (configRepo && notifRepo)
-    ? new CronService({ configRepo, notifRepo, sendToUser, gatewayPort: config.port })
+  const internalChatRepo = db ? new ChatRepository(db) : null;
+  const cronService = (configRepo && notifRepo && internalChatRepo)
+    ? new CronService({ configRepo, notifRepo, chatRepo: internalChatRepo, sendToUser, gatewayPort: config.port })
     : null;
 
   // System config repo (used by JWT, SSO, cert-manager, metrics cache, etc.)
@@ -785,6 +788,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
             userId: string; sessionId: string; text: string;
             timeoutMs?: number; caller?: string;
             workspaceId?: string;
+            persistToDb?: boolean;
           };
           userId = data.userId;
           const timeoutMs = data.timeoutMs || 300_000;
@@ -846,10 +850,37 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
           // 4. Wait for completion with cancellable timeout
           const timeout = rejectAfterTimeout(timeoutMs, data.sessionId);
           try {
-            const resultText = await Promise.race([
-              waitForAgentCompletion(client, promptResult.sessionId),
-              timeout.promise,
-            ]);
+            let resultText: string;
+
+            if (data.persistToDb && db) {
+              // Persistent mode: write tool calls + assistant messages to DB
+              const chatRepoLocal = new ChatRepository(db);
+              const sensitiveStrings: string[] = [];
+              if (modelConfig?.apiKey) sensitiveStrings.push(modelConfig.apiKey);
+              if (modelConfig?.baseUrl) sensitiveStrings.push(modelConfig.baseUrl);
+              const redactionCfg = buildRedactionConfig(
+                credentials?.manifest,
+                credentials?.manifest?.length ? path.resolve(process.cwd(), ".siclaw/credentials") : undefined,
+                sensitiveStrings.length > 0 ? sensitiveStrings : undefined,
+              );
+              const sseResult = await Promise.race([
+                consumeAgentSse({
+                  client,
+                  sessionId: promptResult.sessionId,
+                  userId,
+                  chatRepo: chatRepoLocal,
+                  redactionConfig: redactionCfg,
+                }),
+                timeout.promise,
+              ]);
+              resultText = (sseResult as { resultText: string }).resultText;
+            } else {
+              // Legacy mode: text extraction only, no DB persistence
+              resultText = await Promise.race([
+                waitForAgentCompletion(client, promptResult.sessionId),
+                timeout.promise,
+              ]) as string;
+            }
 
             timeout.cancel();
             const durationMs = Date.now() - startTime;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -852,36 +852,37 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
           try {
             let resultText: string;
 
-            if (data.persistToDb && db) {
-              // Persistent mode: write tool calls + assistant messages to DB
-              const chatRepoLocal = new ChatRepository(db);
+            // Both persistent and non-persistent paths use consumeAgentSse.
+            // When persistToDb=true, tool calls + assistant messages are written to DB.
+            // When false (or no DB), only text extraction happens (chatRepo: null).
+            const chatRepoForRun = (data.persistToDb && db) ? new ChatRepository(db) : null;
+            let redactionCfg = undefined;
+            if (chatRepoForRun) {
               const sensitiveStrings: string[] = [];
               if (modelConfig?.apiKey) sensitiveStrings.push(modelConfig.apiKey);
               if (modelConfig?.baseUrl) sensitiveStrings.push(modelConfig.baseUrl);
-              const redactionCfg = buildRedactionConfig(
+              redactionCfg = buildRedactionConfig(
                 credentials?.manifest,
                 credentials?.manifest?.length ? path.resolve(process.cwd(), ".siclaw/credentials") : undefined,
                 sensitiveStrings.length > 0 ? sensitiveStrings : undefined,
               );
-              const abortCtrl = new AbortController();
+            }
+            const abortCtrl = new AbortController();
+            try {
               const sseResult = await Promise.race([
                 consumeAgentSse({
                   client,
                   sessionId: promptResult.sessionId,
                   userId,
-                  chatRepo: chatRepoLocal,
+                  chatRepo: chatRepoForRun,
                   redactionConfig: redactionCfg,
                   signal: abortCtrl.signal,
                 }),
-                timeout.promise.catch((err) => { abortCtrl.abort(); throw err; }),
-              ]);
-              resultText = (sseResult as { resultText: string }).resultText;
-            } else {
-              // Legacy mode: text extraction only, no DB persistence
-              resultText = await Promise.race([
-                waitForAgentCompletion(client, promptResult.sessionId),
                 timeout.promise,
-              ]) as string;
+              ]);
+              resultText = sseResult.resultText;
+            } finally {
+              abortCtrl.abort();
             }
 
             timeout.cancel();
@@ -1468,73 +1469,7 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
   return gatewayServer;
 }
 
-/** Consume SSE stream from AgentBox and extract final assistant text */
-async function waitForAgentCompletion(client: AgentBoxClient, sessionId: string): Promise<string> {
-  let resultText = "";
-  let taskReportText = "";
-  // Accumulate text deltas per message (claude-sdk brain emits text via
-  // message_update/text_delta and sends empty content in message_end)
-  let currentMsgText = "";
-  // Track last tool name to identify task_report results.
-  // pi-agent emits "tool_execution_start" (toolName field),
-  // claude-sdk emits "tool_start" (name field).
-  let lastToolName = "";
 
-  for await (const event of client.streamEvents(sessionId)) {
-    const evt = event as Record<string, unknown>;
-
-    // Accumulate streaming text deltas
-    if (evt.type === "message_update") {
-      const ame = evt.assistantMessageEvent as Record<string, unknown> | undefined;
-      if (ame?.type === "text_delta" && typeof ame.delta === "string") {
-        currentMsgText += ame.delta;
-      }
-    }
-
-    if (evt.type === "message_start") {
-      currentMsgText = "";
-    }
-
-    if (evt.type === "tool_execution_start" || evt.type === "tool_start") {
-      lastToolName = (evt.toolName as string) || (evt.name as string) || "";
-    }
-
-    if (evt.type === "message_end" || evt.type === "turn_end") {
-      const message = evt.message as Record<string, unknown> | undefined;
-      if (message?.role === "assistant") {
-        let extracted = "";
-        const content = message.content;
-        if (typeof content === "string" && content) {
-          extracted = content;
-        } else if (Array.isArray(content)) {
-          extracted = (content as Array<{ type: string; text?: string }>)
-            .filter((c) => c.type === "text")
-            .map((c) => c.text ?? "")
-            .join("");
-        }
-        resultText = extracted || currentMsgText || resultText;
-      } else if (message?.role === "toolResult" && lastToolName === "task_report") {
-        const content = message.content;
-        const text = typeof content === "string" ? content
-          : Array.isArray(content)
-            ? (content as Array<{ type: string; text?: string }>)
-                .filter((c) => c.type === "text")
-                .map((c) => c.text ?? "")
-                .join("")
-            : "";
-        if (text) taskReportText = text;
-      }
-      currentMsgText = "";
-      if (message?.role === "toolResult") lastToolName = "";
-    }
-    if (evt.type === "agent_end") break;
-  }
-  if (!resultText && currentMsgText) {
-    resultText = currentMsgText;
-  }
-  // task_report takes priority over free text
-  return taskReportText || resultText;
-}
 
 class ExecutionTimeoutError extends Error {
   constructor(sessionId: string, ms: number) {

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -123,8 +123,9 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       pendingToolInputs.delete(toolName);
       pendingToolStartTimes.delete(toolName);
 
-      // task_report detection (tool result in tool_execution_end)
-      if (lastToolName === "task_report" && text) {
+      // task_report detection — use toolName from this event, not lastToolName
+      // (lastToolName tracks the last *started* tool, unreliable with parallel calls)
+      if (toolName === "task_report" && text) {
         taskReportText = text;
       }
     }

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -50,7 +50,7 @@ export interface SseConsumptionResult {
 
 // ── Implementation ──────────────────────────────────
 
-const EMPTY_REDACTION: RedactionConfig = { patterns: [] } as RedactionConfig;
+const EMPTY_REDACTION: RedactionConfig = { patterns: [] };
 
 export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<SseConsumptionResult> {
   const { client, sessionId, userId, chatRepo, onEvent, signal } = opts;
@@ -208,10 +208,13 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
     resultText = currentMsgText;
   }
 
+  const durationMs = Date.now() - startTime;
+  console.log(`[sse-consumer] ${userId} session=${sessionId}: ${eventCount} events, ${durationMs}ms`);
+
   return {
     resultText: taskReportText || resultText,
     taskReportText,
     eventCount,
-    durationMs: Date.now() - startTime,
+    durationMs,
   };
 }

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -1,0 +1,217 @@
+/**
+ * Shared SSE consumer — extracts tool call persistence and result text from
+ * an AgentBox event stream.
+ *
+ * Used by both `chat.send` (pilot) and CronService (via agent-prompt).
+ * Callers add their own behaviour via the `onEvent` callback (e.g. WS
+ * forwarding for pilot, no-op for cron).
+ */
+
+import { AgentBoxClient } from "./agentbox/client.js";
+import { ChatRepository } from "./db/repositories/chat-repo.js";
+import { redactText, type RedactionConfig } from "./output-redactor.js";
+
+// ── Public types ────────────────────────────────────
+
+export type SseEvent = Record<string, unknown>;
+
+export interface SseEventExtras {
+  /** DB message ID when a role="tool" row was inserted for this event. */
+  dbMessageId?: string;
+}
+
+export type OnEventCallback = (
+  event: SseEvent,
+  eventType: string,
+  extras: SseEventExtras,
+) => void;
+
+export interface ConsumeAgentSseOptions {
+  client: AgentBoxClient;
+  sessionId: string;
+  userId: string;
+  /** Pass null/undefined to skip DB persistence (text extraction still works). */
+  chatRepo?: ChatRepository | null;
+  redactionConfig?: RedactionConfig;
+  /** Called for every SSE event after DB writes (so dbMessageId is available). */
+  onEvent?: OnEventCallback;
+  /** Abort signal — breaks the loop when triggered. */
+  signal?: AbortSignal;
+}
+
+export interface SseConsumptionResult {
+  /** Final assistant text (task_report takes priority over free text). */
+  resultText: string;
+  /** Raw task_report output, empty string if task_report was not called. */
+  taskReportText: string;
+  eventCount: number;
+  durationMs: number;
+}
+
+// ── Implementation ──────────────────────────────────
+
+const EMPTY_REDACTION: RedactionConfig = { patterns: [] } as RedactionConfig;
+
+export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<SseConsumptionResult> {
+  const { client, sessionId, userId, chatRepo, onEvent, signal } = opts;
+  const redactionConfig = opts.redactionConfig ?? EMPTY_REDACTION;
+
+  let assistantContent = "";
+  let currentMsgText = "";
+  let resultText = "";
+  let taskReportText = "";
+  let lastToolName = "";
+
+  // Keyed by toolName to handle parallel tool calls
+  const pendingToolInputs = new Map<string, string>();
+  const pendingToolStartTimes = new Map<string, number>();
+
+  let eventCount = 0;
+  const startTime = Date.now();
+
+  for await (const event of client.streamEvents(sessionId)) {
+    if (signal?.aborted) break;
+
+    const evt = event as SseEvent;
+    const eventType = evt.type as string;
+    eventCount++;
+
+    // Log lifecycle events
+    if (
+      eventType === "agent_start" || eventType === "agent_end" ||
+      eventType === "message_end" || eventType === "message_start" ||
+      eventType.includes("error")
+    ) {
+      console.log(`[sse-consumer] ${userId}: ${eventType}`, JSON.stringify(event).slice(0, 300));
+    }
+
+    // ── DB persistence: tool_execution_end ──────────
+    let dbMessageId: string | undefined;
+    if (eventType === "tool_execution_end") {
+      const toolResult = evt.result as {
+        content?: Array<{ type: string; text?: string }>;
+        details?: { blocked?: boolean; error?: boolean };
+      } | undefined;
+      const text =
+        toolResult?.content
+          ?.filter((c) => c.type === "text")
+          .map((c) => c.text ?? "")
+          .join("") ?? "";
+      const toolName = (evt.toolName as string) || "tool";
+
+      let outcome: "success" | "error" | "blocked" = "success";
+      if (toolResult?.details?.blocked) outcome = "blocked";
+      else if (toolResult?.details?.error) outcome = "error";
+
+      const toolStartTime = pendingToolStartTimes.get(toolName);
+      const durationMs = toolStartTime != null ? Date.now() - toolStartTime : undefined;
+      const toolInput = pendingToolInputs.get(toolName) || "";
+
+      if (chatRepo) {
+        dbMessageId = await chatRepo.appendMessage({
+          sessionId,
+          role: "tool",
+          content: redactText(text, redactionConfig),
+          toolName,
+          toolInput: toolInput ? redactText(toolInput, redactionConfig) : undefined,
+          userId,
+          outcome,
+          durationMs,
+        });
+        await chatRepo.incrementMessageCount(sessionId);
+      }
+      pendingToolInputs.delete(toolName);
+      pendingToolStartTimes.delete(toolName);
+
+      // task_report detection (tool result in tool_execution_end)
+      if (lastToolName === "task_report" && text) {
+        taskReportText = text;
+      }
+    }
+
+    // ── DB persistence: message_update (accumulate assistant text) ──
+    if (eventType === "message_update") {
+      const ame = evt.assistantMessageEvent as { type?: string; delta?: string } | undefined;
+      if (ame?.type === "text_delta" && ame.delta) {
+        assistantContent += ame.delta;
+        currentMsgText += ame.delta;
+      }
+    }
+
+    // ── message_start: reset per-message accumulator ──
+    if (eventType === "message_start") {
+      currentMsgText = "";
+    }
+
+    // ── tool_execution_start: capture input + start time ──
+    if (eventType === "tool_execution_start" || eventType === "tool_start") {
+      const startToolName = (evt.toolName as string) || (evt.name as string) || "tool";
+      const args = evt.args as Record<string, unknown> | undefined;
+      pendingToolInputs.set(startToolName, args ? JSON.stringify(args) : "");
+      pendingToolStartTimes.set(startToolName, Date.now());
+      lastToolName = startToolName;
+    }
+
+    // ── message_end / turn_end: persist assistant message + extract result ──
+    if (eventType === "message_end" || eventType === "turn_end") {
+      const message = evt.message as Record<string, unknown> | undefined;
+      if (message?.role === "assistant") {
+        // Extract text for resultText
+        let extracted = "";
+        const content = message.content;
+        if (typeof content === "string" && content) {
+          extracted = content;
+        } else if (Array.isArray(content)) {
+          extracted = (content as Array<{ type: string; text?: string }>)
+            .filter((c) => c.type === "text")
+            .map((c) => c.text ?? "")
+            .join("");
+        }
+        resultText = extracted || currentMsgText || resultText;
+
+        // Persist assistant message
+        if (chatRepo && assistantContent) {
+          await chatRepo.appendMessage({
+            sessionId,
+            role: "assistant",
+            content: redactText(assistantContent, redactionConfig),
+          });
+          await chatRepo.incrementMessageCount(sessionId);
+          assistantContent = "";
+        }
+      } else if (message?.role === "toolResult" && lastToolName === "task_report") {
+        // task_report via turn_end (claude-sdk path)
+        const content = message.content;
+        const text = typeof content === "string" ? content
+          : Array.isArray(content)
+            ? (content as Array<{ type: string; text?: string }>)
+                .filter((c) => c.type === "text")
+                .map((c) => c.text ?? "")
+                .join("")
+            : "";
+        if (text) taskReportText = text;
+      }
+      currentMsgText = "";
+      if (message?.role === "toolResult") lastToolName = "";
+    }
+
+    // ── Callback for caller-specific logic (WS forwarding, DP tracking, etc.) ──
+    if (onEvent) {
+      onEvent(evt, eventType, { dbMessageId });
+    }
+
+    if (eventType === "agent_end") break;
+  }
+
+  // Fallback: if no message_end arrived but we have accumulated text
+  if (!resultText && currentMsgText) {
+    resultText = currentMsgText;
+  }
+
+  return {
+    resultText: taskReportText || resultText,
+    taskReportText,
+    eventCount,
+    durationMs: Date.now() - startTime,
+  };
+}

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -97,7 +97,8 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           ?.filter((c) => c.type === "text")
           .map((c) => c.text ?? "")
           .join("") ?? "";
-      const toolName = (evt.toolName as string) || "tool";
+      // Normalize key: pi-agent uses toolName, claude-sdk may use name
+      const toolName = (evt.toolName as string) || (evt.name as string) || "tool";
 
       let outcome: "success" | "error" | "blocked" = "success";
       if (toolResult?.details?.blocked) outcome = "blocked";


### PR DESCRIPTION
## Summary

- Extract shared SSE consumer (`sse-consumer.ts`) from `chat.send` inline loop — both pilot and cron paths reuse it for DB persistence
- Each cron execution creates a fresh `source="cron"` session with full tool call + assistant message persistence in `messages` table
- `cron_job_runs.sessionId` links each execution to its audit session
- Cron sessions filtered from pilot session list via `sessions.source` discriminator
- `agent-prompt` endpoint gains `persistToDb` mode for DB persistence with proper abort signal handling

## Motivation

Cron jobs previously discarded all tool call data — the only output was a `resultText` string stored in `cron_job_runs`. There was zero audit trail for what tools were called, what arguments were passed, or what results came back.

The pilot (interactive) path already persists full tool call traces to the `messages` table. This PR makes cron reuse that same infrastructure.

## Design decisions

- **Fresh session per execution** (not persistent/reused) to avoid pi-agent compaction edge cases and JSONL growth
- **Shared SSE consumer** extracted as reusable module — pilot adds WS forwarding + DP tracking via `onEvent` callback, cron just needs the DB persistence + result extraction
- **`sessions.source`** field cleanly separates cron from pilot in all queries
- **`cron_job_runs.sessionId`** (not `cron_jobs.sessionId`) because sessions are per-execution, not per-job

## Schema changes

- `sessions`: add `source VARCHAR NOT NULL DEFAULT 'pilot'`
- `cron_job_runs`: add `session_id VARCHAR`
- Both SQLite (`schema-sqlite.ts`, `migrate-sqlite.ts`) and MySQL (`schema-mysql.ts`, `init-schema.ts`) paths updated

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 1475 tests pass (43 files), zero failures
- [ ] Manual: create cron job → verify session created with `source="cron"` → verify tool calls in `messages` table → verify pilot list excludes cron sessions
- [ ] Manual: verify cron run history still shows status/resultText (existing UI unchanged)