### PR TITLE
chore(helm): refresh values-standalone and add values-sicore example

### DIFF
--- a/helm/siclaw/values-sicore.yaml
+++ b/helm/siclaw/values-sicore.yaml
@@ -1,0 +1,67 @@
+# Siclaw Runtime-only Deployment (SiCore upstream)
+# Deploys ONLY the Runtime — phone-homes to an external SiCore apiserver
+# which acts as the management/adapter layer. No Portal, no DB, no MySQL.
+#
+# Prerequisites:
+#   1. SiCore deployed in the same cluster (or reachable via DNS)
+#   2. Register this Runtime in SiCore admin and capture the returned
+#      adapter_secret + runtime id:
+#        curl -X POST <sicore>/api/v1/siclaw/admin/runtimes \
+#          -H "Authorization: Bearer <admin-jwt>" \
+#          -d '{"id":"<runtime-id>","name":"<display-name>"}'
+#   3. Build and push images:
+#        make docker push REGISTRY=your-registry.com TAG=<tag>
+#
+# Deploy:
+#   helm upgrade --install siclaw ./helm/siclaw \
+#     -f helm/siclaw/values-sicore.yaml \
+#     --set image.registry=your-registry.com \
+#     --set image.tag=<tag> \
+#     --set runtime.serverUrl=http://sicore-apiserver.<sicore-ns>.svc:8080 \
+#     --set runtime.portalSecret=<adapter_secret-from-sicore> \
+#     --set runtime.env.SICLAW_AGENT_ID=<runtime-id-registered-in-sicore>
+
+image:
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+# No bundled Portal — SiCore is the upstream
+portal:
+  enabled: false
+
+# Runtime is stateless — no DB needed in this mode
+mysql:
+  enabled: false
+database:
+  url: ""
+
+runtime:
+  serverUrl: ""        # REQUIRED: SiCore apiserver endpoint
+  # adapter_secret returned by SiCore at runtime registration. Sent as
+  # X-Auth-Token on the phone-home WS; SiCore reverse-looks-up runtime_id
+  # from this secret.
+  portalSecret: ""     # REQUIRED
+  env:
+    # Runtime identity registered in SiCore (siclaw_runtimes.id). SiCore's
+    # /ws/runtime endpoint does not actually read this header — it derives
+    # runtime_id from the adapter_secret — but Runtime still sends it for
+    # symmetry with Portal mode and for log/audit clarity.
+    SICLAW_AGENT_ID: ""  # REQUIRED
+  resources:
+    requests: { cpu: 50m,  memory: 128Mi }
+    limits:   { cpu: 500m, memory: 512Mi }
+
+agentbox:
+  persistence:
+    enabled: false     # set true + storageClassName for cross-restart user data
+
+metrics:
+  enabled: false       # turn on if Prometheus operator is installed
+  serviceMonitor:
+    enabled: false
+  podMonitor:
+    enabled: false
+  grafanaDashboard:
+    enabled: false
+  prometheusRule:
+    enabled: false

--- a/helm/siclaw/values-standalone.yaml
+++ b/helm/siclaw/values-standalone.yaml
@@ -1,50 +1,50 @@
 # Siclaw Standalone Deployment
-# Deploy without Upstream — uses Portal for user/agent/cluster management.
+# Self-contained: bundled Portal + Runtime + (optionally bundled MySQL).
+# Use this for isolated test clusters or when there is no SiCore upstream.
 #
 # Prerequisites:
-#   1. MySQL accessible from the cluster
-#   2. Build and push images:
-#      make docker push REGISTRY=your-registry.com
+#   1. Build and push images:
+#        make docker push REGISTRY=your-registry.com TAG=<tag>
+#   2. Provide MySQL — either via mysql.enabled=true (demo) or an external DB.
 #
 # Deploy:
 #   helm upgrade --install siclaw ./helm/siclaw \
 #     -f helm/siclaw/values-standalone.yaml \
-#     --set database.url=mysql://user:pass@mysql-host:3306/siclaw \
-#     --set runtime.jwtSecret=your-jwt-secret \
-#     --set runtime.runtimeSecret=your-runtime-secret \
-#     --set runtime.portalSecret=your-portal-secret \
-#     --set portal.jwtSecret=your-jwt-secret \
-#     --set portal.runtimeSecret=your-runtime-secret \
-#     --set portal.portalSecret=your-portal-secret \
-#     --set image.registry=your-registry.com
+#     --set image.registry=your-registry.com \
+#     --set image.tag=<tag> \
+#     --set database.url=mysql://siclaw:<pw>@siclaw-mysql:3306/siclaw \
+#     --set runtime.portalSecret=<shared-secret> \
+#     --set portal.jwtSecret=<jwt-signing-secret> \
+#     --set portal.portalSecret=<shared-secret>   # must equal runtime.portalSecret
 
 image:
   pullPolicy: Always
   tag: "latest"
 
+# Demo MySQL — for production, set mysql.enabled=false and point database.url
+# at an externally-managed instance.
+mysql:
+  enabled: true
+
 database:
-  url: ""  # REQUIRED: --set database.url=mysql://...
+  url: ""  # REQUIRED: mysql://siclaw:<pw>@siclaw-mysql:3306/siclaw
 
-# Runtime points to Portal (not Upstream)
 runtime:
-  replicas: 1
   serverUrl: "http://siclaw-portal:3003"
-  jwtSecret: ""       # REQUIRED: --set runtime.jwtSecret=...
-  runtimeSecret: ""     # REQUIRED: --set runtime.runtimeSecret=...
-  portalSecret: ""    # REQUIRED: --set runtime.portalSecret=...
+  # Shared secret presented as X-Auth-Token when Runtime phone-homes to Portal.
+  # Must equal portal.portalSecret below.
+  portalSecret: ""
 
-# Portal enabled for standalone
 portal:
   enabled: true
   replicas: 1
-  jwtSecret: ""       # REQUIRED: must match runtime.jwtSecret
-  runtimeSecret: ""     # REQUIRED: must match runtime.runtimeSecret
-  portalSecret: ""    # REQUIRED: must match runtime.portalSecret
+  jwtSecret: ""        # REQUIRED: Portal JWT signing key
+  portalSecret: ""     # REQUIRED: must match runtime.portalSecret
   service:
     type: NodePort
     port: 3003
-    nodePort: 31003   # Access Portal UI at http://<node-ip>:31003
+    nodePort: 31003    # Portal UI: http://<node-ip>:31003
 
 agentbox:
   persistence:
-    enabled: false
+    enabled: false     # set true + storageClassName for cross-restart user data


### PR DESCRIPTION
## Summary

Two Helm values templates were drifting. \`values-standalone.yaml\` still referenced fields the chart no longer reads after #245 and #248 (\`runtime.replicas\`, \`runtime.jwtSecret\`, \`runtime.runtimeSecret\`, \`portal.runtimeSecret\`), so the deploy snippet in its header would have any operator setting four no-op \`--set\` flags. There was also no template for the runtime-only / SiCore mode that this repo's two staging clusters actually use.

## Changes

- **\`values-standalone.yaml\` rewrite** — drop dead fields, simplify the deploy command to only the values the current chart actually consumes (\`database.url\`, \`runtime.portalSecret\`, \`portal.jwtSecret\`, \`portal.portalSecret\`), enable the bundled mysql by default for the demo path, document the production escape hatch (\`mysql.enabled=false\` + external DB).
- **\`values-sicore.yaml\` (new)** — runtime-only template: \`portal.enabled=false\`, no mysql, \`runtime.serverUrl\` points at sicore-apiserver, \`runtime.portalSecret\` = the adapter_secret SiCore returns at \`POST /api/v1/siclaw/admin/runtimes\`. Documents \`SICLAW_AGENT_ID\` semantics (it goes on the wire as \`X-Agent-Id\` but SiCore reverse-looks-up runtime_id from the secret rather than reading the header).

No code, chart-template, or behaviour changes — values-only.

## Test plan

- [x] \`helm template ./helm/siclaw -f helm/siclaw/values-standalone.yaml --set database.url=mysql://... --set runtime.portalSecret=... --set portal.jwtSecret=... --set portal.portalSecret=...\` renders three Deployments (mysql/runtime/portal), no \`SICLAW_RUNTIME_SECRET\`/\`JWT_SECRET\` on runtime, both Recreate strategies present.
- [x] \`helm template ./helm/siclaw -f helm/siclaw/values-sicore.yaml --set runtime.serverUrl=... --set runtime.portalSecret=... --set runtime.env.SICLAW_AGENT_ID=...\` renders a single runtime Deployment with \`SICLAW_PORTAL_SECRET\` + \`SICLAW_AGENT_ID\`, no Portal/MySQL manifests.
- [ ] Apply the SiCore template to a fresh ns and confirm Runtime phone-homes (already verified live in sicore-test on \`main-c57c65e\`; this PR just makes that values shape canonical).