### PR TITLE
feat(chat): per-message timing badges + Metrics latency breakdown

### DIFF
--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useCallback, useMemo } from "react"
+import { useRef, useEffect, useState, useCallback, useMemo, type MouseEvent } from "react"
 import {
   Terminal,
   User,
@@ -24,7 +24,54 @@ import { Markdown } from "./Markdown"
 import { InputArea } from "./InputArea"
 import { SkillCard } from "./SkillCard"
 import { ScheduleCard } from "./ScheduleCard"
-import type { PilotMessage, ContextUsage, ActionChip, PrefixActionChip } from "./types"
+import type { PilotMessage, ContextUsage, ActionChip, PrefixActionChip, MessageTiming } from "./types"
+
+/**
+ * Format a millisecond duration into a compact human-readable string.
+ * <1s → "850ms"; <60s → "3.2s"; ≥60s → "1m 12s".
+ */
+function formatTimingMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return ""
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const m = Math.floor(ms / 60_000)
+  const s = Math.round((ms % 60_000) / 1000)
+  return `${m}m ${s}s`
+}
+
+/**
+ * Inline timing badges shown beneath chat bubbles. Emoji semantics, per spec:
+ *   ⏳ ttftMs        — time-to-first-token (assistant rows)
+ *   💭 thinkingMs    — model reasoning gap before visible text (assistant rows)
+ *   ⚙️ durationMs   — bash/kubectl/skill execution time (tool rows)
+ *
+ * Badge is omitted entirely when no timing is present, so messages without
+ * server-stamped timings (legacy history) render unchanged.
+ */
+function TimingBadges({ timing }: { timing: MessageTiming | undefined }) {
+  if (!timing) return null
+  // Order chosen so the badges read like a timeline left-to-right:
+  //   ⏳ before-first-token (turn anchor)
+  //   💭 thinking (boundary → first delta)
+  //   ✍️ writing (first delta → message_end)
+  //   ⚙️ tool exec (separate from the above; only on tool rows)
+  const items: Array<{ key: string; label: string }> = []
+  if (typeof timing.ttftMs === "number") items.push({ key: "ttft", label: `⏳ ${formatTimingMs(timing.ttftMs)}` })
+  if (typeof timing.thinkingMs === "number") items.push({ key: "think", label: `💭 ${formatTimingMs(timing.thinkingMs)}` })
+  if (typeof timing.outputMs === "number") items.push({ key: "out", label: `✍️ ${formatTimingMs(timing.outputMs)}` })
+  if (typeof timing.durationMs === "number") items.push({ key: "dur", label: `⚙️ ${formatTimingMs(timing.durationMs)}` })
+  if (items.length === 0) return null
+  // `select-text` makes the values copyable so the user can audit timing math
+  // by selecting and pasting. Numbers + units are kept in one span per badge
+  // so a single drag selects the whole figure.
+  return (
+    <div className="flex flex-wrap gap-2 mt-1.5 text-[11px] text-muted-foreground/80 select-text">
+      {items.map((it) => (
+        <span key={it.key} className="font-mono tabular-nums select-text cursor-text">{it.label}</span>
+      ))}
+    </div>
+  )
+}
 
 const DIG_DEEPER_CHIP: PrefixActionChip = {
   kind: "prefix",
@@ -1070,6 +1117,8 @@ function MessageItem({
           <CopyableMessage isUser={isUser} content={textContent} />
         )}
 
+        {!isUser && <TimingBadges timing={message.timing} />}
+
         {renderedSuggestedChips.length > 0 && onChipClick && (
           <div className="flex flex-wrap gap-2 mt-2">
             {renderedSuggestedChips.map((chip) => (
@@ -1485,14 +1534,50 @@ function ToolItem({ message }: { message: PilotMessage }) {
           {message.toolInput && (
             <span className="font-mono text-xs text-muted-foreground truncate min-w-0">{message.toolInput}</span>
           )}
-          {message.toolStatus === "running" && (
-            <Loader2 className="w-3 h-3 animate-spin text-blue-400 ml-auto shrink-0" />
-          )}
-          {message.toolStatus === "success" && (
-            <CheckCircle2 className="w-3.5 h-3.5 text-green-500 ml-auto shrink-0" />
-          )}
-          {message.toolStatus === "error" && <XCircle className="w-3.5 h-3.5 text-red-500 ml-auto shrink-0" />}
-          {message.toolStatus === "aborted" && <Ban className="w-3.5 h-3.5 text-amber-500 ml-auto shrink-0" />}
+          {(() => {
+            // 💭 thinking-before-tool + ⚙️ exec-time. Either, both, or neither
+            // may be present; the first one rendered claims `ml-auto` so the
+            // status icon trails naturally without extra layout branching.
+            const t = message.timing
+            const showThink = typeof t?.thinkingMs === "number"
+            const showDur = typeof t?.durationMs === "number"
+            const hasAnyTiming = showThink || showDur
+            // stopPropagation on mousedown lets the user drag-select the
+            // numbers without the parent <button> capturing it as a click
+            // (which would toggle expand and clear the selection). cursor-text
+            // signals the affordance.
+            const stopSel = (e: MouseEvent) => e.stopPropagation()
+            return (
+              <>
+                {showThink && (
+                  <span
+                    onMouseDown={stopSel}
+                    onClick={stopSel}
+                    className={cn("font-mono text-[11px] text-muted-foreground tabular-nums shrink-0 select-text cursor-text", "ml-auto")}
+                  >
+                    💭 {formatTimingMs(t!.thinkingMs!)}
+                  </span>
+                )}
+                {showDur && (
+                  <span
+                    onMouseDown={stopSel}
+                    onClick={stopSel}
+                    className={cn("font-mono text-[11px] text-muted-foreground tabular-nums shrink-0 select-text cursor-text", showThink ? "ml-2" : "ml-auto")}
+                  >
+                    ⚙️ {formatTimingMs(t!.durationMs!)}
+                  </span>
+                )}
+                {message.toolStatus === "running" && (
+                  <Loader2 className={cn("w-3 h-3 animate-spin text-blue-400 shrink-0", hasAnyTiming ? "ml-1.5" : "ml-auto")} />
+                )}
+                {message.toolStatus === "success" && (
+                  <CheckCircle2 className={cn("w-3.5 h-3.5 text-green-500 shrink-0", hasAnyTiming ? "ml-1.5" : "ml-auto")} />
+                )}
+                {message.toolStatus === "error" && <XCircle className={cn("w-3.5 h-3.5 text-red-500 shrink-0", hasAnyTiming ? "ml-1.5" : "ml-auto")} />}
+                {message.toolStatus === "aborted" && <Ban className={cn("w-3.5 h-3.5 text-amber-500 shrink-0", hasAnyTiming ? "ml-1.5" : "ml-auto")} />}
+              </>
+            )
+          })()}
         </button>
         {isOpen && (
           <div className="overflow-x-auto bg-secondary/30 max-h-80 overflow-y-auto">

--- a/portal-web/src/components/chat/types.ts
+++ b/portal-web/src/components/chat/types.ts
@@ -4,6 +4,31 @@ export type MessageRole = "user" | "assistant" | "tool"
 
 export type ToolStatus = "running" | "success" | "error" | "aborted"
 
+/**
+ * Per-message timing data shown as small badges in the chat bubble.
+ *
+ * Designed so a naive sum of all visible badges equals the turn's wall clock
+ * (within event-dispatch noise) — no double-counting, no missing intervals.
+ *
+ * Assistant messages:
+ *   - ⏳ ttftMs:     first message of a turn ONLY. Time to first token.
+ *   - 💭 thinkingMs: boundary (turn-start or last tool_end) → first text token.
+ *   - ✍️ outputMs:  first text token → message_end (text streaming time).
+ *
+ * Tool messages:
+ *   - 💭 thinkingMs: model reasoning before this tool fired (boundary-based).
+ *   - ⚙️ durationMs: tool wall-clock execution time.
+ *
+ * turnTotalMs is carried for cross-checking but not rendered as a badge.
+ */
+export interface MessageTiming {
+  ttftMs?: number
+  thinkingMs?: number
+  outputMs?: number
+  durationMs?: number
+  turnTotalMs?: number
+}
+
 export interface PilotMessage {
   id: string
   role: MessageRole
@@ -16,6 +41,8 @@ export interface PilotMessage {
   /** Structured details from tool result metadata */
   toolDetails?: Record<string, unknown>
   metadata?: Record<string, unknown>
+  /** Timing badges (⏳ TTFT / 💭 thinking / ⚙️ tool-exec) */
+  timing?: MessageTiming
   fromAgentId?: string | null
   parentSessionId?: string | null
   delegationId?: string | null

--- a/portal-web/src/components/metrics/TimingStatsCard.tsx
+++ b/portal-web/src/components/metrics/TimingStatsCard.tsx
@@ -1,0 +1,99 @@
+/**
+ * Per-metric latency statistics card for the Metrics dashboard.
+ *
+ * Renders three rows — ⏳ TTFT, 💭 Thinking, ⚙️ Bash — each with avg / min /
+ * max / p90 columns. Numbers come from /api/v1/siclaw/metrics/timing which
+ * aggregates the same per-message timing fields the chat UI shows as badges.
+ */
+import type { LatencyStats, TimingStats } from "../../hooks/useMetrics"
+
+interface Props {
+  data: TimingStats | null
+  period: "today" | "7d" | "30d"
+}
+
+const PERIOD_LABEL: Record<Props["period"], string> = {
+  today: "today",
+  "7d": "last 7 days",
+  "30d": "last 30 days",
+}
+
+/** Match the chat-bubble badge formatter so dashboard reads agree with chat. */
+function fmtMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—"
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const m = Math.floor(ms / 60_000)
+  const s = Math.round((ms % 60_000) / 1000)
+  return `${m}m ${s}s`
+}
+
+const ROWS: Array<{ key: keyof TimingStats; emoji: string; label: string; hint: string }> = [
+  { key: "ttft", emoji: "⏳", label: "TTFT", hint: "first token" },
+  { key: "thinking", emoji: "💭", label: "Thinking", hint: "boundary → first token" },
+  { key: "bash", emoji: "⚙️", label: "Bash", hint: "tool execution" },
+]
+
+export function TimingStatsCard({ data, period }: Props) {
+  return (
+    <div className="border border-border rounded-lg bg-card p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-semibold tracking-tight">Latency Breakdown</h3>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            avg · min · max · p90 · {PERIOD_LABEL[period]}
+          </p>
+        </div>
+      </div>
+      <div className="grid grid-cols-[auto_repeat(5,minmax(0,1fr))] gap-x-4 gap-y-1 items-baseline text-[12px]">
+        {/* Header */}
+        <div />
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">avg</div>
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">min</div>
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">max</div>
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">p90</div>
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">n</div>
+        {ROWS.map((row) => {
+          const stats: LatencyStats = data?.[row.key] ?? { count: 0, avg: 0, min: 0, max: 0, p90: 0 }
+          const empty = stats.count === 0
+          return (
+            <Row key={row.key} emoji={row.emoji} label={row.label} hint={row.hint} stats={stats} empty={empty} />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function Row({ emoji, label, hint, stats, empty }: {
+  emoji: string; label: string; hint: string; stats: LatencyStats; empty: boolean
+}) {
+  return (
+    <>
+      <div className="py-1.5">
+        <div className="flex items-center gap-2">
+          <span className="text-base leading-none select-text">{emoji}</span>
+          <div>
+            <div className="font-medium text-foreground">{label}</div>
+            <div className="text-[10px] text-muted-foreground -mt-0.5">{hint}</div>
+          </div>
+        </div>
+      </div>
+      <Cell value={stats.avg} empty={empty} />
+      <Cell value={stats.min} empty={empty} />
+      <Cell value={stats.max} empty={empty} />
+      <Cell value={stats.p90} empty={empty} />
+      <div className={`font-mono tabular-nums text-right py-1.5 select-text ${empty ? "text-muted-foreground/50" : "text-muted-foreground"}`}>
+        {empty ? "—" : stats.count.toLocaleString()}
+      </div>
+    </>
+  )
+}
+
+function Cell({ value, empty }: { value: number; empty: boolean }) {
+  return (
+    <div className={`font-mono tabular-nums text-right py-1.5 select-text ${empty ? "text-muted-foreground/50" : "text-foreground"}`}>
+      {empty ? "—" : fmtMs(value)}
+    </div>
+  )
+}

--- a/portal-web/src/components/metrics/TimingStatsCard.tsx
+++ b/portal-web/src/components/metrics/TimingStatsCard.tsx
@@ -1,11 +1,18 @@
 /**
  * Per-metric latency statistics card for the Metrics dashboard.
  *
- * Renders three rows — ⏳ TTFT, 💭 Thinking, ⚙️ Bash — each with avg / min /
- * max / p90 columns. Numbers come from /api/v1/siclaw/metrics/timing which
- * aggregates the same per-message timing fields the chat UI shows as badges.
+ * Two sections:
+ *   • Model — ⏳ TTFT, 💭 Thinking
+ *   • Tools — top-N tools by invocation count, default top 3, selector for
+ *     3 / 5 / 10. Switching N is a client-side slice (no extra request);
+ *     backend always returns the full sorted list.
+ *
+ * Numbers come from /api/v1/siclaw/metrics/timing — same per-message timing
+ * fields the chat UI shows as ⏳/💭/⚙️ badges. Whatever is summed in chat
+ * for a turn is what gets aggregated here for the period.
  */
-import type { LatencyStats, TimingStats } from "../../hooks/useMetrics"
+import { useState } from "react"
+import type { LatencyStats, TimingStats, ToolLatencyStats } from "../../hooks/useMetrics"
 
 interface Props {
   data: TimingStats | null
@@ -18,6 +25,9 @@ const PERIOD_LABEL: Record<Props["period"], string> = {
   "30d": "last 30 days",
 }
 
+const TOP_OPTIONS = [3, 5, 10] as const
+type TopN = typeof TOP_OPTIONS[number]
+
 /** Match the chat-bubble badge formatter so dashboard reads agree with chat. */
 function fmtMs(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return "—"
@@ -28,13 +38,16 @@ function fmtMs(ms: number): string {
   return `${m}m ${s}s`
 }
 
-const ROWS: Array<{ key: keyof TimingStats; emoji: string; label: string; hint: string }> = [
+const MODEL_ROWS: Array<{ key: "ttft" | "thinking"; emoji: string; label: string; hint: string }> = [
   { key: "ttft", emoji: "⏳", label: "TTFT", hint: "first token" },
   { key: "thinking", emoji: "💭", label: "Thinking", hint: "boundary → first token" },
-  { key: "bash", emoji: "⚙️", label: "Bash", hint: "tool execution" },
 ]
 
 export function TimingStatsCard({ data, period }: Props) {
+  const [topN, setTopN] = useState<TopN>(3)
+  const tools = data?.tools ?? []
+  const visibleTools = tools.slice(0, topN)
+
   return (
     <div className="border border-border rounded-lg bg-card p-4">
       <div className="flex items-center justify-between mb-3">
@@ -44,37 +57,120 @@ export function TimingStatsCard({ data, period }: Props) {
             avg · min · max · p90 · {PERIOD_LABEL[period]}
           </p>
         </div>
+        {data?.truncated && (
+          <span
+            title="Query hit the row-scan cap; figures are a recency-biased sample, not the full window."
+            className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-amber-500/40 text-amber-500 select-text"
+          >
+            sampled
+          </span>
+        )}
       </div>
-      <div className="grid grid-cols-[auto_repeat(5,minmax(0,1fr))] gap-x-4 gap-y-1 items-baseline text-[12px]">
-        {/* Header */}
-        <div />
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">avg</div>
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">min</div>
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">max</div>
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">p90</div>
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">n</div>
-        {ROWS.map((row) => {
+
+      {/* ── Model section: ⏳ + 💭 ───────────────────── */}
+      <StatGrid>
+        <GridHeader />
+        {MODEL_ROWS.map((row) => {
           const stats: LatencyStats = data?.[row.key] ?? { count: 0, avg: 0, min: 0, max: 0, p90: 0 }
           const empty = stats.count === 0
-          return (
-            <Row key={row.key} emoji={row.emoji} label={row.label} hint={row.hint} stats={stats} empty={empty} />
-          )
+          return <Row key={row.key} emoji={row.emoji} label={row.label} hint={row.hint} stats={stats} empty={empty} />
         })}
+      </StatGrid>
+
+      {/* ── Tools section: top-N by invocation count ─── */}
+      <div className="mt-4 pt-3 border-t border-border">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2">
+            {/* Larger gear marks the section header — mirrors the chat
+                bubble's ⚙️ but at twice the body-text size for visual weight. */}
+            <span className="text-[13px] leading-none select-none" aria-hidden="true">⚙️</span>
+            <div className="flex items-baseline gap-2">
+              <h4 className="text-[11px] font-semibold text-foreground">Tools</h4>
+              <span className="text-[10px] text-muted-foreground">
+                top {Math.min(topN, tools.length)} of {tools.length} · by invocation count
+              </span>
+            </div>
+          </div>
+          {/* Slice selector — pure client-side, no re-fetch needed. */}
+          <div className="flex items-center gap-1">
+            {TOP_OPTIONS.map((n) => (
+              <button
+                key={n}
+                onClick={() => setTopN(n)}
+                className={
+                  "px-2 py-0.5 text-[11px] rounded-md border transition-colors " +
+                  (topN === n
+                    ? "border-blue-500 bg-blue-500/10 text-blue-400"
+                    : "border-border bg-secondary text-muted-foreground hover:text-foreground")
+                }
+              >
+                Top {n}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {visibleTools.length === 0 ? (
+          <div className="text-[11px] text-muted-foreground/70 py-2 select-text">
+            No tool executions in this window.
+          </div>
+        ) : (
+          <StatGrid>
+            <GridHeader />
+            {visibleTools.map((tool) => {
+              const empty = tool.count === 0
+              return (
+                <Row
+                  // 🔧 wrench distinguishes individual tool rows from the
+                  // ⚙️ gear used for the section header — same family of
+                  // "tool" iconography, different role.
+                  key={tool.toolName}
+                  emoji="🔧"
+                  label={tool.toolName}
+                  hint="tool execution"
+                  stats={tool}
+                  empty={empty}
+                />
+              )
+            })}
+          </StatGrid>
+        )}
       </div>
     </div>
   )
 }
 
+function StatGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[auto_repeat(5,minmax(0,1fr))] gap-x-4 gap-y-1 items-baseline text-[12px]">
+      {children}
+    </div>
+  )
+}
+
+function GridHeader() {
+  return (
+    <>
+      <div />
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">avg</div>
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">min</div>
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">max</div>
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">p90</div>
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground text-right">n</div>
+    </>
+  )
+}
+
 function Row({ emoji, label, hint, stats, empty }: {
-  emoji: string; label: string; hint: string; stats: LatencyStats; empty: boolean
+  emoji: string; label: string; hint: string; stats: LatencyStats | ToolLatencyStats; empty: boolean
 }) {
   return (
     <>
-      <div className="py-1.5">
+      <div className="py-1.5 min-w-0">
         <div className="flex items-center gap-2">
           <span className="text-base leading-none select-text">{emoji}</span>
-          <div>
-            <div className="font-medium text-foreground">{label}</div>
+          <div className="min-w-0">
+            <div className="font-medium text-foreground truncate select-text" title={label}>{label}</div>
             <div className="text-[10px] text-muted-foreground -mt-0.5">{hint}</div>
           </div>
         </div>

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -48,10 +48,19 @@ export interface LatencyStats {
   p90: number
 }
 
+/** One tool's stats — `toolName` plus the standard latency summary. */
+export interface ToolLatencyStats extends LatencyStats {
+  toolName: string
+}
+
 export interface TimingStats {
   ttft: LatencyStats
   thinking: LatencyStats
-  bash: LatencyStats
+  /** All tools with at least one duration sample, sorted by `count` DESC.
+   *  The card slices client-side to the user-chosen top 3 / 5 / 10. */
+  tools: ToolLatencyStats[]
+  /** True when the backend hit ROW_LIMIT and the figures are a recent-only sample. */
+  truncated?: boolean
 }
 
 export interface AuditLog {

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -35,6 +35,25 @@ export interface SummaryData {
   byUser: Array<{ userId: string; sessions: number; messages: number }>
 }
 
+/**
+ * Aggregate stats for one timing series (ttft, thinking, bash). All ms.
+ * `count = 0` signals "no data" — the card should render an empty-state hint
+ * rather than a row of zeros.
+ */
+export interface LatencyStats {
+  count: number
+  avg: number
+  min: number
+  max: number
+  p90: number
+}
+
+export interface TimingStats {
+  ttft: LatencyStats
+  thinking: LatencyStats
+  bash: LatencyStats
+}
+
 export interface AuditLog {
   id: string
   sessionId: string
@@ -80,6 +99,27 @@ export function useLive(userId: string | null): { data: LiveData | null; loading
   }, [userId, fetchOnce])
 
   return { data, loading, error, refresh: fetchOnce }
+}
+
+export function useTimingStats(period: string, userId: string | null): { data: TimingStats | null; loading: boolean; refresh: () => void } {
+  const [data, setData] = useState<TimingStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const paramsRef = useRef({ period, userId })
+  paramsRef.current = { period, userId }
+
+  const fetchOnce = useCallback(() => {
+    setLoading(true)
+    const { period: p, userId: uid } = paramsRef.current
+    const q = new URLSearchParams({ period: p })
+    if (uid) q.set("userId", uid)
+    return api<TimingStats>(`/siclaw/metrics/timing?${q.toString()}`)
+      .then((d) => { setData(d); setLoading(false) })
+      .catch(() => setLoading(false))
+  }, [])
+
+  useEffect(() => { fetchOnce() }, [period, userId, fetchOnce])
+
+  return { data, loading, refresh: fetchOnce }
 }
 
 export function useSummary(period: string, userId: string | null): { data: SummaryData | null; loading: boolean; refresh: () => void } {

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -228,6 +228,30 @@ function findLastMessageIndex<T>(items: T[], predicate: (item: T) => boolean): n
   return -1;
 }
 
+function extractTiming(metadata: Record<string, unknown> | undefined, durationMs: number | null | undefined): import("../components/chat/types").MessageTiming | undefined {
+  // Tool rows: duration_ms (⚙️ exec) is its own column; pre_thinking_ms
+  // (💭 model-thinking-before-this-tool) lives at metadata.pre_thinking_ms.
+  // Assistant rows: timing sub-object inside metadata holds ⏳ ttft, 💭
+  // thinking-before-text, and turn-total.
+  const t: import("../components/chat/types").MessageTiming = {}
+  const rawTiming = metadata?.timing as Record<string, unknown> | undefined
+  if (rawTiming) {
+    if (typeof rawTiming.ttft_ms === "number") t.ttftMs = rawTiming.ttft_ms
+    if (typeof rawTiming.thinking_ms === "number") t.thinkingMs = rawTiming.thinking_ms
+    if (typeof rawTiming.output_ms === "number") t.outputMs = rawTiming.output_ms
+    if (typeof rawTiming.turn_total_ms === "number") t.turnTotalMs = rawTiming.turn_total_ms
+  }
+  // Pre-tool thinking gets surfaced as the same `thinkingMs` field — it's
+  // semantically the same emoji (💭 model reasoning) just attached to a
+  // tool row instead of a text row. UI uses one badge code path either way.
+  // No threshold: a 0/small 💭 on the 2nd-Nth tool of a batch is the visible
+  // proof that they came from one thinking burst (not N independent ones).
+  const preThinking = metadata?.pre_thinking_ms
+  if (typeof preThinking === "number") t.thinkingMs = preThinking
+  if (typeof durationMs === "number" && durationMs >= 0) t.durationMs = durationMs
+  return Object.keys(t).length > 0 ? t : undefined
+}
+
 function toPilotMessage(m: ChatMessage): PilotMessage {
   const toolArgs = m.tool_input ? tryParseJson(m.tool_input) : undefined
   const metadata = normalizeMetadata(m.metadata)
@@ -242,6 +266,7 @@ function toPilotMessage(m: ChatMessage): PilotMessage {
         recovery_reason: toolIsDelegation ? "stale_delegation_tool" : "stale_running_tool",
       }
     : metadata
+  const timing = extractTiming(metadata, m.duration_ms)
   return {
     id: m.id,
     role: m.role,
@@ -255,6 +280,7 @@ function toPilotMessage(m: ChatMessage): PilotMessage {
     toolInput: toolArgs ? formatToolInput(m.tool_name ?? "", toolArgs) : undefined,
     toolStatus,
     metadata: recoveredMetadata,
+    timing,
     hidden: m.hidden || isDelegationEvent,
     fromAgentId: m.from_agent_id ?? null,
     parentSessionId: m.parent_session_id ?? null,
@@ -690,6 +716,11 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           const toolInput = formatToolInput(toolName ?? "", args)
           const hidden = toolName === "update_plan"
           const dbMessageId = evt.dbMessageId as string | undefined
+          // 💭 Pre-tool thinking time (gap from previous tool_end / turn-start
+          // to now). Server-stamped; matches the value persisted in the row's
+          // metadata.pre_thinking_ms, so live and reload render identically.
+          const preThinkingMs = typeof evt.preThinkingMs === "number" ? evt.preThinkingMs : undefined
+          const showThinking = preThinkingMs != null
 
           setMessages((prev) => [
             ...prev,
@@ -704,6 +735,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
               timestamp: timeNow(),
               isStreaming: true,
               hidden,
+              ...(showThinking ? { timing: { thinkingMs: preThinkingMs } } : {}),
             },
           ])
           break
@@ -723,6 +755,9 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           const isError = evt.isError as boolean | undefined
           // Use real DB message ID if available (enables metadata persistence)
           const dbMessageId = evt.dbMessageId as string | undefined
+          // ⚙️ Server-stamped tool execution duration (matches duration_ms
+          // column written at the same moment).
+          const durationMs = typeof evt.durationMs === "number" ? evt.durationMs : undefined
 
           setMessages((prev) => {
             const index = dbMessageId
@@ -739,6 +774,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
                 toolStatus: isError ? ("error" as const) : ("success" as const),
                 isStreaming: false,
                 ...(toolDetails ? { toolDetails, metadata: toolDetails } : {}),
+                ...(durationMs != null ? { timing: { ...(current.timing ?? {}), durationMs } } : {}),
                 ...(dbMessageId ? { id: dbMessageId } : {}),
               }
               return [
@@ -794,6 +830,26 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           const endMsg = evt.message as
             | { role?: string; toolName?: string; details?: Record<string, unknown> }
             | undefined
+          // ⏳/💭/✍️ Server-stamped per-message timing block, attached to
+          // the event by sse-consumer right before persistence.
+          const evtTiming = evt.timing as
+            | { ttft_ms?: number; thinking_ms?: number; output_ms?: number; turn_total_ms?: number }
+            | undefined
+          if (endMsg?.role === "assistant" && evtTiming) {
+            setMessages((prev) => {
+              const idx = findLastMessageIndex(prev, (m) => m.role === "assistant")
+              if (idx < 0) return prev
+              const current = prev[idx]
+              const timing = {
+                ...(current.timing ?? {}),
+                ...(typeof evtTiming.ttft_ms === "number" ? { ttftMs: evtTiming.ttft_ms } : {}),
+                ...(typeof evtTiming.thinking_ms === "number" ? { thinkingMs: evtTiming.thinking_ms } : {}),
+                ...(typeof evtTiming.output_ms === "number" ? { outputMs: evtTiming.output_ms } : {}),
+                ...(typeof evtTiming.turn_total_ms === "number" ? { turnTotalMs: evtTiming.turn_total_ms } : {}),
+              }
+              return [...prev.slice(0, idx), { ...current, timing }, ...prev.slice(idx + 1)]
+            })
+          }
           if (endMsg?.role === "toolResult" && endMsg.details && Object.keys(endMsg.details).length > 0) {
             // Pi-agent brain: tool result details arrive via message_end (not tool_execution_end).
             // Backfill toolDetails onto the matching tool message.

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, useState } from "react"
 import { Loader2, RefreshCw } from "lucide-react"
-import { useLive, useSummary, useUsers } from "../hooks/useMetrics"
+import { useLive, useSummary, useTimingStats, useUsers } from "../hooks/useMetrics"
 import { KpiCards } from "../components/metrics/KpiCards"
 import { RankedTable } from "../components/metrics/RankedTable"
+import { TimingStatsCard } from "../components/metrics/TimingStatsCard"
 import { AuditTable } from "../components/metrics/AuditTable"
 import { GrafanaFrame } from "../components/metrics/GrafanaFrame"
 
@@ -18,14 +19,15 @@ export function Metrics() {
   const { users } = useUsers()
   const { data: live, loading: liveLoading, refresh: refreshLive } = useLive(filterUserId)
   const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(period, filterUserId)
+  const { data: timing, refresh: refreshTiming } = useTimingStats(period, filterUserId)
 
   const [spinning, setSpinning] = useState(false)
   const handleRefresh = useCallback(() => {
     setSpinning(true)
-    Promise.all([refreshLive(), refreshSummary()]).finally(() => {
+    Promise.all([refreshLive(), refreshSummary(), refreshTiming()]).finally(() => {
       setTimeout(() => setSpinning(false), 600)
     })
-  }, [refreshLive, refreshSummary])
+  }, [refreshLive, refreshSummary, refreshTiming])
 
   const selectedUsername = useMemo(() => {
     if (!userId) return null
@@ -113,6 +115,8 @@ export function Metrics() {
                   toolCallsTotal={(live?.topTools ?? []).reduce((s, t) => s + t.total, 0)}
                   period={period}
                 />
+
+                <TimingStatsCard data={timing} period={period} />
 
                 <div className="grid grid-cols-2 gap-4">
                   <RankedTable

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -106,6 +106,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const orgId = params.orgId as string | undefined;
     const text = params.text as string;
     const incomingSessionId = params.sessionId as string | undefined;
+    // Portal stamps turnStartMs at POST receipt — closer to user click than
+    // the runtime's loop start. Use it as the canonical turn anchor when
+    // present; fall back gracefully so direct callers (tests, /run path)
+    // still work without it.
+    const turnStartMs = typeof params.turnStartMs === "number" ? params.turnStartMs : undefined;
 
     if (!agentId || !userId || !text) {
       throw new Error("agentId, userId, and text are required");
@@ -163,6 +168,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             persistMessages: true,
             redactionConfig,
             signal: abortCtrl.signal,
+            turnStartTime: turnStartMs,
             onEvent: (evt, _eventType, extras) => {
               context.sendEvent("chat.event", {
                 sessionId: promptResult.sessionId,

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -199,7 +199,7 @@ describe("consumeAgentSse — tool execution", () => {
     expect(toolRow.metadata.summary).toBe("concluding");
   });
 
-  it("skips metadata when details contains only blocked/error (already captured by outcome)", async () => {
+  it("drops blocked/error from metadata (already captured by outcome) but keeps timing fields", async () => {
     const events = [
       { type: "tool_execution_start", toolName: "bash", args: {} },
       { type: "tool_execution_end", toolName: "bash",
@@ -207,17 +207,20 @@ describe("consumeAgentSse — tool execution", () => {
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
     const toolRow = updateCalls[0];
-    expect(toolRow.metadata).toBeNull();
+    // blocked/error stripped; pre_thinking_ms is the lone surviving field
+    // (always persisted to support 💭 audit on every tool).
+    expect(toolRow.metadata).toEqual({ pre_thinking_ms: expect.any(Number) });
+    expect(toolRow.metadata.error).toBeUndefined();
   });
 
-  it("skips metadata when details is absent", async () => {
+  it("metadata contains only pre_thinking_ms when details is absent", async () => {
     const events = [
       { type: "tool_execution_start", toolName: "kubectl", args: {} },
       { type: "tool_execution_end", toolName: "kubectl", result: { content: [{ type: "text", text: "ok" }] } },
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
     const toolRow = updateCalls[0];
-    expect(toolRow.metadata).toBeNull();
+    expect(toolRow.metadata).toEqual({ pre_thinking_ms: expect.any(Number) });
   });
 
   it("redacts secrets inside persisted metadata via JSON round-trip", async () => {
@@ -271,6 +274,113 @@ describe("consumeAgentSse — tool execution", () => {
     const b = toolRows.find((r) => r.toolName === "b");
     expect(a.toolInput).toContain("\"x\":1");
     expect(b.toolInput).toContain("\"y\":2");
+  });
+});
+
+// ── Timing (TTFT / 💭 / ⚙️ / turn total) ──────────────
+
+describe("consumeAgentSse — timing", () => {
+  it("attributes pre-tool thinking only to the first tool of a one-thinking-many-tools batch", async () => {
+    // Simulate: model thinks, emits assistant message with text + 3 tool_use
+    // blocks. The runtime executes them serially. Only the FIRST tool should
+    // see meaningful pre_thinking_ms; the next two should be ~0 because the
+    // boundary advances on each tool_execution_end (no new model thinking
+    // happened between them).
+    const events = [
+      { type: "message_start", message: { role: "assistant" } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "checking pods" } },
+      { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods -A" } },
+      { type: "tool_execution_end", toolName: "bash",
+        result: { content: [{ type: "text", text: "pod1" }] } },
+      { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods -n a" } },
+      { type: "tool_execution_end", toolName: "bash",
+        result: { content: [{ type: "text", text: "pod2" }] } },
+      { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods -n b" } },
+      { type: "tool_execution_end", toolName: "bash",
+        result: { content: [{ type: "text", text: "pod3" }] } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    expect(updateCalls).toHaveLength(3);
+    // Every tool row carries pre_thinking_ms — the badge is auditable on all of them.
+    for (const row of updateCalls) {
+      expect(row.metadata.pre_thinking_ms).toEqual(expect.any(Number));
+      expect(row.metadata.pre_thinking_ms).toBeGreaterThanOrEqual(0);
+    }
+    // Crucially, no double-counting: tools 2 and 3 should be near-zero
+    // because the boundary advanced on the previous tool_execution_end.
+    expect(updateCalls[1].metadata.pre_thinking_ms).toBeLessThan(50);
+    expect(updateCalls[2].metadata.pre_thinking_ms).toBeLessThan(50);
+  });
+
+  it("persists ttft_ms / output_ms / turn_total_ms on the first assistant message; thinking_ms suppressed because it equals ttft", async () => {
+    const events = [
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hello" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hello" }] } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    const assistantRow = appendCalls.find((c) => c.role === "assistant");
+    expect(assistantRow).toBeDefined();
+    expect(assistantRow.metadata.timing.ttft_ms).toEqual(expect.any(Number));
+    // thinking_ms intentionally absent on first message: ttft already covers
+    // the same boundary→firstToken interval, so a naive sum would otherwise
+    // double-count it.
+    expect(assistantRow.metadata.timing.thinking_ms).toBeUndefined();
+    expect(assistantRow.metadata.timing.output_ms).toEqual(expect.any(Number));
+    expect(assistantRow.metadata.timing.turn_total_ms).toEqual(expect.any(Number));
+  });
+
+  it("uses caller-supplied turnStartTime when provided (portal POST anchor)", async () => {
+    const earlyAnchor = Date.now() - 5000; // simulate portal stamp 5s ago
+    const events = [
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
+    ];
+    await consumeAgentSse({
+      client: mkClient(events), sessionId: "s", userId: "u",
+      persistMessages: true, turnStartTime: earlyAnchor,
+    });
+    const assistantRow = appendCalls.find((c) => c.role === "assistant");
+    // ttft must reflect the supplied anchor — at least the simulated 5s gap.
+    expect(assistantRow.metadata.timing.ttft_ms).toBeGreaterThanOrEqual(5000);
+  });
+
+  it("emits ttft_ms only on the first assistant message of a turn (avoids double-counting)", async () => {
+    const events = [
+      // First assistant message
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
+      // Second assistant message in same turn — same turnStart anchor, but
+      // ttft would just repeat the same value, so it must be omitted.
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "more" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "more" }] } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    const assistantRows = appendCalls.filter((c) => c.role === "assistant");
+    expect(assistantRows).toHaveLength(2);
+    expect(assistantRows[0].metadata.timing.ttft_ms).toEqual(expect.any(Number));
+    expect(assistantRows[1].metadata.timing.ttft_ms).toBeUndefined();
+    // Both messages still carry thinking_ms + output_ms (their per-message
+    // intervals are independent and additive).
+    expect(assistantRows[1].metadata.timing.thinking_ms).toEqual(expect.any(Number));
+    expect(assistantRows[1].metadata.timing.output_ms).toEqual(expect.any(Number));
+  });
+
+  it("surfaces preThinkingMs and durationMs onto live events for frontend rendering", async () => {
+    const events = [
+      { type: "tool_execution_start", toolName: "kubectl", args: {} },
+      { type: "tool_execution_end", toolName: "kubectl", result: { content: [{ type: "text", text: "ok" }] } },
+    ];
+    const seen: any[] = [];
+    await consumeAgentSse({
+      client: mkClient(events), sessionId: "s", userId: "u",
+      persistMessages: true,
+      onEvent: (evt) => seen.push(evt),
+    });
+    const startEvt = seen.find((e) => e.type === "tool_execution_start");
+    const endEvt = seen.find((e) => e.type === "tool_execution_end");
+    expect(typeof startEvt.preThinkingMs).toBe("number");
+    expect(typeof endEvt.preThinkingMs).toBe("number");
+    expect(typeof endEvt.durationMs).toBe("number");
   });
 });
 

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -44,6 +44,14 @@ export interface ConsumeAgentSseOptions {
   onEvent?: OnEventCallback;
   /** Abort signal — breaks the loop when triggered. */
   signal?: AbortSignal;
+  /**
+   * Optional explicit turn-start anchor (ms epoch). When provided, used as
+   * the basis for ⏳/💭/✍️/turn_total measurements instead of the local
+   * `Date.now()` taken when consumeAgentSse begins iterating. Portal sets
+   * this at POST receipt so the timing covers the portal→runtime RPC hop
+   * the runtime cannot otherwise see.
+   */
+  turnStartTime?: number;
 }
 
 export interface SseConsumptionResult {
@@ -137,9 +145,35 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   const pendingToolInputs = new Map<string, string[]>();
   const pendingToolStartTimes = new Map<string, number[]>();
   const pendingToolMessageIds = new Map<string, string[]>();
+  // Per-tool pre-tool-call thinking time captured at tool_execution_start, to
+  // be merged into the row's metadata at tool_execution_end (so the persisted
+  // metadata survives the round-trip without being clobbered by the
+  // extractPersistableDetails extraction from result.details).
+  const pendingPreThinkingMs = new Map<string, number[]>();
 
   let eventCount = 0;
   const startTime = Date.now();
+
+  // ── Per-turn timing capture (for ⏳ TTFT / 💭 thinking / total) ──
+  // turnStartTime: server-side anchor for the whole user→assistant turn.
+  //   Prefer caller-supplied (portal POST timestamp) over local startTime so
+  //   the portal→runtime RPC hop is included in measurements.
+  // firstTokenTime: first model output of any kind (text or tool call) — TTFT.
+  // lastBoundaryTime: latest moment the model was *given input* — turn start
+  //   initially, then bumped to each tool_execution_end. The gap between
+  //   lastBoundaryTime and the next emission (text_delta or tool_execution_start)
+  //   is what we call "model thinking time" — the part the user previously
+  //   couldn't see for tool-call gaps. Single-clock by design.
+  const turnStartTime = opts.turnStartTime ?? startTime;
+  let firstTokenTime: number | undefined;
+  let lastBoundaryTime = turnStartTime;
+  let assistantMsgFirstTextTime: number | undefined;
+  let pendingThinkingMs: number | undefined;
+  // ttft_ms is a turn-scoped anchor (turnStart → first token of the very
+  // first assistant message). Persisting it on subsequent messages would
+  // make a naive UI sum double-count the same interval N times. Tracked
+  // and only emitted once.
+  let firstAssistantPersisted = false;
 
   for await (const event of client.streamEvents(sessionId)) {
     if (signal?.aborted) break;
@@ -177,9 +211,26 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
 
       const toolStartTime = shiftPending(pendingToolStartTimes, toolName);
       const durationMs = toolStartTime != null ? Date.now() - toolStartTime : undefined;
+      const preThinkingMs = shiftPending(pendingPreThinkingMs, toolName);
+      // Surface duration + pre-thinking on the live event for frontend.
+      if (durationMs != null) {
+        (evt as Record<string, unknown>).durationMs = durationMs;
+      }
+      if (preThinkingMs != null) {
+        (evt as Record<string, unknown>).preThinkingMs = preThinkingMs;
+      }
       const toolInput = shiftPending(pendingToolInputs, toolName) || "";
       const existingMessageId = shiftPending(pendingToolMessageIds, toolName);
-      const metadata = extractPersistableDetails(toolResult?.details, redactionConfig);
+      const detailsMeta = extractPersistableDetails(toolResult?.details, redactionConfig);
+      // Merge pre-thinking back in — extractPersistableDetails only looks at
+      // the tool *result*, so we'd otherwise lose what we recorded at
+      // tool_execution_start. We persist the value even when 0/small so the
+      // UI can render a 💭 badge on every tool: a 0ms badge on the 2nd-Nth
+      // tool of a batch makes "one thinking → many tools" auditable.
+      const metadata: Record<string, unknown> | null =
+        preThinkingMs != null
+          ? { ...(detailsMeta ?? {}), pre_thinking_ms: preThinkingMs }
+          : detailsMeta;
       const delegationId = typeof metadata?.delegation_id === "string" ? metadata.delegation_id : null;
 
       if (persist) {
@@ -207,12 +258,29 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       if (toolName === "task_report" && text) {
         taskReportText = text;
       }
+      // Bump the model-input boundary: the model now has the tool result and
+      // any subsequent thinking/text/tool-use is computed from this point.
+      lastBoundaryTime = Date.now();
     }
 
     // ── DB persistence: message_update (accumulate assistant text) ──
     if (eventType === "message_update") {
       const ame = evt.assistantMessageEvent as { type?: string; delta?: string } | undefined;
       if (ame?.type === "text_delta" && ame.delta) {
+        const nowAtDelta = Date.now();
+        if (firstTokenTime === undefined) firstTokenTime = nowAtDelta;
+        if (assistantMsgFirstTextTime === undefined) {
+          assistantMsgFirstTextTime = nowAtDelta;
+          // Boundary-based: covers thinking after the previous tool result
+          // (or from turn start), not just the gap inside one assistant
+          // message. The thinking is fully attributed to *this* text bubble.
+          pendingThinkingMs = nowAtDelta - lastBoundaryTime;
+        }
+        // Bump boundary on every text delta so a tool emitted right after
+        // text doesn't double-count the same thinking interval. The text
+        // bubble already showed 💭 for that gap; the tool's pre-thinking
+        // measures only the (typically tiny) handoff after text emission.
+        lastBoundaryTime = nowAtDelta;
         assistantContent += ame.delta;
         currentMsgText += ame.delta;
       }
@@ -221,16 +289,35 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
     // ── message_start: reset per-message accumulator ──
     if (eventType === "message_start") {
       currentMsgText = "";
+      const message = evt.message as Record<string, unknown> | undefined;
+      if (message?.role === "assistant") {
+        // Per-message resets only — the boundary anchor (turn-start /
+        // last tool_execution_end) is intentionally NOT touched here, so
+        // pre-text thinking time still counts gaps that started before
+        // this message_start fired.
+        assistantMsgFirstTextTime = undefined;
+        pendingThinkingMs = undefined;
+      }
     }
 
     // ── tool_execution_start: capture input + start time ──
     if (eventType === "tool_execution_start" || eventType === "tool_start") {
+      const nowAtStart = Date.now();
+      if (firstTokenTime === undefined) firstTokenTime = nowAtStart;
       const startToolName = (evt.toolName as string) || (evt.name as string) || "tool";
       const args = evt.args as Record<string, unknown> | undefined;
       const rawToolInput = args ? JSON.stringify(args) : "";
+      // Pre-tool thinking: gap between the previous model-input boundary
+      // (turn start, or the previous tool_execution_end) and this tool's
+      // start. This is the model's "I just got new info, deciding what to
+      // do next" interval — invisible until we measured it explicitly.
+      const preThinkingMs = nowAtStart - lastBoundaryTime;
       pushPending(pendingToolInputs, startToolName, rawToolInput);
-      pushPending(pendingToolStartTimes, startToolName, Date.now());
+      pushPending(pendingToolStartTimes, startToolName, nowAtStart);
+      pushPending(pendingPreThinkingMs, startToolName, preThinkingMs);
       lastToolName = startToolName;
+      // Surface on the live event so frontend can render 💭 immediately.
+      (evt as Record<string, unknown>).preThinkingMs = preThinkingMs;
 
       if (persist) {
         dbMessageId = await appendMessage({
@@ -243,7 +330,8 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           durationMs: null,
           metadata: {
             status: "running",
-            started_at: new Date().toISOString(),
+            started_at: new Date(nowAtStart).toISOString(),
+            pre_thinking_ms: preThinkingMs,
           },
         });
         pushPending(pendingToolMessageIds, startToolName, dbMessageId);
@@ -273,6 +361,42 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         }
         resultText = extracted || currentMsgText || resultText;
 
+        // Build timing metadata for this assistant message. Audit-friendly
+        // by construction: every interval is non-overlapping with every
+        // other badge in the same turn, so a naive sum across all chat
+        // bubbles equals turn_total_ms (within event-dispatch noise).
+        //
+        //   ⏳ ttft_ms       — first message only (turn-anchor; would
+        //                       otherwise double-count if put on every msg)
+        //   💭 thinking_ms   — boundary → first text_delta (per message)
+        //   ✍️ output_ms    — first text_delta → message_end (per message)
+        //   turn_total_ms    — kept for the last message as audit cross-check
+        const nowAtEnd = Date.now();
+        const timing: Record<string, number> = {
+          turn_total_ms: nowAtEnd - turnStartTime,
+        };
+        if (!firstAssistantPersisted && firstTokenTime !== undefined) {
+          timing.ttft_ms = firstTokenTime - turnStartTime;
+        }
+        if (pendingThinkingMs !== undefined) {
+          // Suppress thinking_ms on the first assistant message when ttft is
+          // already on the row — they cover the same interval (turnStart →
+          // first text token), and showing both would let a naive sum
+          // double-count that segment. After the first message, ttft is
+          // omitted, so thinking_ms takes over as the boundary-based gap.
+          if (!(timing.ttft_ms !== undefined && Math.abs(pendingThinkingMs - (timing.ttft_ms as number)) < 50)) {
+            timing.thinking_ms = pendingThinkingMs;
+          }
+        }
+        if (assistantMsgFirstTextTime !== undefined) {
+          // Text streaming time — was previously invisible. Captures the
+          // model's wall-clock cost of emitting the message body.
+          timing.output_ms = nowAtEnd - assistantMsgFirstTextTime;
+        }
+        // Attach timing onto the live event so the SSE consumer (frontend)
+        // can render badges immediately without waiting for DB reload.
+        (evt as Record<string, unknown>).timing = timing;
+
         // Persist assistant message (skip entirely if it's purely an empty-
         // response marker — keeps the trace free of pi-agent diagnostics)
         if (persist && assistantContent) {
@@ -282,11 +406,21 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
               sessionId,
               role: "assistant",
               content: redactText(cleaned, redactionConfig),
+              metadata: { timing },
             });
             await incrementMessageCount(sessionId);
+            firstAssistantPersisted = true;
           }
           assistantContent = "";
         }
+        // Reset per-message thinking marker so the next assistant message
+        // gets its own measurement (firstTokenTime stays — turn-scoped).
+        // Note: lastBoundaryTime is NOT touched here — text deltas already
+        // advanced it, and a pure tool-use assistant message (no text)
+        // intentionally leaves the boundary at the previous tool/turn-start
+        // so the *next* tool's pre-thinking covers the full reasoning gap.
+        pendingThinkingMs = undefined;
+        assistantMsgFirstTextTime = undefined;
       } else if (message?.role === "toolResult" && lastToolName === "task_report") {
         // task_report via turn_end (alternative emission path)
         const content = message.content;

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -71,6 +71,30 @@ export interface SseConsumptionResult {
 const EMPTY_REDACTION: RedactionConfig = { patterns: [] };
 
 /**
+ * Inter-event dispatch jitter — the tightest possible gap between two
+ * timestamps that come from the SSE event loop's natural pacing rather than
+ * any real wall-clock interval. Used by the ttft/thinking dedup below: if
+ * the two values differ by less than this, they are treated as the same
+ * instant and only one is emitted (avoids double-counting on naive sums).
+ *
+ * 50ms is a conservative ceiling for a single Node tick + WS hop; bump it
+ * if you start seeing duplicate ⏳/💭 badges on first-of-turn messages.
+ */
+const NOISE_FLOOR_MS = 50;
+
+/**
+ * Drop negative timing deltas. Same-process measurements are always ≥0, but
+ * cross-process anchors (e.g. portal POST timestamp passed to runtime via
+ * RPC) can briefly produce negatives if the two pods' NTP clocks have drifted
+ * apart. We treat negatives as "unknown" rather than persist them — downstream
+ * (frontend formatter, /metrics/timing aggregation) interprets absence as
+ * unmeasured, which is correct.
+ */
+function nonNegative(ms: number): number | undefined {
+  return Number.isFinite(ms) && ms >= 0 ? ms : undefined;
+}
+
+/**
  * Strip pi-agent's `(Empty response: {...})` diagnostic markers that get
  * appended to an assistant message when the model returns content=[]. These
  * are useful in server logs but pollute the persisted trace shown to users.
@@ -313,15 +337,34 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       // (turn start, or the previous tool_execution_end) and this tool's
       // start. This is the model's "I just got new info, deciding what to
       // do next" interval — invisible until we measured it explicitly.
-      const preThinkingMs = nowAtStart - lastBoundaryTime;
+      // nonNegative() drops cross-pod clock-drift artefacts; absence
+      // downstream means "unknown", which is the correct semantics.
+      const preThinkingMs = nonNegative(nowAtStart - lastBoundaryTime);
       pushPending(pendingToolInputs, startToolName, rawToolInput);
       pushPending(pendingToolStartTimes, startToolName, nowAtStart);
-      pushPending(pendingPreThinkingMs, startToolName, preThinkingMs);
+      if (preThinkingMs !== undefined) {
+        pushPending(pendingPreThinkingMs, startToolName, preThinkingMs);
+      }
       lastToolName = startToolName;
       // Surface on the live event so frontend can render 💭 immediately.
-      (evt as Record<string, unknown>).preThinkingMs = preThinkingMs;
+      if (preThinkingMs !== undefined) {
+        (evt as Record<string, unknown>).preThinkingMs = preThinkingMs;
+      }
 
       if (persist) {
+        // pre_thinking_ms is durable telemetry, NOT debug-only. Persisted on
+        // every tool row even when ~0ms because a near-zero value on the 2nd-
+        // Nth tool of a batch is the visible proof that those tools came from
+        // a single model "thinking burst" — not noise to filter out. Once
+        // production rows carry this field, downstream consumers (analytics,
+        // replay, audit reports) may rely on its presence; keep it stable.
+        const startMetadata: Record<string, unknown> = {
+          status: "running",
+          started_at: new Date(nowAtStart).toISOString(),
+        };
+        if (preThinkingMs !== undefined) {
+          startMetadata.pre_thinking_ms = preThinkingMs;
+        }
         dbMessageId = await appendMessage({
           sessionId,
           role: "tool",
@@ -330,11 +373,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           toolInput: rawToolInput ? redactText(rawToolInput, redactionConfig) : null,
           outcome: null,
           durationMs: null,
-          metadata: {
-            status: "running",
-            started_at: new Date(nowAtStart).toISOString(),
-            pre_thinking_ms: preThinkingMs,
-          },
+          metadata: startMetadata,
         });
         pushPending(pendingToolMessageIds, startToolName, dbMessageId);
         await incrementMessageCount(sessionId);
@@ -393,26 +432,34 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         //   ✍️ output_ms    — first text_delta → message_end (per message)
         //   turn_total_ms    — kept for the last message as audit cross-check
         const nowAtEnd = Date.now();
-        const timing: Record<string, number> = {
-          turn_total_ms: nowAtEnd - turnStartTime,
-        };
+        // turn_total may be slightly negative under cross-pod clock drift
+        // (portal-supplied turnStartTime ahead of runtime's nowAtEnd); drop
+        // it in that case rather than persist garbage.
+        const turnTotal = nonNegative(nowAtEnd - turnStartTime);
+        const timing: Record<string, number> = {};
+        if (turnTotal !== undefined) timing.turn_total_ms = turnTotal;
         if (!firstAssistantPersisted && firstTokenTime !== undefined) {
-          timing.ttft_ms = firstTokenTime - turnStartTime;
+          const ttft = nonNegative(firstTokenTime - turnStartTime);
+          if (ttft !== undefined) timing.ttft_ms = ttft;
         }
         if (pendingThinkingMs !== undefined) {
           // Suppress thinking_ms on the first assistant message when ttft is
           // already on the row — they cover the same interval (turnStart →
-          // first text token), and showing both would let a naive sum
-          // double-count that segment. After the first message, ttft is
-          // omitted, so thinking_ms takes over as the boundary-based gap.
-          if (!(timing.ttft_ms !== undefined && Math.abs(pendingThinkingMs - (timing.ttft_ms as number)) < 50)) {
-            timing.thinking_ms = pendingThinkingMs;
+          // first text token), within event-dispatch jitter. After the first
+          // message, ttft is omitted and thinking_ms takes over.
+          const overlapsTtft =
+            timing.ttft_ms !== undefined &&
+            Math.abs(pendingThinkingMs - timing.ttft_ms) < NOISE_FLOOR_MS;
+          const safeThinking = nonNegative(pendingThinkingMs);
+          if (!overlapsTtft && safeThinking !== undefined) {
+            timing.thinking_ms = safeThinking;
           }
         }
         if (assistantMsgFirstTextTime !== undefined) {
           // Text streaming time — was previously invisible. Captures the
           // model's wall-clock cost of emitting the message body.
-          timing.output_ms = nowAtEnd - assistantMsgFirstTextTime;
+          const out = nonNegative(nowAtEnd - assistantMsgFirstTextTime);
+          if (out !== undefined) timing.output_ms = out;
         }
         // Attach timing onto the live event so the SSE consumer (frontend)
         // can render badges immediately without waiting for DB reload.

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -110,6 +110,12 @@ export function registerChatRoutes(
 ): void {
   // POST /api/v1/siclaw/agents/:id/chat/send — SSE streaming
   router.post("/api/v1/siclaw/agents/:id/chat/send", async (req, res, params) => {
+    // Capture the earliest possible server-side turn anchor: the moment the
+    // POST request lands at portal. This is closer to "user clicked send"
+    // than the runtime's sse-consumer entry, shaving the portal→runtime RPC
+    // overhead off of timing measurements. Single clock by design — passed
+    // down through chat.send so the runtime uses the same epoch.
+    const turnStartMs = Date.now();
     const auth = requireAuth(req, jwtSecret);
     if (!auth) { sendJson(res, 401, { error: "Authentication required" }); return; }
 
@@ -175,6 +181,7 @@ export function registerChatRoutes(
       modelProvider: modelBinding.modelProvider,
       modelId: modelBinding.modelId,
       modelConfig: modelBinding.modelConfig,
+      turnStartMs,
     });
 
     if (!result.ok) {

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2394,12 +2394,14 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
   // Aggregates per-message timing telemetry stamped by sse-consumer:
   //   ⏳ ttft     — chat_messages.metadata.timing.ttft_ms (assistant rows)
   //   💭 thinking — chat_messages.metadata.timing.thinking_ms (assistant)
-  //   ⚙️ bash    — chat_messages.duration_ms (tool rows where tool_name='bash')
+  //   ⚙️ tools   — chat_messages.duration_ms grouped by tool_name (top-N
+  //                 by invocation count, sorted DESC). Returned as an array
+  //                 so the dashboard can show top 3 / 5 / 10 client-side.
   //
-  // Aggregation is done in JS rather than via JSON_EXTRACT so the same code
-  // path works under MySQL and SQLite without the dialect-helpers dance —
-  // the dataset for a 30d window per user is bounded (~thousands of rows)
-  // and we read only the columns we need (`metadata` / `duration_ms`).
+  // Aggregation is done in JS rather than via JSON_EXTRACT/GROUP BY so the
+  // same code path works under MySQL and SQLite without the dialect-helpers
+  // dance — we only read the columns we need (`metadata` / `tool_name` /
+  // `duration_ms`) and bucket in memory.
   router.get("/api/v1/siclaw/metrics/timing", async (req, res) => {
     const admin = requireAdmin(req, config.jwtSecret);
     if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
@@ -2413,6 +2415,26 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
 
     const db = getDb();
 
+    // Hard cap on rows scanned per query. Each chat_messages.metadata can be
+    // multi-KB JSON (timing + tool details + delegation state); a busy tenant
+    // over a 30-day window can produce hundreds of thousands of rows, and
+    // pulling them all would risk OOM-ing the Portal process. ORDER BY DESC +
+    // LIMIT keeps the most-recent slice when the window is too dense; the
+    // response carries `truncated: true` so the dashboard can show a hint
+    // ("sampled view") rather than the call silently lying.
+    //
+    // TODO(metrics): replace this with a nightly batch job that materialises
+    // a `metrics_timing_daily` table (avg/p90 pre-aggregated per day). The
+    // endpoint then SELECTs <30 rows and the limit becomes irrelevant.
+    const ROW_LIMIT = 50_000;
+
+    // Build the two SELECTs and fire them in parallel — they're independent
+    // and read-only, so awaiting sequentially would just double the response
+    // time without buying anything. On SQLite a long-running JSON-pulling
+    // query can also block other read paths in the same process; Promise.all
+    // returns control to the event loop sooner so /metrics/live and
+    // /metrics/summary stay responsive while this one is in flight.
+
     // Assistant rows: pull metadata JSON, parse client-side, harvest ttft/thinking.
     const aParams: unknown[] = [cutoff];
     let assistantSql = `SELECT m.metadata
@@ -2421,36 +2443,72 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       WHERE m.role = 'assistant' AND m.created_at >= ? AND m.metadata IS NOT NULL
         AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
     if (userFilter) { assistantSql += " AND s.user_id = ?"; aParams.push(userFilter); }
-    const [aRows] = await db.query(assistantSql, aParams) as [Array<{ metadata: unknown }>, unknown];
+    assistantSql += " ORDER BY m.created_at DESC LIMIT ?";
+    aParams.push(ROW_LIMIT + 1);
+
+    // Tool rows: bucket duration_ms by tool_name. We pull all tools (not
+    // just bash) so the dashboard can rank by invocation count — the actual
+    // top-N filtering happens client-side so the user can flip 3↔5↔10
+    // without re-querying.
+    const tParams: unknown[] = [cutoff];
+    let toolSql = `SELECT m.tool_name AS toolName, m.duration_ms AS durationMs
+      FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      WHERE m.role = 'tool' AND m.tool_name IS NOT NULL AND m.duration_ms IS NOT NULL
+        AND m.created_at >= ?
+        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+    if (userFilter) { toolSql += " AND s.user_id = ?"; tParams.push(userFilter); }
+    toolSql += " ORDER BY m.created_at DESC LIMIT ?";
+    tParams.push(ROW_LIMIT + 1);
+
+    const [aResult, tResult] = await Promise.all([
+      db.query(assistantSql, aParams) as Promise<[Array<{ metadata: unknown }>, unknown]>,
+      db.query(toolSql, tParams) as Promise<[Array<{ toolName: string; durationMs: number | null }>, unknown]>,
+    ]);
+    const [aRows] = aResult;
+    const [tRows] = tResult;
+    const assistantTruncated = aRows.length > ROW_LIMIT;
+    const aSlice = assistantTruncated ? aRows.slice(0, ROW_LIMIT) : aRows;
 
     const ttftValues: number[] = [];
     const thinkingValues: number[] = [];
-    for (const r of aRows) {
+    for (const r of aSlice) {
       const meta = safeParseJson<Record<string, unknown> | null>(r.metadata, null);
       const timing = meta?.timing as Record<string, unknown> | undefined;
       if (!timing) continue;
-      if (typeof timing.ttft_ms === "number") ttftValues.push(timing.ttft_ms);
-      if (typeof timing.thinking_ms === "number") thinkingValues.push(timing.thinking_ms);
+      // Filter ≥0: historical rows from before the source-side clamp may
+      // carry negatives produced by cross-process clock drift; this matches
+      // the tool-branch filter below.
+      if (typeof timing.ttft_ms === "number" && timing.ttft_ms >= 0) ttftValues.push(timing.ttft_ms);
+      if (typeof timing.thinking_ms === "number" && timing.thinking_ms >= 0) thinkingValues.push(timing.thinking_ms);
     }
 
-    // Bash tool rows: duration_ms is its own column — no JSON parsing needed.
-    const bParams: unknown[] = [cutoff];
-    let bashSql = `SELECT m.duration_ms AS durationMs
-      FROM chat_messages m
-      JOIN chat_sessions s ON m.session_id = s.id
-      WHERE m.role = 'tool' AND m.tool_name = 'bash' AND m.duration_ms IS NOT NULL
-        AND m.created_at >= ?
-        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
-    if (userFilter) { bashSql += " AND s.user_id = ?"; bParams.push(userFilter); }
-    const [bRows] = await db.query(bashSql, bParams) as [Array<{ durationMs: number | null }>, unknown];
-    const bashValues: number[] = bRows
-      .map((r) => Number(r.durationMs))
-      .filter((n) => Number.isFinite(n) && n >= 0);
+    const toolsTruncated = tRows.length > ROW_LIMIT;
+    const tSlice = toolsTruncated ? tRows.slice(0, ROW_LIMIT) : tRows;
+
+    // Bucket per tool_name; same negative-value filter as before.
+    const toolBuckets = new Map<string, number[]>();
+    for (const r of tSlice) {
+      const dur = Number(r.durationMs);
+      if (!Number.isFinite(dur) || dur < 0) continue;
+      const bucket = toolBuckets.get(r.toolName);
+      if (bucket) bucket.push(dur);
+      else toolBuckets.set(r.toolName, [dur]);
+    }
+    const tools = Array.from(toolBuckets.entries())
+      .map(([toolName, values]) => ({ toolName, ...summariseLatency(values) }))
+      // Rank by invocation count DESC — matches the "Top Tools" widget below
+      // so the same tool-of-the-day shows up consistently across cards.
+      .sort((a, b) => b.count - a.count);
 
     sendJson(res, 200, {
       ttft: summariseLatency(ttftValues),
       thinking: summariseLatency(thinkingValues),
-      bash: summariseLatency(bashValues),
+      tools,
+      // Tells callers the window was too dense to scan in full and the
+      // figures above reflect a recency-biased sample. Frontend can show a
+      // "sampled view" badge rather than failing the request.
+      truncated: assistantTruncated || toolsTruncated,
     });
   });
 

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -43,6 +43,28 @@ import { validateKnowledgePackage } from "../shared/knowledge-package.js";
 /** Trace viewer message limit — matches siclaw_main.cron-limits.MAX_TRACE_MESSAGES */
 const MAX_TRACE_MESSAGES = 200;
 
+/**
+ * Summarise a vector of millisecond latency samples into avg / min / max / p90.
+ * Empty input → `count: 0` and the rest 0; the frontend renders a "no data"
+ * state in that case. p90 uses nearest-rank: index = ceil(n * 0.9) - 1.
+ */
+function summariseLatency(values: number[]): {
+  count: number; avg: number; min: number; max: number; p90: number;
+} {
+  if (values.length === 0) return { count: 0, avg: 0, min: 0, max: 0, p90: 0 };
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const p90Index = Math.max(0, Math.ceil(n * 0.9) - 1);
+  return {
+    count: n,
+    avg: Math.round(sum / n),
+    min: sorted[0],
+    max: sorted[n - 1],
+    p90: sorted[p90Index],
+  };
+}
+
 // ── Permission check helper ───────────────────────────────────
 
 interface AccessResult {
@@ -2366,6 +2388,70 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     }
 
     sendJson(res, 200, { totalSessions, totalPrompts, byUser });
+  });
+
+  // GET /api/v1/siclaw/metrics/timing
+  // Aggregates per-message timing telemetry stamped by sse-consumer:
+  //   ⏳ ttft     — chat_messages.metadata.timing.ttft_ms (assistant rows)
+  //   💭 thinking — chat_messages.metadata.timing.thinking_ms (assistant)
+  //   ⚙️ bash    — chat_messages.duration_ms (tool rows where tool_name='bash')
+  //
+  // Aggregation is done in JS rather than via JSON_EXTRACT so the same code
+  // path works under MySQL and SQLite without the dialect-helpers dance —
+  // the dataset for a 30d window per user is bounded (~thousands of rows)
+  // and we read only the columns we need (`metadata` / `duration_ms`).
+  router.get("/api/v1/siclaw/metrics/timing", async (req, res) => {
+    const admin = requireAdmin(req, config.jwtSecret);
+    if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
+
+    const query = parseQuery(req.url ?? "");
+    const period = query.period || "7d";
+    const rangeMs = PERIODS[period];
+    if (!rangeMs) { sendJson(res, 400, { error: "Invalid period" }); return; }
+    const cutoff = new Date(Date.now() - rangeMs);
+    const userFilter = query.userId || null;
+
+    const db = getDb();
+
+    // Assistant rows: pull metadata JSON, parse client-side, harvest ttft/thinking.
+    const aParams: unknown[] = [cutoff];
+    let assistantSql = `SELECT m.metadata
+      FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      WHERE m.role = 'assistant' AND m.created_at >= ? AND m.metadata IS NOT NULL
+        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+    if (userFilter) { assistantSql += " AND s.user_id = ?"; aParams.push(userFilter); }
+    const [aRows] = await db.query(assistantSql, aParams) as [Array<{ metadata: unknown }>, unknown];
+
+    const ttftValues: number[] = [];
+    const thinkingValues: number[] = [];
+    for (const r of aRows) {
+      const meta = safeParseJson<Record<string, unknown> | null>(r.metadata, null);
+      const timing = meta?.timing as Record<string, unknown> | undefined;
+      if (!timing) continue;
+      if (typeof timing.ttft_ms === "number") ttftValues.push(timing.ttft_ms);
+      if (typeof timing.thinking_ms === "number") thinkingValues.push(timing.thinking_ms);
+    }
+
+    // Bash tool rows: duration_ms is its own column — no JSON parsing needed.
+    const bParams: unknown[] = [cutoff];
+    let bashSql = `SELECT m.duration_ms AS durationMs
+      FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      WHERE m.role = 'tool' AND m.tool_name = 'bash' AND m.duration_ms IS NOT NULL
+        AND m.created_at >= ?
+        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+    if (userFilter) { bashSql += " AND s.user_id = ?"; bParams.push(userFilter); }
+    const [bRows] = await db.query(bashSql, bParams) as [Array<{ durationMs: number | null }>, unknown];
+    const bashValues: number[] = bRows
+      .map((r) => Number(r.durationMs))
+      .filter((n) => Number.isFinite(n) && n >= 0);
+
+    sendJson(res, 200, {
+      ttft: summariseLatency(ttftValues),
+      thinking: summariseLatency(thinkingValues),
+      bash: summariseLatency(bashValues),
+    });
   });
 
   // GET /api/v1/siclaw/metrics/audit


### PR DESCRIPTION
Summary
Adds end-to-end timing telemetry to the chat UI and Metrics dashboard. Every assistant message and tool card now shows compact emoji badges reporting where wall-clock time went. The Metrics page gains a Latency Breakdown card with avg / min / max / p90 across all sampled turns.

All timings use a single server clock (Date.now()) anchored at portal POST receipt, threaded into runtime via the chat.send RPC. Persisted in chat_messages.metadata (JSON) and duration_ms, so reloading a session restores all badges.

Badge definitions
Per assistant message:

⏳ TTFT — turn-start → first model token. Shown only on the first message of a turn (turn-anchor; would otherwise double-count).
💭 Thinking — last input boundary (turn-start or previous tool_execution_end) → first text delta. Suppressed on the first message when it equals TTFT.
✍️ Output — first text delta → message_end. The streaming time of the message body.
Per tool message (bash, kubectl, skill, etc.):

💭 Pre-tool thinking — boundary → tool_execution_start. For one-thinking-many-tools batches only the first tool carries a non-zero value.
⚙️ Duration — tool_execution_start → tool_execution_end.
Invariant: ⏳ + Σ💭 + Σ✍️ + Σ⚙️ ≈ turn_total (no overlap, no missing intervals). Badges are selectable for copy-paste auditing.