### PR TITLE
feat(agents): one-click duplicate agent

### DIFF
--- a/portal-web/src/pages/Agents.tsx
+++ b/portal-web/src/pages/Agents.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
-import { Plus, Bot, Trash2, Loader2, MessageSquare, Settings, Eraser, Zap, Plug, Server, Clock, BoltIcon, BookOpen } from "lucide-react"
+import { Plus, Bot, Trash2, Loader2, MessageSquare, Settings, Eraser, Zap, Plug, Server, Clock, BoltIcon, BookOpen, Copy } from "lucide-react"
 import { api, clearAgentMemory } from "../api"
 import { useToast } from "../components/toast"
 import { Tooltip } from "../components/tooltip"
@@ -56,6 +56,14 @@ export function Agents() {
     if (!(await confirmDialog({ title: "Delete Agent", message: "Are you sure you want to delete this agent? This cannot be undone.", destructive: true, confirmLabel: "Delete" }))) return
     await api(`/agents/${id}`, { method: "DELETE" })
     setAgents((prev) => prev.filter((a) => a.id !== id))
+  }
+
+  const handleCopy = async (agent: Agent) => {
+    try {
+      const newAgent = await api<Agent>(`/agents/${agent.id}/copy`, { method: "POST" })
+      setAgents((prev) => [newAgent, ...prev])
+      toast.success(`Copied as "${newAgent.name}"`)
+    } catch (err: any) { toast.error(err.message) }
   }
 
   const handleClearMemory = async (id: string) => {
@@ -198,6 +206,7 @@ export function Agents() {
                 {/* Actions */}
                 <div className="flex items-center gap-0.5 shrink-0">
                   <Tooltip content="Chat"><button onClick={(e) => { e.stopPropagation(); navigate(`/chat?agent=${a.id}`) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><MessageSquare className="h-4 w-4" /></button></Tooltip>
+                  <Tooltip content="Duplicate"><button onClick={(e) => { e.stopPropagation(); handleCopy(a) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><Copy className="h-4 w-4" /></button></Tooltip>
                   <Tooltip content="Clear Memory"><button onClick={(e) => { e.stopPropagation(); handleClearMemory(a.id) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><Eraser className="h-4 w-4" /></button></Tooltip>
                   <Tooltip content="Settings"><button onClick={(e) => { e.stopPropagation(); navigate(`/agents/${a.id}?tab=basic`) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><Settings className="h-4 w-4" /></button></Tooltip>
                   <Tooltip content="Delete"><button onClick={(e) => { e.stopPropagation(); handleDelete(a.id) }} className="p-1.5 rounded-md hover:bg-destructive/20 text-muted-foreground hover:text-red-400"><Trash2 className="h-4 w-4" /></button></Tooltip>

--- a/src/portal/agent-api.ts
+++ b/src/portal/agent-api.ts
@@ -344,6 +344,118 @@ export function registerAgentRoutes(
     });
   });
 
+  // POST /api/v1/agents/:id/copy — duplicate agent + resource bindings (admin only)
+  router.post("/api/v1/agents/:id/copy", async (req, res, params) => {
+    const auth = requireAdmin(req, res, jwtSecret);
+    if (!auth) return;
+
+    const db = getDb();
+    const sourceId = params.id;
+
+    const [sourceRows] = await db.query("SELECT * FROM agents WHERE id = ?", [sourceId]) as any;
+    if (sourceRows.length === 0) {
+      sendJson(res, 404, { error: "Agent not found" });
+      return;
+    }
+    const source = sourceRows[0];
+
+    const newId = crypto.randomUUID();
+    const newName = `${source.name} (copy)`;
+
+    const conn = await db.getConnection();
+    try {
+      await conn.beginTransaction();
+
+      await conn.query(
+        `INSERT INTO agents (id, name, description, status, model_provider, model_id, system_prompt, is_production, icon, color, created_by)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          newId,
+          newName,
+          source.description,
+          source.status,
+          source.model_provider,
+          source.model_id,
+          source.system_prompt,
+          source.is_production,
+          source.icon,
+          source.color,
+          auth.userId,
+        ],
+      );
+
+      // Copy skill bindings
+      const [skillRows] = await conn.query(
+        "SELECT skill_id FROM agent_skills WHERE agent_id = ?",
+        [sourceId],
+      ) as any;
+      for (const row of skillRows) {
+        await conn.query(
+          `${insertIgnorePrefix(db)} INTO agent_skills (agent_id, skill_id) VALUES (?, ?)`,
+          [newId, row.skill_id],
+        );
+      }
+
+      // Copy MCP server bindings
+      const [mcpRows] = await conn.query(
+        "SELECT mcp_server_id FROM agent_mcp_servers WHERE agent_id = ?",
+        [sourceId],
+      ) as any;
+      for (const row of mcpRows) {
+        await conn.query(
+          "INSERT INTO agent_mcp_servers (agent_id, mcp_server_id) VALUES (?, ?)",
+          [newId, row.mcp_server_id],
+        );
+      }
+
+      // Copy cluster bindings
+      const [clusterRows] = await conn.query(
+        "SELECT cluster_id FROM agent_clusters WHERE agent_id = ?",
+        [sourceId],
+      ) as any;
+      for (const row of clusterRows) {
+        await conn.query(
+          "INSERT INTO agent_clusters (agent_id, cluster_id) VALUES (?, ?)",
+          [newId, row.cluster_id],
+        );
+      }
+
+      // Copy host bindings
+      const [hostRows] = await conn.query(
+        "SELECT host_id FROM agent_hosts WHERE agent_id = ?",
+        [sourceId],
+      ) as any;
+      for (const row of hostRows) {
+        await conn.query(
+          "INSERT INTO agent_hosts (agent_id, host_id) VALUES (?, ?)",
+          [newId, row.host_id],
+        );
+      }
+
+      // Copy knowledge repo bindings
+      const [knowledgeRows] = await conn.query(
+        "SELECT repo_id FROM agent_knowledge_repos WHERE agent_id = ?",
+        [sourceId],
+      ) as any;
+      for (const row of knowledgeRows) {
+        await conn.query(
+          "INSERT INTO agent_knowledge_repos (agent_id, repo_id) VALUES (?, ?)",
+          [newId, row.repo_id],
+        );
+      }
+
+      await conn.commit();
+    } catch (err) {
+      await conn.rollback();
+      throw err;
+    } finally {
+      conn.release();
+    }
+
+    const [newRows] = await db.query("SELECT * FROM agents WHERE id = ?", [newId]) as any;
+    sendJson(res, 201, newRows[0]);
+  });
+
   // ================================================================
   // API Keys (Portal-owned)
   // ================================================================


### PR DESCRIPTION
Add a Duplicate button to each agent card. Clicking it calls POST /api/v1/agents/:id/copy, which clones the agent's settings and all resource bindings (skills, MCP servers, clusters, hosts, knowledge repos) in a single transaction. The copy appears at the top of the list with a (copy) name suffix.