### PR TITLE
docs: align README audience tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Siclaw
 
-**Read-only investigation copilot for SRE teams**
+**Read-only investigation copilot for DevOps and SRE teams**
 
 [![npm](https://img.shields.io/npm/v/siclaw?logo=npm)](https://www.npmjs.com/package/siclaw)
 [![CI](https://github.com/scitix/siclaw/actions/workflows/ci.yml/badge.svg)](https://github.com/scitix/siclaw/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary
- Align the README hero tagline with the opening product description by naming both DevOps and SRE teams.

## Verification
- Checked the branch diff only changes the README tagline line.