### PR TITLE
fix(sse-consumer): capture model-level errors instead of silently swallowing them

### DIFF
--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -881,6 +881,17 @@ export async function startGateway(opts: StartGatewayOptions): Promise<GatewaySe
                 timeout.promise,
               ]);
               resultText = sseResult.resultText;
+
+              // Model-level error (e.g. API 404, rate-limit) — surface as failure
+              if (sseResult.errorMessage) {
+                abortCtrl.abort();
+                timeout.cancel();
+                const durationMs = Date.now() - startTime;
+                console.error(`[gateway] agent-prompt model error user=${userId} duration=${durationMs}ms: ${sseResult.errorMessage}`);
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({ status: "error", error: sseResult.errorMessage, resultText, durationMs }));
+                return;
+              }
             } finally {
               abortCtrl.abort();
             }

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { consumeAgentSse } from "./sse-consumer.js";
+import type { AgentBoxClient } from "./agentbox/client.js";
+
+/** Helper: create a mock AgentBoxClient whose streamEvents yields the given events */
+function mockClient(events: Record<string, unknown>[]): AgentBoxClient {
+  return {
+    async *streamEvents() {
+      for (const e of events) yield e;
+    },
+  } as unknown as AgentBoxClient;
+}
+
+describe("consumeAgentSse", () => {
+  const baseOpts = { sessionId: "s1", userId: "u1" };
+
+  it("extracts assistant text from message_end content", async () => {
+    const client = mockClient([
+      { type: "message_start", message: { role: "assistant" } },
+      { type: "message_end", message: { role: "assistant", stopReason: "end_turn", content: [{ type: "text", text: "Hello world" }] } },
+      { type: "agent_end" },
+    ]);
+    const result = await consumeAgentSse({ ...baseOpts, client });
+    expect(result.resultText).toBe("Hello world");
+    expect(result.errorMessage).toBe("");
+  });
+
+  it("extracts text from message_update deltas when message_end content is empty", async () => {
+    const client = mockClient([
+      { type: "message_start", message: { role: "assistant" } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "chunk1 " } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "chunk2" } },
+      { type: "message_end", message: { role: "assistant", stopReason: "end_turn", content: [] } },
+      { type: "agent_end" },
+    ]);
+    const result = await consumeAgentSse({ ...baseOpts, client });
+    expect(result.resultText).toBe("chunk1 chunk2");
+    expect(result.errorMessage).toBe("");
+  });
+
+  it("captures errorMessage when model returns stopReason=error", async () => {
+    const client = mockClient([
+      { type: "message_start", message: { role: "assistant" } },
+      { type: "message_end", message: {
+        role: "assistant",
+        stopReason: "error",
+        content: [],
+        errorMessage: "404 error, status code 404, message: Not Found",
+      }},
+      { type: "agent_end" },
+    ]);
+    const result = await consumeAgentSse({ ...baseOpts, client });
+    expect(result.errorMessage).toBe("404 error, status code 404, message: Not Found");
+    expect(result.resultText).toBe("");
+  });
+
+  it("prefers task_report over free text", async () => {
+    const client = mockClient([
+      { type: "message_start", message: { role: "assistant" } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "thinking..." } },
+      { type: "tool_execution_start", toolName: "task_report", args: {} },
+      { type: "tool_execution_end", toolName: "task_report", result: { content: [{ type: "text", text: "## Report\nAll good" }] } },
+      { type: "message_end", message: { role: "assistant", stopReason: "end_turn", content: [{ type: "text", text: "Done" }] } },
+      { type: "agent_end" },
+    ]);
+    const result = await consumeAgentSse({ ...baseOpts, client });
+    expect(result.resultText).toBe("## Report\nAll good");
+    expect(result.taskReportText).toBe("## Report\nAll good");
+  });
+
+  it("returns empty errorMessage on successful completion", async () => {
+    const client = mockClient([
+      { type: "message_start", message: { role: "assistant" } },
+      { type: "message_end", message: { role: "assistant", stopReason: "end_turn", content: [{ type: "text", text: "ok" }] } },
+      { type: "agent_end" },
+    ]);
+    const result = await consumeAgentSse({ ...baseOpts, client });
+    expect(result.errorMessage).toBe("");
+  });
+
+  it("preserves resultText even when errorMessage is set", async () => {
+    // Some models may emit partial text before erroring
+    const client = mockClient([
+      { type: "message_start", message: { role: "assistant" } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "partial output" } },
+      { type: "message_end", message: {
+        role: "assistant",
+        stopReason: "error",
+        content: [],
+        errorMessage: "rate limit exceeded",
+      }},
+      { type: "agent_end" },
+    ]);
+    const result = await consumeAgentSse({ ...baseOpts, client });
+    expect(result.errorMessage).toBe("rate limit exceeded");
+    expect(result.resultText).toBe("partial output");
+  });
+});

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -44,6 +44,8 @@ export interface SseConsumptionResult {
   resultText: string;
   /** Raw task_report output, empty string if task_report was not called. */
   taskReportText: string;
+  /** Model-level error (e.g. API 404, rate-limit). Empty string if no error. */
+  errorMessage: string;
   eventCount: number;
   durationMs: number;
 }
@@ -60,6 +62,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   let currentMsgText = "";
   let resultText = "";
   let taskReportText = "";
+  let errorMessage = "";
   let lastToolName = "";
 
   // Keyed by toolName to handle parallel tool calls
@@ -158,6 +161,11 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
     if (eventType === "message_end" || eventType === "turn_end") {
       const message = evt.message as Record<string, unknown> | undefined;
       if (message?.role === "assistant") {
+        // Capture model-level errors (e.g. API 404, rate-limit)
+        if (message.stopReason === "error" && message.errorMessage) {
+          errorMessage = String(message.errorMessage);
+        }
+
         // Extract text for resultText
         let extracted = "";
         const content = message.content;
@@ -216,6 +224,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   return {
     resultText: taskReportText || resultText,
     taskReportText,
+    errorMessage,
     eventCount,
     durationMs,
   };


### PR DESCRIPTION
## Summary

- When the model API returns an error (e.g. 404, rate-limit), `consumeAgentSse` only inspected `message.content` (empty in error cases) and ignored `message.errorMessage`. This caused `agent-prompt` to return `status=success` with empty `resultText`, so cron jobs were recorded as blank "successes" and notifications showed no detail.
- Add `errorMessage` field to `SseConsumptionResult` to capture `message.errorMessage` when `stopReason=error`
- Surface model errors as `status=error` from the `agent-prompt` endpoint so cron-service correctly records failures

## Test plan

- [x] Added `sse-consumer.test.ts` with 6 test cases covering: normal text extraction, streaming deltas, model error capture, task_report priority, success path, and partial-text-with-error
- [ ] Deploy and trigger a cron job against a model that returns 404 — verify notification and cron history show the error message