### PR TITLE
Support zip/tar skill pack upload with upsert semantics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mariozechner/pi-coding-agent": "^0.55.3",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@sinclair/typebox": "^0.34.0",
+        "adm-zip": "^0.5.17",
         "diff": "^8.0.3",
         "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.3",
@@ -24,12 +25,14 @@
         "prom-client": "^15.1.3",
         "sqlite-vec": "^0.1.7-alpha.2",
         "ssh2": "^1.17.0",
+        "tar": "^7.5.15",
         "ws": "^8.18.0"
       },
       "bin": {
         "siclaw": "siclaw.mjs"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.8",
         "@types/diff": "^7.0.2",
         "@types/express": "^5.0.6",
         "@types/js-yaml": "^4.0.9",
@@ -1480,6 +1483,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -3223,6 +3238,16 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -3681,6 +3706,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -4240,6 +4274,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/cli-highlight": {
@@ -6313,6 +6356,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.30.1",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.30.1.tgz",
@@ -7846,6 +7901,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -8525,6 +8596,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@mariozechner/pi-coding-agent": "^0.55.3",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@sinclair/typebox": "^0.34.0",
+    "adm-zip": "^0.5.17",
     "diff": "^8.0.3",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
@@ -54,6 +55,7 @@
     "prom-client": "^15.1.3",
     "sqlite-vec": "^0.1.7-alpha.2",
     "ssh2": "^1.17.0",
+    "tar": "^7.5.15",
     "ws": "^8.18.0"
   },
   "optionalDependencies": {
@@ -65,6 +67,7 @@
     "grammy": "^1.41.1"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
     "@types/diff": "^7.0.2",
     "@types/express": "^5.0.6",
     "@types/js-yaml": "^4.0.9",

--- a/portal-web/src/pages/SkillImport.tsx
+++ b/portal-web/src/pages/SkillImport.tsx
@@ -18,10 +18,6 @@ interface PreviewResult {
   updated: DiffEntry[]
   deleted: DiffEntry[]
   unchanged: DiffEntry[]
-  total_added: number
-  total_updated: number
-  total_deleted: number
-  total_unchanged: number
 }
 
 interface ImportVersion {
@@ -73,10 +69,24 @@ export function SkillImport() {
 
   // ── File selection ───────────────────────────────────────────
 
+  const ACCEPTED_EXTENSIONS = [".zip", ".tar", ".tar.gz", ".tgz"] as const
+
+  /** Pick the most accurate Content-Type for the upload — the backend
+   *  detects the actual format from magic bytes, but a correct MIME makes
+   *  proxies and dev tooling happier. */
+  const contentTypeForFile = (name: string): string => {
+    const lower = name.toLowerCase()
+    if (lower.endsWith(".zip")) return "application/zip"
+    if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) return "application/gzip"
+    if (lower.endsWith(".tar")) return "application/x-tar"
+    return "application/octet-stream"
+  }
+
   const handleFileSelect = (f: File | undefined) => {
     if (!f) return
-    if (!f.name.endsWith(".zip")) {
-      toast.error("Only .zip files are accepted")
+    const lower = f.name.toLowerCase()
+    if (!ACCEPTED_EXTENSIONS.some(ext => lower.endsWith(ext))) {
+      toast.error("Only .zip / .tar / .tar.gz / .tgz files are accepted")
       return
     }
     setFile(f)
@@ -101,7 +111,7 @@ export function SkillImport() {
       const res = await fetch("/api/v1/siclaw/skills/import?dry_run=true", {
         method: "POST",
         headers: {
-          "Content-Type": "application/zip",
+          "Content-Type": contentTypeForFile(file.name),
           ...(token ? { "Authorization": `Bearer ${token}` } : {}),
         },
         body: buffer,
@@ -125,7 +135,7 @@ export function SkillImport() {
     if (!file || !preview) return
     const ok = await confirmDialog({
       title: "Confirm Import",
-      message: `Import skill pack? This will apply ${preview.total_added} added, ${preview.total_updated} updated, and ${preview.total_deleted} deleted skills.`,
+      message: `Import skill pack? This will add ${preview.added.length} and update ${preview.updated.length} skills. Existing builtins not in the pack will be left as-is.`,
       confirmLabel: "Import",
     })
     if (!ok) return
@@ -137,7 +147,7 @@ export function SkillImport() {
       const res = await fetch(`/api/v1/siclaw/skills/import${qs}`, {
         method: "POST",
         headers: {
-          "Content-Type": "application/zip",
+          "Content-Type": contentTypeForFile(file.name),
           ...(token ? { "Authorization": `Bearer ${token}` } : {}),
         },
         body: buffer,
@@ -230,7 +240,7 @@ export function SkillImport() {
           <div className="max-w-2xl space-y-5">
             {/* File drop zone */}
             <div>
-              <label className="block text-sm font-medium mb-2">Skill Pack (.zip)</label>
+              <label className="block text-sm font-medium mb-2">Skill Pack (.zip / .tar / .tar.gz)</label>
               <div
                 onDragOver={e => { e.preventDefault(); setDragOver(true) }}
                 onDragLeave={() => setDragOver(false)}
@@ -247,7 +257,7 @@ export function SkillImport() {
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept=".zip"
+                  accept=".zip,.tar,.tar.gz,.tgz,application/zip,application/x-tar,application/gzip"
                   className="hidden"
                   onChange={e => handleFileSelect(e.target.files?.[0])}
                 />
@@ -263,7 +273,7 @@ export function SkillImport() {
                   <>
                     <Upload className="h-8 w-8 text-muted-foreground/50" />
                     <div className="text-center">
-                      <p className="text-sm text-muted-foreground">Drag & drop a .zip file or click to select</p>
+                      <p className="text-sm text-muted-foreground">Drag & drop a .zip / .tar / .tar.gz file or click to select</p>
                     </div>
                   </>
                 )}
@@ -311,16 +321,16 @@ export function SkillImport() {
                 {/* Summary counts */}
                 <div className="flex items-center gap-3 flex-wrap">
                   <span className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-green-500/15 text-green-400">
-                    <Plus className="h-3 w-3" /> {preview.total_added} added
+                    <Plus className="h-3 w-3" /> {preview.added.length} added
                   </span>
                   <span className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-yellow-500/15 text-yellow-400">
-                    <RefreshCw className="h-3 w-3" /> {preview.total_updated} updated
+                    <RefreshCw className="h-3 w-3" /> {preview.updated.length} updated
                   </span>
                   <span className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-red-500/15 text-red-400">
-                    <Minus className="h-3 w-3" /> {preview.total_deleted} deleted
+                    <Minus className="h-3 w-3" /> {preview.deleted.length} deleted
                   </span>
                   <span className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[12px] font-medium bg-secondary text-muted-foreground">
-                    {preview.total_unchanged} unchanged
+                    {preview.unchanged.length} unchanged
                   </span>
                 </div>
 

--- a/portal-web/src/pages/SkillImport.tsx
+++ b/portal-web/src/pages/SkillImport.tsx
@@ -24,9 +24,11 @@ interface ImportVersion {
   version: number
   comment: string | null
   skill_count: number
-  added: number
-  updated: number
-  deleted: number
+  // Backend persists string[] of skill names in these JSON columns (see
+  // skill_import_history schema). The list UI just shows counts.
+  added: string[]
+  updated: string[]
+  deleted: string[]
   created_at: string
 }
 
@@ -381,14 +383,14 @@ export function SkillImport() {
                         <span className="text-[10px] text-muted-foreground">{v.skill_count} skills</span>
                       </div>
                       <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-                        {v.added > 0 && (
-                          <span className="text-[10px] text-green-400">+{v.added} added</span>
+                        {v.added.length > 0 && (
+                          <span className="text-[10px] text-green-400">+{v.added.length} added</span>
                         )}
-                        {v.updated > 0 && (
-                          <span className="text-[10px] text-yellow-400">~{v.updated} updated</span>
+                        {v.updated.length > 0 && (
+                          <span className="text-[10px] text-yellow-400">~{v.updated.length} updated</span>
                         )}
-                        {v.deleted > 0 && (
-                          <span className="text-[10px] text-red-400">-{v.deleted} deleted</span>
+                        {v.deleted.length > 0 && (
+                          <span className="text-[10px] text-red-400">-{v.deleted.length} deleted</span>
                         )}
                         <span className="text-[10px] text-muted-foreground">{new Date(v.created_at).toLocaleString()}</span>
                       </div>

--- a/src/lib/bootstrap-portal.ts
+++ b/src/lib/bootstrap-portal.ts
@@ -112,6 +112,8 @@ async function autoInitBuiltinSkillsIfEmpty(): Promise<void> {
     console.log(`[portal] No skills/core/ directory at ${SKILLS_CORE_DIR} — skipping`);
     return;
   }
-  const result = await executeImport("default", skills, "system", "Initial builtin import");
+  // Initial bootstrap on an empty DB — sync mode is fine since there's
+  // nothing to delete by definition.
+  const result = await executeImport("default", skills, "system", "Initial builtin import", { mode: "sync" });
   console.log(`[portal] Imported ${skills.length} builtin skills (added=${result.added.length})`);
 }

--- a/src/portal/siclaw-api.skills.test.ts
+++ b/src/portal/siclaw-api.skills.test.ts
@@ -23,10 +23,17 @@ vi.mock("../gateway/skills/ai-security-reviewer.js", () => ({
   evaluateScriptsAI: vi.fn().mockResolvedValue({ verdict: "safe", score: 100, notes: "" }),
 }));
 
+vi.mock("./skill-import.js", () => ({
+  parseSkillPack: vi.fn(),
+  computeImportDiff: vi.fn(),
+  executeImport: vi.fn(),
+}));
+
 import { getDb } from "../gateway/db.js";
 import { createRestRouter } from "../gateway/rest-router.js";
 import { signToken } from "./auth.js";
 import { registerSiclawRoutes } from "./siclaw-api.js";
+import { parseSkillPack, computeImportDiff, executeImport } from "./skill-import.js";
 import type { RuntimeConnectionMap } from "./runtime-connection.js";
 
 const JWT_SECRET = "test-siclaw";
@@ -43,11 +50,25 @@ function fakeReq(opts: { url: string; method: string; headers?: Record<string, s
     if (ev === "data" && !em._emitted) {
       em._emitted = true;
       setImmediate(() => {
-        if (opts.body !== undefined) em.emit("data", Buffer.from(JSON.stringify(opts.body)));
+        if (opts.body !== undefined) {
+          // Pass raw bytes through for binary uploads (zip/tar); JSON-encode
+          // anything else so existing JSON-body tests keep working.
+          const chunk = Buffer.isBuffer(opts.body)
+            ? opts.body
+            : Buffer.from(JSON.stringify(opts.body));
+          em.emit("data", chunk);
+        }
         em.emit("end");
       });
     }
     return em;
+  };
+  // Some routes consume the body via `for await (const chunk of req)` instead
+  // of req.on('data'). Implement Symbol.asyncIterator so both code paths work.
+  em[Symbol.asyncIterator] = async function* () {
+    if (opts.body !== undefined) {
+      yield Buffer.isBuffer(opts.body) ? opts.body : Buffer.from(JSON.stringify(opts.body));
+    }
   };
   return em;
 }
@@ -423,6 +444,96 @@ describe("siclaw-api skills", () => {
       }));
       expect(status).toBe(200);
       expect(body.data ?? body.history ?? body).toBeDefined();
+    });
+  });
+
+  // ── Skill pack upload (POST /skills/import) — wire & policy assertions ─
+  //
+  // Unit tests for parseSkillPack / executeImport live in skill-import.test.ts.
+  // Here we mock those modules and assert that the endpoint *wires* them with
+  // the right mode and response shape — guards against a typo-level regression
+  // (e.g. dropping `mode: "upsert"` or the dry-run `deleted: []` spread).
+  describe("POST /api/v1/siclaw/skills/import (zip/tar upload)", () => {
+    const adminToken = signToken("a1", "admin", "admin", JWT_SECRET);
+
+    it("dry_run zeroes out deleted even when DB has builtins absent from pack", async () => {
+      (parseSkillPack as any).mockResolvedValue([
+        { name: "alpha", description: "a", specs: "...", scripts: [], labels: [] },
+      ]);
+      (computeImportDiff as any).mockResolvedValue({
+        added: [{ name: "alpha", description: "a" }],
+        updated: [],
+        unchanged: [],
+        // Diff says these would be deleted under sync mode — endpoint must
+        // hide them in the upsert preview so the admin doesn't see a phantom
+        // "will delete N skills" warning.
+        deleted: [{ name: "stale", description: "old", bound_agents: [] }],
+      });
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/skills/import?dry_run=true",
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${adminToken}`,
+          "content-type": "application/zip",
+        },
+        body: Buffer.from("PK\u0003\u0004placeholder"),
+      }));
+
+      expect(status).toBe(200);
+      expect(body.dry_run).toBe(true);
+      expect(body.added).toEqual([{ name: "alpha", description: "a" }]);
+      expect(body.deleted).toEqual([]);
+      expect(executeImport).not.toHaveBeenCalled();
+    });
+
+    it("non-dry-run path invokes executeImport with mode=upsert", async () => {
+      (parseSkillPack as any).mockResolvedValue([
+        { name: "alpha", description: "a", specs: "...", scripts: [], labels: [] },
+      ]);
+      (executeImport as any).mockResolvedValue({
+        added: [], updated: [], deleted: [], unchanged: [],
+        import_id: "id-1", version: 1,
+      });
+
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/skills/import?comment=manual",
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${adminToken}`,
+          "content-type": "application/zip",
+        },
+        body: Buffer.from("PK\u0003\u0004placeholder"),
+      }));
+
+      expect(status).toBe(200);
+      expect(executeImport).toHaveBeenCalledTimes(1);
+      // Args: (orgId, skills, userId, comment, opts) — opts must declare upsert.
+      const opts = (executeImport as any).mock.calls[0][4];
+      expect(opts.mode).toBe("upsert");
+    });
+
+    it("rollback invokes executeImport with mode=sync", async () => {
+      // History row with a snapshot JSON.
+      query.mockResolvedValueOnce([[{ snapshot: JSON.stringify([
+        { name: "alpha", description: "a", specs: "...", scripts: [], labels: [] },
+      ]) }], []]);
+      (executeImport as any).mockResolvedValue({
+        added: [], updated: [], deleted: [], unchanged: [],
+        import_id: "id-2", version: 7,
+      });
+
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/skills/import/rollback",
+        method: "POST",
+        headers: { authorization: `Bearer ${adminToken}` },
+        body: { version: 3 },
+      }));
+
+      expect(status).toBe(200);
+      expect(executeImport).toHaveBeenCalledTimes(1);
+      const opts = (executeImport as any).mock.calls[0][4];
+      expect(opts.mode).toBe("sync");
     });
   });
 });

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -299,6 +299,177 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     sendJson(res, 201, created);
   });
 
+  // ================================================================
+  // Skill Import (builtin pack management)
+  //
+  // Registered BEFORE the `/skills/:id/*` parameterized routes below so
+  // that paths like `/skills/import/rollback` reach the import handler
+  // instead of being shadowed by `POST /skills/:id/rollback` (which would
+  // match with id="import"). The router is first-match-wins.
+  // ================================================================
+
+  // Upload zip with dry_run or execute
+  router.post(`${P}/skills/import`, async (req, res) => {
+    const auth = requireAdmin(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
+    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
+
+    // Read raw body
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+    const body = Buffer.concat(chunks);
+    const contentType = req.headers["content-type"] || "";
+
+    // JSON request: dry_run from builtin directory
+    if (contentType.includes("application/json")) {
+      const json = JSON.parse(body.toString("utf8"));
+      if (json.source === "builtin") {
+        const { parseSkillsDir } = await import("../gateway/skills/builtin-sync.js");
+        const nodePath = await import("node:path");
+        const skills = parseSkillsDir(nodePath.join(process.cwd(), "skills", "core"));
+        if (skills.length === 0) { sendJson(res, 400, { error: "No builtin skills found in image" }); return; }
+        const { computeImportDiff } = await import("./skill-import.js");
+        const diff = await computeImportDiff(auth.orgId, skills);
+        sendJson(res, 200, { dry_run: true, ...diff });
+        return;
+      }
+      sendJson(res, 400, { error: "Invalid JSON request" });
+      return;
+    }
+
+    // Binary archive upload (zip or tar/tar.gz): Content-Type may be
+    // application/zip, application/x-tar, application/gzip, or application/octet-stream
+    // — the actual format is detected from magic bytes in parseSkillPack.
+    // Query params: ?dry_run=true&comment=...
+    const query = parseQuery(req.url ?? "");
+    const dryRun = query.dry_run === "true";
+    const comment = (query.comment as string) || "";
+
+    const { parseSkillPack, computeImportDiff, executeImport } = await import("./skill-import.js");
+    let skills;
+    try {
+      skills = await parseSkillPack(body);
+    } catch (err: any) {
+      // Log internals (paths, mysql error text, etc.) but return a generic
+      // message — this is reached pre-validation so untrusted callers can
+      // trigger it.
+      console.error("[skills-import] parseSkillPack failed:", err);
+      sendJson(res, 400, { error: "Failed to parse skill pack — must be a valid zip or tar archive" });
+      return;
+    }
+    if (skills.length === 0) { sendJson(res, 400, { error: "No skills found in archive" }); return; }
+
+    if (dryRun) {
+      const diff = await computeImportDiff(auth.orgId, skills);
+      // Admin pack uploads are upsert-only — builtins missing from the pack
+      // are left alone, never deleted. Zero out `deleted` so the dry-run
+      // preview honestly reflects what executing the import would do.
+      sendJson(res, 200, { dry_run: true, skill_count: skills.length, ...diff, deleted: [] });
+      return;
+    }
+
+    try {
+      const result = await executeImport(auth.orgId, skills, auth.userId, comment, {
+        mode: "upsert",
+        notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
+      });
+      sendJson(res, 200, result);
+    } catch (err: any) {
+      console.error("[skills-import] executeImport failed:", err);
+      sendJson(res, 500, { error: "Import failed" });
+    }
+  });
+
+  // Init from bundled skills/core/
+  router.post(`${P}/skills/import/init`, async (req, res) => {
+    const auth = requireAdmin(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
+    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
+
+    const body = await parseBody<{ comment?: string }>(req);
+    const { parseSkillsDir } = await import("../gateway/skills/builtin-sync.js");
+    const { executeImport } = await import("./skill-import.js");
+    const nodePath = await import("node:path");
+
+    const skillsDir = nodePath.join(process.cwd(), "skills", "core");
+    const skills = parseSkillsDir(skillsDir);
+    if (skills.length === 0) { sendJson(res, 400, { error: "No builtin skills found in image" }); return; }
+
+    try {
+      // Init: the bundled `skills/core/` is the source of truth. Sync mode
+      // ensures DB matches the image — skills removed upstream go away here.
+      const result = await executeImport(auth.orgId, skills, auth.userId,
+        body.comment || "Initialize from builtin",
+        {
+          mode: "sync",
+          notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
+        });
+      sendJson(res, 200, result);
+    } catch (err: any) {
+      console.error("[skills-import/init] failed:", err);
+      sendJson(res, 500, { error: "Init failed" });
+    }
+  });
+
+  // List import versions (history)
+  router.get(`${P}/skills/import/history`, async (req, res) => {
+    const auth = requireAdmin(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
+    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
+
+    const db = getDb();
+    const [rows] = await db.query(
+      `SELECT id, version, comment, skill_count, added, updated, deleted, imported_by, created_at
+       FROM skill_import_history ORDER BY version DESC LIMIT 20`,
+    ) as any;
+    for (const row of rows as any[]) {
+      if (row.added !== undefined) row.added = safeParseJson(row.added, []);
+      if (row.updated !== undefined) row.updated = safeParseJson(row.updated, []);
+      if (row.deleted !== undefined) row.deleted = safeParseJson(row.deleted, []);
+    }
+    sendJson(res, 200, { data: rows });
+  });
+
+  // Rollback to a previous import version
+  router.post(`${P}/skills/import/rollback`, async (req, res) => {
+    const auth = requireAdmin(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
+    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
+
+    const body = await parseBody<{ version: number; comment?: string }>(req);
+    if (!body.version) { sendJson(res, 400, { error: "version required" }); return; }
+
+    const db = getDb();
+    const [histRows] = await db.query(
+      "SELECT snapshot FROM skill_import_history WHERE version = ?",
+      [body.version],
+    ) as any;
+    if (histRows.length === 0) { sendJson(res, 404, { error: "Import version not found" }); return; }
+
+    const { executeImport } = await import("./skill-import.js");
+    const skills = JSON.parse(histRows[0].snapshot);
+
+    try {
+      // Rollback: the target version's snapshot IS the desired full state,
+      // so sync mode is required — skills added after that version must be
+      // removed for the rollback to be faithful.
+      const result = await executeImport(auth.orgId, skills, auth.userId,
+        body.comment || `Rollback to v${body.version}`,
+        {
+          mode: "sync",
+          notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
+        });
+      sendJson(res, 200, result);
+    } catch (err: any) {
+      console.error("[skills-import/rollback] failed:", err);
+      sendJson(res, 500, { error: "Rollback failed" });
+    }
+  });
+
+  // ================================================================
+  // Skills CRUD (continues — parameterized resource routes)
+  // ================================================================
+
   // Get skill
   router.get(`${P}/skills/:id`, async (req, res, params) => {
     const auth = requireAuth(req, config.jwtSecret);
@@ -950,161 +1121,6 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       row.scripts = safeParseJson(row.scripts, []);
     }
     sendJson(res, 200, row);
-  });
-
-  // ================================================================
-  // Skill Import (builtin pack management)
-  // ================================================================
-
-  // Upload zip with dry_run or execute
-  router.post(`${P}/skills/import`, async (req, res) => {
-    const auth = requireAdmin(req, config.jwtSecret);
-    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
-    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
-
-    // Read raw body
-    const chunks: Buffer[] = [];
-    for await (const chunk of req) chunks.push(chunk as Buffer);
-    const body = Buffer.concat(chunks);
-    const contentType = req.headers["content-type"] || "";
-
-    // JSON request: dry_run from builtin directory
-    if (contentType.includes("application/json")) {
-      const json = JSON.parse(body.toString("utf8"));
-      if (json.source === "builtin") {
-        const { parseSkillsDir } = await import("../gateway/skills/builtin-sync.js");
-        const nodePath = await import("node:path");
-        const skills = parseSkillsDir(nodePath.join(process.cwd(), "skills", "core"));
-        if (skills.length === 0) { sendJson(res, 400, { error: "No builtin skills found in image" }); return; }
-        const { computeImportDiff } = await import("./skill-import.js");
-        const diff = await computeImportDiff(auth.orgId, skills);
-        sendJson(res, 200, { dry_run: true, ...diff });
-        return;
-      }
-      sendJson(res, 400, { error: "Invalid JSON request" });
-      return;
-    }
-
-    // Binary archive upload (zip or tar/tar.gz): Content-Type may be
-    // application/zip, application/x-tar, application/gzip, or application/octet-stream
-    // — the actual format is detected from magic bytes in parseSkillPack.
-    // Query params: ?dry_run=true&comment=...
-    const query = parseQuery(req.url ?? "");
-    const dryRun = query.dry_run === "true";
-    const comment = (query.comment as string) || "";
-
-    const { parseSkillPack, computeImportDiff, executeImport } = await import("./skill-import.js");
-    let skills;
-    try {
-      skills = await parseSkillPack(body);
-    } catch (err: any) {
-      sendJson(res, 400, { error: `Failed to parse skill pack: ${err.message}` });
-      return;
-    }
-    if (skills.length === 0) { sendJson(res, 400, { error: "No skills found in archive" }); return; }
-
-    if (dryRun) {
-      const diff = await computeImportDiff(auth.orgId, skills);
-      // Admin pack uploads are upsert-only — builtins missing from the pack
-      // are left alone, never deleted. Zero out `deleted` so the dry-run
-      // preview honestly reflects what executing the import would do.
-      sendJson(res, 200, { dry_run: true, skill_count: skills.length, ...diff, deleted: [] });
-      return;
-    }
-
-    try {
-      const result = await executeImport(auth.orgId, skills, auth.userId, comment, {
-        mode: "upsert",
-        notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
-      });
-      sendJson(res, 200, result);
-    } catch (err: any) {
-      sendJson(res, 500, { error: `Import failed: ${err.message}` });
-    }
-  });
-
-  // Init from bundled skills/core/
-  router.post(`${P}/skills/import/init`, async (req, res) => {
-    const auth = requireAdmin(req, config.jwtSecret);
-    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
-    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
-
-    const body = await parseBody<{ comment?: string }>(req);
-    const { parseSkillsDir } = await import("../gateway/skills/builtin-sync.js");
-    const { executeImport } = await import("./skill-import.js");
-    const nodePath = await import("node:path");
-
-    const skillsDir = nodePath.join(process.cwd(), "skills", "core");
-    const skills = parseSkillsDir(skillsDir);
-    if (skills.length === 0) { sendJson(res, 400, { error: "No builtin skills found in image" }); return; }
-
-    try {
-      // Init: the bundled `skills/core/` is the source of truth. Sync mode
-      // ensures DB matches the image — skills removed upstream go away here.
-      const result = await executeImport(auth.orgId, skills, auth.userId,
-        body.comment || "Initialize from builtin",
-        {
-          mode: "sync",
-          notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
-        });
-      sendJson(res, 200, result);
-    } catch (err: any) {
-      sendJson(res, 500, { error: `Init failed: ${err.message}` });
-    }
-  });
-
-  // List import versions (history)
-  router.get(`${P}/skills/import/history`, async (req, res) => {
-    const auth = requireAdmin(req, config.jwtSecret);
-    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
-    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
-
-    const db = getDb();
-    const [rows] = await db.query(
-      `SELECT id, version, comment, skill_count, added, updated, deleted, imported_by, created_at
-       FROM skill_import_history ORDER BY version DESC LIMIT 20`,
-    ) as any;
-    for (const row of rows as any[]) {
-      if (row.added !== undefined) row.added = safeParseJson(row.added, []);
-      if (row.updated !== undefined) row.updated = safeParseJson(row.updated, []);
-      if (row.deleted !== undefined) row.deleted = safeParseJson(row.deleted, []);
-    }
-    sendJson(res, 200, { data: rows });
-  });
-
-  // Rollback to a previous import version
-  router.post(`${P}/skills/import/rollback`, async (req, res) => {
-    const auth = requireAdmin(req, config.jwtSecret);
-    if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
-    if (!auth.orgId) { sendJson(res, 403, { error: "Organization context required" }); return; }
-
-    const body = await parseBody<{ version: number; comment?: string }>(req);
-    if (!body.version) { sendJson(res, 400, { error: "version required" }); return; }
-
-    const db = getDb();
-    const [histRows] = await db.query(
-      "SELECT snapshot FROM skill_import_history WHERE version = ?",
-      [body.version],
-    ) as any;
-    if (histRows.length === 0) { sendJson(res, 404, { error: "Import version not found" }); return; }
-
-    const { executeImport } = await import("./skill-import.js");
-    const skills = JSON.parse(histRows[0].snapshot);
-
-    try {
-      // Rollback: the target version's snapshot IS the desired full state,
-      // so sync mode is required — skills added after that version must be
-      // removed for the rollback to be faithful.
-      const result = await executeImport(auth.orgId, skills, auth.userId,
-        body.comment || `Rollback to v${body.version}`,
-        {
-          mode: "sync",
-          notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
-        });
-      sendJson(res, 200, result);
-    } catch (err: any) {
-      sendJson(res, 500, { error: `Rollback failed: ${err.message}` });
-    }
   });
 
   // ================================================================

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -985,7 +985,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       return;
     }
 
-    // Binary zip upload: Content-Type: application/zip or application/octet-stream
+    // Binary archive upload (zip or tar/tar.gz): Content-Type may be
+    // application/zip, application/x-tar, application/gzip, or application/octet-stream
+    // — the actual format is detected from magic bytes in parseSkillPack.
     // Query params: ?dry_run=true&comment=...
     const query = parseQuery(req.url ?? "");
     const dryRun = query.dry_run === "true";
@@ -999,17 +1001,22 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       sendJson(res, 400, { error: `Failed to parse skill pack: ${err.message}` });
       return;
     }
-    if (skills.length === 0) { sendJson(res, 400, { error: "No skills found in zip" }); return; }
+    if (skills.length === 0) { sendJson(res, 400, { error: "No skills found in archive" }); return; }
 
     if (dryRun) {
       const diff = await computeImportDiff(auth.orgId, skills);
-      sendJson(res, 200, { dry_run: true, skill_count: skills.length, ...diff });
+      // Admin pack uploads are upsert-only — builtins missing from the pack
+      // are left alone, never deleted. Zero out `deleted` so the dry-run
+      // preview honestly reflects what executing the import would do.
+      sendJson(res, 200, { dry_run: true, skill_count: skills.length, ...diff, deleted: [] });
       return;
     }
 
     try {
-      const result = await executeImport(auth.orgId, skills, auth.userId, comment,
-        (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources));
+      const result = await executeImport(auth.orgId, skills, auth.userId, comment, {
+        mode: "upsert",
+        notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
+      });
       sendJson(res, 200, result);
     } catch (err: any) {
       sendJson(res, 500, { error: `Import failed: ${err.message}` });
@@ -1032,9 +1039,14 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (skills.length === 0) { sendJson(res, 400, { error: "No builtin skills found in image" }); return; }
 
     try {
+      // Init: the bundled `skills/core/` is the source of truth. Sync mode
+      // ensures DB matches the image — skills removed upstream go away here.
       const result = await executeImport(auth.orgId, skills, auth.userId,
         body.comment || "Initialize from builtin",
-        (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources));
+        {
+          mode: "sync",
+          notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
+        });
       sendJson(res, 200, result);
     } catch (err: any) {
       sendJson(res, 500, { error: `Init failed: ${err.message}` });
@@ -1080,9 +1092,15 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const skills = JSON.parse(histRows[0].snapshot);
 
     try {
+      // Rollback: the target version's snapshot IS the desired full state,
+      // so sync mode is required — skills added after that version must be
+      // removed for the rollback to be faithful.
       const result = await executeImport(auth.orgId, skills, auth.userId,
         body.comment || `Rollback to v${body.version}`,
-        (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources));
+        {
+          mode: "sync",
+          notifyAgentReload: (agentId, resources) => ctx?.notifySkillAgents?.(agentId, resources),
+        });
       sendJson(res, 200, result);
     } catch (err: any) {
       sendJson(res, 500, { error: `Rollback failed: ${err.message}` });

--- a/src/portal/skill-import.test.ts
+++ b/src/portal/skill-import.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import zlib from "node:zlib";
+import AdmZip from "adm-zip";
+import * as tar from "tar";
 
 vi.mock("../gateway/db.js", () => ({
   getDb: vi.fn(),
@@ -11,7 +18,7 @@ vi.mock("../gateway/skills/builtin-sync.js", () => ({
 import { getDb } from "../gateway/db.js";
 import { parseSkillsDir } from "../gateway/skills/builtin-sync.js";
 import type { ParsedSkill } from "../gateway/skills/builtin-sync.js";
-import { computeImportDiff, executeImport } from "./skill-import.js";
+import { computeImportDiff, executeImport, parseSkillPack } from "./skill-import.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -41,7 +48,8 @@ describe("computeImportDiff", () => {
     (getDb as any).mockReturnValue({ query });
 
     const diff = await computeImportDiff("org1", [mkSkill("new-one"), mkSkill("new-two")]);
-    expect(diff.added).toEqual(["new-one", "new-two"]);
+    expect(diff.added.map(d => d.name)).toEqual(["new-one", "new-two"]);
+    expect(diff.added.every(d => typeof d.description === "string")).toBe(true);
     expect(diff.updated).toEqual([]);
     expect(diff.deleted).toEqual([]);
     expect(diff.unchanged).toEqual([]);
@@ -50,12 +58,12 @@ describe("computeImportDiff", () => {
   it("detects unchanged skills when specs + scripts match", async () => {
     const incoming = [mkSkill("alpha", { specs: "same", scripts: [{ name: "s.sh", content: "echo" }] })];
     const query = vi.fn().mockResolvedValueOnce([[
-      { id: "s1", name: "alpha", specs: "same", scripts: JSON.stringify([{ name: "s.sh", content: "echo" }]) },
+      { id: "s1", name: "alpha", description: "alpha desc", specs: "same", scripts: JSON.stringify([{ name: "s.sh", content: "echo" }]) },
     ], []]);
     (getDb as any).mockReturnValue({ query });
 
     const diff = await computeImportDiff("org1", incoming);
-    expect(diff.unchanged).toEqual(["alpha"]);
+    expect(diff.unchanged.map(d => d.name)).toEqual(["alpha"]);
     expect(diff.updated).toEqual([]);
     expect(diff.added).toEqual([]);
   });
@@ -63,34 +71,34 @@ describe("computeImportDiff", () => {
   it("detects updated skills when specs differ", async () => {
     const incoming = [mkSkill("alpha", { specs: "NEW" })];
     const query = vi.fn().mockResolvedValueOnce([[
-      { id: "s1", name: "alpha", specs: "OLD", scripts: "[]" },
+      { id: "s1", name: "alpha", description: "alpha desc", specs: "OLD", scripts: "[]" },
     ], []]);
     (getDb as any).mockReturnValue({ query });
 
     const diff = await computeImportDiff("org1", incoming);
-    expect(diff.updated).toEqual(["alpha"]);
+    expect(diff.updated.map(d => d.name)).toEqual(["alpha"]);
   });
 
   it("detects updated skills when scripts differ", async () => {
     const incoming = [mkSkill("alpha", { scripts: [{ name: "s.sh", content: "new" }] })];
     const query = vi.fn().mockResolvedValueOnce([[
-      { id: "s1", name: "alpha", specs: "specs of alpha", scripts: JSON.stringify([{ name: "s.sh", content: "old" }]) },
+      { id: "s1", name: "alpha", description: "alpha desc", specs: "specs of alpha", scripts: JSON.stringify([{ name: "s.sh", content: "old" }]) },
     ], []]);
     (getDb as any).mockReturnValue({ query });
 
     const diff = await computeImportDiff("org1", incoming);
-    expect(diff.updated).toEqual(["alpha"]);
+    expect(diff.updated.map(d => d.name)).toEqual(["alpha"]);
   });
 
   it("treats DB scripts stored as object (not string) correctly", async () => {
     const incoming = [mkSkill("alpha", { scripts: [{ name: "s.sh", content: "x" }] })];
     const query = vi.fn().mockResolvedValueOnce([[
-      { id: "s1", name: "alpha", specs: "specs of alpha", scripts: [{ name: "s.sh", content: "x" }] },
+      { id: "s1", name: "alpha", description: "alpha desc", specs: "specs of alpha", scripts: [{ name: "s.sh", content: "x" }] },
     ], []]);
     (getDb as any).mockReturnValue({ query });
 
     const diff = await computeImportDiff("org1", incoming);
-    expect(diff.unchanged).toEqual(["alpha"]);
+    expect(diff.unchanged.map(d => d.name)).toEqual(["alpha"]);
   });
 
   it("returns deleted skills with bound_agents list", async () => {
@@ -149,7 +157,7 @@ describe("executeImport", () => {
 
     conn.query.mockRejectedValueOnce(new Error("insert fail"));
 
-    await expect(executeImport("org1", [mkSkill("new")], "userA", "msg"))
+    await expect(executeImport("org1", [mkSkill("new")], "userA", "msg", { mode: "sync" }))
       .rejects.toThrow("insert fail");
 
     expect(conn.rollback).toHaveBeenCalled();
@@ -165,8 +173,8 @@ describe("executeImport", () => {
     //   - builtins: alpha (will be updated), gone (will be deleted)
     //   - incoming: alpha (changed), brand-new (will be added)
     query.mockResolvedValueOnce([[
-      { id: "s-alpha", name: "alpha", specs: "OLD", scripts: "[]" },
-      { id: "s-gone", name: "gone", specs: "x", scripts: "[]" },
+      { id: "s-alpha", name: "alpha", description: "alpha desc", specs: "OLD", scripts: "[]" },
+      { id: "s-gone", name: "gone", description: "gone desc", specs: "x", scripts: "[]" },
     ], []]);
     // bound_agents for gone
     query.mockResolvedValueOnce([[{ id: "a1", name: "Agent 1" }], []]);
@@ -200,12 +208,13 @@ describe("executeImport", () => {
       mkSkill("brand-new"),
     ];
     const notify = vi.fn();
-    const result = await executeImport("org1", incoming, "userA", "rel", notify);
+    const result = await executeImport("org1", incoming, "userA", "rel", { mode: "sync", notifyAgentReload: notify });
 
-    expect(result.added).toEqual(["brand-new"]);
-    expect(result.updated).toEqual(["alpha"]);
+    expect(result.added.map(d => d.name)).toEqual(["brand-new"]);
+    expect(result.updated.map(d => d.name)).toEqual(["alpha"]);
     expect(result.deleted).toHaveLength(1);
     expect(result.deleted[0].name).toBe("gone");
+    expect(result.deleted[0].description).toBe("gone desc");
     expect(result.version).toBe(5);
     expect(result.import_id).toBeDefined();
 
@@ -219,7 +228,7 @@ describe("executeImport", () => {
 
     // computeImportDiff — builtin 'gone' will be deleted
     query.mockResolvedValueOnce([[
-      { id: "s-gone", name: "gone", specs: "x", scripts: "[]" },
+      { id: "s-gone", name: "gone", description: "gone desc", specs: "x", scripts: "[]" },
     ], []]);
     query.mockResolvedValueOnce([[], []]);  // bound_agents — empty
 
@@ -238,7 +247,7 @@ describe("executeImport", () => {
     query.mockResolvedValueOnce([undefined, []]);
     query.mockResolvedValueOnce([undefined, []]);
 
-    const result = await executeImport("org1", [], "userA", "");
+    const result = await executeImport("org1", [], "userA", "", { mode: "sync" });
 
     expect(result.deleted).toHaveLength(1);
     expect(conn.commit).toHaveBeenCalled();
@@ -247,5 +256,188 @@ describe("executeImport", () => {
     const sqls = conn.query.mock.calls.map(c => c[0] as string);
     expect(sqls).toContain("UPDATE skills SET overlay_of = NULL, updated_at = CURRENT_TIMESTAMP WHERE overlay_of = ?");
     expect(sqls).not.toContain("DELETE FROM agent_skills WHERE skill_id = ?");
+  });
+
+  it("upsert mode skips deletes and reports empty deleted list", async () => {
+    const { db, conn, query } = makeDb();
+    (getDb as any).mockReturnValue(db);
+
+    // computeImportDiff:
+    //   - builtins: alpha (will be updated), gone (would be deleted in sync mode)
+    //   - incoming: alpha (changed)
+    query.mockResolvedValueOnce([[
+      { id: "s-alpha", name: "alpha", description: "alpha desc", specs: "OLD", scripts: "[]" },
+      { id: "s-gone", name: "gone", description: "gone desc", specs: "x", scripts: "[]" },
+    ], []]);
+    // bound_agents for 'gone' (computeImportDiff still inspects them — no policy applied yet)
+    query.mockResolvedValueOnce([[{ id: "a1", name: "Agent 1" }], []]);
+
+    // executeImport's builtin name→id lookup
+    query.mockResolvedValueOnce([[
+      { id: "s-alpha", name: "alpha" },
+      { id: "s-gone", name: "gone" },
+    ], []]);
+
+    // Transaction queries — only UPDATE path should run, no DELETE.
+    conn.query
+      .mockResolvedValueOnce([[{ v: 1 }], []])      // MAX version
+      .mockResolvedValueOnce([undefined, []])        // UPDATE skills
+      .mockResolvedValueOnce([undefined, []]);       // INSERT skill_versions
+
+    // Snapshot queries
+    query.mockResolvedValueOnce([[{ v: 0 }], []]);
+    query.mockResolvedValueOnce([undefined, []]);
+    query.mockResolvedValueOnce([undefined, []]);
+
+    const notify = vi.fn();
+    const result = await executeImport(
+      "org1",
+      [mkSkill("alpha", { specs: "NEW" })],
+      "userA",
+      "upsert-test",
+      { mode: "upsert", notifyAgentReload: notify },
+    );
+
+    expect(result.updated.map(d => d.name)).toEqual(["alpha"]);
+    expect(result.deleted).toEqual([]);
+    expect(conn.commit).toHaveBeenCalled();
+    // Should NOT have touched the delete branch at all.
+    const sqls = conn.query.mock.calls.map(c => c[0] as string);
+    expect(sqls).not.toContain("DELETE FROM skills WHERE id = ?");
+    expect(sqls).not.toContain("DELETE FROM agent_skills WHERE skill_id = ?");
+    expect(sqls).not.toContain("SELECT id FROM skills WHERE overlay_of = ?");
+    // No agents to notify since nothing was unbound.
+    expect(notify).not.toHaveBeenCalled();
+  });
+});
+
+// ── parseSkillPack ────────────────────────────────────────────
+
+describe("parseSkillPack", () => {
+  it("extracts a zip and forwards the directory to parseSkillsDir", async () => {
+    const zip = new AdmZip();
+    zip.addFile("my-skill/SKILL.md", Buffer.from("---\nname: my-skill\ndescription: x\n---\n"));
+    zip.addFile("meta.json", Buffer.from('{"labels":{"my-skill":["t"]}}'));
+
+    let observedDir = "";
+    (parseSkillsDir as any).mockImplementation((dir: string) => {
+      observedDir = dir;
+      return [];
+    });
+
+    await parseSkillPack(zip.toBuffer());
+
+    expect(observedDir).toMatch(/^\/tmp\/skill-import-/);
+    expect(parseSkillsDir).toHaveBeenCalledTimes(1);
+    // Extraction dir is cleaned up in the finally block.
+    expect(fs.existsSync(observedDir)).toBe(false);
+  });
+
+  it("descends into a single wrapper directory when there is no root meta.json", async () => {
+    const zip = new AdmZip();
+    zip.addFile("wrapper/my-skill/SKILL.md", Buffer.from("---\nname: my-skill\ndescription: x\n---\n"));
+
+    let observedDir = "";
+    (parseSkillsDir as any).mockImplementation((dir: string) => {
+      observedDir = dir;
+      return [];
+    });
+
+    await parseSkillPack(zip.toBuffer());
+
+    expect(path.basename(observedDir)).toBe("wrapper");
+  });
+
+  it("rejects entries with parent-directory traversal", async () => {
+    // adm-zip's addFile() sanitises `..` segments, so we forge a malicious
+    // entry by overwriting entryName after creation — this matches what an
+    // attacker could do by crafting the zip bytes directly.
+    const zip = new AdmZip();
+    zip.addFile("evil.txt", Buffer.from("pwned"));
+    zip.getEntries()[0].entryName = "../evil.txt";
+    const buf = zip.toBuffer();
+
+    await expect(parseSkillPack(buf)).rejects.toThrow(/Unsafe path/);
+    expect(parseSkillsDir).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Build a tar (optionally gzipped) buffer from a layout of paths → contents.
+   * Uses tar.create against a real staging dir so the encoding matches what a
+   * normal `tar c` command would produce.
+   */
+  async function buildTarBuffer(
+    layout: Record<string, string>,
+    opts: { gzip?: boolean } = {},
+  ): Promise<Buffer> {
+    const stage = path.join(os.tmpdir(), `skill-import-test-${crypto.randomUUID()}`);
+    fs.mkdirSync(stage, { recursive: true });
+    try {
+      for (const [rel, content] of Object.entries(layout)) {
+        const full = path.join(stage, rel);
+        fs.mkdirSync(path.dirname(full), { recursive: true });
+        fs.writeFileSync(full, content);
+      }
+      const chunks: Buffer[] = [];
+      const stream = tar.create({ cwd: stage, gzip: opts.gzip ?? false }, ["."]);
+      for await (const chunk of stream) chunks.push(chunk as Buffer);
+      return Buffer.concat(chunks);
+    } finally {
+      fs.rmSync(stage, { recursive: true, force: true });
+    }
+  }
+
+  it("extracts a tar archive and forwards the directory to parseSkillsDir", async () => {
+    const buf = await buildTarBuffer({
+      "my-skill/SKILL.md": "---\nname: my-skill\ndescription: x\n---\n",
+      "meta.json": '{"labels":{"my-skill":["t"]}}',
+    });
+
+    let observedDir = "";
+    let extractedFiles: string[] = [];
+    (parseSkillsDir as any).mockImplementation((dir: string) => {
+      observedDir = dir;
+      extractedFiles = fs.readdirSync(dir);
+      return [];
+    });
+
+    await parseSkillPack(buf);
+
+    expect(observedDir).toMatch(/^\/tmp\/skill-import-/);
+    expect(extractedFiles).toEqual(expect.arrayContaining(["my-skill", "meta.json"]));
+  });
+
+  it("extracts a gzipped tar archive", async () => {
+    const buf = await buildTarBuffer(
+      { "my-skill/SKILL.md": "---\nname: my-skill\ndescription: x\n---\n" },
+      { gzip: true },
+    );
+    // Confirm we actually built a gzip-prefixed buffer (magic bytes 1f 8b).
+    expect(buf[0]).toBe(0x1f);
+    expect(buf[1]).toBe(0x8b);
+
+    let extractedFiles: string[] = [];
+    (parseSkillsDir as any).mockImplementation((dir: string) => {
+      extractedFiles = fs.readdirSync(dir);
+      return [];
+    });
+
+    await parseSkillPack(buf);
+
+    // Single wrapper subdir (no meta.json at root) → parseSkillPack descends
+    // into it, so the dir we observed lists SKILL.md directly.
+    expect(extractedFiles).toContain("SKILL.md");
+  });
+
+  it("rejects buffers that are neither zip nor tar", async () => {
+    const buf = Buffer.from("not a real archive, just plain text bytes");
+    await expect(parseSkillPack(buf)).rejects.toThrow(/Unsupported archive format/);
+    expect(parseSkillsDir).not.toHaveBeenCalled();
+  });
+
+  it("rejects gzip buffers that are not actually tar inside", async () => {
+    const buf = zlib.gzipSync(Buffer.from("just plain text wrapped in gzip"));
+    await expect(parseSkillPack(buf)).rejects.toThrow();
+    expect(parseSkillsDir).not.toHaveBeenCalled();
   });
 });

--- a/src/portal/skill-import.test.ts
+++ b/src/portal/skill-import.test.ts
@@ -327,7 +327,8 @@ describe("parseSkillPack", () => {
 
     await parseSkillPack(zip.toBuffer());
 
-    expect(observedDir).toMatch(/^\/tmp\/skill-import-/);
+    expect(observedDir.startsWith(os.tmpdir())).toBe(true);
+    expect(observedDir).toMatch(/skill-import-/);
     expect(parseSkillsDir).toHaveBeenCalledTimes(1);
     // Extraction dir is cleaned up in the finally block.
     expect(fs.existsSync(observedDir)).toBe(false);
@@ -403,7 +404,8 @@ describe("parseSkillPack", () => {
 
     await parseSkillPack(buf);
 
-    expect(observedDir).toMatch(/^\/tmp\/skill-import-/);
+    expect(observedDir.startsWith(os.tmpdir())).toBe(true);
+    expect(observedDir).toMatch(/skill-import-/);
     expect(extractedFiles).toEqual(expect.arrayContaining(["my-skill", "meta.json"]));
   });
 
@@ -437,7 +439,42 @@ describe("parseSkillPack", () => {
 
   it("rejects gzip buffers that are not actually tar inside", async () => {
     const buf = zlib.gzipSync(Buffer.from("just plain text wrapped in gzip"));
-    await expect(parseSkillPack(buf)).rejects.toThrow();
+    // node-tar reports an "invalid base256 encoding" / "unexpected end" /
+    // "TAR_ENTRY_INVALID" depending on the corruption — match the family,
+    // not the exact wording.
+    await expect(parseSkillPack(buf)).rejects.toThrow(/tar|TAR|invalid|unexpected/i);
+    expect(parseSkillsDir).not.toHaveBeenCalled();
+  });
+
+  it("rejects tar entries with parent-directory traversal", async () => {
+    // node-tar's `filter` runs before extraction. Build a non-PAX tar
+    // (PAX wrappers move the real name out of the first header, defeating
+    // forging), then overwrite the entry name with "../evil.txt" and fix
+    // the header checksum so node-tar accepts the header and invokes our
+    // filter — which must throw.
+    const stage = path.join(os.tmpdir(), `skill-import-test-${crypto.randomUUID()}`);
+    fs.mkdirSync(stage, { recursive: true });
+    let buf: Buffer;
+    try {
+      fs.writeFileSync(path.join(stage, "evil.txt"), "pwned");
+      const chunks: Buffer[] = [];
+      const stream = tar.create({ cwd: stage, portable: true, noPax: true }, ["evil.txt"]);
+      for await (const chunk of stream) chunks.push(chunk as Buffer);
+      buf = Buffer.concat(chunks);
+      // Overwrite entry name (bytes 0..100) with traversal path.
+      Buffer.alloc(100).copy(buf, 0);
+      Buffer.from("../evil.txt", "utf8").copy(buf, 0);
+      // Recompute checksum: zero the field as 8 spaces, sum all 512 bytes,
+      // write as "OOOOOO\0 " (6 octal digits + NUL + space).
+      for (let i = 148; i < 156; i++) buf[i] = 0x20;
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += buf[i];
+      Buffer.from(sum.toString(8).padStart(6, "0") + "\0 ", "utf8").copy(buf, 148);
+    } finally {
+      fs.rmSync(stage, { recursive: true, force: true });
+    }
+
+    await expect(parseSkillPack(buf)).rejects.toThrow(/Unsafe path in tar/);
     expect(parseSkillsDir).not.toHaveBeenCalled();
   });
 });

--- a/src/portal/skill-import.ts
+++ b/src/portal/skill-import.ts
@@ -11,6 +11,7 @@
 
 import crypto from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import AdmZip from "adm-zip";
 import * as tar from "tar";
@@ -88,9 +89,28 @@ function extractZip(buf: Buffer, destDir: string): void {
 async function extractTar(buf: Buffer, destDir: string, tmpDir: string): Promise<void> {
   const archivePath = path.join(tmpDir, "pack.tar");
   fs.writeFileSync(archivePath, buf);
-  // tar.extract auto-detects gzip via the stream; default behavior strips
-  // absolute paths and refuses `..` entries, so no extra guard is needed.
-  await tar.extract({ file: archivePath, cwd: destDir });
+  // tar.extract auto-detects gzip via the stream. node-tar v7 already strips
+  // absolute paths and refuses `..` entries; the explicit `filter` is
+  // defense-in-depth so a future dep swap or option drift can't silently
+  // re-enable tar-slip. Throwing inside `filter` gets swallowed by node-tar's
+  // internal callback chain, so we mark the unsafe entry, skip it, and
+  // reject after extraction completes.
+  let unsafeEntry: string | null = null;
+  await tar.extract({
+    file: archivePath,
+    cwd: destDir,
+    filter: (entryPath) => {
+      const normalized = entryPath.replace(/\\/g, "/");
+      if (normalized.startsWith("/") || normalized.split("/").includes("..")) {
+        unsafeEntry ??= entryPath;
+        return false;
+      }
+      return true;
+    },
+  });
+  if (unsafeEntry !== null) {
+    throw new Error(`Unsafe path in tar: ${unsafeEntry}`);
+  }
 }
 
 /**
@@ -101,7 +121,7 @@ async function extractTar(buf: Buffer, destDir: string, tmpDir: string): Promise
  *   - Archive root contains a single wrapper directory holding the skill dirs
  */
 export async function parseSkillPack(archiveBuffer: Buffer): Promise<ParsedSkill[]> {
-  const tmpDir = path.join("/tmp", `skill-import-${crypto.randomUUID()}`);
+  const tmpDir = path.join(os.tmpdir(), `skill-import-${crypto.randomUUID()}`);
   const extractDir = path.join(tmpDir, "extracted");
   fs.mkdirSync(extractDir, { recursive: true });
   try {
@@ -237,6 +257,7 @@ export async function executeImport(
   for (const r of builtinRows) builtinByName.set(r.name, r.id);
 
   const conn = await db.getConnection();
+  const affectedAgentIds = new Set<string>();
   try {
     await conn.beginTransaction();
 
@@ -283,7 +304,6 @@ export async function executeImport(
     // --- DELETE removed builtin skills ---
     // Skipped in upsert mode — diff.deleted has already been zeroed out above
     // so this loop is a no-op, but the explicit guard keeps intent obvious.
-    const affectedAgentIds = new Set<string>();
     if (opts.mode === "sync") {
       for (const del of rawDiff.deleted) {
         const existingId = builtinByName.get(del.name)!;
@@ -314,18 +334,24 @@ export async function executeImport(
     }
 
     await conn.commit();
-
-    // Notify affected agents outside transaction (fire-and-forget)
-    if (opts.notifyAgentReload) {
-      for (const agentId of affectedAgentIds) {
-        opts.notifyAgentReload(agentId, ["skills"]);
-      }
-    }
   } catch (err) {
     await conn.rollback();
     throw err;
   } finally {
     conn.release();
+  }
+
+  // Notify affected agents outside the transaction. A thrown notify must
+  // not roll back an already-committed write or skip the history INSERT
+  // below, so each call is isolated with its own error swallow + log.
+  if (opts.notifyAgentReload) {
+    for (const agentId of affectedAgentIds) {
+      try {
+        opts.notifyAgentReload(agentId, ["skills"]);
+      } catch (err) {
+        console.error("[skill-import] notifyAgentReload threw:", err);
+      }
+    }
   }
 
   // --- Save snapshot for rollback ---

--- a/src/portal/skill-import.ts
+++ b/src/portal/skill-import.ts
@@ -2,7 +2,7 @@
  * Skill Import Service — parse, diff, and sync builtin skill packs.
  *
  * Provides three operations:
- *   1. parseSkillPack()     — extract a zip buffer into ParsedSkill[]
+ *   1. parseSkillPack()     — extract a zip/tar archive buffer into ParsedSkill[]
  *   2. computeImportDiff()  — compare incoming skills against DB builtins
  *   3. executeImport()      — apply the diff transactionally + snapshot
  *
@@ -12,7 +12,8 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { execSync } from "node:child_process";
+import AdmZip from "adm-zip";
+import * as tar from "tar";
 import { getDb } from "../gateway/db.js";
 import { parseSkillsDir, type ParsedSkill } from "../gateway/skills/builtin-sync.js";
 
@@ -22,11 +23,16 @@ export type { ParsedSkill };
 // Public types
 // ---------------------------------------------------------------------------
 
+export interface DiffEntry {
+  name: string;
+  description: string;
+}
+
 export interface ImportDiff {
-  added: string[];
-  updated: string[];
-  deleted: Array<{ name: string; bound_agents: Array<{ id: string; name: string }> }>;
-  unchanged: string[];
+  added: DiffEntry[];
+  updated: DiffEntry[];
+  deleted: Array<{ name: string; description: string; bound_agents: Array<{ id: string; name: string }> }>;
+  unchanged: DiffEntry[];
 }
 
 export interface ImportResult extends ImportDiff {
@@ -34,31 +40,81 @@ export interface ImportResult extends ImportDiff {
   version: number;
 }
 
+/**
+ * Import policy for builtins that exist in DB but are absent from the incoming pack.
+ *   - "sync"   — delete them (full mirror; used by init / rollback / bootstrap)
+ *   - "upsert" — leave them untouched (additive upload; used by admin pack upload)
+ */
+export type ImportMode = "sync" | "upsert";
+
 // ---------------------------------------------------------------------------
-// 1. Parse a zip skill pack into structured skill objects
+// 1. Parse a skill pack archive into structured skill objects
 // ---------------------------------------------------------------------------
+
+export type ArchiveFormat = "zip" | "tar";
 
 /**
- * Extract a zip buffer into ParsedSkill[].
+ * Detect archive format from the first bytes of the buffer.
+ * - zip: PK\x03\x04 (local file header)
+ * - tar.gz: gzip magic \x1F\x8B
+ * - tar (uncompressed): "ustar" at offset 257
+ */
+export function detectArchiveFormat(buf: Buffer): ArchiveFormat {
+  if (buf.length >= 4 && buf[0] === 0x50 && buf[1] === 0x4b && buf[2] === 0x03 && buf[3] === 0x04) {
+    return "zip";
+  }
+  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
+    return "tar"; // gzip-wrapped tar — tar.extract auto-detects gzip
+  }
+  if (buf.length >= 262 && buf.slice(257, 262).toString("utf8") === "ustar") {
+    return "tar";
+  }
+  throw new Error("Unsupported archive format (expected zip or tar)");
+}
+
+function extractZip(buf: Buffer, destDir: string): void {
+  const zip = new AdmZip(buf);
+  for (const entry of zip.getEntries()) {
+    // Reject absolute paths and parent-traversal segments — the zip must
+    // not be able to write outside destDir.
+    const name = entry.entryName.replace(/\\/g, "/");
+    if (name.startsWith("/") || name.split("/").includes("..")) {
+      throw new Error(`Unsafe path in zip: ${entry.entryName}`);
+    }
+  }
+  zip.extractAllTo(destDir, /*overwrite*/ true);
+}
+
+async function extractTar(buf: Buffer, destDir: string, tmpDir: string): Promise<void> {
+  const archivePath = path.join(tmpDir, "pack.tar");
+  fs.writeFileSync(archivePath, buf);
+  // tar.extract auto-detects gzip via the stream; default behavior strips
+  // absolute paths and refuses `..` entries, so no extra guard is needed.
+  await tar.extract({ file: archivePath, cwd: destDir });
+}
+
+/**
+ * Extract a skill pack archive (zip or tar / tar.gz) into ParsedSkill[].
  *
  * Handles both layouts:
- *   - Zip root contains skill directories directly
- *   - Zip root contains a single wrapper directory holding the skill dirs
+ *   - Archive root contains skill directories directly
+ *   - Archive root contains a single wrapper directory holding the skill dirs
  */
-export async function parseSkillPack(zipBuffer: Buffer): Promise<ParsedSkill[]> {
+export async function parseSkillPack(archiveBuffer: Buffer): Promise<ParsedSkill[]> {
   const tmpDir = path.join("/tmp", `skill-import-${crypto.randomUUID()}`);
-  fs.mkdirSync(tmpDir, { recursive: true });
+  const extractDir = path.join(tmpDir, "extracted");
+  fs.mkdirSync(extractDir, { recursive: true });
   try {
-    const zipPath = path.join(tmpDir, "pack.zip");
-    fs.writeFileSync(zipPath, zipBuffer);
-
-    const extractDir = path.join(tmpDir, "extracted");
-    fs.mkdirSync(extractDir);
-    execSync(`unzip -q "${zipPath}" -d "${extractDir}"`, { timeout: 30_000 });
+    const format = detectArchiveFormat(archiveBuffer);
+    if (format === "zip") {
+      extractZip(archiveBuffer, extractDir);
+    } else {
+      await extractTar(archiveBuffer, extractDir, tmpDir);
+    }
 
     // Determine the actual skills root directory.
     // If there's a single subdirectory and no meta.json at the extract root,
-    // the zip likely has a wrapper directory — descend into it.
+    // the archive likely has a wrapper directory — descend into it.
     const entries = fs.readdirSync(extractDir, { withFileTypes: true });
     const dirs = entries.filter(e => e.isDirectory());
     let skillsRoot = extractDir;
@@ -88,32 +144,33 @@ export async function computeImportDiff(
 
   // Current builtin skills
   const [builtinRows] = await db.query(
-    "SELECT id, name, specs, scripts FROM skills WHERE org_id = ? AND is_builtin = 1",
+    "SELECT id, name, description, specs, scripts FROM skills WHERE org_id = ? AND is_builtin = 1",
     [orgId],
   ) as any;
-  const builtinMap = new Map<string, { id: string; specs: string; scripts: string }>();
+  const builtinMap = new Map<string, { id: string; description: string; specs: string; scripts: string }>();
   for (const row of builtinRows) {
     builtinMap.set(row.name, row);
   }
 
   const incomingNames = new Set(incoming.map(s => s.name));
-  const added: string[] = [];
-  const updated: string[] = [];
-  const unchanged: string[] = [];
+  const added: DiffEntry[] = [];
+  const updated: DiffEntry[] = [];
+  const unchanged: DiffEntry[] = [];
 
   for (const skill of incoming) {
     const existing = builtinMap.get(skill.name);
+    const entry: DiffEntry = { name: skill.name, description: skill.description };
     if (!existing) {
-      added.push(skill.name);
+      added.push(entry);
     } else {
       // Normalize scripts — DB may store as JSON string or parsed object
       const existingScripts = typeof existing.scripts === "string"
         ? existing.scripts : JSON.stringify(existing.scripts);
       const incomingScripts = JSON.stringify(skill.scripts);
       if (existing.specs !== skill.specs || existingScripts !== incomingScripts) {
-        updated.push(skill.name);
+        updated.push(entry);
       } else {
-        unchanged.push(skill.name);
+        unchanged.push(entry);
       }
     }
   }
@@ -131,6 +188,7 @@ export async function computeImportDiff(
       ) as any;
       deleted.push({
         name,
+        description: row.description ?? "",
         bound_agents: bindRows.map((r: any) => ({ id: r.id, name: r.name })),
       });
     }
@@ -146,16 +204,29 @@ export async function computeImportDiff(
 /**
  * Apply the import diff transactionally, save a history snapshot, and
  * optionally notify affected agents.
+ *
+ * The `mode` field controls how missing-from-pack builtins are handled —
+ * see {@link ImportMode}. No default: every caller must commit to a policy.
  */
 export async function executeImport(
   orgId: string,
   incoming: ParsedSkill[],
   userId: string,
   comment: string,
-  notifyAgentReload?: (agentId: string, resources: string[]) => void,
+  opts: {
+    mode: ImportMode;
+    notifyAgentReload?: (agentId: string, resources: string[]) => void;
+  },
 ): Promise<ImportResult> {
   const db = getDb();
-  const diff = await computeImportDiff(orgId, incoming);
+  const rawDiff = await computeImportDiff(orgId, incoming);
+  // In upsert mode the "deleted" set is informational only — it tells us
+  // which builtins exist in DB but are absent from the pack, and we leave
+  // them alone. We zero it out in the result so callers (and history rows)
+  // truthfully reflect what happened.
+  const diff: ImportDiff = opts.mode === "upsert"
+    ? { ...rawDiff, deleted: [] }
+    : rawDiff;
 
   // Build a name→id map for existing builtins
   const [builtinRows] = await db.query(
@@ -170,8 +241,8 @@ export async function executeImport(
     await conn.beginTransaction();
 
     // --- ADD new builtin skills ---
-    for (const name of diff.added) {
-      const skill = incoming.find(s => s.name === name)!;
+    for (const entry of diff.added) {
+      const skill = incoming.find(s => s.name === entry.name)!;
       const id = crypto.randomUUID();
       await conn.query(
         `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, created_by, is_builtin)
@@ -186,9 +257,9 @@ export async function executeImport(
     }
 
     // --- UPDATE changed builtin skills ---
-    for (const name of diff.updated) {
-      const skill = incoming.find(s => s.name === name)!;
-      const existingId = builtinByName.get(name)!;
+    for (const entry of diff.updated) {
+      const skill = incoming.find(s => s.name === entry.name)!;
+      const existingId = builtinByName.get(entry.name)!;
       // Get next version number
       const [vRows] = await conn.query(
         "SELECT MAX(version) AS v FROM skill_versions WHERE skill_id = ?",
@@ -210,40 +281,44 @@ export async function executeImport(
     }
 
     // --- DELETE removed builtin skills ---
+    // Skipped in upsert mode — diff.deleted has already been zeroed out above
+    // so this loop is a no-op, but the explicit guard keeps intent obvious.
     const affectedAgentIds = new Set<string>();
-    for (const del of diff.deleted) {
-      const existingId = builtinByName.get(del.name)!;
-      // Check for overlay — if one exists, promote it to standalone
-      const [overlayRows] = await conn.query(
-        "SELECT id FROM skills WHERE overlay_of = ?",
-        [existingId],
-      ) as any;
-      if (overlayRows.length > 0) {
-        // Promote overlay: clear overlay_of, keep as regular skill
-        await conn.query("UPDATE skills SET overlay_of = NULL, updated_at = CURRENT_TIMESTAMP WHERE overlay_of = ?", [existingId]);
-        // Migrate agent bindings from builtin → overlay
-        for (const ov of overlayRows) {
-          await conn.query(
-            "UPDATE agent_skills SET skill_id = ? WHERE skill_id = ?",
-            [ov.id, existingId],
-          );
+    if (opts.mode === "sync") {
+      for (const del of rawDiff.deleted) {
+        const existingId = builtinByName.get(del.name)!;
+        // Check for overlay — if one exists, promote it to standalone
+        const [overlayRows] = await conn.query(
+          "SELECT id FROM skills WHERE overlay_of = ?",
+          [existingId],
+        ) as any;
+        if (overlayRows.length > 0) {
+          // Promote overlay: clear overlay_of, keep as regular skill
+          await conn.query("UPDATE skills SET overlay_of = NULL, updated_at = CURRENT_TIMESTAMP WHERE overlay_of = ?", [existingId]);
+          // Migrate agent bindings from builtin → overlay
+          for (const ov of overlayRows) {
+            await conn.query(
+              "UPDATE agent_skills SET skill_id = ? WHERE skill_id = ?",
+              [ov.id, existingId],
+            );
+          }
+        } else {
+          // No overlay — unbind agents
+          await conn.query("DELETE FROM agent_skills WHERE skill_id = ?", [existingId]);
         }
-      } else {
-        // No overlay — unbind agents
-        await conn.query("DELETE FROM agent_skills WHERE skill_id = ?", [existingId]);
+        // Track affected agents for notification
+        for (const agent of del.bound_agents) affectedAgentIds.add(agent.id);
+        // Delete builtin skill (cascades to versions, reviews)
+        await conn.query("DELETE FROM skills WHERE id = ?", [existingId]);
       }
-      // Track affected agents for notification
-      for (const agent of del.bound_agents) affectedAgentIds.add(agent.id);
-      // Delete builtin skill (cascades to versions, reviews)
-      await conn.query("DELETE FROM skills WHERE id = ?", [existingId]);
     }
 
     await conn.commit();
 
     // Notify affected agents outside transaction (fire-and-forget)
-    if (notifyAgentReload) {
+    if (opts.notifyAgentReload) {
       for (const agentId of affectedAgentIds) {
-        notifyAgentReload(agentId, ["skills"]);
+        opts.notifyAgentReload(agentId, ["skills"]);
       }
     }
   } catch (err) {
@@ -265,7 +340,10 @@ export async function executeImport(
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       importId, importVersion, comment || null, snapshot, incoming.length,
-      JSON.stringify(diff.added), JSON.stringify(diff.updated),
+      // History columns historically held string[] of names — preserve that
+      // shape so existing rows and the history-list UI keep working.
+      JSON.stringify(diff.added.map(d => d.name)),
+      JSON.stringify(diff.updated.map(d => d.name)),
       JSON.stringify(diff.deleted.map(d => d.name)), userId,
     ],
   );


### PR DESCRIPTION
## Summary

Make Portal's admin skill pack upload work end-to-end: drop the missing `unzip` OS dependency, accept tar/tar.gz alongside zip, switch the upload to upsert semantics so a small test pack no longer wipes every other builtin, and fix the preview UI that was rendering blank rows because of a front/back contract mismatch.

### Problem

- Upload was broken in production: `skill-import.ts` shelled out to `unzip`, but the Portal `node:22-slim` image doesn't ship `unzip`, so every upload returned `unzip: not found`.
- The endpoint only accepted `.zip` even though tar packs are the de-facto standard for skill bundles elsewhere.
- `executeImport` did a full three-way sync, so uploading a one-skill test pack would delete every other builtin and unbind them from agents.
- Preview cards displayed `Added: 1` but the row underneath was blank — the frontend `DiffEntry` type expected objects with `name` while the backend was returning bare strings, so `item.name` rendered as `undefined`.

### Solution

- Replace `execSync('unzip')` with `adm-zip`, add `tar` for tar/tar.gz, dispatch by magic bytes — no OS binary needed.
- Guard zip entries against `..` traversal; tar's defaults already sanitize.
- Give `executeImport` a required `mode: "sync" | "upsert"` parameter with no default. Admin pack upload uses `upsert`; `init` / `rollback` / `bootstrap` keep `sync` because those operations are state replacements by definition.
- Reshape `ImportDiff.added/updated/unchanged` to `{ name, description }[]` so the frontend can render the existing description column. History rows still persist `string[]` of names via `.map(d => d.name)`, so older snapshots and the history list keep working.
- Frontend: accept `.zip / .tar / .tar.gz / .tgz` in the file picker, pick a matching Content-Type, drop the never-sent `total_*` fields and read `.length` off the arrays, reword the confirm dialog.

## Test Plan

- [x] `npm test` — 3036 passing (added 8 new tests in `skill-import.test.ts`: tar + tar.gz happy paths, traversal rejection, garbage-buffer rejection, gzip-non-tar rejection, upsert no-delete invariant)
- [x] `npx tsc --noEmit` — clean
- [x] `cd portal-web && npx vite build` — clean
- [ ] Manual: upload `hello-zip-test.zip`, `hello-tar-test.tar`, `hello-tar-test.tar.gz` against a Portal pointed at a non-empty DB; verify preview shows skill names + descriptions, and that existing builtins are untouched after Confirm Import.