### PR TITLE
Add Mermaid diagram rendering controls

### DIFF
--- a/docs/design/chart-rendering.md
+++ b/docs/design/chart-rendering.md
@@ -54,6 +54,30 @@ ChartRenderer  (portal-web/src/components/chat/ChartRenderer.tsx)
         └── spec.type === "line" → renderLine
 ```
 
+## Mermaid Diagram Rendering
+
+Mermaid is a separate baseline Markdown capability, not a `ChartSpec` type and
+not an MCP requirement. The chat frontend recognises fenced Markdown blocks with
+the language tag `mermaid` and renders the initial supported diagram families:
+
+- `flowchart` / `graph` for process, dependency, cause/effect, and remediation
+  flows.
+- `sequenceDiagram` for cross-component request or event ordering.
+- `timeline` for task lifecycles, incidents, and investigation progress.
+
+Mermaid blocks are rendered client-side with Mermaid's strict security mode and
+bounded text/edge limits. Init/config directives in chat-authored diagrams are
+rejected so a response cannot weaken the renderer's security configuration.
+
+Mermaid diagrams share the frontend SVG export helpers used by charts:
+
+- streaming messages keep a stable loading state instead of repeatedly
+  rendering half-arrived diagrams;
+- rendered diagrams expose source copy, larger preview, PNG clipboard copy, and
+  PNG download controls;
+- message/session rich-copy treats rendered Mermaid SVGs as images, matching the
+  chart copy path.
+
 ### Why the spinner, not a partial chart?
 
 The `chart` fence contains a single JSON object. Until the LLM finishes
@@ -179,9 +203,10 @@ automatically.
 
 ## What the Frontend Does NOT Support
 
-- **Other fence tags**: ` ```mermaid `, ` ```echarts `, etc. fall through to the
-  generic `<pre>` renderer (raw text). Add a separate handler in
-  `MARKDOWN_COMPONENTS` in `Markdown.tsx` if you need them.
+- **Unsupported Mermaid families and other diagram tags**: ` ```echarts `,
+  unsupported Mermaid diagram types, and other diagram DSLs fall through to an
+  error/source view or the generic `<pre>` renderer rather than executing custom
+  rendering logic.
 - **Inline `<img>` tags or `data:` URIs as chart output**: these bypass
   `ChartRenderer` entirely and receive no interactivity (hover tooltip,
   copy/download toolbar, log-scale toggle).

--- a/portal-web/package-lock.json
+++ b/portal-web/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "cron-parser": "^5.5.0",
         "lucide-react": "^0.460.0",
+        "mermaid": "^11.15.0",
         "prismjs": "^1.30.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -42,6 +43,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -73,6 +96,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -323,6 +347,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -766,6 +802,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -814,6 +867,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1267,6 +1329,259 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1297,6 +1612,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -1340,6 +1661,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1355,6 +1677,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1366,6 +1695,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1647,6 +1986,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1857,6 +2197,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cron-parser": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
@@ -1886,6 +2235,522 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1928,6 +2793,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1964,6 +2838,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
@@ -1987,6 +2870,16 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2203,6 +3096,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2266,11 +3165,42 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -2396,6 +3326,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2432,6 +3363,42 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2450,6 +3417,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -2527,6 +3500,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -2807,6 +3792,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark": {
@@ -3460,6 +4474,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -3483,6 +4503,12 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
     },
     "node_modules/path-parse": {
@@ -3549,6 +4575,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -3569,6 +4611,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3757,6 +4800,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3769,6 +4813,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3984,6 +5029,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -4029,6 +5080,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4052,6 +5115,18 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -4170,6 +5245,12 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -4323,6 +5404,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4391,6 +5473,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -4539,6 +5630,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -4573,6 +5677,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4689,6 +5794,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/portal-web/package.json
+++ b/portal-web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "cron-parser": "^5.5.0",
     "lucide-react": "^0.460.0",
+    "mermaid": "^11.15.0",
     "prismjs": "^1.30.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/portal-web/src/components/chat/ChartRenderer.tsx
+++ b/portal-web/src/components/chat/ChartRenderer.tsx
@@ -65,12 +65,19 @@ import {
   describeChart,
   chartCanvasSize,
 } from "./chart-utils"
+import {
+  copyBlobToClipboard,
+  downloadBlob,
+  safeDownloadName,
+  svgToPngBlob,
+} from "./svg-export"
 
 // Re-exported so existing import sites (Markdown.tsx, PilotArea.tsx, the test
 // file) can keep importing from "./ChartRenderer" — keeps the refactor's blast
 // radius to this file pair.
 export { collapsePieSlices, tryParseChartSpec, chartSpecLooksIncomplete } from "./chart-utils"
 export type { ChartSpec } from "./chart-utils"
+export { svgToPngDataUrl as svgChartToPngDataUrl } from "./svg-export"
 
 function MarkerShape({
   shape, cx, cy, size, color,
@@ -600,114 +607,6 @@ function renderLine(
   }
 }
 
-// CSS properties whose values vary by theme and must be copied from the live
-// DOM onto a clone before serialisation — once the SVG leaves the document
-// (loaded into an <img>) it no longer sees the parent CSS / Tailwind classes.
-const INLINEABLE_PROPS = ["fill", "stroke", "stroke-width", "font-family", "font-size", "font-weight"] as const
-
-function inlineComputedStyles(src: SVGElement, dst: SVGElement) {
-  const srcAll = [src, ...Array.from(src.querySelectorAll<SVGElement>("*"))]
-  const dstAll = [dst, ...Array.from(dst.querySelectorAll<SVGElement>("*"))]
-  for (let i = 0; i < srcAll.length; i++) {
-    const cs = window.getComputedStyle(srcAll[i])
-    const tgt = dstAll[i]
-    for (const prop of INLINEABLE_PROPS) {
-      const v = cs.getPropertyValue(prop)
-      if (v) tgt.style.setProperty(prop, v)
-    }
-    // Strip class attrs — colors are now inlined, classes would just bloat the
-    // serialised output and require Tailwind in the consumer's context.
-    tgt.removeAttribute("class")
-  }
-}
-
-async function svgToPngBlob(svg: SVGSVGElement, scale = 2): Promise<Blob> {
-  const vb = svg.viewBox.baseVal
-  const w = vb && vb.width ? vb.width : svg.clientWidth || 900
-  const h = vb && vb.height ? vb.height : svg.clientHeight || 520
-
-  // Sample chart-bg's live fill BEFORE cloning — this is the same color the
-  // user sees on-screen (light: white, dark: slate-900). Used as the canvas
-  // base so if inlineComputedStyles ever fails to carry the bg fill onto the
-  // detached clone (CSS var that doesn't resolve out-of-document, future
-  // refactor swapping <rect> for CSS background, etc.) we still rasterise on
-  // the right base color — light-grey text on white was the worst-case
-  // failure mode the previous hardcoded #ffffff fallback would produce.
-  const bgRect = svg.querySelector<SVGRectElement>(".chart-bg")
-  const liveBg = bgRect ? window.getComputedStyle(bgRect).fill : ""
-  const canvasBg = liveBg && liveBg !== "none" && liveBg !== "transparent" ? liveBg : "#ffffff"
-
-  const clone = svg.cloneNode(true) as SVGSVGElement
-  inlineComputedStyles(svg, clone)
-  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg")
-  clone.setAttribute("width", String(w))
-  clone.setAttribute("height", String(h))
-
-  const xml = new XMLSerializer().serializeToString(clone)
-  const url = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(xml)
-
-  const img = new Image()
-  img.crossOrigin = "anonymous"
-  await new Promise<void>((resolve, reject) => {
-    img.onload = () => resolve()
-    img.onerror = () => reject(new Error("SVG rasterisation failed"))
-    img.src = url
-  })
-
-  const canvas = document.createElement("canvas")
-  canvas.width = Math.round(w * scale)
-  canvas.height = Math.round(h * scale)
-  const ctx = canvas.getContext("2d")
-  if (!ctx) throw new Error("canvas 2d context unavailable")
-  // Match the on-screen theme so anti-aliased edges and any potential inline
-  // miss still produce a readable PNG (no light-grey-on-white failure mode).
-  ctx.fillStyle = canvasBg
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
-  ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
-
-  return await new Promise<Blob>((resolve, reject) => {
-    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("toBlob returned null"))), "image/png")
-  })
-}
-
-function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(String(reader.result))
-    reader.onerror = () => reject(new Error("blob -> data URL failed"))
-    reader.readAsDataURL(blob)
-  })
-}
-
-// Rasterise a live chart SVG to a PNG data URL. Used by the message-level copy
-// button (PilotArea) to embed real images in the text/html clipboard payload —
-// copying the bubble's markdown alone would only yield the raw chart JSON.
-export async function svgChartToPngDataUrl(svg: SVGSVGElement, scale = 2): Promise<string> {
-  const blob = await svgToPngBlob(svg, scale)
-  return await blobToDataUrl(blob)
-}
-
-function downloadBlob(blob: Blob, name: string) {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement("a")
-  a.href = url
-  a.download = name
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  setTimeout(() => URL.revokeObjectURL(url), 1000)
-}
-
-async function copyBlobToClipboard(blob: Blob): Promise<boolean> {
-  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false
-  try {
-    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })])
-    return true
-  } catch {
-    return false
-  }
-}
-
 const TOOLBAR_BTN =
   "inline-flex h-7 items-center justify-center rounded-md bg-white/90 dark:bg-slate-800/90 " +
   "text-gray-700 dark:text-gray-100 border border-gray-200 dark:border-slate-700 shadow-sm " +
@@ -786,7 +685,7 @@ function ChartRendererImpl({ spec, className, style, allowPreview = true }: Char
     if (!svgRef.current) return
     try {
       const blob = await svgToPngBlob(svgRef.current, 2)
-      const safeTitle = (spec.title ?? `${spec.type}-chart`).replace(/[\\/:*?"<>|\s]+/g, "_").slice(0, 60)
+      const safeTitle = safeDownloadName(spec.title ?? `${spec.type}-chart`, "chart")
       downloadBlob(blob, `${safeTitle || "chart"}.png`)
       flash("ok", "PNG downloaded")
     } catch {

--- a/portal-web/src/components/chat/ChartRenderer.tsx
+++ b/portal-web/src/components/chat/ChartRenderer.tsx
@@ -710,9 +710,10 @@ function ChartRendererImpl({ spec, className, style, allowPreview = true }: Char
       if (ok) flash("ok", "Image copied to clipboard")
       else {
         downloadBlob(blob, "chart.png")
-        flash("ok", "Clipboard image copy not supported — downloaded PNG instead")
+        flash("ok", "Clipboard image copy unavailable — downloaded PNG instead")
       }
-    } catch {
+    } catch (err) {
+      console.warn("[copy] chart image copy failed:", err)
       flash("err", "Copy failed")
     }
   }, [flash])

--- a/portal-web/src/components/chat/Markdown.test.tsx
+++ b/portal-web/src/components/chat/Markdown.test.tsx
@@ -51,6 +51,17 @@ describe("Markdown Mermaid fences", () => {
     })
   })
 
+  it("repairs leaked stream content prefixes inside Mermaid blocks", () => {
+    expect(validateMermaidSource("flowchart TD\n  178-content: A --> B")).toMatchObject({
+      ok: true,
+      source: "flowchart TD\nA --> B",
+    })
+    expect(validateMermaidSource("sequenceDiagram\n  9-text: A->>B: hello")).toMatchObject({
+      ok: true,
+      source: "sequenceDiagram\nA->>B: hello",
+    })
+  })
+
   it("rejects unsupported diagram families and init directives", () => {
     expect(validateMermaidSource("classDiagram\n  A <|-- B")).toMatchObject({
       ok: false,

--- a/portal-web/src/components/chat/Markdown.test.tsx
+++ b/portal-web/src/components/chat/Markdown.test.tsx
@@ -32,6 +32,15 @@ describe("Markdown Mermaid fences", () => {
     expect(html).not.toContain("language-mermaid")
   })
 
+  it("keeps incomplete mermaid fences in loading state while streaming", () => {
+    const html = renderToStaticMarkup(
+      <Markdown isStreaming>{"```mermaid\nflowchart TD\n  A -->"}</Markdown>,
+    )
+
+    expect(html).toContain("Rendering diagram")
+    expect(html).not.toContain("Failed to render Mermaid diagram")
+  })
+
   it("accepts the initial diagram set", () => {
     expect(validateMermaidSource("flowchart TD\n  A --> B")).toMatchObject({
       ok: true,

--- a/portal-web/src/components/chat/Markdown.test.tsx
+++ b/portal-web/src/components/chat/Markdown.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
 import { Markdown } from "./Markdown"
+import { countMermaidEdges, validateMermaidSource } from "./MermaidRenderer"
 
 const incompleteChart = '```chart\n{"type":"bar","data":\n```'
 
@@ -17,5 +18,49 @@ describe("Markdown chart fences", () => {
 
     expect(html).toContain("Chart output incomplete")
     expect(html).not.toContain("Generating chart")
+  })
+})
+
+describe("Markdown Mermaid fences", () => {
+  it("routes mermaid fences to the diagram renderer shell", () => {
+    const html = renderToStaticMarkup(
+      <Markdown>{"```mermaid\nflowchart TD\n  A --> B\n```"}</Markdown>,
+    )
+
+    expect(html).toContain("mermaid-host")
+    expect(html).toContain("Rendering diagram")
+    expect(html).not.toContain("language-mermaid")
+  })
+
+  it("accepts the initial diagram set", () => {
+    expect(validateMermaidSource("flowchart TD\n  A --> B")).toMatchObject({
+      ok: true,
+      kind: "flowchart",
+    })
+    expect(validateMermaidSource("graph LR\n  A --> B")).toMatchObject({
+      ok: true,
+      kind: "flowchart",
+    })
+    expect(validateMermaidSource("sequenceDiagram\n  A->>B: hello")).toMatchObject({
+      ok: true,
+      kind: "sequence",
+    })
+    expect(validateMermaidSource("timeline\n  title Task lifecycle\n  Created")).toMatchObject({
+      ok: true,
+      kind: "timeline",
+    })
+  })
+
+  it("rejects unsupported diagram families and init directives", () => {
+    expect(validateMermaidSource("classDiagram\n  A <|-- B")).toMatchObject({
+      ok: false,
+    })
+    expect(validateMermaidSource("%%{init: {'securityLevel': 'loose'}}%%\nflowchart TD\nA-->B")).toMatchObject({
+      ok: false,
+    })
+  })
+
+  it("counts Mermaid edges for complexity limits", () => {
+    expect(countMermaidEdges("flowchart TD\n  A --> B\n  B --- C\n  C ==> D")).toBe(3)
   })
 })

--- a/portal-web/src/components/chat/Markdown.tsx
+++ b/portal-web/src/components/chat/Markdown.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm"
 import { Check, Copy } from "lucide-react"
 import { cn } from "./cn"
 import { ChartRenderer, chartSpecLooksIncomplete, tryParseChartSpec } from "./ChartRenderer"
+import { MermaidRenderer } from "./MermaidRenderer"
 import { useCopyFeedback } from "./clipboard"
 
 interface MarkdownProps {
@@ -211,6 +212,11 @@ function ChartFence({ text }: { text: string }) {
   return <ChartParseError source={trimmed} />
 }
 
+function MermaidFence({ text }: { text: string }) {
+  const isStreaming = useContext(ChartStreamingContext)
+  return <MermaidRenderer source={text} isStreaming={isStreaming} />
+}
+
 // Hoisted to module scope so each entry has stable function identity across
 // <Markdown> re-renders. Inlining this object inside the render body produces
 // fresh function references every token, which react-markdown surfaces as a
@@ -246,6 +252,10 @@ const MARKDOWN_COMPONENTS: Components = {
 
     if (hasLanguageClass(className, "chart")) {
       return <ChartFence text={text} />
+    }
+
+    if (hasLanguageClass(className, "mermaid")) {
+      return <MermaidFence text={text} />
     }
 
     return <CodeBlock language={extractLanguage(className)} text={text} />

--- a/portal-web/src/components/chat/MermaidRenderer.tsx
+++ b/portal-web/src/components/chat/MermaidRenderer.tsx
@@ -45,6 +45,9 @@ export function countMermaidEdges(source: string): number {
   ).length
 }
 
+// Layered guard before mounting Mermaid output: bound input size/complexity,
+// reject init directives so chat content cannot weaken renderer config, then
+// whitelist only the diagram families Siclaw intentionally supports.
 export function validateMermaidSource(raw: string): MermaidValidation {
   const source = normalizeMermaidSource(raw)
   if (!source) return { ok: false, reason: "The Mermaid block is empty." }
@@ -94,6 +97,9 @@ export function validateMermaidSource(raw: string): MermaidValidation {
 function mermaidConfig() {
   return {
     startOnLoad: false,
+    // This is the load-bearing XSS defense for the SVG later mounted with
+    // dangerouslySetInnerHTML. Chat-authored %%{init}%% directives are rejected
+    // above so a response cannot downgrade this setting.
     securityLevel: "strict",
     maxTextSize: MAX_MERMAID_CHARS,
     maxEdges: MAX_MERMAID_EDGES,
@@ -121,6 +127,9 @@ function mermaidConfig() {
 }
 
 function decorateMermaidSvg(svg: string): string {
+  // Mermaid already parsed/rendered this string under strict mode. Keep this as
+  // a tiny string decoration so we do not need to reparse browser-only SVG DOM
+  // just to add accessibility metadata.
   return svg.replace(/<svg\b[^>]*>/, (tag) => {
     let next = /\brole=/.test(tag)
       ? tag.replace(/\srole=(["']).*?\1/, ' role="img"')
@@ -237,9 +246,10 @@ export function MermaidRenderer({
       if (ok) flash("ok", "Image copied to clipboard")
       else {
         downloadBlob(blob, "mermaid-diagram.png")
-        flash("ok", "Clipboard image copy not supported — downloaded PNG instead")
+        flash("ok", "Clipboard image copy unavailable — downloaded PNG instead")
       }
-    } catch {
+    } catch (err) {
+      console.warn("[copy] Mermaid image copy failed:", err)
       flash("err", "Copy failed")
     }
   }, [flash, getSvg])
@@ -252,7 +262,8 @@ export function MermaidRenderer({
       const base = mermaidDownloadBase(cleanSource, validation.ok ? validation.kind : "diagram")
       downloadBlob(blob, `${base}.png`)
       flash("ok", "PNG downloaded")
-    } catch {
+    } catch (err) {
+      console.warn("[download] Mermaid PNG export failed:", err)
       flash("err", "Download failed")
     }
   }, [cleanSource, flash, getSvg, validation])
@@ -281,9 +292,12 @@ export function MermaidRenderer({
       try {
         const mermaid = (await import("mermaid")).default
         mermaid.initialize(mermaidConfig())
-        const parsed = await mermaid.parse(validation.source, { suppressErrors: true })
+        const parsed = await mermaid.parse(validation.source)
         if (!parsed) throw new Error("Mermaid parser rejected the diagram syntax.")
         const { svg } = await mermaid.render(nextMermaidId(), validation.source)
+        // Dynamic import/render can resolve after a newer source or streaming
+        // state has already triggered another effect; avoid replacing fresh
+        // state with a stale render.
         if (!cancelled) setState({ status: "ready", svg: decorateMermaidSvg(svg) })
       } catch (err) {
         if (cancelled) return

--- a/portal-web/src/components/chat/MermaidRenderer.tsx
+++ b/portal-web/src/components/chat/MermaidRenderer.tsx
@@ -1,0 +1,424 @@
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Check, Clipboard, Copy, Download, Maximize2, X } from "lucide-react"
+import { useCopyFeedback } from "./clipboard"
+import {
+  copyBlobToClipboard,
+  downloadBlob,
+  safeDownloadName,
+  svgToPngBlob,
+} from "./svg-export"
+
+const MAX_MERMAID_CHARS = 12000
+const MAX_MERMAID_LINES = 160
+const MAX_MERMAID_EDGES = 80
+
+type MermaidValidation =
+  | { ok: true; source: string; kind: "flowchart" | "sequence" | "timeline" }
+  | { ok: false; reason: string }
+
+type RenderState =
+  | { status: "rendering" }
+  | { status: "ready"; svg: string }
+  | { status: "error"; title: string; description: string }
+
+let mermaidIdSeq = 0
+
+function nextMermaidId(): string {
+  mermaidIdSeq += 1
+  return `siclaw-mermaid-${Date.now()}-${mermaidIdSeq}`
+}
+
+function firstMeaningfulLine(source: string): string {
+  return source
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line && !line.startsWith("%%")) ?? ""
+}
+
+export function countMermaidEdges(source: string): number {
+  return (
+    source.match(/(?:-->|---|==>|->>|-->>|-\)|--\)|<-->|<->|--x|--o)/g) ?? []
+  ).length
+}
+
+export function validateMermaidSource(raw: string): MermaidValidation {
+  const source = raw.trim()
+  if (!source) return { ok: false, reason: "The Mermaid block is empty." }
+  if (source.length > MAX_MERMAID_CHARS) {
+    return {
+      ok: false,
+      reason: `The Mermaid block is too large (${source.length} characters, max ${MAX_MERMAID_CHARS}).`,
+    }
+  }
+  const lines = source.split(/\r?\n/)
+  if (lines.length > MAX_MERMAID_LINES) {
+    return {
+      ok: false,
+      reason: `The Mermaid block has too many lines (${lines.length}, max ${MAX_MERMAID_LINES}).`,
+    }
+  }
+  if (/^\s*%%\{/m.test(source)) {
+    return {
+      ok: false,
+      reason: "Mermaid init/config directives are not allowed in chat diagrams.",
+    }
+  }
+  const edges = countMermaidEdges(source)
+  if (edges > MAX_MERMAID_EDGES) {
+    return {
+      ok: false,
+      reason: `The Mermaid diagram has too many edges (${edges}, max ${MAX_MERMAID_EDGES}).`,
+    }
+  }
+
+  const head = firstMeaningfulLine(source)
+  if (/^(flowchart|graph)\s+/i.test(head)) {
+    return { ok: true, source, kind: "flowchart" }
+  }
+  if (/^sequenceDiagram\b/i.test(head)) {
+    return { ok: true, source, kind: "sequence" }
+  }
+  if (/^timeline\b/i.test(head)) {
+    return { ok: true, source, kind: "timeline" }
+  }
+  return {
+    ok: false,
+    reason: "Only flowchart/graph, sequenceDiagram, and timeline diagrams are supported.",
+  }
+}
+
+function mermaidConfig() {
+  return {
+    startOnLoad: false,
+    securityLevel: "strict",
+    maxTextSize: MAX_MERMAID_CHARS,
+    maxEdges: MAX_MERMAID_EDGES,
+    theme: "base",
+    flowchart: {
+      htmlLabels: false,
+      useMaxWidth: true,
+    },
+    sequence: {
+      useMaxWidth: true,
+    },
+    themeVariables: {
+      background: "#ffffff",
+      mainBkg: "#f8fafc",
+      primaryColor: "#e0f2fe",
+      primaryTextColor: "#0f172a",
+      primaryBorderColor: "#0284c7",
+      secondaryColor: "#f1f5f9",
+      tertiaryColor: "#f8fafc",
+      lineColor: "#475569",
+      textColor: "#0f172a",
+      fontFamily: "Inter, ui-sans-serif, system-ui, sans-serif",
+    },
+  } as const
+}
+
+function decorateMermaidSvg(svg: string): string {
+  return svg.replace(/<svg\b[^>]*>/, (tag) => {
+    let next = /\brole=/.test(tag)
+      ? tag.replace(/\srole=(["']).*?\1/, ' role="img"')
+      : tag.replace("<svg", '<svg role="img"')
+    next = /\baria-label=/.test(next)
+      ? next.replace(/\saria-label=(["']).*?\1/, ' aria-label="Mermaid diagram"')
+      : next.replace("<svg", '<svg aria-label="Mermaid diagram"')
+    return next
+  })
+}
+
+function mermaidDownloadBase(source: string, kind: string): string {
+  const title = source
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => /^title\s+/i.test(line))
+    ?.replace(/^title\s+/i, "")
+  return safeDownloadName(title || `mermaid-${kind}`, "mermaid-diagram")
+}
+
+const TOOLBAR_BTN =
+  "inline-flex h-7 w-7 items-center justify-center rounded-md text-slate-500 transition-colors " +
+  "hover:bg-slate-200 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+
+function MermaidShell({
+  source,
+  children,
+  actions,
+}: {
+  source: string
+  children: ReactNode
+  actions?: ReactNode
+}) {
+  const [copied, copy] = useCopyFeedback()
+  return (
+    <div className="mermaid-host my-3 overflow-hidden rounded-lg border border-border bg-white text-slate-900 shadow-sm dark:border-slate-700 dark:bg-slate-950">
+      <div className="flex items-center justify-between border-b border-slate-200 bg-slate-50 px-3 py-1 dark:border-slate-800 dark:bg-slate-900">
+        <span className="font-mono text-[11px] font-medium text-slate-500 dark:text-slate-400">
+          mermaid
+        </span>
+        <div className="flex items-center gap-1">
+          {actions}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              void copy(source)
+            }}
+            aria-label="Copy Mermaid source"
+            title="Copy Mermaid source"
+            className={TOOLBAR_BTN}
+          >
+            {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+          </button>
+        </div>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function MermaidError({
+  source,
+  title,
+  description,
+}: {
+  source: string
+  title: string
+  description: string
+}) {
+  return (
+    <MermaidShell source={source}>
+      <div className="p-3 text-sm text-red-900 dark:text-red-100">
+        <div className="font-semibold">{title}</div>
+        <div className="mt-1 text-xs opacity-80">{description}</div>
+        <details className="mt-2">
+          <summary className="cursor-pointer text-xs font-medium">View Mermaid source</summary>
+          <pre className="mt-2 max-h-56 overflow-auto rounded bg-slate-950 p-3 text-xs text-slate-100">
+            {source}
+          </pre>
+        </details>
+      </div>
+    </MermaidShell>
+  )
+}
+
+export function MermaidRenderer({
+  source,
+  isStreaming = false,
+}: {
+  source: string
+  isStreaming?: boolean
+}) {
+  const validation = useMemo(() => validateMermaidSource(source), [source])
+  const cleanSource = validation.ok ? validation.source : source.trim()
+  const [state, setState] = useState<RenderState>({ status: "rendering" })
+  const [status, setStatus] = useState<null | { kind: "ok" | "err"; text: string }>(null)
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const diagramRef = useRef<HTMLDivElement | null>(null)
+
+  const flash = useCallback((kind: "ok" | "err", text: string) => {
+    setStatus({ kind, text })
+    setTimeout(() => setStatus(null), 1800)
+  }, [])
+
+  const getSvg = useCallback(() => diagramRef.current?.querySelector<SVGSVGElement>("svg") ?? null, [])
+
+  const onCopyImage = useCallback(async () => {
+    const svg = getSvg()
+    if (!svg) return
+    try {
+      const blob = await svgToPngBlob(svg, 2)
+      const ok = await copyBlobToClipboard(blob)
+      if (ok) flash("ok", "Image copied to clipboard")
+      else {
+        downloadBlob(blob, "mermaid-diagram.png")
+        flash("ok", "Clipboard image copy not supported — downloaded PNG instead")
+      }
+    } catch {
+      flash("err", "Copy failed")
+    }
+  }, [flash, getSvg])
+
+  const onDownload = useCallback(async () => {
+    const svg = getSvg()
+    if (!svg) return
+    try {
+      const blob = await svgToPngBlob(svg, 2)
+      const base = mermaidDownloadBase(cleanSource, validation.ok ? validation.kind : "diagram")
+      downloadBlob(blob, `${base}.png`)
+      flash("ok", "PNG downloaded")
+    } catch {
+      flash("err", "Download failed")
+    }
+  }, [cleanSource, flash, getSvg, validation])
+
+  useEffect(() => {
+    let cancelled = false
+    if (isStreaming) {
+      setState({ status: "rendering" })
+      return () => {
+        cancelled = true
+      }
+    }
+    if (!validation.ok) {
+      setState({
+        status: "error",
+        title: "Unsupported Mermaid diagram",
+        description: validation.reason,
+      })
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setState({ status: "rendering" })
+    void (async () => {
+      try {
+        const mermaid = (await import("mermaid")).default
+        mermaid.initialize(mermaidConfig())
+        const parsed = await mermaid.parse(validation.source, { suppressErrors: true })
+        if (!parsed) throw new Error("Mermaid parser rejected the diagram syntax.")
+        const { svg } = await mermaid.render(nextMermaidId(), validation.source)
+        if (!cancelled) setState({ status: "ready", svg: decorateMermaidSvg(svg) })
+      } catch (err) {
+        if (cancelled) return
+        setState({
+          status: "error",
+          title: "Failed to render Mermaid diagram",
+          description: err instanceof Error ? err.message : String(err),
+        })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [validation, isStreaming])
+
+  useEffect(() => {
+    if (!previewOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setPreviewOpen(false)
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [previewOpen])
+
+  if (state.status === "error") {
+    return (
+      <MermaidError
+        source={cleanSource}
+        title={state.title}
+        description={state.description}
+      />
+    )
+  }
+
+  const actions = state.status === "ready" ? (
+    <>
+      <button
+        type="button"
+        onClick={() => setPreviewOpen(true)}
+        aria-label="Open larger Mermaid preview"
+        title="Open larger Mermaid preview"
+        className={TOOLBAR_BTN}
+      >
+        <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={onCopyImage}
+        aria-label="Copy Mermaid diagram as PNG to clipboard"
+        title="Copy Mermaid diagram as PNG to clipboard"
+        className={TOOLBAR_BTN}
+      >
+        <Clipboard className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        onClick={onDownload}
+        aria-label="Download Mermaid diagram as PNG"
+        title="Download Mermaid diagram as PNG"
+        className={TOOLBAR_BTN}
+      >
+        <Download className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+    </>
+  ) : null
+
+  return (
+    <>
+      <MermaidShell source={cleanSource} actions={actions}>
+        <div className="relative">
+          {state.status === "ready" ? (
+            <div
+              ref={diagramRef}
+              className="overflow-auto p-4 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-full"
+              aria-label="Mermaid diagram"
+              dangerouslySetInnerHTML={{ __html: state.svg }}
+            />
+          ) : (
+            <div className="flex items-center gap-2 px-4 py-6 text-sm text-slate-500 dark:text-slate-400" role="status">
+              <svg
+                className="h-4 w-4 animate-spin"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                aria-hidden="true"
+              >
+                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+              </svg>
+              Rendering diagram...
+            </div>
+          )}
+          {status && (
+            <div
+              className={`absolute left-1/2 top-3 -translate-x-1/2 rounded-md px-2.5 py-1 text-xs shadow-sm ${
+                status.kind === "ok" ? "bg-emerald-600 text-white" : "bg-red-600 text-white"
+              }`}
+            >
+              {status.text}
+            </div>
+          )}
+        </div>
+      </MermaidShell>
+
+      {state.status === "ready" && previewOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Mermaid preview"
+          onClick={() => setPreviewOpen(false)}
+        >
+          <div
+            className="max-h-[92vh] w-[min(1200px,96vw)] overflow-auto rounded-lg border border-slate-200 bg-white p-4 shadow-2xl dark:border-slate-700 dark:bg-slate-950"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <div className="min-w-0 truncate text-sm font-medium text-slate-700 dark:text-slate-200">
+                Mermaid preview
+              </div>
+              <button
+                type="button"
+                onClick={() => setPreviewOpen(false)}
+                aria-label="Close Mermaid preview"
+                title="Close Mermaid preview"
+                className={TOOLBAR_BTN}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </div>
+            <div
+              className="overflow-auto p-4 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-w-none"
+              dangerouslySetInnerHTML={{ __html: state.svg }}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/portal-web/src/components/chat/MermaidRenderer.tsx
+++ b/portal-web/src/components/chat/MermaidRenderer.tsx
@@ -35,6 +35,10 @@ function firstMeaningfulLine(source: string): string {
     .find((line) => line && !line.startsWith("%%")) ?? ""
 }
 
+function normalizeMermaidSource(raw: string): string {
+  return raw.trim().replace(/^\s*\d+-(?:content|text):\s*/gm, "")
+}
+
 export function countMermaidEdges(source: string): number {
   return (
     source.match(/(?:-->|---|==>|->>|-->>|-\)|--\)|<-->|<->|--x|--o)/g) ?? []
@@ -42,7 +46,7 @@ export function countMermaidEdges(source: string): number {
 }
 
 export function validateMermaidSource(raw: string): MermaidValidation {
-  const source = raw.trim()
+  const source = normalizeMermaidSource(raw)
   if (!source) return { ok: false, reason: "The Mermaid block is empty." }
   if (source.length > MAX_MERMAID_CHARS) {
     return {

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -1195,12 +1195,13 @@ function escapeHtml(text: string): string {
 // whose source failed validation.
 //
 // KNOWN LIMITATION — this PNG↔fence mapping is best-effort, not exact. It
-// assumes `tryParseChartSpec` succeeding here implies the fence rendered a real
-// `.chart-host svg` in the DOM. That can drift if a fence parsed but the chart
-// did not actually mount (e.g. it was still in the streaming/loading state, or
-// future render-gating changes), in which case later images attach to the
-// wrong message. Acceptable for a copy-to-clipboard convenience; if it ever
-// needs to be exact, walk per-message DOM nodes instead of re-parsing text.
+// assumes `tryParseChartSpec` / `validateMermaidSource` succeeding here implies
+// the fence rendered a real `.chart-host svg` / `.mermaid-host svg` in the DOM.
+// That can drift if a fence parsed but the visual did not actually mount (e.g.
+// it was still in the streaming/loading state, or future render-gating changes),
+// in which case later images attach to the wrong message. Acceptable for a
+// copy-to-clipboard convenience; if it ever needs to be exact, walk per-message
+// DOM nodes instead of re-parsing text.
 function serializeSessionToHtml(messages: PilotMessage[], visualUrls: string[]): string {
   const fenceRe = /```(chart|mermaid)\s*([\s\S]*?)```/g
   let visualIdx = 0
@@ -1225,6 +1226,8 @@ function serializeSessionToHtml(messages: PilotMessage[], visualUrls: string[]):
         const parsed = lang === "chart" ? Boolean(tryParseChartSpec(raw)) : validateMermaidSource(raw).ok
         if (parsed && visualIdx < visualUrls.length) {
           html += `<p><img src="${visualUrls[visualIdx++]}" alt="${lang}" style="max-width:100%;height:auto"/></p>`
+        } else if (lang === "mermaid") {
+          html += "<p>[diagram]</p>"
         } else {
           html += `<p>[${lang}]</p>`
         }

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -21,7 +21,9 @@ import {
 } from "lucide-react"
 import { cn } from "./cn"
 import { Markdown } from "./Markdown"
-import { svgChartToPngDataUrl, tryParseChartSpec } from "./ChartRenderer"
+import { tryParseChartSpec } from "./ChartRenderer"
+import { validateMermaidSource } from "./MermaidRenderer"
+import { svgToPngDataUrl } from "./svg-export"
 import { useCopyFeedback } from "./clipboard"
 import { InputArea } from "./InputArea"
 import { SkillCard } from "./SkillCard"
@@ -1166,7 +1168,7 @@ function serializeSessionToText(messages: PilotMessage[]): string {
     if (m.role === "user") {
       lines.push(`You:\n${m.content.trim()}`)
     } else if (m.role === "assistant") {
-      const body = stripChartFences(m.content ?? "")
+      const body = stripVisualizationFences(m.content ?? "")
       if (body) lines.push(`Assistant:\n${body}`)
     } else if (m.role === "tool") {
       const name = m.toolName ?? "tool"
@@ -1187,11 +1189,10 @@ function escapeHtml(text: string): string {
     .replace(/>/g, "&gt;")
 }
 
-// Build a text/html rendition of the whole session with each ```chart fenced
+// Build a text/html rendition of the whole session with each visual fenced
 // block swapped for its rasterised PNG. The PNGs are passed in DOM order; an
 // assistant message's fences are mapped to them left-to-right, skipping fences
-// whose JSON failed to parse (those rendered no chart in the DOM, so they did
-// not consume a PNG).
+// whose source failed validation.
 //
 // KNOWN LIMITATION — this PNG↔fence mapping is best-effort, not exact. It
 // assumes `tryParseChartSpec` succeeding here implies the fence rendered a real
@@ -1200,9 +1201,9 @@ function escapeHtml(text: string): string {
 // future render-gating changes), in which case later images attach to the
 // wrong message. Acceptable for a copy-to-clipboard convenience; if it ever
 // needs to be exact, walk per-message DOM nodes instead of re-parsing text.
-function serializeSessionToHtml(messages: PilotMessage[], chartUrls: string[]): string {
-  const fenceRe = /```chart\s*([\s\S]*?)```/g
-  let chartIdx = 0
+function serializeSessionToHtml(messages: PilotMessage[], visualUrls: string[]): string {
+  const fenceRe = /```(chart|mermaid)\s*([\s\S]*?)```/g
+  let visualIdx = 0
   const parts: string[] = []
   for (const m of messages) {
     if (m.hidden) continue
@@ -1219,11 +1220,13 @@ function serializeSessionToHtml(messages: PilotMessage[], chartUrls: string[]): 
       while ((match = fenceRe.exec(body)) !== null) {
         const before = body.slice(last, match.index).trim()
         if (before) html += `<p>${escapeHtml(before).replace(/\n/g, "<br/>")}</p>`
-        const parsed = tryParseChartSpec(match[1].trim())
-        if (parsed && chartIdx < chartUrls.length) {
-          html += `<p><img src="${chartUrls[chartIdx++]}" alt="chart" style="max-width:100%;height:auto"/></p>`
+        const lang = match[1]
+        const raw = match[2].trim()
+        const parsed = lang === "chart" ? Boolean(tryParseChartSpec(raw)) : validateMermaidSource(raw).ok
+        if (parsed && visualIdx < visualUrls.length) {
+          html += `<p><img src="${visualUrls[visualIdx++]}" alt="${lang}" style="max-width:100%;height:auto"/></p>`
         } else {
-          html += "<p>[chart]</p>"
+          html += `<p>[${lang}]</p>`
         }
         last = match.index + match[0].length
       }
@@ -1248,12 +1251,14 @@ async function copySessionWithCharts(
   container: HTMLElement,
   messages: PilotMessage[],
 ): Promise<boolean> {
-  const svgs = Array.from(container.querySelectorAll<SVGSVGElement>('.chart-host svg[role="img"]'))
+  const svgs = Array.from(container.querySelectorAll<SVGSVGElement>(
+    '.chart-host svg[role="img"], .mermaid-host svg[role="img"]',
+  ))
   if (svgs.length === 0) return false
   if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false
   try {
-    const chartUrls = await Promise.all(svgs.map((svg) => svgChartToPngDataUrl(svg)))
-    const html = serializeSessionToHtml(messages, chartUrls)
+    const visualUrls = await Promise.all(svgs.map((svg) => svgToPngDataUrl(svg)))
+    const html = serializeSessionToHtml(messages, visualUrls)
     const plain = serializeSessionToText(messages)
     await navigator.clipboard.write([
       new ClipboardItem({
@@ -1327,23 +1332,29 @@ function CopyIconButton({
 
 // Plain-text fallback for the clipboard: a ```chart fenced JSON block is noise
 // when pasted as text, so swap it for a readable placeholder.
-function stripChartFences(markdown: string): string {
-  return markdown.replace(/```chart\s*[\s\S]*?```/g, "[chart]").replace(/\n{3,}/g, "\n\n").trim()
+function stripVisualizationFences(markdown: string): string {
+  return markdown
+    .replace(/```chart\s*[\s\S]*?```/g, "[chart]")
+    .replace(/```mermaid\s*[\s\S]*?```/g, "[diagram]")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
 }
 
-// Copy a rendered message bubble as rich text/html with charts rasterised to
+// Copy a rendered message bubble as rich text/html with visualisations rasterised to
 // inline PNGs, plus a text/plain fallback. Returns false when there are no
-// charts or the browser can't do a rich clipboard write, so the caller can
+// visualisations or the browser can't do a rich clipboard write, so the caller can
 // fall back to a plain markdown copy. Without this, "copy answer" yielded the
-// raw chart JSON spec instead of the picture the user actually sees.
+// raw chart JSON spec or Mermaid source instead of the picture the user sees.
 async function copyBubbleWithCharts(bubble: HTMLElement, content: string): Promise<boolean> {
-  const charts = Array.from(bubble.querySelectorAll<SVGSVGElement>('.chart-host svg[role="img"]'))
-  if (charts.length === 0) return false
+  const visuals = Array.from(bubble.querySelectorAll<SVGSVGElement>(
+    '.chart-host svg[role="img"], .mermaid-host svg[role="img"]',
+  ))
+  if (visuals.length === 0) return false
   if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false
   try {
-    const dataUrls = await Promise.all(charts.map((svg) => svgChartToPngDataUrl(svg)))
+    const dataUrls = await Promise.all(visuals.map((svg) => svgToPngDataUrl(svg)))
     const clone = bubble.cloneNode(true) as HTMLElement
-    const cloneHosts = Array.from(clone.querySelectorAll<HTMLElement>(".chart-host"))
+    const cloneHosts = Array.from(clone.querySelectorAll<HTMLElement>(".chart-host, .mermaid-host"))
     cloneHosts.forEach((host, i) => {
       const img = document.createElement("img")
       img.src = dataUrls[i] ?? ""
@@ -1354,7 +1365,7 @@ async function copyBubbleWithCharts(bubble: HTMLElement, content: string): Promi
     // Drop any leftover interactive controls (chart toolbars etc.).
     clone.querySelectorAll("button").forEach((b) => b.remove())
     const html = `<div>${clone.innerHTML}</div>`
-    const plain = stripChartFences(content)
+    const plain = stripVisualizationFences(content)
     await navigator.clipboard.write([
       new ClipboardItem({
         "text/html": new Blob([html], { type: "text/html" }),

--- a/portal-web/src/components/chat/svg-export.ts
+++ b/portal-web/src/components/chat/svg-export.ts
@@ -1,0 +1,109 @@
+// Browser helpers shared by chat visualisations that render as inline SVG.
+// They intentionally know nothing about ChartSpec or Mermaid syntax.
+
+const INLINEABLE_PROPS = ["fill", "stroke", "stroke-width", "font-family", "font-size", "font-weight"] as const
+
+function inlineComputedStyles(src: SVGElement, dst: SVGElement) {
+  const srcAll = [src, ...Array.from(src.querySelectorAll<SVGElement>("*"))]
+  const dstAll = [dst, ...Array.from(dst.querySelectorAll<SVGElement>("*"))]
+  for (let i = 0; i < srcAll.length; i++) {
+    const cs = window.getComputedStyle(srcAll[i])
+    const tgt = dstAll[i]
+    for (const prop of INLINEABLE_PROPS) {
+      const v = cs.getPropertyValue(prop)
+      if (v) tgt.style.setProperty(prop, v)
+    }
+    tgt.removeAttribute("class")
+  }
+}
+
+function svgCanvasSize(svg: SVGSVGElement): { width: number; height: number } {
+  const vb = svg.viewBox.baseVal
+  if (vb && vb.width && vb.height) return { width: vb.width, height: vb.height }
+  const rect = svg.getBoundingClientRect()
+  return {
+    width: rect.width || svg.clientWidth || 900,
+    height: rect.height || svg.clientHeight || 520,
+  }
+}
+
+function svgBackground(svg: SVGSVGElement): string {
+  const bgRect = svg.querySelector<SVGRectElement>(".chart-bg")
+  const liveBg = bgRect ? window.getComputedStyle(bgRect).fill : ""
+  return liveBg && liveBg !== "none" && liveBg !== "transparent" ? liveBg : "#ffffff"
+}
+
+export async function svgToPngBlob(svg: SVGSVGElement, scale = 2): Promise<Blob> {
+  const { width, height } = svgCanvasSize(svg)
+  const canvasBg = svgBackground(svg)
+
+  const clone = svg.cloneNode(true) as SVGSVGElement
+  inlineComputedStyles(svg, clone)
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg")
+  clone.setAttribute("width", String(width))
+  clone.setAttribute("height", String(height))
+
+  const xml = new XMLSerializer().serializeToString(clone)
+  const url = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(xml)
+
+  const img = new Image()
+  img.crossOrigin = "anonymous"
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => resolve()
+    img.onerror = () => reject(new Error("SVG rasterisation failed"))
+    img.src = url
+  })
+
+  const canvas = document.createElement("canvas")
+  canvas.width = Math.round(width * scale)
+  canvas.height = Math.round(height * scale)
+  const ctx = canvas.getContext("2d")
+  if (!ctx) throw new Error("canvas 2d context unavailable")
+  ctx.fillStyle = canvasBg
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("toBlob returned null"))), "image/png")
+  })
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(new Error("blob -> data URL failed"))
+    reader.readAsDataURL(blob)
+  })
+}
+
+export async function svgToPngDataUrl(svg: SVGSVGElement, scale = 2): Promise<string> {
+  const blob = await svgToPngBlob(svg, scale)
+  return await blobToDataUrl(blob)
+}
+
+export function downloadBlob(blob: Blob, name: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = name
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+export async function copyBlobToClipboard(blob: Blob): Promise<boolean> {
+  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false
+  try {
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })])
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function safeDownloadName(input: string, fallback: string): string {
+  const safe = input.replace(/[\\/:*?"<>|\s]+/g, "_").slice(0, 60)
+  return safe || fallback
+}

--- a/portal-web/src/components/chat/svg-export.ts
+++ b/portal-web/src/components/chat/svg-export.ts
@@ -1,7 +1,24 @@
 // Browser helpers shared by chat visualisations that render as inline SVG.
 // They intentionally know nothing about ChartSpec or Mermaid syntax.
 
-const INLINEABLE_PROPS = ["fill", "stroke", "stroke-width", "font-family", "font-size", "font-weight"] as const
+// Inline the CSS properties that affect chart/Mermaid appearance before the
+// SVG leaves the document. The <img> used for rasterisation cannot see parent
+// Tailwind classes or Mermaid's in-document stylesheet.
+const INLINEABLE_PROPS = [
+  "fill",
+  "stroke",
+  "stroke-width",
+  "stroke-dasharray",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "marker-end",
+  "marker-start",
+  "marker-mid",
+  "opacity",
+  "font-family",
+  "font-size",
+  "font-weight",
+] as const
 
 function inlineComputedStyles(src: SVGElement, dst: SVGElement) {
   const srcAll = [src, ...Array.from(src.querySelectorAll<SVGElement>("*"))]
@@ -13,6 +30,9 @@ function inlineComputedStyles(src: SVGElement, dst: SVGElement) {
       const v = cs.getPropertyValue(prop)
       if (v) tgt.style.setProperty(prop, v)
     }
+    // Strip class attrs because colors/styles are now inlined. Keeping classes
+    // would bloat the serialized output and require Tailwind/Mermaid CSS in the
+    // consumer's context.
     tgt.removeAttribute("class")
   }
 }
@@ -28,6 +48,11 @@ function svgCanvasSize(svg: SVGSVGElement): { width: number; height: number } {
 }
 
 function svgBackground(svg: SVGSVGElement): string {
+  // Chart SVGs include .chart-bg; sample its live fill before cloning so the
+  // canvas base matches what the user sees, even if future style inlining fails
+  // to carry the background fill onto the detached clone. Mermaid SVGs do not
+  // have .chart-bg and are currently rendered/exported on the intentional white
+  // base from mermaidConfig().
   const bgRect = svg.querySelector<SVGRectElement>(".chart-bg")
   const liveBg = bgRect ? window.getComputedStyle(bgRect).fill : ""
   return liveBg && liveBg !== "none" && liveBg !== "transparent" ? liveBg : "#ffffff"
@@ -78,6 +103,8 @@ function blobToDataUrl(blob: Blob): Promise<string> {
 }
 
 export async function svgToPngDataUrl(svg: SVGSVGElement, scale = 2): Promise<string> {
+  // Used by rich clipboard text/html payloads so copied chat bubbles contain a
+  // real image instead of raw chart JSON or Mermaid source.
   const blob = await svgToPngBlob(svg, scale)
   return await blobToDataUrl(blob)
 }
@@ -98,7 +125,8 @@ export async function copyBlobToClipboard(blob: Blob): Promise<boolean> {
   try {
     await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })])
     return true
-  } catch {
+  } catch (err) {
+    console.warn("[copy] clipboard image write failed:", err)
     return false
   }
 }

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -111,6 +111,13 @@ const DEFAULT_TEMPLATE = `You are Siclaw, a personal SRE AI assistant. You help 
 <!-- /web-only --><!-- cli-only -->- **Skill authoring**: To create or modify a skill, output SKILL.md and scripts in fenced code blocks so the user can copy from the terminal.
 <!-- /cli-only -->- **Response discipline**: Be precise (use filters, avoid full dumps), be actionable (every response must call a tool or give a conclusion), be concise (no filler like "anything else?"). When user only asks to list resources, summarize and ask which to investigate further.
 
+## Visual Output
+
+- You may use Mermaid diagrams as a native response format when the user asks to draw/diagram a flow, sequence, lifecycle, timeline, topology, or dependency chain, or when a compact diagram clearly makes an SRE explanation easier to verify.
+- Supported Mermaid forms are \`flowchart\` / \`graph\`, \`sequenceDiagram\`, and \`timeline\`. Keep diagrams small and readable; prefer roughly 5-12 nodes/events and avoid decorative detail.
+- Use \`flowchart\` for cause/effect, decision, dependency, or remediation flows; \`sequenceDiagram\` for request paths and cross-component call order; \`timeline\` for incidents, task lifecycles, and investigation progress.
+- Do not force a diagram into simple answers. If exact times or relationships are unknown, label them as unknown/approx instead of inventing precision.
+
 ## Understand Before Acting
 
 When you receive ANY technical request from the user, you MUST follow this workflow in order. No exceptions unless the user explicitly tells you to skip.

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -116,6 +116,7 @@ const DEFAULT_TEMPLATE = `You are Siclaw, a personal SRE AI assistant. You help 
 - You may use Mermaid diagrams as a native response format when the user asks to draw/diagram a flow, sequence, lifecycle, timeline, topology, or dependency chain, or when a compact diagram clearly makes an SRE explanation easier to verify.
 - Supported Mermaid forms are \`flowchart\` / \`graph\`, \`sequenceDiagram\`, and \`timeline\`. Keep diagrams small and readable; prefer roughly 5-12 nodes/events and avoid decorative detail.
 - Use \`flowchart\` for cause/effect, decision, dependency, or remediation flows; \`sequenceDiagram\` for request paths and cross-component call order; \`timeline\` for incidents, task lifecycles, and investigation progress.
+- Inside Mermaid fences, output only Mermaid syntax. Do not add line numbers, event labels, or stream prefixes such as \`123-content:\`.
 - Do not force a diagram into simple answers. If exact times or relationships are unknown, label them as unknown/approx instead of inventing precision.
 
 ## Understand Before Acting


### PR DESCRIPTION
## Summary
- Add native Mermaid rendering for flowchart/graph, sequenceDiagram, and timeline fenced blocks in chat.
- Reuse shared SVG export helpers so charts and Mermaid diagrams share PNG copy/download behavior without changing the chart MCP contract.
- Keep streaming Mermaid blocks in a stable loading state, then render once complete, and include Mermaid images in rich message/session copy.
- Document the Mermaid rendering boundary and update prompt guidance for when agents should use Mermaid.

## Validation
- `npm test -- src/components/chat/Markdown.test.tsx src/components/chat/ChartRenderer.test.ts src/components/chat/chart-utils.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- Deployed test image to `sdliu-siclaw` and verified the Mermaid toolbar/rendered SVG via the local portal page.