### PR TITLE
Feat/code block copy

### DIFF
--- a/portal-web/src/components/chat/Markdown.tsx
+++ b/portal-web/src/components/chat/Markdown.tsx
@@ -151,9 +151,9 @@ function CodeBlock({ language, text }: { language: string; text: string }) {
     void copy(text)
   }
   return (
-    <div className="my-3 overflow-hidden rounded-lg border border-border bg-secondary/60">
-      <div className="flex items-center justify-between border-b border-border/60 bg-secondary/80 px-3 py-1.5">
-        <span className="font-mono text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+    <div className="my-2 overflow-hidden rounded-lg border border-border bg-secondary/60">
+      <div className="flex items-center justify-between border-b border-border/60 bg-secondary/80 px-3 py-0.5">
+        <span className="font-mono text-[11px] font-medium text-muted-foreground">
           {language}
         </span>
         <button
@@ -167,7 +167,7 @@ function CodeBlock({ language, text }: { language: string; text: string }) {
           {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
         </button>
       </div>
-      <pre className="overflow-x-auto p-3 text-[13px] leading-relaxed font-mono text-foreground whitespace-pre-wrap">
+      <pre className="overflow-x-auto px-3 py-2 text-[13px] leading-snug font-mono text-foreground whitespace-pre-wrap">
         {text}
       </pre>
     </div>

--- a/portal-web/src/components/chat/Markdown.tsx
+++ b/portal-web/src/components/chat/Markdown.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
+import { Check, Copy } from "lucide-react"
+import { cn } from "./cn"
 import { ChartRenderer, chartSpecLooksIncomplete, tryParseChartSpec } from "./ChartRenderer"
+import { useCopyFeedback } from "./clipboard"
 
 interface MarkdownProps {
   children: string
@@ -128,6 +131,49 @@ function ChartParseError({ source }: { source: string }) {
   )
 }
 
+// Pull the language slug ("bash", "python", …) out of react-markdown's
+// `language-xxx` className. Falls back to `code` so the header is never empty
+// for bare ``` ``` fences.
+function extractLanguage(className: string | undefined): string {
+  if (!className) return "code"
+  const match = className.match(/language-([\w+\-.]+)/)
+  return match?.[1] ?? "code"
+}
+
+// Fenced code block with a language label (top-left) and a copy button
+// (top-right). Matches the Codex / ChatGPT convention so an SRE can grab a
+// suggested command without dragging a selection. Inline `code` spans are
+// unaffected — react-markdown routes those through the `code` component below.
+function CodeBlock({ language, text }: { language: string; text: string }) {
+  const [copied, copy] = useCopyFeedback()
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    void copy(text)
+  }
+  return (
+    <div className="my-3 overflow-hidden rounded-lg border border-border bg-secondary/60">
+      <div className="flex items-center justify-between border-b border-border/60 bg-secondary/80 px-3 py-1.5">
+        <span className="font-mono text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          {language}
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          title="Copy code"
+          className={cn(
+            "transition-opacity p-1 rounded-md text-muted-foreground/70 hover:text-foreground hover:bg-secondary",
+          )}
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+      <pre className="overflow-x-auto p-3 text-[13px] leading-relaxed font-mono text-foreground whitespace-pre-wrap">
+        {text}
+      </pre>
+    </div>
+  )
+}
+
 // Parses the inner text of a ```chart fence into a chart spec. Each <pre>
 // node react-markdown produces is a separate component instance with its own
 // hook state, so useMemo here keys cleanly off the chunk of JSON text — the
@@ -183,11 +229,7 @@ const MARKDOWN_COMPONENTS: Components = {
       return <ChartFence text={text} />
     }
 
-    return (
-      <pre className="bg-secondary/60 text-foreground border border-border rounded-lg p-3 overflow-x-auto my-3 text-[13px] leading-relaxed font-mono whitespace-pre-wrap">
-        {text}
-      </pre>
-    )
+    return <CodeBlock language={extractLanguage(className)} text={text} />
   },
   // Inline code only — block code never reaches here (see `pre` above).
   code({ children, ...props }) {

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -22,6 +22,7 @@ import {
 import { cn } from "./cn"
 import { Markdown } from "./Markdown"
 import { svgChartToPngDataUrl, tryParseChartSpec } from "./ChartRenderer"
+import { useCopyFeedback } from "./clipboard"
 import { InputArea } from "./InputArea"
 import { SkillCard } from "./SkillCard"
 import { ScheduleCard } from "./ScheduleCard"
@@ -1155,60 +1156,6 @@ function DelegationStatusNotice({ content }: { content: string }) {
       </div>
     </div>
   )
-}
-
-// Copy `text` to clipboard. Prefers the async Clipboard API, falls back to a
-// legacy textarea + execCommand path for non-secure origins (HTTP access via
-// host IP — `navigator.clipboard` is undefined there). Returns true on success.
-async function copyTextToClipboard(text: string): Promise<boolean> {
-  try {
-    if (navigator.clipboard && window.isSecureContext) {
-      await navigator.clipboard.writeText(text)
-      return true
-    }
-  } catch (err) {
-    console.warn("[copy] clipboard API failed, falling back:", err)
-  }
-  try {
-    const ta = document.createElement("textarea")
-    ta.value = text
-    ta.setAttribute("readonly", "")
-    ta.style.position = "fixed"
-    ta.style.top = "0"
-    ta.style.left = "0"
-    ta.style.opacity = "0"
-    document.body.appendChild(ta)
-    ta.select()
-    const ok = document.execCommand("copy")
-    document.body.removeChild(ta)
-    return ok
-  } catch (err) {
-    console.warn("[copy] fallback failed:", err)
-    return false
-  }
-}
-
-// Tracks "copied" feedback state with a self-cancelling timer so back-to-back
-// clicks don't leave a dangling timeout that clears the green check too early.
-// `flash` lets callers that copy via a custom path (e.g. rich text/html with
-// rasterised charts) still surface the same green-check feedback.
-function useCopyFeedback(): [boolean, (text: string) => Promise<void>, () => void] {
-  const [copied, setCopied] = useState(false)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => () => {
-    if (timerRef.current) clearTimeout(timerRef.current)
-  }, [])
-  const flash = useCallback(() => {
-    setCopied(true)
-    if (timerRef.current) clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(() => setCopied(false), 2000)
-  }, [])
-  const copy = useCallback(async (text: string) => {
-    const ok = await copyTextToClipboard(text)
-    if (!ok) return
-    flash()
-  }, [flash])
-  return [copied, copy, flash]
 }
 
 function serializeSessionToText(messages: PilotMessage[]): string {

--- a/portal-web/src/components/chat/clipboard.ts
+++ b/portal-web/src/components/chat/clipboard.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+// Copy `text` to clipboard. Prefers the async Clipboard API, falls back to a
+// legacy textarea + execCommand path for non-secure origins (HTTP access via
+// host IP — `navigator.clipboard` is undefined there). Returns true on success.
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch (err) {
+    console.warn("[copy] clipboard API failed, falling back:", err)
+  }
+  try {
+    const ta = document.createElement("textarea")
+    ta.value = text
+    ta.setAttribute("readonly", "")
+    ta.style.position = "fixed"
+    ta.style.top = "0"
+    ta.style.left = "0"
+    ta.style.opacity = "0"
+    document.body.appendChild(ta)
+    ta.select()
+    const ok = document.execCommand("copy")
+    document.body.removeChild(ta)
+    return ok
+  } catch (err) {
+    console.warn("[copy] fallback failed:", err)
+    return false
+  }
+}
+
+// Tracks "copied" feedback state with a self-cancelling timer so back-to-back
+// clicks don't leave a dangling timeout that clears the green check too early.
+// `flash` lets callers that copy via a custom path (e.g. rich text/html with
+// rasterised charts) still surface the same green-check feedback.
+export function useCopyFeedback(): [boolean, (text: string) => Promise<void>, () => void] {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+  }, [])
+  const flash = useCallback(() => {
+    setCopied(true)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setCopied(false), 2000)
+  }, [])
+  const copy = useCallback(async (text: string) => {
+    const ok = await copyTextToClipboard(text)
+    if (!ok) return
+    flash()
+  }, [flash])
+  return [copied, copy, flash]
+}


### PR DESCRIPTION
Fenced code blocks ( ```bash,  ```python, …) now render with a header bar: language tag on the left, copy button on the right. Lets users grab suggested commands without dragging a selection. Shared copyTextToClipboard / useCopyFeedback extracted to clipboard.ts. Inline code spans and  ```chart fences unchanged.