### PR TITLE
feat(timing): add per-turn response timing instrumentation and dashboard statistics

### DIFF
--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -321,7 +321,11 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
     // Subscribe to buffer events so SSE can replay them even if it connects late
     const brainUnsub = managed.brain.subscribe((event) => {
       if (!managed._promptDone) {
-        managed._eventBuffer.push(event);
+        // Stamp with server time when emitted so replayed events have accurate timestamps
+        const tsEvent = typeof event === "object" && event !== null
+          ? { ...(event as object), ts: Date.now() }
+          : event;
+        managed._eventBuffer.push(tsEvent);
       }
       // Null dpState.checklist when deep_search completes — this is the exit signal
       // for the SDK brain's auto-continue loop in claude-sdk-brain.ts.
@@ -343,6 +347,7 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
           type: "tool_progress",
           toolName: "deep_search",
           progress: event,
+          ts: Date.now(),
         });
       }
       // Sync phase events to SDK brain's dpState so the auto-continue loop
@@ -551,7 +556,11 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
       if (closed || res.writableEnded) return;
       try {
         sseEventCount++;
-        const data = JSON.stringify(event);
+        // Add server timestamp if not already present (buffered events carry their original ts)
+        const out = typeof event === "object" && event !== null && !("ts" in (event as object))
+          ? { ...(event as object), ts: Date.now() }
+          : event;
+        const data = JSON.stringify(out);
         res.write(`data: ${data}\n\n`);
       } catch (err) {
         console.warn(`[agentbox-http] SSE write error for session ${sessionId}:`, err);

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 export interface ChannelConfig {
   enabled: boolean;
   [key: string]: unknown;
@@ -23,5 +26,15 @@ const DEFAULT_CONFIG: GatewayConfig = {
 };
 
 export function loadGatewayConfig(): GatewayConfig {
+  try {
+    // Read port from shared settings.json so one file controls everything
+    const configPath = process.env.SICLAW_CONFIG_DIR
+      ? path.resolve(process.env.SICLAW_CONFIG_DIR, "settings.json")
+      : path.resolve(process.cwd(), ".siclaw", "config", "settings.json");
+    const raw = JSON.parse(fs.readFileSync(configPath, "utf-8")) as { server?: { port?: number } };
+    if (raw?.server?.port) {
+      return { ...DEFAULT_CONFIG, port: raw.server.port };
+    }
+  } catch { /* fall through to default */ }
   return { ...DEFAULT_CONFIG };
 }

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -163,6 +163,17 @@ function reduceInvestigationProgress(
 }
 
 const SESSION_KEY_STORAGE = 'siclaw_current_session';
+
+const TIMING_MAX_SAMPLES = 200;
+function appendTimingSample(key: string, ms: number): void {
+    try {
+        const arr = JSON.parse(localStorage.getItem(key) ?? '[]') as number[];
+        arr.push(Math.round(ms));
+        if (arr.length > TIMING_MAX_SAMPLES) arr.splice(0, arr.length - TIMING_MAX_SAMPLES);
+        localStorage.setItem(key, JSON.stringify(arr));
+        window.dispatchEvent(new CustomEvent('siclaw_timing_update'));
+    } catch { /* ignore storage errors */ }
+}
 const SESSION_WORKSPACE_STORAGE = 'siclaw_session_workspace';
 const SELECTED_BRAIN_STORAGE = 'siclaw_selected_brain';
 
@@ -320,6 +331,8 @@ export function usePilot() {
     // Parked TTFT value (message_start.ts - lastServerTsRef) awaiting attachment to a message
     const pendingWaitMsRef = useRef<number>(0);
 
+    // Ref for sendRpc — handleWsMessage has [] deps and can't close over sendRpc directly
+    const sendRpcRef = useRef<(<T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>) | null>(null);
     // Ref to allow loadSessions calls from event handler without stale closures
     const loadSessionsRef = useRef<() => void>(() => {});
     // Ref for fetching context usage from event handler
@@ -441,6 +454,8 @@ export function usePilot() {
                     // Claim pending TTFT (set at message_start when LLM only emitted tool calls)
                     const waitMs = pendingWaitMsRef.current || undefined;
                     pendingWaitMsRef.current = 0;
+                    if (waitMs != null) appendTimingSample('siclaw_timing_ttft', waitMs);
+                    if (thinkMs != null) appendTimingSample('siclaw_timing_llm', thinkMs);
                     // end_investigation cleanup now driven by dp_status "completed" event from gateway.
                     setMessages(prev => [...prev, {
                         id: `tool-${Date.now()}`,
@@ -475,6 +490,11 @@ export function usePilot() {
                     // inside the state updater (React StrictMode calls updaters twice).
                     const endedToolName = payload.toolName as string | undefined;
                     const endPerfNow = performance.now();
+                    // Capture timing from the running tool BEFORE setMessages (messagesRef is last committed state)
+                    const runningTool = [...messagesRef.current].reverse().find(m => m.role === 'tool' && m.isStreaming);
+                    const durationMsSnap = runningTool?.startedAt != null ? Math.round(endPerfNow - runningTool.startedAt) : undefined;
+                    const toolWaitMs = runningTool?.waitMs;
+                    const toolLlmDurationMs = runningTool?.llmDurationMs;
                     // When deep_search completes, mark all remaining checklist items
                     // as done and auto-clear after 3s. This replaces the old
                     // manage_checklist(conclusion=done) trigger.
@@ -513,6 +533,17 @@ export function usePilot() {
                         }
                         return prev;
                     });
+                    // Collect tool execution time sample for dashboard statistics
+                    if (durationMsSnap != null) appendTimingSample('siclaw_timing_tool', durationMsSnap);
+                    // Persist timing + toolStatus to DB via metadata so they survive navigation and session reload
+                    if (dbMessageId && sendRpcRef.current) {
+                        const meta: Record<string, unknown> = {};
+                        meta.toolStatus = isError ? 'error' : 'success';
+                        if (durationMsSnap != null) meta.durationMs = durationMsSnap;
+                        if (toolWaitMs != null) meta.waitMs = toolWaitMs;
+                        if (toolLlmDurationMs != null) meta.llmDurationMs = toolLlmDurationMs;
+                        sendRpcRef.current('message.updateMeta', { id: dbMessageId, metadata: meta }).catch(() => {});
+                    }
                     break;
                 }
 
@@ -597,6 +628,8 @@ export function usePilot() {
                             m => m.role === 'assistant' && m.isStreaming
                         );
                         if (hasStreamingAssistant) {
+                            if (waitMs != null) appendTimingSample('siclaw_timing_ttft', waitMs);
+                            appendTimingSample('siclaw_timing_llm', llmDurationMs);
                             setMessages(prev => {
                                 for (let i = prev.length - 1; i >= 0; i--) {
                                     if (prev[i].role === 'assistant' && prev[i].isStreaming) {
@@ -680,6 +713,33 @@ export function usePilot() {
                     loadModelsRef.current();
                     fetchModelRef.current();
 
+                    // Persist timing for assistant messages — they have no dbMessageId during streaming,
+                    // so we fetch the just-saved DB messages and match by role+content to update metadata.
+                    if (!isAbortingRef.current && sendRpcRef.current && currentSessionKeyRef.current) {
+                        const sessionId = currentSessionKeyRef.current;
+                        const rpc = sendRpcRef.current;
+                        const assistantsToSave = messagesRef.current.filter(m =>
+                            m.role === 'assistant' && (m.llmDurationMs != null || m.waitMs != null)
+                        );
+                        if (assistantsToSave.length > 0) {
+                            setTimeout(async () => {
+                                try {
+                                    const res = await rpc<{ messages: PilotMessage[] }>('chat.history', { sessionId });
+                                    const dbMessages = res.messages ?? [];
+                                    for (const m of assistantsToSave) {
+                                        const match = dbMessages.find(d => d.role === 'assistant' && d.content === m.content);
+                                        if (match) {
+                                            const meta: Record<string, unknown> = {};
+                                            if (m.llmDurationMs != null) meta.llmDurationMs = m.llmDurationMs;
+                                            if (m.waitMs != null) meta.waitMs = m.waitMs;
+                                            await rpc('message.updateMeta', { id: match.id, metadata: meta });
+                                        }
+                                    }
+                                } catch { /* best-effort */ }
+                            }, 800);
+                        }
+                    }
+
                     // DP checklist completion now handled by dp_status "completed" event from gateway.
                     // No safety-net needed — gateway emits dp_status on agent_end when status is concluding.
                     break;
@@ -760,7 +820,8 @@ export function usePilot() {
         }
     }, [isConnected, sendRpc, workspaceId]);
 
-    // Keep ref in sync
+    // Keep refs in sync
+    sendRpcRef.current = sendRpc;
     loadSessionsRef.current = loadSessions;
     loadModelsRef.current = loadModels;
     fetchModelRef.current = fetchCurrentModel;
@@ -790,6 +851,11 @@ export function usePilot() {
 
     const mapMessages = (raw: PilotMessage[]) => raw.map(m => ({
         ...m,
+        // Restore timing + toolStatus from metadata (persisted at runtime; absent on first load before any conversation)
+        toolStatus: m.toolStatus ?? (m.metadata?.toolStatus as ToolStatus | undefined) ?? (m.role === 'tool' && m.content ? 'success' as ToolStatus : undefined),
+        durationMs: m.durationMs ?? (m.metadata?.durationMs as number | undefined),
+        llmDurationMs: m.llmDurationMs ?? (m.metadata?.llmDurationMs as number | undefined),
+        waitMs: m.waitMs ?? (m.metadata?.waitMs as number | undefined),
         toolInput: m.role === 'tool' && m.toolInput
             ? parseToolInput(m.toolName ?? '', m.toolInput)
             : undefined,

--- a/src/gateway/web/src/hooks/usePilot.ts
+++ b/src/gateway/web/src/hooks/usePilot.ts
@@ -34,6 +34,14 @@ export interface PilotMessage {
     isStreaming?: boolean;
     /** Hidden from chat bubbles (e.g. update_plan tool messages) */
     hidden?: boolean;
+    /** performance.now() when tool_execution_start was received — drives live stopwatch */
+    startedAt?: number;
+    /** Elapsed ms from tool_execution_start to tool_execution_end */
+    durationMs?: number;
+    /** Elapsed ms for LLM thinking (message_start to message_end) — on assistant messages */
+    llmDurationMs?: number;
+    /** ms from last anchor event (tool_execution_end or send) to message_start — TTFT approximation */
+    waitMs?: number;
 }
 
 export interface Session {
@@ -300,6 +308,18 @@ export function usePilot() {
     // The actual brain type of the current active session (from backend), null = no session / unknown
     const [sessionBrainType, setSessionBrainType] = useState<BrainType | null>(null);
 
+    // Timing: performance.now() when the current prompt was sent (drives ThinkingIndicator stopwatch)
+    const [loadingStartedAt, setLoadingStartedAt] = useState<number | null>(null);
+    // Ref tracks performance.now() of last message_start for LLM duration calculation
+    const llmStartRef = useRef<number>(0);
+    // When LLM only emits tool calls (no text), llmDurationMs has nowhere to attach —
+    // park it here until the next tool_execution_start claims it
+    const pendingLlmDurationMsRef = useRef<number>(0);
+    // Server-side Date.now() of last anchor event (sendMessage or tool_execution_end) — for TTFT calc
+    const lastServerTsRef = useRef<number>(0);
+    // Parked TTFT value (message_start.ts - lastServerTsRef) awaiting attachment to a message
+    const pendingWaitMsRef = useRef<number>(0);
+
     // Ref to allow loadSessions calls from event handler without stale closures
     const loadSessionsRef = useRef<() => void>(() => {});
     // Ref for fetching context usage from event handler
@@ -415,6 +435,12 @@ export function usePilot() {
                         setInvestigationProgress(prev => prev ?? { hypotheses: [] });
                         // Checklist creation now handled by dp_status event from gateway.
                     }
+                    // Claim pending LLM thinking duration (set when LLM only emitted tool calls, no text)
+                    const thinkMs = pendingLlmDurationMsRef.current || undefined;
+                    pendingLlmDurationMsRef.current = 0;
+                    // Claim pending TTFT (set at message_start when LLM only emitted tool calls)
+                    const waitMs = pendingWaitMsRef.current || undefined;
+                    pendingWaitMsRef.current = 0;
                     // end_investigation cleanup now driven by dp_status "completed" event from gateway.
                     setMessages(prev => [...prev, {
                         id: `tool-${Date.now()}`,
@@ -426,11 +452,16 @@ export function usePilot() {
                         timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
                         isStreaming: true,
                         hidden,
+                        startedAt: performance.now(),
+                        llmDurationMs: thinkMs,
+                        waitMs,
                     }]);
                     break;
                 }
 
                 case 'tool_execution_end': {
+                    // Update anchor timestamp for next TTFT calculation
+                    if (payload.ts) lastServerTsRef.current = payload.ts as number;
                     const result = payload.result as { content?: Array<{ type: string; text?: string }>; details?: Record<string, unknown> } | undefined;
                     const resultText = result?.content
                         ?.filter((c: { type: string }) => c.type === 'text')
@@ -443,6 +474,7 @@ export function usePilot() {
                     // Check toolName before entering setMessages to avoid side effects
                     // inside the state updater (React StrictMode calls updaters twice).
                     const endedToolName = payload.toolName as string | undefined;
+                    const endPerfNow = performance.now();
                     // When deep_search completes, mark all remaining checklist items
                     // as done and auto-clear after 3s. This replaces the old
                     // manage_checklist(conclusion=done) trigger.
@@ -463,6 +495,9 @@ export function usePilot() {
                     setMessages(prev => {
                         const last = prev[prev.length - 1];
                         if (last?.role === 'tool' && last.isStreaming) {
+                            const durationMs = last.startedAt != null
+                                ? Math.round(endPerfNow - last.startedAt)
+                                : undefined;
                             return [
                                 ...prev.slice(0, -1),
                                 {
@@ -470,6 +505,7 @@ export function usePilot() {
                                     content: resultText,
                                     toolStatus: isError ? 'error' as const : 'success' as const,
                                     isStreaming: false,
+                                    durationMs,
                                     ...(toolDetails ? { toolDetails } : {}),
                                     ...(dbMessageId ? { id: dbMessageId } : {}),
                                 }
@@ -515,6 +551,13 @@ export function usePilot() {
                 }
 
                 case 'message_start': {
+                    llmStartRef.current = performance.now();
+                    // Compute TTFT: server ts of this event minus server ts of last anchor
+                    if (payload.ts && lastServerTsRef.current > 0) {
+                        pendingWaitMsRef.current = Math.max(0, Math.round((payload.ts as number) - lastServerTsRef.current));
+                    } else {
+                        pendingWaitMsRef.current = 0;
+                    }
                     const msg = payload.message as { role?: string; customType?: string; details?: Record<string, unknown>; content?: string | Array<{ type: string; text?: string }> } | undefined;
 
                     // Show steer (user) messages injected mid-conversation.
@@ -542,6 +585,34 @@ export function usePilot() {
 
                 case 'message_end': {
                     const endMsg = payload.message as { role?: string; toolName?: string; details?: Record<string, unknown> } | undefined;
+                    // Stamp LLM duration + TTFT onto the last streaming assistant message.
+                    // If LLM only emitted tool calls (no text), no streaming assistant message exists —
+                    // park both in pending refs so tool_execution_start can claim them.
+                    if (endMsg?.role === 'assistant' && llmStartRef.current > 0) {
+                        const llmDurationMs = Math.round(performance.now() - llmStartRef.current);
+                        llmStartRef.current = 0;
+                        const waitMs = pendingWaitMsRef.current || undefined;
+                        pendingWaitMsRef.current = 0;
+                        const hasStreamingAssistant = messagesRef.current.some(
+                            m => m.role === 'assistant' && m.isStreaming
+                        );
+                        if (hasStreamingAssistant) {
+                            setMessages(prev => {
+                                for (let i = prev.length - 1; i >= 0; i--) {
+                                    if (prev[i].role === 'assistant' && prev[i].isStreaming) {
+                                        const updated = [...prev];
+                                        updated[i] = { ...prev[i], llmDurationMs, waitMs };
+                                        return updated;
+                                    }
+                                }
+                                return prev;
+                            });
+                        } else {
+                            pendingLlmDurationMsRef.current = llmDurationMs;
+                            // waitMs stays in pendingWaitMsRef — already cleared above, restore it
+                            pendingWaitMsRef.current = waitMs ?? 0;
+                        }
+                    }
                     if (endMsg?.role === 'toolResult' && endMsg.details && Object.keys(endMsg.details).length > 0) {
                         // Pi-agent brain: tool result details arrive via message_end (not tool_execution_end).
                         // Backfill toolDetails onto the matching tool message.
@@ -601,6 +672,7 @@ export function usePilot() {
                     // During abort, don't unlock here — abortResponse will do it after RPC completes
                     if (!isAbortingRef.current) {
                         setIsLoading(false);
+                        setLoadingStartedAt(null);
                     }
                     setPendingMessages([]);
                     loadSessionsRef.current();
@@ -811,6 +883,9 @@ export function usePilot() {
         };
         setMessages(prev => [...prev, userMsg]);
         setIsLoading(true);
+        setLoadingStartedAt(performance.now());
+        lastServerTsRef.current = Date.now();
+        pendingWaitMsRef.current = 0;
 
         try {
             const result = await sendRpc<{ sessionId: string; brainType?: BrainType }>('chat.send', {
@@ -1278,5 +1353,6 @@ export function usePilot() {
         selectedBrain,
         selectBrain,
         sessionBrainType,
+        loadingStartedAt,
     };
 }

--- a/src/gateway/web/src/pages/Metrics/DashboardTab.tsx
+++ b/src/gateway/web/src/pages/Metrics/DashboardTab.tsx
@@ -6,6 +6,7 @@ import { SessionsChart } from './SessionsChart';
 import { ToolCallsPanel } from './ToolCallsPanel';
 import { SkillCallsPanel } from './SkillCallsPanel';
 import { CumulativePanel } from './CumulativePanel';
+import { TimingStatsPanel } from './TimingStatsPanel';
 
 interface DashboardTabProps {
     data: TimeseriesResponse | null;
@@ -48,7 +49,10 @@ export function DashboardTab({ data, range, loading }: DashboardTabProps) {
                 {/* Row 4: Sessions & Connections (full width) */}
                 <SessionsChart buckets={buckets} />
 
-                {/* Row 5: Cumulative Statistics (full width) */}
+                {/* Row 5: Response Timing Distribution (full width) */}
+                <TimingStatsPanel />
+
+                {/* Row 6: Cumulative Statistics (full width) */}
                 <CumulativePanel />
             </div>
         </div>

--- a/src/gateway/web/src/pages/Metrics/TimingStatsPanel.tsx
+++ b/src/gateway/web/src/pages/Metrics/TimingStatsPanel.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect } from 'react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+
+function readSamples(key: string): number[] {
+    try { return JSON.parse(localStorage.getItem(key) ?? '[]') as number[]; } catch { return []; }
+}
+
+function computeStats(samples: number[]) {
+    if (samples.length === 0) return null;
+    const sorted = [...samples].sort((a, b) => a - b);
+    const n = sorted.length;
+    const pct = (p: number) => sorted[Math.min(Math.ceil(n * p) - 1, n - 1)];
+    return {
+        min: sorted[0],
+        avg: Math.round(samples.reduce((s, v) => s + v, 0) / n),
+        p95: pct(0.95),
+        p99: pct(0.99),
+        max: sorted[n - 1],
+        count: n,
+    };
+}
+
+function fmt(ms: number | undefined): string {
+    if (ms == null) return '—';
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(2)}s`;
+}
+
+type StatKey = 'min' | 'avg' | 'p95' | 'p99' | 'max';
+const STAT_ROWS: { key: StatKey; label: string }[] = [
+    { key: 'min', label: 'MIN' },
+    { key: 'avg', label: 'AVG' },
+    { key: 'p95', label: 'P95' },
+    { key: 'p99', label: 'P99' },
+    { key: 'max', label: 'MAX' },
+];
+
+const METRICS = [
+    { key: 'siclaw_timing_ttft', label: 'TTFT', color: '#6366f1' },
+    { key: 'siclaw_timing_llm',  label: 'Thinking', color: '#f59e0b' },
+    { key: 'siclaw_timing_tool', label: 'Tool Exec', color: '#10b981' },
+] as const;
+
+export function TimingStatsPanel() {
+    const [tick, setTick] = useState(0);
+
+    useEffect(() => {
+        const handler = () => setTick(t => t + 1);
+        window.addEventListener('siclaw_timing_update', handler);
+        return () => window.removeEventListener('siclaw_timing_update', handler);
+    }, []);
+
+    const stats = METRICS.map(m => ({
+        ...m,
+        samples: tick >= 0 ? readSamples(m.key) : [],
+        stat: null as ReturnType<typeof computeStats>,
+    })).map(m => ({ ...m, stat: computeStats(m.samples) }));
+
+    const totalSamples = Math.max(...stats.map(m => m.samples.length));
+    const hasData = totalSamples > 0;
+
+    const handleClear = () => {
+        METRICS.forEach(m => localStorage.removeItem(m.key));
+        setTick(t => t + 1);
+    };
+
+    // Bar chart data: one bar per metric, height = avg
+    const barData = stats.map(m => ({
+        name: m.label,
+        avg: m.stat?.avg ?? 0,
+        color: m.color,
+    }));
+
+    return (
+        <div className="bg-white rounded-lg border border-gray-200 p-5">
+            <div className="flex items-center justify-between mb-5">
+                <div>
+                    <h3 className="text-sm font-semibold text-gray-900">Response Timing Statistics</h3>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                        TTFT, thinking, and tool execution times
+                        {hasData ? ` — last ${totalSamples} / 200 calls` : ''}
+                    </p>
+                </div>
+                {hasData && (
+                    <button
+                        type="button"
+                        onClick={handleClear}
+                        className="text-xs text-gray-400 hover:text-red-500 px-2 py-1 rounded hover:bg-red-50 transition-colors"
+                    >
+                        Clear
+                    </button>
+                )}
+            </div>
+
+            {!hasData ? (
+                <div className="h-40 flex items-center justify-center text-xs text-gray-400 border border-dashed border-gray-200 rounded-lg">
+                    No data yet — start a conversation to collect timing samples
+                </div>
+            ) : (
+                <div className="flex gap-8 items-start">
+                    {/* Left: bar chart comparing avg of each metric */}
+                    <div className="flex-1 min-w-0">
+                        <p className="text-xs text-gray-400 mb-2">Average comparison</p>
+                        <ResponsiveContainer width="100%" height={200}>
+                            <BarChart data={barData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+                                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f3f4f6" />
+                                <XAxis dataKey="name" tick={{ fontSize: 12 }} axisLine={false} tickLine={false} />
+                                <YAxis
+                                    tickFormatter={(v: number) => fmt(v)}
+                                    tick={{ fontSize: 10 }}
+                                    width={56}
+                                    axisLine={false}
+                                    tickLine={false}
+                                />
+                                <Tooltip
+                                    formatter={(v: unknown) => [fmt(v as number), 'Average']}
+                                    contentStyle={{ fontSize: 12, borderRadius: 6 }}
+                                    cursor={{ fill: '#f9fafb' }}
+                                />
+                                <Bar dataKey="avg" radius={[4, 4, 0, 0]}>
+                                    {barData.map((entry, i) => (
+                                        <Cell key={i} fill={entry.color} />
+                                    ))}
+                                </Bar>
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+
+                    {/* Right: stats table */}
+                    <div className="shrink-0">
+                        <p className="text-xs text-gray-400 mb-2">Percentiles</p>
+                        <table className="text-xs border-collapse">
+                            <thead>
+                                <tr>
+                                    <th className="text-left pr-4 pb-2 font-medium text-gray-400 w-10"></th>
+                                    {stats.map(m => (
+                                        <th key={m.key} className="text-right pr-4 pb-2 font-semibold" style={{ color: m.color }}>
+                                            {m.label}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {STAT_ROWS.map(({ key, label }) => (
+                                    <tr key={key} className="border-t border-gray-100">
+                                        <td className="pr-4 py-1.5 font-medium text-gray-400">{label}</td>
+                                        {stats.map(m => (
+                                            <td key={m.key} className="text-right pr-4 py-1.5 font-mono text-gray-700">
+                                                {fmt(m.stat?.[key])}
+                                            </td>
+                                        ))}
+                                    </tr>
+                                ))}
+                                <tr className="border-t border-gray-200">
+                                    <td className="pr-4 pt-2 text-gray-400">n</td>
+                                    {stats.map(m => (
+                                        <td key={m.key} className="text-right pr-4 pt-2 font-mono text-gray-400">
+                                            {m.stat?.count ?? 0}
+                                        </td>
+                                    ))}
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -60,6 +60,8 @@ export interface PilotAreaProps {
     /** Current workspace ID for cron job operations */
     selectedWorkspaceId?: string | null;
     isAdmin?: boolean;
+    /** performance.now() when the current prompt was sent — drives the top-level stopwatch */
+    loadingStartedAt?: number | null;
 }
 
 /** Compute superseded status for schedule messages */
@@ -108,7 +110,7 @@ function computeScheduleStatuses(messages: PilotMessage[]): Map<string, Schedule
     return statuses;
 }
 
-export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, isRetrying, onOpenSchedulePanel, onOpenSkillPanel, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials, sessionKey, selectedWorkspaceId, isAdmin }: PilotAreaProps) {
+export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isConnected, hasMore, isLoadingMore, sendMessage, abortResponse, loadMoreHistory, sendRpc, contextUsage, isCompacting, isRetrying, onOpenSchedulePanel, onOpenSkillPanel, updateMessageMeta, pendingMessages, onRemovePending, investigationProgress, dpActive, onSetDpActive, dpFocus, dpChecklist, onHypothesesConfirmed, onExitDp, systemStatus, onNavigateModels, onNavigateCredentials, sessionKey, selectedWorkspaceId, isAdmin, loadingStartedAt }: PilotAreaProps) {
     const scrollRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
     const prevScrollHeightRef = useRef(0);
@@ -501,7 +503,7 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
                                 <DpChecklistCard items={dpChecklist} investigationProgress={investigationProgress} onDismiss={onExitDp} />
                             )}
 
-                            {isLoading && <ThinkingIndicator />}
+                            {isLoading && <ThinkingIndicator startedAt={loadingStartedAt ?? undefined} />}
 
                             {showFeedbackHint && (
                                 <div className={cn(
@@ -536,9 +538,10 @@ export function PilotArea({ messages, isLoading, isLoadingHistory, wsStatus, isC
     );
 }
 
-function ThinkingIndicator() {
+function ThinkingIndicator({ startedAt }: { startedAt?: number }) {
     const [tipIndex, setTipIndex] = useState(0);
     const [visible, setVisible] = useState(true);
+    const [elapsed, setElapsed] = useState(0);
 
     useEffect(() => {
         const interval = setInterval(() => {
@@ -550,6 +553,12 @@ function ThinkingIndicator() {
         }, 8000);
         return () => clearInterval(interval);
     }, []);
+
+    useEffect(() => {
+        if (!startedAt) return;
+        const tick = setInterval(() => setElapsed(Math.floor((performance.now() - startedAt) / 1000)), 1000);
+        return () => clearInterval(tick);
+    }, [startedAt]);
 
     return (
         <div className="flex gap-4">
@@ -564,6 +573,9 @@ function ThinkingIndicator() {
                 )}>
                     {THINKING_TIPS[tipIndex]}
                 </span>
+                {startedAt != null && elapsed > 0 && (
+                    <span className="text-xs font-mono text-gray-400">{elapsed}s</span>
+                )}
             </div>
         </div>
     );
@@ -761,6 +773,12 @@ function MessageItem({ message, scheduleStatus, onOpenSchedulePanel, onOpenSkill
                     {message.isStreaming && !isUser && (
                         <Loader2 className="w-3 h-3 animate-spin text-gray-400" />
                     )}
+                    {!message.isStreaming && !isUser && message.waitMs != null && message.waitMs > 100 && (
+                        <span className="text-xs font-mono text-gray-400">⏳{formatDuration(message.waitMs)}</span>
+                    )}
+                    {!message.isStreaming && !isUser && message.llmDurationMs != null && (
+                        <span className="text-xs font-mono text-gray-400">{formatDuration(message.llmDurationMs)}</span>
+                    )}
                 </div>
 
                 {/* Reference chips (user messages only) */}
@@ -828,12 +846,38 @@ function MessageItem({ message, scheduleStatus, onOpenSchedulePanel, onOpenSkill
     );
 }
 
+function ToolItemTimer({ startedAt }: { startedAt: number }) {
+    const [elapsed, setElapsed] = useState(0);
+    useEffect(() => {
+        const tick = setInterval(() => setElapsed(Math.floor((performance.now() - startedAt) / 1000)), 1000);
+        return () => clearInterval(tick);
+    }, [startedAt]);
+    return <span className="text-xs font-mono text-blue-400 ml-auto shrink-0">{elapsed}s</span>;
+}
+
+function formatDuration(ms: number): string {
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
+}
+
 function ToolItem({ message }: { message: PilotMessage }) {
     const [expanded, setExpanded] = useState(false);
     const isOpen = message.isStreaming || expanded;
 
     return (
         <div className="pl-12 min-w-0">
+            {message.waitMs != null && message.waitMs > 100 && (
+                <div className="flex items-center gap-1.5 px-3 py-1 text-xs text-gray-400 font-mono">
+                    <span>⏳</span>
+                    <span>等待模型 {formatDuration(message.waitMs)}</span>
+                </div>
+            )}
+            {message.llmDurationMs != null && (
+                <div className="flex items-center gap-1.5 px-3 py-1 text-xs text-gray-400 font-mono">
+                    <span>💭</span>
+                    <span>思考 {formatDuration(message.llmDurationMs)}</span>
+                </div>
+            )}
             <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden">
                 <button
                     type="button"
@@ -849,14 +893,27 @@ function ToolItem({ message }: { message: PilotMessage }) {
                     {message.toolInput && (
                         <span className="font-mono text-xs text-gray-500 truncate min-w-0">{message.toolInput}</span>
                     )}
-                    {message.toolStatus === 'running' && (
+                    {message.toolStatus === 'running' && message.startedAt != null && (
+                        <ToolItemTimer startedAt={message.startedAt} />
+                    )}
+                    {message.toolStatus === 'running' && message.startedAt == null && (
                         <Loader2 className="w-3 h-3 animate-spin text-blue-400 ml-auto shrink-0" />
                     )}
                     {message.toolStatus === 'success' && (
-                        <CheckCircle2 className="w-3.5 h-3.5 text-green-500 ml-auto shrink-0" />
+                        <span className="flex items-center gap-1 ml-auto shrink-0">
+                            {message.durationMs != null && (
+                                <span className="text-xs font-mono text-gray-400">{formatDuration(message.durationMs)}</span>
+                            )}
+                            <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />
+                        </span>
                     )}
                     {message.toolStatus === 'error' && (
-                        <XCircle className="w-3.5 h-3.5 text-red-500 ml-auto shrink-0" />
+                        <span className="flex items-center gap-1 ml-auto shrink-0">
+                            {message.durationMs != null && (
+                                <span className="text-xs font-mono text-gray-400">{formatDuration(message.durationMs)}</span>
+                            )}
+                            <XCircle className="w-3.5 h-3.5 text-red-500" />
+                        </span>
                     )}
                     {message.toolStatus === 'aborted' && (
                         <Ban className="w-3.5 h-3.5 text-amber-500 ml-auto shrink-0" />

--- a/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
+++ b/src/gateway/web/src/pages/Pilot/components/PilotArea.tsx
@@ -777,7 +777,7 @@ function MessageItem({ message, scheduleStatus, onOpenSchedulePanel, onOpenSkill
                         <span className="text-xs font-mono text-gray-400">⏳{formatDuration(message.waitMs)}</span>
                     )}
                     {!message.isStreaming && !isUser && message.llmDurationMs != null && (
-                        <span className="text-xs font-mono text-gray-400">{formatDuration(message.llmDurationMs)}</span>
+                        <span className="text-xs font-mono text-gray-400">💭{formatDuration(message.llmDurationMs)}</span>
                     )}
                 </div>
 
@@ -869,13 +869,13 @@ function ToolItem({ message }: { message: PilotMessage }) {
             {message.waitMs != null && message.waitMs > 100 && (
                 <div className="flex items-center gap-1.5 px-3 py-1 text-xs text-gray-400 font-mono">
                     <span>⏳</span>
-                    <span>等待模型 {formatDuration(message.waitMs)}</span>
+                    <span>Waiting {formatDuration(message.waitMs)}</span>
                 </div>
             )}
             {message.llmDurationMs != null && (
                 <div className="flex items-center gap-1.5 px-3 py-1 text-xs text-gray-400 font-mono">
                     <span>💭</span>
-                    <span>思考 {formatDuration(message.llmDurationMs)}</span>
+                    <span>Thinking {formatDuration(message.llmDurationMs)}</span>
                 </div>
             )}
             <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden">

--- a/src/gateway/web/src/pages/Pilot/index.tsx
+++ b/src/gateway/web/src/pages/Pilot/index.tsx
@@ -170,6 +170,7 @@ export function PilotPage() {
                         onNavigateCredentials={() => navigate('/credentials')}
                         sessionKey={pilot.currentSessionKey}
                         isAdmin={isAdmin}
+                        loadingStartedAt={pilot.loadingStartedAt}
                     />
                 </div>
             </div>


### PR DESCRIPTION
Track three timing metrics per agent turn: **TTFT**(time from last anchor event to first LLM token), **LLM Thinking** (message_start → message_end via performance.now()), and **Tool Execution** (tool_execution_start → tool_execution_end)

Display ⏳ TTFT and 💭 thinking duration as inline chips on assistant message headers; tool execution time shown in each tool bubble

Persist all timing values and toolStatus to DB metadata via message.updateMeta RPC so they survive page navigation and session reload

Add TimingStatsPanel to the Dashboard: a bar chart comparing average TTFT / Thinking / Tool Exec, paired with a MIN / AVG / P95 / P99 / MAX percentile table; samples stored in localStorage (capped at 200 per metric), updated live via siclaw_timing_update CustomEvent