### PR TITLE
Feat/resizable import mcp dialog

### DIFF
--- a/portal-web/src/pages/MCP.tsx
+++ b/portal-web/src/pages/MCP.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo, useRef } from "react"
-import { Plus, Trash2, Loader2, Plug, Pencil, Power, Search, X, Download, Upload, Check, ChevronRight } from "lucide-react"
+import { useState, useEffect, useLayoutEffect, useMemo, useRef } from "react"
+import { Plus, Trash2, Loader2, Plug, Pencil, Power, Search, X, Download, Upload, Check } from "lucide-react"
 import { api } from "../api"
 import { useToast } from "../components/toast"
 import { useConfirm } from "../components/confirm-dialog"
@@ -74,10 +74,75 @@ function downloadJson(filename: string, data: unknown) {
   setTimeout(() => URL.revokeObjectURL(url), 1000)
 }
 
-function formatDiffValue(v: unknown): string {
-  if (v === null || v === undefined) return "—"
-  if (typeof v === "object") return JSON.stringify(v)
+function formatFieldValue(v: unknown): string {
+  if (v === null || v === undefined) return ""
+  if (typeof v === "object") return JSON.stringify(v, null, 2)
+  if (typeof v === "boolean") return v ? "true" : "false"
   return String(v)
+}
+
+type DiffLine = { type: "same" | "add" | "remove"; content: string }
+
+function computeLineDiff(before: unknown, after: unknown): DiffLine[] {
+  const bStr = formatFieldValue(before)
+  const aStr = formatFieldValue(after)
+  const bLines = bStr === "" ? [] : bStr.split("\n")
+  const aLines = aStr === "" ? [] : aStr.split("\n")
+  const m = bLines.length, n = aLines.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i][j] = bLines[i - 1] === aLines[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1])
+  const result: DiffLine[] = []
+  let i = m, j = n
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && bLines[i - 1] === aLines[j - 1]) {
+      result.unshift({ type: "same", content: bLines[i - 1] })
+      i--; j--
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift({ type: "add", content: aLines[j - 1] })
+      j--
+    } else {
+      result.unshift({ type: "remove", content: bLines[i - 1] })
+      i--
+    }
+  }
+  return result
+}
+
+const TRUNCATE_CHARS = 100
+
+function DiffLineRow({ dl }: { dl: DiffLine }) {
+  const [expanded, setExpanded] = useState(false)
+  const isLong = dl.content.length > TRUNCATE_CHARS
+  const bg = dl.type === "add" ? "bg-emerald-50 dark:bg-emerald-950/25"
+    : dl.type === "remove" ? "bg-red-50 dark:bg-red-950/25" : ""
+  const textColor = dl.type === "add" ? "text-emerald-700 dark:text-emerald-400"
+    : dl.type === "remove" ? "text-red-600 dark:text-red-400" : "text-foreground/60"
+  const marker = dl.type === "add" ? "+" : dl.type === "remove" ? "-" : " "
+  return (
+    <div className={`flex items-baseline ${bg} min-w-0`}>
+      <span className={`select-none px-2 py-0.5 shrink-0 font-bold ${textColor}`}>{marker}</span>
+      <div
+        className={`flex-1 py-0.5 min-w-0 font-mono text-xs ${expanded ? "whitespace-pre-wrap break-all" : "overflow-hidden"}`}
+        style={!expanded ? {
+          whiteSpace: "nowrap",
+          WebkitMaskImage: isLong ? "linear-gradient(to right, black 82%, transparent 100%)" : undefined,
+          maskImage: isLong ? "linear-gradient(to right, black 82%, transparent 100%)" : undefined,
+        } : undefined}
+      >
+        <span className={textColor}>{dl.content || " "}</span>
+      </div>
+      {isLong && !expanded && (
+        <button
+          onClick={() => setExpanded(true)}
+          className="shrink-0 px-2 py-0.5 text-[10px] text-blue-500 hover:text-blue-700 hover:underline whitespace-nowrap"
+        >
+          view details
+        </button>
+      )}
+    </div>
+  )
 }
 
 // ── KV Editor ──────────────────────────────────────────────────────
@@ -333,35 +398,29 @@ function ImportPreviewPanel({ preview }: { preview: McpImportPreview }) {
       )}
 
       {preview.diffs.length > 0 && (
-        <div className="space-y-1">
+        <div className="space-y-1.5">
           <p className="text-xs font-medium text-muted-foreground">Changes</p>
           <div className="rounded border border-border overflow-hidden">
-            <table className="w-full text-xs">
-              <thead className="bg-secondary/60">
-                <tr>
-                  <th className="px-2 py-1 text-left font-medium text-muted-foreground w-28">Field</th>
-                  <th className="px-2 py-1 text-left font-medium text-muted-foreground">Before</th>
-                  <th className="px-2 py-1 text-center font-medium text-muted-foreground w-4">
-                    <ChevronRight className="h-3 w-3 mx-auto" />
-                  </th>
-                  <th className="px-2 py-1 text-left font-medium text-muted-foreground">After</th>
-                </tr>
-              </thead>
-              <tbody>
-                {preview.diffs.map((d) => (
-                  <tr key={d.field} className="border-t border-border/50">
-                    <td className="px-2 py-1 font-mono text-muted-foreground">{d.field}</td>
-                    <td className="px-2 py-1 font-mono text-red-600 dark:text-red-400 max-w-[140px] truncate" title={formatDiffValue(d.before)}>
-                      {formatDiffValue(d.before)}
-                    </td>
-                    <td className="px-1 py-1 text-muted-foreground/40 text-center">→</td>
-                    <td className="px-2 py-1 font-mono text-emerald-600 dark:text-emerald-400 max-w-[140px] truncate" title={formatDiffValue(d.after)}>
-                      {formatDiffValue(d.after)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            {preview.diffs.map((d, di) => {
+              const diffLines = computeLineDiff(d.before, d.after)
+              const hasChanges = diffLines.some((l) => l.type !== "same")
+              if (!hasChanges) return null
+              const onlyRemoves = diffLines.every((l) => l.type !== "add")
+              return (
+                <div key={d.field} className={di > 0 ? "border-t border-border/50" : undefined}>
+                  <div className="bg-secondary/60 px-2 py-1 text-[11px] font-mono text-muted-foreground select-none">
+                    @@ <span className="text-foreground/80 font-semibold">{d.field}</span> @@
+                  </div>
+                  {diffLines.map((dl, li) => <DiffLineRow key={li} dl={dl} />)}
+                  {onlyRemoves && (
+                    <div className="flex items-baseline bg-secondary/10 font-mono text-xs text-muted-foreground/50">
+                      <span className="select-none px-2 py-0.5">+</span>
+                      <span className="py-0.5 italic">(will be unset)</span>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
       )}
@@ -377,6 +436,27 @@ function ImportPreviewPanel({ preview }: { preview: McpImportPreview }) {
 
 // ── Import Dialog ──────────────────────────────────────────────────
 
+const RESIZE_EDGE_PX = 6
+
+// Collapse consecutive blank lines to at most one, and remove all trailing blank lines.
+function compactJson(text: string) {
+  const lines = text.replace(/\r\n/g, "\n").split("\n")
+  const out: string[] = []
+  let blankRun = 0
+  for (const line of lines) {
+    if (line.trim() === "") {
+      blankRun++
+      if (blankRun === 1) out.push("")  // keep at most one blank line
+    } else {
+      blankRun = 0
+      out.push(line)
+    }
+  }
+  // Strip trailing blank lines
+  while (out.length > 0 && out[out.length - 1].trim() === "") out.pop()
+  return out.join("\n")
+}
+
 function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; onImported: () => void }) {
   const [configText, setConfigText] = useState("")
   const [fileName, setFileName] = useState("")
@@ -384,7 +464,50 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
   const [previewing, setPreviewing] = useState(false)
   const [applying, setApplying] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const previewRef = useRef<HTMLDivElement>(null)
   const toast = useToast()
+
+  // Width is always explicit; height starts as auto (content-driven) and only
+  // becomes fixed once the user drags a resize handle.
+  const [dialogWidth, setDialogWidth] = useState(() => Math.min(700, Math.round(window.innerWidth * 0.85)))
+  const [fixedHeight, setFixedHeight] = useState<number | null>(null)
+  const resizeDrag = useRef<{
+    edge: string; startX: number; startY: number; startW: number; startH: number
+  } | null>(null)
+  // Tracks whether a resize drag moved the mouse; swallows the spurious backdrop
+  // click that fires when mouseup lands outside the dialog.
+  const didResizeDrag = useRef(false)
+
+  const startResize = (e: React.MouseEvent, edge: string) => {
+    e.preventDefault()
+    e.stopPropagation()
+    // Read actual rendered dimensions so the starting size is always correct,
+    // regardless of whether height is auto or fixed.
+    const el = dialogRef.current!
+    resizeDrag.current = { edge, startX: e.clientX, startY: e.clientY, startW: el.offsetWidth, startH: el.offsetHeight }
+
+    const onMove = (me: MouseEvent) => {
+      const d = resizeDrag.current
+      if (!d) return
+      didResizeDrag.current = true
+      const dx = me.clientX - d.startX
+      const dy = me.clientY - d.startY
+      if (d.edge.includes("e")) setDialogWidth(Math.max(480, d.startW + dx))
+      else if (d.edge.includes("w")) setDialogWidth(Math.max(480, d.startW - dx))
+      if (d.edge.includes("s")) setFixedHeight(Math.max(320, d.startH + dy))
+      else if (d.edge.includes("n")) setFixedHeight(Math.max(320, d.startH - dy))
+    }
+    const onUp = () => {
+      resizeDrag.current = null
+      window.removeEventListener("mousemove", onMove)
+      window.removeEventListener("mouseup", onUp)
+    }
+    window.addEventListener("mousemove", onMove)
+    window.addEventListener("mouseup", onUp)
+  }
 
   const parseBundle = (): { ok: boolean; bundle?: McpConfigBundle; error?: string } => {
     if (!configText.trim()) return { ok: false, error: "Paste or upload a config file" }
@@ -400,7 +523,7 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
     const file = e.target.files?.[0]
     if (!file) return
     setFileName(file.name)
-    file.text().then(setConfigText).catch(() => toast.error("Failed to read file"))
+    file.text().then((t) => setConfigText(compactJson(t))).catch(() => toast.error("Failed to read file"))
   }
 
   const handlePreview = async () => {
@@ -442,17 +565,63 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
 
   const canApply = preview !== null && preview.errors.length === 0 && preview.action !== "invalid" && preview.action !== "unchanged"
 
+  // Grow textarea to fit content; cap at 55 vh so the dialog doesn't overflow.
+  useLayoutEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    el.style.height = "auto"
+    el.style.height = `${Math.min(el.scrollHeight, Math.round(window.innerHeight * 0.55))}px`
+  }, [configText])
+
+  // Auto-scroll to preview panel once it appears in the DOM.
+  useLayoutEffect(() => {
+    if (preview) previewRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+  }, [preview])
+
+  const e = RESIZE_EDGE_PX
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
-      <div className="w-full max-w-lg rounded-lg border border-border bg-card shadow-xl" onClick={(e) => e.stopPropagation()}>
-        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={() => { if (didResizeDrag.current) { didResizeDrag.current = false; return } onClose() }}>
+      <div
+        ref={dialogRef}
+        className="relative flex flex-col rounded-lg border border-border bg-card shadow-xl overflow-hidden"
+        style={{
+          width: dialogWidth,
+          ...(fixedHeight !== null ? { height: fixedHeight } : {}),
+          maxWidth: "calc(100vw - 32px)",
+          maxHeight: "calc(100vh - 32px)",
+        }}
+        onClick={(ev) => ev.stopPropagation()}
+      >
+        {/* ── Resize handles ── */}
+        {/* edges */}
+        <div style={{ position: "absolute", inset: `0 ${e}px auto ${e}px`, height: e, cursor: "ns-resize", zIndex: 10 }} onMouseDown={(ev) => startResize(ev, "n")} />
+        <div style={{ position: "absolute", inset: `auto ${e}px 0 ${e}px`, height: e, cursor: "ns-resize", zIndex: 10 }} onMouseDown={(ev) => startResize(ev, "s")} />
+        <div style={{ position: "absolute", inset: `${e}px auto ${e}px 0`, width: e, cursor: "ew-resize", zIndex: 10 }} onMouseDown={(ev) => startResize(ev, "w")} />
+        <div style={{ position: "absolute", inset: `${e}px 0 ${e}px auto`, width: e, cursor: "ew-resize", zIndex: 10 }} onMouseDown={(ev) => startResize(ev, "e")} />
+        {/* corners */}
+        <div style={{ position: "absolute", top: 0, left: 0, width: e * 2, height: e * 2, cursor: "nwse-resize", zIndex: 11 }} onMouseDown={(ev) => startResize(ev, "nw")} />
+        <div style={{ position: "absolute", top: 0, right: 0, width: e * 2, height: e * 2, cursor: "nesw-resize", zIndex: 11 }} onMouseDown={(ev) => startResize(ev, "ne")} />
+        <div style={{ position: "absolute", bottom: 0, left: 0, width: e * 2, height: e * 2, cursor: "nesw-resize", zIndex: 11 }} onMouseDown={(ev) => startResize(ev, "sw")} />
+        <div style={{ position: "absolute", bottom: 0, right: 0, width: e * 2, height: e * 2, cursor: "nwse-resize", zIndex: 11 }} onMouseDown={(ev) => startResize(ev, "se")} />
+
+        {/* ── Header ── */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
           <h2 className="text-sm font-semibold">Import MCP Config</h2>
           <button onClick={onClose} className="p-1 rounded text-muted-foreground hover:text-foreground">
             <X className="h-4 w-4" />
           </button>
         </div>
 
-        <div className="p-4 space-y-3">
+        {/* ── Scrollable body ──
+            When height is auto (no user resize yet): give body an explicit max-height
+            so content can scroll instead of overflowing the viewport.
+            When height is fixed (user has resized): use flex-1 to fill remaining space. */}
+        <div
+          ref={bodyRef}
+          className={`overflow-y-auto p-4 space-y-3 ${fixedHeight !== null ? "flex-1 min-h-0" : ""}`}
+          style={fixedHeight === null ? { maxHeight: "calc(100vh - 180px)" } : undefined}
+        >
           <div className="space-y-1.5">
             <div className="flex items-center gap-2">
               <label className="text-xs font-medium text-muted-foreground">Config JSON</label>
@@ -466,34 +635,37 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
               <input ref={fileRef} type="file" accept=".json,application/json" className="hidden" onChange={handleFileChange} />
             </div>
             <textarea
+              ref={textareaRef}
               value={configText}
-              onChange={(e) => { setConfigText(e.target.value); setPreview(null) }}
+              onChange={(e) => { setConfigText(compactJson(e.target.value)); setPreview(null) }}
               placeholder='{"mcpServer": {"name": "...", "transport": "stdio", ...}}'
-              rows={6}
-              className="w-full px-3 py-2 text-xs font-mono rounded-md border border-border bg-background resize-none"
+              rows={1}
+              className="w-full px-3 py-2 text-xs font-mono rounded-md border border-border bg-background resize-none overflow-hidden"
+              style={{ minHeight: "2rem" }}
             />
           </div>
 
-          {preview && <ImportPreviewPanel preview={preview} />}
+          {preview && <div ref={previewRef}><ImportPreviewPanel preview={preview} /></div>}
+        </div>
 
-          <div className="flex justify-end gap-2">
-            <button onClick={onClose} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
-            <button
-              onClick={handlePreview}
-              disabled={previewing || !configText.trim()}
-              className="h-8 px-4 text-sm rounded-md border border-border text-foreground disabled:opacity-50"
-            >
-              {previewing ? <Loader2 className="h-3.5 w-3.5 animate-spin inline mr-1" /> : null}Preview
-            </button>
-            <button
-              onClick={handleApply}
-              disabled={applying || !canApply}
-              className="flex items-center gap-1.5 h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50"
-            >
-              {applying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-              Apply
-            </button>
-          </div>
+        {/* ── Footer ── */}
+        <div className="flex justify-end gap-2 px-4 py-3 border-t border-border shrink-0">
+          <button onClick={onClose} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
+          <button
+            onClick={handlePreview}
+            disabled={previewing || !configText.trim()}
+            className="h-8 px-4 text-sm rounded-md border border-border text-foreground disabled:opacity-50"
+          >
+            {previewing ? <Loader2 className="h-3.5 w-3.5 animate-spin inline mr-1" /> : null}Preview
+          </button>
+          <button
+            onClick={handleApply}
+            disabled={applying || !canApply}
+            className="flex items-center gap-1.5 h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50"
+          >
+            {applying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+            Apply
+          </button>
         </div>
       </div>
     </div>

--- a/portal-web/src/pages/MCP.tsx
+++ b/portal-web/src/pages/MCP.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useMemo } from "react"
-import { Plus, Trash2, Loader2, Plug, Pencil, Power, Search, X } from "lucide-react"
+import { useState, useEffect, useMemo, useRef } from "react"
+import { Plus, Trash2, Loader2, Plug, Pencil, Power, Search, X, Download, Upload, Check, ChevronRight } from "lucide-react"
 import { api } from "../api"
 import { useToast } from "../components/toast"
 import { useConfirm } from "../components/confirm-dialog"
@@ -25,6 +25,32 @@ interface McpServer {
   updated_at: string
 }
 
+interface McpConfigEntry {
+  name?: string
+  transport?: string
+  url?: string | null
+  command?: string | null
+  args?: string[] | null
+  env?: Record<string, string> | null
+  headers?: Record<string, string> | null
+  description?: string | null
+  enabled?: boolean
+}
+
+interface McpConfigBundle { mcpServer?: McpConfigEntry }
+
+interface McpImportFieldDiff { field: string; before: unknown; after: unknown }
+
+interface McpImportPreview {
+  action: "create" | "update" | "unchanged" | "invalid"
+  name?: string
+  id?: string
+  transport?: string
+  bound_agents?: number
+  diffs: McpImportFieldDiff[]
+  errors: string[]
+}
+
 const TRANSPORT_OPTIONS: { value: McpTransport; label: string }[] = [
   { value: "streamable-http", label: "Streamable HTTP" },
   { value: "sse", label: "SSE" },
@@ -35,6 +61,23 @@ const TRANSPORT_LABELS: Record<McpTransport, string> = {
   "streamable-http": "Streamable HTTP",
   sse: "SSE",
   stdio: "Stdio",
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function downloadJson(filename: string, data: unknown) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url; a.download = filename
+  document.body.appendChild(a); a.click(); a.remove()
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+function formatDiffValue(v: unknown): string {
+  if (v === null || v === undefined) return "—"
+  if (typeof v === "object") return JSON.stringify(v)
+  return String(v)
 }
 
 // ── KV Editor ──────────────────────────────────────────────────────
@@ -131,7 +174,6 @@ function McpForm({ server, onSave, onCancel }: {
     <div className="p-4 rounded-lg border border-border bg-card space-y-3">
       <p className="text-sm font-medium">{isEditing ? "Edit MCP Server" : "New MCP Server"}</p>
 
-      {/* Transport selector */}
       <div className="space-y-1.5">
         <label className="text-xs font-medium text-muted-foreground">Transport</label>
         <div className="flex gap-1.5">
@@ -153,7 +195,6 @@ function McpForm({ server, onSave, onCancel }: {
         </div>
       </div>
 
-      {/* Name + Description */}
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1">
           <label className="text-xs font-medium text-muted-foreground">Name *</label>
@@ -165,7 +206,6 @@ function McpForm({ server, onSave, onCancel }: {
         </div>
       </div>
 
-      {/* Transport-specific fields */}
       {transport === "stdio" ? (
         <div className="space-y-3">
           <div className="grid grid-cols-2 gap-3">
@@ -190,12 +230,271 @@ function McpForm({ server, onSave, onCancel }: {
         </div>
       )}
 
-      {/* Actions */}
       <div className="flex gap-2">
         <button onClick={handleSave} disabled={saving || !canSave} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">
           {saving ? "..." : isEditing ? "Save" : "Create"}
         </button>
         <button onClick={onCancel} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
+      </div>
+    </div>
+  )
+}
+
+// ── Export Dialog ──────────────────────────────────────────────────
+
+function ExportMcpConfigDialog({ server, onClose }: { server: McpServer | null; onClose: () => void }) {
+  const [downloading, setDownloading] = useState(false)
+  const toast = useToast()
+
+  if (!server) return null
+
+  const handleDownload = async () => {
+    setDownloading(true)
+    try {
+      const res = await api<{ data: McpConfigBundle }>("/siclaw/mcp/export", {
+        method: "POST",
+        body: { mcp_server_id: server.id },
+      })
+      downloadJson(`${server.name}-mcp-config.json`, res.data)
+    } catch (err: any) {
+      toast.error(err.message || "Export failed")
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+      <div className="w-full max-w-md rounded-lg border border-border bg-card shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <h2 className="text-sm font-semibold">Export Config — {server.name}</h2>
+          <button onClick={onClose} className="p-1 rounded text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="p-4 space-y-3">
+          <div className="rounded-md bg-secondary/40 border border-border px-3 py-2.5 text-xs text-muted-foreground leading-relaxed">
+            Downloads this MCP server as a reusable config file. Plain values are included; re-enter any sensitive credentials after import.
+          </div>
+          <div className="flex justify-end gap-2">
+            <button onClick={onClose} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
+            <button
+              onClick={handleDownload}
+              disabled={downloading}
+              className="flex items-center gap-1.5 h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50"
+            >
+              {downloading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+              Download
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Import Preview Panel ───────────────────────────────────────────
+
+const ACTION_STYLES: Record<string, string> = {
+  create: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+  update: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  unchanged: "bg-secondary text-muted-foreground",
+  invalid: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+}
+
+function ImportPreviewPanel({ preview }: { preview: McpImportPreview }) {
+  return (
+    <div className="rounded-md border border-border bg-secondary/20 p-3 space-y-2.5 text-sm">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className={`px-2 py-0.5 text-[11px] font-medium rounded ${ACTION_STYLES[preview.action]}`}>
+          {preview.action.toUpperCase()}
+        </span>
+        {preview.name && <span className="font-mono text-sm font-medium">{preview.name}</span>}
+        {preview.transport && (
+          <span className="px-2 py-0.5 text-[10px] font-mono rounded border border-border text-muted-foreground">
+            {TRANSPORT_LABELS[preview.transport as McpTransport] || preview.transport}
+          </span>
+        )}
+        {(preview.bound_agents ?? 0) > 0 && (
+          <span className="text-xs text-amber-600 dark:text-amber-400">
+            {preview.bound_agents} agent{preview.bound_agents! > 1 ? "s" : ""} affected
+          </span>
+        )}
+      </div>
+
+      {preview.errors.length > 0 && (
+        <div className="space-y-1">
+          {preview.errors.map((e, i) => (
+            <p key={i} className="text-xs text-red-600 dark:text-red-400 flex items-start gap-1">
+              <X className="h-3 w-3 mt-0.5 shrink-0" />{e}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {preview.diffs.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground">Changes</p>
+          <div className="rounded border border-border overflow-hidden">
+            <table className="w-full text-xs">
+              <thead className="bg-secondary/60">
+                <tr>
+                  <th className="px-2 py-1 text-left font-medium text-muted-foreground w-28">Field</th>
+                  <th className="px-2 py-1 text-left font-medium text-muted-foreground">Before</th>
+                  <th className="px-2 py-1 text-center font-medium text-muted-foreground w-4">
+                    <ChevronRight className="h-3 w-3 mx-auto" />
+                  </th>
+                  <th className="px-2 py-1 text-left font-medium text-muted-foreground">After</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.diffs.map((d) => (
+                  <tr key={d.field} className="border-t border-border/50">
+                    <td className="px-2 py-1 font-mono text-muted-foreground">{d.field}</td>
+                    <td className="px-2 py-1 font-mono text-red-600 dark:text-red-400 max-w-[140px] truncate" title={formatDiffValue(d.before)}>
+                      {formatDiffValue(d.before)}
+                    </td>
+                    <td className="px-1 py-1 text-muted-foreground/40 text-center">→</td>
+                    <td className="px-2 py-1 font-mono text-emerald-600 dark:text-emerald-400 max-w-[140px] truncate" title={formatDiffValue(d.after)}>
+                      {formatDiffValue(d.after)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {preview.action === "unchanged" && preview.errors.length === 0 && (
+        <p className="text-xs text-muted-foreground flex items-center gap-1">
+          <Check className="h-3 w-3 text-emerald-500" /> No changes — server config is already up to date.
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ── Import Dialog ──────────────────────────────────────────────────
+
+function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; onImported: () => void }) {
+  const [configText, setConfigText] = useState("")
+  const [fileName, setFileName] = useState("")
+  const [preview, setPreview] = useState<McpImportPreview | null>(null)
+  const [previewing, setPreviewing] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
+  const toast = useToast()
+
+  const parseBundle = (): { ok: boolean; bundle?: McpConfigBundle; error?: string } => {
+    if (!configText.trim()) return { ok: false, error: "Paste or upload a config file" }
+    try {
+      const parsed = JSON.parse(configText)
+      return { ok: true, bundle: parsed }
+    } catch {
+      return { ok: false, error: "Invalid JSON" }
+    }
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setFileName(file.name)
+    file.text().then(setConfigText).catch(() => toast.error("Failed to read file"))
+  }
+
+  const handlePreview = async () => {
+    const { ok, bundle, error } = parseBundle()
+    if (!ok) { toast.error(error!); return }
+    setPreviewing(true); setPreview(null)
+    try {
+      const res = await api<{ data: McpImportPreview }>("/siclaw/mcp/import/preview", {
+        method: "POST",
+        body: { bundle },
+      })
+      setPreview(res.data)
+    } catch (err: any) {
+      toast.error(err.message || "Preview failed")
+    } finally {
+      setPreviewing(false)
+    }
+  }
+
+  const handleApply = async () => {
+    const { ok, bundle, error } = parseBundle()
+    if (!ok) { toast.error(error!); return }
+    setApplying(true)
+    try {
+      const res = await api<{ data: { created: number; updated: number; unchanged: number } }>("/siclaw/mcp/import", {
+        method: "POST",
+        body: { bundle },
+      })
+      const { created, updated, unchanged } = res.data
+      const parts = [created && `${created} created`, updated && `${updated} updated`, unchanged && `${unchanged} unchanged`].filter(Boolean)
+      toast.success(`Import complete: ${parts.join(", ")}`)
+      onImported(); onClose()
+    } catch (err: any) {
+      toast.error(err.message || "Import failed")
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const canApply = preview !== null && preview.errors.length === 0 && preview.action !== "invalid" && preview.action !== "unchanged"
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+      <div className="w-full max-w-lg rounded-lg border border-border bg-card shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <h2 className="text-sm font-semibold">Import MCP Config</h2>
+          <button onClick={onClose} className="p-1 rounded text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-3">
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <label className="text-xs font-medium text-muted-foreground">Config JSON</label>
+              <button
+                type="button"
+                onClick={() => fileRef.current?.click()}
+                className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border border-border text-muted-foreground hover:text-foreground"
+              >
+                <Upload className="h-3 w-3" /> {fileName || "Upload file"}
+              </button>
+              <input ref={fileRef} type="file" accept=".json,application/json" className="hidden" onChange={handleFileChange} />
+            </div>
+            <textarea
+              value={configText}
+              onChange={(e) => { setConfigText(e.target.value); setPreview(null) }}
+              placeholder='{"mcpServer": {"name": "...", "transport": "stdio", ...}}'
+              rows={6}
+              className="w-full px-3 py-2 text-xs font-mono rounded-md border border-border bg-background resize-none"
+            />
+          </div>
+
+          {preview && <ImportPreviewPanel preview={preview} />}
+
+          <div className="flex justify-end gap-2">
+            <button onClick={onClose} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
+            <button
+              onClick={handlePreview}
+              disabled={previewing || !configText.trim()}
+              className="h-8 px-4 text-sm rounded-md border border-border text-foreground disabled:opacity-50"
+            >
+              {previewing ? <Loader2 className="h-3.5 w-3.5 animate-spin inline mr-1" /> : null}Preview
+            </button>
+            <button
+              onClick={handleApply}
+              disabled={applying || !canApply}
+              className="flex items-center gap-1.5 h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50"
+            >
+              {applying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+              Apply
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   )
@@ -212,11 +511,10 @@ export function MCP() {
   const toast = useToast()
   const confirmDialog = useConfirm()
 
-  // Create / Edit
   const [showCreate, setShowCreate] = useState(false)
   const [editingServer, setEditingServer] = useState<McpServer | null>(null)
-
-  // Action loading states
+  const [exportTarget, setExportTarget] = useState<McpServer | null>(null)
+  const [showImport, setShowImport] = useState(false)
   const [toggling, setToggling] = useState<string | null>(null)
 
   const fetchServers = async () => {
@@ -326,9 +624,20 @@ export function MCP() {
           </p>
         </div>
         {isAdmin && (
-          <button onClick={() => { setShowCreate(true); setEditingServer(null) }} className="flex items-center gap-1.5 h-8 px-3 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90">
-            <Plus className="h-3.5 w-3.5" /> New Server
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowImport(true)}
+              className="flex items-center gap-1.5 h-8 px-3 text-sm rounded-md border border-border text-foreground hover:bg-secondary"
+            >
+              <Upload className="h-3.5 w-3.5" /> Import Config
+            </button>
+            <button
+              onClick={() => { setShowCreate(true); setEditingServer(null) }}
+              className="flex items-center gap-1.5 h-8 px-3 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90"
+            >
+              <Plus className="h-3.5 w-3.5" /> New Server
+            </button>
+          </div>
         )}
       </div>
 
@@ -388,7 +697,6 @@ export function MCP() {
           <div className="px-6 py-4 space-y-2">
             {filtered.map((server) => (
               <div key={server.id} className="rounded-lg border border-border/50">
-                {/* Server row */}
                 <div className="flex items-center justify-between p-3 hover:bg-secondary/30 transition-colors">
                   <div className="flex items-center gap-3 flex-1 min-w-0">
                     <span className={`h-2 w-2 rounded-full shrink-0 ${server.enabled ? "bg-green-500" : "bg-muted-foreground/40"}`} />
@@ -404,7 +712,7 @@ export function MCP() {
                       {TRANSPORT_LABELS[server.transport] || server.transport}
                     </span>
                     <span className="text-xs text-muted-foreground font-mono max-w-[200px] truncate hidden sm:block">
-                      {server.url || server.command || "\u2014"}
+                      {server.url || server.command || "—"}
                     </span>
                     {isAdmin && (
                       <div className="flex items-center gap-1">
@@ -419,6 +727,13 @@ export function MCP() {
                           title={server.enabled ? "Disable" : "Enable"}
                         >
                           {toggling === server.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Power className="h-3.5 w-3.5" />}
+                        </button>
+                        <button
+                          onClick={() => setExportTarget(server)}
+                          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                          title="Export config"
+                        >
+                          <Download className="h-3.5 w-3.5" />
                         </button>
                         <button
                           onClick={() => { setEditingServer(server); setShowCreate(false) }}
@@ -439,7 +754,6 @@ export function MCP() {
                   </div>
                 </div>
 
-                {/* Edit form (inline below the server row) */}
                 {editingServer?.id === server.id && (
                   <div className="border-t border-border/50 p-3 bg-secondary/10">
                     <McpForm
@@ -454,6 +768,13 @@ export function MCP() {
           </div>
         )}
       </div>
+
+      {exportTarget && (
+        <ExportMcpConfigDialog server={exportTarget} onClose={() => setExportTarget(null)} />
+      )}
+      {showImport && (
+        <ImportMcpConfigDialog onClose={() => setShowImport(false)} onImported={fetchServers} />
+      )}
     </div>
   )
 }

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -70,6 +70,105 @@ function summariseLatency(values: number[]): {
   };
 }
 
+// ── MCP config import / export ────────────────────────────────
+
+interface McpConfigEntry {
+  name?: string;
+  transport?: string;
+  url?: string | null;
+  command?: string | null;
+  args?: string[] | null;
+  env?: Record<string, string> | null;
+  headers?: Record<string, string> | null;
+  description?: string | null;
+  enabled?: boolean;
+}
+
+interface McpConfigBundle { mcpServer?: McpConfigEntry }
+type McpImportAction = "create" | "update" | "unchanged" | "invalid";
+interface McpImportFieldDiff { field: string; before: unknown; after: unknown }
+interface McpImportPreview {
+  action: McpImportAction;
+  name?: string;
+  id?: string;
+  transport?: string;
+  bound_agents?: number;
+  diffs: McpImportFieldDiff[];
+  errors: string[];
+}
+interface ImportMcpConfigResult { created: number; updated: number; unchanged: number; errors?: string[] }
+
+const MCP_DIFF_FIELDS = ["name", "transport", "url", "command", "args", "env", "headers", "description", "enabled"] as const;
+
+function normalizeMcpImportEntry(entry: McpConfigEntry | undefined): string[] {
+  const errors: string[] = [];
+  if (!entry) { errors.push("mcpServer is required"); return errors; }
+  if (!entry.name?.trim()) errors.push("name is required");
+  else if (entry.name.length > 255) errors.push("name too long (max 255)");
+  const t = entry.transport;
+  if (!t) { errors.push("transport is required"); }
+  else if (!["stdio", "sse", "streamable-http"].includes(t)) { errors.push(`unknown transport: ${t}`); }
+  else if (t === "stdio" && !entry.command?.trim()) { errors.push("command is required for stdio transport"); }
+  else if (t !== "stdio" && !entry.url?.trim()) { errors.push("url is required for sse/streamable-http transport"); }
+  if (entry.url && entry.url.length > 500) errors.push("url too long (max 500)");
+  if (entry.command && entry.command.length > 500) errors.push("command too long (max 500)");
+  if (entry.description && entry.description.length > 500) errors.push("description too long (max 500)");
+  return errors;
+}
+
+function mcpEntryDiffs(existing: Record<string, unknown>, desired: McpConfigEntry): McpImportFieldDiff[] {
+  const diffs: McpImportFieldDiff[] = [];
+  for (const f of MCP_DIFF_FIELDS) {
+    const before = existing[f] ?? null;
+    const after = (desired as Record<string, unknown>)[f] ?? null;
+    if (JSON.stringify(before) !== JSON.stringify(after)) diffs.push({ field: f, before, after });
+  }
+  return diffs;
+}
+
+async function buildMcpImportPreview(bundle: McpConfigBundle, orgId: string): Promise<McpImportPreview> {
+  const entry = bundle.mcpServer;
+  const errors = normalizeMcpImportEntry(entry);
+  if (errors.length > 0) return { action: "invalid", diffs: [], errors };
+
+  const db = getDb();
+  const [rows] = await db.query(
+    "SELECT * FROM mcp_servers WHERE org_id = ? AND name = ?",
+    [orgId, entry!.name!.trim()],
+  ) as any;
+
+  if (rows.length === 0) {
+    return { action: "create", name: entry!.name, transport: entry!.transport, diffs: mcpEntryDiffs({}, entry!), errors: [] };
+  }
+
+  const existing = rows[0];
+  existing.args = safeParseJson(existing.args, null);
+  existing.env = safeParseJson(existing.env, null);
+  existing.headers = safeParseJson(existing.headers, null);
+  existing.enabled = !!existing.enabled;
+
+  if (existing.transport !== entry!.transport) {
+    return {
+      action: "invalid", name: entry!.name, id: existing.id,
+      transport: entry!.transport, diffs: [],
+      errors: [`Cannot change transport from "${existing.transport}" to "${entry!.transport}"`],
+    };
+  }
+
+  const [countRows] = await db.query(
+    "SELECT COUNT(*) AS count FROM agent_mcp_servers WHERE mcp_server_id = ?",
+    [existing.id],
+  ) as any;
+  const bound_agents = Number(countRows[0].count);
+
+  const diffs = mcpEntryDiffs(existing, entry!);
+  return {
+    action: diffs.length > 0 ? "update" : "unchanged",
+    name: existing.name, id: existing.id, transport: existing.transport,
+    bound_agents, diffs, errors: [],
+  };
+}
+
 // ── Permission check helper ───────────────────────────────────
 
 interface AccessResult {
@@ -1180,6 +1279,103 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       created.headers = safeParseJson(created.headers, null);
     }
     sendJson(res, 201, created);
+  });
+
+  // Export MCP config bundle
+  router.post(`${P}/mcp/export`, async (req, res) => {
+    const auth = requireAuth(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
+    if (await guardAccess(res, config, auth, "write")) return;
+
+    const body = await parseBody<{ mcp_server_id?: string }>(req);
+    if (!body.mcp_server_id) { sendJson(res, 400, { error: "mcp_server_id required" }); return; }
+
+    const db = getDb();
+    const [rows] = await db.query(
+      "SELECT * FROM mcp_servers WHERE id = ? AND org_id = ?",
+      [body.mcp_server_id, auth.orgId],
+    ) as any;
+    if (rows.length === 0) { sendJson(res, 404, { error: "MCP server not found" }); return; }
+
+    const s = rows[0];
+    const entry: McpConfigEntry = {
+      name: s.name,
+      transport: s.transport,
+      ...(s.url ? { url: s.url } : {}),
+      ...(s.command ? { command: s.command } : {}),
+      ...(safeParseJson(s.args, null) ? { args: safeParseJson(s.args, null) } : {}),
+      ...(safeParseJson(s.env, null) ? { env: safeParseJson(s.env, null) } : {}),
+      ...(safeParseJson(s.headers, null) ? { headers: safeParseJson(s.headers, null) } : {}),
+      ...(s.description ? { description: s.description } : {}),
+      enabled: !!s.enabled,
+    };
+    sendJson(res, 200, { data: { mcpServer: entry } });
+  });
+
+  // Preview MCP config import (dry-run)
+  router.post(`${P}/mcp/import/preview`, async (req, res) => {
+    const auth = requireAuth(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
+    if (await guardAccess(res, config, auth, "write")) return;
+
+    const body = await parseBody<{ bundle?: McpConfigBundle }>(req);
+    const preview = await buildMcpImportPreview(body.bundle ?? {}, auth.orgId!);
+    sendJson(res, 200, { data: preview });
+  });
+
+  // Apply MCP config import
+  router.post(`${P}/mcp/import`, async (req, res) => {
+    const auth = requireAuth(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
+    if (await guardAccess(res, config, auth, "write")) return;
+
+    const body = await parseBody<{ bundle?: McpConfigBundle }>(req);
+    const preview = await buildMcpImportPreview(body.bundle ?? {}, auth.orgId!);
+
+    if (preview.errors.length > 0) {
+      sendJson(res, 400, { error: preview.errors.join("; ") });
+      return;
+    }
+
+    const entry = body.bundle!.mcpServer!;
+    const db = getDb();
+    const result: ImportMcpConfigResult = { created: 0, updated: 0, unchanged: 0 };
+
+    if (preview.action === "create") {
+      const id = crypto.randomUUID();
+      await db.query(
+        `INSERT INTO mcp_servers (id, org_id, name, transport, url, command, args, env, headers, enabled, description, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          id, auth.orgId, entry.name, entry.transport,
+          entry.url || null, entry.command || null,
+          JSON.stringify(entry.args || null), JSON.stringify(entry.env || null),
+          JSON.stringify(entry.headers || null), entry.enabled !== false ? 1 : 0,
+          entry.description || null, auth.userId,
+        ],
+      );
+      result.created = 1;
+    } else if (preview.action === "update") {
+      await db.query(
+        `UPDATE mcp_servers SET
+         name = ?, url = ?, command = ?, args = ?, env = ?, headers = ?,
+         description = ?, enabled = ?, updated_at = CURRENT_TIMESTAMP
+         WHERE id = ?`,
+        [
+          entry.name, entry.url || null, entry.command || null,
+          JSON.stringify(entry.args || null), JSON.stringify(entry.env || null),
+          JSON.stringify(entry.headers || null),
+          entry.description || null, entry.enabled !== false ? 1 : 0,
+          preview.id,
+        ],
+      );
+      ctx?.notifyMcpAgents?.(preview.id!, ["mcp"]);
+      result.updated = 1;
+    } else {
+      result.unchanged = 1;
+    }
+
+    sendJson(res, 200, { data: result });
   });
 
   // Get MCP server

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -120,7 +120,10 @@ function mcpEntryDiffs(existing: Record<string, unknown>, desired: McpConfigEntr
   const diffs: McpImportFieldDiff[] = [];
   for (const f of MCP_DIFF_FIELDS) {
     const before = existing[f] ?? null;
-    const after = (desired as Record<string, unknown>)[f] ?? null;
+    let after = (desired as Record<string, unknown>)[f] ?? null;
+    // Mirror the actual import write: omitted `enabled` is treated as true,
+    // matching `entry.enabled !== false ? 1 : 0` in the INSERT/UPDATE path.
+    if (f === "enabled" && after === null) after = true;
     if (JSON.stringify(before) !== JSON.stringify(after)) diffs.push({ field: f, before, after });
   }
   return diffs;


### PR DESCRIPTION
## Summary

- Add MCP config export: download individual server config as JSON
- Add MCP config import with preview: paste/upload JSON, preview create/update/unchanged diff, then apply
- Import dialog is resizable (8-direction drag handles: 4 edges + 4 corners), default size 720×580 px so config JSON is immediately readable
- Dialog body scrolls independently; textarea fills available height; footer buttons are always sticky

## Test plan

- [ ] Export a server config → download works
- [ ] Import Config → dialog opens at ~720×580 px
- [ ] Drag each edge/corner to resize in all 8 directions
- [ ] Paste a large JSON blob → textarea and preview panel scroll within dialog
- [ ] Footer buttons stay visible when dialog is resized small
- [ ] Preview shows correct create/update/unchanged diff
- [ ] Apply imports servers correctly
