### PR TITLE
Truncate chat session title fields before persistence

### DIFF
--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -633,6 +633,25 @@ describe("chat.ensureSession", () => {
     expect(query.mock.calls[0][1]).toContain("New Session");
   });
 
+  it("truncates long title and preview fields before upsert", async () => {
+    const query = mockQuery([]);
+
+    await getHandler("chat.ensureSession")(
+      {
+        session_id: "sess1",
+        agent_id: "a1",
+        user_id: "u1",
+        title: "t".repeat(300),
+        preview: "p".repeat(600),
+      },
+      "a1",
+    );
+
+    const params = query.mock.calls[0][1];
+    expect(params[3]).toHaveLength(255);
+    expect(params[4]).toHaveLength(500);
+  });
+
   it("persists delegation lineage fields", async () => {
     const query = mockQuery([]);
 

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -15,6 +15,7 @@ import {
   parseBody,
   type RestRouter,
 } from "../gateway/rest-router.js";
+import { normalizeChatSessionPreview, normalizeChatSessionTitle } from "./chat-session-fields.js";
 
 function requireInternalAuth(req: http.IncomingMessage, internalSecret: string): boolean {
   const token = req.headers["x-auth-token"] as string | undefined;
@@ -568,7 +569,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
       "chat_sessions",
       ["id", "agent_id", "user_id", "title", "preview", "message_count", "origin", "parent_session_id", "parent_agent_id", "delegation_id", "target_agent_id"],
       [body.session_id, body.agent_id, body.user_id,
-       body.title || "New Session", body.preview || null, 0, body.origin || null,
+       normalizeChatSessionTitle(body.title), normalizeChatSessionPreview(body.preview), 0, body.origin || null,
        body.parent_session_id ?? null, body.parent_agent_id ?? null,
        body.delegation_id ?? null, body.target_agent_id ?? null],
       ["id"],
@@ -1871,7 +1872,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
       "chat_sessions",
       ["id", "agent_id", "user_id", "title", "preview", "message_count", "origin", "parent_session_id", "parent_agent_id", "delegation_id", "target_agent_id"],
       [params.session_id, params.agent_id, params.user_id,
-       params.title || "New Session", params.preview || null, 0, params.origin || null,
+       normalizeChatSessionTitle(params.title), normalizeChatSessionPreview(params.preview), 0, params.origin || null,
        params.parent_session_id ?? null, params.parent_agent_id ?? null,
        params.delegation_id ?? null, params.target_agent_id ?? null],
       ["id"],

--- a/src/portal/chat-session-fields.test.ts
+++ b/src/portal/chat-session-fields.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeChatSessionPreview,
+  normalizeChatSessionTitle,
+  truncateChatSessionTitle,
+} from "./chat-session-fields.js";
+
+describe("chat session field normalization", () => {
+  it("uses the default title when title is missing or empty", () => {
+    expect(normalizeChatSessionTitle(undefined)).toBe("New Session");
+    expect(normalizeChatSessionTitle("")).toBe("New Session");
+  });
+
+  it("truncates title and preview to their database column limits", () => {
+    expect(normalizeChatSessionTitle("t".repeat(300))).toHaveLength(255);
+    expect(normalizeChatSessionPreview("p".repeat(600))).toHaveLength(500);
+  });
+
+  it("preserves explicit update-time title clearing", () => {
+    expect(truncateChatSessionTitle("")).toBe("");
+    expect(truncateChatSessionTitle(null)).toBeNull();
+    expect(truncateChatSessionTitle(undefined)).toBeNull();
+  });
+
+  it("does not split surrogate pairs when truncating", () => {
+    const title = `${"t".repeat(254)}👋extra`;
+    const truncated = normalizeChatSessionTitle(title);
+
+    expect(truncated).toBe("t".repeat(254));
+    expect(truncated).toHaveLength(254);
+    expect(truncated).not.toContain("\uD83D");
+  });
+
+  it("normalizes absent preview to null", () => {
+    expect(normalizeChatSessionPreview(undefined)).toBeNull();
+    expect(normalizeChatSessionPreview("")).toBeNull();
+  });
+});

--- a/src/portal/chat-session-fields.ts
+++ b/src/portal/chat-session-fields.ts
@@ -1,0 +1,28 @@
+const CHAT_SESSION_TITLE_MAX_CHARS = 255;
+const CHAT_SESSION_PREVIEW_MAX_CHARS = 500;
+
+function truncateField(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+
+  let truncated = "";
+  for (const char of value) {
+    if (truncated.length + char.length > maxChars) break;
+    truncated += char;
+  }
+  return truncated;
+}
+
+export function normalizeChatSessionTitle(title: unknown): string {
+  const value = typeof title === "string" && title.length > 0 ? title : "New Session";
+  return truncateField(value, CHAT_SESSION_TITLE_MAX_CHARS);
+}
+
+export function truncateChatSessionTitle(title: unknown): string | null {
+  if (typeof title !== "string") return null;
+  return truncateField(title, CHAT_SESSION_TITLE_MAX_CHARS);
+}
+
+export function normalizeChatSessionPreview(preview: unknown): string | null {
+  if (typeof preview !== "string" || preview.length === 0) return null;
+  return truncateField(preview, CHAT_SESSION_PREVIEW_MAX_CHARS);
+}

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -155,6 +155,26 @@ describe("siclaw-api misc routes", () => {
     });
   });
 
+  describe("PUT /api/v1/siclaw/agents/:id/chat/sessions/:sid", () => {
+    it("allows explicitly clearing the title", async () => {
+      query
+        .mockResolvedValueOnce([[{ id: "s1" }], []])
+        .mockResolvedValueOnce([{}, []])
+        .mockResolvedValueOnce([[{ id: "s1", title: "" }], []]);
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/sessions/s1",
+        method: "PUT",
+        body: { title: "" },
+      }));
+
+      expect(status).toBe(200);
+      expect(query.mock.calls[1][0]).toContain("UPDATE chat_sessions SET title = ?");
+      expect(query.mock.calls[1][1][0]).toBe("");
+      expect(body.title).toBe("");
+    });
+  });
+
   describe("DELETE /api/v1/siclaw/agents/:id/chat/sessions/:sid", () => {
     it("returns 401 without auth", async () => {
       const { status } = await runRoute(router, fakeReq({

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -39,6 +39,11 @@ import { evaluateScriptsAI } from "../gateway/skills/ai-security-reviewer.js";
 import { parseFrontmatter } from "../gateway/skills/builtin-sync.js";
 import { validateSchedule } from "../cron/cron-limits.js";
 import { validateKnowledgePackage } from "../shared/knowledge-package.js";
+import {
+  normalizeChatSessionPreview,
+  normalizeChatSessionTitle,
+  truncateChatSessionTitle,
+} from "./chat-session-fields.js";
 
 /** Trace viewer message limit — matches siclaw_main.cron-limits.MAX_TRACE_MESSAGES */
 const MAX_TRACE_MESSAGES = 200;
@@ -1307,7 +1312,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
        VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
       [
         id, params.id, auth.userId,
-        body.title || "New Session", body.preview || null, 0,
+        normalizeChatSessionTitle(body.title), normalizeChatSessionPreview(body.preview), 0,
       ],
     );
 
@@ -1334,7 +1339,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
 
     const fields: string[] = [];
     const values: unknown[] = [];
-    if ("title" in body) { fields.push("title = ?"); values.push(body.title); }
+    if ("title" in body) { fields.push("title = ?"); values.push(truncateChatSessionTitle(body.title)); }
     if (fields.length === 0) { sendJson(res, 400, { error: "Nothing to update" }); return; }
 
     values.push(params.sid);


### PR DESCRIPTION
## Summary
- clamp chat session titles and previews to their MySQL column limits before persistence
- reuse the same normalization for adapter RPC, internal adapter route, and portal chat session routes
- add unit coverage for long title/preview handling

## Test plan
- npm test -- src/portal/chat-session-fields.test.ts src/portal/adapter-rpc.test.ts
- npm run build

## Context
Long prompts were being used as chat session titles. MySQL rejects values longer than chat_sessions.title VARCHAR(255), which can surface as `Data too long for column 'title' at row 1` and interrupt chat sends even though the actual message content can be stored separately.