### PR TITLE
fix(test): eliminate flaky kubectl timeout in restricted-bash test

### DIFF
--- a/src/tools/cmd-exec/restricted-bash.test.ts
+++ b/src/tools/cmd-exec/restricted-bash.test.ts
@@ -12,6 +12,7 @@ import {
   validateKubectlInPipeline,
 } from "./restricted-bash.js";
 import { extractPipeline } from "../infra/command-validator.js";
+import { preExecSecurity } from "../infra/security-pipeline.js";
 
 describe("extractCommands", () => {
   it("splits pipe", () => {
@@ -395,15 +396,17 @@ describe("createRestrictedBashTool", () => {
     ];
 
     for (const cmd of allowedCmds) {
-      it(`allows: ${cmd}`, async () => {
-        const result = await tool.execute(
-          "test-id",
-          { command: cmd },
-          undefined,
-          {} as any
-        );
-        const text = result.content[0].text;
-        expect(text).not.toContain("Blocked");
+      // Validate only the security gate — do NOT execute the command.
+      // Calling tool.execute() would spawn a real subprocess (e.g. kubectl
+      // trying to reach a cluster) which hangs in CI and hits the 5 s timeout.
+      it(`allows: ${cmd}`, () => {
+        const pre = preExecSecurity(cmd, {
+          context: "local",
+          extraAllowed: new Set(["kubectl"]),
+          isAllowed: isSkillScript,
+          pipelineValidators: [validateKubectlInPipeline],
+        });
+        expect(pre.error).toBeNull();
       });
     }
   });


### PR DESCRIPTION
The "allows kubectl pipelines" test cases called tool.execute(), which spawns a real subprocess. Blocked-command tests return before exec() and are fast; 
allowed-command tests reach exec() and run kubectl get pods -n default, which hangs on CI (no cluster reachable) until vitest's 5 s timeout fires.

Fix: replace tool.execute() in the allows suite with synchronous preExecSecurity() calls — the test intent is "security validator does not block this command", 
not "kubectl succeeds".