### PR TITLE
fix(web): improve abort UX with visual feedback and prompt restore

### DIFF
--- a/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/InputArea.tsx
@@ -40,6 +40,7 @@ interface InputAreaProps {
 export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, isCompacting, pendingMessages, onRemovePending, dpFocus, dpActive, onSetDpActive, hasMessages, draft, draftSeq }: InputAreaProps) {
     const [value, setValue] = useState('');
     const [isFocused, setIsFocused] = useState(false);
+    const [isAborting, setIsAborting] = useState(false);
     const isComposingRef = useRef(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -57,6 +58,11 @@ export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, 
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [draft, draftSeq]);
+
+    // Reset aborting state when loading finishes
+    useEffect(() => {
+        if (!isLoading) setIsAborting(false);
+    }, [isLoading]);
 
     // Deep investigation toggle — controlled by parent (usePilot manages state)
     const deepInvestigation = dpActive ?? false;
@@ -236,11 +242,14 @@ export function InputArea({ onSend, onAbort, disabled, isLoading, contextUsage, 
                             </button>
                         ) : isLoading ? (
                             <button
-                                onClick={onAbort}
-                                className="absolute right-3 bottom-3 p-2 rounded-lg bg-red-500 text-white shadow-md hover:bg-red-600 transition-all"
-                                title="Stop generating"
+                                onClick={() => { setIsAborting(true); onAbort?.(); }}
+                                className={cn(
+                                    "absolute right-3 bottom-3 p-2 rounded-lg text-white shadow-md transition-all",
+                                    isAborting ? "bg-red-400 hover:bg-red-500" : "bg-red-500 hover:bg-red-600",
+                                )}
+                                title={isAborting ? "Stopping..." : "Stop generating"}
                             >
-                                <Square className="w-5 h-5" />
+                                {isAborting ? <Loader2 className="w-5 h-5 animate-spin" /> : <Square className="w-5 h-5" />}
                             </button>
                         ) : (
                             <button

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -139,6 +139,21 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
     // Suggested reply draft — chip click populates input instead of sending immediately
     const [chipSeq, setChipSeq] = useState(0);
     const [chipDraft, setChipDraft] = useState<string | null>(null);
+
+    // Track last user message so abort can restore it to the input box
+    const lastSentRef = useRef<string | null>(null);
+    const wrappedSendMessage = useCallback((text: string) => {
+        lastSentRef.current = text;
+        sendMessage(text);
+    }, [sendMessage]);
+    const wrappedAbort = useCallback(() => {
+        abortResponse?.();
+        if (lastSentRef.current) {
+            setChipSeq(s => s + 1);
+            setChipDraft(lastSentRef.current);
+            lastSentRef.current = null;
+        }
+    }, [abortResponse]);
     const [showHypothesesLocator, setShowHypothesesLocator] = useState(false);
 
     // Feedback hint: show once per session after agent finishes first response
@@ -423,7 +438,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                     ) : messages.length === 0 ? (
                         <WelcomeArea
                             systemStatus={systemStatus ?? null}
-                            onSendPrompt={sendMessage}
+                            onSendPrompt={wrappedSendMessage}
                             onNavigateModels={onNavigateModels ?? (() => {})}
                             onNavigateCredentials={onNavigateCredentials ?? (() => {})}
                             isAdmin={isAdmin}
@@ -452,7 +467,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                     onOpenSkillPanel={onOpenSkillPanel}
                                     updateMessageMeta={updateMessageMeta}
                                     investigationProgress={investigationProgress}
-                                    sendMessage={sendMessage}
+                                    sendMessage={wrappedSendMessage}
                                     dpFocus={dpFocus}
                                     dpChecklistActive={dpChecklist != null && dpChecklist.length > 0}
                                     onHypothesesConfirmed={onHypothesesConfirmed}
@@ -470,7 +485,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                     <button
                                         type="button"
                                         disabled={isLoading}
-                                        onClick={() => sendMessage('Your conclusion may not be the root cause. Please dig deeper — trace where the problematic values, configurations, or states come from. Check the upstream resources, dependencies, and configuration sources until you find the original cause.')}
+                                        onClick={() => wrappedSendMessage('Your conclusion may not be the root cause. Please dig deeper — trace where the problematic values, configurations, or states come from. Check the upstream resources, dependencies, and configuration sources until you find the original cause.')}
                                         className="flex items-center gap-2 px-5 py-2 rounded-full bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-600 hover:to-primary-700 text-white text-sm font-medium shadow-sm hover:shadow-md transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                                     >
                                         <SearchCode className="w-4 h-4" />
@@ -514,7 +529,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                     </div>
                 </div>
             )}
-            <InputArea onSend={sendMessage} onAbort={abortResponse} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} hasMessages={messages.length > 0} draft={chipDraft} draftSeq={chipSeq} />
+            <InputArea onSend={wrappedSendMessage} onAbort={wrappedAbort} disabled={!isConnected} isLoading={isLoading} contextUsage={contextUsage} isCompacting={isCompacting} pendingMessages={pendingMessages} onRemovePending={onRemovePending} dpFocus={dpFocus} dpActive={dpActive} onSetDpActive={onSetDpActive} hasMessages={messages.length > 0} draft={chipDraft} draftSeq={chipSeq} />
         </div>
     );
 }

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -140,12 +140,13 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
     const [chipSeq, setChipSeq] = useState(0);
     const [chipDraft, setChipDraft] = useState<string | null>(null);
 
-    // Track last user message so abort can restore it to the input box
+    // Track last user-initiated message so abort can restore it to the input box.
+    // Only record when not already loading (skips steer messages and system-generated prompts).
     const lastSentRef = useRef<string | null>(null);
     const wrappedSendMessage = useCallback((text: string) => {
-        lastSentRef.current = text;
+        if (!isLoading) lastSentRef.current = text;
         sendMessage(text);
-    }, [sendMessage]);
+    }, [sendMessage, isLoading]);
     const wrappedAbort = useCallback(() => {
         abortResponse?.();
         if (lastSentRef.current) {


### PR DESCRIPTION
## Summary

- Stop button shows spinning loader after first click to indicate abort is in progress
- Button remains clickable (not disabled) so user can retry if first abort didn't reach AgentBox
- On abort, last sent message is restored to the input box for easy re-send or edit

## Motivation

Users click Stop repeatedly because there's no feedback that the abort was sent. The agent may take time to finish a running tool call before it can honor the abort. Without visual feedback, users think the button is broken.

Additionally, after aborting, users typically want to re-send the same prompt (or a modified version). Restoring it to the input box saves the copy-paste step.

## Test plan

- [ ] Manual: send a message, click Stop — verify spinner appears, prompt returns to input box
- [ ] Manual: click Stop multiple times — verify each click sends abort (not blocked)
- [ ] Manual: agent finishes normally — verify button resets to square icon