### PR TITLE
fix(core): break core → portal type dependency to unblock agentbox build

### DIFF
--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -84,9 +84,9 @@ export interface CreateSiclawSessionOpts {
    */
   portalCredentialsDir?: string;
   /** Metadata for all Portal-configured agents (used by /agent + /ls to show list). */
-  portalAvailableAgents?: import("../portal/cli-snapshot-api.js").CliSnapshotAgentMeta[];
+  portalAvailableAgents?: import("../shared/cli-snapshot-types.js").CliSnapshotAgentMeta[];
   /** The Portal agent this session is scoped to, null/undefined = unscoped. */
-  portalActiveAgent?: import("../portal/cli-snapshot-api.js").CliSnapshotActiveAgent | null;
+  portalActiveAgent?: import("../shared/cli-snapshot-types.js").CliSnapshotActiveAgent | null;
   /**
    * Base URL of the live local Portal (e.g. http://127.0.0.1:3000). When set,
    * `/setup` switches to read-only mode + opens Portal Web UI for writes so

--- a/src/core/extensions/agent.ts
+++ b/src/core/extensions/agent.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import type { CliSnapshotAgentMeta, CliSnapshotActiveAgent } from "../../portal/cli-snapshot-api.js";
+import type { CliSnapshotAgentMeta, CliSnapshotActiveAgent } from "../../shared/cli-snapshot-types.js";
 
 export interface AgentExtensionDeps {
   activeAgent: CliSnapshotActiveAgent | null;

--- a/src/core/extensions/ls.ts
+++ b/src/core/extensions/ls.ts
@@ -16,7 +16,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import type { Skill } from "@mariozechner/pi-coding-agent";
-import type { CliSnapshotAgentMeta, CliSnapshotActiveAgent } from "../../portal/cli-snapshot-api.js";
+import type { CliSnapshotAgentMeta, CliSnapshotActiveAgent } from "../../shared/cli-snapshot-types.js";
 import { loadConfig } from "../config.js";
 import { listCredentials } from "../../tools/infra/credential-manager.js";
 

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -171,24 +171,16 @@ interface AgentRow {
   color: string | null;
 }
 
-export interface CliSnapshotAgentMeta {
-  /** Display name; used as `--agent <name>` value. */
-  name: string;
-  description: string | null;
-  /** Model this agent prefers, if configured in Portal. */
-  modelProvider: string | null;
-  modelId: string | null;
-  icon: string | null;
-  color: string | null;
-}
-
-export interface CliSnapshotActiveAgent {
-  name: string;
-  description: string | null;
-  systemPrompt: string | null;
-  modelProvider: string | null;
-  modelId: string | null;
-}
+// The two type contracts below used to live here. They have been relocated
+// to `src/shared/cli-snapshot-types.ts` so that `src/core/` (compiled into
+// the AgentBox image) can type-check against them without a compile-time
+// dependency on this Portal handler module — which the agentbox Dockerfile
+// intentionally does not copy. Re-export here preserves the original import
+// paths for existing external consumers (portal-web, siclaw-tui, etc.).
+export type {
+  CliSnapshotAgentMeta,
+  CliSnapshotActiveAgent,
+} from "../shared/cli-snapshot-types.js";
 
 export interface CliSnapshotSkill {
   /** Name from SKILL.md frontmatter; used as the materialized directory name. */

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -175,12 +175,15 @@ interface AgentRow {
 // to `src/shared/cli-snapshot-types.ts` so that `src/core/` (compiled into
 // the AgentBox image) can type-check against them without a compile-time
 // dependency on this Portal handler module — which the agentbox Dockerfile
-// intentionally does not copy. Re-export here preserves the original import
-// paths for existing external consumers (portal-web, siclaw-tui, etc.).
-export type {
+// intentionally does not copy. The `import type` brings the names into this
+// file's local scope (used by L224, L226, L487, L496 below); the `export
+// type` preserves the original public import path for existing external
+// consumers (portal-web, siclaw-tui, etc.).
+import type {
   CliSnapshotAgentMeta,
   CliSnapshotActiveAgent,
 } from "../shared/cli-snapshot-types.js";
+export type { CliSnapshotAgentMeta, CliSnapshotActiveAgent };
 
 export interface CliSnapshotSkill {
   /** Name from SKILL.md frontmatter; used as the materialized directory name. */

--- a/src/shared/cli-snapshot-types.ts
+++ b/src/shared/cli-snapshot-types.ts
@@ -1,0 +1,32 @@
+/**
+ * CLI snapshot public type contracts.
+ *
+ * These live in `src/shared/` (not `src/portal/`) so that `src/core/` — the
+ * agent-runtime code compiled into the AgentBox image — can type-check
+ * against them without pulling in the Portal REST handler module. The
+ * handler (`src/portal/cli-snapshot-api.ts`) transitively depends on
+ * `gateway/rest-router` and `gateway/db`, neither of which are part of the
+ * AgentBox Docker build context (by design — AgentBox ↛ Portal layering).
+ *
+ * `src/portal/cli-snapshot-api.ts` re-exports these for back-compat; keep
+ * this file as the canonical location.
+ */
+
+export interface CliSnapshotAgentMeta {
+  /** Display name; used as `--agent <name>` value. */
+  name: string;
+  description: string | null;
+  /** Model this agent prefers, if configured in Portal. */
+  modelProvider: string | null;
+  modelId: string | null;
+  icon: string | null;
+  color: string | null;
+}
+
+export interface CliSnapshotActiveAgent {
+  name: string;
+  description: string | null;
+  systemPrompt: string | null;
+  modelProvider: string | null;
+  modelId: string | null;
+}


### PR DESCRIPTION
## Why

The AgentBox Dockerfile (`Dockerfile.agentbox`) intentionally does **not** copy `src/portal/` into the builder stage — it's a deliberate layering rule (AgentBox runtime ↛ Portal UI/REST). But a recent change added type-only imports from `src/portal/cli-snapshot-api.ts` into `src/core/`:

- `src/core/agent-factory.ts:87,89` — two inline `import(...)` references
- `src/core/extensions/agent.ts:13` — `import type ... from "../../portal/cli-snapshot-api.js"`
- `src/core/extensions/ls.ts:19` — same as above

**GitHub Actions' `CI / Type Check`** runs `tsc` on the full source tree so it sees `src/portal/` and reports no error — that's why this slipped past review.

The **internal siflow image build** runs `npx tsc -p tsconfig.agentbox.json` *inside the Dockerfile builder stage*, which only has the AgentBox-scoped COPY subset. There `src/portal/` does not exist, so tsc fails:

```
src/core/agent-factory.ts(87,34): error TS2307: Cannot find module '../portal/cli-snapshot-api.js'
src/core/agent-factory.ts(89,30): error TS2307: Cannot find module '../portal/cli-snapshot-api.js'
src/core/extensions/agent.ts(13,67): error TS2307: Cannot find module '../../portal/cli-snapshot-api.js'
src/core/extensions/ls.ts(19,67): error TS2307: Cannot find module '../../portal/cli-snapshot-api.js'
```

Our internal CI has been unable to produce `siclaw-agentbox` images on any main SHA since this import was introduced (we spotted it while trying to deploy the latest main — the last working image tag is `main-8c2d9a1`).

## What

All four imports are strictly **type-only** and only reference two interfaces: `CliSnapshotAgentMeta` and `CliSnapshotActiveAgent`. Both are plain POJOs with zero runtime dependencies.

- Create `src/shared/cli-snapshot-types.ts` as the canonical home for the two interfaces (already copied by `Dockerfile.agentbox` and in `tsconfig.agentbox.json`'s include list)
- Re-export them from the original `src/portal/cli-snapshot-api.ts` location so existing external consumers (portal-web, siclaw-tui, etc.) don't need to touch their imports
- Point the three `src/core/*` files at the new shared location

**Zero runtime behavior change**; this is purely a compile-time dependency realignment that restores the intended AgentBox ↛ Portal layering.

## Verification

- `npx tsc -p tsconfig.agentbox.json --noEmit` passes locally (exit 0)
- `grep` confirms no remaining `../portal/` imports under the AgentBox compile scope (`core/`, `agentbox/`, `cron/`, `memory/`, `shared/`, `tools/`, `gateway/agentbox/`, `gateway/security/`, and the four gateway top-level `.ts` files in the Dockerfile)
- External consumers keep their existing import path via the re-export in `src/portal/cli-snapshot-api.ts`

## Follow-up (not in this PR)

GitHub Actions `CI / Type Check` running on the full tree makes this class of bug invisible. Consider adding a CI job that specifically runs `tsc -p tsconfig.agentbox.json` inside a Dockerfile-equivalent COPY subset (or just running a lightweight `docker build --target builder -f Dockerfile.agentbox .` smoke test on PRs) to catch future regressions.