### PR TITLE
docs(readme): add prominent Try-Demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack&logoColor=white)](https://join.slack.com/t/siclaw-scitix/shared_invite/zt-3rrsoc2ic-JIfbfvT1_04sqgQorSRfmw)
 
-[Website](https://www.siclaw.ai) | [Documentation](https://docs.siclaw.ai) | [Slack](https://join.slack.com/t/siclaw-scitix/shared_invite/zt-3rrsoc2ic-JIfbfvT1_04sqgQorSRfmw)
+[Website](https://www.siclaw.ai) | [Live Preview](https://www.siclaw.ai/demo/) | [Documentation](https://docs.siclaw.ai) | [Slack](https://join.slack.com/t/siclaw-scitix/shared_invite/zt-3rrsoc2ic-JIfbfvT1_04sqgQorSRfmw)
 
 </div>
 
 ---
 
 Siclaw is an open-source AI agent for DevOps and SRE teams. It is built for **read-only infrastructure diagnostics**: gather evidence, form hypotheses, validate them, and return a clear root-cause analysis without changing your environment directly. Describe a problem in plain language and Siclaw investigates it from the terminal, the web UI, or your team's chat channels.
+
+A hosted preview of the Portal UI — 4 specialist agents, recorded investigation sessions, and the built-in diagnostic skill set — is available at **[siclaw.ai/demo](https://www.siclaw.ai/demo/)**.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Surface the live demo (https://www.siclaw.ai/demo/) near the top of the README so new visitors can click through the Portal UI in seconds instead of going straight to install docs.

Three discoverability touches in one commit:
1. **\"Live Demo — Try it now\" badge** at the top of the badges row — visually pops
2. **\"Try Demo →\" entry** in the existing quick-nav link list alongside Website / Docs / Slack
3. **A short callout paragraph** right after the header describing what's in the demo: 4 specialist agents (Workload / Network / Volcano / Infra), real investigation histories, 30 built-in diagnostic skills; no signup, no install

No other README content changed.

## Preview

> 🚀 **Want to see it in action first?** Click **[siclaw.ai/demo](https://www.siclaw.ai/demo/)** for an interactive tour of the Portal UI — 4 specialist agents, real investigation histories, 30 built-in diagnostic skills. No signup, no install.

## Test plan

- [x] Rendered the README diff locally — all three touches render correctly
- [x] Demo URL verified live: \`curl -sSL https://www.siclaw.ai/demo/\` → 200
- [x] Badge shield URL validated (shields.io for-the-badge style)