### PR TITLE
fix: derive developer-role support for compatible models

### DIFF
--- a/src/core/extensions/setup.ts
+++ b/src/core/extensions/setup.ts
@@ -40,6 +40,7 @@ import {
   type SiclawConfig,
 } from "../config.js";
 import { PRESETS } from "../provider-presets.js";
+import { defaultProviderModelCompat } from "../model-compat.js";
 
 // ---------------------------------------------------------------------------
 // Credential type labels
@@ -779,8 +780,6 @@ async function handleAddModel(
   const existingProvider = entries.find(([n]) => n === providerName)?.[1];
   if (!existingProvider) return;
 
-  const isAnthropic = existingProvider.api === "anthropic";
-
   const newModel: ProviderConfig["models"][number] = {
     id: modelId,
     name: modelName || modelId,
@@ -789,11 +788,10 @@ async function handleAddModel(
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow,
     maxTokens,
-    compat: {
-      supportsDeveloperRole: !isAnthropic,
-      supportsUsageInStreaming: true,
-      maxTokensField: "max_tokens",
-    },
+    compat: defaultProviderModelCompat({
+      api: existingProvider.api,
+      baseUrl: existingProvider.baseUrl,
+    }),
   };
 
   // Write to config

--- a/src/core/model-compat.test.ts
+++ b/src/core/model-compat.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { defaultProviderModelCompat } from "./model-compat.js";
+
+describe("defaultProviderModelCompat", () => {
+  it("keeps developer-role messages for the official OpenAI API", () => {
+    expect(defaultProviderModelCompat({
+      api: "openai-completions",
+      baseUrl: "https://api.openai.com/v1",
+    }).supportsDeveloperRole).toBe(true);
+  });
+
+  it("disables developer-role messages for OpenAI-compatible gateways", () => {
+    expect(defaultProviderModelCompat({
+      api: "openai-completions",
+      baseUrl: "https://api.example.com/model-api",
+    }).supportsDeveloperRole).toBe(false);
+  });
+
+  it("disables developer-role messages for Anthropic providers", () => {
+    expect(defaultProviderModelCompat({
+      api: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+    }).supportsDeveloperRole).toBe(false);
+  });
+});

--- a/src/core/model-compat.ts
+++ b/src/core/model-compat.ts
@@ -1,0 +1,28 @@
+import type { ProviderModelCompat } from "./config.js";
+
+export interface ProviderCompatInput {
+  api?: string | null;
+  baseUrl?: string | null;
+}
+
+function isOfficialOpenAIBaseUrl(baseUrl?: string | null): boolean {
+  if (!baseUrl) return false;
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === "api.openai.com";
+  } catch {
+    return false;
+  }
+}
+
+export function defaultProviderModelCompat(provider: ProviderCompatInput): Required<
+  Pick<ProviderModelCompat, "supportsDeveloperRole" | "supportsUsageInStreaming" | "maxTokensField">
+> {
+  const api = (provider.api ?? "").toLowerCase();
+  const usesChatCompletions = api === "openai" || api === "openai-completions";
+
+  return {
+    supportsDeveloperRole: usesChatCompletions && isOfficialOpenAIBaseUrl(provider.baseUrl),
+    supportsUsageInStreaming: true,
+    maxTokensField: "max_tokens",
+  };
+}

--- a/src/core/provider-presets.ts
+++ b/src/core/provider-presets.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ProviderConfig } from "./config.js";
+import { defaultProviderModelCompat } from "./model-compat.js";
 
 export interface ProviderPreset {
   label: string;
@@ -29,7 +30,7 @@ export const PRESETS: ProviderPreset[] = [
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 128000,
         maxTokens: 16384,
-        compat: { supportsDeveloperRole: true, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+        compat: defaultProviderModelCompat({ api: "openai-completions", baseUrl: "https://api.openai.com/v1" }),
       },
       {
         id: "gpt-4o-mini",
@@ -39,7 +40,7 @@ export const PRESETS: ProviderPreset[] = [
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 128000,
         maxTokens: 16384,
-        compat: { supportsDeveloperRole: true, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+        compat: defaultProviderModelCompat({ api: "openai-completions", baseUrl: "https://api.openai.com/v1" }),
       },
     ],
   },
@@ -57,7 +58,7 @@ export const PRESETS: ProviderPreset[] = [
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 200000,
         maxTokens: 16000,
-        compat: { supportsDeveloperRole: false, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+        compat: defaultProviderModelCompat({ api: "anthropic", baseUrl: "https://api.anthropic.com/v1" }),
       },
       {
         id: "claude-opus-4-20250514",
@@ -67,7 +68,7 @@ export const PRESETS: ProviderPreset[] = [
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 200000,
         maxTokens: 16000,
-        compat: { supportsDeveloperRole: false, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+        compat: defaultProviderModelCompat({ api: "anthropic", baseUrl: "https://api.anthropic.com/v1" }),
       },
     ],
   },
@@ -86,7 +87,7 @@ export const PRESETS: ProviderPreset[] = [
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 128000,
         maxTokens: 8192,
-        compat: { supportsDeveloperRole: true, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+        compat: defaultProviderModelCompat({ api: "openai-completions", baseUrl: "" }),
       },
     ],
   },

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -107,9 +107,37 @@ describe("config.getSettings", () => {
     expect(result.providers.openai.baseUrl).toBe("https://api.openai.com");
     expect(result.providers.openai.apiKey).toBe("sk-key");
     expect(result.providers.openai.models).toEqual([
-      { id: "gpt-4", name: "GPT-4", reasoning: false, contextWindow: 128000, maxTokens: 4096 },
+      {
+        id: "gpt-4",
+        name: "GPT-4",
+        reasoning: false,
+        contextWindow: 128000,
+        maxTokens: 4096,
+        compat: { supportsDeveloperRole: true, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+      },
     ]);
     expect(result.default).toEqual({ provider: "openai", modelId: "gpt-4" });
+  });
+
+  it("marks OpenAI-compatible gateway settings as not supporting developer-role messages", async () => {
+    mockQuery(
+      [{ model_provider: "compatible", model_id: "compatible-chat" }],
+      [{
+        id: "p-compatible",
+        name: "compatible",
+        base_url: "https://api.example.com/model-api",
+        api_key: "sk-key",
+        api_type: "openai-completions",
+      }],
+      [{ model_id: "compatible-chat", name: "Compatible Chat", reasoning: 0, context_window: 128000, max_tokens: 8192 }],
+    );
+
+    const result = await getHandler("config.getSettings")({ agentId: "a1" }, "a1");
+    expect(result.providers.compatible.models[0].compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsUsageInStreaming: true,
+      maxTokensField: "max_tokens",
+    });
   });
 
   it("returns empty providers when agent has no model_provider", async () => {
@@ -151,6 +179,32 @@ describe("config.getModelBinding", () => {
     expect(result.binding.modelConfig.models[0].reasoning).toBe(true);
     expect(result.binding.modelConfig.models[0].input).toEqual(["text"]);
     expect(result.binding.modelConfig.models[0].cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    expect(result.binding.modelConfig.models[0].compat).toMatchObject({
+      supportsDeveloperRole: true,
+      supportsUsageInStreaming: true,
+      maxTokensField: "max_tokens",
+    });
+  });
+
+  it("marks OpenAI-compatible gateway bindings as not supporting developer-role messages", async () => {
+    mockQuery(
+      [{ model_provider: "compatible", model_id: "compatible-chat" }],
+      [{
+        id: "p-compatible",
+        name: "compatible",
+        base_url: "https://api.example.com/model-api",
+        api_key: "sk-key",
+        api_type: "openai-completions",
+      }],
+      [{ model_id: "compatible-chat", name: "Compatible Chat", reasoning: 1, context_window: 128000, max_tokens: 8192 }],
+    );
+
+    const result = await getHandler("config.getModelBinding")({ agentId: "a1" }, "a1");
+    expect(result.binding.modelConfig.models[0].compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsUsageInStreaming: true,
+      maxTokensField: "max_tokens",
+    });
   });
 
   it("returns null binding when agent has no model_provider", async () => {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -15,6 +15,7 @@ import {
   parseBody,
   type RestRouter,
 } from "../gateway/rest-router.js";
+import { defaultProviderModelCompat } from "../core/model-compat.js";
 import { normalizeChatSessionPreview, normalizeChatSessionTitle } from "./chat-session-fields.js";
 
 function requireInternalAuth(req: http.IncomingMessage, internalSecret: string): boolean {
@@ -449,6 +450,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
             reasoning: !!m.reasoning,
             contextWindow: m.context_window,
             maxTokens: m.max_tokens,
+            compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
           })),
         },
       },
@@ -1037,6 +1039,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: m.context_window,
       maxTokens: m.max_tokens,
+      compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
     }));
     sendJson(res, 200, {
       binding: {
@@ -1455,6 +1458,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
             reasoning: !!m.reasoning,
             contextWindow: m.context_window,
             maxTokens: m.max_tokens,
+            compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
           })),
         },
       },
@@ -1492,6 +1496,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: m.context_window,
       maxTokens: m.max_tokens,
+      compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
     }));
     return {
       binding: {

--- a/src/portal/chat-gateway.test.ts
+++ b/src/portal/chat-gateway.test.ts
@@ -176,6 +176,47 @@ describe("chat-gateway routes", () => {
         sessionId: "s1",
       }));
     });
+
+    it("forwards model compatibility for OpenAI-compatible gateway chat sends", async () => {
+      query
+        .mockResolvedValueOnce([[{ model_provider: "compatible", model_id: "compatible-chat" }], []])
+        .mockResolvedValueOnce([[{
+          id: "p1",
+          name: "compatible",
+          base_url: "https://api.example.com/model-api",
+          api_key: "k",
+          api_type: "openai-completions",
+        }], []])
+        .mockResolvedValueOnce([[{
+          model_id: "compatible-chat",
+          name: "Compatible Chat",
+          reasoning: 1,
+          context_window: 128000,
+          max_tokens: 4096,
+        }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: { text: "hi", session_id: "s1" },
+      });
+
+      router.handle(req, res);
+
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      expect(command.modelConfig.models[0].compat).toMatchObject({
+        supportsDeveloperRole: false,
+        supportsUsageInStreaming: true,
+        maxTokensField: "max_tokens",
+      });
+    });
   });
 
   // ── chat.steer ───────────────────────────────────────────

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -21,6 +21,7 @@ import {
   isErrorDetail,
   type ErrorDetail,
 } from "../lib/error-envelope.js";
+import { defaultProviderModelCompat } from "../core/model-compat.js";
 
 /** Resolve model binding directly from Portal's own DB. */
 async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelBinding | null> {
@@ -53,6 +54,7 @@ async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelB
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: m.context_window,
     maxTokens: m.max_tokens,
+    compat: defaultProviderModelCompat({ api: provider.api_type, baseUrl: provider.base_url }),
   }));
 
   return {
@@ -389,4 +391,3 @@ export function registerChatRoutes(
     }
   });
 }
-

--- a/src/portal/cli-snapshot-api.test.ts
+++ b/src/portal/cli-snapshot-api.test.ts
@@ -176,7 +176,31 @@ describe("GET /api/v1/cli-snapshot", () => {
     expect(body.providers.openai.models).toHaveLength(1);
     expect(body.providers.openai.models[0].id).toBe("gpt-4o");
     expect(body.providers.openai.models[0].contextWindow).toBe(128000);
+    expect(body.providers.openai.models[0].compat.supportsDeveloperRole).toBe(true);
     expect(body.default).toEqual({ provider: "openai", modelId: "gpt-4o" });
+  });
+
+  it("marks non-OpenAI compatible providers as not supporting developer-role messages", async () => {
+    const db = getDb();
+    await db.query(
+      "INSERT INTO model_providers (id, org_id, name, base_url, api_key, api_type, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ["p-compatible", "default", "compatible", "https://api.example.com/model-api", "sk-test", "openai-completions", 0],
+    );
+    await db.query(
+      "INSERT INTO model_entries (id, provider_id, model_id, name, reasoning, context_window, max_tokens, is_default, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ["m-compatible", "p-compatible", "compatible-chat", "Compatible Chat", 0, 128000, 8192, 1, 0],
+    );
+
+    const { status, body } = await runRoute(
+      router,
+      fakeReq({ url: "/api/v1/cli-snapshot", headers: authedHeaders() }),
+    );
+    expect(status).toBe(200);
+    expect(body.providers.compatible.models[0].compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsUsageInStreaming: true,
+      maxTokensField: "max_tokens",
+    });
   });
 
   it("filters out providers with empty or NULL api_key", async () => {

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -30,6 +30,7 @@ import { timingSafeEqual } from "node:crypto";
 import type { RestRouter } from "../gateway/rest-router.js";
 import { sendJson } from "../gateway/rest-router.js";
 import { getDb } from "../gateway/db.js";
+import { defaultProviderModelCompat } from "../core/model-compat.js";
 import type {
   CliSnapshotKnowledgeRepo,
   CliSnapshotClusterCredential,
@@ -358,7 +359,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           contextWindow: m.context_window,
           maxTokens: m.max_tokens,
-          compat: { supportsDeveloperRole: true, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+          compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
         })),
       };
       // First model flagged is_default wins. If none, first provider's first model is a fallback.


### PR DESCRIPTION
## Summary
- Add a shared model compatibility helper for default provider/model capabilities.
- Keep developer-role messages enabled for the official OpenAI API.
- Disable developer-role messages for OpenAI-compatible non-OpenAI gateways such as `https://api.example.com/model-api`, preventing 422 errors from providers that reject `role: "developer"`.
- Reuse the same helper in Portal CLI snapshots, provider presets, and `/setup` model creation.

## Verification
- `npm test -- src/core/model-compat.test.ts src/portal/cli-snapshot-api.test.ts`

## Notes
- This replaces the temporary inner build-time patch with a source-level Siclaw fix.