### PR TITLE
Fix chart renderer label clipping and preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,18 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm test
+
+  portal-web-test:
+    name: Portal Web Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: portal-web/package-lock.json
+      - run: npm ci
+        working-directory: portal-web
+      - run: npm test
+        working-directory: portal-web

--- a/portal-web/src/components/chat/ChartRenderer.tsx
+++ b/portal-web/src/components/chat/ChartRenderer.tsx
@@ -30,6 +30,7 @@ import {
   useEffect,
   useMemo,
 } from "react"
+import { Maximize2, X } from "lucide-react"
 import {
   type ChartSpec,
   type Axis,
@@ -137,6 +138,15 @@ function Title({ text, width }: { text?: string; width: number }) {
     <text x={width / 2} y={22} textAnchor="middle" fontSize={TITLE_SIZE} fontWeight={600}
           className="chart-title">{shown}</text>
   )
+}
+
+function ellipsizeText(text: string, maxW: number, fontSize: number): string {
+  if (approxTextWidth(text, fontSize) <= maxW) return text
+  let shown = text
+  while (shown.length > 1 && approxTextWidth(`${shown}…`, fontSize) > maxW) {
+    shown = shown.slice(0, -1)
+  }
+  return `${shown.replace(/\s+$/, "")}…`
 }
 
 // Renders the legend, wrapping to multiple centred rows when the series don't
@@ -269,11 +279,12 @@ function renderPie(
   const top = titleH + padY
   const bottom = height - padY
   const innerH = bottom - top
-  const labels = slices.map(
-    (s) => `${s.label} (${fmtNumber(s.value)}, ${((s.value / total) * 100).toFixed(1)}%)`,
-  )
+  const labels = slices.map((s) => {
+    const suffix = ` (${fmtNumber(s.value)}, ${((s.value / total) * 100).toFixed(1)}%)`
+    return { name: s.label, suffix, full: `${s.label}${suffix}` }
+  })
   const legendW = Math.min(
-    Math.max(...labels.map((l) => approxTextWidth(l, LEGEND_SIZE))) + 28,
+    Math.max(...labels.map((l) => approxTextWidth(l.full, LEGEND_SIZE))) + 28,
     width * 0.42,
   )
   const pieAreaW = width - legendW - 32
@@ -334,13 +345,22 @@ function renderPie(
   const legBlockH = labels.length * lineH
   let legY = Math.max(top + 8, top + (innerH - legBlockH) / 2 + LEGEND_SIZE)
   const legendEls: ReactNode[] = []
+  const legendTextW = Math.max(24, legendW - 30)
   labels.forEach((label, i) => {
     const color = pieSliceColor(i, othersIndex)
+    const suffixW = approxTextWidth(label.suffix, LEGEND_SIZE)
+    const nameW = Math.max(24, legendTextW - suffixW)
+    const shown = approxTextWidth(label.full, LEGEND_SIZE) > legendTextW
+      ? `${ellipsizeText(label.name, nameW, LEGEND_SIZE)}${label.suffix}`
+      : label.full
     legendEls.push(
       <rect key={`ls${i}`} x={legX} y={legY - LEGEND_SIZE + 2} width={14} height={14}
             fill={color} rx={2} />,
       <text key={`lt${i}`} x={legX + 22} y={legY + 2} fontSize={LEGEND_SIZE}
-            className="chart-legend">{label}</text>,
+            className="chart-legend">
+        <title>{label.full}</title>
+        {shown}
+      </text>,
     )
     legY += lineH
   })
@@ -361,10 +381,15 @@ function renderBar(
   }
   const hasLegend = series.length > 1
   const legendNames = series.map((s) => s.name)
-  const { rotate, tickBandH } = barTickLayout(categories, width)
+  const { rotate, tickBandH, sidePaddingLeft, sidePaddingRight } = barTickLayout(
+    categories,
+    width,
+    { hasYAxisLabel: !!spec.y_label },
+  )
   const plot = computePlot(
     width, height, !!spec.title, legendRows, true, rotate,
     !!spec.y_label, !!spec.x_label, tickBandH,
+    { left: sidePaddingLeft, right: sidePaddingRight },
   )
 
   const finiteVals: number[] = []
@@ -692,17 +717,19 @@ interface ChartRendererProps {
   spec: ChartSpec
   className?: string
   style?: CSSProperties
+  allowPreview?: boolean
 }
 
 // Active hover target: which column / pie slice, plus where to place the
 // tooltip (px relative to the chart-area wrapper, already edge-clamped).
 interface HoverState { index: number; left: number; top: number }
 
-function ChartRendererImpl({ spec, className, style }: ChartRendererProps) {
+function ChartRendererImpl({ spec, className, style, allowPreview = true }: ChartRendererProps) {
   const hostRef = useRef<HTMLDivElement | null>(null)
   const svgRef = useRef<SVGSVGElement | null>(null)
   const [status, setStatus] = useState<null | { kind: "ok" | "err"; text: string }>(null)
   const [hover, setHover] = useState<HoverState | null>(null)
+  const [previewOpen, setPreviewOpen] = useState(false)
 
   // Responsive: render the chart at the container's real width (capped at the
   // spec's ideal width so it never upscales) instead of letting a fixed-size
@@ -766,6 +793,15 @@ function ChartRendererImpl({ spec, className, style }: ChartRendererProps) {
       flash("err", "Download failed")
     }
   }, [spec.title, spec.type, flash])
+
+  useEffect(() => {
+    if (!previewOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPreviewOpen(false)
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [previewOpen])
 
   const onCopy = useCallback(async () => {
     if (!svgRef.current) return
@@ -894,11 +930,12 @@ function ChartRendererImpl({ spec, className, style }: ChartRendererProps) {
   const a11yLabel = spec.title || `${spec.type} chart`
 
   return (
-    <div
-      ref={hostRef}
-      className={`chart-host group relative my-3 w-full ${THEME_CLASSES} ${className ?? ""}`}
-      style={{ lineHeight: 0, ...style }}
-    >
+    <>
+      <div
+        ref={hostRef}
+        className={`chart-host group relative my-3 w-full ${THEME_CLASSES} ${className ?? ""}`}
+        style={{ lineHeight: 0, ...style }}
+      >
       {/* Toolbar sits in its own flow row above the chart — never overlaps the
           title or legend the way an absolutely-positioned overlay did. */}
       <div
@@ -914,6 +951,17 @@ function ChartRendererImpl({ spec, className, style }: ChartRendererProps) {
             className={`${TOOLBAR_BTN} px-2 text-[11px] font-medium`}
           >
             {effectiveLog ? "Log" : "Linear"}
+          </button>
+        )}
+        {allowPreview && (
+          <button
+            type="button"
+            onClick={() => setPreviewOpen(true)}
+            aria-label="Open larger chart preview"
+            title="Open larger chart preview"
+            className={`${TOOLBAR_BTN} w-7`}
+          >
+            <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
           </button>
         )}
         <button
@@ -998,7 +1046,39 @@ function ChartRendererImpl({ spec, className, style }: ChartRendererProps) {
           {status.text}
         </div>
       )}
-    </div>
+      </div>
+
+      {allowPreview && previewOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Chart preview"
+          onClick={() => setPreviewOpen(false)}
+        >
+          <div
+            className="max-h-[92vh] w-[min(1200px,96vw)] overflow-auto rounded-lg border border-gray-200 bg-white p-4 shadow-2xl dark:border-slate-700 dark:bg-slate-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-2 flex items-center justify-between gap-3" style={{ lineHeight: "normal" }}>
+              <div className="min-w-0 truncate text-sm font-medium text-gray-700 dark:text-gray-200">
+                {spec.title || "Chart preview"}
+              </div>
+              <button
+                type="button"
+                onClick={() => setPreviewOpen(false)}
+                aria-label="Close chart preview"
+                title="Close chart preview"
+                className={`${TOOLBAR_BTN} h-8 w-8 shrink-0 opacity-100`}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+            <ChartRendererImpl spec={spec} className="my-0" allowPreview={false} />
+          </div>
+        </div>
+      )}
+    </>
   )
 }
 
@@ -1013,5 +1093,6 @@ function ChartRendererImpl({ spec, className, style }: ChartRendererProps) {
 export const ChartRenderer = memo(ChartRendererImpl, (prev, next) => {
   if (prev.className !== next.className) return false
   if (prev.style !== next.style) return false
+  if (prev.allowPreview !== next.allowPreview) return false
   return JSON.stringify(prev.spec) === JSON.stringify(next.spec)
 })

--- a/portal-web/src/components/chat/Markdown.test.tsx
+++ b/portal-web/src/components/chat/Markdown.test.tsx
@@ -1,0 +1,21 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { Markdown } from "./Markdown"
+
+const incompleteChart = '```chart\n{"type":"bar","data":\n```'
+
+describe("Markdown chart fences", () => {
+  it("keeps incomplete chart fences in loading state while streaming", () => {
+    const html = renderToStaticMarkup(<Markdown isStreaming>{incompleteChart}</Markdown>)
+
+    expect(html).toContain("Generating chart")
+    expect(html).not.toContain("Chart output incomplete")
+  })
+
+  it("shows an error for incomplete chart fences after streaming finishes", () => {
+    const html = renderToStaticMarkup(<Markdown>{incompleteChart}</Markdown>)
+
+    expect(html).toContain("Chart output incomplete")
+    expect(html).not.toContain("Generating chart")
+  })
+})

--- a/portal-web/src/components/chat/Markdown.tsx
+++ b/portal-web/src/components/chat/Markdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { createContext, useContext, useMemo } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { Check, Copy } from "lucide-react"
@@ -8,7 +8,10 @@ import { useCopyFeedback } from "./clipboard"
 
 interface MarkdownProps {
   children: string
+  isStreaming?: boolean
 }
+
+const ChartStreamingContext = createContext(false)
 
 // CommonMark renders any line indented 4+ spaces as an "indented code block" —
 // a grey monospace box. LLM chat output never intends these (it always fences
@@ -114,13 +117,19 @@ function ChartLoading() {
   )
 }
 
-function ChartParseError({ source }: { source: string }) {
+function ChartParseError({
+  source,
+  title = "Failed to parse chart JSON",
+  description = "Check whether the chart block returned by render_chart was rewritten or extra-escaped.",
+}: {
+  source: string
+  title?: string
+  description?: string
+}) {
   return (
     <div className="my-3 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-900 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-100">
-      <div className="font-semibold">Failed to parse chart JSON</div>
-      <div className="mt-1 text-xs opacity-80">
-        Check whether the chart block returned by render_chart was rewritten or extra-escaped.
-      </div>
+      <div className="font-semibold">{title}</div>
+      <div className="mt-1 text-xs opacity-80">{description}</div>
       <details className="mt-2">
         <summary className="cursor-pointer text-xs font-medium">View raw chart content</summary>
         <pre className="mt-2 max-h-56 overflow-auto rounded bg-slate-950 p-3 text-xs text-slate-100">
@@ -181,6 +190,7 @@ function CodeBlock({ language, text }: { language: string; text: string }) {
 // which lets ChartRenderer's React.memo short-circuit cleanly while the LLM
 // continues streaming prose after the chart fence has closed.
 function ChartFence({ text }: { text: string }) {
+  const isStreaming = useContext(ChartStreamingContext)
   const trimmed = text.trim()
   const spec = useMemo(() => tryParseChartSpec(trimmed), [trimmed])
   if (spec) return <ChartRenderer spec={spec} />
@@ -188,7 +198,16 @@ function ChartFence({ text }: { text: string }) {
   // on every token, so an unclosed chart fence would otherwise flash the
   // error box for every chart until streaming finishes. Only treat it as a
   // real error once the JSON has finished arriving.
-  if (chartSpecLooksIncomplete(trimmed)) return <ChartLoading />
+  if (chartSpecLooksIncomplete(trimmed)) {
+    if (isStreaming) return <ChartLoading />
+    return (
+      <ChartParseError
+        source={trimmed}
+        title="Chart output incomplete"
+        description="The response finished before a complete chart JSON block arrived."
+      />
+    )
+  }
   return <ChartParseError source={trimmed} />
 }
 
@@ -326,14 +345,16 @@ const MARKDOWN_COMPONENTS: Components = {
   },
 }
 
-export function Markdown({ children }: MarkdownProps) {
+export function Markdown({ children, isStreaming = false }: MarkdownProps) {
   return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkDemoteIndentedCode]}
-      urlTransform={permissiveUrlTransform}
-      components={MARKDOWN_COMPONENTS}
-    >
-      {escapeIntraWordUnderscores(children)}
-    </ReactMarkdown>
+    <ChartStreamingContext.Provider value={isStreaming}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkDemoteIndentedCode]}
+        urlTransform={permissiveUrlTransform}
+        components={MARKDOWN_COMPONENTS}
+      >
+        {escapeIntraWordUnderscores(children)}
+      </ReactMarkdown>
+    </ChartStreamingContext.Provider>
   )
 }

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -1125,7 +1125,7 @@ function MessageItem({
         )}
 
         {textContent && (
-          <CopyableMessage isUser={isUser} content={textContent} />
+          <CopyableMessage isUser={isUser} content={textContent} isStreaming={message.isStreaming} />
         )}
 
         {renderedSuggestedChips.length > 0 && onChipClick && (
@@ -1368,7 +1368,15 @@ async function copyBubbleWithCharts(bubble: HTMLElement, content: string): Promi
   }
 }
 
-function CopyableMessage({ isUser, content }: { isUser: boolean; content: string }) {
+function CopyableMessage({
+  isUser,
+  content,
+  isStreaming = false,
+}: {
+  isUser: boolean
+  content: string
+  isStreaming?: boolean
+}) {
   const [copied, copy, flashCopied] = useCopyFeedback()
   const bubbleRef = useRef<HTMLDivElement | null>(null)
 
@@ -1395,7 +1403,7 @@ function CopyableMessage({ isUser, content }: { isUser: boolean; content: string
             : "bg-card border border-border text-foreground rounded-tl-sm",
         )}
       >
-        <Markdown>{content}</Markdown>
+        <Markdown isStreaming={isStreaming}>{content}</Markdown>
       </div>
       <button
         onClick={handleCopy}
@@ -1783,13 +1791,14 @@ function ToolItem({ message }: { message: PilotMessage }) {
               const t = message.timing
               const showThink = typeof t?.thinkingMs === "number"
               const showDur = typeof t?.durationMs === "number"
+              const durationLabel = message.toolStatus === "running" ? "running" : "ran"
               return (
                 <>
                   {(showThink || showDur) && (
                     <span className="text-[11px] text-muted-foreground tabular-nums select-text">
                       {showThink && <>thinking {formatTimingMs(t!.thinkingMs!)}</>}
                       {showThink && showDur && ", "}
-                      {showDur && <>running {formatTimingMs(t!.durationMs!)}</>}
+                      {showDur && <>{durationLabel} {formatTimingMs(t!.durationMs!)}</>}
                     </span>
                   )}
                 </>

--- a/portal-web/src/components/chat/chart-utils.test.ts
+++ b/portal-web/src/components/chat/chart-utils.test.ts
@@ -10,6 +10,8 @@ import {
   layoutLegendRows,
   computePlot,
   barTickLayout,
+  BAR_TICK_ROTATE_DEG,
+  approxTextWidth,
   legendRowsFor,
   chartCanvasSize,
   seriesDash,
@@ -196,6 +198,29 @@ describe("barTickLayout", () => {
     const l = barTickLayout(cats, 720)
     expect(l.rotate).toBe(true)
     expect(l.tickBandH).toBeGreaterThan(50)
+  })
+
+  it("reserves left margin so a long first rotated label is not clipped", () => {
+    const cats = [
+      "very-long-left-edge-category-name",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+    ]
+    const l = barTickLayout(cats, 460, { hasYAxisLabel: true })
+    expect(l.rotate).toBe(true)
+    expect(l.sidePaddingLeft).toBeGreaterThan(0)
+
+    const plot = computePlot(460, 520, true, 0, true, true, true, true, l.tickBandH, {
+      left: l.sidePaddingLeft,
+      right: l.sidePaddingRight,
+    })
+    const firstAnchor = plot.left + plot.w / cats.length / 2
+    const firstLabelLeft =
+      firstAnchor - approxTextWidth(cats[0], 12) * Math.cos((BAR_TICK_ROTATE_DEG * Math.PI) / 180)
+    expect(firstLabelLeft).toBeGreaterThanOrEqual(6)
   })
 
   it("makes chartCanvasSize grow the canvas to fit a tall rotated tick band", () => {

--- a/portal-web/src/components/chat/chart-utils.ts
+++ b/portal-web/src/components/chat/chart-utils.ts
@@ -255,12 +255,15 @@ export interface Plot { left: number; right: number; top: number; bottom: number
 // caller measures it from the actual longest label (see barTickLayout) so a
 // long category label never overhangs past the canvas bottom. Defaults to the
 // historic fixed value for callers that don't rotate.
+// `xTickSidePadding` reserves left/right plot margins for rotated edge labels;
+// without this, the first long -30deg x label can extend beyond the SVG viewBox.
 export function computePlot(
   width: number, height: number,
   hasTitle: boolean, legendRows: number,
   hasXLabels: boolean, rotateXTicks: boolean,
   hasYAxisLabel: boolean, hasXAxisLabel: boolean,
   rotatedTickH = 50,
+  xTickSidePadding: { left?: number; right?: number } = {},
 ): Plot {
   const titleH = hasTitle ? 30 : 6
   const legendH = legendRows > 0 ? legendRows * LEGEND_LINE_H + 6 : 0
@@ -269,8 +272,8 @@ export function computePlot(
   const yLabelW = hasYAxisLabel ? 22 : 0
   const top = titleH + legendH + 8
   const bottom = height - xTickH - xLabelH - 8
-  const left = 60 + yLabelW
-  const right = width - 24
+  const left = 60 + yLabelW + Math.max(0, xTickSidePadding.left ?? 0)
+  const right = width - 24 - Math.max(0, xTickSidePadding.right ?? 0)
   return { left, right, top, bottom, w: right - left, h: bottom - top }
 }
 
@@ -287,16 +290,45 @@ export const BAR_TICK_BASE_H = 50
 
 export function barTickLayout(
   categories: string[], width: number,
-): { rotate: boolean; tickBandH: number } {
+  opts: { hasYAxisLabel?: boolean } = {},
+): { rotate: boolean; tickBandH: number; sidePaddingLeft: number; sidePaddingRight: number } {
   const longest = categories.reduce(
     (m, c) => Math.max(m, approxTextWidth(c, TICK_SIZE)),
     0,
   )
   const approxGroupW = categories.length ? (width - 80) / categories.length : width
   const rotate = longest + 4 > approxGroupW
-  if (!rotate) return { rotate: false, tickBandH: 26 }
-  const overhang = longest * Math.sin((BAR_TICK_ROTATE_DEG * Math.PI) / 180)
-  return { rotate: true, tickBandH: Math.ceil(BAR_TICK_GAP + overhang + 8) }
+  if (!rotate) return { rotate: false, tickBandH: 26, sidePaddingLeft: 0, sidePaddingRight: 0 }
+  const angle = (BAR_TICK_ROTATE_DEG * Math.PI) / 180
+  const verticalOverhang = longest * Math.sin(angle)
+
+  // Rotated bar labels are end-anchored, so the first label extends up-left
+  // from its category centre. Reserve enough extra left margin for that label
+  // to stay inside the SVG viewport. The right edge does not need symmetric
+  // padding with the current end-anchor geometry, but keep the field explicit
+  // so computePlot has a stable shape if the label anchoring changes later.
+  const first = categories[0] ?? ""
+  const firstW = approxTextWidth(first, TICK_SIZE)
+  const baseLeft = 60 + (opts.hasYAxisLabel ? 22 : 0)
+  const baseRight = width - 24
+  const n = Math.max(1, categories.length)
+  const basePlotW = Math.max(1, baseRight - baseLeft)
+  const firstAnchor = baseLeft + basePlotW / n / 2
+  const edgePad = 8
+  const deficit = firstW * Math.cos(angle) + edgePad - firstAnchor
+  const denom = 1 - 1 / (2 * n)
+  const maxSidePadding = Math.max(0, width * 0.28)
+  const sidePaddingLeft = Math.min(
+    maxSidePadding,
+    Math.max(0, Math.ceil(deficit / denom)),
+  )
+
+  return {
+    rotate: true,
+    tickBandH: Math.ceil(BAR_TICK_GAP + verticalOverhang + 8),
+    sidePaddingLeft,
+    sidePaddingRight: 0,
+  }
 }
 
 export function defaultSize(type: ChartSpec["type"]): { width: number; height: number } {
@@ -339,7 +371,7 @@ export function chartCanvasSize(
   // historic fixed tick band — same "canvas GROWS, plot never collapses"
   // philosophy as the legend-row growth above.
   if (spec.type === "bar") {
-    const { tickBandH } = barTickLayout(spec.data.categories, width)
+    const { tickBandH } = barTickLayout(spec.data.categories, width, { hasYAxisLabel: !!spec.y_label })
     height += Math.max(0, tickBandH - BAR_TICK_BASE_H)
   }
   return { width, height, legendRows }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "portal-web/**"],
+  },
+})


### PR DESCRIPTION
## Summary

- reserve left-side plot padding for rotated bar chart x-axis labels so long first labels are not clipped
- add a lightweight larger chart preview dialog that reuses the existing renderer and keeps copy/download/log controls available
- cover the rotated-label clipping case with a focused chart-utils regression test

## Validation

- `npm test -- portal-web/src/components/chat/chart-utils.test.ts portal-web/src/components/chat/ChartRenderer.test.ts`
- `npm run build` from `portal-web`
