### PR TITLE
Feat/mcp multi import

### DIFF
--- a/portal-web/src/pages/MCP.tsx
+++ b/portal-web/src/pages/MCP.tsx
@@ -51,6 +51,15 @@ interface McpImportPreview {
   errors: string[]
 }
 
+interface McpImportBatchSummary {
+  total: number
+  create: number
+  update: number
+  unchanged: number
+  invalid: number
+  error: number
+}
+
 const TRANSPORT_OPTIONS: { value: McpTransport; label: string }[] = [
   { value: "streamable-http", label: "Streamable HTTP" },
   { value: "sse", label: "SSE" },
@@ -434,9 +443,63 @@ function ImportPreviewPanel({ preview }: { preview: McpImportPreview }) {
   )
 }
 
+// ── Batch Import Preview Panel ─────────────────────────────────────
+
+function computeBatchSummary(items: McpImportPreview[]): McpImportBatchSummary {
+  return {
+    total: items.length,
+    create: items.filter((p) => p.action === "create").length,
+    update: items.filter((p) => p.action === "update").length,
+    unchanged: items.filter((p) => p.action === "unchanged").length,
+    invalid: items.filter((p) => p.action === "invalid").length,
+    error: items.filter((p) => p.errors.length > 0).length,
+  }
+}
+
+function BatchImportPreviewPanel({ items }: { items: McpImportPreview[] }) {
+  const summary = computeBatchSummary(items)
+  const hasErrors = items.some((p) => p.errors.length > 0)
+
+  return (
+    <div className="space-y-3">
+      <div className={`rounded-md border p-3 text-sm ${hasErrors ? "border-red-200 bg-red-50/70 dark:border-red-900/60 dark:bg-red-950/20" : "border-border bg-secondary/20"}`}>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium text-muted-foreground">Batch preview</span>
+          <span className="px-2 py-0.5 text-[11px] rounded bg-background border border-border">
+            {summary.total} total
+          </span>
+          <span className={`px-2 py-0.5 text-[11px] rounded ${ACTION_STYLES.create}`}>
+            {summary.create} create
+          </span>
+          <span className={`px-2 py-0.5 text-[11px] rounded ${ACTION_STYLES.update}`}>
+            {summary.update} update
+          </span>
+          <span className={`px-2 py-0.5 text-[11px] rounded ${ACTION_STYLES.unchanged}`}>
+            {summary.unchanged} unchanged
+          </span>
+          {(summary.invalid > 0 || summary.error > 0) && (
+            <span className={`px-2 py-0.5 text-[11px] rounded ${ACTION_STYLES.invalid}`}>
+              {summary.error || summary.invalid} error
+            </span>
+          )}
+        </div>
+        {hasErrors && (
+          <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+            Fix the errors above before applying.
+          </p>
+        )}
+      </div>
+      {items.map((p, i) => <ImportPreviewPanel key={i} preview={p} />)}
+    </div>
+  )
+}
+
 // ── Import Dialog ──────────────────────────────────────────────────
 
 const RESIZE_EDGE_PX = 6
+const MCP_IMPORT_EDITOR_EMPTY_HEIGHT = 352
+const MCP_IMPORT_EDITOR_MIN_HEIGHT = 224
+const MCP_IMPORT_EDITOR_MAX_VIEWPORT_RATIO = 0.55
 
 // Collapse consecutive blank lines to at most one, and remove all trailing blank lines.
 function compactJson(text: string) {
@@ -612,12 +675,15 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
     previews.every((p) => p.errors.length === 0) &&
     previews.some((p) => p.action === "create" || p.action === "update")
 
-  // Grow textarea to fit content; cap at 55 vh so the dialog doesn't overflow.
+  // Grow textarea to fit content; empty textarea shows a taller min-height for better UX.
   useLayoutEffect(() => {
     const el = textareaRef.current
     if (!el) return
+    const maxHeight = Math.max(MCP_IMPORT_EDITOR_MIN_HEIGHT, Math.round(window.innerHeight * MCP_IMPORT_EDITOR_MAX_VIEWPORT_RATIO))
+    const contentHeight = configText.trim() ? el.scrollHeight : Math.max(el.scrollHeight, MCP_IMPORT_EDITOR_EMPTY_HEIGHT)
     el.style.height = "auto"
-    el.style.height = `${Math.min(el.scrollHeight, Math.round(window.innerHeight * 0.55))}px`
+    el.style.height = `${Math.min(contentHeight, maxHeight)}px`
+    el.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden"
   }, [configText])
 
   // Auto-scroll to preview panel once it appears in the DOM.
@@ -666,7 +732,7 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
             When height is fixed (user has resized): use flex-1 to fill remaining space. */}
         <div
           ref={bodyRef}
-          className={`overflow-y-auto p-4 space-y-3 ${fixedHeight !== null ? "flex-1 min-h-0" : ""}`}
+          className={`overflow-y-auto p-4 pr-3 space-y-3 ${fixedHeight !== null ? "flex-1 min-h-0" : ""}`}
           style={fixedHeight === null ? { maxHeight: "calc(100vh - 180px)" } : undefined}
         >
           <div className="space-y-1.5">
@@ -701,15 +767,16 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
               value={configText}
               onChange={(e) => { setConfigText(compactJson(e.target.value)); setPreviews([]) }}
               placeholder='{"mcpServer": {"name": "...", "transport": "stdio", ...}}  or  [{...}, {...}]'
+              spellCheck={false}
               rows={1}
-              className="w-full px-3 py-2 text-xs font-mono rounded-md border border-border bg-background resize-none overflow-hidden"
-              style={{ minHeight: "2rem" }}
+              className="w-full px-3 py-2 text-xs font-mono rounded-md border border-border bg-background resize-none"
+              style={{ minHeight: `${configText.trim() ? MCP_IMPORT_EDITOR_MIN_HEIGHT : MCP_IMPORT_EDITOR_EMPTY_HEIGHT}px` }}
             />
           </div>
 
           {previews.length > 0 && (
-            <div ref={previewRef} className="space-y-2">
-              {previews.map((p, i) => <ImportPreviewPanel key={i} preview={p} />)}
+            <div ref={previewRef}>
+              <BatchImportPreviewPanel items={previews} />
             </div>
           )}
         </div>

--- a/portal-web/src/pages/MCP.tsx
+++ b/portal-web/src/pages/MCP.tsx
@@ -457,10 +457,31 @@ function compactJson(text: string) {
   return out.join("\n")
 }
 
+function mergeUploadedFiles(files: { name: string; text: string }[]): string {
+  if (files.length === 0) return ""
+  const all: unknown[] = []
+  for (const f of files) {
+    try {
+      const parsed = JSON.parse(f.text)
+      if (Array.isArray(parsed)) {
+        all.push(...parsed.filter((x) => x && typeof x === "object"))
+      } else if (parsed && typeof parsed === "object") {
+        all.push(parsed)
+      }
+    } catch {
+      // fall back to raw text so the user can see the problematic content
+      return f.text
+    }
+  }
+  if (all.length === 0) return ""
+  if (all.length === 1) return JSON.stringify(all[0], null, 2)
+  return JSON.stringify(all, null, 2)
+}
+
 function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; onImported: () => void }) {
   const [configText, setConfigText] = useState("")
-  const [fileName, setFileName] = useState("")
-  const [preview, setPreview] = useState<McpImportPreview | null>(null)
+  const [uploadedFiles, setUploadedFiles] = useState<{ name: string; text: string }[]>([])
+  const [previews, setPreviews] = useState<McpImportPreview[]>([])
   const [previewing, setPreviewing] = useState(false)
   const [applying, setApplying] = useState(false)
   const fileRef = useRef<HTMLInputElement>(null)
@@ -509,33 +530,57 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
     window.addEventListener("mouseup", onUp)
   }
 
-  const parseBundle = (): { ok: boolean; bundle?: McpConfigBundle; error?: string } => {
+  const parseBundles = (): { ok: boolean; bundles?: McpConfigBundle[]; error?: string } => {
     if (!configText.trim()) return { ok: false, error: "Paste or upload a config file" }
     try {
       const parsed = JSON.parse(configText)
-      return { ok: true, bundle: parsed }
+      if (Array.isArray(parsed)) {
+        const bundles = parsed.filter((x) => x && typeof x === "object") as McpConfigBundle[]
+        if (bundles.length === 0) return { ok: false, error: "Array contains no valid entries" }
+        return { ok: true, bundles }
+      }
+      if (parsed && typeof parsed === "object") return { ok: true, bundles: [parsed] }
+      return { ok: false, error: "Expected a JSON object or array" }
     } catch {
       return { ok: false, error: "Invalid JSON" }
     }
   }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    setFileName(file.name)
-    file.text().then((t) => setConfigText(compactJson(t))).catch(() => toast.error("Failed to read file"))
+    const files = Array.from(e.target.files ?? [])
+    if (files.length === 0) return
+    e.target.value = ""
+    Promise.all(files.map((f) => f.text().then((t) => ({ name: f.name, text: t }))))
+      .then((newFiles) => {
+        setUploadedFiles((prev) => {
+          const updated = [...prev, ...newFiles]
+          setConfigText(compactJson(mergeUploadedFiles(updated)))
+          setPreviews([])
+          return updated
+        })
+      })
+      .catch(() => toast.error("Failed to read file"))
+  }
+
+  const removeFile = (idx: number) => {
+    setUploadedFiles((prev) => {
+      const updated = prev.filter((_, i) => i !== idx)
+      setConfigText(updated.length === 0 ? "" : compactJson(mergeUploadedFiles(updated)))
+      setPreviews([])
+      return updated
+    })
   }
 
   const handlePreview = async () => {
-    const { ok, bundle, error } = parseBundle()
+    const { ok, bundles, error } = parseBundles()
     if (!ok) { toast.error(error!); return }
-    setPreviewing(true); setPreview(null)
+    setPreviewing(true); setPreviews([])
     try {
-      const res = await api<{ data: McpImportPreview }>("/siclaw/mcp/import/preview", {
+      const res = await api<{ data: McpImportPreview[] }>("/siclaw/mcp/import/preview", {
         method: "POST",
-        body: { bundle },
+        body: { bundles },
       })
-      setPreview(res.data)
+      setPreviews(res.data)
     } catch (err: any) {
       toast.error(err.message || "Preview failed")
     } finally {
@@ -544,13 +589,13 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
   }
 
   const handleApply = async () => {
-    const { ok, bundle, error } = parseBundle()
+    const { ok, bundles, error } = parseBundles()
     if (!ok) { toast.error(error!); return }
     setApplying(true)
     try {
       const res = await api<{ data: { created: number; updated: number; unchanged: number } }>("/siclaw/mcp/import", {
         method: "POST",
-        body: { bundle },
+        body: { bundles },
       })
       const { created, updated, unchanged } = res.data
       const parts = [created && `${created} created`, updated && `${updated} updated`, unchanged && `${unchanged} unchanged`].filter(Boolean)
@@ -563,7 +608,9 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
     }
   }
 
-  const canApply = preview !== null && preview.errors.length === 0 && preview.action !== "invalid" && preview.action !== "unchanged"
+  const canApply = previews.length > 0 &&
+    previews.every((p) => p.errors.length === 0) &&
+    previews.some((p) => p.action === "create" || p.action === "update")
 
   // Grow textarea to fit content; cap at 55 vh so the dialog doesn't overflow.
   useLayoutEffect(() => {
@@ -575,8 +622,8 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
 
   // Auto-scroll to preview panel once it appears in the DOM.
   useLayoutEffect(() => {
-    if (preview) previewRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
-  }, [preview])
+    if (previews.length > 0) previewRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+  }, [previews])
 
   const e = RESIZE_EDGE_PX
 
@@ -623,29 +670,48 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
           style={fixedHeight === null ? { maxHeight: "calc(100vh - 180px)" } : undefined}
         >
           <div className="space-y-1.5">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center flex-wrap gap-1.5">
               <label className="text-xs font-medium text-muted-foreground">Config JSON</label>
+              {uploadedFiles.map((f, i) => (
+                <span key={i} className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border border-border bg-secondary text-muted-foreground">
+                  <Upload className="h-3 w-3 shrink-0" />
+                  <span className="max-w-[200px] truncate">{f.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => removeFile(i)}
+                    className="ml-0.5 rounded hover:text-foreground"
+                    aria-label={`Remove ${f.name}`}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
                 className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border border-border text-muted-foreground hover:text-foreground"
               >
-                <Upload className="h-3 w-3" /> {fileName || "Upload file"}
+                <Upload className="h-3 w-3" />
+                {uploadedFiles.length === 0 ? "Upload file" : "Add more files"}
               </button>
-              <input ref={fileRef} type="file" accept=".json,application/json" className="hidden" onChange={handleFileChange} />
+              <input ref={fileRef} type="file" accept=".json,application/json" multiple className="hidden" onChange={handleFileChange} />
             </div>
             <textarea
               ref={textareaRef}
               value={configText}
-              onChange={(e) => { setConfigText(compactJson(e.target.value)); setPreview(null) }}
-              placeholder='{"mcpServer": {"name": "...", "transport": "stdio", ...}}'
+              onChange={(e) => { setConfigText(compactJson(e.target.value)); setPreviews([]) }}
+              placeholder='{"mcpServer": {"name": "...", "transport": "stdio", ...}}  or  [{...}, {...}]'
               rows={1}
               className="w-full px-3 py-2 text-xs font-mono rounded-md border border-border bg-background resize-none overflow-hidden"
               style={{ minHeight: "2rem" }}
             />
           </div>
 
-          {preview && <div ref={previewRef}><ImportPreviewPanel preview={preview} /></div>}
+          {previews.length > 0 && (
+            <div ref={previewRef} className="space-y-2">
+              {previews.map((p, i) => <ImportPreviewPanel key={i} preview={p} />)}
+            </div>
+          )}
         </div>
 
         {/* ── Footer ── */}
@@ -653,7 +719,7 @@ function ImportMcpConfigDialog({ onClose, onImported }: { onClose: () => void; o
           <button onClick={onClose} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
           <button
             onClick={handlePreview}
-            disabled={previewing || !configText.trim()}
+            disabled={previewing || !configText.trim() || applying}
             className="h-8 px-4 text-sm rounded-md border border-border text-foreground disabled:opacity-50"
           >
             {previewing ? <Loader2 className="h-3.5 w-3.5 animate-spin inline mr-1" /> : null}Preview

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -1315,67 +1315,75 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     sendJson(res, 200, { data: { mcpServer: entry } });
   });
 
-  // Preview MCP config import (dry-run)
+  // Preview MCP config import (dry-run) — accepts bundles[] (multi) or bundle (legacy single)
   router.post(`${P}/mcp/import/preview`, async (req, res) => {
     const auth = requireAuth(req, config.jwtSecret);
     if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
     if (await guardAccess(res, config, auth, "write")) return;
 
-    const body = await parseBody<{ bundle?: McpConfigBundle }>(req);
-    const preview = await buildMcpImportPreview(body.bundle ?? {}, auth.orgId!);
-    sendJson(res, 200, { data: preview });
+    const body = await parseBody<{ bundle?: McpConfigBundle; bundles?: McpConfigBundle[] }>(req);
+    const bundles = body.bundles ?? (body.bundle ? [body.bundle] : [{}]);
+    const previews = await Promise.all(bundles.map((b) => buildMcpImportPreview(b, auth.orgId!)));
+    sendJson(res, 200, { data: previews });
   });
 
-  // Apply MCP config import
+  // Apply MCP config import — accepts bundles[] (multi) or bundle (legacy single)
   router.post(`${P}/mcp/import`, async (req, res) => {
     const auth = requireAuth(req, config.jwtSecret);
     if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
     if (await guardAccess(res, config, auth, "write")) return;
 
-    const body = await parseBody<{ bundle?: McpConfigBundle }>(req);
-    const preview = await buildMcpImportPreview(body.bundle ?? {}, auth.orgId!);
+    const body = await parseBody<{ bundle?: McpConfigBundle; bundles?: McpConfigBundle[] }>(req);
+    const bundles = body.bundles ?? (body.bundle ? [body.bundle] : [{}]);
 
-    if (preview.errors.length > 0) {
-      sendJson(res, 400, { error: preview.errors.join("; ") });
+    // Preview all first — reject the entire batch if any entry has errors
+    const previews = await Promise.all(bundles.map((b) => buildMcpImportPreview(b, auth.orgId!)));
+    const allErrors = previews.flatMap((p) => p.errors);
+    if (allErrors.length > 0) {
+      sendJson(res, 400, { error: allErrors.join("; ") });
       return;
     }
 
-    const entry = body.bundle!.mcpServer!;
     const db = getDb();
     const result: ImportMcpConfigResult = { created: 0, updated: 0, unchanged: 0 };
 
-    if (preview.action === "create") {
-      const id = crypto.randomUUID();
-      await db.query(
-        `INSERT INTO mcp_servers (id, org_id, name, transport, url, command, args, env, headers, enabled, description, created_by)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [
-          id, auth.orgId, entry.name, entry.transport,
-          entry.url || null, entry.command || null,
-          JSON.stringify(entry.args || null), JSON.stringify(entry.env || null),
-          JSON.stringify(entry.headers || null), entry.enabled !== false ? 1 : 0,
-          entry.description || null, auth.userId,
-        ],
-      );
-      result.created = 1;
-    } else if (preview.action === "update") {
-      await db.query(
-        `UPDATE mcp_servers SET
-         name = ?, url = ?, command = ?, args = ?, env = ?, headers = ?,
-         description = ?, enabled = ?, updated_at = CURRENT_TIMESTAMP
-         WHERE id = ?`,
-        [
-          entry.name, entry.url || null, entry.command || null,
-          JSON.stringify(entry.args || null), JSON.stringify(entry.env || null),
-          JSON.stringify(entry.headers || null),
-          entry.description || null, entry.enabled !== false ? 1 : 0,
-          preview.id,
-        ],
-      );
-      ctx?.notifyMcpAgents?.(preview.id!, ["mcp"]);
-      result.updated = 1;
-    } else {
-      result.unchanged = 1;
+    for (let i = 0; i < bundles.length; i++) {
+      const preview = previews[i];
+      const entry = bundles[i].mcpServer!;
+
+      if (preview.action === "create") {
+        const id = crypto.randomUUID();
+        await db.query(
+          `INSERT INTO mcp_servers (id, org_id, name, transport, url, command, args, env, headers, enabled, description, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            id, auth.orgId, entry.name, entry.transport,
+            entry.url || null, entry.command || null,
+            JSON.stringify(entry.args || null), JSON.stringify(entry.env || null),
+            JSON.stringify(entry.headers || null), entry.enabled !== false ? 1 : 0,
+            entry.description || null, auth.userId,
+          ],
+        );
+        result.created++;
+      } else if (preview.action === "update") {
+        await db.query(
+          `UPDATE mcp_servers SET
+           name = ?, url = ?, command = ?, args = ?, env = ?, headers = ?,
+           description = ?, enabled = ?, updated_at = CURRENT_TIMESTAMP
+           WHERE id = ?`,
+          [
+            entry.name, entry.url || null, entry.command || null,
+            JSON.stringify(entry.args || null), JSON.stringify(entry.env || null),
+            JSON.stringify(entry.headers || null),
+            entry.description || null, entry.enabled !== false ? 1 : 0,
+            preview.id,
+          ],
+        );
+        ctx?.notifyMcpAgents?.(preview.id!, ["mcp"]);
+        result.updated++;
+      } else {
+        result.unchanged++;
+      }
     }
 
     sendJson(res, 200, { data: result });


### PR DESCRIPTION
Upgrade the Import MCP Config dialog to support multiple JSON files (select at once or add one-by-one) and array-format configs. Adds a batch preview summary bar (total / create / update / unchanged) matching the sicore design. Backend processes all bundles atomically — preview-all-then-write.