### PR TITLE
fix(portal): order skills/mcp_servers DDL before junction tables

### DIFF
--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -91,6 +91,75 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     CONSTRAINT fk_ah_host FOREIGN KEY (host_id) REFERENCES hosts(id) ON DELETE CASCADE
   )`,
 
+  // Skills + MCP servers must be created BEFORE their junction tables below,
+  // otherwise CREATE TABLE agent_skills / agent_mcp_servers fails on MySQL with
+  // ER_FK_CANNOT_OPEN_PARENT (1824). SQLite tolerates forward FK refs, which is
+  // why the SQLite-only migrate test never caught this.
+  `CREATE TABLE IF NOT EXISTS skills (
+    id CHAR(36) PRIMARY KEY,
+    org_id CHAR(36) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    labels TEXT,
+    author_id CHAR(36) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'draft',
+    version INT NOT NULL DEFAULT 1,
+    specs MEDIUMTEXT,
+    scripts TEXT,
+    created_by CHAR(36) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )`,
+
+  `CREATE TABLE IF NOT EXISTS skill_versions (
+    id CHAR(36) PRIMARY KEY,
+    skill_id CHAR(36) NOT NULL,
+    version INT NOT NULL,
+    specs MEDIUMTEXT,
+    scripts TEXT,
+    diff TEXT,
+    commit_message VARCHAR(500),
+    author_id CHAR(36) NOT NULL,
+    is_approved TINYINT(1) NOT NULL DEFAULT 0,
+    labels TEXT DEFAULT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (skill_id, version),
+    CONSTRAINT fk_skill_versions_skill FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+  )`,
+
+  `CREATE TABLE IF NOT EXISTS skill_reviews (
+    id CHAR(36) PRIMARY KEY,
+    skill_id CHAR(36) NOT NULL,
+    version INT NOT NULL,
+    diff TEXT,
+    security_assessment TEXT,
+    submitted_by CHAR(36) NOT NULL,
+    reviewed_by CHAR(36),
+    decision VARCHAR(20),
+    reject_reason TEXT,
+    submitted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    reviewed_at TIMESTAMP,
+    CONSTRAINT fk_review_skill FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
+  )`,
+
+  `CREATE TABLE IF NOT EXISTS mcp_servers (
+    id CHAR(36) PRIMARY KEY,
+    org_id CHAR(36) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    transport VARCHAR(30) NOT NULL,
+    url VARCHAR(500),
+    command VARCHAR(500),
+    args TEXT,
+    env TEXT,
+    headers TEXT,
+    enabled TINYINT(1) NOT NULL DEFAULT 1,
+    description TEXT,
+    created_by CHAR(36) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (org_id, name)
+  )`,
+
   // Agent <-> Skill junction
   `CREATE TABLE IF NOT EXISTS agent_skills (
     agent_id CHAR(36) NOT NULL,
@@ -198,76 +267,9 @@ const PORTAL_SCHEMA_SQLS: string[] = [
   )`,
 
   // ================================================================
-  // Siclaw core tables (skills, MCP, chat, tasks, models, etc.)
+  // Siclaw core tables (chat, tasks, models, etc.)
+  // skills + mcp_servers are defined above, before their junction tables.
   // ================================================================
-
-  // Skills — note: unique index on (org_id, name) is added separately below,
-  // then downgraded to a non-unique index when skill overlays are introduced.
-  `CREATE TABLE IF NOT EXISTS skills (
-    id CHAR(36) PRIMARY KEY,
-    org_id CHAR(36) NOT NULL,
-    name VARCHAR(255) NOT NULL,
-    description TEXT,
-    labels TEXT,
-    author_id CHAR(36) NOT NULL,
-    status VARCHAR(20) NOT NULL DEFAULT 'draft',
-    version INT NOT NULL DEFAULT 1,
-    specs MEDIUMTEXT,
-    scripts TEXT,
-    created_by CHAR(36) NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-  )`,
-
-  `CREATE TABLE IF NOT EXISTS skill_versions (
-    id CHAR(36) PRIMARY KEY,
-    skill_id CHAR(36) NOT NULL,
-    version INT NOT NULL,
-    specs MEDIUMTEXT,
-    scripts TEXT,
-    diff TEXT,
-    commit_message VARCHAR(500),
-    author_id CHAR(36) NOT NULL,
-    is_approved TINYINT(1) NOT NULL DEFAULT 0,
-    labels TEXT DEFAULT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE (skill_id, version),
-    CONSTRAINT fk_skill_versions_skill FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
-  )`,
-
-  `CREATE TABLE IF NOT EXISTS skill_reviews (
-    id CHAR(36) PRIMARY KEY,
-    skill_id CHAR(36) NOT NULL,
-    version INT NOT NULL,
-    diff TEXT,
-    security_assessment TEXT,
-    submitted_by CHAR(36) NOT NULL,
-    reviewed_by CHAR(36),
-    decision VARCHAR(20),
-    reject_reason TEXT,
-    submitted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    reviewed_at TIMESTAMP,
-    CONSTRAINT fk_review_skill FOREIGN KEY (skill_id) REFERENCES skills(id) ON DELETE CASCADE
-  )`,
-
-  // MCP Servers
-  `CREATE TABLE IF NOT EXISTS mcp_servers (
-    id CHAR(36) PRIMARY KEY,
-    org_id CHAR(36) NOT NULL,
-    name VARCHAR(255) NOT NULL,
-    transport VARCHAR(30) NOT NULL,
-    url VARCHAR(500),
-    command VARCHAR(500),
-    args TEXT,
-    env TEXT,
-    headers TEXT,
-    enabled TINYINT(1) NOT NULL DEFAULT 1,
-    description TEXT,
-    created_by CHAR(36) NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE (org_id, name)
-  )`,
 
   // Chat
   `CREATE TABLE IF NOT EXISTS chat_sessions (

--- a/src/portal/schema-invariants.test.ts
+++ b/src/portal/schema-invariants.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { PORTAL_SCHEMA_SQLS } from "./migrate.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORTAL_DIR = path.resolve(__dirname);
@@ -169,6 +170,48 @@ describe("schema invariants: updated_at must be set on every UPDATE", () => {
     if (offenders.length > 0) {
       const msg = offenders.map((o) => `  ${o.file}: ${o.snippet}`).join("\n");
       expect.fail(`Found MySQL date functions still in business SQL:\n${msg}`);
+    }
+  });
+
+  // SQLite (even with PRAGMA foreign_keys=ON) accepts CREATE TABLE with FK
+  // references to non-existent parent tables — the constraint is only enforced
+  // on INSERT/UPDATE. MySQL rejects such CREATE TABLE outright with errno 1824
+  // (ER_FK_CANNOT_OPEN_PARENT). Production deployments avoid the trap because
+  // their pre-existing schema already has both tables and `IF NOT EXISTS` skips
+  // them. A fresh MySQL DB hits it on the first migration. This static check
+  // closes the test gap by parsing the DDL array directly.
+  it("every FOREIGN KEY references a table created earlier in PORTAL_SCHEMA_SQLS", () => {
+    const createPos = new Map<string, number>();
+    const createPattern = /CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+(\w+)/i;
+    PORTAL_SCHEMA_SQLS.forEach((sql, idx) => {
+      const m = sql.match(createPattern);
+      if (m) createPos.set(m[1], idx);
+    });
+
+    const fkPattern = /REFERENCES\s+(\w+)\s*\(/gi;
+    const violations: Array<{ child: string; parent: string; childIdx: number; parentIdx: number | undefined }> = [];
+
+    PORTAL_SCHEMA_SQLS.forEach((sql, idx) => {
+      const m = sql.match(createPattern);
+      if (!m) return;
+      const child = m[1];
+      let fkMatch: RegExpExecArray | null;
+      const re = new RegExp(fkPattern.source, fkPattern.flags);
+      while ((fkMatch = re.exec(sql)) !== null) {
+        const parent = fkMatch[1];
+        if (parent === child) continue; // self-reference, ignore
+        const parentIdx = createPos.get(parent);
+        if (parentIdx === undefined || parentIdx > idx) {
+          violations.push({ child, parent, childIdx: idx, parentIdx });
+        }
+      }
+    });
+
+    if (violations.length > 0) {
+      const msg = violations
+        .map((v) => `  CREATE TABLE ${v.child} (idx ${v.childIdx}) REFERENCES ${v.parent} (idx ${v.parentIdx ?? "MISSING"})`)
+        .join("\n");
+      expect.fail(`FK parent must precede child in PORTAL_SCHEMA_SQLS:\n${msg}`);
     }
   });
 });


### PR DESCRIPTION
## Summary

- `CREATE TABLE agent_skills` / `agent_mcp_servers` were declared in `PORTAL_SCHEMA_SQLS` *before* their FK parents (`skills`, `mcp_servers`), causing `runPortalMigrations()` to crash with `ER_FK_CANNOT_OPEN_PARENT (1824)` on any MySQL where those parent tables don't already exist.
- Existing prod MySQL deploys never hit this — `IF NOT EXISTS` skipped both junction and parent tables, so the FK was never re-evaluated. Fresh MySQL deploys (e.g. helm `mysql.enabled=true`, or any environment where Siclaw Portal's unprefixed schema is being applied for the first time) crash on first migration.
- The SQLite-only `migrate-sqlite.test.ts` did not catch this: even with `PRAGMA foreign_keys = ON`, SQLite tolerates `CREATE TABLE` with forward FK references and only enforces them on INSERT/UPDATE.

## Changes

- **`src/portal/migrate.ts`** — moved `skills`, `skill_versions`, `skill_reviews`, `mcp_servers` DDL blocks above their junction tables. Added a comment explaining why ordering matters.
- **`src/portal/schema-invariants.test.ts`** — added a static check that walks `PORTAL_SCHEMA_SQLS` and asserts every `REFERENCES <parent>` target appears earlier in the array. This closes the SQLite/MySQL FK-semantics test gap so any future ordering regression fails CI without needing a real MySQL instance.

## Bug introduced

`0c7ed02 refactor: migrate all DB ownership from Runtime to Portal` (2026-04-15) — `skills` was moved into `migrate.ts` after `agent_skills`. Latent for ~12 days because all hits required a fresh MySQL + the new unprefixed schema.

## Test plan

- [x] `npx vitest run src/portal/migrate-sqlite.test.ts src/portal/schema-invariants.test.ts` — 11/11 pass
- [x] Manually verified on the broken environment: pre-creating the missing parent tables let the migration complete; with this fix, no manual pre-creation needed