### PR TITLE
chore(helm): drop stale runtimeSecret from values-standalone

### DIFF
--- a/helm/siclaw/values-standalone.yaml
+++ b/helm/siclaw/values-standalone.yaml
@@ -15,6 +15,13 @@
 #     --set portal.jwtSecret=your-jwt-secret \
 #     --set portal.portalSecret=your-portal-secret \
 #     --set image.registry=your-registry.com
+#
+# Re-deploying with the same image tag (e.g. rebuilding "main-<sha>" without
+# bumping the tag): helm upgrade alone will NOT roll the pods because the
+# rendered Deployment spec is unchanged. Either use a unique tag per build
+# (e.g. main-<sha>-<timestamp>) or force a rollout afterwards:
+#
+#   kubectl -n <ns> rollout restart deploy/siclaw-runtime deploy/siclaw-portal
 
 image:
   pullPolicy: Always

--- a/helm/siclaw/values-standalone.yaml
+++ b/helm/siclaw/values-standalone.yaml
@@ -11,10 +11,8 @@
 #     -f helm/siclaw/values-standalone.yaml \
 #     --set database.url=mysql://user:pass@mysql-host:3306/siclaw \
 #     --set runtime.jwtSecret=your-jwt-secret \
-#     --set runtime.runtimeSecret=your-runtime-secret \
 #     --set runtime.portalSecret=your-portal-secret \
 #     --set portal.jwtSecret=your-jwt-secret \
-#     --set portal.runtimeSecret=your-runtime-secret \
 #     --set portal.portalSecret=your-portal-secret \
 #     --set image.registry=your-registry.com
 
@@ -30,7 +28,6 @@ runtime:
   replicas: 1
   serverUrl: "http://siclaw-portal:3003"
   jwtSecret: ""       # REQUIRED: --set runtime.jwtSecret=...
-  runtimeSecret: ""     # REQUIRED: --set runtime.runtimeSecret=...
   portalSecret: ""    # REQUIRED: --set runtime.portalSecret=...
 
 # Portal enabled for standalone
@@ -38,7 +35,6 @@ portal:
   enabled: true
   replicas: 1
   jwtSecret: ""       # REQUIRED: must match runtime.jwtSecret
-  runtimeSecret: ""     # REQUIRED: must match runtime.runtimeSecret
   portalSecret: ""    # REQUIRED: must match runtime.portalSecret
   service:
     type: NodePort


### PR DESCRIPTION
## Summary

PR #248 removed \`runtimeSecret\` from the chart (the inbound \`/ws\` trusted-proxy path it secured was deleted), but \`helm/siclaw/values-standalone.yaml\` still lists it as REQUIRED in both the header deploy snippet and the runtime/portal value blocks. Anyone copy-pasting the deploy command would set two no-op \`--set\` flags.

## Changes

Drop the four \`runtimeSecret\` references in \`values-standalone.yaml\`:

- two \`--set runtime.runtimeSecret=...\` / \`--set portal.runtimeSecret=...\` lines in the deploy snippet
- two \`runtimeSecret: ""\` field declarations under \`runtime:\` and \`portal:\`

Everything else in the file is left as-is. \`helm template\` still renders cleanly.