### PR TITLE
fix(runtime): make chat.send ack async to escape sicore's 30s RPC timeout

### DIFF
--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -112,20 +112,12 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       throw new Error("agentId, userId, and text are required");
     }
 
-    // Get or create AgentBox for this agent — one pod per agent, shared by
-    // all callers. Caller identity travels as sessionId.
-    const handle = await agentBoxManager.getOrCreate(agentId);
-    const client = new AgentBoxClient(handle.endpoint, 30000, agentBoxTlsOptions);
-
-    // Pre-generate a UUID so the AgentBox doesn't fall back to the literal
-    // "default" session id (LocalSpawner behaviour), which would merge every
-    // caller's trace into one chat_sessions row.
+    // Pre-generate a UUID so AgentBox doesn't fall back to the literal
+    // "default" session id (LocalSpawner behaviour), which would merge
+    // every caller's trace into one chat_sessions row.
     const sessionId = incomingSessionId ?? crypto.randomUUID();
-    // Record sessionId → userId so AgentBox → Runtime internal-api callbacks
-    // can recover user attribution for Upstream audit.
     sessionRegistry.remember(sessionId, userId, agentId);
 
-    // Build prompt options from params (Upstream sends full context)
     const modelConfig = params.modelConfig as PromptOptions["modelConfig"];
     const promptOpts: PromptOptions = {
       sessionId,
@@ -138,40 +130,57 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       modelConfig,
     };
 
-    let promptResult: Awaited<ReturnType<typeof client.prompt>>;
-    try {
-      promptResult = await client.prompt(promptOpts);
-    } catch (err) {
-      // Concurrent send: agentbox returns 409 "Session is already running.
-      // Use the steer endpoint to add input to the active prompt." when the
-      // user double-taps send before the previous prompt's pi-agent retries
-      // settle. Per agentbox's own hint, inject as steer instead of erroring
-      // — surfaces nothing to the user, message goes into the running session.
-      if (err instanceof Error && err.message.includes("Session is already running")) {
-        await client.steerSession(sessionId, text);
+    // Async-ack protocol: return { ok, sessionId } within milliseconds; do
+    // every slow step (agentbox spawn, prompt() roundtrip, SSE consume) in
+    // the background and stream events back to Portal via the chat.event
+    // WS channel.
+    //
+    // Why: sicore's WS RPC carries a fixed 30s timeout. Coupling the ack
+    // to "agentbox is ready and prompt() returned" forced that timeout to
+    // cover worst-case cold-start (image pull, container start, ready
+    // probe), which routinely exceeds 30s and produced spurious
+    // CONNECTION_TIMEOUT bubbles even when the runtime was healthy. Once
+    // the bubble fires, sicore tears down the SSE response and the
+    // delayed reply (which still arrives later) is dropped — leaving a
+    // ghost session in DB and a confused user.
+    //
+    // After the ack, the existing chat.event stream (agent_start /
+    // agent_end / agent_message / stream_error / prompt_done) carries
+    // every observable progress signal the frontend needs.
+    (async () => {
+      try {
+        // Persist user message + ensure session row before any agent events
+        // could land. consumeAgentSse writes assistant/tool rows with FK
+        // referencing chat_sessions, so the row has to exist first.
+        await ensureChatSession(sessionId, agentId, userId, text);
         await appendMessage({ sessionId, role: "user", content: text });
         await incrementMessageCount(sessionId);
-        return { ok: true, sessionId, steered: true };
-      }
-      throw err;
-    }
 
-    // Ensure chat_sessions exists + persist the user message BEFORE the SSE
-    // consumer starts writing assistant/tool rows (FK on chat_messages).
-    await ensureChatSession(promptResult.sessionId, agentId, userId, text);
-    await appendMessage({ sessionId: promptResult.sessionId, role: "user", content: text });
-    await incrementMessageCount(promptResult.sessionId);
+        const handle = await agentBoxManager.getOrCreate(agentId);
+        const client = new AgentBoxClient(handle.endpoint, 30000, agentBoxTlsOptions);
 
-    // Minimal redaction: scrub the apiKey + baseUrl from any captured tool
-    // output. Credential-manifest redaction is follow-up work.
-    const redactionConfig = buildRedactionConfigForModelConfig(modelConfig);
+        let promptResult: Awaited<ReturnType<typeof client.prompt>>;
+        try {
+          promptResult = await client.prompt(promptOpts);
+        } catch (err) {
+          // Concurrent send: agentbox returns 409 "Session is already
+          // running. Use the steer endpoint to add input to the active
+          // prompt." when the user double-taps send before the previous
+          // prompt's pi-agent retries settle. Per agentbox's own hint,
+          // inject as steer — the message rides on the still-running
+          // prompt's stream. Don't emit prompt_done here: the running
+          // prompt will fire its own when it actually finishes, and an
+          // extra one would close the frontend stream prematurely.
+          if (err instanceof Error && err.message.includes("Session is already running")) {
+            await client.steerSession(sessionId, text);
+            return;
+          }
+          throw err;
+        }
 
-    // Stream + persist events back to Portal via sendEvent (FrontendWsClient).
-    {
-      const abortCtrl = new AbortController();
+        const redactionConfig = buildRedactionConfigForModelConfig(modelConfig);
+        const abortCtrl = new AbortController();
 
-      // Non-blocking: consume events in background
-      (async () => {
         try {
           await consumeAgentSse({
             client,
@@ -187,15 +196,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
               });
             },
           });
-          // Signal Portal that the prompt is fully complete (all agent turns done).
-          // agent_end fires after each turn — prompt_done fires once at the very end.
           context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
         } catch (err) {
           if (!abortCtrl.signal.aborted) {
             console.error(`[runtime] SSE stream error for session=${promptResult.sessionId}:`, err);
-            // Surface the failure as an inline error bubble (proxy translates
-            // stream_error to an SSE error frame). Without this the frontend
-            // sees the stream silently stop.
             const detail = wrapError(err, {
               code: ErrorCodes.STREAM_INTERRUPTED,
               retriable: true,
@@ -205,13 +209,26 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
               event: { type: "stream_error", error: detail },
             });
           }
-          // Ensure prompt_done is sent even on error so Portal SSE doesn't hang
           context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
         }
-      })();
-    }
+      } catch (err) {
+        // Failure before/during agentbox spawn or prompt() — surface as a
+        // stream_error so the frontend renders an inline bubble instead of
+        // hanging on the spawning state forever.
+        console.error(`[runtime] chat.send background failure for session=${sessionId}:`, err);
+        const detail = wrapError(err, {
+          code: ErrorCodes.INTERNAL,
+          retriable: true,
+        });
+        context.sendEvent("chat.event", {
+          sessionId,
+          event: { type: "stream_error", error: detail },
+        });
+        context.sendEvent("chat.event", { sessionId, event: { type: "prompt_done" } });
+      }
+    })();
 
-    return { ok: true, sessionId: promptResult.sessionId };
+    return { ok: true, sessionId };
   });
 
   rpcMethods.set("chat.abort", async (params) => {


### PR DESCRIPTION
## Summary

sicore's WS RPC (the channel between sicore-apiserver and the runtime gateway) carries a fixed 30s timeout that applies to every `SendCommand`. The previous `chat.send` handler kept the RPC pending until `agentBoxManager.getOrCreate` plus `client.prompt()` returned, which on a cold-start (image pull, container start, ready probe) routinely exceeds 30s. The result was a spurious `CONNECTION_TIMEOUT` red bubble even though the runtime was healthy: sicore tore down the SSE response when the RPC timed out, the eventual reply still arrived later but had no subscriber to receive it, and the user was left with an error bubble plus a ghost session in the DB whose assistant reply was only visible after a page refresh.

### Problem

- 30s is the hard ceiling sicore applies to all WS RPCs (see `internal/siclaw/ws/connection_map.go:245` in scitix/sicore).
- A cold-start of the agentbox pod regularly hits 5–60s in real clusters (image pull from far registry, scheduler delay on busy nodes, ready-probe stabilisation).
- Bumping that timeout helps generic cases but doesn't fix the fundamental shape — long agentbox spawns will always sit somewhere on the tail.

### Solution

Decouple the RPC ack from the slow work. `chat.send` now returns `{ ok, sessionId }` within milliseconds, and every subsequent step runs in a background async block that streams events back to Portal on the existing `chat.event` WS channel. The 30s RPC timeout no longer covers cold-start; it only has to cover "is the runtime still reachable".

The chat.event stream itself is unchanged — `agent_start` / `agent_end` / `agent_message` / `stream_error` / `prompt_done` carry every observable progress signal exactly as before. There is no new event type, no new client-side state to track, and no new failure mode for callers that aren't aware of this PR. Frontends that already render the existing chat.event stream get the timeout fix transparently.

The 409 "Session is already running" path keeps the steer-fallback behaviour but no longer emits `prompt_done` (the still-running prompt fires its own — an extra one would close the SSE prematurely).

User-message persistence (`ensureChatSession` + `appendMessage` + `incrementMessageCount`) moves inside the async block at its earliest point, so the row exists before any agent events could land while still happening before the slow spawn.

The matching frontend complement (Portal sicore-web) is in [scitix/sicore!301](http://gitlab.scitix-inner.ai/k8s/sicore/-/merge_requests/301): it adds a soft "Still working on it…" reassurance after 10s of continuous Thinking… so legitimate long waits don't look like the agent has hung. The reassurance is purely a function of elapsed time — no protocol coupling.

## Test Plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean.
- [x] `npx vitest run` clean (no new test failures introduced).
- [x] Verified end-to-end on a single-node test cluster paired with the scitix/sicore!301 frontend build:
   - Cold-start (~32s simulated): chat completes after the wait without a CONNECTION_TIMEOUT bubble; a single chat session row is created (no ghost session); the assistant reply streams in normally; "Still working on it…" appears once Thinking… crosses the 10s mark.
   - Hot-path (subsequent message in same session, fast spawn): unchanged perceived latency; no behavioural regression.
   - 409 "Session is already running" steer-fallback: a second concurrent send routes into the running prompt's stream — frontend sees one continuous response.
- [ ] One more pass against a freshly-cycled production-like cluster to confirm no regressions on real cold starts.