### PR TITLE
Fix chat session title truncation

### DIFF
--- a/src/gateway/chat-repo.test.ts
+++ b/src/gateway/chat-repo.test.ts
@@ -89,6 +89,12 @@ describe("ensureChatSession", () => {
       target_agent_id: "target-agent",
     });
   });
+
+  it("truncates overlong titles before sending them to the upstream repo", async () => {
+    await ensureChatSession("sid", "agent", "user", "t".repeat(300));
+
+    expect(fake.calls[0].params.title).toHaveLength(255);
+  });
 });
 
 describe("appendMessage", () => {

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -6,6 +6,7 @@
  */
 
 import type { FrontendWsClient } from "./frontend-ws-client.js";
+import { normalizeChatSessionTitle } from "./chat-session-fields.js";
 
 export interface ChatSessionLineageInput {
   /** Parent chat session for delegated child sessions. Null/undefined for normal top-level chat. */
@@ -116,7 +117,7 @@ export async function ensureChatSession(
 ): Promise<void> {
   const payload: Record<string, unknown> = {
     session_id: sessionId, agent_id: agentId, user_id: userId,
-    title, preview, origin,
+    title: normalizeChatSessionTitle(title), preview, origin,
   };
   if (lineage) {
     payload.parent_session_id = lineage.parentSessionId ?? null;

--- a/src/gateway/chat-session-fields.test.ts
+++ b/src/gateway/chat-session-fields.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeChatSessionTitle } from "./chat-session-fields.js";
+
+describe("chat session field normalization", () => {
+  it("leaves absent titles absent so the upstream default still applies", () => {
+    expect(normalizeChatSessionTitle(undefined)).toBeUndefined();
+  });
+
+  it("truncates titles before sending them to upstream storage", () => {
+    expect(normalizeChatSessionTitle("t".repeat(300))).toHaveLength(255);
+  });
+
+  it("does not split surrogate pairs when truncating", () => {
+    const title = `${"t".repeat(254)}👋extra`;
+    const truncated = normalizeChatSessionTitle(title);
+
+    expect(truncated).toBe("t".repeat(254));
+    expect(truncated).not.toContain("\uD83D");
+  });
+});

--- a/src/gateway/chat-session-fields.ts
+++ b/src/gateway/chat-session-fields.ts
@@ -1,0 +1,17 @@
+const CHAT_SESSION_TITLE_MAX_CHARS = 255;
+
+function truncateField(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+
+  let truncated = "";
+  for (const char of value) {
+    if (truncated.length + char.length > maxChars) break;
+    truncated += char;
+  }
+  return truncated;
+}
+
+export function normalizeChatSessionTitle(title: string | undefined): string | undefined {
+  if (typeof title !== "string") return undefined;
+  return truncateField(title, CHAT_SESSION_TITLE_MAX_CHARS);
+}


### PR DESCRIPTION
## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **DB parity**: Schema changes keep `src/portal/migrate.ts` compatible with both MySQL and SQLite (see [`docs/design/invariants.md §5`](../docs/design/invariants.md)).
- [ ] **Tool protocol**: New tools register through `src/core/tool-registry.ts` and use the TypeBox `ToolDefinition` protocol.

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
