### PR TITLE
Fix/streaming cache stuck

### DIFF
--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -1160,6 +1160,16 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           }
         } finally {
           if (abortControllerRef.current === controller) abortControllerRef.current = null
+          // Unconditionally mark this session as no longer streaming in the cache.
+          // If the user navigated away while the stream was running, the isActive
+          // checks above skip setStreaming(false) — but the cache entry must still
+          // be cleared so that switching back to this session triggers a DB load
+          // (which has the complete, persisted messages) instead of restoring a
+          // stale cache snapshot that shows "streaming" forever.
+          if (streamSessionId) {
+            const cached = messagesCacheRef.current.get(streamSessionId)
+            if (cached) cached.streaming = false
+          }
         }
       })()
     },

--- a/portal-web/src/main.tsx
+++ b/portal-web/src/main.tsx
@@ -14,7 +14,6 @@ import { Skills } from "./pages/Skills"
 import { SkillDetail } from "./pages/SkillDetail"
 import { MCP } from "./pages/MCP"
 import { Models } from "./pages/Models"
-import { Chat } from "./pages/Chat"
 import { MyTasks } from "./pages/MyTasks"
 import { TaskRuns } from "./pages/TaskRuns"
 import { TaskRunDetail } from "./pages/TaskRunDetail"
@@ -40,7 +39,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Route index element={<Navigate to="/agents" replace />} />
         <Route path="agents" element={<Agents />} />
         <Route path="agents/:id" element={<AgentDetail />} />
-        <Route path="chat" element={<Chat />} />
+        <Route path="chat" element={null} />
         <Route path="skills" element={<Skills />} />
         <Route path="skills/import" element={<SkillImport />} />
         <Route path="skills/new" element={<SkillDetail />} />

--- a/portal-web/src/pages/Chat.tsx
+++ b/portal-web/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useSearchParams } from "react-router-dom"
+import { useSearchParams, useLocation } from "react-router-dom"
 import { Bot, Loader2, MessageSquare } from "lucide-react"
 import { api } from "../api"
 import { AgentChat } from "../components/AgentChat"
@@ -10,9 +10,20 @@ interface Agent {
 
 export function Chat() {
   const [searchParams, setSearchParams] = useSearchParams()
+  const location = useLocation()
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedAgentId, setSelectedAgentId] = useState<string>(searchParams.get("agent") || "")
+
+  // Sync agent selection when the URL's ?agent= param changes (e.g. deep link
+  // navigation while the component is always mounted in Layout).
+  const agentFromUrl = searchParams.get("agent")
+  useEffect(() => {
+    if (agentFromUrl && agentFromUrl !== selectedAgentId) {
+      setSelectedAgentId(agentFromUrl)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentFromUrl])
 
   useEffect(() => {
     api<{ data: Agent[] }>("/agents")
@@ -30,7 +41,9 @@ export function Chat() {
 
   const handleSelectAgent = (agentId: string) => {
     setSelectedAgentId(agentId)
-    setSearchParams({ agent: agentId })
+    if (location.pathname.startsWith("/chat")) {
+      setSearchParams({ agent: agentId })
+    }
   }
 
   if (loading) {

--- a/portal-web/src/pages/Layout.tsx
+++ b/portal-web/src/pages/Layout.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Outlet, Link, useLocation } from "react-router-dom"
 import { Bot, MessageSquare, Zap, Plug, Settings, LogOut, Server, Monitor, ChevronDown, ChevronRight, Cpu, Users, Radio, BarChart3, BookOpen, PanelLeftClose, PanelLeftOpen, Sun, Moon } from "lucide-react"
 import { api, clearToken } from "../api"
 import { NotificationBell } from "../components/NotificationBell"
 import { useTheme } from "../hooks/useTheme"
+import { Chat } from "./Chat"
 
 const siclawItems = [
   { path: "/chat", label: "Chat", icon: MessageSquare },
@@ -26,6 +27,12 @@ const COLLAPSED_KEY = "siclaw.sidebar.collapsed"
 export function Layout() {
   const location = useLocation()
   const { theme, toggle: toggleTheme } = useTheme()
+  // Lazy keep-alive: mount Chat only after the user first visits /chat so that
+  // hidden API calls (agents, sessions, messages) don't fire on unrelated pages.
+  // Once mounted it stays in the DOM so SSE streams survive sidebar navigation.
+  const hasChatMountedRef = useRef(false)
+  const isOnChat = location.pathname.startsWith("/chat")
+  if (isOnChat) hasChatMountedRef.current = true
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try { return localStorage.getItem(COLLAPSED_KEY) === "1" } catch { return false }
   })
@@ -190,7 +197,18 @@ export function Layout() {
         </button>
       </aside>
       <main className="flex-1 overflow-hidden">
-        <Outlet />
+        {/* Lazy keep-alive: Chat is only rendered after the user first visits
+            /chat, then stays mounted so SSE streams survive sidebar navigation. */}
+        {hasChatMountedRef.current && (
+          <div className={isOnChat ? "h-full" : "hidden"}>
+            <Chat />
+          </div>
+        )}
+        {!isOnChat && (
+          <div className="h-full">
+            <Outlet />
+          </div>
+        )}
       </main>
     </div>
   )

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -166,6 +166,10 @@ export function registerChatRoutes(
       "Connection": "keep-alive",
       "X-Accel-Buffering": "no",
     });
+    // Disable Nagle algorithm so each SSE frame is sent as its own TCP segment
+    // rather than waiting up to 40 ms for coalescing. Small text_delta frames
+    // are exactly the case Nagle hurts most.
+    res.socket?.setNoDelay(true);
 
     // Subscribe to chat events for this agent, filter by sessionId
     let unsubscribe: (() => void) | null = null;


### PR DESCRIPTION
fix(streaming): keep Chat mounted so SSE stream survives navigation

Navigating away from /chat unmounted the component, destroying the usePilotChat hook and its SSE stream. On return, the Thinking spinner was gone.

Fix: render <Chat /> permanently in Layout with CSS hidden/block toggle. The stream and all hook state now survive sidebar navigation intact.