### PR TITLE
fix(internal-api): pass agentId to config.getMcpServers + getSkillBundle

### DIFF
--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -117,7 +117,7 @@ describe("handleMcpServers", () => {
     const res = new FakeRes();
     await handleMcpServers(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
     expect(res.statusCode).toBe(200);
-    expect(frontend.calls[1].params).toEqual({ ids: ["m1", "m2"] });
+    expect(frontend.calls[1].params).toEqual({ agentId: "agent-1", ids: ["m1", "m2"] });
     expect(JSON.parse(res.body).mcpServers.m1).toEqual({ url: "x" });
   });
 
@@ -160,7 +160,7 @@ describe("handleSkillsBundle", () => {
     await handleSkillsBundle(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
     expect(res.statusCode).toBe(200);
     const call = frontend.calls.find((c) => c.method === "config.getSkillBundle");
-    expect(call!.params).toEqual({ skill_ids: ["s1", "s2"], is_production: false });
+    expect(call!.params).toEqual({ agentId: "agent-1", skill_ids: ["s1", "s2"], is_production: false });
   });
 
   it("returns 500 — NOT an empty bundle — when config.getResources fails (regression guard)", async () => {

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -113,6 +113,10 @@ export async function handleMcpServers(
     }
 
     const data = await frontendClient.request("config.getMcpServers", {
+      // Upstream uses agentId to resolve the caller's org and reject
+      // cross-org id requests. Without it, sicore falls back to the WS
+      // runtime_id and the org lookup fails ("agent <runtime_id> not found").
+      agentId: identity.agentId,
       ids: mcpServerIds,
     });
     sendJson(res, 200, { mcpServers: data.mcpServers });
@@ -137,6 +141,12 @@ export async function handleSkillsBundle(
     const { skillIds, isProduction } = await fetchAgentResources(frontendClient, identity.orgId, identity.agentId);
 
     const data = await frontendClient.request("config.getSkillBundle", {
+      // Upstream uses agentId to resolve the caller's org and reject
+      // cross-org skill_id requests. Without it, sicore falls back to the
+      // WS runtime_id and the org lookup fails ("agent <runtime_id> not
+      // found"), which manifests as repeated `skills/bundle error` in
+      // Runtime logs and a fresh AgentBox with no skills materialised.
+      agentId: identity.agentId,
       skill_ids: skillIds,
       is_production: isProduction,
     });


### PR DESCRIPTION
## Summary

Two `config.*` RPCs Runtime sends to its upstream are missing `agentId`. On sicore, the handler tries to fall back to the WS `runtime_id` for org-scoping (`id := str(p, "agentId"); if id == "" { id = agentID }`), then `getAgentOrgID(runtimeID)` fails because `runtime_id` is not an agent UUID.

## Symptom

Observed live in sicore-test runtime logs:

```
[mtls] Authenticated GET /api/internal/skills/bundle - agentId=5037eff6-...
[internal-api] skills/bundle error: Error: agent shanghai not found
```

(`shanghai` is the WS-registered runtime_id, not an agent.)

Effect: a fresh AgentBox cannot fetch its skill bundle and ends up with no skills materialised. The same defect exists for `config.getMcpServers` but doesn't trigger when an agent has no MCP servers bound, because Runtime short-circuits on empty `mcpServerIds`.

## Audit

I checked every `frontendClient.request(...)` call site for missing agentId. All others are correct:

| RPC | agentId in params? | Notes |
|---|---|---|
| `config.getResources` | ✅ | |
| `config.getSettings` | ✅ | |
| `config.getMcpServers` | ❌ → ✅ | **fixed in this PR** |
| `config.getSkillBundle` | ❌ → ✅ | **fixed in this PR** |
| `config.getKnowledgeBundle` | ✅ | |
| `config.getModelBinding` | ✅ | |
| `credential.list/get` | ✅ via `rpcParams()` | |
| `task.list/create/update/delete` | ✅ `agent_id` | |
| `task.listActive`, `task.runStart` etc. | n/a (uses runtime_id from WS auth) | by design |
| `channel.list` | n/a | by design |
| `chat.ensureSession` | ✅ `agent_id` | |
| `chat.appendMessage`, `chat.getMessages` | n/a (session-scoped) | |

## Changes

- `src/gateway/internal-api.ts` — add `agentId: identity.agentId` to both RPC param objects
- `src/gateway/internal-api.test.ts` — assert agentId is in outbound params (regression guard)

## Test plan

- [ ] `npm test` — `150 files / 3094 tests` pass
- [ ] `npx tsc --noEmit` — clean (only pre-existing ssh-client errors remain)
- [ ] Deploy to sicore-test, confirm `[internal-api] skills/bundle error` no longer appears in runtime logs and AgentBox successfully materialises skills
- [ ] Confirm Portal mode still works (Portal's adapter uses `params.skill_ids` directly so adding agentId is harmless there)

## Out of scope

Portal-side adapters for `config.getSkillBundle` / `config.getMcpServers` accept any id list without org-scoping. That's a Portal hardening concern separate from this Runtime-side correctness fix.