### PR TITLE
optimize(skill): add hardware diagnostic discovery to node-health-check

### DIFF
--- a/skills/core/node-health-check/SKILL.md
+++ b/skills/core/node-health-check/SKILL.md
@@ -143,6 +143,10 @@ kubectl describe node <node> | grep -A 20 "Allocated resources"
 
 Compare the total requests against allocatable resources. If CPU or memory requests exceed 90% of allocatable, new pods may fail to schedule on this node.
 
+### 6. Node hardware / resource diagnostics
+
+After general health checks, search your skill list for node-level hardware or resource diagnostic skills (e.g., RDMA/RoCE config checks, GPU diagnostics, storage checks). Run any that match this node's characteristics. Each skill auto-detects whether it applies to the node — no pre-check needed on your part.
+
 ## Notes
 
 - `kubectl top` requires the Metrics Server to be installed in the cluster. If it returns an error, the metrics server may not be available.


### PR DESCRIPTION
## Summary

- Add step 6 to `node-health-check` skill: after general health checks, search the skill list for node-level hardware/resource diagnostic skills (RDMA/RoCE, GPU, storage, etc.) and run any that match the node.
- Generalizes the previous hardcoded `roce-check-node-config` reference so future hardware diagnostic skills are auto-discovered.

## Test plan

- [ ] Run node-health-check on a node with RoCE — verify it discovers and runs the RoCE skill
- [ ] Run on a node without specialized hardware — verify it completes without errors