### PR TITLE
feat(runtime): make Runtime restart non-disruptive to active AgentBoxes

### DIFF
--- a/helm/siclaw/templates/NOTES.txt
+++ b/helm/siclaw/templates/NOTES.txt
@@ -9,3 +9,21 @@ Thank you for installing {{ include "siclaw.fullname" . }}!
    {{- end }}
    Gateway will create per-user subdirectories automatically.
 {{- end }}
+
+ℹ️  Runtime mTLS CA
+   {{- $caSecret := include "siclaw.runtimeTls.caSecret" . }}
+   {{- $generateCa := include "siclaw.runtimeTls.generateCa" . }}
+   {{- if $caSecret }}
+   Source: external Secret "{{ $caSecret }}" (kubernetes.io/tls).
+   Rotate the Secret then `kubectl rollout restart deploy/{{ include "siclaw.fullname" . }}-runtime`
+   and delete cached AgentBox client cert Secrets to re-issue.
+   {{- else if eq $generateCa "true" }}
+   Source: chart-managed Secret "{{ include "siclaw.runtimeCaSecretName" . }}".
+   Annotated `helm.sh/resource-policy: keep` so it survives `helm uninstall`.
+   To rotate: `kubectl delete secret {{ include "siclaw.runtimeCaSecretName" . }} -n {{ .Release.Namespace }}`
+   then `helm upgrade` (this also requires deleting AgentBox client cert Secrets and recycling AgentBox pods).
+   ⚠️  GitOps users: do NOT run `helm template … | kubectl apply -f -` against a live cluster
+       — `lookup` cannot read the cluster from render-only contexts and would emit a fresh CA
+       every render, overwriting this Secret and breaking mTLS for every running AgentBox.
+       For pre-rendered pipelines, set runtime.tls.generateCa=false and supply runtime.tls.caSecret.
+   {{- end }}

--- a/helm/siclaw/templates/_helpers.tpl
+++ b/helm/siclaw/templates/_helpers.tpl
@@ -77,3 +77,57 @@ in the same namespace don't collide; users can override via
 {{- define "siclaw.dataPvcName" -}}
 {{- default (printf "%s-data" (include "siclaw.fullname" .)) .Values.agentbox.persistence.claimName -}}
 {{- end }}
+
+{{/*
+Name of the chart-managed Runtime CA Secret.
+*/}}
+{{- define "siclaw.runtimeCaSecretName" -}}
+{{- printf "%s-runtime-ca" (include "siclaw.fullname" .) -}}
+{{- end }}
+
+{{/*
+Resolve runtime.tls.generateCa. Returns the literal string "true" or "false".
+Defaults to "true" when the field is missing — critical for `helm upgrade
+--reuse-values` against a release created with a pre-tls chart, where
+.Values.runtime.tls itself is nil.
+*/}}
+{{- define "siclaw.runtimeTls.generateCa" -}}
+{{- $tls := .Values.runtime.tls | default dict -}}
+{{- if hasKey $tls "generateCa" -}}{{- $tls.generateCa -}}{{- else -}}true{{- end -}}
+{{- end }}
+
+{{/*
+Resolve runtime.tls.caSecret. Returns "" when missing.
+*/}}
+{{- define "siclaw.runtimeTls.caSecret" -}}
+{{- $tls := .Values.runtime.tls | default dict -}}
+{{- $tls.caSecret | default "" -}}
+{{- end }}
+
+{{/*
+Resolve the Secret that backs SICLAW_CA_CERT/KEY. caSecret wins when set,
+otherwise the chart-managed name is used. Empty result means TLS is mis-
+configured — callers must guard with siclaw.validateRuntimeTls first.
+*/}}
+{{- define "siclaw.runtimeCaSecretRef" -}}
+{{- $caSecret := include "siclaw.runtimeTls.caSecret" . -}}
+{{- $generateCa := include "siclaw.runtimeTls.generateCa" . -}}
+{{- if $caSecret -}}
+{{- $caSecret -}}
+{{- else if eq $generateCa "true" -}}
+{{- include "siclaw.runtimeCaSecretName" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Fail-fast guard. Without a CA Secret the Runtime falls back to an ephemeral
+in-memory CA, and every Runtime restart silently invalidates the client certs
+held by existing AgentBox pods. Refuse to render the chart in that state.
+*/}}
+{{- define "siclaw.validateRuntimeTls" -}}
+{{- $caSecret := include "siclaw.runtimeTls.caSecret" . -}}
+{{- $generateCa := include "siclaw.runtimeTls.generateCa" . -}}
+{{- if and (ne $generateCa "true") (eq $caSecret "") -}}
+{{- fail "runtime.tls misconfigured: set generateCa=true OR caSecret to a kubernetes.io/tls Secret name. Ephemeral CA is not supported in K8s — old AgentBox pods would lose mTLS on every Runtime restart." -}}
+{{- end -}}
+{{- end }}

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -73,6 +73,23 @@ spec:
                 secretKeyRef:
                   name: {{ include "siclaw.fullname" . }}-runtime
                   key: portal-secret
+            {{- $caSecret := include "siclaw.runtimeCaSecretRef" . }}
+            {{- if $caSecret }}
+            # mTLS CA — persisted so existing AgentBox client certs survive
+            # Runtime restarts. See runtime-ca-secret.yaml.
+            - name: SICLAW_CA_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $caSecret }}
+                  key: tls.crt
+            - name: SICLAW_CA_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $caSecret }}
+                  key: tls.key
+            {{- end }}
+            # User-supplied env entries come last so callers can override any
+            # of the values above (e.g. swap in SICLAW_CA_CERT_FILE).
             {{- range $key, $value := .Values.runtime.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/helm/siclaw/templates/runtime-ca-secret.yaml
+++ b/helm/siclaw/templates/runtime-ca-secret.yaml
@@ -1,0 +1,42 @@
+{{- /*
+WARNING: this template uses the `lookup` function to reuse a CA Secret that
+already exists in the cluster. `lookup` is a NO-OP in `helm template`,
+`helm install --dry-run`, and any other render-only context — those paths
+ALWAYS take the `genCA` branch and emit a fresh CA. If you pipe such output
+to `kubectl apply -f -`, you will OVERWRITE the live CA Secret and silently
+invalidate every AgentBox client cert in the cluster, causing mTLS to fail
+until each AgentBox pod is recreated.
+
+Use `helm install` / `helm upgrade` (which run against a real cluster) for
+this chart. Render-then-apply pipelines must inject a stable CA via
+`runtime.tls.caSecret` and set `runtime.tls.generateCa=false`.
+*/}}
+{{- include "siclaw.validateRuntimeTls" . }}
+{{- if eq (include "siclaw.runtimeTls.generateCa" .) "true" }}
+{{- $secretName := include "siclaw.runtimeCaSecretName" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "siclaw.labels" (dict "ctx" . "component" "runtime") | nindent 4 }}
+  annotations:
+    # Survive `helm uninstall` so re-installing into the same namespace does
+    # not regenerate the CA and orphan AgentBox client certs from the prior
+    # release.
+    "helm.sh/resource-policy": keep
+type: kubernetes.io/tls
+data:
+{{- if and $existing (index $existing.data "tls.crt") (index $existing.data "tls.key") }}
+  # Reuse the CA already in the cluster so `helm upgrade` keeps the same key
+  # material and existing AgentBox client certs stay valid.
+  tls.crt: {{ index $existing.data "tls.crt" }}
+  tls.key: {{ index $existing.data "tls.key" }}
+{{- else }}
+  {{- $ca := genCA "siclaw-runtime-ca" 3650 }}
+  tls.crt: {{ $ca.Cert | b64enc }}
+  tls.key: {{ $ca.Key  | b64enc }}
+{{- end }}
+{{- end }}

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -28,6 +28,27 @@ runtime:
   #   Standalone mode: http://siclaw-portal:3003
   #   Upstream mode:     http://upstream-apiserver:8080
   serverUrl: "http://siclaw-portal:3003"
+  # Runtime ↔ AgentBox mTLS CA. Without persistence, every Runtime restart
+  # generates a fresh CA and existing AgentBox pods (which hold client certs
+  # signed by the previous CA) immediately fail mTLS — sessions hang until
+  # those pods are reaped.
+  #
+  # Pick exactly one:
+  #   generateCa: true  — chart genCAs once and stores it in a Secret with
+  #                       helm.sh/resource-policy=keep so upgrades reuse it.
+  #                       NOTE: relies on `helm lookup` to detect the existing
+  #                       Secret. `helm template` / `helm install --dry-run`
+  #                       cannot lookup the cluster and will emit a FRESH CA
+  #                       every render — never pipe their output to
+  #                       `kubectl apply -f -`, you will overwrite the live
+  #                       Secret and break mTLS for all running AgentBoxes.
+  #                       For GitOps / render-then-apply use caSecret instead.
+  #   caSecret: "name"  — bring-your-own kubernetes.io/tls Secret (keys
+  #                       tls.crt / tls.key). Useful with cert-manager,
+  #                       Vault PKI, or any pipeline that pre-renders manifests.
+  tls:
+    generateCa: true
+    caSecret: ""
   resources:
     requests:
       cpu: "100m"

--- a/src/gateway/credential-proxy.test.ts
+++ b/src/gateway/credential-proxy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import http from "node:http";
 import { handleCredentialRequest, handleCredentialList } from "./credential-proxy.js";
-import { CredentialService, CredentialNotFoundError } from "./credential-service.js";
+import { CredentialService, CredentialNotFoundError, SessionOwnershipError } from "./credential-service.js";
 import type { CertificateIdentity } from "./security/cert-manager.js";
 
 // ── Fakes ──────────────────────────────────────────────────
@@ -115,6 +115,15 @@ describe("handleCredentialRequest", () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it("403 when service throws SessionOwnershipError — request never reaches upstream", async () => {
+    service.getClusterCredential.mockRejectedValue(new SessionOwnershipError("session sess-x belongs to agent other, not a1"));
+    const req = new FakeReq(JSON.stringify({ source: "cluster", source_id: "x" }));
+    const res = new FakeRes();
+    await handleCredentialRequest(asHttpReq(req), asHttpRes(res), goodIdentity, service as unknown as CredentialService);
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/belongs to agent/);
+  });
+
   it("502 when service throws some other error", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     service.getClusterCredential.mockRejectedValue(new Error("upstream is burning"));
@@ -181,6 +190,15 @@ describe("handleCredentialList", () => {
     const res = new FakeRes();
     await handleCredentialList(asHttpReq(req), asHttpRes(res), goodIdentity, service as unknown as CredentialService);
     expect(res.statusCode).toBe(400);
+  });
+
+  it("403 when service throws SessionOwnershipError on list — request never reaches upstream", async () => {
+    service.listClusters.mockRejectedValue(new SessionOwnershipError("session sess-x belongs to agent other, not a1"));
+    const req = new FakeReq(JSON.stringify({ kind: "cluster" }));
+    const res = new FakeRes();
+    await handleCredentialList(asHttpReq(req), asHttpRes(res), goodIdentity, service as unknown as CredentialService);
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/belongs to agent/);
   });
 
   it("502 on service error", async () => {

--- a/src/gateway/credential-proxy.ts
+++ b/src/gateway/credential-proxy.ts
@@ -13,7 +13,7 @@
 import http from "node:http";
 import type { CertificateIdentity } from "./security/cert-manager.js";
 import type { Identity } from "../shared/credential-types.js";
-import { CredentialService, CredentialNotFoundError } from "./credential-service.js";
+import { CredentialService, CredentialNotFoundError, SessionOwnershipError } from "./credential-service.js";
 
 interface CredentialRequestBody {
   source?: string;
@@ -105,6 +105,10 @@ export async function handleCredentialRequest(
       : await service.getHostCredential(id, body.source_id, body.purpose ?? "");
     sendJson(res, 200, payload);
   } catch (err) {
+    if (err instanceof SessionOwnershipError) {
+      sendError(res, 403, err.message);
+      return;
+    }
     if (err instanceof CredentialNotFoundError) {
       sendError(res, 404, err.message);
       return;
@@ -144,6 +148,10 @@ export async function handleCredentialList(
       sendJson(res, 200, { hosts });
     }
   } catch (err) {
+    if (err instanceof SessionOwnershipError) {
+      sendError(res, 403, err.message);
+      return;
+    }
     console.error(`[credential-proxy] list${body.kind} failed:`, err);
     sendError(res, 502, err instanceof Error ? err.message : "Unknown error");
   }

--- a/src/gateway/credential-service.test.ts
+++ b/src/gateway/credential-service.test.ts
@@ -3,6 +3,7 @@ import {
   CredentialService,
   createCredentialService,
   CredentialNotFoundError,
+  SessionOwnershipError,
 } from "./credential-service.js";
 import type { FrontendWsClient } from "./frontend-ws-client.js";
 import type { Identity } from "../shared/credential-types.js";
@@ -153,6 +154,44 @@ describe("CredentialNotFoundError", () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("CredentialNotFoundError");
     expect(err.message).toBe("missing");
+  });
+});
+
+describe("CredentialService cross-agent ownership guard", () => {
+  // All four public methods feed through the same `rpcParams`, so any one
+  // bypassing the guard would leak attribution. Parameterized so a future
+  // refactor cannot accidentally regress only one path.
+  type Method = "listClusters" | "listHosts" | "getClusterCredential" | "getHostCredential";
+  const methods: { name: Method; invoke: (svc: CredentialService, id: Identity) => Promise<unknown> }[] = [
+    { name: "listClusters", invoke: (s, id) => s.listClusters(id) },
+    { name: "listHosts", invoke: (s, id) => s.listHosts(id) },
+    { name: "getClusterCredential", invoke: (s, id) => s.getClusterCredential(id, "c1", "purpose-x") },
+    { name: "getHostCredential", invoke: (s, id) => s.getHostCredential(id, "h1", "purpose-x") },
+  ];
+
+  for (const m of methods) {
+    it(`${m.name} throws SessionOwnershipError when session_id resolves to a different agent`, async () => {
+      const reg = new SessionRegistry();
+      reg.remember("sess-1", "u-foreign", "other");
+      const fakeFrontend = new FakeFrontendClient();
+      const guarded = new CredentialService(fakeFrontend as unknown as FrontendWsClient, reg);
+
+      await expect(m.invoke(guarded, { ...identity, sessionId: "sess-1" }))
+        .rejects.toBeInstanceOf(SessionOwnershipError);
+      // Critical: upstream RPC must not have been invoked under any path.
+      expect(fakeFrontend.calls).toHaveLength(0);
+    });
+  }
+
+  it("does not throw when sessionId is empty (graceful degradation)", async () => {
+    const reg = new SessionRegistry();
+    const fakeFrontend = new FakeFrontendClient();
+    fakeFrontend.responses.set("credential.list:cluster", { clusters: [] });
+    const guarded = new CredentialService(fakeFrontend as unknown as FrontendWsClient, reg);
+
+    await expect(guarded.listClusters({ ...identity, sessionId: "" }))
+      .resolves.toEqual([]);
+    expect(fakeFrontend.calls[0].params.userId).toBe("");
   });
 });
 

--- a/src/gateway/credential-service.ts
+++ b/src/gateway/credential-service.ts
@@ -21,11 +21,28 @@ export class CredentialService {
     private readonly registry: SessionRegistry = sessionRegistry,
   ) {}
 
-  private rpcParams(identity: Identity, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  private async rpcParams(identity: Identity, extra: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
     // AgentBox is user-unaware — it doesn't know the caller's userId. Runtime
     // recovers the attribution from the session registry (populated at chat
-    // entry) so Upstream still sees a concrete userId for audit purposes.
-    const userId = this.registry.resolveUser(identity.sessionId);
+    // entry, with a Portal RPC fallback for cache misses) so Upstream still
+    // sees a concrete userId for audit purposes.
+    //
+    // Cross-agent attribution is rejected: if AgentBox A (cert agentId=A)
+    // passes a session_id whose owner agentId=B, we refuse rather than
+    // silently audit B's user as the caller. Unknown sessions degrade to
+    // empty userId (graceful, same as pre-fallback behaviour).
+    let userId = "";
+    if (identity.sessionId) {
+      const owner = await this.registry.get(identity.sessionId);
+      if (owner) {
+        if (owner.agentId !== identity.agentId) {
+          throw new SessionOwnershipError(
+            `session ${identity.sessionId} belongs to agent ${owner.agentId}, not ${identity.agentId}`,
+          );
+        }
+        userId = owner.userId;
+      }
+    }
     return {
       userId,
       agentId: identity.agentId,
@@ -39,7 +56,7 @@ export class CredentialService {
   async listClusters(identity: Identity): Promise<ClusterMeta[]> {
     const data = await this.frontendClient.request(
       "credential.list",
-      this.rpcParams(identity, { kind: "cluster" }),
+      await this.rpcParams(identity, { kind: "cluster" }),
     ) as { clusters?: ClusterMeta[] };
     if (!Array.isArray(data.clusters)) {
       throw new Error("Adapter credential-list returned malformed cluster list response");
@@ -50,7 +67,7 @@ export class CredentialService {
   async listHosts(identity: Identity): Promise<HostMeta[]> {
     const data = await this.frontendClient.request(
       "credential.list",
-      this.rpcParams(identity, { kind: "host" }),
+      await this.rpcParams(identity, { kind: "host" }),
     ) as { hosts?: HostMeta[] };
     if (!Array.isArray(data.hosts)) {
       throw new Error("Adapter credential-list returned malformed host list response");
@@ -61,20 +78,30 @@ export class CredentialService {
   async getClusterCredential(identity: Identity, clusterName: string, purpose: string): Promise<CredentialPayload> {
     return this.frontendClient.request(
       "credential.get",
-      this.rpcParams(identity, { source: "cluster", source_id: clusterName, purpose }),
+      await this.rpcParams(identity, { source: "cluster", source_id: clusterName, purpose }),
     ) as Promise<CredentialPayload>;
   }
 
   async getHostCredential(identity: Identity, hostName: string, purpose: string): Promise<CredentialPayload> {
     return this.frontendClient.request(
       "credential.get",
-      this.rpcParams(identity, { source: "host", source_id: hostName, purpose }),
+      await this.rpcParams(identity, { source: "host", source_id: hostName, purpose }),
     ) as Promise<CredentialPayload>;
   }
 }
 
 export class CredentialNotFoundError extends Error {
   constructor(message: string) { super(message); this.name = "CredentialNotFoundError"; }
+}
+
+/**
+ * Thrown when a credential request carries a sessionId that resolves to a
+ * different agent than the calling cert. credential-proxy translates this
+ * into HTTP 403 — never falls through to the upstream RPC, which would
+ * otherwise audit the wrong user.
+ */
+export class SessionOwnershipError extends Error {
+  constructor(message: string) { super(message); this.name = "SessionOwnershipError"; }
 }
 
 export function createCredentialService(frontendClient: FrontendWsClient): CredentialService {

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -271,6 +271,23 @@ describe("handleAgentTasksCreate", () => {
     expect(res.statusCode).toBe(201);
     expect(frontend.calls[0].params.user_id).toBe("");
   });
+
+  it("403 when session_id resolves to a different agent — refuses to audit cross-agent attribution", async () => {
+    const { sessionRegistry } = await import("./session-registry.js");
+    // Register session under agent-2; the calling cert (identity) is agent-1.
+    sessionRegistry.remember("sess-foreign", "u-other", "agent-2");
+    frontend.responses.set("task.create", { id: "should-not-be-called" });
+    const res = new FakeRes();
+    await handleAgentTasksCreate(
+      asReq(new FakeReq(JSON.stringify({ name: "n", schedule: "*/5 * * * *", prompt: "p", session_id: "sess-foreign" }))),
+      asRes(res), identity, frontend as unknown as FrontendWsClient,
+    );
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/ownership/i);
+    // Critical: upstream RPC must NOT have been called with the foreign user's id.
+    expect(frontend.calls.find(c => c.method === "task.create")).toBeUndefined();
+    sessionRegistry.forget("sess-foreign");
+  });
 });
 
 // ── agent tasks: update ──────────────────────────────────

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -43,51 +43,82 @@ function sendJson(res: http.ServerResponse, status: number, data: unknown): void
   res.end(JSON.stringify(data));
 }
 
-function sessionBelongsToIdentity(sessionId: string | null | undefined, identity: CertificateIdentity): boolean {
+async function sessionBelongsToIdentity(sessionId: string | null | undefined, identity: CertificateIdentity): Promise<boolean> {
   if (!sessionId) return true;
-  const owner = sessionRegistry.get(sessionId);
+  const owner = await sessionRegistry.get(sessionId);
   return !owner || owner.agentId === identity.agentId;
+}
+
+/**
+ * Resolve sessionId → userId, **enforcing that the session belongs to the
+ * calling cert's agent**. Cross-agent attribution is rejected (`ok: false`)
+ * — without this check, AgentBox A could pass a session_id owned by
+ * AgentBox B and have its task / credential request audited under B's user.
+ *
+ * Unknown sessions degrade gracefully (`ok: true`, `userId: ""`); only an
+ * explicit ownership mismatch trips the gate.
+ */
+async function resolveUserForIdentity(
+  sessionId: string | null | undefined,
+  identity: CertificateIdentity,
+): Promise<{ userId: string; ok: boolean }> {
+  if (!sessionId) return { userId: "", ok: true };
+  const owner = await sessionRegistry.get(sessionId);
+  if (!owner) return { userId: "", ok: true };
+  if (owner.agentId !== identity.agentId) return { userId: "", ok: false };
+  return { userId: owner.userId, ok: true };
 }
 
 function agentMatchesIdentity(agentId: string | null | undefined, identity: CertificateIdentity): boolean {
   return !agentId || agentId === identity.agentId;
 }
 
-function validateDelegationEventActor(
+async function validateDelegationEventActor(
   event: DelegationPersistenceEvent,
   identity: CertificateIdentity,
-): { status: number; error: string } | null {
+): Promise<{ status: number; error: string } | null> {
   switch (event.type) {
     case "delegation.ensure_session": {
       if (!event.userId) return { status: 400, error: "delegation.ensure_session requires userId" };
       if (!agentMatchesIdentity(event.agentId, identity)) return { status: 403, error: "delegation agent mismatch" };
-      if (!sessionBelongsToIdentity(event.sessionId, identity)) return { status: 403, error: "delegation session mismatch" };
-      if (!sessionBelongsToIdentity(event.lineage?.parentSessionId, identity)) return { status: 403, error: "delegation parent session mismatch" };
       if (!agentMatchesIdentity(event.lineage?.parentAgentId, identity)) return { status: 403, error: "delegation parent agent mismatch" };
       if (!agentMatchesIdentity(event.lineage?.targetAgentId, identity)) return { status: 403, error: "delegation target agent mismatch" };
+      // Two ownership checks; each can be a Portal RPC on cache miss. Run
+      // them in parallel — the unhappy path wastes one extra RPC but the
+      // happy path's latency is halved.
+      const [own, parentOwn] = await Promise.all([
+        sessionBelongsToIdentity(event.sessionId, identity),
+        sessionBelongsToIdentity(event.lineage?.parentSessionId, identity),
+      ]);
+      if (!own) return { status: 403, error: "delegation session mismatch" };
+      if (!parentOwn) return { status: 403, error: "delegation parent session mismatch" };
       return null;
     }
     case "delegation.append_message": {
-      if (!sessionBelongsToIdentity(event.message.sessionId, identity)) return { status: 403, error: "delegation session mismatch" };
-      if (!sessionBelongsToIdentity(event.message.parentSessionId, identity)) return { status: 403, error: "delegation parent session mismatch" };
       if (!agentMatchesIdentity(event.message.fromAgentId, identity)) return { status: 403, error: "delegation source agent mismatch" };
       if (!agentMatchesIdentity(event.message.targetAgentId, identity)) return { status: 403, error: "delegation target agent mismatch" };
+      const [own, parentOwn] = await Promise.all([
+        sessionBelongsToIdentity(event.message.sessionId, identity),
+        sessionBelongsToIdentity(event.message.parentSessionId, identity),
+      ]);
+      if (!own) return { status: 403, error: "delegation session mismatch" };
+      if (!parentOwn) return { status: 403, error: "delegation parent session mismatch" };
       return null;
     }
     case "delegation.update_message":
     case "delegation.update_tool_message": {
-      if (!sessionBelongsToIdentity(event.message.sessionId, identity)) return { status: 403, error: "delegation session mismatch" };
+      if (!(await sessionBelongsToIdentity(event.message.sessionId, identity))) return { status: 403, error: "delegation session mismatch" };
       return null;
     }
     case "delegation.append_event": {
       if (!event.event.userId) return { status: 400, error: "delegation.append_event requires userId" };
-      if (!sessionBelongsToIdentity(event.event.parentSessionId, identity)) return { status: 403, error: "delegation parent session mismatch" };
+      if (!(await sessionBelongsToIdentity(event.event.parentSessionId, identity))) return { status: 403, error: "delegation parent session mismatch" };
       if (!agentMatchesIdentity(event.event.parentAgentId, identity)) return { status: 403, error: "delegation parent agent mismatch" };
       if (!agentMatchesIdentity(event.event.targetAgentId, identity)) return { status: 403, error: "delegation target agent mismatch" };
       return null;
     }
     case "delegation.emit_chat_event": {
-      if (!sessionBelongsToIdentity(event.sessionId, identity)) return { status: 403, error: "delegation session mismatch" };
+      if (!(await sessionBelongsToIdentity(event.sessionId, identity))) return { status: 403, error: "delegation session mismatch" };
       return null;
     }
     default:
@@ -253,7 +284,8 @@ export async function handleAgentTasksList(
   try {
     // Session may be threaded via query param for GET; resolve → userId for audit.
     const sessionId = new URL(req.url || "/", "http://_").searchParams.get("session_id") ?? "";
-    const userId = sessionRegistry.resolveUser(sessionId);
+    const { userId, ok } = await resolveUserForIdentity(sessionId, identity);
+    if (!ok) { sendJson(res, 403, { error: "session ownership mismatch" }); return; }
     const data = await frontendClient.request("task.list", {
       agent_id: identity.agentId,
       user_id: userId,
@@ -306,7 +338,8 @@ export async function handleAgentTasksCreate(
     const invalid = validateSchedule(body.schedule);
     if (invalid) { sendJson(res, 400, { error: invalid }); return; }
 
-    const userId = sessionRegistry.resolveUser(body.session_id);
+    const { userId, ok } = await resolveUserForIdentity(body.session_id, identity);
+    if (!ok) { sendJson(res, 403, { error: "session ownership mismatch" }); return; }
     const data = await frontendClient.request("task.create", {
       id: randomUUID(),
       agent_id: identity.agentId,
@@ -345,7 +378,8 @@ export async function handleAgentTasksUpdate(
     }
 
     const sessionId = typeof body.session_id === "string" ? body.session_id : undefined;
-    const userId = sessionRegistry.resolveUser(sessionId);
+    const { userId, ok } = await resolveUserForIdentity(sessionId, identity);
+    if (!ok) { sendJson(res, 403, { error: "session ownership mismatch" }); return; }
     const data = await frontendClient.request("task.update", {
       task_id: taskId,
       agent_id: identity.agentId,
@@ -375,7 +409,8 @@ export async function handleAgentTasksDelete(
 ): Promise<void> {
   try {
     const sessionId = new URL(req.url || "/", "http://_").searchParams.get("session_id") ?? "";
-    const userId = sessionRegistry.resolveUser(sessionId);
+    const { userId, ok } = await resolveUserForIdentity(sessionId, identity);
+    if (!ok) { sendJson(res, 403, { error: "session ownership mismatch" }); return; }
     const data = await frontendClient.request("task.delete", {
       task_id: taskId,
       agent_id: identity.agentId,
@@ -496,7 +531,7 @@ export async function handleDelegationEvents(
 ): Promise<void> {
   try {
     const event = await readJsonBody(req) as DelegationPersistenceEvent;
-    const actorError = validateDelegationEventActor(event, identity);
+    const actorError = await validateDelegationEventActor(event, identity);
     if (actorError) {
       sendJson(res, actorError.status, { error: actorError.error });
       return;

--- a/src/gateway/security/cert-manager.test.ts
+++ b/src/gateway/security/cert-manager.test.ts
@@ -100,6 +100,122 @@ describe("CertificateManager.create — loading priority", () => {
     const m = await CertificateManager.create();
     expect(m.getCACertificate()).toContain("BEGIN CERTIFICATE");
   }, 60_000);
+
+  it("uses the loaded CA's actual subject as the issuer of new certs (verifies under OpenSSL/Node)", async () => {
+    clearCaEnv();
+    // Generate a CA whose subject deliberately does NOT match the legacy
+    // hardcoded "Siclaw Runtime CA, O=Siclaw, OU=Security" DN. This mirrors
+    // what Helm `genCA "siclaw-runtime-ca"` produces (CN only, no O/OU).
+    const kp = forge.pki.rsa.generateKeyPair(1024);
+    const ca = forge.pki.createCertificate();
+    ca.publicKey = kp.publicKey;
+    ca.serialNumber = "03";
+    ca.validity.notBefore = new Date();
+    ca.validity.notAfter = new Date(Date.now() + 86400_000);
+    ca.setSubject([{ name: "commonName", value: "siclaw-runtime-ca" }]);
+    ca.setIssuer([{ name: "commonName", value: "siclaw-runtime-ca" }]);
+    ca.setExtensions([{ name: "basicConstraints", cA: true }]);
+    ca.sign(kp.privateKey, forge.md.sha256.create());
+
+    process.env.SICLAW_CA_CERT = forge.pki.certificateToPem(ca);
+    process.env.SICLAW_CA_KEY = forge.pki.privateKeyToPem(kp.privateKey);
+
+    const m = await CertificateManager.create();
+    const bundle = m.issueAgentBoxCertificate("agent-x", "org-x", "box-x");
+
+    // Issuer DN of the issued cert must equal the CA's subject DN; otherwise
+    // X.509 path validation rejects with "unable to verify the first
+    // certificate" (see helm chart-managed CA bug).
+    const issued = forge.pki.certificateFromPem(bundle.cert);
+    const issuerCN = issued.issuer.attributes.find(a => a.name === "commonName")?.value;
+    const issuerO = issued.issuer.attributes.find(a => a.name === "organizationName")?.value;
+    expect(issuerCN).toBe("siclaw-runtime-ca");
+    expect(issuerO).toBeUndefined();
+
+    // The issuer DN must mirror the CA's subject DN exactly — same attribute
+    // count, same names, same values. Anything else breaks chain validation.
+    const dnEntries = (attrs: any[]) =>
+      attrs
+        .map(a => `${a.name}=${a.value}`)
+        .sort()
+        .join(",");
+    expect(dnEntries(issued.issuer.attributes)).toBe(dnEntries(ca.subject.attributes));
+
+    // Signature on the issued cert verifies under the loaded CA's public key.
+    expect(ca.verify(issued)).toBe(true);
+  }, 60_000);
+
+  it("preserves the full CA Subject DN on issued certs (C/ST/L not just CN/O/OU)", async () => {
+    clearCaEnv();
+    // Mirror what cert-manager / Vault PKI / corporate CAs typically produce —
+    // a multi-component DN with country, state, locality. A lossy {CN, O, OU}
+    // projection would drop these and break X.509 chain validation.
+    const kp = forge.pki.rsa.generateKeyPair(1024);
+    const ca = forge.pki.createCertificate();
+    ca.publicKey = kp.publicKey;
+    ca.serialNumber = "05";
+    ca.validity.notBefore = new Date();
+    ca.validity.notAfter = new Date(Date.now() + 86400_000);
+    const fullDn = [
+      { name: "countryName", value: "US" },
+      { name: "stateOrProvinceName", value: "California" },
+      { name: "localityName", value: "San Francisco" },
+      { name: "organizationName", value: "Acme Corp" },
+      { name: "organizationalUnitName", value: "PKI" },
+      { name: "commonName", value: "Acme Internal Root" },
+    ];
+    ca.setSubject(fullDn);
+    ca.setIssuer(fullDn);
+    ca.setExtensions([{ name: "basicConstraints", cA: true }]);
+    ca.sign(kp.privateKey, forge.md.sha256.create());
+
+    process.env.SICLAW_CA_CERT = forge.pki.certificateToPem(ca);
+    process.env.SICLAW_CA_KEY = forge.pki.privateKeyToPem(kp.privateKey);
+
+    const m = await CertificateManager.create();
+    const bundle = m.issueAgentBoxCertificate("agent-y", "org-y", "box-y");
+    const issued = forge.pki.certificateFromPem(bundle.cert);
+
+    // Issued cert's issuer attributes must equal the CA's subject attributes
+    // — same names, same values, same order. Anything dropped breaks chain
+    // validation downstream.
+    const dn = (attrs: any[]) =>
+      attrs.map(a => `${a.name}=${a.value}`).join(",");
+    expect(dn(issued.issuer.attributes)).toBe(dn(ca.subject.attributes));
+
+    // Signature must verify under the CA's public key.
+    expect(ca.verify(issued)).toBe(true);
+  }, 60_000);
+
+  it("accepts a CA whose subject has no Common Name (CN is not required by X.509)", async () => {
+    clearCaEnv();
+    const kp = forge.pki.rsa.generateKeyPair(1024);
+    const ca = forge.pki.createCertificate();
+    ca.publicKey = kp.publicKey;
+    ca.serialNumber = "04";
+    ca.validity.notBefore = new Date();
+    ca.validity.notAfter = new Date(Date.now() + 86400_000);
+    const cnLessDn = [
+      { name: "organizationName", value: "no-cn-org" },
+      { name: "organizationalUnitName", value: "PKI" },
+    ];
+    ca.setSubject(cnLessDn);
+    ca.setIssuer(cnLessDn);
+    ca.setExtensions([{ name: "basicConstraints", cA: true }]);
+    ca.sign(kp.privateKey, forge.md.sha256.create());
+
+    process.env.SICLAW_CA_CERT = forge.pki.certificateToPem(ca);
+    process.env.SICLAW_CA_KEY = forge.pki.privateKeyToPem(kp.privateKey);
+
+    const m = await CertificateManager.create();
+    const bundle = m.issueAgentBoxCertificate("agent-z", "org-z", "box-z");
+    const issued = forge.pki.certificateFromPem(bundle.cert);
+
+    // Issuer DN mirrors the CA's CN-less subject DN.
+    const dn = (attrs: any[]) => attrs.map(a => `${a.name}=${a.value}`).join(",");
+    expect(dn(issued.issuer.attributes)).toBe(dn(ca.subject.attributes));
+    expect(ca.verify(issued)).toBe(true);
+  }, 60_000);
 });
 
 // ── issueAgentBoxCertificate + verifyCertificate round-trip ───────

--- a/src/gateway/security/cert-manager.ts
+++ b/src/gateway/security/cert-manager.ts
@@ -47,10 +47,27 @@ export interface CertificateBundle {
 export class CertificateManager {
   private caCert: string;
   private caKey: string;
+  /**
+   * Subject attributes of the loaded CA, in their original forge form.
+   *
+   * Issued certs MUST reference the exact subject of the signing CA — X.509
+   * path validation does a byte-wise DN comparison. We carry the attribute
+   * array through verbatim (instead of projecting onto a {CN, O, OU} shape)
+   * so external CAs that include C / ST / L / serialNumber / etc.
+   * (cert-manager, Vault PKI, corporate roots) still produce a matching
+   * Issuer↔Subject pair.
+   */
+  private readonly caSubjectAttrs: any[];
 
   private constructor(caCert: string, caKey: string) {
     this.caCert = caCert;
     this.caKey = caKey;
+    const ca = forge.pki.certificateFromPem(caCert);
+    // Carry the CA's subject attribute array verbatim — every field flows
+    // into issued certs as-is. X.509 does not require a Common Name in the
+    // subject, and externally-managed CAs (cert-manager / Vault PKI / org
+    // roots) sometimes omit it; we accept whatever the CA presents.
+    this.caSubjectAttrs = ca.subject.attributes;
   }
 
   /**
@@ -106,7 +123,7 @@ export class CertificateManager {
 
     const cert = CertificateManager.createCertificateStatic({
       subject: { CN: hostname, O: "Siclaw", OU: "Runtime" },
-      issuer: { CN: "Siclaw Runtime CA", O: "Siclaw", OU: "Security" },
+      issuerAttrs: this.caSubjectAttrs,
       publicKey,
       signingKey: this.caKey,
       isCA: false,
@@ -141,7 +158,7 @@ export class CertificateManager {
 
     const cert = CertificateManager.createCertificateStatic({
       subject: { CN: agentId, O: orgId, serialNumber: boxId },
-      issuer: { CN: "Siclaw Runtime CA", O: "Siclaw", OU: "Security" },
+      issuerAttrs: this.caSubjectAttrs,
       publicKey,
       signingKey: this.caKey,
       isCA: false,
@@ -255,12 +272,20 @@ export class CertificateManager {
     if (opts.subject.serialNumber) subjectAttrs.push({ name: "serialNumber", value: opts.subject.serialNumber });
     cert.setSubject(subjectAttrs);
 
-    const issuerData = opts.issuer || opts.subject;
-    const issuerAttrs = [];
-    if (issuerData.CN) issuerAttrs.push({ name: "commonName", value: issuerData.CN });
-    if (issuerData.O) issuerAttrs.push({ name: "organizationName", value: issuerData.O });
-    if (issuerData.OU) issuerAttrs.push({ name: "organizationalUnitName", value: issuerData.OU });
-    cert.setIssuer(issuerAttrs);
+    if (opts.issuerAttrs) {
+      // Byte-exact copy of the CA's subject DN — preserves every attribute
+      // (C / ST / L / serialNumber / …) so X.509 path validation, which does
+      // a byte-wise Issuer↔Subject comparison, accepts the chain.
+      cert.setIssuer(opts.issuerAttrs);
+    } else {
+      // Self-sign or string-shape fallback (used by `generateCA`).
+      const issuerData = opts.issuer || opts.subject;
+      const issuerAttrs = [];
+      if (issuerData.CN) issuerAttrs.push({ name: "commonName", value: issuerData.CN });
+      if (issuerData.O) issuerAttrs.push({ name: "organizationName", value: issuerData.O });
+      if (issuerData.OU) issuerAttrs.push({ name: "organizationalUnitName", value: issuerData.OU });
+      cert.setIssuer(issuerAttrs);
+    }
 
     const extensions: any[] = [
       { name: "basicConstraints", cA: opts.isCA },
@@ -308,7 +333,12 @@ function isIpAddress(s: string): boolean {
 
 interface CertOpts {
   subject: Record<string, string>;
-  issuer: Record<string, string> | null;
+  /**
+   * Byte-exact issuer attributes copied from the signing CA's subject DN.
+   * Takes precedence over `issuer` when set.
+   */
+  issuerAttrs?: any[];
+  issuer?: Record<string, string> | null;
   publicKey: string;
   signingKey: string;
   isCA: boolean;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -86,6 +86,44 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   if (!opts.credentialService) throw new Error("credentialService is required in StartRuntimeOptions");
   const credentialService = opts.credentialService;
 
+  // ── Session Registry resolver ────────────────────────────
+  // Cache misses (e.g. async AgentBox callbacks arriving after a Runtime
+  // restart, before the next chat.send refills the LRU) fall back to Portal,
+  // where chat_sessions.user_id is the source of truth.
+  //
+  // Wrapped in a 5s timeout so a slow / unresponsive Portal can't stall every
+  // internal-api callback for the full FrontendWsClient default (30s). On
+  // timeout we degrade to "" userId, which matches the pre-fallback behaviour.
+  const RESOLVE_SESSION_TIMEOUT_MS = 5000;
+  sessionRegistry.setResolver(async (sessionId) => {
+    // Hold the timer handle outside Promise.race so we can cancel it once
+    // the rpc wins — otherwise every successful resolve leaks a pending 5s
+    // timer, and the post-restart callback burst this PR targets is exactly
+    // the case that piles up the most.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const rpc = frontendClient.request("chat.resolveSession", { session_id: sessionId });
+      const data = await Promise.race([
+        rpc,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`chat.resolveSession timed out after ${RESOLVE_SESSION_TIMEOUT_MS}ms`)),
+            RESOLVE_SESSION_TIMEOUT_MS,
+          );
+        }),
+      ]) as
+        | { found: false }
+        | { found: true; user_id: string; agent_id: string };
+      if (!data.found) return null;
+      return { userId: data.user_id, agentId: data.agent_id };
+    } catch (err) {
+      console.error("[session-registry] resolveSession RPC failed:", err);
+      return null;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  });
+
   // ── Certificate Manager ──────────────────────────────────
   const certManager = opts.certManager ?? await CertificateManager.create();
   agentBoxManager.setCertManager(certManager);

--- a/src/gateway/session-registry.test.ts
+++ b/src/gateway/session-registry.test.ts
@@ -1,56 +1,159 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { SessionRegistry } from "./session-registry.js";
 
 describe("SessionRegistry", () => {
-  it("resolves a remembered session back to its user", () => {
+  it("resolves a remembered session back to its user", async () => {
     const reg = new SessionRegistry();
     reg.remember("s1", "alice", "agent-a");
-    expect(reg.resolveUser("s1")).toBe("alice");
-    expect(reg.get("s1")).toMatchObject({ userId: "alice", agentId: "agent-a" });
+    expect(await reg.resolveUser("s1")).toBe("alice");
+    expect(await reg.get("s1")).toMatchObject({ userId: "alice", agentId: "agent-a" });
   });
 
-  it("returns empty string for unknown sessionId so callers never NPE", () => {
+  it("returns empty string for unknown sessionId so callers never NPE", async () => {
     const reg = new SessionRegistry();
-    expect(reg.resolveUser("missing")).toBe("");
-    expect(reg.resolveUser(undefined)).toBe("");
-    expect(reg.get("missing")).toBeUndefined();
+    expect(await reg.resolveUser("missing")).toBe("");
+    expect(await reg.resolveUser(undefined)).toBe("");
+    expect(await reg.get("missing")).toBeUndefined();
   });
 
-  it("forget drops the mapping", () => {
+  it("forget drops the mapping", async () => {
     const reg = new SessionRegistry();
     reg.remember("s1", "u1", "a1");
     reg.forget("s1");
-    expect(reg.resolveUser("s1")).toBe("");
+    expect(await reg.resolveUser("s1")).toBe("");
   });
 
-  it("remember updates the record in place when userId changes (rebind)", () => {
+  it("remember updates the record in place when userId changes (rebind)", async () => {
     const reg = new SessionRegistry();
     reg.remember("s1", "alice", "agent-a");
     reg.remember("s1", "bob", "agent-a");
-    expect(reg.resolveUser("s1")).toBe("bob");
+    expect(await reg.resolveUser("s1")).toBe("bob");
     expect(reg.size).toBe(1);
   });
 
-  it("evicts the oldest entry once capacity is exceeded", () => {
+  it("evicts the oldest entry once capacity is exceeded", async () => {
     const reg = new SessionRegistry(2);
     reg.remember("s1", "u1", "a");
     reg.remember("s2", "u2", "a");
     reg.remember("s3", "u3", "a");
     expect(reg.size).toBe(2);
     // s1 is the oldest; it should be evicted
-    expect(reg.resolveUser("s1")).toBe("");
-    expect(reg.resolveUser("s2")).toBe("u2");
-    expect(reg.resolveUser("s3")).toBe("u3");
+    expect(await reg.resolveUser("s1")).toBe("");
+    expect(await reg.resolveUser("s2")).toBe("u2");
+    expect(await reg.resolveUser("s3")).toBe("u3");
   });
 
-  it("re-remembering refreshes LRU position so the entry survives eviction", () => {
+  it("re-remembering refreshes LRU position so the entry survives eviction", async () => {
     const reg = new SessionRegistry(2);
     reg.remember("s1", "u1", "a");
     reg.remember("s2", "u2", "a");
     // Touch s1 to refresh; s2 becomes oldest.
     reg.remember("s1", "u1", "a");
     reg.remember("s3", "u3", "a");
-    expect(reg.resolveUser("s1")).toBe("u1");
-    expect(reg.resolveUser("s2")).toBe(""); // evicted
+    expect(await reg.resolveUser("s1")).toBe("u1");
+    expect(await reg.resolveUser("s2")).toBe(""); // evicted
+  });
+
+  describe("fallback resolver", () => {
+    it("calls resolver on cache miss and back-fills", async () => {
+      const reg = new SessionRegistry();
+      const resolver = vi.fn().mockResolvedValue({ userId: "alice", agentId: "agent-a" });
+      reg.setResolver(resolver);
+
+      expect(await reg.resolveUser("s1")).toBe("alice");
+      expect(resolver).toHaveBeenCalledWith("s1");
+      // Back-filled — second call hits cache, no second RPC.
+      expect(await reg.resolveUser("s1")).toBe("alice");
+      expect(resolver).toHaveBeenCalledTimes(1);
+      expect(reg.peek("s1")).toMatchObject({ userId: "alice", agentId: "agent-a" });
+    });
+
+    it("returns empty string when resolver reports the session is unknown", async () => {
+      const reg = new SessionRegistry();
+      const resolver = vi.fn().mockResolvedValue(null);
+      reg.setResolver(resolver);
+
+      expect(await reg.resolveUser("ghost")).toBe("");
+      expect(resolver).toHaveBeenCalledTimes(1);
+      // Negative result is not cached — next miss retries.
+      expect(await reg.resolveUser("ghost")).toBe("");
+      expect(resolver).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not call resolver when the cache already holds the entry", async () => {
+      const reg = new SessionRegistry();
+      const resolver = vi.fn();
+      reg.setResolver(resolver);
+      reg.remember("s1", "alice", "agent-a");
+
+      expect(await reg.resolveUser("s1")).toBe("alice");
+      expect(resolver).not.toHaveBeenCalled();
+    });
+
+    it("get() also benefits from fallback", async () => {
+      const reg = new SessionRegistry();
+      reg.setResolver(async () => ({ userId: "bob", agentId: "agent-b" }));
+
+      const rec = await reg.get("s2");
+      expect(rec).toMatchObject({ userId: "bob", agentId: "agent-b" });
+      // Cached after first lookup.
+      expect(reg.peek("s2")).toMatchObject({ userId: "bob", agentId: "agent-b" });
+    });
+
+    it("forget() during an in-flight resolver does not let the late response re-insert", async () => {
+      const reg = new SessionRegistry();
+      let resolveFn: ((v: { userId: string; agentId: string }) => void) | undefined;
+      reg.setResolver(() => new Promise(r => { resolveFn = r; }));
+
+      // Kick off a resolver call.
+      const pending = reg.resolveUser("s1");
+      await Promise.resolve();
+
+      // Explicit invalidation arrives while the RPC is still pending.
+      reg.forget("s1");
+
+      // Portal eventually responds — must NOT re-cache.
+      resolveFn!({ userId: "alice", agentId: "agent-a" });
+      // The in-flight callback that triggered the lookup still gets the
+      // value (so audit attribution for THAT request still works).
+      expect(await pending).toBe("alice");
+      // But the cache must remain empty — forget() was authoritative.
+      expect(reg.peek("s1")).toBeUndefined();
+    });
+
+    it("single-flights concurrent misses for the same sessionId", async () => {
+      const reg = new SessionRegistry();
+      let calls = 0;
+      let resolveFn: ((v: { userId: string; agentId: string }) => void) | undefined;
+      const pending = new Promise<{ userId: string; agentId: string }>((resolve) => {
+        resolveFn = resolve;
+      });
+      reg.setResolver(() => {
+        calls++;
+        return pending;
+      });
+
+      // Fire many concurrent lookups — only one resolver call should be made.
+      const inflight = Promise.all([
+        reg.resolveUser("s1"),
+        reg.resolveUser("s1"),
+        reg.resolveUser("s1"),
+        reg.resolveUser("s1"),
+      ]);
+      // Yield so all four reach the resolver-dispatch path.
+      await Promise.resolve();
+      expect(calls).toBe(1);
+
+      resolveFn!({ userId: "alice", agentId: "agent-a" });
+      const results = await inflight;
+      expect(results).toEqual(["alice", "alice", "alice", "alice"]);
+      expect(calls).toBe(1);
+
+      // Subsequent miss after the in-flight settled goes through to a fresh call.
+      reg.forget("s1");
+      await reg.resolveUser("s1").catch(() => undefined);
+      // pending was already settled; new call starts fresh
+      expect(calls).toBe(2);
+    });
   });
 });

--- a/src/gateway/session-registry.ts
+++ b/src/gateway/session-registry.ts
@@ -10,10 +10,10 @@
  *  - AgentBox → Runtime internal-api callbacks carry `sessionId` in the body.
  *    Handlers call `resolveUser(sessionId)` before forwarding to Upstream.
  *
- * This is an in-process LRU. Entries are lost on runtime restart; downstream
- * Upstream calls that land after a restart attribute to an empty user_id until
- * the next chat message re-populates the mapping. Cross-runtime consistency
- * is not required — each runtime serves its own agent pods.
+ * The map is an in-process LRU cache. On miss, an injected resolver (Portal
+ * RPC) is consulted so attribution survives Runtime restarts: the
+ * `chat_sessions` row is the source of truth, and the registry merely
+ * accelerates lookup.
  */
 
 const DEFAULT_CAPACITY = 10_000;
@@ -24,10 +24,27 @@ export interface SessionRecord {
   lastSeen: number;
 }
 
+export type SessionResolver = (
+  sessionId: string,
+) => Promise<{ userId: string; agentId: string } | null>;
+
 export class SessionRegistry {
   private map = new Map<string, SessionRecord>();
+  private resolver?: SessionResolver;
+  /**
+   * In-flight resolver promises keyed by sessionId. Coalesces concurrent
+   * cache misses for the same sid into one upstream RPC — relevant right
+   * after a Runtime restart, when many buffered AgentBox callbacks can
+   * arrive simultaneously and would otherwise fan out N identical RPCs.
+   */
+  private inflight = new Map<string, Promise<SessionRecord | undefined>>();
 
   constructor(private readonly capacity = DEFAULT_CAPACITY) {}
+
+  /** Inject a fallback resolver (e.g. Portal RPC). Pass `undefined` to clear. */
+  setResolver(resolver: SessionResolver | undefined): void {
+    this.resolver = resolver;
+  }
 
   /** Record that `sessionId` belongs to `userId` on `agentId`. Updates recency. */
   remember(sessionId: string, userId: string, agentId: string): void {
@@ -41,28 +58,88 @@ export class SessionRegistry {
     }
   }
 
-  /** Resolve `sessionId` to a userId. Returns empty string when unknown. */
-  resolveUser(sessionId: string | undefined): string {
-    if (!sessionId) return "";
-    const rec = this.map.get(sessionId);
-    if (!rec) return "";
-    rec.lastSeen = Date.now();
-    return rec.userId;
+  /**
+   * Resolve `sessionId` to a userId. On cache miss, calls the injected
+   * resolver and back-fills. Returns empty string when unknown.
+   */
+  async resolveUser(sessionId: string | undefined): Promise<string> {
+    const rec = await this.lookup(sessionId);
+    return rec ? rec.userId : "";
   }
 
-  /** Full record lookup. Returns `undefined` when unknown. */
-  get(sessionId: string | undefined): SessionRecord | undefined {
+  /**
+   * Full record lookup. On cache miss, calls the injected resolver and
+   * back-fills. Returns `undefined` when unknown.
+   */
+  async get(sessionId: string | undefined): Promise<SessionRecord | undefined> {
+    return this.lookup(sessionId);
+  }
+
+  /** Cache-only peek; no fallback. Useful in tests and tight sync paths. */
+  peek(sessionId: string | undefined): SessionRecord | undefined {
     if (!sessionId) return undefined;
     return this.map.get(sessionId);
   }
 
-  /** Drop an entry (e.g. when a session is terminated). */
+  /**
+   * Drop an entry (e.g. when a session is terminated). Also tombstones any
+   * in-flight resolver for the same sid so its eventual response cannot
+   * silently re-insert the entry we just invalidated.
+   */
   forget(sessionId: string): void {
     this.map.delete(sessionId);
+    this.tombstones.add(sessionId);
+    this.inflight.delete(sessionId);
   }
 
   get size(): number {
     return this.map.size;
+  }
+
+  /**
+   * Sessions invalidated while a resolver call was in flight. The resolver
+   * promise must check this set on settle and skip `remember()` — otherwise
+   * an explicit `forget()` can be undone by a racing Portal response.
+   */
+  private tombstones = new Set<string>();
+
+  private async lookup(sessionId: string | undefined): Promise<SessionRecord | undefined> {
+    if (!sessionId) return undefined;
+    const cached = this.map.get(sessionId);
+    if (cached) {
+      cached.lastSeen = Date.now();
+      return cached;
+    }
+    if (!this.resolver) return undefined;
+
+    // Single-flight: piggyback on any in-flight resolver call for this sid.
+    const inflight = this.inflight.get(sessionId);
+    if (inflight) return inflight;
+
+    const resolver = this.resolver;
+    // Snapshot any pre-existing tombstone so this lookup starts fresh; we
+    // only honor tombstones created while THIS resolver call is in flight.
+    this.tombstones.delete(sessionId);
+    const promise = (async () => {
+      try {
+        const fetched = await resolver(sessionId);
+        if (!fetched) return undefined;
+        // If forget() raced us while the RPC was outstanding, do NOT
+        // re-insert. Awaiters of THIS call still get the fetched record so
+        // the in-flight callback can still attribute, but the next miss
+        // will go to Portal afresh.
+        if (this.tombstones.has(sessionId)) {
+          return { ...fetched, lastSeen: Date.now() };
+        }
+        this.remember(sessionId, fetched.userId, fetched.agentId);
+        return this.map.get(sessionId);
+      } finally {
+        this.inflight.delete(sessionId);
+        this.tombstones.delete(sessionId);
+      }
+    })();
+    this.inflight.set(sessionId, promise);
+    return promise;
   }
 }
 

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -657,6 +657,40 @@ describe("chat.ensureSession", () => {
   });
 });
 
+describe("chat.resolveSession", () => {
+  it("returns found with user_id and agent_id when row exists", async () => {
+    mockQuery([{ user_id: "u1", agent_id: "a1" }]);
+    const result = await getHandler("chat.resolveSession")(
+      { session_id: "sess1" }, "a1",
+    );
+    expect(result).toEqual({ found: true, user_id: "u1", agent_id: "a1" });
+  });
+
+  it("returns found:false when sessionId is unknown", async () => {
+    mockQuery([]);
+    const result = await getHandler("chat.resolveSession")(
+      { session_id: "nope" }, "a1",
+    );
+    expect(result).toEqual({ found: false });
+  });
+
+  it("still resolves attribution for a soft-deleted session — late callbacks must find userId", async () => {
+    // The SQL deliberately omits `AND deleted_at IS NULL` so that audit
+    // attribution does not vanish when a user soft-deletes their chat.
+    // This test pins the invariant: a row whose deleted_at is non-null
+    // still surfaces through chat.resolveSession.
+    const query = mockQuery([{ user_id: "u-deleted", agent_id: "a-deleted" }]);
+    const result = await getHandler("chat.resolveSession")(
+      { session_id: "sess-soft-deleted" }, "a1",
+    );
+    expect(result).toEqual({ found: true, user_id: "u-deleted", agent_id: "a-deleted" });
+    // Defense in depth: the SQL must not mention deleted_at. If anyone
+    // re-adds that predicate in a future "cleanup" PR this regresses.
+    const sql = (query.mock.calls[0][0] as string).toLowerCase();
+    expect(sql).not.toContain("deleted_at");
+  });
+});
+
 describe("chat.appendMessage", () => {
   it("inserts message and bumps session count", async () => {
     const query = mockQuery([], []);
@@ -1241,9 +1275,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 43 handlers", () => {
+  it("registers exactly 44 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(43);
+    expect(handlers.size).toBe(44);
   });
 
   it("all expected handler names are registered", () => {
@@ -1254,7 +1288,7 @@ describe("buildAdapterRpcHandlers", () => {
       "config.getSystemConfig", "config.setSystemConfig", "config.getDefaultModel",
       "credential.list", "credential.get", "credential.checkAccess",
       "credential.resourceManifest", "credential.hostSearch",
-      "chat.ensureSession", "chat.appendMessage", "chat.updateMessage", "chat.updateDelegationToolMessage", "chat.getMessages",
+      "chat.ensureSession", "chat.resolveSession", "chat.appendMessage", "chat.updateMessage", "chat.updateDelegationToolMessage", "chat.getMessages",
       "task.listActive", "task.getStatus", "task.list", "task.create",
       "task.update", "task.delete", "task.runRecord", "task.runStart",
       "task.runFinalize", "task.updateMeta", "task.fireNow", "task.notify", "task.prune",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1861,6 +1861,20 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
 
   // --- chat.* ---
 
+  handlers.set("chat.resolveSession", async (params) => {
+    const db = getDb();
+    // Intentionally NOT filtering on deleted_at — soft-deleted sessions still
+    // need attribution for late-arriving AgentBox callbacks (audit / task
+    // outcomes). The row's user_id is immutable history, regardless of
+    // visibility in the UI.
+    const [rows] = await db.query(
+      `SELECT user_id, agent_id FROM chat_sessions WHERE id = ? LIMIT 1`,
+      [params.session_id],
+    ) as any;
+    if (!rows || rows.length === 0) return { found: false };
+    return { found: true, user_id: rows[0].user_id, agent_id: rows[0].agent_id };
+  });
+
   handlers.set("chat.ensureSession", async (params) => {
     const db = getDb();
     // last_active_at omitted: relies on schema DEFAULT CURRENT_TIMESTAMP for


### PR DESCRIPTION
Three coordinated fixes that together let a Runtime pod restart leave existing AgentBox pods, in-flight chats, and async callback attribution intact.

cert-manager: derive issuer DN from the loaded CA subject instead of hardcoding "Siclaw Runtime CA". Hardcoding broke chart-managed CAs (Helm genCA only sets CN) — issued certs claimed an issuer that no AgentBox could verify against, surfacing as "unable to verify the first certificate" on every mTLS handshake.

helm chart: persist the mTLS CA in a kubernetes.io/tls Secret. lookup reuses the existing CA on upgrade; first-install genCA writes once. Annotated helm.sh/resource-policy=keep so helm uninstall does not orphan AgentBox client certs. SICLAW_CA_CERT/KEY injected into the Runtime Deployment via secretKeyRef before runtime.env so user overrides still win. Default generateCa=true with a fail-fast helper rejecting ephemeral mode in K8s.

session-registry: on cache miss, call a Portal-side chat.resolveSession RPC and back-fill, so async AgentBox callbacks that arrive after a Runtime restart but before the next chat.send still resolve user attribution. Resolver wired through credential-service and internal- api delegation/task paths.

## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **DB parity**: Schema changes keep `src/portal/migrate.ts` compatible with both MySQL and SQLite (see [`docs/design/invariants.md §5`](../docs/design/invariants.md)).
- [ ] **Tool protocol**: New tools register through `src/core/tool-registry.ts` and use the TypeBox `ToolDefinition` protocol.

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
