### PR TITLE
fix: derive AgentBox gateway URL from runtime hostname

### DIFF
--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -79,6 +79,12 @@ const deletePodImpl = { set fn(f: (a: any) => Promise<any>) { g.__k8sImpls.delet
 const createSecretImpl = { set fn(f: (a: any) => Promise<any>) { g.__k8sImpls.createNamespacedSecret = f; }, get fn() { return g.__k8sImpls.createNamespacedSecret; } };
 const listPodImpl = { set fn(f: (a: any) => Promise<any>) { g.__k8sImpls.listNamespacedPod = f; }, get fn() { return g.__k8sImpls.listNamespacedPod; } };
 
+const originalGatewayEnv = {
+  SICLAW_GATEWAY_INTERNAL_URL: process.env.SICLAW_GATEWAY_INTERNAL_URL,
+  SICLAW_GATEWAY_HOSTNAME: process.env.SICLAW_GATEWAY_HOSTNAME,
+  SICLAW_INTERNAL_PORT: process.env.SICLAW_INTERNAL_PORT,
+};
+
 // Import SUT after mocks.
 import { K8sSpawner } from "./k8s-spawner.js";
 
@@ -100,6 +106,13 @@ function resetCalls() {
 
 beforeEach(() => {
   resetCalls();
+  for (const key of Object.keys(originalGatewayEnv) as Array<keyof typeof originalGatewayEnv>) {
+    if (originalGatewayEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalGatewayEnv[key];
+    }
+  }
   // Reset impls to defaults
   g.__k8sImpls.readNamespacedPod = async () => { throw Object.assign(new Error("not found"), { code: 404 }); };
   g.__k8sImpls.createNamespacedPod = async () => ({});
@@ -183,6 +196,54 @@ describe("K8sSpawner — pod name sanitization + invariant §3 (mTLS K8s-only)",
 });
 
 describe("K8sSpawner — spawn branches", () => {
+  it("injects AgentBox gateway URL from the configured runtime hostname", async () => {
+    process.env.SICLAW_GATEWAY_HOSTNAME = "siclaw-debug-runtime.siclaw-debug.svc.cluster.local";
+    process.env.SICLAW_INTERNAL_PORT = "3002";
+
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "10.0.0.8", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    await s.spawn({ agentId: "default" });
+
+    const env = calls.createNamespacedPod[0].body.spec.containers[0].env;
+    expect(env).toContainEqual({
+      name: "SICLAW_GATEWAY_URL",
+      value: "https://siclaw-debug-runtime.siclaw-debug.svc.cluster.local:3002",
+    });
+  });
+
+  it("lets explicit SICLAW_GATEWAY_INTERNAL_URL override the runtime hostname", async () => {
+    process.env.SICLAW_GATEWAY_INTERNAL_URL = "https://custom-runtime.svc:3002";
+    process.env.SICLAW_GATEWAY_HOSTNAME = "siclaw-debug-runtime.siclaw-debug.svc.cluster.local";
+
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "10.0.0.9", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    await s.spawn({ agentId: "default" });
+
+    const env = calls.createNamespacedPod[0].body.spec.containers[0].env;
+    expect(env).toContainEqual({
+      name: "SICLAW_GATEWAY_URL",
+      value: "https://custom-runtime.svc:3002",
+    });
+  });
+
   it("reuses a Running pod without creating a new one", async () => {
     const cm = new FakeCertManager();
     const s = new K8sSpawner();

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -69,6 +69,19 @@ export class K8sSpawner implements BoxSpawner {
     return `agentbox-${sanitized}`;
   }
 
+  private gatewayUrl(namespace: string): string {
+    if (process.env.SICLAW_GATEWAY_INTERNAL_URL) {
+      return process.env.SICLAW_GATEWAY_INTERNAL_URL;
+    }
+
+    if (process.env.SICLAW_GATEWAY_HOSTNAME) {
+      const port = process.env.SICLAW_INTERNAL_PORT || "3002";
+      return `https://${process.env.SICLAW_GATEWAY_HOSTNAME}:${port}`;
+    }
+
+    return `https://siclaw-runtime.${namespace}.svc.cluster.local:3002`;
+  }
+
   /**
    * Create an AgentBox Pod
    */
@@ -156,7 +169,7 @@ export class K8sSpawner implements BoxSpawner {
     // Environment variables — only bootstrap deps that cannot come from settings.json
     const env: k8s.V1EnvVar[] = [
       { name: "PI_CODING_AGENT_DIR", value: ".siclaw/user-data/agent" },
-      { name: "SICLAW_GATEWAY_URL", value: process.env.SICLAW_GATEWAY_INTERNAL_URL || `https://siclaw-runtime.${namespace}.svc.cluster.local:3002` },
+      { name: "SICLAW_GATEWAY_URL", value: this.gatewayUrl(namespace) },
       { name: "SICLAW_AGENT_ID", value: agentId },
     ];
 


### PR DESCRIPTION
## Summary

Fix K8s AgentBox pods using a hard-coded runtime service DNS name when they bootstrap their internal gateway connection.

The K8s spawner previously injected:

```ts
SICLAW_GATEWAY_URL=https://siclaw-runtime.<namespace>.svc.cluster.local:3002
```

That only works when the Helm release fullname is exactly `siclaw`. Releases such as `siclaw-debug` create services like `siclaw-debug-runtime`, so AgentBox cannot resolve the gateway and fails to load settings, MCP servers, skills, and other runtime-managed resources.

## Changes

- Add a small `gatewayUrl()` helper in `K8sSpawner`.
- Preserve explicit `SICLAW_GATEWAY_INTERNAL_URL` as the highest-priority override.
- Otherwise derive the URL from the already configured `SICLAW_GATEWAY_HOSTNAME` and `SICLAW_INTERNAL_PORT`.
- Keep the old `siclaw-runtime.<namespace>` URL as a final fallback.
- Add tests for hostname-derived URLs and explicit override precedence.

## Validation

```bash
npm test -- src/gateway/agentbox/k8s-spawner.test.ts
npm run build
```

Both passed locally.
