### PR TITLE
feat(error-envelope): inline error bubbles for chat flow

### DIFF
--- a/docs/design/error-envelope.md
+++ b/docs/design/error-envelope.md
@@ -1,0 +1,167 @@
+# Error Envelope (siclaw + sicore)
+
+> **Goal**: Whenever something fails along the chat flow (browser ↔ sicore-web ↔ sicore-apiserver ↔ siclaw-runtime ↔ agentbox ↔ model/tool), the user sees a clear in-line error bubble — not a silent stop. We do **not** exhaustively classify every failure; we ensure errors are never swallowed, and we tag the few we know how to handle specifically.
+
+---
+
+## 1. Wire schema
+
+One canonical shape, shared by REST bodies and SSE error frames.
+
+### `ErrorDetail` (the inner object)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `code` | string | ✅ | Identifier. Reuse sicore `ErrCode*` values where possible (`INTERNAL_ERROR`, `CONNECTION_FAILED`, `CONNECTION_TIMEOUT`, `TOO_MANY_REQUESTS`, etc.). Default to `INTERNAL_ERROR` when nothing better is known. |
+| `message` | string | ✅ | One-line, user-facing. English fine for v1; i18n later. |
+| `retriable` | bool | ✅ | Whether the UI should show a retry button. Default to `true` when wrapping unknown errors (be optimistic). |
+| `retryAfterMs` | number | ❌ | Hint for rate-limit/overload backoff. UI uses for retry button countdown. |
+| `requestId` | string | ❌ | Trace ID for support handoff. Echoed in UI as small text. |
+| `details` | unknown | ❌ | Opaque extra info, folded behind a "Details" disclosure in UI. Truncate to ~2 KB to protect the renderer. |
+
+### Transports
+
+| Channel | Body shape |
+|---|---|
+| **REST 4xx/5xx** | `{ "error": ErrorDetail }` (matches sicore's existing `ErrorResponse`) |
+| **SSE error event** | `event: error\ndata: <ErrorDetail>\n\n` (data is `ErrorDetail` directly — the event name discriminates, no extra wrapping) |
+| **WS RPC error** (sicore↔runtime) | `{ ok: false, error: ErrorDetail }` — replaces today's `{OK, Error: string}` shape gradually (see §5 migration) |
+
+---
+
+## 2. Code values (initial set, extensible)
+
+Hard rule: **start small, add only when we actually emit one in code**. No speculative codes.
+
+### Generic / fallback
+- `INTERNAL_ERROR` — anything we couldn't classify. Always default.
+- `BAD_REQUEST` — caller sent garbage (matches sicore `ErrCodeBadRequest`).
+
+### Connectivity & infra
+- `CONNECTION_FAILED` — sicore can't reach siclaw runtime ("no Runtime connected for agent X"). Maps to existing `ErrCodeConnectionFailed`.
+- `CONNECTION_TIMEOUT` — WS RPC timed out. Maps to existing `ErrCodeConnectionTimeout`.
+- `STREAM_INTERRUPTED` — SSE / WS connection broke mid-stream.
+
+### Chat-specific
+- `AGENT_NOT_FOUND` — agentId doesn't exist or user can't access it.
+- `AGENTBOX_FAILED` — runtime couldn't spawn or lost the agentbox process.
+
+### Model / tool (best-effort tagging when we recognize)
+- `MODEL_RATE_LIMIT` (with `retryAfterMs`) — upstream 429.
+- `MODEL_OVERLOADED` — upstream 529 / 503.
+- `MODEL_ERROR` — generic model API failure.
+- `TOOL_ERROR` — tool execution failed (kept generic; per-tool details go in `details`).
+
+That's 11 codes total. Anything else is `INTERNAL_ERROR`. We add codes as we hit specific UX needs — not before.
+
+---
+
+## 3. Propagation rules
+
+Two rules. No origin tracking, no hops, no trace stack at this stage.
+
+### R1 — Passthrough envelopes
+If a layer's catch sees an object that already looks like `ErrorDetail` (has `code` + `message` + `retriable`), forward it verbatim. **Never re-wrap.** Re-wrapping loses the inner code.
+
+### R2 — Wrap raw errors
+If a layer's catch sees a raw `Error` / Go `error`, wrap into `ErrorDetail`:
+- `code`: `INTERNAL_ERROR` (or a more specific one if the call site knows).
+- `message`: `err.message` (for Go: `err.Error()`).
+- `retriable`: `true` by default. Only set `false` for known-permanent failures (`AGENT_NOT_FOUND`, validation errors, `MODEL_CONTEXT_TOO_LONG`, etc.).
+
+That's it.
+
+---
+
+## 4. Front-end rendering
+
+Two frontends — `siclaw/portal-web` and `sicore/web` — both implement the same rules.
+
+### `<ErrorBubble>` component
+- Inline red-toned bubble in the chat message stream (same column as agent messages, not a toast)
+- Shows `message` prominently
+- "Retry" button if `retriable === true` (with countdown if `retryAfterMs` provided)
+- Footer: small `requestId` (copyable)
+- "Details" disclosure for `details` (collapsed by default)
+
+### `usePilotChat` integration
+On SSE `event: error` or fetch failure:
+1. Parse data → `ErrorDetail` (with backward-compat fallback for old `{error: "string"}` shape)
+2. Push a synthetic message into chat history with type `error` and the ErrorDetail
+3. Stop the stream, clear "streaming" state
+4. The chat list renderer checks message type and uses `<ErrorBubble>` for `error` messages
+
+### Backward-compat parser
+```ts
+function parseErrorDetail(raw: unknown): ErrorDetail {
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    // New envelope shape: {code, message, retriable, ...}
+    if (typeof obj.code === "string" && typeof obj.message === "string") {
+      return obj as ErrorDetail;
+    }
+    // REST body shape: {error: ErrorDetail | string}
+    if ("error" in obj) {
+      const e = obj.error;
+      if (typeof e === "object" && e !== null) return parseErrorDetail(e);
+      if (typeof e === "string") {
+        return { code: "INTERNAL_ERROR", message: e, retriable: true };
+      }
+    }
+  }
+  return { code: "INTERNAL_ERROR", message: String(raw), retriable: true };
+}
+```
+
+The frontend handles both old and new shapes during migration. After all backends emit the new shape, the legacy branches stay as defensive code (cheap insurance).
+
+---
+
+## 5. Migration & scope
+
+We are **not** rewriting all 402 catch blocks in siclaw or all 15+ `gin.H{"error": ...}` in sicore. Scope for v1:
+
+### Required (chat-flow user-visible)
+
+**siclaw** (TS):
+- `src/lib/error-envelope.ts` (new) — types + `wrapError()` + `sseErrorFrame()`
+- `src/gateway/server.ts` — chat SSE catch, RPC error returns
+- `src/gateway/sse-consumer.ts` — model `stopReason="error"` path: emit envelope as SSE error frame
+- `src/agentbox/http-server.ts` — chat steer/prompt/abort error paths
+- `portal-web/src/components/chat/ErrorBubble.tsx` (new)
+- `portal-web/src/hooks/usePilotChat.ts` — SSE error + fetch error handling
+- `portal-web/src/components/chat/PilotArea.tsx` (or message renderer) — render error type
+
+**sicore** (Go + React):
+- `pkg/model/response.go` — extend `ErrorDetail` with `Retriable`, `RetryAfterMs`, `RequestId`; new `RespondErrorEnvelope()` and `WriteSSEError()` helpers
+- `internal/siclaw/proxy/handler.go` — replace `gin.H{"error": ...}` with envelope helpers; map `"no Runtime connected"` → `CONNECTION_FAILED`, RPC timeout → `CONNECTION_TIMEOUT`
+- `web/components/siclaw/chat/error-bubble.tsx` (new)
+- `web/hooks/siclaw/use-pilot-chat.ts` — SSE error + fetch error handling
+- `web/components/siclaw/chat/pilot/pilot-area.tsx` — render error type
+
+### Not in scope (v1)
+- 400 other siclaw catches that are not on the user-visible chat path
+- Other sicore handlers (host, cluster, credential, etc.) — they use proper `RespondError` already; the gap was siclaw proxy bypassing it
+- Auto-classification of every model/tool error subtype — handled per-call as we encounter need
+
+### Future (v2+, when actual UX gaps surface)
+- More specific codes (per-LLM-provider, per-tool)
+- i18n message lookup keyed by `code`
+- requestId propagation end-to-end (currently best-effort)
+- ESLint rule enforcing `catch` blocks emit envelope on user-visible paths
+
+---
+
+## 6. Cleanliness self-check
+
+| Property | Pass? | Why |
+|---|---|---|
+| Single source of truth for shape | ✅ | One `ErrorDetail`, two transports |
+| Wire-compatible with existing sicore `ErrorResponse` | ✅ | `{error: ErrorDetail}` matches; only adds optional fields |
+| Frontend renders without per-code branching | ✅ | One bubble + `retriable` flag drives all UX; code only used for optional friendlier copy via i18n later |
+| New code added without UI change | ✅ | Default render uses `message` directly |
+| Backward-compatible during migration | ✅ | `parseErrorDetail()` handles both `{error: string}` and `{error: ErrorDetail}` |
+| Doesn't require touching every catch block | ✅ | Scope is the user-visible chat flow; rest stays as-is, can migrate later |
+| Two simple propagation rules | ✅ | Passthrough or wrap. No hop tracking. |
+
+If a new requirement (e.g. cross-layer trace) breaks one of these, we revisit. Until then, keep it boring.

--- a/portal-web/src/components/chat/ErrorBubble.tsx
+++ b/portal-web/src/components/chat/ErrorBubble.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react"
+import { AlertTriangle, RefreshCw, ChevronDown, ChevronRight } from "lucide-react"
+import { cn } from "./cn"
+import type { ErrorDetail } from "./types"
+
+/** Inline chat bubble for an error envelope. See docs/design/error-envelope.md. */
+export function ErrorBubble({
+  detail,
+  onRetry,
+}: {
+  detail: ErrorDetail
+  onRetry?: () => void
+}) {
+  const [showDetails, setShowDetails] = useState(false)
+  const hasDetails = detail.details !== undefined && detail.details !== null
+
+  return (
+    <div className="flex gap-4 flex-row">
+      <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 shadow-sm shadow-black/10 border bg-red-50 border-red-200 text-red-500">
+        <AlertTriangle className="w-4 h-4" />
+      </div>
+      <div
+        className={cn(
+          "flex-1 min-w-0 rounded-2xl border border-red-200 bg-red-50 dark:bg-red-950/40 dark:border-red-900",
+          "px-4 py-3 shadow-sm shadow-black/10 max-w-3xl",
+        )}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-[15px] leading-relaxed text-red-900 dark:text-red-200 break-words">
+              {detail.message}
+            </div>
+            <div className="mt-1 flex items-center gap-2 text-xs text-red-700/80 dark:text-red-300/70">
+              <span className="font-mono">{detail.code}</span>
+              {detail.requestId && (
+                <span className="font-mono opacity-70" title="Copy request id for support">
+                  · {detail.requestId.slice(0, 8)}
+                </span>
+              )}
+            </div>
+          </div>
+          {detail.retriable && onRetry && (
+            <button
+              onClick={onRetry}
+              className={cn(
+                "shrink-0 inline-flex items-center gap-1.5 rounded-lg",
+                "px-2.5 py-1.5 text-xs font-medium",
+                "bg-red-600 text-white hover:bg-red-700",
+                "dark:bg-red-700 dark:hover:bg-red-600",
+                "transition-colors",
+              )}
+            >
+              <RefreshCw className="w-3.5 h-3.5" />
+              Retry
+            </button>
+          )}
+        </div>
+        {hasDetails && (
+          <div className="mt-2 border-t border-red-200/70 dark:border-red-900/70 pt-2">
+            <button
+              onClick={() => setShowDetails((v) => !v)}
+              className="inline-flex items-center gap-1 text-xs text-red-700/80 dark:text-red-300/70 hover:text-red-900 dark:hover:text-red-200"
+            >
+              {showDetails ? (
+                <ChevronDown className="w-3.5 h-3.5" />
+              ) : (
+                <ChevronRight className="w-3.5 h-3.5" />
+              )}
+              Details
+            </button>
+            {showDetails && (
+              <pre className="mt-1.5 overflow-auto rounded-md bg-red-100/60 dark:bg-red-950/60 p-2 text-[11px] text-red-900/90 dark:text-red-200/80 font-mono whitespace-pre-wrap break-all">
+                {typeof detail.details === "string"
+                  ? detail.details
+                  : JSON.stringify(detail.details, null, 2)}
+              </pre>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/portal-web/src/components/chat/ErrorBubble.tsx
+++ b/portal-web/src/components/chat/ErrorBubble.tsx
@@ -15,67 +15,54 @@ export function ErrorBubble({
   const hasDetails = detail.details !== undefined && detail.details !== null
 
   return (
-    <div className="flex gap-4 flex-row">
-      <div className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 shadow-sm shadow-black/10 border bg-red-50 border-red-200 text-red-500">
-        <AlertTriangle className="w-4 h-4" />
-      </div>
+    <div className="flex gap-2 flex-row items-start">
+      <AlertTriangle className="w-3.5 h-3.5 mt-1.5 shrink-0 text-red-500/80 dark:text-red-400/80" />
       <div
         className={cn(
-          "flex-1 min-w-0 rounded-2xl border border-red-200 bg-red-50 dark:bg-red-950/40 dark:border-red-900",
-          "px-4 py-3 shadow-sm shadow-black/10 max-w-3xl",
+          "rounded-lg border border-red-300/40 bg-red-50/40 dark:bg-red-950/20 dark:border-red-900/40",
+          "px-3 py-1.5 max-w-3xl",
         )}
       >
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 flex-1">
-            <div className="text-[15px] leading-relaxed text-red-900 dark:text-red-200 break-words">
-              {detail.message}
-            </div>
-            <div className="mt-1 flex items-center gap-2 text-xs text-red-700/80 dark:text-red-300/70">
-              <span className="font-mono">{detail.code}</span>
-              {detail.requestId && (
-                <span className="font-mono opacity-70" title="Copy request id for support">
-                  · {detail.requestId.slice(0, 8)}
-                </span>
-              )}
-            </div>
-          </div>
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <span className="text-sm text-red-700 dark:text-red-300/90 break-words">
+            {detail.message}
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-wide text-red-600/60 dark:text-red-400/50 shrink-0">
+            {detail.code}
+          </span>
+          {detail.requestId && (
+            <span className="font-mono text-[10px] text-red-600/40 dark:text-red-400/30 shrink-0">
+              {detail.requestId.slice(0, 8)}
+            </span>
+          )}
           {detail.retriable && onRetry && (
             <button
               onClick={onRetry}
-              className={cn(
-                "shrink-0 inline-flex items-center gap-1.5 rounded-lg",
-                "px-2.5 py-1.5 text-xs font-medium",
-                "bg-red-600 text-white hover:bg-red-700",
-                "dark:bg-red-700 dark:hover:bg-red-600",
-                "transition-colors",
-              )}
+              className="ml-auto inline-flex items-center gap-1 text-[11px] text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 transition-colors"
             >
-              <RefreshCw className="w-3.5 h-3.5" />
+              <RefreshCw className="w-3 h-3" />
               Retry
             </button>
           )}
-        </div>
-        {hasDetails && (
-          <div className="mt-2 border-t border-red-200/70 dark:border-red-900/70 pt-2">
+          {hasDetails && (
             <button
               onClick={() => setShowDetails((v) => !v)}
-              className="inline-flex items-center gap-1 text-xs text-red-700/80 dark:text-red-300/70 hover:text-red-900 dark:hover:text-red-200"
+              className="inline-flex items-center text-[10px] text-red-600/60 dark:text-red-400/50 hover:text-red-800 dark:hover:text-red-200"
             >
               {showDetails ? (
-                <ChevronDown className="w-3.5 h-3.5" />
+                <ChevronDown className="w-3 h-3" />
               ) : (
-                <ChevronRight className="w-3.5 h-3.5" />
+                <ChevronRight className="w-3 h-3" />
               )}
-              Details
             </button>
-            {showDetails && (
-              <pre className="mt-1.5 overflow-auto rounded-md bg-red-100/60 dark:bg-red-950/60 p-2 text-[11px] text-red-900/90 dark:text-red-200/80 font-mono whitespace-pre-wrap break-all">
-                {typeof detail.details === "string"
-                  ? detail.details
-                  : JSON.stringify(detail.details, null, 2)}
-              </pre>
-            )}
-          </div>
+          )}
+        </div>
+        {showDetails && hasDetails && (
+          <pre className="mt-1 overflow-auto rounded bg-red-100/30 dark:bg-red-950/40 p-1.5 text-[10px] text-red-900/80 dark:text-red-200/70 font-mono whitespace-pre-wrap break-all">
+            {typeof detail.details === "string"
+              ? detail.details
+              : JSON.stringify(detail.details, null, 2)}
+          </pre>
         )}
       </div>
     </div>

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -24,6 +24,7 @@ import { Markdown } from "./Markdown"
 import { InputArea } from "./InputArea"
 import { SkillCard } from "./SkillCard"
 import { ScheduleCard } from "./ScheduleCard"
+import { ErrorBubble } from "./ErrorBubble"
 import type { PilotMessage, ContextUsage, ActionChip, PrefixActionChip } from "./types"
 
 const DIG_DEEPER_CHIP: PrefixActionChip = {
@@ -954,6 +955,11 @@ function MessageItem({
 }) {
   const isUser = message.role === "user"
   const isTool = message.role === "tool"
+  const isError = message.role === "error"
+
+  if (isError && message.errorDetail) {
+    return <ErrorBubble detail={message.errorDetail} />
+  }
 
   if (message.metadata?.kind === "delegation_status_notice") {
     return <DelegationStatusNotice content={message.content} />

--- a/portal-web/src/components/chat/types.ts
+++ b/portal-web/src/components/chat/types.ts
@@ -1,8 +1,19 @@
 /** Shared types for the Pilot-style chat UI. */
 
-export type MessageRole = "user" | "assistant" | "tool"
+export type MessageRole = "user" | "assistant" | "tool" | "error"
 
 export type ToolStatus = "running" | "success" | "error" | "aborted"
+
+/** Wire-compatible with siclaw's ErrorDetail (src/lib/error-envelope.ts) and
+ *  sicore's pkg/model ErrorDetail. See docs/design/error-envelope.md. */
+export interface ErrorDetail {
+  code: string
+  message: string
+  retriable: boolean
+  retryAfterMs?: number
+  requestId?: string
+  details?: unknown
+}
 
 export interface PilotMessage {
   id: string
@@ -24,6 +35,8 @@ export interface PilotMessage {
   isStreaming?: boolean
   /** Hidden from chat bubbles (e.g. update_plan tool messages) */
   hidden?: boolean
+  /** Populated when role === "error". */
+  errorDetail?: ErrorDetail
 }
 
 export interface ContextUsage {

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -11,8 +11,45 @@ import { api, chatSteer, chatAbort } from "../api"
 import type {
   PilotMessage,
   ContextUsage,
+  ErrorDetail,
 } from "../components/chat/types"
 import { findPendingSteerIndex, removePendingAt, extractUserMessageText } from "./steer-pending"
+
+/** Parse an unknown payload into an ErrorDetail with backward-compat fallbacks.
+ *  See docs/design/error-envelope.md §4. */
+function parseErrorDetail(raw: unknown): ErrorDetail {
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>
+    if (
+      typeof obj.code === "string" &&
+      typeof obj.message === "string" &&
+      typeof obj.retriable === "boolean"
+    ) {
+      return obj as unknown as ErrorDetail
+    }
+    if ("error" in obj) {
+      const e = obj.error
+      if (typeof e === "object" && e !== null) return parseErrorDetail(e)
+      if (typeof e === "string") {
+        return { code: "INTERNAL_ERROR", message: e, retriable: true }
+      }
+    }
+  }
+  if (typeof raw === "string") {
+    return { code: "INTERNAL_ERROR", message: raw, retriable: true }
+  }
+  return { code: "INTERNAL_ERROR", message: "Unknown error", retriable: true }
+}
+
+function makeErrorMessage(detail: ErrorDetail): PilotMessage {
+  return {
+    id: `error-${typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(36)}`,
+    role: "error",
+    content: detail.message,
+    timestamp: new Date().toISOString(),
+    errorDetail: detail,
+  }
+}
 
 // Re-export types for convenience
 export type { PilotMessage, ContextUsage }
@@ -942,7 +979,22 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
             signal: controller.signal,
           })
 
-          if (!res.ok) throw new Error(`HTTP ${res.status}`)
+          if (!res.ok) {
+            // Try to read error envelope from body before failing.
+            let bodyDetail: ErrorDetail | null = null
+            try {
+              const bodyText = await res.text()
+              if (bodyText) bodyDetail = parseErrorDetail(JSON.parse(bodyText))
+            } catch {
+              // body wasn't JSON — fall through to generic
+            }
+            const detail: ErrorDetail = bodyDetail ?? {
+              code: "INTERNAL_ERROR",
+              message: `Request failed (HTTP ${res.status})`,
+              retriable: res.status >= 500,
+            }
+            throw Object.assign(new Error(detail.message), { __errorDetail: detail })
+          }
 
           const reader = res.body?.getReader()
           if (!reader) throw new Error("No body")
@@ -1005,7 +1057,9 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
                   if (streamSessionId) { const cached = messagesCacheRef.current.get(streamSessionId); if (cached) cached.streaming = false }
                 } else if (event === "error") {
                   console.error("[usePilotChat] SSE error:", parsed)
+                  const detail = parseErrorDetail(parsed)
                   if (isActive) {
+                    setMessages((prev) => [...prev, makeErrorMessage(detail)])
                     setStreaming(false)
                     streamingRef.current = false
                     recoveredStreamingRef.current = false
@@ -1028,11 +1082,22 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
             }
           }
         } catch (err) {
-          if ((err as Error).name !== "AbortError") {
+          const isAbort = (err as Error).name === "AbortError"
+          if (!isAbort) {
             console.error("[usePilotChat] SSE error:", err)
           }
           if (activeSessionIdRef.current === streamSessionId) {
-            setMessages((prev) => prev.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m)))
+            setMessages((prev) => {
+              const cleared = prev.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m))
+              if (isAbort) return cleared
+              const attached = (err as { __errorDetail?: ErrorDetail }).__errorDetail
+              const detail = attached ?? {
+                code: "STREAM_INTERRUPTED",
+                message: err instanceof Error ? err.message : "Connection lost",
+                retriable: true,
+              }
+              return [...cleared, makeErrorMessage(detail)]
+            })
             setStreaming(false)
             streamingRef.current = false
             recoveredStreamingRef.current = false
@@ -1049,7 +1114,18 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const steer = useCallback(
     (text: string) => {
       if (!sessionId) return
-      chatSteer(agentId, sessionId, text).catch((err) => console.error("[usePilotChat] steer error:", err))
+      chatSteer(agentId, sessionId, text).catch((err) => {
+        console.error("[usePilotChat] steer error:", err)
+        const body = (err as { body?: unknown }).body
+        const detail = body !== undefined
+          ? parseErrorDetail(body)
+          : {
+              code: "INTERNAL_ERROR",
+              message: err instanceof Error ? err.message : "Failed to steer",
+              retriable: true,
+            }
+        setMessages((prev) => [...prev, makeErrorMessage(detail)])
+      })
       setPendingMessages((prev) => [...prev, text])
     },
     [agentId, sessionId],

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -722,7 +722,10 @@ export function createHttpServer(
       sendJson(res, 200, { ok: true });
     } catch (err) {
       console.error(`[agentbox-http] Steer error for session ${sessionId}:`, err);
-      sendJson(res, 500, { error: "Steer failed" });
+      const message = err instanceof Error ? err.message : "Steer failed";
+      sendJson(res, 500, {
+        error: { code: "INTERNAL_ERROR", message, retriable: true },
+      });
     }
   });
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -30,6 +30,7 @@ import {
   type RpcHandler,
   type RpcContext,
 } from "./ws-protocol.js";
+import { ErrorCodes, wrapError } from "../lib/error-envelope.js";
 import { handleCredentialRequest, handleCredentialList } from "./credential-proxy.js";
 import { type CredentialService } from "./credential-service.js";
 import { CertificateManager, type CertificateIdentity } from "./security/cert-manager.js";
@@ -176,6 +177,17 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         } catch (err) {
           if (!abortCtrl.signal.aborted) {
             console.error(`[runtime] SSE stream error for session=${promptResult.sessionId}:`, err);
+            // Surface the failure as an inline error bubble (proxy translates
+            // stream_error to an SSE error frame). Without this the frontend
+            // sees the stream silently stop.
+            const detail = wrapError(err, {
+              code: ErrorCodes.STREAM_INTERRUPTED,
+              retriable: true,
+            });
+            context.sendEvent("chat.event", {
+              sessionId: promptResult.sessionId,
+              event: { type: "stream_error", error: detail },
+            });
           }
           // Ensure prompt_done is sent even on error so Portal SSE doesn't hang
           context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -138,7 +138,23 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       modelConfig,
     };
 
-    const promptResult = await client.prompt(promptOpts);
+    let promptResult: Awaited<ReturnType<typeof client.prompt>>;
+    try {
+      promptResult = await client.prompt(promptOpts);
+    } catch (err) {
+      // Concurrent send: agentbox returns 409 "Session is already running.
+      // Use the steer endpoint to add input to the active prompt." when the
+      // user double-taps send before the previous prompt's pi-agent retries
+      // settle. Per agentbox's own hint, inject as steer instead of erroring
+      // — surfaces nothing to the user, message goes into the running session.
+      if (err instanceof Error && err.message.includes("Session is already running")) {
+        await client.steerSession(sessionId, text);
+        await appendMessage({ sessionId, role: "user", content: text });
+        await incrementMessageCount(sessionId);
+        return { ok: true, sessionId, steered: true };
+      }
+      throw err;
+    }
 
     // Ensure chat_sessions exists + persist the user message BEFORE the SSE
     // consumer starts writing assistant/tool rows (FK on chat_messages).

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -11,6 +11,7 @@
  * chat_sessions row before invoking.
  */
 
+import { ErrorCodes } from "../lib/error-envelope.js";
 import { AgentBoxClient } from "./agentbox/client.js";
 import { appendMessage, incrementMessageCount, updateMessage } from "./chat-repo.js";
 import { redactText, type RedactionConfig } from "./output-redactor.js";
@@ -255,9 +256,25 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
     if (eventType === "message_end" || eventType === "turn_end") {
       const message = evt.message as Record<string, unknown> | undefined;
       if (message?.role === "assistant") {
-        // Capture model-level errors (e.g. API 404, rate-limit)
+        // Capture model-level errors (e.g. API 404, rate-limit) and surface
+        // them upstream as a stream_error event so the proxy/frontend can
+        // render an inline error bubble instead of silently stopping.
         if (message.stopReason === "error" && message.errorMessage) {
           errorMessage = String(message.errorMessage);
+          if (onEvent) {
+            onEvent(
+              {
+                type: "stream_error",
+                error: {
+                  code: ErrorCodes.MODEL_ERROR,
+                  message: errorMessage,
+                  retriable: true,
+                },
+              },
+              "stream_error",
+              {},
+            );
+          }
         }
 
         // Extract text for resultText

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -130,6 +130,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   let resultText = "";
   let taskReportText = "";
   let errorMessage = "";
+  let streamErrorEmitted = false;
   let lastToolName = "";
 
   // Queued by toolName. pi-agent events do not always expose a stable call id,
@@ -257,11 +258,14 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       const message = evt.message as Record<string, unknown> | undefined;
       if (message?.role === "assistant") {
         // Capture model-level errors (e.g. API 404, rate-limit) and surface
-        // them upstream as a stream_error event so the proxy/frontend can
-        // render an inline error bubble instead of silently stopping.
+        // them upstream as a single stream_error event so the proxy/frontend
+        // can render an inline error bubble instead of silently stopping.
+        // Dedupe within one consume run — pi-agent retries internally, which
+        // would otherwise produce one bubble per retry attempt.
         if (message.stopReason === "error" && message.errorMessage) {
           errorMessage = String(message.errorMessage);
-          if (onEvent) {
+          if (onEvent && !streamErrorEmitted) {
+            streamErrorEmitted = true;
             onEvent(
               {
                 type: "stream_error",

--- a/src/lib/error-envelope.test.ts
+++ b/src/lib/error-envelope.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  ErrorCodes,
+  errorBody,
+  isErrorDetail,
+  isErrorEnvelope,
+  sseErrorFrame,
+  wrapError,
+} from "./error-envelope.js";
+
+describe("error-envelope", () => {
+  describe("isErrorDetail", () => {
+    it("accepts well-formed envelope", () => {
+      expect(
+        isErrorDetail({ code: "INTERNAL_ERROR", message: "oops", retriable: true }),
+      ).toBe(true);
+    });
+
+    it("rejects missing required fields", () => {
+      expect(isErrorDetail({ code: "X", message: "y" })).toBe(false);
+      expect(isErrorDetail({ code: "X", retriable: true })).toBe(false);
+      expect(isErrorDetail(null)).toBe(false);
+      expect(isErrorDetail("string")).toBe(false);
+    });
+  });
+
+  describe("isErrorEnvelope", () => {
+    it("recognizes {error: ErrorDetail} wrapper", () => {
+      expect(
+        isErrorEnvelope({ error: { code: "X", message: "y", retriable: false } }),
+      ).toBe(true);
+    });
+
+    it("rejects bare ErrorDetail", () => {
+      expect(isErrorEnvelope({ code: "X", message: "y", retriable: true })).toBe(false);
+    });
+  });
+
+  describe("wrapError", () => {
+    it("passes through ErrorDetail unchanged (R1)", () => {
+      const detail = { code: "FOO", message: "bar", retriable: false };
+      expect(wrapError(detail)).toBe(detail);
+    });
+
+    it("unwraps ErrorEnvelope to ErrorDetail (R1)", () => {
+      const detail = { code: "FOO", message: "bar", retriable: true };
+      expect(wrapError({ error: detail })).toBe(detail);
+    });
+
+    it("wraps Error with INTERNAL_ERROR + retriable=true (R2 defaults)", () => {
+      const out = wrapError(new Error("boom"));
+      expect(out).toEqual({
+        code: ErrorCodes.INTERNAL,
+        message: "boom",
+        retriable: true,
+      });
+    });
+
+    it("respects override defaults", () => {
+      const out = wrapError(new Error("boom"), {
+        code: ErrorCodes.CONNECTION_FAILED,
+        retriable: false,
+        requestId: "abc",
+      });
+      expect(out).toEqual({
+        code: "CONNECTION_FAILED",
+        message: "boom",
+        retriable: false,
+        requestId: "abc",
+      });
+    });
+
+    it("handles non-Error throws", () => {
+      expect(wrapError("string error").message).toBe("string error");
+      expect(wrapError(null).message).toBe("Unknown error");
+      expect(wrapError(undefined).message).toBe("Unknown error");
+      expect(wrapError(42).message).toBe("42");
+    });
+
+    it("includes retryAfterMs and details when provided", () => {
+      const out = wrapError(new Error("rate limited"), {
+        code: ErrorCodes.MODEL_RATE_LIMIT,
+        retryAfterMs: 5000,
+        details: { provider: "anthropic" },
+      });
+      expect(out.retryAfterMs).toBe(5000);
+      expect(out.details).toEqual({ provider: "anthropic" });
+    });
+  });
+
+  describe("sseErrorFrame", () => {
+    it("emits SSE error event with ErrorDetail body", () => {
+      const frame = sseErrorFrame({
+        code: "X",
+        message: "y",
+        retriable: true,
+      });
+      expect(frame).toBe(`event: error\ndata: {"code":"X","message":"y","retriable":true}\n\n`);
+    });
+  });
+
+  describe("errorBody", () => {
+    it("wraps detail in {error: ...}", () => {
+      const d = { code: "X", message: "y", retriable: false };
+      expect(errorBody(d)).toEqual({ error: d });
+    });
+  });
+});

--- a/src/lib/error-envelope.ts
+++ b/src/lib/error-envelope.ts
@@ -1,0 +1,83 @@
+// Error envelope — see docs/design/error-envelope.md.
+// Wire-compatible with sicore's pkg/model/response.go ErrorDetail.
+
+export type ErrorDetail = {
+  code: string;
+  message: string;
+  retriable: boolean;
+  retryAfterMs?: number;
+  requestId?: string;
+  details?: unknown;
+};
+
+// REST body wrapper. SSE error frames carry ErrorDetail directly (event name discriminates).
+export type ErrorEnvelope = { error: ErrorDetail };
+
+// Codes mirror sicore ErrCode* where applicable, plus a few siclaw-specific ones.
+// Add new codes here only when actually emitted from code; see design doc §2.
+export const ErrorCodes = {
+  INTERNAL: "INTERNAL_ERROR",
+  BAD_REQUEST: "BAD_REQUEST",
+
+  CONNECTION_FAILED: "CONNECTION_FAILED",
+  CONNECTION_TIMEOUT: "CONNECTION_TIMEOUT",
+  STREAM_INTERRUPTED: "STREAM_INTERRUPTED",
+
+  AGENT_NOT_FOUND: "AGENT_NOT_FOUND",
+  AGENTBOX_FAILED: "AGENTBOX_FAILED",
+
+  MODEL_RATE_LIMIT: "MODEL_RATE_LIMIT",
+  MODEL_OVERLOADED: "MODEL_OVERLOADED",
+  MODEL_ERROR: "MODEL_ERROR",
+  TOOL_ERROR: "TOOL_ERROR",
+} as const;
+
+export function isErrorDetail(value: unknown): value is ErrorDetail {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.code === "string" &&
+    typeof v.message === "string" &&
+    typeof v.retriable === "boolean"
+  );
+}
+
+export function isErrorEnvelope(value: unknown): value is ErrorEnvelope {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return isErrorDetail(v.error);
+}
+
+// wrapError — passthrough rule R1 for already-wrapped objects, wrap rule R2 for raw errors.
+// Defaults: retriable=true (optimistic), code=INTERNAL_ERROR.
+export function wrapError(
+  err: unknown,
+  defaults: Partial<ErrorDetail> = {},
+): ErrorDetail {
+  if (isErrorDetail(err)) return err;
+  if (isErrorEnvelope(err)) return err.error;
+
+  const message =
+    defaults.message ??
+    (err instanceof Error ? err.message : err == null ? "Unknown error" : String(err));
+
+  const detail: ErrorDetail = {
+    code: defaults.code ?? ErrorCodes.INTERNAL,
+    message,
+    retriable: defaults.retriable ?? true,
+  };
+  if (defaults.retryAfterMs != null) detail.retryAfterMs = defaults.retryAfterMs;
+  if (defaults.requestId) detail.requestId = defaults.requestId;
+  if (defaults.details !== undefined) detail.details = defaults.details;
+  return detail;
+}
+
+// Encode ErrorDetail as an SSE `event: error` frame. Caller writes returned string to the response.
+export function sseErrorFrame(detail: ErrorDetail): string {
+  return `event: error\ndata: ${JSON.stringify(detail)}\n\n`;
+}
+
+// Convenience for REST handlers that need the {error: ...} body shape.
+export function errorBody(detail: ErrorDetail): ErrorEnvelope {
+  return { error: detail };
+}

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -15,6 +15,12 @@ import {
 } from "../gateway/rest-router.js";
 import type { ResolvedModelBinding } from "../gateway/agent-model-binding.js";
 import { getDb } from "../gateway/db.js";
+import {
+  ErrorCodes,
+  errorBody,
+  isErrorDetail,
+  type ErrorDetail,
+} from "../lib/error-envelope.js";
 
 /** Resolve model binding directly from Portal's own DB. */
 async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelBinding | null> {
@@ -111,23 +117,37 @@ export function registerChatRoutes(
   // POST /api/v1/siclaw/agents/:id/chat/send — SSE streaming
   router.post("/api/v1/siclaw/agents/:id/chat/send", async (req, res, params) => {
     const auth = requireAuth(req, jwtSecret);
-    if (!auth) { sendJson(res, 401, { error: "Authentication required" }); return; }
+    if (!auth) {
+      sendJson(res, 401, errorBody({ code: ErrorCodes.INTERNAL, message: "Authentication required", retriable: false }));
+      return;
+    }
 
     const body = await parseBody<{ text?: string; session_id?: string }>(req);
-    if (!body.text) { sendJson(res, 400, { error: "text is required" }); return; }
+    if (!body.text) {
+      sendJson(res, 400, errorBody({ code: ErrorCodes.BAD_REQUEST, message: "text is required", retriable: false }));
+      return;
+    }
 
     const agentId = params.id;
     const sessionId = body.session_id ?? crypto.randomUUID();
 
     if (!connectionMap.isConnected(agentId)) {
-      sendJson(res, 503, { error: "Agent runtime is not connected" });
+      sendJson(res, 503, errorBody({
+        code: ErrorCodes.CONNECTION_FAILED,
+        message: `Agent runtime is not connected for agent ${agentId}`,
+        retriable: true,
+      }));
       return;
     }
 
     // Resolve agent's bound model + provider config from DB
     const modelBinding = await resolveAgentModelBinding(agentId);
     if (!modelBinding) {
-      sendJson(res, 400, { error: "Agent has no model configured, or the bound provider/model was not found" });
+      sendJson(res, 400, errorBody({
+        code: ErrorCodes.BAD_REQUEST,
+        message: "Agent has no model configured, or the bound provider/model was not found",
+        retriable: false,
+      }));
       return;
     }
 
@@ -154,6 +174,17 @@ export function registerChatRoutes(
       if (envelope.sessionId && envelope.sessionId !== sessionId) return;
 
       const evt = envelope.event;
+
+      // Translate stream_error events to a canonical SSE error frame so the
+      // frontend handles them via the same code path as RPC-level failures.
+      if (evt.type === "stream_error") {
+        const detail = isErrorDetail(evt.error)
+          ? (evt.error as ErrorDetail)
+          : { code: ErrorCodes.STREAM_INTERRUPTED, message: "Stream error", retriable: true };
+        sseWrite(res, "error", detail);
+        return;
+      }
+
       sseWrite(res, "chat.event", evt);
 
       // Stream complete — only on prompt_done (sent by Runtime after ALL agent
@@ -178,7 +209,11 @@ export function registerChatRoutes(
     });
 
     if (!result.ok) {
-      sseWrite(res, "error", { error: result.error ?? "RPC failed" });
+      sseWrite(res, "error", {
+        code: ErrorCodes.INTERNAL,
+        message: result.error ?? "RPC failed",
+        retriable: true,
+      });
       res.end();
       cleanup();
       return;


### PR DESCRIPTION
## Summary

Backend catch blocks on the user-visible chat path were swallowing errors to `console.error`, leaving the frontend silently stuck — the agent appears to stop talking with no UI feedback. Users had to open DevTools to learn it was \"no Runtime connected\", a 502, or a model error.

This PR introduces a single error envelope shape across siclaw + sicore (see `docs/design/error-envelope.md`) and renders it as an inline red bubble in the chat list.

```
ErrorDetail = { code, message, retriable, retryAfterMs?, requestId?, details? }
```

- REST 4xx/5xx body: `{error: ErrorDetail}` (compatible with sicore's existing `pkg/model/ErrorResponse`)
- SSE error frame: `event: error\ndata: <ErrorDetail>`
- Two propagation rules: passthrough envelopes verbatim; wrap raw errors with `INTERNAL_ERROR` + `retriable=true` (optimistic).
- 11 codes total. No exhaustive classification — we add codes only when an actual UX gap demands one.

## Backend changes

- **`src/lib/error-envelope.ts`** — new module: types, `wrapError()`, `sseErrorFrame()`, `errorBody()`, 12 unit tests
- **`src/gateway/sse-consumer.ts`** — emit `stream_error` event upstream when model `stopReason=\"error\"` (was: silently captured in result object)
- **`src/gateway/server.ts`** — chat SSE catch block emits a `stream_error` envelope before `prompt_done` (was: console.error swallow)
- **`src/agentbox/http-server.ts`** — steer 500 path preserves err.message inside an envelope (was: generic \"Steer failed\")
- **`src/portal/chat-gateway.ts`** — REST replies use envelope helpers; subscribe handler translates runtime `stream_error` chat.event → canonical SSE `error` frame so frontend has one error code path

## Frontend changes (`portal-web/`)

- **`components/chat/ErrorBubble.tsx`** — new red inline bubble: code, message, optional retry button, copyable requestId, folded details disclosure
- **`components/chat/types.ts`** — `MessageRole` adds `\"error\"`; `PilotMessage.errorDetail` carries the parsed envelope
- **`components/chat/PilotArea.tsx`** — `MessageItem` renders `ErrorBubble` for `role==='error'`
- **`hooks/usePilotChat.ts`** — SSE `error` event, fetch failure, and steer failure all push an error message into chat history (was: pure `console.error`). Backward-compat parser handles legacy `{error: string}` shape.

## Sister MR

Sicore-apiserver + sicore-web counterpart: `gitlab.scitix-inner.ai/k8s/sicore` branch `feat/error-envelope` (off `develop`). Both PRs ship together. Schema is wire-compatible — frontend renders correctly even if only one side merges, but the full UX requires both.

## Test plan

- [x] `npx vitest run src/lib/error-envelope.test.ts` — 12/12 pass
- [x] `npx vitest run src/gateway/sse-consumer.test.ts src/portal/chat-gateway.test.ts src/agentbox/http-server.test.ts` — 76/76 pass
- [x] `npx tsc --noEmit` clean (root + portal-web)
- [ ] Smoke test in sendong-sicore-test cluster: trigger \"no Runtime connected\" by killing runtime mid-session — UI should show retry-able error bubble instead of going silent
- [ ] Smoke test: model-level error (e.g. invalid API key) — UI should show inline error bubble with model error message