### PR TITLE
revert: enforce session ownership on chat.* write RPCs (#247)

### DIFF
--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -658,21 +658,19 @@ describe("chat.ensureSession", () => {
 });
 
 describe("chat.appendMessage", () => {
-  it("inserts message and bumps session count when caller owns the session", async () => {
-    const query = mockQuery([{ agent_id: "a1" }], [], []);
+  it("inserts message and bumps session count", async () => {
+    const query = mockQuery([], []);
 
     const result = await getHandler("chat.appendMessage")(
       { session_id: "sess1", role: "user", content: "Hello", metadata: { key: "val" } }, "a1",
     );
     expect(result.id).toBeDefined();
     expect(typeof result.id).toBe("string");
-    // 1 ownership SELECT + INSERT + session UPDATE
-    expect(query).toHaveBeenCalledTimes(3);
-    expect(query.mock.calls[0][0]).toContain("SELECT agent_id FROM chat_sessions");
+    expect(query).toHaveBeenCalledTimes(2);
   });
 
   it("inserts delegated message lineage", async () => {
-    const query = mockQuery([{ agent_id: "target-agent" }], [], []);
+    const query = mockQuery([], []);
 
     await getHandler("chat.appendMessage")(
       {
@@ -686,40 +684,17 @@ describe("chat.appendMessage", () => {
       },
       "target-agent",
     );
-    // INSERT params land on call index 1 now (call 0 is the ownership SELECT)
-    expect(query.mock.calls[1][1]).toEqual(expect.arrayContaining([
+    expect(query.mock.calls[0][1]).toEqual(expect.arrayContaining([
       "target-agent",
       "parent",
       "delegation-1",
     ]));
   });
-
-  it("rejects when caller does not own the session", async () => {
-    const query = mockQuery([{ agent_id: "victim" }]);
-
-    await expect(getHandler("chat.appendMessage")(
-      { session_id: "victim-session", role: "user", content: "smuggled", metadata: null }, "attacker",
-    )).rejects.toThrow(/not owned by agent attacker/);
-
-    // Only the ownership SELECT ran; no INSERT, no session UPDATE.
-    expect(query).toHaveBeenCalledTimes(1);
-  });
-
-  it("permits write when session is not yet registered (ensureSession-first contract)", async () => {
-    const query = mockQuery([], [], []);
-
-    const result = await getHandler("chat.appendMessage")(
-      { session_id: "fresh", role: "user", content: "Hello", metadata: null }, "a1",
-    );
-
-    expect(result.id).toBeDefined();
-    expect(query).toHaveBeenCalledTimes(3);
-  });
 });
 
 describe("chat.updateMessage", () => {
   it("updates message fields without bumping session count", async () => {
-    const query = mockQuery([{ agent_id: "a1" }], [], []);
+    const query = mockQuery([], []);
 
     const result = await getHandler("chat.updateMessage")(
       {
@@ -736,10 +711,9 @@ describe("chat.updateMessage", () => {
     );
 
     expect(result).toEqual({ ok: true });
-    expect(query).toHaveBeenCalledTimes(3);
-    expect(query.mock.calls[0][0]).toContain("SELECT agent_id FROM chat_sessions");
-    expect(query.mock.calls[1][0]).toContain("UPDATE chat_messages");
-    expect(query.mock.calls[1][1]).toEqual([
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0][0]).toContain("UPDATE chat_messages");
+    expect(query.mock.calls[0][1]).toEqual([
       "Done",
       "delegate_to_agent",
       "{\"scope\":\"check\"}",
@@ -750,30 +724,13 @@ describe("chat.updateMessage", () => {
       "msg-1",
       "sess1",
     ]);
-    expect(query.mock.calls[2][0]).toContain("UPDATE chat_sessions SET last_active_at");
-  });
-
-  it("rejects when caller does not own the session", async () => {
-    const query = mockQuery([{ agent_id: "owner" }]);
-
-    await expect(getHandler("chat.updateMessage")(
-      {
-        id: "msg-x",
-        session_id: "other-session",
-        content: "edit",
-        outcome: "success",
-        duration_ms: 1,
-      },
-      "intruder",
-    )).rejects.toThrow(/not owned by agent intruder/);
-
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[1][0]).toContain("UPDATE chat_sessions SET last_active_at");
   });
 });
 
 describe("chat.updateDelegationToolMessage", () => {
   it("updates async delegation tool rows by delegation id", async () => {
-    const query = mockQuery([{ agent_id: "a1" }], [], []);
+    const query = mockQuery([], []);
 
     const result = await getHandler("chat.updateDelegationToolMessage")(
       {
@@ -789,10 +746,9 @@ describe("chat.updateDelegationToolMessage", () => {
     );
 
     expect(result).toEqual({ ok: true });
-    expect(query).toHaveBeenCalledTimes(3);
-    expect(query.mock.calls[0][0]).toContain("SELECT agent_id FROM chat_sessions");
-    expect(query.mock.calls[1][0]).toContain("WHERE session_id = ? AND role = 'tool' AND tool_name = ? AND delegation_id = ?");
-    expect(query.mock.calls[1][1]).toEqual([
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0][0]).toContain("WHERE session_id = ? AND role = 'tool' AND tool_name = ? AND delegation_id = ?");
+    expect(query.mock.calls[0][1]).toEqual([
       "{\"status\":\"done\"}",
       "{\"status\":\"done\"}",
       "success",
@@ -801,26 +757,7 @@ describe("chat.updateDelegationToolMessage", () => {
       "delegate_to_agents",
       "call-1",
     ]);
-    expect(query.mock.calls[2][0]).toContain("UPDATE chat_sessions SET last_active_at");
-  });
-
-  it("rejects when caller does not own the session", async () => {
-    const query = mockQuery([{ agent_id: "owner" }]);
-
-    await expect(getHandler("chat.updateDelegationToolMessage")(
-      {
-        session_id: "other-session",
-        tool_name: "delegate_to_agents",
-        delegation_id: "call-x",
-        content: "{}",
-        metadata: "{}",
-        outcome: "success",
-        duration_ms: 1,
-      },
-      "intruder",
-    )).rejects.toThrow(/not owned by agent intruder/);
-
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[1][0]).toContain("UPDATE chat_sessions SET last_active_at");
   });
 });
 

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1861,40 +1861,6 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
 
   // --- chat.* ---
 
-  /**
-   * Verify the calling Runtime owns `sessionId` before mutating it.
-   *
-   * The chat.* RPCs receive the connection's authenticated agentId as the
-   * second arg from buildAdapterRpcHandlers. Without this check, a buggy
-   * or compromised Runtime could write rows into another agent's chat
-   * session by passing an arbitrary session_id in the body. internal-api's
-   * validateDelegationEventActor already covers the delegation.* event
-   * surface; this closes the gap on the plain chat.* RPC surface
-   * (chent1996 review #4 / jacoblee #6).
-   *
-   * Permissive on "session not found" so first-write call paths can still
-   * land — the adapter's caller is expected to chat.ensureSession first,
-   * which sets agent_id atomically and is itself protected by the same
-   * authentication.
-   */
-  async function assertSessionBelongsToAgent(
-    db: { query: (sql: string, params?: unknown[]) => Promise<unknown> },
-    sessionId: string,
-    callerAgentId: string,
-  ): Promise<void> {
-    if (!callerAgentId) return;
-    if (!sessionId) return;
-    const [rows] = (await db.query(
-      "SELECT agent_id FROM chat_sessions WHERE id = ?",
-      [sessionId],
-    )) as [Array<{ agent_id: string | null }>, unknown];
-    if (rows.length === 0) return;
-    const ownerAgentId = rows[0].agent_id;
-    if (ownerAgentId && ownerAgentId !== callerAgentId) {
-      throw new Error(`session ${sessionId} not owned by agent ${callerAgentId}`);
-    }
-  }
-
   handlers.set("chat.ensureSession", async (params) => {
     const db = getDb();
     // last_active_at omitted: relies on schema DEFAULT CURRENT_TIMESTAMP for
@@ -1915,10 +1881,9 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     return { ok: true };
   });
 
-  handlers.set("chat.appendMessage", async (params, agentId) => {
+  handlers.set("chat.appendMessage", async (params) => {
     const id = crypto.randomUUID();
     const db = getDb();
-    await assertSessionBelongsToAgent(db, params.session_id, agentId);
     await db.query(
       `INSERT INTO chat_messages (id, session_id, role, content, tool_name, tool_input, metadata, outcome, duration_ms, from_agent_id, parent_session_id, delegation_id, target_agent_id)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1936,9 +1901,8 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     return { id };
   });
 
-  handlers.set("chat.updateMessage", async (params, agentId) => {
+  handlers.set("chat.updateMessage", async (params) => {
     const db = getDb();
-    await assertSessionBelongsToAgent(db, params.session_id, agentId);
     await db.query(
       `UPDATE chat_messages
        SET content = ?, tool_name = ?, tool_input = ?, metadata = ?, outcome = ?, duration_ms = ?,
@@ -1963,9 +1927,8 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     return { ok: true };
   });
 
-  handlers.set("chat.updateDelegationToolMessage", async (params, agentId) => {
+  handlers.set("chat.updateDelegationToolMessage", async (params) => {
     const db = getDb();
-    await assertSessionBelongsToAgent(db, params.session_id, agentId);
     await db.query(
       `UPDATE chat_messages
        SET content = ?, metadata = ?, outcome = ?, duration_ms = ?


### PR DESCRIPTION
## Summary

Reverts 821965a from PR #247. That commit ships a session-ownership check on `chat.appendMessage` / `chat.updateMessage` / `chat.updateDelegationToolMessage` that is incompatible with how Runtime actually connects to Portal, and bricks every chat in standalone Siclaw deployments.

Verified broken on \`sendong-siclaw\` running \`siclaw-{portal,runtime,agentbox}:main-5a67f39\`: agentbox emits the assistant message correctly, but Portal rejects the persistence RPC with \`session <id> not owned by agent runtime\` and the frontend logs \`[usePilotChat] SSE error\`.

## Why the check is broken

\`assertSessionBelongsToAgent\` compares the session's stored \`agent_id\` to the WS connection's authenticated agentId. But Runtime opens **one** WS to Portal with agentId hardcoded to the string \`"runtime"\` (\`src/lib/bootstrap-runtime.ts:52\`). It's a multi-tenant proxy — one connection serves every agent it spawns — so the WS-level identity is **never** a real agent UUID. The check therefore rejects 100% of writes.

The unit tests passed because they invoked the handler directly with UUID-shaped strings as the \`callerAgentId\` arg, which masked the architectural gap between WS-level identity and per-RPC agent identity. There was no integration test covering the actual Runtime → Portal RPC path.

## What about the original security concern?

The original review comments (chent1996 #4, jacoblee #6) flagged a real threat — a buggy Runtime could inject writes into other sessions. That is still true. But the fix needs a different design: either per-agent WS identities, or per-RPC agent tokens that Portal can verify independently of the WS. That's follow-up work and out of scope here.

For now the trust boundary on the Runtime↔Portal channel is back to mTLS + portalSecret, exactly as it was before #247.

## Notes on the diff

- The handler-count assertion (\`registers exactly 43 handlers\`) is **kept** at 43. 821965a flipped it from 42 → 43, but that part was a stale-test fix unrelated to ownership — \`adapter.ts\` already had 43 handlers before #247 (verified via \`git show 821965a^:src/portal/adapter.ts | grep -c handlers.set\`).
- Five tests added by 821965a covering the ownership-check happy path / cross-agent rejection / not-yet-persisted permissive branch are removed alongside the check.

## Test plan

- [x] \`npm test\` — 3009 passed, 0 failed
- [ ] Smoke test on \`sendong-siclaw\` after image rebuilds — agent should reply end-to-end