### PR TITLE
fix(pi-agent-brain): skip empty-response retry on stopReason=error

### DIFF
--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -82,6 +82,25 @@ describe("PiAgentBrain", () => {
     expect(session.prompt).toHaveBeenCalledTimes(1);
   });
 
+  it("prompt skips retry when stopReason is error", async () => {
+    // Model errors (auth/quota/network give-up after pi-agent-core's
+    // transport retries) reach the brain as stopReason="error" with empty
+    // content. The empty-response retry must NOT engage — re-prompting just
+    // hammers the same permanent failure and flickers the frontend Thinking
+    // indicator with each agent_start/agent_end retry pair.
+    const session = makeFakeSession();
+    session.prompt = vi.fn(async (_text: string) => {
+      session.__emit({ type: "message_start", message: { role: "assistant" } });
+      session.__emit({
+        type: "message_end",
+        message: { role: "assistant", content: [], stopReason: "error", errorMessage: "Connection error." },
+      });
+    });
+    const brain = new PiAgentBrain(session);
+    await brain.prompt("q");
+    expect(session.prompt).toHaveBeenCalledTimes(1);
+  });
+
   it("prompt retries up to MAX_EMPTY_RETRIES when content is empty", async () => {
     const session = makeFakeSession();
     let attempt = 0;

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -71,10 +71,18 @@ export class PiAgentBrain implements BrainSession {
       // by an intentional abort (user Stop, or an extension force-aborting a
       // turn). Re-prompting the original text in that case re-runs input
       // handlers and can corrupt extension state.
+      //
+      // Skip retry when stopReason === "error": pi-agent-core has already
+      // exhausted its transport-level retries by the time it surfaces a
+      // failed turn this way (auth/quota/network give-up). Re-prompting just
+      // hammers the same failure, while each retry emits agent_start /
+      // agent_end pairs that flicker the frontend Thinking indicator on/off
+      // even though stream_error has already shown the user the error bubble.
       let retries = 0;
       while (
         !lastAssistantHadContent &&
         lastAssistantMessage?.stopReason !== "aborted" &&
+        lastAssistantMessage?.stopReason !== "error" &&
         retries < PiAgentBrain.MAX_EMPTY_RETRIES
       ) {
         retries++;


### PR DESCRIPTION
## Summary

The brain's empty-response retry guard was only excluding `stopReason === "aborted"`. When pi-agent-core's transport-level retries finally give up on a model call (auth/quota/network give-up) it surfaces the turn as `stopReason: "error"` with empty content, and the brain treated that the same way as the Kimi-K2.5 empty-response quirk — re-prompting up to `MAX_EMPTY_RETRIES` times. Each retry round emits an `agent_start` / `agent_end` pair, which the chat frontend mirrors as `setStreaming(true) / false`. Combined with the dedupe inside `sse-consumer` (the bubble only renders once), the user saw a single error bubble plus a "Thinking…" indicator that kept flickering on/off until the brain finally gave up.

### Problem

Bad API key (or any other permanent model error) reaches the brain as `{stopReason: "error", content: []}`. The retry loop interpreted "no content + not aborted" as the Kimi quirk and re-ran the whole prompt, hammering the same broken transport for several rounds. The user-visible symptom was a stale "Thinking…" indicator that persisted long after the error bubble had already rendered.

### Solution

Add `stopReason !== "error"` to the retry-loop condition. Transport-level retries already happened inside pi-agent-core by the time the brain sees this state, so re-prompting at the brain layer just produces noise with no chance of recovery. The aborted path is unchanged, and legitimate empty-response retries (`stopReason: "end_turn"` / `"stop"` with empty content) still trigger as before — only the error path is excluded.

## Test Plan

- [x] `npx vitest run src/core/brains/pi-agent-brain.test.ts` — 20 / 20 passing (includes new regression test mirroring the existing `stopReason: "aborted"` test)
- [ ] Deploy `siclaw-runtime` + `siclaw-agentbox` built from this branch to a test cluster, configure an agent with an invalid model API key, send a message: confirm one red error bubble appears, "Thinking…" clears immediately and stays cleared, and the prompt does not retry on the backend.
- [ ] Same cluster, valid API key: regular conversation flows out with no extra abort or behavior change (happy path is unaffected because the loop only enters when content is empty AND stopReason is not aborted/error).

## Architecture Checklist

- [x] **Deployment mode**: pure logic change inside `pi-agent-brain`, no spawner / filesystem / sync touched.
- [x] **Security model**: no shell execution paths.
- [x] **DB parity**: no schema changes.
- [x] **Tool protocol**: not relevant.

## General Checklist

- [x] Single logical change (one condition + a regression test)
- [x] Conventional Commit subject
- [x] No unrelated changes