### PR TITLE
fix(portal): eliminate chart flicker during streaming

### DIFF
--- a/docs/design/chart-rendering.md
+++ b/docs/design/chart-rendering.md
@@ -1,0 +1,189 @@
+---
+title: "Chart Rendering"
+sidebarTitle: "Chart Rendering"
+description: "Contract between MCP chart tools and the Portal frontend renderer."
+---
+
+# Chart Rendering
+
+> **Purpose**: Document the contract between any MCP tool that produces charts and
+> the Portal chat frontend that renders them. Read this before writing a new chart
+> tool or adding a new chart type.
+
+---
+
+## How It Works
+
+The frontend recognises chart output through a single convention: a fenced
+Markdown code block with the language tag `chart`.
+
+```
+```chart
+{"type":"pie","data":{"slices":[{"label":"kube-system","value":1005}]}}
+```
+```
+
+Any MCP tool that produces this block will have its output rendered as an
+interactive SVG chart inside the chat bubble. No frontend changes are required
+as long as the fence tag is `chart` and the JSON matches the `ChartSpec` schema
+(see [§ ChartSpec schema](#chartspec-schema) below).
+
+---
+
+## The Rendering Pipeline
+
+```
+MCP tool
+  └── emits  ```chart\n{JSON}\n```  in its text response
+
+Markdown.tsx  (portal-web/src/components/chat/Markdown.tsx)
+  └── react-markdown encounters a <pre><code className="language-chart">
+        └── hasLanguageClass(className, "chart") → true
+              └── <ChartFence text={rawJson} />
+
+ChartFence  (inside Markdown.tsx)
+  └── useMemo → tryParseChartSpec(text)
+        ├── JSON incomplete (still streaming)  → <ChartLoading /> spinner
+        ├── JSON complete, parse fails         → <ChartParseError />
+        └── JSON complete, parse succeeds      → <ChartRenderer spec={spec} />
+
+ChartRenderer  (portal-web/src/components/chat/ChartRenderer.tsx)
+  └── wrapped in React.memo — skips re-render when spec is unchanged
+        ├── spec.type === "pie"  → renderPie
+        ├── spec.type === "bar"  → renderBar
+        └── spec.type === "line" → renderLine
+```
+
+### Why the spinner, not a partial chart?
+
+The `chart` fence contains a single JSON object. Until the LLM finishes
+streaming that object the JSON is syntactically incomplete (`tryParseChartSpec`
+returns `null`). There is no meaningful partial state to display, so the
+frontend shows a spinner until the spec is fully parseable.
+
+### Why React.memo?
+
+The chat bubble re-renders on every streamed token. Without memoization the SVG
+subtree (hundreds of nodes) would be rebuilt on every token the LLM emits
+*after* the chart fence has closed — producing visible flicker for as long as
+the model keeps streaming prose. `React.memo` with a `JSON.stringify`-based
+comparator ensures the chart paints exactly once after the spec arrives and is
+then frozen until the spec actually changes.
+
+---
+
+## ChartSpec Schema
+
+`tryParseChartSpec` (in `portal-web/src/components/chat/chart-utils.ts`)
+validates and normalises the JSON. The accepted shapes are:
+
+### Pie chart
+
+```json
+{
+  "type": "pie",
+  "data": {
+    "slices": [
+      { "label": "kube-system", "value": 1005 },
+      { "label": "monitoring",  "value": 383  }
+    ]
+  },
+  "title": "Pod distribution",
+  "width": 760,
+  "height": 480
+}
+```
+
+### Bar chart
+
+```json
+{
+  "type": "bar",
+  "data": {
+    "categories": ["kube-system", "monitoring"],
+    "series": [
+      { "name": "Pods", "values": [1005, 383] }
+    ]
+  },
+  "title": "Top namespaces",
+  "y_label": "Pod count"
+}
+```
+
+### Line chart
+
+```json
+{
+  "type": "line",
+  "data": {
+    "series": [
+      {
+        "name": "total pods",
+        "points": [
+          { "x": 1716000000, "y": 1840 },
+          { "x": 1716003600, "y": 1856 }
+        ]
+      }
+    ]
+  },
+  "title": "Pod count over time",
+  "x_label": "Time",
+  "y_label": "Pods"
+}
+```
+
+**Common optional fields** (all chart types): `title`, `width`, `height`,
+`x_label`, `y_label`.
+
+**Line chart x values**: pass epoch seconds as a `number` for time-series data;
+the renderer formats them as `HH:MM`. Pass a `string` for categorical x-axes.
+
+---
+
+## Writing a New MCP Chart Tool
+
+The only contract the frontend enforces is the fence tag and the JSON shape.
+To have your tool's output rendered as a chart:
+
+1. Serialise your data as one of the `ChartSpec` shapes above.
+2. Wrap it in a `chart` fence and include it verbatim in your tool's text
+   response:
+
+```ts
+const markdownEmbed = "```chart\n" + JSON.stringify(spec) + "\n```"
+```
+
+3. Instruct the LLM to paste the block as-is (do not re-escape or re-wrap it).
+
+The frontend needs no changes. All three chart types — and any future type added
+to `ChartSpec` — share the same fence tag and the same anti-flicker path.
+
+---
+
+## Adding a New Chart Type
+
+If pie/bar/line do not cover your use case, add a new type to the union:
+
+| File | Change |
+|---|---|
+| `portal-web/src/components/chat/chart-utils.ts` | Extend `ChartSpec` union; add validation in `tryParseChartSpec`; add any new layout helpers |
+| `portal-web/src/components/chat/ChartRenderer.tsx` | Add a `renderXxx` function; add a branch in the `useMemo` inside `ChartRenderer` |
+| `mcp/create-chart/src/handler.ts` | Add the new type to the input schema enum and `validate()` |
+| `mcp/create-chart/src/types.ts` | Extend `RenderChartArgs` |
+
+**No changes needed in `Markdown.tsx`** — the `hasLanguageClass(className, "chart")`
+gate and the `ChartFence` memoization cover every type in the `ChartSpec` union
+automatically.
+
+---
+
+## What the Frontend Does NOT Support
+
+- **Other fence tags**: ` ```mermaid `, ` ```echarts `, etc. fall through to the
+  generic `<pre>` renderer (raw text). Add a separate handler in
+  `MARKDOWN_COMPONENTS` in `Markdown.tsx` if you need them.
+- **Inline `<img>` tags or `data:` URIs as chart output**: these bypass
+  `ChartRenderer` entirely and receive no interactivity (hover tooltip,
+  copy/download toolbar, log-scale toggle).
+- **Streaming partial charts**: the spinner is the only streaming state; there
+  is no incremental render of partially-arrived data.

--- a/portal-web/src/components/chat/ChartRenderer.tsx
+++ b/portal-web/src/components/chat/ChartRenderer.tsx
@@ -23,6 +23,7 @@
 import {
   type CSSProperties,
   type ReactNode,
+  memo,
   useRef,
   useState,
   useCallback,
@@ -697,7 +698,7 @@ interface ChartRendererProps {
 // tooltip (px relative to the chart-area wrapper, already edge-clamped).
 interface HoverState { index: number; left: number; top: number }
 
-export function ChartRenderer({ spec, className, style }: ChartRendererProps) {
+function ChartRendererImpl({ spec, className, style }: ChartRendererProps) {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const svgRef = useRef<SVGSVGElement | null>(null)
   const [status, setStatus] = useState<null | { kind: "ok" | "err"; text: string }>(null)
@@ -1000,3 +1001,17 @@ export function ChartRenderer({ spec, className, style }: ChartRendererProps) {
     </div>
   )
 }
+
+// Wrap with React.memo so the SVG subtree skips reconciliation when the parent
+// re-renders with an equivalent spec. The chart lives inside a streaming chat
+// bubble whose <Markdown> parent re-runs on every token the LLM emits *after*
+// the chart fence closes — without this guard each trailing prose token would
+// rebuild hundreds of SVG nodes, producing visible flicker for the seconds it
+// takes the model to finish the reply. We compare by serialised spec (cheap —
+// specs are small JSON) so a freshly-parsed-but-equal spec object
+// short-circuits identically to a referentially-stable one.
+export const ChartRenderer = memo(ChartRendererImpl, (prev, next) => {
+  if (prev.className !== next.className) return false
+  if (prev.style !== next.style) return false
+  return JSON.stringify(prev.spec) === JSON.stringify(next.spec)
+})

--- a/portal-web/src/components/chat/Markdown.tsx
+++ b/portal-web/src/components/chat/Markdown.tsx
@@ -1,4 +1,5 @@
-import ReactMarkdown from "react-markdown"
+import { useMemo } from "react"
+import ReactMarkdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { ChartRenderer, chartSpecLooksIncomplete, tryParseChartSpec } from "./ChartRenderer"
 
@@ -127,158 +128,168 @@ function ChartParseError({ source }: { source: string }) {
   )
 }
 
+// Parses the inner text of a ```chart fence into a chart spec. Each <pre>
+// node react-markdown produces is a separate component instance with its own
+// hook state, so useMemo here keys cleanly off the chunk of JSON text — the
+// returned spec is referentially stable as long as the text is unchanged,
+// which lets ChartRenderer's React.memo short-circuit cleanly while the LLM
+// continues streaming prose after the chart fence has closed.
+function ChartFence({ text }: { text: string }) {
+  const trimmed = text.trim()
+  const spec = useMemo(() => tryParseChartSpec(trimmed), [trimmed])
+  if (spec) return <ChartRenderer spec={spec} />
+  // Don't show the red parse-failed box mid-stream — ReactMarkdown re-renders
+  // on every token, so an unclosed chart fence would otherwise flash the
+  // error box for every chart until streaming finishes. Only treat it as a
+  // real error once the JSON has finished arriving.
+  if (chartSpecLooksIncomplete(trimmed)) return <ChartLoading />
+  return <ChartParseError source={trimmed} />
+}
+
+// Hoisted to module scope so each entry has stable function identity across
+// <Markdown> re-renders. Inlining this object inside the render body produces
+// fresh function references every token, which react-markdown surfaces as a
+// *new component type* for <pre>, <code>, etc., forcing React to unmount and
+// remount the entire chart subtree on every streamed token. That remount is
+// what made the SVG visibly flicker during (and a few seconds after) chart
+// generation while the model continued streaming prose past the chart fence.
+const MARKDOWN_COMPONENTS: Components = {
+  // Code blocks. ```chart fenced blocks contain a JSON spec emitted by mcp
+  // render_chart; we parse and render via the React ChartRenderer (theme-
+  // aware, no <pre> dark background, no SVG echo from the model).
+  //
+  // Every other fenced block — language-tagged or not — is rendered here by
+  // extracting the raw text and drawing one soft-styled <pre>. We do NOT pass
+  // `children` (the inner <code> element) through, because the `code`
+  // component below can't tell block code from inline code (a no-language
+  // fence's <code> carries no className) and would render it as orange inline
+  // text on a slate-900 box — the "black box, yellow text" artifact. Handling
+  // all block code here keeps `code` purely for inline spans.
+  pre({ children }) {
+    const child = Array.isArray(children) ? children[0] : children
+    const isElement =
+      !!child && typeof child === "object" && "props" in child
+    const className = isElement
+      ? (child as { props: { className?: string } }).props.className
+      : undefined
+    const rawChildren = isElement
+      ? (child as { props: { children?: unknown } }).props.children
+      : children
+    const text = Array.isArray(rawChildren)
+      ? rawChildren.join("")
+      : String(rawChildren ?? "")
+
+    if (hasLanguageClass(className, "chart")) {
+      return <ChartFence text={text} />
+    }
+
+    return (
+      <pre className="bg-secondary/60 text-foreground border border-border rounded-lg p-3 overflow-x-auto my-3 text-[13px] leading-relaxed font-mono whitespace-pre-wrap">
+        {text}
+      </pre>
+    )
+  },
+  // Inline code only — block code never reaches here (see `pre` above).
+  code({ children, ...props }) {
+    return (
+      <code
+        className="bg-secondary text-orange-400 px-1.5 py-0.5 rounded text-[13px] font-mono"
+        {...props}
+      >
+        {children}
+      </code>
+    )
+  },
+  p({ children }) {
+    return <p className="mb-2 last:mb-0">{children}</p>
+  },
+  ul({ children }) {
+    return <ul className="list-disc pl-5 mb-2 space-y-1">{children}</ul>
+  },
+  ol({ children }) {
+    return <ol className="list-decimal pl-5 mb-2 space-y-1">{children}</ol>
+  },
+  li({ children }) {
+    return <li className="leading-relaxed">{children}</li>
+  },
+  h1({ children }) {
+    return <h1 className="text-xl font-bold mb-2 mt-3 first:mt-0">{children}</h1>
+  },
+  h2({ children }) {
+    return <h2 className="text-lg font-bold mb-2 mt-3 first:mt-0">{children}</h2>
+  },
+  h3({ children }) {
+    return <h3 className="text-base font-bold mb-1.5 mt-2 first:mt-0">{children}</h3>
+  },
+  a({ href, children }) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-400 hover:underline"
+      >
+        {children}
+      </a>
+    )
+  },
+  blockquote({ children }) {
+    return (
+      <blockquote className="border-l-4 border-border pl-4 my-2 text-muted-foreground italic">
+        {children}
+      </blockquote>
+    )
+  },
+  table({ children }) {
+    return (
+      <div className="overflow-x-auto my-2">
+        <table className="min-w-full text-sm border border-border rounded">
+          {children}
+        </table>
+      </div>
+    )
+  },
+  thead({ children }) {
+    return <thead className="bg-secondary/50">{children}</thead>
+  },
+  th({ children }) {
+    return (
+      <th className="border-b border-border px-3 py-2 text-left font-semibold text-foreground">
+        {children}
+      </th>
+    )
+  },
+  td({ children }) {
+    return (
+      <td className="border-b border-border/50 px-3 py-2 text-foreground">
+        {children}
+      </td>
+    )
+  },
+  hr() {
+    return <hr className="my-3 border-border" />
+  },
+  strong({ children }) {
+    return <strong className="font-semibold">{children}</strong>
+  },
+  // Explicit width caps so a chart fits the chat bubble.
+  img({ src, alt }) {
+    return (
+      <img
+        src={src}
+        alt={alt ?? ""}
+        className="-mx-5 -my-3.5 max-w-none w-[calc(100%+2.5rem)] h-auto block"
+      />
+    )
+  },
+}
+
 export function Markdown({ children }: MarkdownProps) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkDemoteIndentedCode]}
       urlTransform={permissiveUrlTransform}
-      components={{
-        // Code blocks. ```chart fenced blocks contain a JSON spec emitted by
-        // mcp render_chart; we parse and render via the React ChartRenderer
-        // (theme-aware, no <pre> dark background, no SVG echo from the model).
-        //
-        // Every other fenced block — language-tagged or not — is rendered here
-        // by extracting the raw text and drawing one soft-styled <pre>. We do
-        // NOT pass `children` (the inner <code> element) through, because the
-        // `code` component below can't tell block code from inline code (a
-        // no-language fence's <code> carries no className) and would render it
-        // as orange inline text on a slate-900 box — the "black box, yellow
-        // text" artifact. Handling all block code here keeps `code` purely for
-        // inline spans.
-        pre({ children }) {
-          const child = Array.isArray(children) ? children[0] : children
-          const isElement =
-            !!child && typeof child === "object" && "props" in child
-          const className = isElement
-            ? (child as { props: { className?: string } }).props.className
-            : undefined
-          const rawChildren = isElement
-            ? (child as { props: { children?: unknown } }).props.children
-            : children
-          const text = Array.isArray(rawChildren)
-            ? rawChildren.join("")
-            : String(rawChildren ?? "")
-
-          if (hasLanguageClass(className, "chart")) {
-            const trimmed = text.trim()
-            const spec = tryParseChartSpec(trimmed)
-            if (spec) return <ChartRenderer spec={spec} />
-            // Don't show the red parse-failed box mid-stream — ReactMarkdown
-            // re-renders on every token, so an unclosed chart fence flashes
-            // an error for every chart until streaming finishes. Only treat
-            // it as a real error once the JSON has finished arriving.
-            if (chartSpecLooksIncomplete(trimmed)) return <ChartLoading />
-            return <ChartParseError source={trimmed} />
-          }
-
-          return (
-            <pre className="bg-secondary/60 text-foreground border border-border rounded-lg p-3 overflow-x-auto my-3 text-[13px] leading-relaxed font-mono whitespace-pre-wrap">
-              {text}
-            </pre>
-          )
-        },
-        // Inline code only — block code never reaches here (see `pre` above).
-        code({ children, ...props }) {
-          return (
-            <code
-              className="bg-secondary text-orange-400 px-1.5 py-0.5 rounded text-[13px] font-mono"
-              {...props}
-            >
-              {children}
-            </code>
-          )
-        },
-        // Paragraphs
-        p({ children }) {
-          return <p className="mb-2 last:mb-0">{children}</p>
-        },
-        // Lists
-        ul({ children }) {
-          return <ul className="list-disc pl-5 mb-2 space-y-1">{children}</ul>
-        },
-        ol({ children }) {
-          return <ol className="list-decimal pl-5 mb-2 space-y-1">{children}</ol>
-        },
-        li({ children }) {
-          return <li className="leading-relaxed">{children}</li>
-        },
-        // Headings
-        h1({ children }) {
-          return <h1 className="text-xl font-bold mb-2 mt-3 first:mt-0">{children}</h1>
-        },
-        h2({ children }) {
-          return <h2 className="text-lg font-bold mb-2 mt-3 first:mt-0">{children}</h2>
-        },
-        h3({ children }) {
-          return <h3 className="text-base font-bold mb-1.5 mt-2 first:mt-0">{children}</h3>
-        },
-        // Links
-        a({ href, children }) {
-          return (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-400 hover:underline"
-            >
-              {children}
-            </a>
-          )
-        },
-        // Blockquotes
-        blockquote({ children }) {
-          return (
-            <blockquote className="border-l-4 border-border pl-4 my-2 text-muted-foreground italic">
-              {children}
-            </blockquote>
-          )
-        },
-        // Tables (GFM)
-        table({ children }) {
-          return (
-            <div className="overflow-x-auto my-2">
-              <table className="min-w-full text-sm border border-border rounded">
-                {children}
-              </table>
-            </div>
-          )
-        },
-        thead({ children }) {
-          return <thead className="bg-secondary/50">{children}</thead>
-        },
-        th({ children }) {
-          return (
-            <th className="border-b border-border px-3 py-2 text-left font-semibold text-foreground">
-              {children}
-            </th>
-          )
-        },
-        td({ children }) {
-          return (
-            <td className="border-b border-border/50 px-3 py-2 text-foreground">
-              {children}
-            </td>
-          )
-        },
-        // Horizontal rule
-        hr() {
-          return <hr className="my-3 border-border" />
-        },
-        // Strong / em
-        strong({ children }) {
-          return <strong className="font-semibold">{children}</strong>
-        },
-        // Images — explicit width caps so a chart fits the chat bubble.
-        img({ src, alt }) {
-          return (
-            <img
-              src={src}
-              alt={alt ?? ""}
-              className="-mx-5 -my-3.5 max-w-none w-[calc(100%+2.5rem)] h-auto block"
-            />
-          )
-        },
-      }}
+      components={MARKDOWN_COMPONENTS}
     >
       {escapeIntraWordUnderscores(children)}
     </ReactMarkdown>


### PR DESCRIPTION
Hoist MARKDOWN_COMPONENTS to module scope and wrap ChartRenderer with React.memo to prevent SVG remount on every streamed token, eliminating chart flicker during and after generation.