### PR TITLE
feat(portal-web): collapsible sidebar + promote Metrics to top-level

### DIFF
--- a/portal-web/src/components/NotificationBell.tsx
+++ b/portal-web/src/components/NotificationBell.tsx
@@ -30,7 +30,7 @@ function formatRelative(iso: string): string {
  * Bell + dropdown. WS subscription to /ws/notifications for live push,
  * REST bootstrap on mount, persistent across reconnects.
  */
-export function NotificationBell() {
+export function NotificationBell({ collapsed = false }: { collapsed?: boolean } = {}) {
   const [open, setOpen] = useState(false)
   const [items, setItems] = useState<Notification[]>([])
   const [unread, setUnread] = useState(0)
@@ -149,9 +149,11 @@ export function NotificationBell() {
     <div ref={anchorRef} className="relative">
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-2.5 px-4 py-3 text-[13px] text-muted-foreground hover:text-foreground border-t border-border w-full"
+        title={collapsed ? "Notifications" : undefined}
+        aria-label="Notifications"
+        className={`flex items-center ${collapsed ? "justify-center px-0" : "gap-2.5 px-4"} py-3 text-[13px] text-muted-foreground hover:text-foreground border-t border-border w-full`}
       >
-        <div className="relative">
+        <div className="relative shrink-0">
           <Bell className="h-4 w-4" />
           {unread > 0 && (
             <span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] px-1 rounded-full bg-red-500 text-[9px] font-medium text-white flex items-center justify-center leading-none">
@@ -159,7 +161,7 @@ export function NotificationBell() {
             </span>
           )}
         </div>
-        Notifications
+        {!collapsed && "Notifications"}
       </button>
 
       {open && (

--- a/portal-web/src/pages/Layout.tsx
+++ b/portal-web/src/pages/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { Outlet, Link, useLocation } from "react-router-dom"
-import { Bot, MessageSquare, Zap, Plug, Settings, LogOut, Server, Monitor, ChevronDown, ChevronRight, Cpu, Users, Radio, BarChart3, BookOpen } from "lucide-react"
+import { Bot, MessageSquare, Zap, Plug, Settings, LogOut, Server, Monitor, ChevronDown, ChevronRight, Cpu, Users, Radio, BarChart3, BookOpen, PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { api, clearToken } from "../api"
 import { NotificationBell } from "../components/NotificationBell"
 
@@ -12,7 +12,6 @@ const siclawItems = [
 ]
 
 const settingsItems = [
-  { path: "/metrics", label: "Metrics", icon: BarChart3 },
   { path: "/settings/users", label: "Users", icon: Users },
   { path: "/settings/clusters", label: "Clusters", icon: Server },
   { path: "/settings/hosts", label: "Hosts", icon: Monitor },
@@ -21,10 +20,15 @@ const settingsItems = [
   { path: "/settings/knowledge", label: "Knowledge", icon: BookOpen },
 ]
 
+const COLLAPSED_KEY = "siclaw.sidebar.collapsed"
+
 export function Layout() {
   const location = useLocation()
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try { return localStorage.getItem(COLLAPSED_KEY) === "1" } catch { return false }
+  })
   const [settingsOpen, setSettingsOpen] = useState(
-    location.pathname.startsWith("/settings") || location.pathname.startsWith("/metrics")
+    location.pathname.startsWith("/settings")
   )
   const [isAdmin, setIsAdmin] = useState(false)
 
@@ -34,76 +38,141 @@ export function Layout() {
       .catch(() => {})
   }, [])
 
+  useEffect(() => {
+    try { localStorage.setItem(COLLAPSED_KEY, collapsed ? "1" : "0") } catch { /* ignore */ }
+  }, [collapsed])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "b") {
+        const t = e.target as HTMLElement | null
+        const tag = t?.tagName
+        if (tag === "INPUT" || tag === "TEXTAREA" || t?.isContentEditable) return
+        e.preventDefault()
+        setCollapsed((c) => !c)
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [])
+
   const isActive = (path: string) => location.pathname.startsWith(path)
+
+  const rowBase = "flex items-center py-2 text-[13px] transition-colors"
+  const rowLayout = collapsed ? "justify-center px-0" : "gap-2.5 px-4"
+  const rowActive = "text-foreground bg-secondary"
+  const rowIdle = "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
 
   return (
     <div className="flex h-screen">
-      <aside className="w-[200px] border-r border-border flex flex-col bg-card">
-        <div className="px-4 py-4 border-b border-border">
-          <h1 className="text-sm font-bold tracking-wide">SICLAW</h1>
-          <p className="text-[10px] text-muted-foreground mt-0.5">Agent Runtime Portal</p>
+      <aside
+        className={`${collapsed ? "w-14" : "w-[200px]"} border-r border-border flex flex-col bg-card transition-[width] duration-200 ease-out`}
+      >
+        <div className={`border-b border-border ${collapsed ? "py-3 flex justify-center" : "px-4 py-4 flex items-start justify-between gap-2"}`}>
+          {!collapsed && (
+            <div className="min-w-0">
+              <h1 className="text-sm font-bold tracking-wide">SICLAW</h1>
+              <p className="text-[10px] text-muted-foreground mt-0.5 truncate">Agent Runtime Portal</p>
+            </div>
+          )}
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            title={collapsed ? "Expand sidebar (⌘B)" : "Collapse sidebar (⌘B)"}
+            aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+          >
+            {collapsed
+              ? <PanelLeftOpen className="h-4 w-4" />
+              : <PanelLeftClose className="h-4 w-4" />}
+          </button>
         </div>
-        <nav className="flex-1 py-2 overflow-y-auto">
-          {/* Siclaw section — matches Frontend sidebar style */}
-          <span className="px-4 py-1.5 text-[11px] font-medium tracking-wider text-muted-foreground block">
-            Siclaw
-          </span>
+
+        <nav className="flex-1 py-2 overflow-y-auto overflow-x-hidden">
+          {!collapsed && (
+            <span className="px-4 py-1.5 text-[11px] font-medium tracking-wider text-muted-foreground block">
+              Siclaw
+            </span>
+          )}
           {siclawItems.map(({ path, label, icon: Icon }) => (
             <Link
               key={path}
               to={path}
-              className={`flex items-center gap-2.5 px-4 py-2 text-[13px] transition-colors ${
-                isActive(path)
-                  ? "text-foreground bg-secondary"
-                  : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
-              }`}
+              title={collapsed ? label : undefined}
+              className={`${rowBase} ${rowLayout} ${isActive(path) ? rowActive : rowIdle}`}
             >
-              <Icon className="h-4 w-4" />
-              {label}
+              <Icon className="h-4 w-4 shrink-0" />
+              {!collapsed && <span className="truncate">{label}</span>}
             </Link>
           ))}
 
-          {/* Settings section — admin only, collapsible */}
           {isAdmin && (
             <div className="mt-2">
-              <button
-                onClick={() => setSettingsOpen(!settingsOpen)}
-                className={`flex items-center gap-2.5 px-4 py-2 text-[13px] w-full transition-colors ${
-                  isActive("/settings") || isActive("/metrics")
-                    ? "text-foreground"
-                    : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
-                }`}
-              >
-                <Settings className="h-4 w-4" />
-                <span className="flex-1 text-left">Settings</span>
-                {settingsOpen
-                  ? <ChevronDown className="h-3.5 w-3.5" />
-                  : <ChevronRight className="h-3.5 w-3.5" />}
-              </button>
-              {settingsOpen && settingsItems.map(({ path, label, icon: Icon }) => (
-                <Link
-                  key={path}
-                  to={path}
-                  className={`flex items-center gap-2.5 pl-7 pr-4 py-2 text-[13px] transition-colors ${
-                    isActive(path)
-                      ? "text-foreground bg-secondary"
-                      : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
+              {collapsed ? (
+                <button
+                  onClick={() => { setCollapsed(false); setSettingsOpen(true) }}
+                  title="Settings"
+                  aria-label="Settings"
+                  className={`${rowBase} ${rowLayout} w-full ${
+                    isActive("/settings") ? rowActive : rowIdle
                   }`}
                 >
-                  <Icon className="h-4 w-4" />
-                  {label}
-                </Link>
-              ))}
+                  <Settings className="h-4 w-4 shrink-0" />
+                </button>
+              ) : (
+                <>
+                  <button
+                    onClick={() => setSettingsOpen(!settingsOpen)}
+                    className={`${rowBase} gap-2.5 px-4 w-full ${
+                      isActive("/settings") ? "text-foreground" : rowIdle
+                    }`}
+                  >
+                    <Settings className="h-4 w-4 shrink-0" />
+                    <span className="flex-1 text-left">Settings</span>
+                    {settingsOpen
+                      ? <ChevronDown className="h-3.5 w-3.5" />
+                      : <ChevronRight className="h-3.5 w-3.5" />}
+                  </button>
+                  {settingsOpen && settingsItems.map(({ path, label, icon: Icon }) => (
+                    <Link
+                      key={path}
+                      to={path}
+                      className={`flex items-center gap-2.5 pl-7 pr-4 py-2 text-[13px] transition-colors ${
+                        isActive(path) ? rowActive : rowIdle
+                      }`}
+                    >
+                      <Icon className="h-4 w-4" />
+                      {label}
+                    </Link>
+                  ))}
+                </>
+              )}
             </div>
           )}
         </nav>
-        <NotificationBell />
+
+        {isAdmin && (
+          <Link
+            to="/metrics"
+            title={collapsed ? "Metrics" : undefined}
+            className={`flex items-center ${collapsed ? "justify-center px-0" : "gap-2.5 px-4"} py-3 text-[13px] border-t border-border transition-colors ${
+              isActive("/metrics") ? rowActive : rowIdle
+            }`}
+          >
+            <BarChart3 className="h-4 w-4 shrink-0" />
+            {!collapsed && "Metrics"}
+          </Link>
+        )}
+
+        <NotificationBell collapsed={collapsed} />
+
         <button
           onClick={() => { clearToken(); window.location.href = "/login" }}
-          className="flex items-center gap-2.5 px-4 py-3 text-[13px] text-muted-foreground hover:text-foreground border-t border-border"
+          title={collapsed ? "Logout" : undefined}
+          aria-label="Logout"
+          className={`flex items-center ${collapsed ? "justify-center px-0" : "gap-2.5 px-4"} py-3 text-[13px] text-muted-foreground hover:text-foreground border-t border-border`}
         >
-          <LogOut className="h-4 w-4" />
-          Logout
+          <LogOut className="h-4 w-4 shrink-0" />
+          {!collapsed && "Logout"}
         </button>
       </aside>
       <main className="flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary

The Portal sidebar was a fixed 200px rail with no way to reclaim horizontal space, and the admin **Settings** group buried **Metrics** alongside configuration items. This PR makes the sidebar collapsible and promotes Metrics to its own top-level entry.

### Solution

- **Collapsible sidebar** (`portal-web/src/pages/Layout.tsx`)
  - Header toggle button + `Cmd/Ctrl+B` keyboard shortcut (suppressed while typing in inputs / textareas / contentEditable, so it doesn't steal focus for text editing)
  - State persists via `localStorage["siclaw.sidebar.collapsed"]`
  - Collapsed width `w-14` (56px), expanded `w-[200px]`, `transition-[width] duration-200` for smooth animation
  - All nav rows fall back to icon-only with native `title` tooltips when collapsed
- **Settings in collapsed mode** — clicking the gear re-expands the sidebar and opens the submenu, keeping the 6 admin sub-items reachable without introducing a flyout pattern
- **Metrics** — moved out of the Settings submenu into its own admin-only row above Notifications. Metrics is observability, not configuration, and belongs with the persistent footer entries (Notifications, Logout)
- **NotificationBell** (`portal-web/src/components/NotificationBell.tsx`) — accepts an optional `collapsed` prop; in collapsed mode renders bell + unread badge only, hiding the "Notifications" label

Pure frontend change — no backend, config, or infra touched.

## Test Plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds (portal-web)
- [x] Manual: run `siclaw local`, log in as admin
  - [x] Toggle via button + `Cmd+B`; `localStorage` persists across reloads
  - [x] Collapsed: icons + tooltips visible; active row still highlights
  - [x] Collapsed → click Settings gear → sidebar expands + submenu opens
  - [x] Metrics link routes to `/metrics` and only shows for admin role
  - [x] NotificationBell dropdown still opens correctly when sidebar is collapsed