### PR TITLE
fix(command-sets): move -r/-R/--recursive block from category to per-command

### DIFF
--- a/src/tools/infra/command-sets.test.ts
+++ b/src/tools/infra/command-sets.test.ts
@@ -1381,4 +1381,47 @@ describe("validateCommandRestrictions", () => {
       expect(validateCommandRestrictions("")).toBeNull();
     });
   });
+
+  describe("grep -r blocked per-command, not per-category (#218)", () => {
+    const local = { context: "local", piped: true };
+    const node  = { context: "node" };
+    const pod   = { context: "pod" };
+
+    it("blocks grep -r in all contexts", () => {
+      for (const opts of [local, node, pod]) {
+        const err = validateCommandRestrictions("grep -r pattern .", opts);
+        expect(err).not.toBeNull();
+      }
+    });
+
+    it("blocks grep -R and --recursive", () => {
+      expect(validateCommandRestrictions("grep -R pattern .", local)).not.toBeNull();
+      expect(validateCommandRestrictions("grep --recursive pattern .", local)).not.toBeNull();
+    });
+
+    it("blocks egrep/fgrep -r", () => {
+      expect(validateCommandRestrictions("egrep -r pattern .", local)).not.toBeNull();
+      expect(validateCommandRestrictions("fgrep -r pattern .", local)).not.toBeNull();
+    });
+
+    it("allows jq -r in local context", () => {
+      expect(validateCommandRestrictions("jq -r .name", local)).toBeNull();
+    });
+
+    it("allows sort -r in local context", () => {
+      expect(validateCommandRestrictions("sort -r", local)).toBeNull();
+    });
+
+    it("allows sort -rn (combined short flags) in local context", () => {
+      expect(validateCommandRestrictions("sort -rn", local)).toBeNull();
+    });
+
+    it("allows yq -r in local context", () => {
+      expect(validateCommandRestrictions("yq -r .name", local)).toBeNull();
+    });
+
+    it("allows grep without -r in local context", () => {
+      expect(validateCommandRestrictions("grep pattern", local)).toBeNull();
+    });
+  });
 });

--- a/src/tools/infra/command-sets.ts
+++ b/src/tools/infra/command-sets.ts
@@ -947,9 +947,9 @@ export interface CommandDef {
  */
 export const COMMANDS: Record<string, CommandDef> = {
   // ── text processing ──
-  grep:   { category: "text" },
-  egrep:  { category: "text" },
-  fgrep:  { category: "text" },
+  grep:   { category: "text", blockedFlags: ["-r", "-R", "--recursive"] },
+  egrep:  { category: "text", blockedFlags: ["-r", "-R", "--recursive"] },
+  fgrep:  { category: "text", blockedFlags: ["-r", "-R", "--recursive"] },
   sort:   { category: "text", allowedFlags: [
     "-r", "-n", "-k", "-t", "-u", "-f", "-h", "-V", "-s", "-b", "-g", "-M", "-d", "-i",
     "--reverse", "--numeric-sort", "--key", "--field-separator", "--unique",
@@ -1189,9 +1189,7 @@ const CONTEXT_POLICIES: Record<string, ContextPolicy> = {
       "activity", "stream", "general", "flow",
     ],
     pipeOnlyCategories: ["text"],
-    categoryBlockedFlags: {
-      text: ["-r", "-R", "--recursive"],
-    },
+    categoryBlockedFlags: {},
   },
   node: { available: ALL_COMMAND_CATEGORIES },
   pod:  { available: ALL_COMMAND_CATEGORIES },


### PR DESCRIPTION
Closes #218

## Summary
- Remove `-r/-R/--recursive` from `CONTEXT_POLICIES.local.categoryBlockedFlags.text` (was blocking all text commands)
- Add `blockedFlags: ["-r", "-R", "--recursive"]` to `grep`/`egrep`/`fgrep` CommandDef entries
- This unblocks `jq -r`, `sort -r`, `yq -r` in local context while keeping `grep -r` blocked
- Side effect: `grep -r` is now blocked in **all** contexts (previously only local), which is a security tightening

## Test plan
- [x] 292 existing tests pass
- [x] 8 new regression tests covering:
  - `grep -r` blocked in local/node/pod contexts
  - `grep -R` and `--recursive` blocked
  - `egrep/fgrep -r` blocked
  - `jq -r`, `sort -r`, `sort -rn`, `yq -r` allowed in local context
  - `grep` without `-r` allowed in local context