### PR TITLE
fix(local): wire knowledge sync, task notifications, and schedule card rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,51 @@ On first launch, open the web UI and **register the first user** — registratio
 - Database: `.siclaw/data/portal.db` — override with `DATABASE_URL=sqlite:///custom/path.db` or `DATABASE_URL=mysql://...`
 - Secrets: `.siclaw/local-secrets.json` — auto-generated JWT / Runtime / Portal secrets, 0600 perms
 
+#### Pairing the web UI and the CLI
+
+`siclaw local` runs the Portal **and** makes itself available as a data
+source for the plain `siclaw` TUI. In one terminal start the server; in
+a second terminal (same working directory) start the TUI and it
+auto-pairs against the running Portal.
+
+```bash
+# Terminal A — server + web UI
+siclaw local
+
+# Terminal B — TUI, same cwd
+siclaw
+```
+
+- **Pairing anchor: cwd.** Both processes read the same
+  `.siclaw/local-secrets.json` and the same `.siclaw/data/portal.db`.
+  Running the TUI from a different directory opens a different,
+  independent workspace — not a lost one.
+- **Portal is the source of truth.** Providers, agents, skills,
+  knowledge, clusters, and hosts are edited in the web UI; the TUI
+  pulls them as an ephemeral read-only snapshot at startup.
+  In-session slash commands like `/setup` become read-only listings
+  that link back to the matching Portal page.
+- **Edits aren't hot-reloaded.** Change a skill or add a cluster in the
+  web UI, then `Ctrl+C` and re-run the TUI to pick up the new snapshot.
+  The snapshot is materialized to `.siclaw/.portal-snapshot/` and wiped
+  on exit (SIGINT / SIGTERM / normal exit).
+- **Custom ports: set both env vars.** The server reads `PORTAL_PORT`;
+  the TUI's snapshot probe reads `SICLAW_PORTAL_PORT`. Leave both
+  unset to use the default 3000:
+
+  ```bash
+  PORTAL_PORT=8080        siclaw local
+  SICLAW_PORTAL_PORT=8080 siclaw
+  ```
+
+- **Back up the workspace** by copying the entire `.siclaw/` directory
+  — DB, secrets, and any materialized snapshots all live under it.
+  Nothing outside `.siclaw/` is state.
+
+Without a running `siclaw local` in the same directory, `siclaw` falls
+back to standalone file-system mode (`.siclaw/config/settings.json` +
+first-run wizard) — identical to earlier behaviour.
+
 ### 3. Kubernetes — Team / enterprise
 
 Production deployment uses Helm plus three container images: `runtime`, `portal`, and `agentbox`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "files": [
     "dist/",
+    "portal-web/dist/",
     "siclaw.mjs",
     "skills/",
     "settings.example.json"
@@ -88,6 +89,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build && cd portal-web && npm ci && npm run build",
     "dev": "tsx src/cli-main.ts",
     "dev:runtime": "tsx src/gateway-main.ts",
     "dev:agentbox": "tsx src/agentbox-main.ts",

--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -322,6 +322,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
         {activeSessionId ? (
           <>
             <PilotArea
+              agentId={agentId}
               messages={pilot.messages}
               isLoading={pilot.streaming}
               hasMore={pilot.hasMore}

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -62,6 +62,7 @@ export interface PilotAreaProps {
   sessionKey?: string | null
   onOpenSkillPanel?: (msg: PilotMessage) => void
   onOpenSchedulePanel?: (msg: PilotMessage) => void
+  agentId?: string
 }
 
 export function PilotArea({
@@ -86,6 +87,7 @@ export function PilotArea({
   sessionKey,
   onOpenSkillPanel,
   onOpenSchedulePanel,
+  agentId,
 }: PilotAreaProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -279,6 +281,7 @@ export function PilotArea({
                     }}
                     onOpenSkillPanel={onOpenSkillPanel}
                     onOpenSchedulePanel={onOpenSchedulePanel}
+                    agentId={agentId}
                   />
                 ))}
 
@@ -465,6 +468,7 @@ function MessageItem({
   onChipClick,
   onOpenSkillPanel,
   onOpenSchedulePanel,
+  agentId,
 }: {
   message: PilotMessage
   investigationProgress?: InvestigationProgress | null
@@ -478,6 +482,7 @@ function MessageItem({
   onChipClick?: (key: string) => void
   onOpenSkillPanel?: (msg: PilotMessage) => void
   onOpenSchedulePanel?: (msg: PilotMessage) => void
+  agentId?: string
 }) {
   const isUser = message.role === "user"
   const isTool = message.role === "tool"
@@ -493,8 +498,8 @@ function MessageItem({
         </div>
       )
     }
-    if (message.toolName === "schedule_preview" && !message.isStreaming) {
-      return <ScheduleCard message={message} onOpenPanel={onOpenSchedulePanel} />
+    if (message.toolName === "manage_schedule" && !message.isStreaming) {
+      return <ScheduleCard message={message} onOpenPanel={onOpenSchedulePanel} agentId={agentId} />
     }
     if (message.toolName === "deep_search") {
       if (message.isStreaming && (dpFocus || dpChecklistActive)) {

--- a/portal-web/src/components/chat/ScheduleCard.tsx
+++ b/portal-web/src/components/chat/ScheduleCard.tsx
@@ -1,4 +1,5 @@
-import { Clock, Check, Eye } from "lucide-react"
+import { Clock, Eye, ExternalLink } from "lucide-react"
+import { Link } from "react-router-dom"
 import { cn } from "./cn"
 import type { PilotMessage } from "./types"
 
@@ -22,9 +23,11 @@ interface ParsedResult {
 export function ScheduleCard({
   message,
   onOpenPanel,
+  agentId,
 }: {
   message: PilotMessage
   onOpenPanel?: (msg: PilotMessage) => void
+  agentId?: string
 }) {
   let parsed: ParsedResult | null = null
   try {
@@ -89,7 +92,7 @@ export function ScheduleCard({
           {actionLabel}
         </span>
 
-        {/* View button */}
+        {/* View button — opens side panel with full details */}
         {onOpenPanel && (
           <button
             onClick={() => onOpenPanel(message)}
@@ -98,6 +101,30 @@ export function ScheduleCard({
             <Eye className="w-3 h-3" />
             View
           </button>
+        )}
+
+        {/* Open in Tasks page — deep link when we have the task id + current agentId. */}
+        {!isDelete && parsed.id && agentId && (
+          <Link
+            to={`/agents/${agentId}/tasks/${parsed.id}`}
+            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-muted-foreground hover:text-amber-400 hover:bg-amber-500/10 transition-colors"
+          >
+            <ExternalLink className="w-3 h-3" />
+            Open
+          </Link>
+        )}
+
+        {/* Fallback: jump to the tasks list.
+            Fires for delete (the per-task page is gone even though `id` is
+            still in the payload), and whenever id or agentId are missing. */}
+        {(isDelete || !parsed.id || !agentId) && (
+          <Link
+            to="/my-tasks"
+            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-muted-foreground hover:text-amber-400 hover:bg-amber-500/10 transition-colors"
+          >
+            <ExternalLink className="w-3 h-3" />
+            Tasks
+          </Link>
         )}
       </div>
     </div>

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -89,10 +89,23 @@ function sendJson(res: http.ServerResponse, status: number, data: unknown): void
 }
 
 
+export interface CreateHttpServerOptions {
+  /**
+   * If true, skip the 5-minute idle self-destruct. Intended for LocalSpawner,
+   * which runs AgentBox in-process with the Portal — `process.exit(0)` from
+   * the idle timer would take the whole `siclaw local` process down with it.
+   * K8s mode must keep the default so idle pods get recycled.
+   */
+  disableIdleShutdown?: boolean;
+}
+
 /**
  * Create HTTP or HTTPS server (auto-detects certificates)
  */
-export function createHttpServer(sessionManager: AgentBoxSessionManager): http.Server | https.Server {
+export function createHttpServer(
+  sessionManager: AgentBoxSessionManager,
+  options: CreateHttpServerOptions = {},
+): http.Server | https.Server {
   // Initialize credential broker synchronously before any session is created.
   // The broker reference is captured by value into each session's KubeconfigRef,
   // so we cannot defer initialization — a late-arriving broker would never be
@@ -134,6 +147,7 @@ export function createHttpServer(sessionManager: AgentBoxSessionManager): http.S
   }
 
   function checkIdle(): void {
+    if (options.disableIdleShutdown) return;
     if (activeSseCount === 0 && sessionManager.activeCount() === 0) {
       if (idleTimer) return; // already scheduled
       idleTimer = setTimeout(() => {

--- a/src/gateway/agentbox/local-spawner.ts
+++ b/src/gateway/agentbox/local-spawner.ts
@@ -13,6 +13,8 @@ import type { BoxSpawner } from "./spawner.js";
 import type { AgentBoxConfig, AgentBoxHandle, AgentBoxInfo } from "./types.js";
 import { createHttpServer } from "../../agentbox/http-server.js";
 import { AgentBoxSessionManager } from "../../agentbox/session.js";
+import { GatewayClient } from "../../agentbox/gateway-client.js";
+import { syncResource } from "../../agentbox/resource-sync.js";
 import type { MemoryIndexer } from "../../memory/index.js";
 import type { CertificateManager } from "../security/cert-manager.js";
 
@@ -95,7 +97,10 @@ export class LocalSpawner implements BoxSpawner {
       ".siclaw/credentials",
       agentId,
     );
-    const httpServer = createHttpServer(sessionManager);
+    // disableIdleShutdown: LocalSpawner runs AgentBox in the same process as
+    // the Portal — the 5-min idle timer's `process.exit(0)` would take the
+    // whole `siclaw local` down and strand the web UI.
+    const httpServer = createHttpServer(sessionManager, { disableIdleShutdown: true });
 
     await new Promise<void>((resolve, reject) => {
       httpServer.listen(port, "127.0.0.1", () => {
@@ -104,6 +109,28 @@ export class LocalSpawner implements BoxSpawner {
       });
       httpServer.on("error", reject);
     });
+
+    // K8s mode pulls knowledge via syncAllResources() in agentbox-main.ts.
+    // LocalSpawner bypasses that entrypoint, so without this call the agent's
+    // bound knowledge repos never land in .siclaw/knowledge/. Skills and MCP
+    // are intentionally skipped: their handlers wipe a shared directory and
+    // would clobber other users' state (invariant #1 in CLAUDE.md).
+    //
+    // Fire-and-forget: spawn() must stay cheap — sync retries (up to 7s) run
+    // in the background while the caller proceeds. A slow first chat is
+    // better than a blocked spawn.
+    void (async () => {
+      try {
+        const gatewayClient = new GatewayClient({
+          gatewayUrl: this.gatewayInternalUrl,
+          certPath: certDir,
+        });
+        await syncResource("knowledge", gatewayClient.toClientLike());
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[local-spawner] Initial knowledge sync failed for agent=${agentId}: ${msg}`);
+      }
+    })();
 
     const box: LocalBox = {
       agentId,

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1126,9 +1126,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 40 handlers", () => {
+  it("registers exactly 41 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(40);
+    expect(handlers.size).toBe(41);
   });
 
   it("all expected handler names are registered", () => {
@@ -1142,7 +1142,7 @@ describe("buildAdapterRpcHandlers", () => {
       "chat.ensureSession", "chat.appendMessage", "chat.getMessages",
       "task.listActive", "task.getStatus", "task.list", "task.create",
       "task.update", "task.delete", "task.runRecord", "task.runStart",
-      "task.runFinalize", "task.updateMeta", "task.fireNow", "task.prune",
+      "task.runFinalize", "task.updateMeta", "task.fireNow", "task.notify", "task.prune",
       "channel.list", "channel.resolveBinding", "channel.pair",
       "agent.listForSkill", "agent.listForMcp", "agent.listForCluster", "agent.listForHost",
       "metrics.summary", "metrics.audit", "metrics.auditDetail",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -9,6 +9,7 @@ import crypto from "node:crypto";
 import http from "node:http";
 import { getDb } from "../gateway/db.js";
 import { buildUpsert, safeParseJson, toSqlTimestamp } from "../gateway/dialect-helpers.js";
+import { createTaskNotification } from "./notification-api.js";
 import {
   sendJson,
   parseBody,
@@ -2056,6 +2057,26 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
       [params.task_id],
     );
     return { outcome: "ok", task: row };
+  });
+
+  // Runtime's TaskCoordinator emits this after each cron run completes.
+  // Missing handler = silent drop = no NotificationBell update = user
+  // thinks the task never ran. The HTTP /api/internal/task-notify route
+  // already existed but no caller reached it; the Runtime uses the RPC path.
+  handlers.set("task.notify", async (params) => {
+    if (!params.userId || !params.taskId || !params.status) {
+      throw new Error("userId, taskId, status are required");
+    }
+    const { id } = await createTaskNotification({
+      userId: params.userId as string,
+      taskId: params.taskId as string,
+      status: params.status as string,
+      agentId: params.agentId as string | undefined,
+      runId: params.runId as string | undefined,
+      title: params.title as string | undefined,
+      message: params.message as string | undefined,
+    });
+    return { id };
   });
 
   handlers.set("task.prune", async (params) => {

--- a/src/portal/notification-api.ts
+++ b/src/portal/notification-api.ts
@@ -72,6 +72,49 @@ function pushToUser(userId: string, notification: Notification): void {
   }
 }
 
+/**
+ * Persist a task-completion notification + push to live WS subscribers.
+ * Shared by the internal HTTP route and the `task.notify` RPC handler — they
+ * used to diverge, leaving the RPC path (the one the Runtime actually uses)
+ * with no handler and cron runs producing no notifications.
+ */
+export async function createTaskNotification(params: {
+  userId: string;
+  taskId: string;
+  status: string;
+  agentId?: string | null;
+  runId?: string | null;
+  title?: string;
+  message?: string | null;
+}): Promise<{ id: string }> {
+  const id = crypto.randomUUID();
+  const type = params.status === "success" ? "task_success" : "task_failure";
+  const title = params.title ?? (params.status === "success" ? "Task completed" : "Task failed");
+  const message = params.message ?? null;
+
+  const db = getDb();
+  await db.query(
+    `INSERT INTO notifications (id, user_id, type, title, message, related_agent_id, related_task_id, related_run_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, params.userId, type, title, message, params.agentId ?? null, params.taskId, params.runId ?? null],
+  );
+
+  pushToUser(params.userId, {
+    id,
+    userId: params.userId,
+    type,
+    title,
+    message,
+    relatedAgentId: params.agentId ?? null,
+    relatedTaskId: params.taskId,
+    relatedRunId: params.runId ?? null,
+    readAt: null,
+    createdAt: new Date().toISOString(),
+  });
+
+  return { id };
+}
+
 // ── Row helpers ───────────────────────────────────────────────
 
 function rowToNotification(row: any): Notification {
@@ -224,33 +267,15 @@ export function registerNotificationRoutes(
       return;
     }
 
-    const id = crypto.randomUUID();
-    const type = body.status === "success" ? "task_success" : "task_failure";
-    const title = body.title ?? (body.status === "success" ? "Task completed" : "Task failed");
-    const message = body.message ?? null;
-
-    const db = getDb();
-    await db.query(
-      `INSERT INTO notifications (id, user_id, type, title, message, related_agent_id, related_task_id, related_run_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      [id, body.userId, type, title, message, body.agentId ?? null, body.taskId, body.runId ?? null],
-    );
-
-    // Push to any live WS connection — best effort, persistence is source of truth.
-    const notification: Notification = {
-      id,
+    const { id } = await createTaskNotification({
       userId: body.userId,
-      type,
-      title,
-      message,
-      relatedAgentId: body.agentId ?? null,
-      relatedTaskId: body.taskId,
-      relatedRunId: body.runId ?? null,
-      readAt: null,
-      createdAt: new Date().toISOString(),
-    };
-    pushToUser(body.userId, notification);
-
+      taskId: body.taskId,
+      status: body.status,
+      agentId: body.agentId,
+      runId: body.runId,
+      title: body.title,
+      message: body.message,
+    });
     sendJson(res, 201, { id });
   });
 }

--- a/src/tools/workflow/manage-schedule.test.ts
+++ b/src/tools/workflow/manage-schedule.test.ts
@@ -117,7 +117,9 @@ describe("manage_schedule tool", () => {
 
   describe("delete / pause / resume", () => {
     beforeEach(() => {
-      mockClient.listAgentTasks.mockResolvedValue([{ id: "t1", name: "foo" }]);
+      mockClient.listAgentTasks.mockResolvedValue([
+        { id: "t1", name: "foo", schedule: "0 9 * * *", status: "active" },
+      ]);
     });
 
     it("deletes by name", async () => {
@@ -126,16 +128,40 @@ describe("manage_schedule tool", () => {
       expect(mockClient.deleteAgentTask).toHaveBeenCalledWith("t1");
     });
 
-    it("pauses", async () => {
+    it("pauses and echoes the current cron in the schedule field", async () => {
       const res = await tool.execute("id", { action: "pause", id: "t1" });
-      expect(JSON.parse(res.content[0].text).summary).toContain("Paused");
+      const parsed = JSON.parse(res.content[0].text);
+      expect(parsed.summary).toContain("Paused");
       expect(mockClient.updateAgentTask).toHaveBeenCalledWith("t1", { status: "paused" });
+      // Regression guard: schedule field must carry the real cron (not "")
+      // and reflect the new status so ScheduleCard renders them correctly.
+      expect(parsed.schedule).toEqual({
+        name: "foo",
+        schedule: "0 9 * * *",
+        status: "paused",
+      });
     });
 
-    it("resumes", async () => {
+    it("resumes and echoes the current cron in the schedule field", async () => {
       const res = await tool.execute("id", { action: "resume", id: "t1" });
-      expect(JSON.parse(res.content[0].text).summary).toContain("Resumed");
+      const parsed = JSON.parse(res.content[0].text);
+      expect(parsed.summary).toContain("Resumed");
       expect(mockClient.updateAgentTask).toHaveBeenCalledWith("t1", { status: "active" });
+      expect(parsed.schedule).toEqual({
+        name: "foo",
+        schedule: "0 9 * * *",
+        status: "active",
+      });
+    });
+
+    it("pause omits the schedule field when resolveId cannot surface the cron", async () => {
+      // resolveId's fallback path (id matches nothing in list) returns just
+      // { id, name } — pause must then omit `schedule` rather than emit "".
+      mockClient.listAgentTasks.mockResolvedValue([]);
+      const res = await tool.execute("id", { action: "pause", id: "t-unknown" });
+      const parsed = JSON.parse(res.content[0].text);
+      expect(parsed.summary).toContain("Paused");
+      expect("schedule" in parsed ? parsed.schedule : undefined).toBeUndefined();
     });
   });
 

--- a/src/tools/workflow/manage-schedule.ts
+++ b/src/tools/workflow/manage-schedule.ts
@@ -121,26 +121,43 @@ Common cron patterns:
         content: [{ type: "text" as const, text: JSON.stringify({ error: msg }) }],
         details: { error: true },
       });
-      const ok = (summary: string) => ({
-        content: [{ type: "text" as const, text: JSON.stringify({ summary }) }],
+      // Emit the full shape expected by portal-web's ScheduleCard /
+      // SchedulePanel so the UI can render a card (with View button + deep
+      // link) instead of the raw JSON summary.
+      const ok = (summary: string, extra: {
+        action?: string;
+        id?: string;
+        name?: string;
+        newName?: string;
+        schedule?: { name: string; description?: string; schedule: string; status: string };
+      } = {}) => ({
+        content: [{ type: "text" as const, text: JSON.stringify({ ...extra, summary }) }],
         details: {},
       });
 
       // Resolve an id either from params.id or by looking up by name via list.
-      const resolveId = async (): Promise<{ id: string; name: string } | null> => {
+      // Returns schedule + status when a hit row is found (both paths already
+      // run a full list call, so surfacing those fields is free) so the
+      // caller — notably pause/resume — can echo the current cron in the
+      // tool result instead of emitting an empty-string placeholder.
+      const resolveId = async (): Promise<
+        { id: string; name: string; schedule?: string; status?: string } | null
+      > => {
         if (params.id) {
           // We still need the name for the summary message — list once to find it.
           try {
             const list = await client.listAgentTasks();
             const hit = list.find((t) => t.id === params.id);
-            if (hit) return { id: hit.id, name: hit.name };
+            if (hit) return { id: hit.id, name: hit.name, schedule: hit.schedule, status: hit.status };
             return { id: params.id, name: params.id };
           } catch { return { id: params.id, name: params.id }; }
         }
         if (!params.name) return null;
         const list = await client.listAgentTasks();
         const match = list.find((t) => t.name === params.name);
-        return match ? { id: match.id, name: match.name } : null;
+        return match
+          ? { id: match.id, name: match.name, schedule: match.schedule, status: match.status }
+          : null;
       };
 
       const validateSchedule = (schedule: string) => {
@@ -176,14 +193,30 @@ Common cron patterns:
           if (!params.name?.trim()) return fail("Schedule name is required.");
           if (!params.schedule?.trim()) return fail("Cron schedule expression is required.");
           validateSchedule(params.schedule.trim());
-          await client.createAgentTask({
-            name: params.name.trim(),
-            schedule: params.schedule.trim(),
-            prompt: params.description?.trim() || params.name.trim(),
+          const status = params.status ?? "active";
+          const name = params.name.trim();
+          const schedule = params.schedule.trim();
+          const created = await client.createAgentTask({
+            name,
+            schedule,
+            prompt: params.description?.trim() || name,
             description: params.description?.trim(),
-            status: params.status ?? "active",
+            status,
           });
-          return ok(`Created scheduled task "${params.name.trim()}" (${params.schedule.trim()}).`);
+          return ok(
+            `Created scheduled task "${name}" (${schedule}).`,
+            {
+              action: "create",
+              id: created?.id,
+              name,
+              schedule: {
+                name,
+                description: params.description?.trim(),
+                schedule,
+                status,
+              },
+            },
+          );
         }
 
         if (params.action === "update") {
@@ -197,23 +230,52 @@ Common cron patterns:
             description: params.description?.trim(),
             status: params.status,
           });
-          return ok(`Updated scheduled task "${target.name}".`);
+          const finalName = params.name?.trim() || target.name;
+          return ok(`Updated scheduled task "${target.name}".`, {
+            action: "update",
+            id: target.id,
+            name: finalName,
+            schedule: params.schedule?.trim()
+              ? {
+                  name: finalName,
+                  description: params.description?.trim(),
+                  schedule: params.schedule.trim(),
+                  status: params.status ?? "active",
+                }
+              : undefined,
+          });
         }
 
         if (params.action === "delete") {
           const target = await resolveId();
           if (!target) return fail("Schedule ID or name is required for delete.");
           await client.deleteAgentTask(target.id);
-          return ok(`Deleted scheduled task "${target.name}".`);
+          return ok(`Deleted scheduled task "${target.name}".`, {
+            action: "delete",
+            id: target.id,
+            name: target.name,
+          });
         }
 
         if (params.action === "pause" || params.action === "resume") {
           const target = await resolveId();
           if (!target) return fail(`Schedule ID or name is required for ${params.action}.`);
-          await client.updateAgentTask(target.id, {
-            status: params.action === "pause" ? "paused" : "active",
-          });
-          return ok(`${params.action === "pause" ? "Paused" : "Resumed"} scheduled task "${target.name}".`);
+          const newStatus = params.action === "pause" ? "paused" : "active";
+          await client.updateAgentTask(target.id, { status: newStatus });
+          return ok(
+            `${params.action === "pause" ? "Paused" : "Resumed"} scheduled task "${target.name}".`,
+            {
+              action: params.action,
+              id: target.id,
+              name: target.name,
+              // Emit schedule object only when resolveId surfaced the current
+              // cron; otherwise follow the update-branch pattern and omit it
+              // so ScheduleCard doesn't render an empty cron field.
+              schedule: target.schedule
+                ? { name: target.name, schedule: target.schedule, status: newStatus }
+                : undefined,
+            },
+          );
         }
 
         if (params.action === "rename") {
@@ -221,7 +283,15 @@ Common cron patterns:
           if (!target) return fail("Schedule ID or current name is required for rename.");
           if (!params.newName?.trim()) return fail("New name is required for rename.");
           await client.updateAgentTask(target.id, { name: params.newName.trim() });
-          return ok(`Renamed scheduled task "${target.name}" → "${params.newName.trim()}".`);
+          return ok(
+            `Renamed scheduled task "${target.name}" → "${params.newName.trim()}".`,
+            {
+              action: "rename",
+              id: target.id,
+              name: target.name,
+              newName: params.newName.trim(),
+            },
+          );
         }
 
         return fail(`Unknown action: ${params.action}`);


### PR DESCRIPTION
## Summary

Three independent fixes for local-mode (`siclaw local`) + Portal UX gaps
observed while smoke-testing the multi-agent flow. All three are
orthogonal to PR #237 — they touch files unrelated to that PR's CLI
snapshot work.

### 1. `fix(local)` — Knowledge never reached agents; idle timer killed the process

`LocalSpawner.spawn()` bypasses `agentbox-main.ts`, so the
`syncAllResources()` call that K8s pods run at startup never fires in
local mode. Bound knowledge repos stayed in the DB and the agent's
`Read .siclaw/knowledge/index.md` always returned *Path not found*.

Separately, the 5-min idle self-destruct in `http-server.ts` calls
`process.exit(0)`. In K8s that recycles a pod; in local mode AgentBox
shares the `siclaw local` process with Portal, so the exit silently
takes port 3000 down.

**Fix:** `LocalSpawner.spawn` fire-and-forgets `syncResource("knowledge", ...)`
via the agent's mTLS cert (skills / mcp deliberately skipped to respect
invariant #1). `createHttpServer` gains `{ disableIdleShutdown }`;
LocalSpawner passes it so only K8s keeps the timer.

### 2. `fix(portal)` — Cron runs produced no notifications

Runtime's `TaskCoordinator` emits `task.notify` over WebSocket RPC after
each cron run, but Portal never registered a handler. A parallel HTTP
route `/api/internal/task-notify` existed but nothing called it.
`notifications` stayed empty; the NotificationBell was always dark.

**Fix:** Extract `createTaskNotification()` helper (persist + WS push)
in `notification-api.ts`, route the HTTP handler through it, and
register the missing `task.notify` RPC handler in `adapter.ts`.
`adapter-rpc.test.ts`'s "exactly 40 handlers" assertion bumps to 41.

### 3. `fix(ui)` — `manage_schedule` tool results rendered as raw JSON

`PilotArea` checked `message.toolName === "schedule_preview"` but the
backend tool is `manage_schedule` — the condition never matched, so
`ScheduleCard` never rendered. The tool's `ok()` also emitted only
`{ summary }`, so even a matching card couldn't show action / cron /
status.

**Fix:** `manage_schedule.ts` returns structured `{ action, id, name,
schedule, summary }`. `PilotArea` uses the correct tool name and threads
`agentId` down to `ScheduleCard`, which adds an Open button
deep-linking to `/agents/:agentId/tasks/:taskId` (or `/my-tasks` when
id is unknown).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` + `portal-web && npm run build` — clean
- [x] `npm test -- local-spawner http-server manage-schedule notification adapter-rpc` — **169/169 pass**
- [x] End-to-end on `siclaw local` (port 3000):
  - network-doctor agent reads `.siclaw/knowledge/index.md` and quotes the runbook correctly
  - `siclaw local` process stays up past 5 min idle
  - Firing a scheduled task produces a row in `notifications` and
    `GET /api/v1/notifications` returns `unread: 1`
  - Chat response for "create a task every 5 min" renders ScheduleCard
    with View + Open buttons