### PR TITLE
fix(tools): allow agent to read truncated output files in /tmp

### DIFF
--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-
+import os from "node:os";
 import path from "node:path";
 import { buildKnowledgeOverview } from "../memory/overview-generator.js";
 import { readFile as fsReadFile, writeFile as fsWriteFile, access as fsAccess, mkdir as fsMkdir } from "node:fs/promises";
@@ -354,7 +354,7 @@ export async function createSiclawSession(
   const docsDir = path.resolve(cwd, config.paths.docsDir);
   const tracesDir = path.resolve(cwd, ".siclaw", "traces");
   const knowledgeDir = path.resolve(cwd, config.paths.knowledgeDir);
-  const readAllowedDirs = [builtinSkillsRoot, skillsBase, userDataDir, reportsDir, tracesDir, reposDir, docsDir, knowledgeDir];
+  const readAllowedDirs = [builtinSkillsRoot, skillsBase, userDataDir, reportsDir, tracesDir, reposDir, docsDir, knowledgeDir, os.tmpdir()];
   const writeAllowedDirs = [userDataDir];
 
   const restrictedFileTools = [


### PR DESCRIPTION
## Summary
- `processToolOutput` saves full output to `/tmp/siclaw-output-*.log` when truncating long tool output, but the agent's `read` tool blocks access because `/tmp/` is not in `readAllowedDirs`
- Add `os.tmpdir()` to `readAllowedDirs` (read-only) so the agent can read its own saved output
- `/tmp/` files are auto-cleaned on pod restart, no extra cleanup needed

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/tools/infra/tool-render.test.ts src/tools/infra/security-pipeline.test.ts` passes
- [ ] Deploy and run a script with long output, verify agent can `read` the truncated output file