### PR TITLE
feat(chat): persist steered follow-ups in session history

### DIFF
--- a/portal-web/src/api.ts
+++ b/portal-web/src/api.ts
@@ -123,8 +123,20 @@ export function chatSSE(
   return { abort: () => controller.abort() }
 }
 
-export async function chatSteer(agentId: string, sessionId: string, text: string): Promise<void> {
-  await api(`/siclaw/agents/${agentId}/chat/steer`, {
+export interface ChatSteerResponse {
+  ok?: boolean
+  message?: {
+    id: string
+    session_id?: string
+    role: "user"
+    content: string
+    metadata?: Record<string, unknown>
+    created_at?: string
+  }
+}
+
+export async function chatSteer(agentId: string, sessionId: string, text: string): Promise<ChatSteerResponse> {
+  return api(`/siclaw/agents/${agentId}/chat/steer`, {
     method: "POST",
     body: { session_id: sessionId, text },
   })

--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -296,9 +296,35 @@ export function AgentChat({ agentId }: AgentChatProps) {
 
   // Auto-title: track whether we already titled this session
   const titledSessionRef = useRef<string | null>(null)
+  const activeSessionIdRef = useRef<string | null>(null)
+  const wasStreamingRef = useRef(false)
 
   // Pilot-style chat hook
   const pilot = usePilotChat({ agentId, sessionId: activeSessionId })
+
+  useEffect(() => {
+    activeSessionIdRef.current = activeSessionId
+  }, [activeSessionId])
+
+  const loadSessions = useCallback(async (): Promise<ChatSession[]> => {
+    const res = await api<{ data: ChatSession[] }>(`/siclaw/agents/${agentId}/chat/sessions`)
+    const items = Array.isArray(res.data) ? res.data : Array.isArray(res) ? (res as any) : []
+    return sortSessions(items)
+  }, [agentId])
+
+  const refreshSessions = useCallback(async (opts?: { selectDefault?: boolean; silent?: boolean }) => {
+    try {
+      const sorted = await loadSessions()
+      setSessions(sorted)
+      if (opts?.selectDefault && sorted.length > 0 && !activeSessionIdRef.current) {
+        setActiveSessionId(sorted[0].id)
+      }
+      return sorted
+    } catch (err: any) {
+      if (!opts?.silent) toast.error(err.message || "Failed to load sessions")
+      return null
+    }
+  }, [loadSessions, toast])
 
   // Fetch sessions
   useEffect(() => {
@@ -306,12 +332,10 @@ export function AgentChat({ agentId }: AgentChatProps) {
     async function fetchSessions() {
       try {
         setLoading(true)
-        const res = await api<{ data: ChatSession[] }>(`/siclaw/agents/${agentId}/chat/sessions`)
-        const items = Array.isArray(res.data) ? res.data : Array.isArray(res) ? (res as any) : []
+        const sorted = await loadSessions()
         if (!cancelled) {
-          const sorted = sortSessions(items)
           setSessions(sorted)
-          if (sorted.length > 0 && !activeSessionId) {
+          if (sorted.length > 0 && !activeSessionIdRef.current) {
             setActiveSessionId(sorted[0].id)
           }
         }
@@ -325,7 +349,28 @@ export function AgentChat({ agentId }: AgentChatProps) {
     return () => {
       cancelled = true
     }
-  }, [agentId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [agentId, loadSessions, toast])
+
+  useEffect(() => {
+    if (!showSessions) return
+    let stopped = false
+    const poll = () => {
+      if (!stopped) void refreshSessions({ silent: true })
+    }
+    poll()
+    const id = window.setInterval(poll, 3000)
+    return () => {
+      stopped = true
+      window.clearInterval(id)
+    }
+  }, [showSessions, refreshSessions])
+
+  useEffect(() => {
+    if (wasStreamingRef.current && !pilot.streaming) {
+      void refreshSessions({ silent: true })
+    }
+    wasStreamingRef.current = pilot.streaming
+  }, [pilot.streaming, refreshSessions])
 
   // Auto-generate title from first user message (only if still default name)
   useEffect(() => {

--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -331,8 +331,6 @@ export function AgentChat({ agentId }: AgentChatProps) {
               sendMessage={handleSend}
               abortResponse={pilot.abort}
               contextUsage={pilot.contextUsage}
-              pendingMessages={pilot.pendingMessages}
-              onRemovePending={pilot.removePending}
               dpActive={pilot.dpActive}
               onSetDpActive={pilot.setDpActive}
               sessionKey={activeSessionId}

--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react"
-import { Plus, Trash2, Loader2, MessageSquare, Search, Pencil, Check, X, History } from "lucide-react"
+import { Plus, Trash2, Loader2, MessageSquare, Search, Pencil, Check, X, History, Pin } from "lucide-react"
 import { api } from "../api"
 import { useToast } from "./toast"
 import { useConfirm } from "./confirm-dialog"
@@ -14,12 +14,83 @@ interface ChatSession {
   title?: string
   created_at: string
   updated_at?: string
+  last_active_at?: string
+  last_viewed_at?: string | null
+  pinned_at?: string | null
+  message_count?: number
 }
 
 // ── Session Sidebar ────────────────────────────────────────
 
+const DEFAULT_VISIBLE_SESSIONS = 5
+
+function parsePortalTimestamp(value?: string | null): Date | null {
+  if (!value) return null
+  const isoish = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value)
+    ? `${value.replace(" ", "T")}Z`
+    : value
+  const ms = Date.parse(isoish)
+  return Number.isFinite(ms) ? new Date(ms) : null
+}
+
+function sessionActivityDate(session: ChatSession): Date | null {
+  return parsePortalTimestamp(session.last_active_at ?? session.updated_at ?? session.created_at)
+}
+
+function formatSessionAge(session: ChatSession, now = new Date()): string {
+  const activity = sessionActivityDate(session)
+  if (!activity) return ""
+  const diffMs = Math.max(0, now.getTime() - activity.getTime())
+  const minute = 60 * 1000
+  const hour = 60 * minute
+  const day = 24 * hour
+  if (diffMs < minute) return "now"
+  if (diffMs < hour) return `${Math.max(1, Math.floor(diffMs / minute))}m`
+  if (diffMs < day) return `${Math.floor(diffMs / hour)}h`
+  if (diffMs < 7 * day) return `${Math.floor(diffMs / day)}d`
+  const sameYear = activity.getFullYear() === now.getFullYear()
+  return activity.toLocaleDateString(undefined, sameYear
+    ? { month: "short", day: "numeric" }
+    : { year: "numeric", month: "short", day: "numeric" })
+}
+
+function formatSessionTooltip(session: ChatSession): string {
+  const activity = sessionActivityDate(session)
+  if (!activity) return ""
+  return activity.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+function sortSessions(sessions: ChatSession[]): ChatSession[] {
+  return [...sessions].sort((a, b) => {
+    const aPinned = a.pinned_at ? 0 : 1
+    const bPinned = b.pinned_at ? 0 : 1
+    if (aPinned !== bPinned) return aPinned - bPinned
+    const aPinnedAt = parsePortalTimestamp(a.pinned_at)?.getTime() ?? 0
+    const bPinnedAt = parsePortalTimestamp(b.pinned_at)?.getTime() ?? 0
+    if (aPinnedAt !== bPinnedAt) return bPinnedAt - aPinnedAt
+    const aActive = sessionActivityDate(a)?.getTime() ?? 0
+    const bActive = sessionActivityDate(b)?.getTime() ?? 0
+    if (aActive !== bActive) return bActive - aActive
+    return (parsePortalTimestamp(b.created_at)?.getTime() ?? 0) - (parsePortalTimestamp(a.created_at)?.getTime() ?? 0)
+  })
+}
+
+function hasUnseenActivity(session: ChatSession, activeSessionId: string | null): boolean {
+  if (session.id === activeSessionId) return false
+  const activeAt = sessionActivityDate(session)?.getTime()
+  if (!activeAt) return false
+  const viewedAt = parsePortalTimestamp(session.last_viewed_at)?.getTime()
+  return viewedAt == null ? Boolean(session.message_count && session.message_count > 0) : activeAt > viewedAt
+}
+
 function SessionSidebar({
-  sessions, activeSessionId, agentId, onSelect, onNew, onDelete, onRenamed,
+  sessions, activeSessionId, agentId, onSelect, onNew, onDelete, onRenamed, onTogglePinned,
 }: {
   sessions: ChatSession[]
   activeSessionId: string | null
@@ -28,15 +99,23 @@ function SessionSidebar({
   onNew: () => void
   onDelete: (id: string) => void
   onRenamed: (id: string, title: string) => void
+  onTogglePinned: (session: ChatSession) => void
 }) {
   const toast = useToast()
   const [search, setSearch] = useState("")
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState("")
+  const [showMore, setShowMore] = useState(false)
+  const now = new Date()
 
   const filtered = search
     ? sessions.filter(s => (s.title || "").toLowerCase().includes(search.toLowerCase()))
-    : sessions
+    : sortSessions(sessions)
+  const pinned = search ? [] : filtered.filter((s) => s.pinned_at)
+  const normal = search ? filtered : filtered.filter((s) => !s.pinned_at)
+  const visibleNormal = search || showMore ? normal : normal.slice(0, DEFAULT_VISIBLE_SESSIONS)
+  const extraCount = search ? 0 : Math.max(0, normal.length - DEFAULT_VISIBLE_SESSIONS)
+  const visibleSessions = search ? filtered : [...pinned, ...visibleNormal]
 
   const handleStartRename = (s: ChatSession) => {
     setRenamingId(s.id)
@@ -54,6 +133,11 @@ function SessionSidebar({
     } catch (err: any) {
       toast.error(err.message)
     }
+  }
+
+  const handleCancelRename = () => {
+    setRenamingId(null)
+    setRenameValue("")
   }
 
   return (
@@ -84,44 +168,81 @@ function SessionSidebar({
             {search ? "No matches" : "No sessions"}
           </p>
         ) : (
-          filtered.map(s => (
-            <div
-              key={s.id}
-              onClick={() => { if (renamingId !== s.id) onSelect(s.id) }}
-              className={`group flex items-center justify-between px-3 py-2.5 cursor-pointer border-b border-border/20 transition-colors ${
-                activeSessionId === s.id
-                  ? "bg-secondary/50 text-foreground"
-                  : "text-muted-foreground hover:text-foreground hover:bg-secondary/30"
-              }`}
-            >
-              {renamingId === s.id ? (
-                <div className="flex items-center gap-1 flex-1 min-w-0" onClick={e => e.stopPropagation()}>
-                  <input
-                    value={renameValue}
-                    onChange={e => setRenameValue(e.target.value)}
-                    onKeyDown={e => { if (e.key === "Enter") handleSaveRename(); if (e.key === "Escape") setRenamingId(null); }}
-                    autoFocus
-                    className="flex-1 h-6 px-1.5 text-[12px] rounded border border-border bg-background min-w-0"
-                  />
-                  <button onClick={handleSaveRename} title="Save" className="p-0.5 rounded hover:bg-secondary text-green-400"><Check className="h-3 w-3" /></button>
-                  <button onClick={() => setRenamingId(null)} title="Cancel" className="p-0.5 rounded hover:bg-secondary text-muted-foreground"><X className="h-3 w-3" /></button>
-                </div>
-              ) : (
-                <>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-[13px] truncate">{s.title || "Untitled"}</p>
-                    <p className="text-[10px] text-muted-foreground/60">
-                      {new Date(s.created_at).toLocaleDateString()}
-                    </p>
+          <>
+            {visibleSessions.map(s => (
+              <div
+                key={s.id}
+                onClick={() => { if (renamingId !== s.id) onSelect(s.id) }}
+                className={`group mx-2 my-0.5 flex h-10 items-center gap-2 rounded-md px-3 cursor-pointer transition-colors ${
+                  activeSessionId === s.id
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
+                }`}
+              >
+                {renamingId === s.id ? (
+                  <div className="flex items-center gap-1 flex-1 min-w-0" onClick={e => e.stopPropagation()}>
+                    <input
+                      value={renameValue}
+                      onChange={e => setRenameValue(e.target.value)}
+                      onKeyDown={e => { if (e.key === "Enter") handleSaveRename(); if (e.key === "Escape") handleCancelRename(); }}
+                      autoFocus
+                      className="flex-1 h-7 px-2 text-[13px] rounded-md border border-border bg-background min-w-0"
+                    />
+                    <button onClick={handleSaveRename} title="Save" className="p-1 rounded-md hover:bg-secondary text-green-400"><Check className="h-3.5 w-3.5" /></button>
+                    <button onClick={handleCancelRename} title="Cancel" className="p-1 rounded-md hover:bg-secondary text-muted-foreground"><X className="h-3.5 w-3.5" /></button>
                   </div>
-                  <div className="opacity-0 group-hover:opacity-100 flex items-center gap-0.5 transition-opacity">
-                    <button onClick={e => { e.stopPropagation(); handleStartRename(s) }} title="Rename" className="p-1 rounded hover:bg-secondary text-muted-foreground"><Pencil className="h-3 w-3" /></button>
-                    <button onClick={e => { e.stopPropagation(); onDelete(s.id) }} title="Delete" className="p-1 rounded hover:bg-destructive/20 hover:text-red-400 text-muted-foreground"><Trash2 className="h-3 w-3" /></button>
-                  </div>
-                </>
-              )}
-            </div>
-          ))
+                ) : (
+                  <>
+                    <span className={`flex-1 min-w-0 truncate text-[13px] ${activeSessionId === s.id ? "font-semibold" : "font-medium"}`}>
+                      {s.title || "Untitled"}
+                    </span>
+                    {hasUnseenActivity(s, activeSessionId) && (
+                      <span className="h-2 w-2 shrink-0 rounded-full bg-blue-500" title="Updated" />
+                    )}
+                    <span
+                      className={`shrink-0 text-[12px] text-muted-foreground/70 ${activeSessionId === s.id ? "hidden" : "group-hover:hidden"}`}
+                      title={formatSessionTooltip(s)}
+                    >
+                      {formatSessionAge(s, now)}
+                    </span>
+                    <div className={`shrink-0 items-center gap-0.5 ${activeSessionId === s.id ? "flex" : "hidden group-hover:flex"}`}>
+                      <button
+                        onClick={e => { e.stopPropagation(); onTogglePinned(s) }}
+                        title={s.pinned_at ? "Unpin session" : "Pin session"}
+                        className={`p-1 rounded-md hover:bg-background/60 ${s.pinned_at ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+                      >
+                        <Pin className="h-3.5 w-3.5" />
+                      </button>
+                      <button onClick={e => { e.stopPropagation(); handleStartRename(s) }} title="Rename" className="p-1 rounded-md hover:bg-background/60 text-muted-foreground hover:text-foreground">
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button onClick={e => { e.stopPropagation(); onDelete(s.id) }} title="Delete session" className="p-1 rounded-md hover:bg-background/60 text-muted-foreground hover:text-red-400">
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            ))}
+            {!search && extraCount > 0 && !showMore && (
+              <button
+                type="button"
+                onClick={() => setShowMore(true)}
+                className="mx-3 mt-2 px-2 py-1 text-[13px] text-muted-foreground/80 hover:text-foreground transition-colors"
+              >
+                Show more
+              </button>
+            )}
+            {!search && showMore && extraCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowMore(false)}
+                className="mx-3 mt-2 px-2 py-1 text-[13px] text-muted-foreground/80 hover:text-foreground transition-colors"
+              >
+                Show less
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -162,9 +283,10 @@ export function AgentChat({ agentId }: AgentChatProps) {
         const res = await api<{ data: ChatSession[] }>(`/siclaw/agents/${agentId}/chat/sessions`)
         const items = Array.isArray(res.data) ? res.data : Array.isArray(res) ? (res as any) : []
         if (!cancelled) {
-          setSessions(items)
-          if (items.length > 0 && !activeSessionId) {
-            setActiveSessionId(items[0].id)
+          const sorted = sortSessions(items)
+          setSessions(sorted)
+          if (sorted.length > 0 && !activeSessionId) {
+            setActiveSessionId(sorted[0].id)
           }
         }
       } catch (err: any) {
@@ -194,7 +316,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
     titledSessionRef.current = activeSessionId
     const title = userMsg.content.slice(0, 40).trim() || "Chat"
     setSessions((prev) =>
-      prev.map((s) => (s.id === activeSessionId ? { ...s, title } : s)),
+      sortSessions(prev.map((s) => (s.id === activeSessionId ? { ...s, title } : s))),
     )
     // Persist to DB
     api(`/siclaw/agents/${agentId}/chat/sessions/${activeSessionId}`, {
@@ -211,7 +333,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
   const handleNewSession = useCallback(async () => {
     try {
       const session = await api<ChatSession>(`/siclaw/agents/${agentId}/chat/sessions`, { method: "POST" })
-      setSessions((prev) => [session, ...prev])
+      setSessions((prev) => sortSessions([session, ...prev]))
       setActiveSessionId(session.id)
     } catch (err: any) {
       toast.error(err.message || "Failed to create session")
@@ -241,6 +363,32 @@ export function AgentChat({ agentId }: AgentChatProps) {
     [agentId, activeSessionId, toast, confirmDialog],
   )
 
+  const acknowledgeSession = useCallback(async (sid: string) => {
+    const viewedAt = new Date().toISOString()
+    setSessions((prev) => sortSessions(prev.map((s) => s.id === sid ? { ...s, last_viewed_at: viewedAt } : s)))
+    try {
+      const updated = await api<ChatSession>(`/siclaw/agents/${agentId}/chat/sessions/${sid}`, {
+        method: "PUT",
+        body: { viewed: true },
+      })
+      setSessions((prev) => sortSessions(prev.map((s) => s.id === sid ? updated : s)))
+    } catch (err: any) {
+      toast.error(err.message || "Failed to update session")
+    }
+  }, [agentId, toast])
+
+  const handleSelectSession = useCallback((sid: string) => {
+    setActiveSessionId(sid)
+    void acknowledgeSession(sid)
+  }, [acknowledgeSession])
+
+  useEffect(() => {
+    if (!activeSessionId) return
+    const current = sessions.find((s) => s.id === activeSessionId)
+    if (!current || !hasUnseenActivity(current, null)) return
+    void acknowledgeSession(activeSessionId)
+  }, [activeSessionId, acknowledgeSession, sessions])
+
   // Wrap send to also handle first-message session creation
   const handleSend = useCallback(
     (text: string) => {
@@ -248,7 +396,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
         // Create a new session first, then send
         api<ChatSession>(`/siclaw/agents/${agentId}/chat/sessions`, { method: "POST" })
           .then((session) => {
-            setSessions((prev) => [session, ...prev])
+            setSessions((prev) => sortSessions([session, ...prev]))
             setActiveSessionId(session.id)
             // Short delay to let state propagate
             setTimeout(() => pilot.send(text), 50)
@@ -258,10 +406,33 @@ export function AgentChat({ agentId }: AgentChatProps) {
           })
         return
       }
+      const now = new Date().toISOString()
+      setSessions((prev) => sortSessions(prev.map((s) =>
+        s.id === activeSessionId ? { ...s, last_active_at: now, last_viewed_at: now } : s,
+      )))
       pilot.send(text)
     },
     [activeSessionId, agentId, pilot, toast],
   )
+
+  const handleTogglePinned = useCallback(async (session: ChatSession) => {
+    const pinned = !session.pinned_at
+    const pinnedAt = pinned ? new Date().toISOString() : null
+    const previous = sessions
+    setSessions((prev) => sortSessions(prev.map((s) =>
+      s.id === session.id ? { ...s, pinned_at: pinnedAt } : s,
+    )))
+    try {
+      const updated = await api<ChatSession>(`/siclaw/agents/${agentId}/chat/sessions/${session.id}`, {
+        method: "PUT",
+        body: { pinned },
+      })
+      setSessions((prev) => sortSessions(prev.map((s) => s.id === session.id ? updated : s)))
+    } catch (err: any) {
+      setSessions(previous)
+      toast.error(err.message || "Failed to update session")
+    }
+  }, [agentId, sessions, toast])
 
   if (loading) {
     return (
@@ -288,10 +459,11 @@ export function AgentChat({ agentId }: AgentChatProps) {
               sessions={sessions}
               activeSessionId={activeSessionId}
               agentId={agentId}
-              onSelect={(id) => { setActiveSessionId(id); setShowSessions(false) }}
+              onSelect={(id) => { handleSelectSession(id); setShowSessions(false) }}
               onNew={() => { handleNewSession(); setShowSessions(false) }}
               onDelete={handleDeleteSession}
-              onRenamed={(sid, title) => setSessions(prev => prev.map(s => s.id === sid ? { ...s, title } : s))}
+              onRenamed={(sid, title) => setSessions(prev => sortSessions(prev.map(s => s.id === sid ? { ...s, title } : s)))}
+              onTogglePinned={handleTogglePinned}
             />
           </div>
         </>

--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -115,7 +115,6 @@ function SessionSidebar({
   const normal = search ? filtered : filtered.filter((s) => !s.pinned_at)
   const visibleNormal = search || showMore ? normal : normal.slice(0, DEFAULT_VISIBLE_SESSIONS)
   const extraCount = search ? 0 : Math.max(0, normal.length - DEFAULT_VISIBLE_SESSIONS)
-  const visibleSessions = search ? filtered : [...pinned, ...visibleNormal]
 
   const handleStartRename = (s: ChatSession) => {
     setRenamingId(s.id)
@@ -139,6 +138,68 @@ function SessionSidebar({
     setRenamingId(null)
     setRenameValue("")
   }
+
+  const renderSessionRow = (s: ChatSession) => (
+    <div
+      key={s.id}
+      onClick={() => { if (renamingId !== s.id) onSelect(s.id) }}
+      className={`group mx-2 my-0.5 flex h-10 items-center gap-2 rounded-md px-3 cursor-pointer transition-colors ${
+        activeSessionId === s.id
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
+      }`}
+    >
+      {renamingId === s.id ? (
+        <div className="flex items-center gap-1 flex-1 min-w-0" onClick={e => e.stopPropagation()}>
+          <input
+            value={renameValue}
+            onChange={e => setRenameValue(e.target.value)}
+            onKeyDown={e => { if (e.key === "Enter") handleSaveRename(); if (e.key === "Escape") handleCancelRename(); }}
+            autoFocus
+            className="flex-1 h-7 px-2 text-[13px] rounded-md border border-border bg-background min-w-0"
+          />
+          <button onClick={handleSaveRename} title="Save" className="p-1 rounded-md hover:bg-secondary text-green-400"><Check className="h-3.5 w-3.5" /></button>
+          <button onClick={handleCancelRename} title="Cancel" className="p-1 rounded-md hover:bg-secondary text-muted-foreground"><X className="h-3.5 w-3.5" /></button>
+        </div>
+      ) : (
+        <>
+          <span className={`flex-1 min-w-0 truncate text-[13px] ${activeSessionId === s.id ? "font-semibold" : "font-medium"}`}>
+            {s.title || "Untitled"}
+          </span>
+          {hasUnseenActivity(s, activeSessionId) && (
+            <span className="h-2 w-2 shrink-0 rounded-full bg-blue-500" title="Updated" />
+          )}
+          {s.pinned_at && (
+            <Pin
+              className={`h-3.5 w-3.5 shrink-0 text-muted-foreground/70 ${activeSessionId === s.id ? "hidden" : "group-hover:hidden"}`}
+              aria-label="Pinned"
+            />
+          )}
+          <span
+            className={`shrink-0 text-[12px] text-muted-foreground/70 ${activeSessionId === s.id ? "hidden" : "group-hover:hidden"}`}
+            title={formatSessionTooltip(s)}
+          >
+            {formatSessionAge(s, now)}
+          </span>
+          <div className={`shrink-0 items-center gap-0.5 ${activeSessionId === s.id ? "flex" : "hidden group-hover:flex"}`}>
+            <button
+              onClick={e => { e.stopPropagation(); onTogglePinned(s) }}
+              title={s.pinned_at ? "Unpin session" : "Pin session"}
+              className={`p-1 rounded-md hover:bg-background/60 ${s.pinned_at ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+            >
+              <Pin className="h-3.5 w-3.5" />
+            </button>
+            <button onClick={e => { e.stopPropagation(); handleStartRename(s) }} title="Rename" className="p-1 rounded-md hover:bg-background/60 text-muted-foreground hover:text-foreground">
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+            <button onClick={e => { e.stopPropagation(); onDelete(s.id) }} title="Delete session" className="p-1 rounded-md hover:bg-background/60 text-muted-foreground hover:text-red-400">
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
@@ -169,61 +230,26 @@ function SessionSidebar({
           </p>
         ) : (
           <>
-            {visibleSessions.map(s => (
-              <div
-                key={s.id}
-                onClick={() => { if (renamingId !== s.id) onSelect(s.id) }}
-                className={`group mx-2 my-0.5 flex h-10 items-center gap-2 rounded-md px-3 cursor-pointer transition-colors ${
-                  activeSessionId === s.id
-                    ? "bg-secondary text-foreground"
-                    : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
-                }`}
-              >
-                {renamingId === s.id ? (
-                  <div className="flex items-center gap-1 flex-1 min-w-0" onClick={e => e.stopPropagation()}>
-                    <input
-                      value={renameValue}
-                      onChange={e => setRenameValue(e.target.value)}
-                      onKeyDown={e => { if (e.key === "Enter") handleSaveRename(); if (e.key === "Escape") handleCancelRename(); }}
-                      autoFocus
-                      className="flex-1 h-7 px-2 text-[13px] rounded-md border border-border bg-background min-w-0"
-                    />
-                    <button onClick={handleSaveRename} title="Save" className="p-1 rounded-md hover:bg-secondary text-green-400"><Check className="h-3.5 w-3.5" /></button>
-                    <button onClick={handleCancelRename} title="Cancel" className="p-1 rounded-md hover:bg-secondary text-muted-foreground"><X className="h-3.5 w-3.5" /></button>
-                  </div>
-                ) : (
-                  <>
-                    <span className={`flex-1 min-w-0 truncate text-[13px] ${activeSessionId === s.id ? "font-semibold" : "font-medium"}`}>
-                      {s.title || "Untitled"}
-                    </span>
-                    {hasUnseenActivity(s, activeSessionId) && (
-                      <span className="h-2 w-2 shrink-0 rounded-full bg-blue-500" title="Updated" />
-                    )}
-                    <span
-                      className={`shrink-0 text-[12px] text-muted-foreground/70 ${activeSessionId === s.id ? "hidden" : "group-hover:hidden"}`}
-                      title={formatSessionTooltip(s)}
-                    >
-                      {formatSessionAge(s, now)}
-                    </span>
-                    <div className={`shrink-0 items-center gap-0.5 ${activeSessionId === s.id ? "flex" : "hidden group-hover:flex"}`}>
-                      <button
-                        onClick={e => { e.stopPropagation(); onTogglePinned(s) }}
-                        title={s.pinned_at ? "Unpin session" : "Pin session"}
-                        className={`p-1 rounded-md hover:bg-background/60 ${s.pinned_at ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
-                      >
-                        <Pin className="h-3.5 w-3.5" />
-                      </button>
-                      <button onClick={e => { e.stopPropagation(); handleStartRename(s) }} title="Rename" className="p-1 rounded-md hover:bg-background/60 text-muted-foreground hover:text-foreground">
-                        <Pencil className="h-3.5 w-3.5" />
-                      </button>
-                      <button onClick={e => { e.stopPropagation(); onDelete(s.id) }} title="Delete session" className="p-1 rounded-md hover:bg-background/60 text-muted-foreground hover:text-red-400">
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
+            {search ? (
+              filtered.map(renderSessionRow)
+            ) : (
+              <>
+                {pinned.length > 0 && (
+                  <div className="pt-3 pb-1">
+                    <div className="px-4 pb-1 text-[12px] font-medium text-muted-foreground/70">
+                      Pinned
                     </div>
-                  </>
+                    {pinned.map(renderSessionRow)}
+                  </div>
                 )}
-              </div>
-            ))}
+                {pinned.length > 0 && normal.length > 0 && (
+                  <div className="px-4 pt-3 pb-1 text-[12px] font-medium text-muted-foreground/70">
+                    Recent
+                  </div>
+                )}
+                {visibleNormal.map(renderSessionRow)}
+              </>
+            )}
             {!search && extraCount > 0 && !showMore && (
               <button
                 type="button"

--- a/portal-web/src/components/chat/InputArea.tsx
+++ b/portal-web/src/components/chat/InputArea.tsx
@@ -37,8 +37,6 @@ interface InputAreaProps {
   disabled?: boolean
   isLoading?: boolean
   contextUsage?: ContextUsage | null
-  pendingMessages?: string[]
-  onRemovePending?: (index: number) => void
   dpActive?: boolean
   onSetDpActive?: (active: boolean) => void
   hasMessages?: boolean
@@ -55,8 +53,6 @@ export function InputArea({
   disabled,
   isLoading,
   contextUsage,
-  pendingMessages,
-  onRemovePending,
   dpActive,
   onSetDpActive,
   hasMessages,
@@ -82,7 +78,7 @@ export function InputArea({
     const nextHeight = Math.min(el.scrollHeight, maxHeight)
     el.style.height = `${nextHeight}px`
     el.style.overflowY = el.scrollHeight > maxHeight ? "auto" : "hidden"
-  }, [value, activePrefix, pendingMessages])
+  }, [value, activePrefix])
 
   // When external draft changes, populate input and focus
   useEffect(() => {
@@ -313,28 +309,6 @@ export function InputArea({
               </div>
             )}
 
-            {/* Pending steer messages */}
-            {pendingMessages && pendingMessages.length > 0 && (
-              <div className="flex flex-col gap-1 px-4 pb-1">
-                {pendingMessages.map((msg, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-amber-500/10 border border-amber-200 text-xs text-amber-400"
-                  >
-                    <span className="flex-1 truncate">{msg}</span>
-                    <button
-                      type="button"
-                      className="p-0.5 rounded hover:bg-amber-500/100/20 transition-colors shrink-0"
-                      onClick={() => onRemovePending?.(i)}
-                      title="Remove this instruction"
-                    >
-                      <X className="w-3 h-3" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-
             <div className="relative w-full">
               <textarea
                 ref={textareaRef}
@@ -368,7 +342,7 @@ export function InputArea({
               <button
                 onClick={handleSend}
                 className="absolute right-3 bottom-3 p-2 rounded-lg bg-blue-600 text-white shadow-md hover:bg-blue-700 transition-all"
-                title="Send steer instruction"
+                title="Send follow-up"
               >
                 <ArrowUp className="w-5 h-5" />
               </button>

--- a/portal-web/src/components/chat/PilotArea.test.ts
+++ b/portal-web/src/components/chat/PilotArea.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { findLatestEditableUserMessageId, hideEditedUserMessageBubbles } from "./PilotArea"
+
+describe("hideEditedUserMessageBubbles", () => {
+  it("hides only the edited user bubble and keeps the old assistant reply visible", () => {
+    const messages = [
+      { id: "user-old", role: "user", content: "old prompt" },
+      { id: "assistant-old", role: "assistant", content: "old answer" },
+      { id: "user-new", role: "user", content: "edited prompt" },
+    ]
+
+    expect(hideEditedUserMessageBubbles(messages, new Set(["user-old"]))).toEqual([
+      { id: "assistant-old", role: "assistant", content: "old answer" },
+      { id: "user-new", role: "user", content: "edited prompt" },
+    ])
+  })
+})
+
+describe("findLatestEditableUserMessageId", () => {
+  it("treats a steered user message as the latest editable user bubble", () => {
+    expect(
+      findLatestEditableUserMessageId(
+        [
+          { id: "user-normal", role: "user", content: "normal prompt" },
+          { id: "assistant", role: "assistant", content: "answer" },
+          {
+            id: "user-steer",
+            role: "user",
+            content: "follow-up",
+            metadata: { kind: "steer", steer_status: "steered" },
+          },
+        ],
+        false,
+      ),
+    ).toBe("user-steer")
+  })
+
+  it("allows an already-steered message to be edited while the run is still loading", () => {
+    expect(
+      findLatestEditableUserMessageId(
+        [
+          { id: "user-normal", role: "user", content: "normal prompt" },
+          {
+            id: "user-steered",
+            role: "user",
+            content: "follow-up",
+            metadata: { kind: "steer", steer_status: "steered" },
+          },
+        ],
+        true,
+      ),
+    ).toBe("user-steered")
+  })
+
+  it("does not offer edit for a pending steer that cannot be cancelled client-side", () => {
+    expect(
+      findLatestEditableUserMessageId(
+        [
+          { id: "user-normal", role: "user", content: "normal prompt" },
+          {
+            id: "user-pending-steer",
+            role: "user",
+            content: "follow-up",
+            metadata: { kind: "steer", steer_status: "pending" },
+          },
+        ],
+        true,
+      ),
+    ).toBeNull()
+  })
+})

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useCallback, useMemo, useLayoutEffect } from "react"
+import { Fragment, useRef, useEffect, useState, useCallback, useMemo, useLayoutEffect } from "react"
 import type { KeyboardEvent } from "react"
 import {
   Terminal,
@@ -164,8 +164,6 @@ export interface PilotAreaProps {
   sendMessage: (text: string) => void
   abortResponse?: () => void
   contextUsage?: ContextUsage | null
-  pendingMessages?: string[]
-  onRemovePending?: (index: number) => void
   dpActive?: boolean
   onSetDpActive?: (active: boolean) => void
   sessionKey?: string | null
@@ -184,8 +182,6 @@ export function PilotArea({
   sendMessage,
   abortResponse,
   contextUsage,
-  pendingMessages,
-  onRemovePending,
   dpActive,
   onSetDpActive,
   sessionKey,
@@ -292,6 +288,7 @@ export function PilotArea({
     for (let i = renderMessages.length - 1; i >= 0; i--) {
       const message = renderMessages[i]
       if (message.hidden || message.role !== "user" || message.isStreaming) continue
+      if (message.metadata?.kind === "steer") continue
       if (getEditableUserText(message.content)) return message.id
     }
     return null
@@ -400,34 +397,36 @@ export function PilotArea({
               {renderMessages
                 .filter((m) => !m.hidden)
                 .map((msg) => (
-                  <MessageItem
-                    key={msg.id}
-                    message={msg}
-                    sendMessage={wrappedSendMessage}
-                    showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
-                    dpActive={dpActive}
-                    canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
-                    editingContent={editingMessageId === msg.id ? editingDraft : null}
-                    onStartEditMessage={startEditingMessage}
-                    onEditMessageChange={setEditingDraft}
-                    onCancelEditMessage={cancelEditingMessage}
-                    onSubmitEditMessage={submitEditedMessage}
-                    onChipClick={(chip, meta) => {
-                      if (meta.isDpCheckpoint) {
-                        const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
-                        if (prefixChip) {
-                          setActivePrefix(prefixChip)
-                          setChipDraft(null)
-                          return
+                  <Fragment key={msg.id}>
+                    {isSteeredMessage(msg) && <SteeredConversationDivider />}
+                    <MessageItem
+                      message={msg}
+                      sendMessage={wrappedSendMessage}
+                      showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
+                      dpActive={dpActive}
+                      canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
+                      editingContent={editingMessageId === msg.id ? editingDraft : null}
+                      onStartEditMessage={startEditingMessage}
+                      onEditMessageChange={setEditingDraft}
+                      onCancelEditMessage={cancelEditingMessage}
+                      onSubmitEditMessage={submitEditedMessage}
+                      onChipClick={(chip, meta) => {
+                        if (meta.isDpCheckpoint) {
+                          const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
+                          if (prefixChip) {
+                            setActivePrefix(prefixChip)
+                            setChipDraft(null)
+                            return
+                          }
                         }
-                      }
-                      setChipSeq((s) => s + 1)
-                      setChipDraft(chip.insertText + " ")
-                    }}
-                    onOpenSkillPanel={onOpenSkillPanel}
-                    onOpenSchedulePanel={onOpenSchedulePanel}
-                    agentId={agentId}
-                  />
+                        setChipSeq((s) => s + 1)
+                        setChipDraft(chip.insertText + " ")
+                      }}
+                      onOpenSkillPanel={onOpenSkillPanel}
+                      onOpenSchedulePanel={onOpenSchedulePanel}
+                      agentId={agentId}
+                    />
+                  </Fragment>
                 ))}
 
               {/* Dig deeper — shown when agent produced a conclusion and user may want
@@ -458,8 +457,6 @@ export function PilotArea({
         disabled={false}
         isLoading={isLoading}
         contextUsage={contextUsage}
-        pendingMessages={pendingMessages}
-        onRemovePending={onRemovePending}
         dpActive={dpActive}
         onSetDpActive={onSetDpActive}
         hasMessages={messages.length > 0}
@@ -499,6 +496,24 @@ function ThinkingIndicator() {
           {THINKING_TIPS[tipIndex]}
         </span>
       </div>
+    </div>
+  )
+}
+
+function isSteeredMessage(message: PilotMessage): boolean {
+  return (
+    message.role === "user" &&
+    message.metadata?.kind === "steer" &&
+    message.metadata?.steer_status === "steered"
+  )
+}
+
+function SteeredConversationDivider() {
+  return (
+    <div className="flex items-center gap-3 text-sm text-muted-foreground/70">
+      <div className="h-px flex-1 bg-border/70" />
+      <span className="shrink-0">Steered conversation</span>
+      <div className="h-px flex-1 bg-border/70" />
     </div>
   )
 }

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -154,6 +154,67 @@ const THINKING_TIPS = [
   "Working on it...",
 ]
 
+const EDITED_MESSAGE_HIDE_STORAGE_PREFIX = "siclaw.editedHiddenMessages.v1"
+
+type EditableMessageCandidate = {
+  id: string
+  role?: string
+  content?: string
+  hidden?: boolean
+  isStreaming?: boolean
+  metadata?: Record<string, unknown>
+}
+
+function editedMessageHideStorageKey(sessionKey: string): string {
+  return `${EDITED_MESSAGE_HIDE_STORAGE_PREFIX}:${sessionKey}`
+}
+
+function readHiddenEditedMessageIds(sessionKey: string | null | undefined): Set<string> {
+  if (!sessionKey || sessionKey === "__new__" || typeof window === "undefined") return new Set()
+  try {
+    const raw = window.sessionStorage.getItem(editedMessageHideStorageKey(sessionKey))
+    const parsed = raw ? JSON.parse(raw) : []
+    return new Set(Array.isArray(parsed) ? parsed.filter((id) => typeof id === "string") : [])
+  } catch {
+    return new Set()
+  }
+}
+
+function writeHiddenEditedMessageIds(sessionKey: string | null | undefined, ids: ReadonlySet<string>): void {
+  if (!sessionKey || sessionKey === "__new__" || typeof window === "undefined") return
+  window.sessionStorage.setItem(editedMessageHideStorageKey(sessionKey), JSON.stringify([...ids]))
+}
+
+export function hideEditedUserMessageBubbles<T extends { id: string; role?: string; hidden?: boolean }>(
+  messages: readonly T[],
+  hiddenEditedMessageIds: ReadonlySet<string>,
+): T[] {
+  return messages.filter(
+    (message) => !message.hidden && !(message.role === "user" && hiddenEditedMessageIds.has(message.id)),
+  )
+}
+
+function canEditWhileLoading(message: EditableMessageCandidate): boolean {
+  return message.metadata?.kind === "steer" && message.metadata?.steer_status !== "pending"
+}
+
+function canEditUserMessageNow(message: EditableMessageCandidate | undefined, isLoading: boolean): boolean {
+  if (!message || message.hidden || message.role !== "user" || message.isStreaming) return false
+  if (!getEditableUserText(message.content ?? "")) return false
+  return !isLoading || canEditWhileLoading(message)
+}
+
+export function findLatestEditableUserMessageId(
+  messages: readonly EditableMessageCandidate[],
+  isLoading: boolean,
+): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (canEditUserMessageNow(message, isLoading)) return message.id
+  }
+  return null
+}
+
 export interface PilotAreaProps {
   messages: PilotMessage[]
   isLoading: boolean
@@ -213,6 +274,9 @@ export function PilotArea({
   const [activePrefix, setActivePrefix] = useState<PrefixActionChip | null>(null)
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null)
   const [editingDraft, setEditingDraft] = useState("")
+  const [hiddenEditedMessageIds, setHiddenEditedMessageIds] = useState<Set<string>>(() =>
+    readHiddenEditedMessageIds(sessionKey),
+  )
   const userMessageHistory = useMemo(
     () =>
       messages
@@ -225,6 +289,7 @@ export function PilotArea({
     setActivePrefix(null)
     setEditingMessageId(null)
     setEditingDraft("")
+    setHiddenEditedMessageIds(readHiddenEditedMessageIds(sessionKey))
   }, [sessionKey])
 
   const lastSentRef = useRef<string | null>(null)
@@ -284,15 +349,14 @@ export function PilotArea({
       .some((m) => m.role === "assistant" && !m.isStreaming && (m.content?.trim().length ?? 0) > 0)
   }, [messages, isLoading, dpActive])
   const renderMessages = useMemo(() => withDelegationStatusNotices(messages), [messages])
-  const latestEditableUserMessageId = useMemo(() => {
-    for (let i = renderMessages.length - 1; i >= 0; i--) {
-      const message = renderMessages[i]
-      if (message.hidden || message.role !== "user" || message.isStreaming) continue
-      if (message.metadata?.kind === "steer") continue
-      if (getEditableUserText(message.content)) return message.id
-    }
-    return null
-  }, [renderMessages])
+  const visibleRenderMessages = useMemo(
+    () => hideEditedUserMessageBubbles(renderMessages, hiddenEditedMessageIds),
+    [renderMessages, hiddenEditedMessageIds],
+  )
+  const latestEditableUserMessageId = useMemo(
+    () => findLatestEditableUserMessageId(visibleRenderMessages, isLoading),
+    [visibleRenderMessages, isLoading],
+  )
 
   const startEditingMessage = useCallback((id: string, content: string) => {
     setActivePrefix(null)
@@ -307,7 +371,17 @@ export function PilotArea({
 
   const submitEditedMessage = useCallback(() => {
     const text = editingDraft.trim()
-    if (!text || isLoading) return
+    const editedMessage = visibleRenderMessages.find((message) => message.id === editingMessageId)
+    if (!text || !canEditUserMessageNow(editedMessage, isLoading)) return
+    const editedMessageId = editingMessageId
+    if (editedMessageId) {
+      setHiddenEditedMessageIds((prev) => {
+        const next = new Set(prev)
+        next.add(editedMessageId)
+        writeHiddenEditedMessageIds(sessionKey, next)
+        return next
+      })
+    }
     wrappedSendMessage(text)
     // wrappedSendMessage records lastSentRef so wrappedAbort can restore the
     // draft if the user aborts a normal send. For edit-resends the message is
@@ -316,7 +390,7 @@ export function PilotArea({
     lastSentRef.current = null
     setEditingMessageId(null)
     setEditingDraft("")
-  }, [editingDraft, isLoading, wrappedSendMessage])
+  }, [editingDraft, editingMessageId, isLoading, sessionKey, visibleRenderMessages, wrappedSendMessage])
 
   // Auto-scroll logic
   useEffect(() => {
@@ -394,8 +468,7 @@ export function PilotArea({
                 </div>
               )}
 
-              {renderMessages
-                .filter((m) => !m.hidden)
+              {visibleRenderMessages
                 .map((msg) => {
                   const steerDivider = getSteerDivider(msg)
                   return (
@@ -406,7 +479,7 @@ export function PilotArea({
                         sendMessage={wrappedSendMessage}
                         showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
                         dpActive={dpActive}
-                        canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
+                        canEditMessage={msg.id === latestEditableUserMessageId}
                         editingContent={editingMessageId === msg.id ? editingDraft : null}
                         onStartEditMessage={startEditingMessage}
                         onEditMessageChange={setEditingDraft}

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -396,38 +396,41 @@ export function PilotArea({
 
               {renderMessages
                 .filter((m) => !m.hidden)
-                .map((msg) => (
-                  <Fragment key={msg.id}>
-                    {isSteeredMessage(msg) && <SteeredConversationDivider />}
-                    <MessageItem
-                      message={msg}
-                      sendMessage={wrappedSendMessage}
-                      showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
-                      dpActive={dpActive}
-                      canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
-                      editingContent={editingMessageId === msg.id ? editingDraft : null}
-                      onStartEditMessage={startEditingMessage}
-                      onEditMessageChange={setEditingDraft}
-                      onCancelEditMessage={cancelEditingMessage}
-                      onSubmitEditMessage={submitEditedMessage}
-                      onChipClick={(chip, meta) => {
-                        if (meta.isDpCheckpoint) {
-                          const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
-                          if (prefixChip) {
-                            setActivePrefix(prefixChip)
-                            setChipDraft(null)
-                            return
+                .map((msg) => {
+                  const steerDivider = getSteerDivider(msg)
+                  return (
+                    <Fragment key={msg.id}>
+                      {steerDivider && <SteerConversationDivider state={steerDivider} />}
+                      <MessageItem
+                        message={msg}
+                        sendMessage={wrappedSendMessage}
+                        showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
+                        dpActive={dpActive}
+                        canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
+                        editingContent={editingMessageId === msg.id ? editingDraft : null}
+                        onStartEditMessage={startEditingMessage}
+                        onEditMessageChange={setEditingDraft}
+                        onCancelEditMessage={cancelEditingMessage}
+                        onSubmitEditMessage={submitEditedMessage}
+                        onChipClick={(chip, meta) => {
+                          if (meta.isDpCheckpoint) {
+                            const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
+                            if (prefixChip) {
+                              setActivePrefix(prefixChip)
+                              setChipDraft(null)
+                              return
+                            }
                           }
-                        }
-                        setChipSeq((s) => s + 1)
-                        setChipDraft(chip.insertText + " ")
-                      }}
-                      onOpenSkillPanel={onOpenSkillPanel}
-                      onOpenSchedulePanel={onOpenSchedulePanel}
-                      agentId={agentId}
-                    />
-                  </Fragment>
-                ))}
+                          setChipSeq((s) => s + 1)
+                          setChipDraft(chip.insertText + " ")
+                        }}
+                        onOpenSkillPanel={onOpenSkillPanel}
+                        onOpenSchedulePanel={onOpenSchedulePanel}
+                        agentId={agentId}
+                      />
+                    </Fragment>
+                  )
+                })}
 
               {/* Dig deeper — shown when agent produced a conclusion and user may want
                   to trace the root cause upstream. Hidden while a prefix chip is active. */}
@@ -500,20 +503,50 @@ function ThinkingIndicator() {
   )
 }
 
-function isSteeredMessage(message: PilotMessage): boolean {
-  return (
-    message.role === "user" &&
-    message.metadata?.kind === "steer" &&
-    message.metadata?.steer_status === "steered"
-  )
+function getSteerDivider(message: PilotMessage): {
+  label: string
+  className: string
+  lineClassName: string
+  Icon?: typeof Loader2
+  iconClassName?: string
+} | null {
+  if (message.role !== "user" || message.metadata?.kind !== "steer") return null
+
+  switch (message.metadata?.steer_status) {
+    case "steered":
+      return {
+        label: "Steered conversation",
+        className: "text-muted-foreground/70",
+        lineClassName: "bg-border/70",
+      }
+    case "failed":
+      return {
+        label: "Follow-up not delivered",
+        className: "text-red-400/80",
+        lineClassName: "bg-red-400/25",
+        Icon: XCircle,
+      }
+    default:
+      return {
+        label: "Queued follow-up",
+        className: "text-blue-400/80",
+        lineClassName: "bg-blue-400/25",
+        Icon: Loader2,
+        iconClassName: "animate-spin",
+      }
+  }
 }
 
-function SteeredConversationDivider() {
+function SteerConversationDivider({ state }: { state: NonNullable<ReturnType<typeof getSteerDivider>> }) {
+  const Icon = state.Icon
   return (
-    <div className="flex items-center gap-3 text-sm text-muted-foreground/70">
-      <div className="h-px flex-1 bg-border/70" />
-      <span className="shrink-0">Steered conversation</span>
-      <div className="h-px flex-1 bg-border/70" />
+    <div className={cn("flex items-center gap-3 text-sm", state.className)}>
+      <div className={cn("h-px flex-1", state.lineClassName)} />
+      <span className="shrink-0 inline-flex items-center gap-1.5">
+        {Icon && <Icon className={cn("h-3.5 w-3.5", state.iconClassName)} />}
+        {state.label}
+      </span>
+      <div className={cn("h-px flex-1", state.lineClassName)} />
     </div>
   )
 }

--- a/portal-web/src/hooks/steer-pending.ts
+++ b/portal-web/src/hooks/steer-pending.ts
@@ -1,32 +1,4 @@
 /**
- * Pure functions for steer pending-message state management.
- *
- * Extracted so the logic can be unit-tested without React/jsdom.
- */
-
-/**
- * Match an incoming steer message (from SSE message_start) against the pending queue.
- * Returns the index of the matched pending message, or -1 if not found.
- *
- * Uses trimmed comparison to tolerate minor whitespace differences between
- * what the frontend sent and what pi-agent echoes back.
- */
-export function findPendingSteerIndex(pending: readonly string[], incomingText: string): number {
-  const trimmed = incomingText.trim()
-  if (!trimmed) return -1
-  return pending.findIndex((p) => p.trim() === trimmed)
-}
-
-/**
- * Remove a pending message by index, returning the new array.
- * Returns the original array unchanged if index is out of bounds.
- */
-export function removePendingAt(pending: readonly string[], index: number): string[] {
-  if (index < 0 || index >= pending.length) return [...pending]
-  return [...pending.slice(0, index), ...pending.slice(index + 1)]
-}
-
-/**
  * Extract text from a pi-ai UserMessage content field.
  * content can be a plain string or an array of TextContent/ImageContent blocks.
  */

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -13,7 +13,7 @@ import type {
   ContextUsage,
   ErrorDetail,
 } from "../components/chat/types"
-import { findPendingSteerIndex, removePendingAt, extractUserMessageText } from "./steer-pending"
+import { extractUserMessageText } from "./steer-pending"
 
 /** Parse an unknown payload into an ErrorDetail with backward-compat fallbacks.
  *  See docs/design/error-envelope.md §4. */
@@ -90,7 +90,6 @@ interface UsePilotChatReturn {
   dpActive: boolean
   contextUsage: ContextUsage | null
   isCompacting: boolean
-  pendingMessages: string[]
   hasMore: boolean
   loadingMore: boolean
   send: (text: string) => void
@@ -98,7 +97,6 @@ interface UsePilotChatReturn {
   abort: () => void
   loadMore: () => void
   setDpActive: (active: boolean) => void
-  removePending: (index: number) => void
   exitDp: () => void
 }
 
@@ -201,6 +199,10 @@ function formatToolInput(toolName: string, args?: Record<string, unknown>): stri
 /** Reduce individual progress events into accumulated investigation state */
 function timeNow(): string {
   return new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+}
+
+function randomMessageId(prefix: string): string {
+  return `${prefix}-${typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(36)}`
 }
 
 function tryParseJson(s: string): Record<string, unknown> | undefined {
@@ -326,6 +328,28 @@ function toPilotMessage(m: ChatMessage): PilotMessage {
     timestamp: formatPortalTimestamp(m.created_at),
     isStreaming: toolStatus === "running",
   }
+}
+
+function makePendingSteerMessage(text: string): PilotMessage {
+  return {
+    id: randomMessageId("steer"),
+    role: "user",
+    content: text,
+    timestamp: timeNow(),
+    metadata: {
+      kind: "steer",
+      steer_status: "pending",
+    },
+  }
+}
+
+function isPendingSteerMessage(message: PilotMessage, text?: string): boolean {
+  return (
+    message.role === "user" &&
+    message.metadata?.kind === "steer" &&
+    message.metadata?.steer_status !== "steered" &&
+    (text == null || message.content.trim() === text.trim())
+  )
 }
 
 function hasRunningPersistedMessages(messages: PilotMessage[]): boolean {
@@ -457,7 +481,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const [streamText, setStreamText] = useState("")
   const [dpActive, setDpActive] = useState(false)
   const [contextUsage, setContextUsage] = useState<ContextUsage | null>(null)
-  const [pendingMessages, setPendingMessages] = useState<string[]>([])
   const [hasMore, setHasMore] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const pageRef = useRef(1)
@@ -629,7 +652,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           recoveredStreamingRef.current = false
           setStreaming(false)
           streamingRef.current = false
-          setPendingMessages([])
           return
         }
       } catch (err) {
@@ -836,26 +858,44 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
               }
             | undefined
 
-          // Show steer (user) messages injected mid-conversation.
-          // The initial prompt's user message is already displayed by send(),
-          // so only create a PilotMessage if the text is in pendingMessages (= steer).
+          // Mark a previously submitted follow-up as truly consumed by the
+          // runtime. The user bubble entered the message list when the user
+          // clicked send; this event only moves it from pending → steered.
           if (msg?.role === "user") {
             const text = extractUserMessageText(msg.content)
             if (text) {
-              setPendingMessages((prev) => {
-                const idx = findPendingSteerIndex(prev, text)
-                if (idx < 0) return prev // not a steer — already displayed
-                // Steer message: add to chat and remove from pending
-                setMessages((msgs) => [
-                  ...msgs,
+              const dbMessageId = typeof evt.dbMessageId === "string" ? evt.dbMessageId : undefined
+              setMessages((prev) => {
+                let idx = dbMessageId
+                  ? prev.findIndex((message) => message.id === dbMessageId)
+                  : -1
+                if (idx < 0) {
+                  idx = prev.findIndex((message) => isPendingSteerMessage(message, text))
+                }
+                if (idx >= 0) {
+                  const current = prev[idx]
+                  const next: PilotMessage = {
+                    ...current,
+                    ...(dbMessageId ? { id: dbMessageId } : {}),
+                    metadata: {
+                      ...(current.metadata ?? {}),
+                      kind: "steer",
+                      steer_status: "steered",
+                    },
+                  }
+                  return [...prev.slice(0, idx), next, ...prev.slice(idx + 1)]
+                }
+                if (!dbMessageId) return prev
+                return [
+                  ...prev,
                   {
-                    id: `msg-${Date.now()}`,
+                    id: dbMessageId,
                     role: "user" as const,
                     content: text,
                     timestamp: timeNow(),
+                    metadata: { kind: "steer", steer_status: "steered" },
                   },
-                ])
-                return removePendingAt(prev, idx)
+                ]
               })
             }
           }
@@ -934,7 +974,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
             streamingRef.current = false
             recoveredStreamingRef.current = false
           }
-          setPendingMessages([])
           break
 
         // --- Agent start (agent started processing) ---
@@ -951,7 +990,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           setStreaming(false)
           streamingRef.current = false
           recoveredStreamingRef.current = false
-          setPendingMessages([])
           // Update context usage from agent_end event
           const cu = evt.contextUsage as ContextUsage | undefined
           if (cu) {
@@ -994,13 +1032,72 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     }
   }, [agentId, sessionId, hasMore, loadingMore])
 
+  const submitSteer = useCallback(
+    (text: string) => {
+      if (!sessionId) return
+      const optimistic = makePendingSteerMessage(text)
+      setMessages((prev) => [...prev, optimistic])
+
+      chatSteer(agentId, sessionId, text)
+        .then((res) => {
+          const persisted = res.message
+          if (!persisted) return
+          setMessages((prev) => {
+            let idx = prev.findIndex((message) => message.id === optimistic.id)
+            if (idx < 0) {
+              idx = prev.findIndex((message) => message.id === persisted.id)
+            }
+            if (idx < 0) return prev
+            const current = prev[idx]
+            const nextMetadata = {
+              ...(persisted.metadata ?? {}),
+              ...(current.metadata?.steer_status === "steered" ? current.metadata : {}),
+            }
+            const next: PilotMessage = {
+              ...current,
+              id: persisted.id,
+              content: persisted.content,
+              metadata: nextMetadata,
+              timestamp: persisted.created_at ? formatPortalTimestamp(persisted.created_at) : current.timestamp,
+            }
+            return [...prev.slice(0, idx), next, ...prev.slice(idx + 1)]
+          })
+        })
+        .catch((err) => {
+          console.error("[usePilotChat] steer error:", err)
+          setMessages((prev) => {
+            const idx = prev.findIndex((message) => message.id === optimistic.id)
+            if (idx < 0) return prev
+            const current = prev[idx]
+            const failed: PilotMessage = {
+              ...current,
+              metadata: {
+                ...(current.metadata ?? {}),
+                kind: "steer",
+                steer_status: "failed",
+              },
+            }
+            return [...prev.slice(0, idx), failed, ...prev.slice(idx + 1)]
+          })
+          const body = (err as { body?: unknown }).body
+          const detail = body !== undefined
+            ? parseErrorDetail(body)
+            : {
+                code: "INTERNAL_ERROR",
+                message: err instanceof Error ? err.message : "Failed to steer",
+                retriable: true,
+              }
+          setMessages((prev) => [...prev, makeErrorMessage(detail)])
+        })
+    },
+    [agentId, sessionId],
+  )
+
   // --- Send a message ---
   const send = useCallback(
     (text: string) => {
       if ((streamingRef.current || hasPendingDelegationSynthesis(messages)) && sessionId) {
-        // While streaming, send as steer
-        chatSteer(agentId, sessionId, text).catch((err) => console.error("[usePilotChat] steer error:", err))
-        setPendingMessages((prev) => [...prev, text])
+        submitSteer(text)
         return
       }
 
@@ -1107,7 +1204,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
                     setStreaming(false)
                     streamingRef.current = false
                     recoveredStreamingRef.current = false
-                    setPendingMessages([])
                   }
                   // Update cache: mark stream as finished so switching back shows final state
                   if (streamSessionId) { const cached = messagesCacheRef.current.get(streamSessionId); if (cached) cached.streaming = false }
@@ -1173,35 +1269,21 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         }
       })()
     },
-    [agentId, sessionId, messages, handleChatEvent],
+    [agentId, sessionId, messages, handleChatEvent, submitSteer],
   )
 
   // --- Steer ---
   const steer = useCallback(
     (text: string) => {
-      if (!sessionId) return
-      chatSteer(agentId, sessionId, text).catch((err) => {
-        console.error("[usePilotChat] steer error:", err)
-        const body = (err as { body?: unknown }).body
-        const detail = body !== undefined
-          ? parseErrorDetail(body)
-          : {
-              code: "INTERNAL_ERROR",
-              message: err instanceof Error ? err.message : "Failed to steer",
-              retriable: true,
-            }
-        setMessages((prev) => [...prev, makeErrorMessage(detail)])
-      })
-      setPendingMessages((prev) => [...prev, text])
+      submitSteer(text)
     },
-    [agentId, sessionId],
+    [submitSteer],
   )
 
   // --- Abort ---
   const abort = useCallback(async () => {
     if (!sessionId) return
     isAbortingRef.current = true
-    setPendingMessages([])
     // Mark all streaming messages as complete visually
     setMessages((prev) =>
       prev.map((m) =>
@@ -1223,11 +1305,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     recoveredStreamingRef.current = false
   }, [agentId, sessionId])
 
-  // --- Remove pending ---
-  const removePending = useCallback((index: number) => {
-    setPendingMessages((prev) => [...prev.slice(0, index), ...prev.slice(index + 1)])
-  }, [])
-
   // --- Exit DP ---
   const exitDp = useCallback(() => {
     if (sessionId) {
@@ -1243,7 +1320,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     dpActive,
     contextUsage,
     isCompacting,
-    pendingMessages,
     hasMore,
     loadingMore,
     send,
@@ -1251,7 +1327,6 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     abort,
     loadMore,
     setDpActive,
-    removePending,
     exitDp,
   }
 }

--- a/src/gateway/chat-repo.test.ts
+++ b/src/gateway/chat-repo.test.ts
@@ -5,6 +5,7 @@ import {
   appendMessage,
   appendDelegationEvent,
   updateMessage,
+  markSteerConsumed,
   updateDelegationToolMessage,
   incrementMessageCount,
   getMessages,
@@ -279,6 +280,29 @@ describe("updateMessage", () => {
         duration_ms: 42,
       },
     });
+  });
+});
+
+describe("markSteerConsumed", () => {
+  it("marks a persisted steer row as consumed and returns the row id", async () => {
+    fake.responses.set("chat.markSteerConsumed", { id: "msg-steer" });
+
+    const id = await markSteerConsumed({ sessionId: "sid", content: "follow up" });
+
+    expect(id).toBe("msg-steer");
+    expect(fake.calls[0]).toEqual({
+      method: "chat.markSteerConsumed",
+      params: {
+        session_id: "sid",
+        content: "follow up",
+      },
+    });
+  });
+
+  it("returns null when the adapter has no matching pending steer row", async () => {
+    fake.responses.set("chat.markSteerConsumed", { id: null });
+
+    await expect(markSteerConsumed({ sessionId: "sid", content: "missing" })).resolves.toBeNull();
   });
 });
 

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -47,6 +47,11 @@ export interface UpdateMessageInput {
   delegationId?: string | null;
 }
 
+export interface MarkSteerConsumedInput {
+  sessionId: string;
+  content: string;
+}
+
 export interface UpdateDelegationToolMessageInput {
   sessionId: string;
   toolName: string;
@@ -207,6 +212,15 @@ export async function updateMessage(msg: UpdateMessageInput): Promise<void> {
     duration_ms: msg.durationMs ?? null,
     delegation_id: msg.delegationId ?? null,
   });
+}
+
+/** Mark the first pending steer user message with matching content as consumed by runtime. */
+export async function markSteerConsumed(msg: MarkSteerConsumedInput): Promise<string | null> {
+  const result = await getClient().request("chat.markSteerConsumed", {
+    session_id: msg.sessionId,
+    content: msg.content,
+  });
+  return typeof result.id === "string" ? result.id : null;
 }
 
 /** Update the parent async delegation tool row after its background batch finishes. */

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -8,7 +8,9 @@ import { AgentBoxClient } from "./agentbox/client.js";
 
 const appendCalls: any[] = [];
 const updateCalls: any[] = [];
+const markSteerCalls: any[] = [];
 let appendCounter = 0;
+let nextMarkedSteerId: string | null = "msg-steer";
 
 vi.mock("./chat-repo.js", () => ({
   appendMessage: vi.fn(async (msg: any) => {
@@ -17,6 +19,10 @@ vi.mock("./chat-repo.js", () => ({
   }),
   updateMessage: vi.fn(async (msg: any) => {
     updateCalls.push(msg);
+  }),
+  markSteerConsumed: vi.fn(async (msg: any) => {
+    markSteerCalls.push(msg);
+    return nextMarkedSteerId;
   }),
   incrementMessageCount: vi.fn(async () => {}),
   ensureChatSession: vi.fn(async () => {}),
@@ -41,7 +47,9 @@ function mkClient(events: unknown[]): AgentBoxClient {
 beforeEach(() => {
   appendCalls.length = 0;
   updateCalls.length = 0;
+  markSteerCalls.length = 0;
   appendCounter = 0;
+  nextMarkedSteerId = "msg-steer";
 });
 
 // ── Tests ──────────────────────────────────────────────
@@ -57,6 +65,34 @@ describe("consumeAgentSse — empty stream", () => {
 });
 
 describe("consumeAgentSse — assistant message flow", () => {
+  it("marks persisted steer messages consumed when a user message_start arrives", async () => {
+    const onEvent = vi.fn();
+    const events = [
+      { type: "message_start", message: { role: "user", content: [{ type: "text", text: "try this next" }] } },
+    ];
+
+    await consumeAgentSse({
+      client: mkClient(events),
+      sessionId: "sid",
+      userId: "u",
+      persistMessages: true,
+      onEvent,
+    });
+
+    expect(markSteerCalls).toEqual([{ sessionId: "sid", content: "try this next" }]);
+    expect(onEvent).toHaveBeenCalledWith(events[0], "message_start", { dbMessageId: "msg-steer" });
+  });
+
+  it("does not mark user message_start events when persistence is disabled", async () => {
+    const events = [
+      { type: "message_start", message: { role: "user", content: "not persisted" } },
+    ];
+
+    await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u" });
+
+    expect(markSteerCalls).toHaveLength(0);
+  });
+
   it("accumulates text deltas across message_update events and returns the concatenated result", async () => {
     const events = [
       { type: "message_start" },

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -13,7 +13,7 @@
 
 import { ErrorCodes } from "../lib/error-envelope.js";
 import { AgentBoxClient } from "./agentbox/client.js";
-import { appendMessage, incrementMessageCount, updateMessage } from "./chat-repo.js";
+import { appendMessage, incrementMessageCount, markSteerConsumed, updateMessage } from "./chat-repo.js";
 import { redactText, type RedactionConfig } from "./output-redactor.js";
 
 // ── Public types ────────────────────────────────────
@@ -323,6 +323,19 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         // this message_start fired.
         assistantMsgFirstTextTime = undefined;
         pendingThinkingMs = undefined;
+      } else if (persist && message?.role === "user") {
+        const content = message.content;
+        const text = typeof content === "string"
+          ? content
+          : Array.isArray(content)
+            ? (content as Array<{ type?: string; text?: string }>)
+                .filter((c) => c.type === "text")
+                .map((c) => c.text ?? "")
+                .join("")
+            : "";
+        if (text.trim()) {
+          dbMessageId = (await markSteerConsumed({ sessionId, content: text })) ?? undefined;
+        }
       }
     }
 

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -835,6 +835,50 @@ describe("chat.updateMessage", () => {
   });
 });
 
+describe("chat.markSteerConsumed", () => {
+  it("marks the oldest matching pending steer row as steered", async () => {
+    const query = mockQuery([
+      { id: "m1", metadata: JSON.stringify({ kind: "steer", steer_status: "steered" }) },
+      { id: "m2", metadata: JSON.stringify({ kind: "steer", steer_status: "pending", queued_at: "2026-05-22T00:00:00.000Z" }) },
+      { id: "m3", metadata: JSON.stringify({ kind: "steer", steer_status: "pending" }) },
+    ], [], []);
+
+    const result = await getHandler("chat.markSteerConsumed")(
+      { session_id: "sess1", content: "follow up" },
+      "a1",
+    );
+
+    expect(result).toEqual({ id: "m2" });
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(query.mock.calls[0][0]).toContain("WHERE session_id = ? AND role = 'user' AND content = ?");
+    expect(query.mock.calls[0][1]).toEqual(["sess1", "follow up"]);
+    expect(query.mock.calls[1][0]).toContain("UPDATE chat_messages SET metadata");
+    expect(JSON.parse(query.mock.calls[1][1][0])).toMatchObject({
+      kind: "steer",
+      steer_status: "steered",
+      queued_at: "2026-05-22T00:00:00.000Z",
+      steered_at: expect.any(String),
+    });
+    expect(query.mock.calls[1][1].slice(1)).toEqual(["m2", "sess1"]);
+    expect(query.mock.calls[2][0]).toContain("UPDATE chat_sessions SET last_active_at");
+  });
+
+  it("returns null when no pending steer row matches", async () => {
+    const query = mockQuery([
+      { id: "m1", metadata: JSON.stringify({ kind: "steer", steer_status: "steered" }) },
+      { id: "m2", metadata: JSON.stringify({ kind: "delegation_event" }) },
+    ]);
+
+    const result = await getHandler("chat.markSteerConsumed")(
+      { session_id: "sess1", content: "follow up" },
+      "a1",
+    );
+
+    expect(result).toEqual({ id: null });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("chat.updateDelegationToolMessage", () => {
   it("updates async delegation tool rows by delegation id", async () => {
     const query = mockQuery([], []);
@@ -1348,9 +1392,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 44 handlers", () => {
+  it("registers exactly 45 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(44);
+    expect(handlers.size).toBe(45);
   });
 
   it("all expected handler names are registered", () => {
@@ -1361,7 +1405,7 @@ describe("buildAdapterRpcHandlers", () => {
       "config.getSystemConfig", "config.setSystemConfig", "config.getDefaultModel",
       "credential.list", "credential.get", "credential.checkAccess",
       "credential.resourceManifest", "credential.hostSearch",
-      "chat.ensureSession", "chat.resolveSession", "chat.appendMessage", "chat.updateMessage", "chat.updateDelegationToolMessage", "chat.getMessages",
+      "chat.ensureSession", "chat.resolveSession", "chat.appendMessage", "chat.updateMessage", "chat.markSteerConsumed", "chat.updateDelegationToolMessage", "chat.getMessages",
       "task.listActive", "task.getStatus", "task.list", "task.create",
       "task.update", "task.delete", "task.runRecord", "task.runStart",
       "task.runFinalize", "task.updateMeta", "task.fireNow", "task.notify", "task.prune",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1947,6 +1947,38 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     return { ok: true };
   });
 
+  handlers.set("chat.markSteerConsumed", async (params) => {
+    const db = getDb();
+    const [rows] = await db.query(
+      `SELECT id, metadata FROM chat_messages
+       WHERE session_id = ? AND role = 'user' AND content = ?
+       ORDER BY created_at ASC, id ASC`,
+      [params.session_id, params.content ?? ""],
+    ) as any;
+
+    for (const row of rows as any[]) {
+      const metadata = safeParseJson(row.metadata, null) as Record<string, unknown> | null;
+      if (metadata?.kind !== "steer" || metadata.steer_status === "steered") continue;
+
+      const nextMetadata = {
+        ...metadata,
+        steer_status: "steered",
+        steered_at: new Date().toISOString(),
+      };
+      await db.query(
+        `UPDATE chat_messages SET metadata = ? WHERE id = ? AND session_id = ?`,
+        [jsonParam(nextMetadata), row.id, params.session_id],
+      );
+      await db.query(
+        `UPDATE chat_sessions SET last_active_at = CURRENT_TIMESTAMP WHERE id = ?`,
+        [params.session_id],
+      );
+      return { id: row.id };
+    }
+
+    return { id: null };
+  });
+
   handlers.set("chat.updateDelegationToolMessage", async (params) => {
     const db = getDb();
     await db.query(

--- a/src/portal/chat-gateway.test.ts
+++ b/src/portal/chat-gateway.test.ts
@@ -242,6 +242,10 @@ describe("chat-gateway routes", () => {
 
     it("forwards to runtime and returns 200 on ok", async () => {
       connMap.sendCommand = vi.fn().mockResolvedValue({ ok: true });
+      query
+        .mockResolvedValueOnce([[{ id: "s1" }], []])
+        .mockResolvedValueOnce([[], []])
+        .mockResolvedValueOnce([[], []]);
       const res = await runRoute(router, fakeReq({
         url: "/api/v1/siclaw/agents/a1/chat/steer",
         method: "POST",
@@ -252,10 +256,24 @@ describe("chat-gateway routes", () => {
       expect(connMap.sendCommand).toHaveBeenCalledWith("a1", "chat.steer", expect.objectContaining({
         sessionId: "s1", text: "redirect",
       }));
+      expect(query.mock.calls[1][0]).toContain("INSERT INTO chat_messages");
+      expect(JSON.parse(query.mock.calls[1][1][3])).toMatchObject({
+        kind: "steer",
+        steer_status: "pending",
+      });
+      expect(JSON.parse(res._body).message).toMatchObject({
+        role: "user",
+        content: "redirect",
+      });
     });
 
     it("returns 502 when runtime RPC fails", async () => {
       connMap.sendCommand = vi.fn().mockResolvedValue({ ok: false, error: "nope" });
+      query
+        .mockResolvedValueOnce([[{ id: "s1" }], []])
+        .mockResolvedValueOnce([[], []])
+        .mockResolvedValueOnce([[], []])
+        .mockResolvedValueOnce([[], []]);
       const res = await runRoute(router, fakeReq({
         url: "/api/v1/siclaw/agents/a1/chat/steer",
         method: "POST",
@@ -263,6 +281,19 @@ describe("chat-gateway routes", () => {
         body: { session_id: "s1", text: "x" },
       }));
       expect(res._status).toBe(502);
+      expect(query.mock.calls[3][0]).toContain("UPDATE chat_messages SET metadata");
+    });
+
+    it("returns 404 when steering a session that does not belong to the user", async () => {
+      query.mockResolvedValueOnce([[], []]);
+      const res = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/steer",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: { session_id: "missing", text: "x" },
+      }));
+      expect(res._status).toBe(404);
+      expect(connMap.sendCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -111,6 +111,62 @@ function sseWrite(res: import("node:http").ServerResponse, event: string, data: 
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
+function steerMetadata(status: "pending" | "failed"): Record<string, unknown> {
+  return {
+    kind: "steer",
+    steer_status: status,
+    created_at: new Date().toISOString(),
+  };
+}
+
+async function appendPendingSteerMessage(
+  agentId: string,
+  userId: string,
+  sessionId: string,
+  text: string,
+): Promise<{
+  id: string;
+  session_id: string;
+  role: "user";
+  content: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}> {
+  const db = getDb();
+  const [sessionRows] = await db.query(
+    "SELECT id FROM chat_sessions WHERE id = ? AND agent_id = ? AND user_id = ? AND deleted_at IS NULL",
+    [sessionId, agentId, userId],
+  ) as any;
+  if (!Array.isArray(sessionRows) || sessionRows.length === 0) {
+    throw Object.assign(new Error("Session not found"), { statusCode: 404 });
+  }
+
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  const metadata = steerMetadata("pending");
+  await db.query(
+    `INSERT INTO chat_messages (id, session_id, role, content, metadata)
+     VALUES (?, ?, 'user', ?, ?)`,
+    [id, sessionId, text, JSON.stringify(metadata)],
+  );
+  await db.query(
+    `UPDATE chat_sessions
+     SET message_count = message_count + 1, last_active_at = CURRENT_TIMESTAMP
+     WHERE id = ?`,
+    [sessionId],
+  );
+
+  return { id, session_id: sessionId, role: "user", content: text, metadata, created_at: createdAt };
+}
+
+async function markSteerMessageFailed(sessionId: string, messageId: string): Promise<void> {
+  const db = getDb();
+  await db.query(
+    `UPDATE chat_messages SET metadata = ? WHERE id = ? AND session_id = ?`,
+    [JSON.stringify({ ...steerMetadata("failed"), failed_at: new Date().toISOString() }), messageId, sessionId],
+  );
+}
+
 export function registerChatRoutes(
   router: RestRouter,
   connectionMap: RuntimeConnectionMap,
@@ -244,6 +300,17 @@ export function registerChatRoutes(
     const body = await parseBody<{ session_id?: string; text?: string }>(req);
     if (!body.session_id || !body.text) { sendJson(res, 400, { error: "session_id and text are required" }); return; }
 
+    let message: Awaited<ReturnType<typeof appendPendingSteerMessage>>;
+    try {
+      message = await appendPendingSteerMessage(params.id, auth.userId, body.session_id, body.text);
+    } catch (err) {
+      const statusCode = typeof (err as { statusCode?: unknown }).statusCode === "number"
+        ? (err as { statusCode: number }).statusCode
+        : 500;
+      sendJson(res, statusCode, { error: err instanceof Error ? err.message : "Failed to persist steer message" });
+      return;
+    }
+
     const result = await connectionMap.sendCommand(params.id, "chat.steer", {
       agentId: params.id,
       userId: auth.userId,
@@ -251,7 +318,13 @@ export function registerChatRoutes(
       text: body.text,
     });
 
-    sendJson(res, result.ok ? 200 : 502, result);
+    if (!result.ok) {
+      await markSteerMessageFailed(body.session_id, message.id).catch(() => {});
+      sendJson(res, 502, { ...result, message });
+      return;
+    }
+
+    sendJson(res, 200, { ...result, message });
   });
 
   // POST /api/v1/siclaw/agents/:id/chat/abort — abort current execution

--- a/src/portal/migrate-sqlite.test.ts
+++ b/src/portal/migrate-sqlite.test.ts
@@ -68,6 +68,7 @@ describe("runPortalMigrations on SQLite :memory:", () => {
     // legacy idempotence.
     const expectedIndexes = [
       "idx_chat_sessions_user",
+      "idx_chat_sessions_user_pinned",
       "idx_chat_sessions_agent",
       "idx_chat_sessions_origin",
       "idx_chat_sessions_parent",
@@ -144,9 +145,13 @@ describe("runPortalMigrations on SQLite :memory:", () => {
 
     // Later-added index co-exists with the pre-populated legacy index.
     const [idxRows] = await db.query<Array<{ name: string }>>(
-      "SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('idx_chat_sessions_user', 'idx_chat_sessions_agent')",
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('idx_chat_sessions_user', 'idx_chat_sessions_agent', 'idx_chat_sessions_user_pinned')",
     );
-    expect(idxRows.map((r) => r.name).sort()).toEqual(["idx_chat_sessions_agent", "idx_chat_sessions_user"]);
+    expect(idxRows.map((r) => r.name).sort()).toEqual([
+      "idx_chat_sessions_agent",
+      "idx_chat_sessions_user",
+      "idx_chat_sessions_user_pinned",
+    ]);
   });
 
   it("is idempotent when run twice", async () => {
@@ -188,6 +193,8 @@ describe("runPortalMigrations on SQLite :memory:", () => {
       "parent_agent_id",
       "delegation_id",
       "target_agent_id",
+      "last_viewed_at",
+      "pinned_at",
     ]));
 
     const [messageRows] = await db.query<Array<{ name: string }>>("PRAGMA table_info(chat_messages)");

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -286,6 +286,8 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     target_agent_id CHAR(36) DEFAULT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_active_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_viewed_at TIMESTAMP NULL DEFAULT NULL,
+    pinned_at TIMESTAMP NULL DEFAULT NULL,
     deleted_at TIMESTAMP NULL DEFAULT NULL
   )`,
 
@@ -455,6 +457,7 @@ async function createIndexes(): Promise<void> {
   const db = getDb();
   // chat_sessions
   await ensureIndex(db, "chat_sessions", "idx_chat_sessions_user", "user_id, last_active_at");
+  await ensureIndex(db, "chat_sessions", "idx_chat_sessions_user_pinned", "user_id, pinned_at, last_active_at");
   await ensureIndex(db, "chat_sessions", "idx_chat_sessions_agent", "agent_id");
   await ensureIndex(db, "chat_sessions", "idx_chat_sessions_origin", "origin");
   await ensureIndex(db, "chat_sessions", "idx_chat_sessions_parent", "parent_session_id, created_at");
@@ -500,6 +503,8 @@ export async function runPortalMigrations(): Promise<void> {
   await safeAlterTable(db, "chat_sessions", "parent_agent_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "delegation_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "target_agent_id", "CHAR(36) DEFAULT NULL");
+  await safeAlterTable(db, "chat_sessions", "last_viewed_at", "TIMESTAMP NULL DEFAULT NULL");
+  await safeAlterTable(db, "chat_sessions", "pinned_at", "TIMESTAMP NULL DEFAULT NULL");
   await safeAlterTable(db, "chat_messages", "from_agent_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_messages", "parent_session_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_messages", "delegation_id", "CHAR(36) DEFAULT NULL");
@@ -518,6 +523,7 @@ export async function runPortalMigrations(): Promise<void> {
 
   // Data backfill (safe to run repeatedly).
   await db.query("UPDATE chat_sessions SET origin = 'task' WHERE origin = 'cron'");
+  await db.query("UPDATE chat_sessions SET last_viewed_at = last_active_at WHERE last_viewed_at IS NULL");
   await db.query("UPDATE skills SET is_builtin = 1 WHERE created_by = 'system' AND is_builtin = 0");
 
   console.log("[portal-migrate] All tables ready");

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -141,6 +141,22 @@ describe("siclaw-api misc routes", () => {
       expect(status).toBe(200);
       expect(body.data ?? body.sessions ?? body).toBeDefined();
     });
+
+    it("orders pinned sessions first and then by last activity", async () => {
+      query
+        .mockResolvedValueOnce([[{ count: 2 }], []])
+        .mockResolvedValueOnce([[{ id: "pinned" }, { id: "active" }], []]);
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/sessions",
+        method: "GET",
+      }));
+
+      expect(status).toBe(200);
+      expect(body.data.map((s: { id: string }) => s.id)).toEqual(["pinned", "active"]);
+      expect(query.mock.calls[1][0]).toContain("pinned_at DESC");
+      expect(query.mock.calls[1][0]).toContain("last_active_at DESC");
+    });
   });
 
   describe("POST /api/v1/siclaw/agents/:id/chat/sessions", () => {
@@ -172,6 +188,40 @@ describe("siclaw-api misc routes", () => {
       expect(query.mock.calls[1][0]).toContain("UPDATE chat_sessions SET title = ?");
       expect(query.mock.calls[1][1][0]).toBe("");
       expect(body.title).toBe("");
+    });
+
+    it("toggles pin state without requiring a title change", async () => {
+      query
+        .mockResolvedValueOnce([[{ id: "s1" }], []])
+        .mockResolvedValueOnce([{}, []])
+        .mockResolvedValueOnce([[{ id: "s1", pinned_at: "2026-05-22 01:02:03" }], []]);
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/sessions/s1",
+        method: "PUT",
+        body: { pinned: true },
+      }));
+
+      expect(status).toBe(200);
+      expect(query.mock.calls[1][0]).toContain("pinned_at = CURRENT_TIMESTAMP");
+      expect(body.pinned_at).toBe("2026-05-22 01:02:03");
+    });
+
+    it("marks sessions viewed for active-dot acknowledgement", async () => {
+      query
+        .mockResolvedValueOnce([[{ id: "s1" }], []])
+        .mockResolvedValueOnce([{}, []])
+        .mockResolvedValueOnce([[{ id: "s1", last_viewed_at: "2026-05-22 01:02:03" }], []]);
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/sessions/s1",
+        method: "PUT",
+        body: { viewed: true },
+      }));
+
+      expect(status).toBe(200);
+      expect(query.mock.calls[1][0]).toContain("last_viewed_at = CURRENT_TIMESTAMP");
+      expect(body.last_viewed_at).toBe("2026-05-22 01:02:03");
     });
   });
 

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -1548,7 +1548,11 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
         `SELECT * FROM chat_sessions
          WHERE agent_id = ? AND user_id = ? AND deleted_at IS NULL
            AND (origin IS NULL OR origin NOT IN ('task', 'delegation'))
-         ORDER BY last_active_at DESC LIMIT ? OFFSET ?`,
+         ORDER BY CASE WHEN pinned_at IS NULL THEN 1 ELSE 0 END ASC,
+                  pinned_at DESC,
+                  last_active_at DESC,
+                  created_at DESC
+         LIMIT ? OFFSET ?`,
         [params.id, auth.userId, pageSize, offset],
       ),
     ]) as [any, any];
@@ -1571,8 +1575,8 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const db = getDb();
 
     await db.query(
-      `INSERT INTO chat_sessions (id, agent_id, user_id, title, preview, message_count, last_active_at)
-       VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+      `INSERT INTO chat_sessions (id, agent_id, user_id, title, preview, message_count, last_active_at, last_viewed_at)
+       VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
       [
         id, params.id, auth.userId,
         normalizeChatSessionTitle(body.title), normalizeChatSessionPreview(body.preview), 0,
@@ -1603,6 +1607,14 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const fields: string[] = [];
     const values: unknown[] = [];
     if ("title" in body) { fields.push("title = ?"); values.push(truncateChatSessionTitle(body.title)); }
+    if ("pinned" in body) {
+      if (typeof body.pinned !== "boolean") { sendJson(res, 400, { error: "pinned must be a boolean" }); return; }
+      fields.push(body.pinned ? "pinned_at = CURRENT_TIMESTAMP" : "pinned_at = NULL");
+    }
+    if ("viewed" in body) {
+      if (typeof body.viewed !== "boolean") { sendJson(res, 400, { error: "viewed must be a boolean" }); return; }
+      fields.push(body.viewed ? "last_viewed_at = CURRENT_TIMESTAMP" : "last_viewed_at = NULL");
+    }
     if (fields.length === 0) { sendJson(res, 400, { error: "Nothing to update" }); return; }
 
     values.push(params.sid);


### PR DESCRIPTION
## Summary

- Persist queued/steered follow-up messages as regular user messages in the chat transcript instead of keeping them only in transient input state.
- Mark messages as `Steered conversation` when the runtime actually starts processing them.
- Add active session history controls: pinned sessions, activity-based ordering, viewed/unread tracking, top active sessions with Show more, and a lightweight refresh loop while the drawer is open.

## Why

The prior queue UI made follow-ups feel separate from the conversation and could lose visible state on refresh. The Codex-style behavior is simpler: queued messages live in the transcript immediately, then get labeled as steered when they are actually consumed. Session history also needed to be driven by real activity time rather than creation time, with pinned and unread state visible in the drawer.

## Validation

- `npm test`
- `cd portal-web && npm test`
- `npm run build`
- `cd portal-web && npm run build`
- Deployed and validated in `sdliu-siclaw` with portal image `registry-cn-shanghai.siflow.cn/k8s/siclaw-portal:session-history-refresh-c0777d7-20260522154032`.
- Verified in UI that pinned sessions have a separate section/marker, active sessions refresh while the drawer stays open, and unread blue dots appear without switching sessions.
