### PR TITLE
Add portal attachment OCR parsing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.DS_Store
+
+node_modules
+portal-web/node_modules
+
+dist
+portal-web/dist
+coverage
+
+*.log
+__pycache__
+*.pyc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - run: npm ci
+      - run: PYTHONPATH=services/ocr-backend python -m unittest discover -s services/ocr-backend -p '*_test.py'
       - run: npm test
 
   portal-web-test:

--- a/Dockerfile.ocr
+++ b/Dockerfile.ocr
@@ -1,0 +1,43 @@
+FROM python:3.11-slim-bookworm
+
+ARG PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_INDEX_URL=${PIP_INDEX_URL} \
+    PADDLEOCR_BACKEND_HOST=0.0.0.0 \
+    PADDLEOCR_BACKEND_PORT=8088 \
+    PADDLEOCR_DEVICE=cpu \
+    PADDLEOCR_PRELOAD=1 \
+    SICLAW_OCR_MAX_CONCURRENCY=1 \
+    SICLAW_OCR_HARD_TIMEOUT_MS=150000 \
+    SICLAW_OCR_MAX_PDF_PAGES=10 \
+    SICLAW_OCR_ENABLE_STRUCTURE=0
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    libglib2.0-0 \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY services/ocr-backend/requirements.txt ./
+RUN python -m pip install --upgrade pip \
+    && pip install -r requirements.txt
+
+# PaddleOCR 3.x pulls opencv-contrib-python, which requires libGL at import
+# time even though the service runs headless.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY services/ocr-backend/server.py services/ocr-backend/parse_once.py ./
+
+EXPOSE 8088
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8088/healthz', timeout=3).read()" || exit 1
+
+CMD ["python", "server.py"]

--- a/docs/design/attachment-ocr.md
+++ b/docs/design/attachment-ocr.md
@@ -1,0 +1,254 @@
+# Attachment OCR
+
+Siclaw supports pasted image/PDF understanding by preprocessing attachments in
+Portal and forwarding extracted OCR text as evidence to the agent. This is not
+an MCP flow.
+
+## Product goal
+
+P0 focuses on text-heavy operational screenshots:
+
+- English terminal screenshots and command output.
+- Chinese or bilingual table screenshots.
+- Text-heavy PDFs, including scanned or image-based pages.
+
+Monitoring charts are deliberately not the primary target. Prefer dashboard
+URLs or metrics tools when exact chart values matter.
+
+## Architecture
+
+```text
+browser chat input
+  -> Portal chat API
+  -> independent OCR backend Service
+  -> Portal appends OCR evidence to the user prompt
+  -> Runtime/AgentBox receive text only
+```
+
+Portal is the attachment boundary because it already owns chat HTTP auth,
+request validation, and the browser-facing contract. Runtime and AgentBox stay
+focused on agent execution and do not need raw attachment access.
+
+The OCR backend is independently deployed so it can be scaled, tuned, replaced,
+or disabled without rebuilding the main agent path. Swapping PaddleOCR for
+RapidOCR, DeepSeek-OCR, or a company-managed document service should be a
+deployment/configuration change at the OCR service boundary, not a Runtime
+change.
+
+## Supported input types
+
+Portal accepts up to four attachments per chat turn:
+
+- PNG
+- JPEG
+- WebP
+- PDF
+
+Each attachment is currently limited to 6 MiB in the browser and roughly 8 MiB
+base64 payload size at Portal. Other text file types such as YAML, XML, JSON,
+CSV, and logs are intentionally out of scope for this path; users can paste
+those as text more reliably.
+
+## OCR backend contract
+
+Portal calls:
+
+```text
+POST ${SICLAW_OCR_BACKEND_URL}
+```
+
+with `x-request-id` when Portal originates the request. External callers can
+also pass `request_id` in the JSON body.
+
+with:
+
+```json
+{
+  "request_id": "optional-caller-request-id",
+  "input": "terminal.png",
+  "kind_hint": "terminal",
+  "language_hint": "auto",
+  "expected_output": "siclaw_screenshot_evidence_v1",
+  "source": {
+    "type": "file_base64",
+    "filename": "terminal.png",
+    "mime_type": "image/png",
+    "data": "..."
+  }
+}
+```
+
+The backend returns OCR evidence:
+
+```json
+{
+  "kind": "terminal",
+  "language": "en",
+  "route": "text",
+  "text": "recognized text",
+  "confidence": 0.91,
+  "blocks": [{ "type": "ocr_text", "text": "..." }],
+  "tables": [],
+  "warnings": []
+}
+```
+
+Portal appends this to the prompt with system framing so the agent treats the
+OCR as evidence and mentions uncertainty when the backend reports warnings.
+
+OCR backend logs are metadata-only for auditability and debugging:
+
+```text
+request_id status status_code kind mime route elapsed_ms size
+```
+
+They intentionally do not include raw image/PDF bytes or extracted OCR text.
+Image/PDF bytes are request-scoped; the standalone path does not persist raw
+attachments for chat-history replay. Model caches, when enabled, store only
+PaddleOCR/PaddleX model artifacts.
+
+The OCR service is safe to reuse from another API gateway as long as that system
+uses the same `/parse` contract. For example, Sicore can call a shared OCR
+service from its siclaw proxy layer, or point to an externally managed service
+with the same request/response shape, then forward only text evidence to
+Siclaw. Sicore-specific proxy code should live in Sicore, not in this Siclaw
+standalone OCR change.
+
+## Deployment
+
+The Helm chart supports three deployment profiles:
+
+- Full standalone Siclaw: Runtime + Portal + OCR. This is the default profile.
+- Standalone Siclaw without OCR: Runtime + Portal only, using
+  `helm/siclaw/values-no-ocr.yaml`.
+- OCR-only addon: OCR Deployment + Service only, using
+  `helm/siclaw/values-ocr-only.yaml`. This is intended for external callers
+  such as Sicore's Siclaw proxy.
+
+The chart creates the OCR Deployment and Service whenever:
+
+```yaml
+ocr:
+  enabled: true
+  maxConcurrency: 1
+  hardTimeoutMs: 150000
+  maxPdfPages: 10
+  maxImagePixels: 50000000
+```
+
+Portal receives:
+
+```text
+SICLAW_OCR_BACKEND_URL=http://<release>-ocr-backend:8088/parse
+SICLAW_OCR_TIMEOUT_MS=120000
+SICLAW_OCR_MAX_EVIDENCE_TEXT_CHARS=32768
+SICLAW_OCR_MAX_TOTAL_EVIDENCE_TEXT_CHARS=65536
+```
+
+When `ocr.enabled=false` and `ocr.externalUrl` is empty, Portal treats OCR as
+unavailable. Attachment sends remain recoverable and include an OCR-unavailable
+evidence note instead of calling a missing backend.
+
+To use an external or replacement service:
+
+```yaml
+ocr:
+  enabled: false
+  externalUrl: "http://ocr.example.svc:8088/parse"
+```
+
+`ocr.maxConcurrency` maps to `SICLAW_OCR_MAX_CONCURRENCY` and limits admitted
+in-flight OCR requests per Pod. PaddleOCR inference is still serialized inside
+each backend process; this setting is a backpressure guard, not a guarantee of
+parallel OCR decoding. If the backend is already at capacity, it returns HTTP
+503 with `Retry-After: 1`; Portal keeps the chat recoverable by sending the user
+message with an OCR failure note.
+
+Keep `ocr.maxConcurrency=1` while `ocr.hardTimeoutMs` is enabled. The watchdog
+restarts the backend process on pathological OCR hangs, so production throughput
+should scale with more OCR replicas rather than multiple in-flight requests in
+one OCR process.
+
+`ocr.maxEvidenceTextChars` maps to `SICLAW_OCR_MAX_EVIDENCE_TEXT_CHARS` and
+caps the OCR text injected into the agent prompt per attachment. When OCR output
+exceeds the cap, Portal truncates the injected evidence and adds a warning with
+the original character count.
+
+`ocr.maxTotalEvidenceTextChars` maps to
+`SICLAW_OCR_MAX_TOTAL_EVIDENCE_TEXT_CHARS` and caps aggregate OCR evidence for
+one chat turn. `ocr.maxImagePixels` maps to `SICLAW_OCR_MAX_IMAGE_PIXELS` and
+rejects decompression-bomb style image inputs before OCR decoding.
+
+For shared OCR deployments, enable `ocr.networkPolicy.enabled=true` and allow
+only the intended caller Pods with `ocr.networkPolicy.ingressFrom`. The OCR
+Service is ClusterIP, but without a NetworkPolicy any Pod in the cluster may be
+able to call `/parse`.
+
+`ocr.hardTimeoutMs` maps to `SICLAW_OCR_HARD_TIMEOUT_MS`. It is a process-level
+watchdog for pathological PaddleOCR hangs: after the window expires, the backend
+logs metadata only and exits so Kubernetes can restart a clean container. The
+chart also uses `startupProbe` for slow first-time model loading and emptyDir
+model caches for container restarts within the same Pod.
+
+`ocr.maxPdfPages` maps to `SICLAW_OCR_MAX_PDF_PAGES`. The OCR backend enforces
+this before PaddleOCR runs so an 80-page PDF does not monopolize workers and
+delay normal screenshot/table requests. The default is 10 pages. Larger PDFs
+are parsed from the first 10 pages only and the OCR response includes a warning;
+set it to `0` only when a deployment intentionally accepts full-document OCR
+cost.
+
+## Default engine choice
+
+Default backend: PaddleOCR text extraction.
+
+Rationale:
+
+- Works on CPU nodes.
+- Good practical coverage for Chinese and English OCR.
+- Keeps PDF and screenshot parsing in one service.
+- Avoids GPU/model-service dependency before DeepSeek-OCR or a VLM backend is
+  available.
+
+`PPStructureV3` is disabled by default and exposed as an experiment through:
+
+```text
+SICLAW_OCR_ENABLE_STRUCTURE=1
+```
+
+The default route prefers stability and latency over perfect table
+reconstruction. Table-like OCR text is usually enough for the language model to
+answer operational questions.
+
+The default CPU deployment also disables Paddle's MKLDNN/oneDNN path. On the
+current test cluster, enabling that path makes PP-OCRv5 fail fast with a Paddle
+attribute-conversion error instead of improving latency.
+
+PaddleOCR's `server` and `mobile` model families are exposed through deployment
+environment variables. Siclaw defaults to the mobile profile for the current P0
+workflow because pasted evidence is mostly English terminal screenshots, where
+mobile was both faster and closer to the original command spacing in the test
+fixtures. The mobile profile reduced terminal/table/PDF OCR calls from roughly
+14-20 seconds to roughly 4-7 seconds, with similar output on terminal and simple
+English PDFs but slightly lower confidence on the Chinese table sample.
+
+```yaml
+ocr:
+  textDetectionModelName: "PP-OCRv5_mobile_det"
+  textRecognitionModelName: "PP-OCRv5_mobile_rec"
+```
+
+For a quality-first deployment with more dense Chinese tables or scanned PDFs,
+clear both model names to let PaddleOCR choose its server model:
+
+```yaml
+ocr:
+  textDetectionModelName: ""
+  textRecognitionModelName: ""
+```
+
+## Failure behavior
+
+Attachment upload should not be rejected merely because OCR may fail. If the OCR
+backend errors, times out, or returns no text, Portal still sends the user's
+message and includes an OCR failure note. This keeps chat interaction
+recoverable and avoids hiding the user's original context.

--- a/helm/siclaw/templates/NOTES.txt
+++ b/helm/siclaw/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Thank you for installing {{ include "siclaw.fullname" . }}!
 
-{{- if .Values.agentbox.persistence.enabled }}
+{{- if and (eq (include "siclaw.runtime.enabled" .) "true") .Values.agentbox.persistence.enabled }}
 
 ℹ️  User data persistence is enabled.
    Chart-managed PVC: "{{ include "siclaw.dataPvcName" . }}" (ReadWriteMany).
@@ -10,6 +10,7 @@ Thank you for installing {{ include "siclaw.fullname" . }}!
    Gateway will create per-user subdirectories automatically.
 {{- end }}
 
+{{- if eq (include "siclaw.runtime.enabled" .) "true" }}
 ℹ️  Runtime mTLS CA
    {{- $caSecret := include "siclaw.runtimeTls.caSecret" . }}
    {{- $generateCa := include "siclaw.runtimeTls.generateCa" . }}
@@ -27,3 +28,4 @@ Thank you for installing {{ include "siclaw.fullname" . }}!
        every render, overwriting this Secret and breaking mTLS for every running AgentBox.
        For pre-rendered pipelines, set runtime.tls.generateCa=false and supply runtime.tls.caSecret.
    {{- end }}
+{{- end }}

--- a/helm/siclaw/templates/_helpers.tpl
+++ b/helm/siclaw/templates/_helpers.tpl
@@ -63,10 +63,43 @@ Usage: {{ include "siclaw.image" (dict "component" "gateway" "ctx" .) }}
 {{- end }}
 
 {{/*
+Resolve runtime.enabled. Returns the literal string "true" or "false".
+Defaults to "true" when the field is missing so helm upgrade --reuse-values
+keeps older Runtime releases enabled.
+*/}}
+{{- define "siclaw.runtime.enabled" -}}
+{{- $runtime := .Values.runtime | default dict -}}
+{{- if hasKey $runtime "enabled" -}}{{- $runtime.enabled -}}{{- else -}}true{{- end -}}
+{{- end }}
+
+{{/*
 Build agentbox image string — same registry/tag as gateway, different component name.
 */}}
 {{- define "siclaw.agentboxImage" -}}
 {{- include "siclaw.image" (dict "component" "agentbox" "ctx" .) -}}
+{{- end }}
+
+{{/*
+Build OCR image string. Allows the independently deployed OCR service to move
+faster than the main Portal/Runtime images when desired.
+*/}}
+{{- define "siclaw.ocrImage" -}}
+{{- $ocr := .Values.ocr | default dict -}}
+{{- $image := $ocr.image | default dict -}}
+{{- $repo := $image.repository | default "" -}}
+{{- $tag := $image.tag | default .Values.image.tag -}}
+{{- if $repo -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- else -}}
+{{- include "siclaw.image" (dict "component" "ocr" "ctx" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the OCR backend Service.
+*/}}
+{{- define "siclaw.ocrServiceName" -}}
+{{- printf "%s-ocr-backend" (include "siclaw.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "siclaw.runtime.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -123,3 +124,4 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "siclaw.dataPvcName" . }}
         {{- end }}
+{{- end }}

--- a/helm/siclaw/templates/gateway-rbac.yaml
+++ b/helm/siclaw/templates/gateway-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "siclaw.runtime.enabled" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -42,3 +43,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "siclaw.fullname" . }}-gateway
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/siclaw/templates/gateway-service.yaml
+++ b/helm/siclaw/templates/gateway-service.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "siclaw.runtime.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
       name: https-internal
   selector:
     {{- include "siclaw.selectorLabels" (dict "ctx" . "component" "runtime") | nindent 4 }}
+{{- end }}

--- a/helm/siclaw/templates/gateway-servicemonitor.yaml
+++ b/helm/siclaw/templates/gateway-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and (eq (include "siclaw.runtime.enabled" .) "true") .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/helm/siclaw/templates/ocr-deployment.yaml
+++ b/helm/siclaw/templates/ocr-deployment.yaml
@@ -1,0 +1,113 @@
+{{- $ocr := .Values.ocr | default dict -}}
+{{- $image := $ocr.image | default dict -}}
+{{- $service := $ocr.service | default dict -}}
+{{- $cache := $ocr.cache | default dict -}}
+{{- $cacheEnabled := true -}}
+{{- if hasKey $cache "enabled" -}}
+{{- $cacheEnabled = $cache.enabled -}}
+{{- end -}}
+{{- $port := $service.port | default 8088 -}}
+{{- if $ocr.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "siclaw.ocrServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "siclaw.labels" (dict "ctx" . "component" "ocr") | nindent 4 }}
+spec:
+  replicas: {{ $ocr.replicas }}
+  selector:
+    matchLabels:
+      {{- include "siclaw.selectorLabels" (dict "ctx" . "component" "ocr") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "siclaw.selectorLabels" (dict "ctx" . "component" "ocr") | nindent 8 }}
+    spec:
+      containers:
+        - name: ocr
+          image: {{ include "siclaw.ocrImage" . }}
+          imagePullPolicy: {{ $image.pullPolicy | default .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $port }}
+              protocol: TCP
+          env:
+            - name: PADDLEOCR_BACKEND_HOST
+              value: "0.0.0.0"
+            - name: PADDLEOCR_BACKEND_PORT
+              value: {{ $port | quote }}
+            - name: PADDLEOCR_DEVICE
+              value: {{ $ocr.device | quote }}
+            - name: PADDLEOCR_PRELOAD
+              value: {{ ternary "1" "0" $ocr.preload | quote }}
+            - name: PADDLEOCR_MAX_REQUEST_BYTES
+              value: {{ $ocr.maxRequestBytes | quote }}
+            - name: SICLAW_OCR_MAX_CONCURRENCY
+              value: {{ $ocr.maxConcurrency | quote }}
+            - name: SICLAW_OCR_HARD_TIMEOUT_MS
+              value: {{ $ocr.hardTimeoutMs | quote }}
+            - name: SICLAW_OCR_MAX_PDF_PAGES
+              value: {{ $ocr.maxPdfPages | default 10 | quote }}
+            - name: SICLAW_OCR_MAX_IMAGE_PIXELS
+              value: {{ $ocr.maxImagePixels | default 50000000 | quote }}
+            - name: SICLAW_OCR_ENABLE_STRUCTURE
+              value: {{ ternary "1" "0" $ocr.enableStructure | quote }}
+            {{- if $ocr.textDetectionModelName }}
+            - name: PADDLEOCR_TEXT_DETECTION_MODEL_NAME
+              value: {{ $ocr.textDetectionModelName | quote }}
+            {{- end }}
+            {{- if $ocr.textRecognitionModelName }}
+            - name: PADDLEOCR_TEXT_RECOGNITION_MODEL_NAME
+              value: {{ $ocr.textRecognitionModelName | quote }}
+            {{- end }}
+            {{- if $ocr.textDetLimitSideLen }}
+            - name: PADDLEOCR_TEXT_DET_LIMIT_SIDE_LEN
+              value: {{ $ocr.textDetLimitSideLen | quote }}
+            {{- end }}
+            - name: PADDLE_PDX_ENABLE_MKLDNN_BYDEFAULT
+              value: "0"
+            - name: FLAGS_use_mkldnn
+              value: "0"
+            {{- range $key, $value := $ocr.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml $ocr.resources | nindent 12 }}
+          {{- if $cacheEnabled }}
+          volumeMounts:
+            - name: paddlex-cache
+              mountPath: /root/.paddlex
+            - name: paddleocr-cache
+              mountPath: /root/.paddleocr
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 30
+      {{- if $cacheEnabled }}
+      volumes:
+        - name: paddlex-cache
+          emptyDir: {}
+        - name: paddleocr-cache
+          emptyDir: {}
+      {{- end }}
+{{- end }}

--- a/helm/siclaw/templates/ocr-networkpolicy.yaml
+++ b/helm/siclaw/templates/ocr-networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- $ocr := .Values.ocr | default dict -}}
+{{- $networkPolicy := $ocr.networkPolicy | default dict -}}
+{{- if and $ocr.enabled $networkPolicy.enabled }}
+{{- $extraIngressFrom := $networkPolicy.ingressFrom | default list -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "siclaw.ocrServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "siclaw.labels" (dict "ctx" . "component" "ocr") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "siclaw.selectorLabels" (dict "ctx" . "component" "ocr") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  {{- if or .Values.portal.enabled $extraIngressFrom }}
+  ingress:
+    - from:
+        {{- if .Values.portal.enabled }}
+        - podSelector:
+            matchLabels:
+              {{- include "siclaw.selectorLabels" (dict "ctx" . "component" "portal") | nindent 14 }}
+        {{- end }}
+        {{- if $extraIngressFrom }}
+        {{- toYaml $extraIngressFrom | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: http
+  {{- else }}
+  ingress: []
+  {{- end }}
+{{- end }}

--- a/helm/siclaw/templates/ocr-service.yaml
+++ b/helm/siclaw/templates/ocr-service.yaml
@@ -1,0 +1,21 @@
+{{- $ocr := .Values.ocr | default dict -}}
+{{- $service := $ocr.service | default dict -}}
+{{- $port := $service.port | default 8088 -}}
+{{- if $ocr.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "siclaw.ocrServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "siclaw.labels" (dict "ctx" . "component" "ocr") | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "siclaw.selectorLabels" (dict "ctx" . "component" "ocr") | nindent 4 }}
+{{- end }}

--- a/helm/siclaw/templates/portal-deployment.yaml
+++ b/helm/siclaw/templates/portal-deployment.yaml
@@ -44,7 +44,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "siclaw.fullname" . }}-portal
                   key: portal-secret
-            {{- range $key, $value := .Values.portal.env }}
+            {{- $ocr := .Values.ocr | default dict }}
+            {{- $ocrService := $ocr.service | default dict }}
+            {{- $ocrPort := $ocrService.port | default 8088 }}
+            {{- if or $ocr.enabled $ocr.externalUrl }}
+            - name: SICLAW_OCR_BACKEND_URL
+              value: {{ default (printf "http://%s:%v/parse" (include "siclaw.ocrServiceName" .) $ocrPort) $ocr.externalUrl | quote }}
+            - name: SICLAW_OCR_TIMEOUT_MS
+              value: {{ $ocr.timeoutMs | quote }}
+            - name: SICLAW_OCR_MAX_EVIDENCE_TEXT_CHARS
+              value: {{ $ocr.maxEvidenceTextChars | quote }}
+            - name: SICLAW_OCR_MAX_TOTAL_EVIDENCE_TEXT_CHARS
+              value: {{ $ocr.maxTotalEvidenceTextChars | default 65536 | quote }}
+            {{- end }}
+            {{- $portalEnv := omit (.Values.portal.env | default dict) "SICLAW_OCR_BACKEND_URL" "SICLAW_OCR_TIMEOUT_MS" "SICLAW_OCR_MAX_EVIDENCE_TEXT_CHARS" "SICLAW_OCR_MAX_TOTAL_EVIDENCE_TEXT_CHARS" }}
+            {{- range $key, $value := $portalEnv }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}

--- a/helm/siclaw/templates/runtime-ca-secret.yaml
+++ b/helm/siclaw/templates/runtime-ca-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "siclaw.runtime.enabled" .) "true" }}
 {{- /*
 WARNING: this template uses the `lookup` function to reuse a CA Secret that
 already exists in the cluster. `lookup` is a NO-OP in `helm template`,
@@ -38,5 +39,6 @@ data:
   {{- $ca := genCA "siclaw-runtime-ca" 3650 }}
   tls.crt: {{ $ca.Cert | b64enc }}
   tls.key: {{ $ca.Key  | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/siclaw/templates/runtime-secret.yaml
+++ b/helm/siclaw/templates/runtime-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "siclaw.runtime.enabled" .) "true" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ metadata:
 type: Opaque
 data:
   portal-secret: {{ .Values.runtime.portalSecret | b64enc | quote }}
+{{- end }}

--- a/helm/siclaw/templates/siclaw-data-pvc.yaml
+++ b/helm/siclaw/templates/siclaw-data-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agentbox.persistence.enabled }}
+{{- if and (eq (include "siclaw.runtime.enabled" .) "true") .Values.agentbox.persistence.enabled }}
 # Shared data PVC — user memory, investigations, sessions.
 # Mounted by Runtime and every AgentBox pod; Runtime writes per-user
 # subdirectories (users/{userId}/{agentId}/) and AgentBox pods mount via subPath.

--- a/helm/siclaw/templates/tests/test-connection.yaml
+++ b/helm/siclaw/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "siclaw.runtime.enabled" .) "true" }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -14,3 +15,4 @@ spec:
       image: busybox
       command: ["wget"]
       args: ["--spider", "--timeout=5", "http://{{ include "siclaw.fullname" . }}-runtime.{{ .Release.Namespace }}.svc.cluster.local:3001/api/health"]
+{{- end }}

--- a/helm/siclaw/values-no-ocr.yaml
+++ b/helm/siclaw/values-no-ocr.yaml
@@ -1,0 +1,9 @@
+# Standalone Siclaw without OCR.
+#
+# Use this when Portal + Runtime should run normally but pasted image/PDF
+# attachments should not call an OCR backend. Attachment sends stay recoverable:
+# Portal injects an OCR-unavailable note instead of contacting a missing Service.
+
+ocr:
+  enabled: false
+  externalUrl: ""

--- a/helm/siclaw/values-ocr-only.yaml
+++ b/helm/siclaw/values-ocr-only.yaml
@@ -1,0 +1,21 @@
+# OCR-only deployment profile.
+#
+# Use this when Siclaw provides the shared OCR addon service for another
+# caller, such as Sicore's Siclaw proxy. It deploys only the OCR backend and
+# its ClusterIP Service; no Portal, Runtime, Runtime RBAC, Runtime CA, or
+# Runtime test hook is rendered.
+
+runtime:
+  enabled: false
+
+portal:
+  enabled: false
+
+ocr:
+  enabled: true
+  replicas: 4
+  maxConcurrency: 1
+  maxPdfPages: 10
+
+metrics:
+  enabled: false

--- a/helm/siclaw/values-standalone.yaml
+++ b/helm/siclaw/values-standalone.yaml
@@ -32,6 +32,7 @@ database:
 
 # Runtime points to Portal (not Upstream)
 runtime:
+  enabled: true
   replicas: 1
   serverUrl: "http://siclaw-portal:3003"
   jwtSecret: ""       # REQUIRED: --set runtime.jwtSecret=...
@@ -47,6 +48,9 @@ portal:
     type: NodePort
     port: 3003
     nodePort: 31003   # Access Portal UI at http://<node-ip>:31003
+
+ocr:
+  enabled: true
 
 agentbox:
   persistence:

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -23,6 +23,7 @@ database:
 # first, so multiple replicas of the same release would continuously fight.
 # Scale horizontally by deploying multiple releases with distinct identities.
 runtime:
+  enabled: true
   portalSecret: ""      # Runtime → Portal/Upstream API auth (X-Auth-Token on phone-home WS)
   # Where Runtime gets Agent/Credential info from:
   #   Standalone mode: http://siclaw-portal:3003
@@ -76,6 +77,68 @@ portal:
       cpu: "500m"
       memory: "512Mi"
   env: {}
+
+# -- OCR backend for Portal image/PDF attachment preprocessing
+ocr:
+  enabled: true
+  replicas: 1
+  # Set when OCR is provided by another service. If enabled=false and this is
+  # empty, Portal treats OCR as unavailable and keeps chat sends recoverable.
+  externalUrl: ""
+  timeoutMs: 120000
+  image:
+    # Empty repository uses image.registry + image.tag as siclaw-ocr:<tag>.
+    repository: ""
+    tag: ""
+    pullPolicy: ""
+  service:
+    port: 8088
+  device: "cpu"
+  preload: true
+  enableStructure: false
+  # Per-Pod admitted in-flight OCR requests. PaddleOCR inference is serialized
+  # inside each backend process; requests above this limit receive HTTP 503.
+  maxConcurrency: 1
+  # Per-attachment OCR text characters that Portal may inject into the prompt.
+  maxEvidenceTextChars: 32768
+  # Total OCR evidence characters that Portal may inject for one chat turn.
+  maxTotalEvidenceTextChars: 65536
+  # Hard process-level watchdog for a single OCR request. If PaddleOCR hangs past
+  # this window, the backend exits and Kubernetes restarts the container.
+  hardTimeoutMs: 150000
+  # PDF inputs are capped before PaddleOCR runs so a long paper does not occupy
+  # OCR workers and delay screenshot/table requests. Set 0 to disable.
+  maxPdfPages: 10
+  # Decoded image pixel cap before OCR runs. Set 0 to disable.
+  maxImagePixels: 50000000
+  textDetectionModelName: "PP-OCRv5_mobile_det"
+  textRecognitionModelName: "PP-OCRv5_mobile_rec"
+  textDetLimitSideLen: ""
+  maxRequestBytes: "10485760"
+  cache:
+    # Cache PaddleOCR/PaddleX model downloads across container restarts in the
+    # same Pod. This does not store user uploads or OCR text.
+    enabled: true
+  resources:
+    requests:
+      cpu: "2"
+      memory: "4Gi"
+    limits:
+      cpu: "4"
+      memory: "8Gi"
+  env: {}
+  networkPolicy:
+    enabled: false
+    # Extra Kubernetes NetworkPolicy from entries for OCR-only/shared-service
+    # deployments. Example:
+    # ingressFrom:
+    #   - namespaceSelector:
+    #       matchLabels:
+    #         kubernetes.io/metadata.name: sicore
+    #     podSelector:
+    #       matchLabels:
+    #         app.kubernetes.io/name: sicore-apiserver
+    ingressFrom: []
 
 # -- AgentBox (spawned at runtime by K8s spawner)
 agentbox:

--- a/package.json
+++ b/package.json
@@ -113,7 +113,9 @@
     "docker:build:runtime": "docker build -f Dockerfile.runtime -t siclaw/siclaw-runtime:latest .",
     "docker:build:portal": "docker build -f Dockerfile.portal -t siclaw/siclaw-portal:latest .",
     "docker:build:agentbox": "docker build -f Dockerfile.agentbox -t siclaw/siclaw-agentbox:latest .",
+    "docker:build:ocr": "docker build -f Dockerfile.ocr -t siclaw/siclaw-ocr:latest .",
     "docker:push:runtime": "docker push siclaw/siclaw-runtime:latest",
+    "docker:push:ocr": "docker push siclaw/siclaw-ocr:latest",
     "docker:push:agentbox": "docker push siclaw/siclaw-agentbox:latest"
   }
 }

--- a/portal-web/src/api.ts
+++ b/portal-web/src/api.ts
@@ -123,10 +123,10 @@ export function chatSSE(
   return { abort: () => controller.abort() }
 }
 
-export async function chatSteer(agentId: string, sessionId: string, text: string): Promise<void> {
+export async function chatSteer(agentId: string, sessionId: string, text: string, attachments?: unknown[]): Promise<void> {
   await api(`/siclaw/agents/${agentId}/chat/steer`, {
     method: "POST",
-    body: { session_id: sessionId, text },
+    body: { session_id: sessionId, text, attachments },
   })
 }
 

--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -7,7 +7,7 @@ import { usePilotChat } from "../hooks/usePilotChat"
 import { PilotArea } from "./chat/PilotArea"
 import { SkillPanel } from "./chat/SkillPanel"
 import { SchedulePanel } from "./chat/SchedulePanel"
-import type { PilotMessage } from "./chat/types"
+import type { ChatAttachment, PilotMessage } from "./chat/types"
 
 interface ChatSession {
   id: string
@@ -243,7 +243,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
 
   // Wrap send to also handle first-message session creation
   const handleSend = useCallback(
-    (text: string) => {
+    (text: string, attachments?: ChatAttachment[]) => {
       if (!activeSessionId) {
         // Create a new session first, then send
         api<ChatSession>(`/siclaw/agents/${agentId}/chat/sessions`, { method: "POST" })
@@ -251,14 +251,14 @@ export function AgentChat({ agentId }: AgentChatProps) {
             setSessions((prev) => [session, ...prev])
             setActiveSessionId(session.id)
             // Short delay to let state propagate
-            setTimeout(() => pilot.send(text), 50)
+            setTimeout(() => pilot.send(text, attachments), 50)
           })
           .catch((err: any) => {
             toast.error(err.message || "Failed to create session")
           })
         return
       }
-      pilot.send(text)
+      pilot.send(text, attachments)
     },
     [activeSessionId, agentId, pilot, toast],
   )

--- a/portal-web/src/components/chat/ImageAttachmentPreview.tsx
+++ b/portal-web/src/components/chat/ImageAttachmentPreview.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react"
+import { FileText, X, ZoomIn, ZoomOut } from "lucide-react"
+import { cn } from "./cn"
+import type { ChatAttachment } from "./types"
+
+interface ImageAttachmentPreviewProps {
+  attachments: ChatAttachment[]
+  className?: string
+  tileClassName?: string
+  imageClassName?: string
+  onRemove?: (index: number) => void
+}
+
+export function ImageAttachmentPreview({
+  attachments,
+  className,
+  tileClassName,
+  imageClassName,
+  onRemove,
+}: ImageAttachmentPreviewProps) {
+  const items = attachments.map((attachment, index) => ({ attachment, index }))
+  const [preview, setPreview] = useState<ChatAttachment | null>(null)
+  const [zoomed, setZoomed] = useState(false)
+
+  if (items.length === 0) return null
+
+  const previewSrc = preview ? imageSrc(preview) : ""
+
+  return (
+    <>
+      <div className={cn("flex flex-wrap gap-2", className)}>
+        {items.map(({ attachment, index }) => (
+          <div key={`${attachment.filename}-${index}`} className="relative">
+            {attachment.kind === "image" ? (
+              <div
+                className={cn(
+                  "relative overflow-hidden rounded-md border border-blue-500/30 bg-blue-500/10 shadow-sm shadow-black/10",
+                  tileClassName,
+                )}
+              >
+                <button
+                  type="button"
+                  className="block h-full w-full bg-background/70"
+                  onClick={() => {
+                    setPreview(attachment)
+                    setZoomed(false)
+                  }}
+                  title="Preview image"
+                >
+                  <img
+                    src={imageSrc(attachment)}
+                    alt="Pasted image preview"
+                    className={cn("h-full w-full object-contain", imageClassName)}
+                  />
+                </button>
+              </div>
+            ) : (
+              <div className="flex h-[64px] w-[min(360px,calc(100vw-64px))] items-center gap-3 rounded-2xl border border-border bg-background/90 px-3 pr-9 text-left shadow-sm shadow-black/5">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-red-500/10 text-red-500">
+                  <FileText className="h-5 w-5" />
+                </div>
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-foreground" title={attachment.filename}>
+                    {attachment.filename}
+                  </div>
+                  <div className="mt-0.5 text-xs font-medium uppercase text-muted-foreground">
+                    PDF
+                  </div>
+                </div>
+              </div>
+            )}
+            {onRemove && (
+              <button
+                type="button"
+                className="absolute right-1 top-1 rounded bg-black/55 p-0.5 text-white shadow-sm transition-colors hover:bg-black/75"
+                onClick={() => onRemove(index)}
+                title="Remove"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {preview && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/78 p-6"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setPreview(null)}
+        >
+          <div className="absolute right-5 top-5 flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded-full bg-white/12 p-2 text-white shadow-sm transition-colors hover:bg-white/20"
+              onClick={(e) => {
+                e.stopPropagation()
+                setZoomed((value) => !value)
+              }}
+              title={zoomed ? "Fit to screen" : "View actual size"}
+            >
+              {zoomed ? <ZoomOut className="h-5 w-5" /> : <ZoomIn className="h-5 w-5" />}
+            </button>
+            <button
+              type="button"
+              className="rounded-full bg-white/12 p-2 text-white shadow-sm transition-colors hover:bg-white/20"
+              onClick={(e) => {
+                e.stopPropagation()
+                setPreview(null)
+              }}
+              title="Close"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+          <div
+            className="max-h-[88vh] max-w-[94vw] overflow-auto rounded-md bg-white shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img
+              src={previewSrc}
+              alt="Pasted image preview"
+              className={cn(
+                "block bg-white",
+                zoomed
+                  ? "h-auto max-h-none max-w-none cursor-zoom-out"
+                  : "max-h-[88vh] max-w-[94vw] cursor-zoom-in object-contain",
+              )}
+              onClick={() => setZoomed((value) => !value)}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+function imageSrc(attachment: ChatAttachment): string {
+  return `data:${attachment.mimeType};base64,${attachment.data}`
+}

--- a/portal-web/src/components/chat/InputArea.tsx
+++ b/portal-web/src/components/chat/InputArea.tsx
@@ -1,8 +1,10 @@
-import { ArrowUp, ArrowDown, Square, X, Loader2, SearchCode, Plus, Check, ArrowRight, PencilLine, FileText } from "lucide-react"
-import type { ContextUsage, PrefixActionChip } from "./types"
+import { ArrowUp, ArrowDown, Square, X, Loader2, SearchCode, Plus, Check, ArrowRight, PencilLine, FileText, Paperclip } from "lucide-react"
+import type { ChatAttachment, ContextUsage, PrefixActionChip } from "./types"
 import { useState, useCallback, useRef, useEffect, useLayoutEffect } from "react"
-import type { KeyboardEvent } from "react"
+import type { ClipboardEvent, KeyboardEvent } from "react"
 import { cn } from "./cn"
+import { ImageAttachmentPreview } from "./ImageAttachmentPreview"
+import { useToast } from "../toast"
 
 /** Format token count: 0 -> "0", 1234 -> "1.2k" */
 function formatTokens(n: number): string {
@@ -32,7 +34,7 @@ function PrefixChipIcon({ chip }: { chip: PrefixActionChip }) {
 }
 
 interface InputAreaProps {
-  onSend: (message: string) => void
+  onSend: (message: string, attachments?: ChatAttachment[]) => void
   onAbort?: () => void
   disabled?: boolean
   isLoading?: boolean
@@ -47,6 +49,51 @@ interface InputAreaProps {
   historyMessages?: string[]
   activePrefix?: PrefixActionChip | null
   onClearPrefix?: () => void
+}
+
+const MAX_PASTED_IMAGE_BYTES = 6 * 1024 * 1024
+const MAX_PASTED_PDF_BYTES = 6 * 1024 * 1024
+const MAX_ATTACHMENTS = 4
+const ACCEPTED_ATTACHMENT_TYPES = ".png,.jpg,.jpeg,.webp,.pdf,image/png,image/jpeg,image/webp,application/pdf"
+const SUPPORTED_IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"])
+
+function readFileBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const value = String(reader.result ?? "")
+      resolve(value.includes(",") ? value.slice(value.indexOf(",") + 1) : value)
+    }
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read attachment"))
+    reader.readAsDataURL(file)
+  })
+}
+
+function pastedImageName(file: File, index: number): string {
+  if (file.name) return file.name
+  const ext = file.type === "image/jpeg" ? "jpg" : file.type === "image/webp" ? "webp" : "png"
+  return `pasted-image-${index + 1}.${ext}`
+}
+
+function pastedPdfName(file: File, index: number): string {
+  return file.name || `pasted-document-${index + 1}.pdf`
+}
+
+function normalizedAttachmentMimeType(file: File): string {
+  const mimeType = file.type.toLowerCase()
+  if (mimeType === "application/pdf" || SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) return mimeType
+
+  const lowerName = file.name.toLowerCase()
+  if (lowerName.endsWith(".pdf")) return "application/pdf"
+  if (lowerName.endsWith(".png")) return "image/png"
+  if (lowerName.endsWith(".jpg") || lowerName.endsWith(".jpeg")) return "image/jpeg"
+  if (lowerName.endsWith(".webp")) return "image/webp"
+  return mimeType
+}
+
+function isSupportedPastedFile(file: File): boolean {
+  const mimeType = normalizedAttachmentMimeType(file)
+  return SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) || mimeType === "application/pdf"
 }
 
 export function InputArea({
@@ -67,10 +114,13 @@ export function InputArea({
   onClearPrefix,
 }: InputAreaProps) {
   const [value, setValue] = useState("")
+  const [attachments, setAttachments] = useState<ChatAttachment[]>([])
   const [isFocused, setIsFocused] = useState(false)
   const [isAborting, setIsAborting] = useState(false)
+  const toast = useToast()
   const isComposingRef = useRef(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const historyCursorRef = useRef<number | null>(null)
   const draftBeforeHistoryRef = useRef("")
 
@@ -111,10 +161,62 @@ export function InputArea({
 
   const [showActionMenu, setShowActionMenu] = useState(false)
 
+  const addFiles = useCallback((files: File[]) => {
+    const supportedFiles = files.filter(isSupportedPastedFile)
+    if (supportedFiles.length === 0) {
+      if (files.length > 0) toast.error("Only PNG, JPEG, WebP, and PDF attachments are supported.")
+      return
+    }
+    const unsupportedCount = files.length - supportedFiles.length
+    if (unsupportedCount > 0) {
+      toast.error(`${unsupportedCount} unsupported attachment${unsupportedCount === 1 ? "" : "s"} skipped.`)
+    }
+
+    void Promise.allSettled(supportedFiles.map(async (file, index) => {
+      const mimeType = normalizedAttachmentMimeType(file)
+      const isPdf = mimeType === "application/pdf"
+      const filename = isPdf ? pastedPdfName(file, index) : pastedImageName(file, index)
+      const maxBytes = isPdf ? MAX_PASTED_PDF_BYTES : MAX_PASTED_IMAGE_BYTES
+      if (file.size > maxBytes) {
+        throw new Error(`${filename} is too large`)
+      }
+      return {
+        kind: isPdf ? "pdf" as const : "image" as const,
+        filename,
+        mimeType,
+        data: await readFileBase64(file),
+      }
+    }))
+      .then((results) => {
+        const next: ChatAttachment[] = []
+        const errors: string[] = []
+        for (const result of results) {
+          if (result.status === "fulfilled") {
+            next.push(result.value)
+          } else {
+            errors.push(result.reason instanceof Error ? result.reason.message : "Failed to read attachment")
+          }
+        }
+        if (next.length > 0) {
+          const availableSlots = Math.max(0, MAX_ATTACHMENTS - attachments.length)
+          const accepted = next.slice(0, availableSlots)
+          const skipped = next.length - accepted.length
+          if (skipped > 0) {
+            toast.error(`Attachment limit is ${MAX_ATTACHMENTS}; ${skipped} file${skipped === 1 ? "" : "s"} skipped.`)
+          }
+          if (accepted.length > 0) setAttachments((prev) => [...prev, ...accepted].slice(0, MAX_ATTACHMENTS))
+        }
+        for (const error of errors) toast.error(error)
+      })
+      .catch((err) => {
+        toast.error(err instanceof Error ? err.message : "Failed to read attachment")
+      })
+  }, [attachments.length, toast])
+
   const handleSend = useCallback(async () => {
     const text = value.trim()
     if (disabled) return
-    if (!text && !activePrefix) return
+    if (!text && !activePrefix && attachments.length === 0) return
 
     let fullMessage = ""
     if (deepInvestigation) {
@@ -131,12 +233,25 @@ export function InputArea({
       fullMessage += text
     }
 
-    onSend(fullMessage.trim())
+    onSend(fullMessage.trim(), attachments.length > 0 ? attachments : undefined)
     setValue("")
+    setAttachments([])
     historyCursorRef.current = null
     draftBeforeHistoryRef.current = ""
     onClearPrefix?.()
-  }, [value, disabled, onSend, deepInvestigation, activePrefix, onClearPrefix])
+  }, [value, disabled, onSend, deepInvestigation, activePrefix, onClearPrefix, attachments])
+
+  const handlePaste = useCallback((e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const files = Array.from(e.clipboardData?.items ?? [])
+      .filter((item) => item.kind === "file")
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => !!file)
+      .filter(isSupportedPastedFile)
+
+    if (files.length === 0) return
+    e.preventDefault()
+    addFiles(files)
+  }, [addFiles])
 
   const navigateHistory = useCallback(
     (direction: "previous" | "next") => {
@@ -223,7 +338,7 @@ export function InputArea({
     [handleSend, activePrefix, onClearPrefix, navigateHistory],
   )
 
-  const hasContent = value.trim() || !!activePrefix
+  const hasContent = !!value.trim() || !!activePrefix || attachments.length > 0
 
   return (
     <>
@@ -239,6 +354,18 @@ export function InputArea({
             {/* Toolbar */}
             <div className="flex items-center gap-1 px-4 pt-3 pb-1 min-w-0">
               <div className="relative">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={ACCEPTED_ATTACHMENT_TYPES}
+                  multiple
+                  className="hidden"
+                  onChange={(e) => {
+                    const files = Array.from(e.currentTarget.files ?? [])
+                    if (files.length > 0) addFiles(files)
+                    e.currentTarget.value = ""
+                  }}
+                />
                 <button
                   type="button"
                   onClick={() => setShowActionMenu(!showActionMenu)}
@@ -259,6 +386,18 @@ export function InputArea({
                     <div className="fixed inset-0 z-10" onClick={() => setShowActionMenu(false)} />
                     <div className="absolute bottom-full left-0 mb-1 bg-card rounded-xl shadow-xl shadow-black/20 border border-border z-20 w-[220px]">
                       <div className="py-1">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setShowActionMenu(false)
+                            fileInputRef.current?.click()
+                          }}
+                          className="flex items-center gap-3 w-full px-3 py-2.5 text-left hover:bg-secondary transition-colors"
+                        >
+                          <Paperclip className="w-4 h-4 text-muted-foreground shrink-0" />
+                          <span className="flex-1 text-sm text-foreground">Add photos & files</span>
+                        </button>
+
                         {/* Deep Investigation */}
                         <button
                           type="button"
@@ -335,6 +474,15 @@ export function InputArea({
               </div>
             )}
 
+            {attachments.length > 0 && (
+              <ImageAttachmentPreview
+                attachments={attachments}
+                className="px-4 pb-2"
+                tileClassName="h-28 w-44"
+                onRemove={(idx) => setAttachments((prev) => prev.filter((_, i) => i !== idx))}
+              />
+            )}
+
             <div className="relative w-full">
               <textarea
                 ref={textareaRef}
@@ -346,6 +494,7 @@ export function InputArea({
                   resetHistoryNavigation(e.target.value)
                 }}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 onCompositionStart={() => {
                   isComposingRef.current = true
                 }}
@@ -364,7 +513,7 @@ export function InputArea({
               />
             </div>
 
-            {isLoading && value.trim() ? (
+            {isLoading && (value.trim() || attachments.length > 0 || activePrefix) ? (
               <button
                 onClick={handleSend}
                 className="absolute right-3 bottom-3 p-2 rounded-lg bg-blue-600 text-white shadow-md hover:bg-blue-700 transition-all"

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -27,10 +27,12 @@ import { validateMermaidSource } from "./MermaidRenderer"
 import { svgToPngDataUrl } from "./svg-export"
 import { useCopyFeedback } from "./clipboard"
 import { InputArea } from "./InputArea"
+import { ImageAttachmentPreview } from "./ImageAttachmentPreview"
 import { SkillCard } from "./SkillCard"
 import { ScheduleCard } from "./ScheduleCard"
 import { ErrorBubble } from "./ErrorBubble"
-import type { PilotMessage, ContextUsage, ActionChip, PrefixActionChip, MessageTiming } from "./types"
+import { stripAttachmentOcrEvidence } from "./user-message-text"
+import type { ChatAttachment, PilotMessage, ContextUsage, ActionChip, PrefixActionChip, MessageTiming } from "./types"
 
 /**
  * Format a millisecond duration into a compact human-readable string.
@@ -161,7 +163,7 @@ export interface PilotAreaProps {
   hasMore?: boolean
   loadingMore?: boolean
   onLoadMore?: () => void
-  sendMessage: (text: string) => void
+  sendMessage: (text: string, attachments?: ChatAttachment[]) => void
   abortResponse?: () => void
   contextUsage?: ContextUsage | null
   pendingMessages?: string[]
@@ -233,9 +235,9 @@ export function PilotArea({
 
   const lastSentRef = useRef<string | null>(null)
   const wrappedSendMessage = useCallback(
-    (text: string) => {
+    (text: string, attachments?: ChatAttachment[]) => {
       if (!isLoading) lastSentRef.current = text
-      sendMessage(text)
+      sendMessage(text, attachments)
     },
     [sendMessage, isLoading],
   )
@@ -579,7 +581,7 @@ function parseActionChipMarker(content: string): { chip: PrefixActionChip | null
 }
 
 function getVisibleUserText(content: string): string {
-  const { text: afterDeepInvestigation } = parseDeepInvestigation(content)
+  const { text: afterDeepInvestigation } = parseDeepInvestigation(stripAttachmentOcrEvidence(content))
   const { text: afterActionChip } = parseActionChipMarker(afterDeepInvestigation)
   const { text: afterScripts } = parseScriptRefs(afterActionChip)
   const { text } = parseSkillRef(afterScripts)
@@ -1131,7 +1133,7 @@ function MessageItem({
 
   // Parse references from user messages
   const { isDeepInvestigation, text: afterDeepInv } = isUser
-    ? parseDeepInvestigation(message.content)
+    ? parseDeepInvestigation(stripAttachmentOcrEvidence(message.content))
     : { isDeepInvestigation: false, text: message.content }
   const { chip: actionChip, text: afterChip } = isUser
     ? parseActionChipMarker(afterDeepInv)
@@ -1216,6 +1218,14 @@ function MessageItem({
           </div>
         )}
 
+        {isUser && message.attachments && message.attachments.length > 0 && (
+          <ImageAttachmentPreview
+            attachments={message.attachments}
+            className="mb-2 max-w-[560px] justify-end"
+            tileClassName="h-32 w-56"
+          />
+        )}
+
         {isUser && editingContent != null && canRenderEditor ? (
           <EditableUserMessage
             content={editingContent}
@@ -1234,6 +1244,10 @@ function MessageItem({
                 : undefined
             }
           />
+        ) : isUser && message.attachments && message.attachments.length > 0 ? (
+          <div className="rounded-xl bg-muted px-3 py-2 text-sm text-muted-foreground">
+            (No content)
+          </div>
         ) : null}
 
         {renderedSuggestedChips.length > 0 && onChipClick && (

--- a/portal-web/src/components/chat/attachment-prompt.ts
+++ b/portal-web/src/components/chat/attachment-prompt.ts
@@ -1,0 +1,1 @@
+export const ATTACHMENT_ONLY_PROMPT = "Please analyze the attached file(s)."

--- a/portal-web/src/components/chat/types.ts
+++ b/portal-web/src/components/chat/types.ts
@@ -44,6 +44,7 @@ export interface PilotMessage {
   id: string
   role: MessageRole
   content: string
+  attachments?: ChatAttachment[]
   toolName?: string
   toolInput?: string
   /** Raw parsed tool input, when available, for structured cards. */
@@ -75,6 +76,13 @@ export interface ContextUsage {
   cacheReadTokens: number
   cacheWriteTokens: number
   cost: number
+}
+
+export interface ChatAttachment {
+  kind: "image" | "pdf"
+  filename: string
+  mimeType: string
+  data: string
 }
 
 /**

--- a/portal-web/src/components/chat/user-message-text.test.ts
+++ b/portal-web/src/components/chat/user-message-text.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { stripAttachmentOcrEvidence } from "./user-message-text"
+
+describe("stripAttachmentOcrEvidence", () => {
+  it("leaves ordinary user text unchanged", () => {
+    expect(stripAttachmentOcrEvidence("这个能看到吗")).toBe("这个能看到吗")
+  })
+
+  it("removes OCR evidence from user-visible text", () => {
+    const content = [
+      "这个能看到吗",
+      "",
+      "[System: The user pasted image or PDF attachment(s). OCR evidence extracted by Siclaw is below. Use it as evidence.]",
+      "",
+      "### image.png",
+      "kind: screenshot",
+      "route: text",
+      "kubectl get pods",
+    ].join("\n")
+
+    expect(stripAttachmentOcrEvidence(content)).toBe("这个能看到吗")
+  })
+})

--- a/portal-web/src/components/chat/user-message-text.ts
+++ b/portal-web/src/components/chat/user-message-text.ts
@@ -1,0 +1,8 @@
+const ATTACHMENT_OCR_EVIDENCE_MARKER =
+  "[System: The user pasted image or PDF attachment(s). OCR evidence extracted by Siclaw is below."
+
+export function stripAttachmentOcrEvidence(content: string): string {
+  const index = content.indexOf(ATTACHMENT_OCR_EVIDENCE_MARKER)
+  if (index < 0) return content
+  return content.slice(0, index).trimEnd()
+}

--- a/portal-web/src/hooks/steer-pending.test.ts
+++ b/portal-web/src/hooks/steer-pending.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { extractUserMessageText, findPendingSteerIndex, pendingSteerMatchText } from "./steer-pending"
+
+const OCR_EVIDENCE = [
+  "",
+  "",
+  "[System: The user pasted image or PDF attachment(s). OCR evidence extracted by Siclaw is below. Use it as evidence.]",
+  "",
+  "### image.png",
+  "kind: screenshot",
+  "kubectl get pods",
+].join("\n")
+
+describe("steer pending matching", () => {
+  it("matches pending steer text even when runtime echoes OCR evidence", () => {
+    expect(findPendingSteerIndex(["这个能看到吗"], `这个能看到吗${OCR_EVIDENCE}`)).toBe(0)
+  })
+
+  it("matches attachment-only steer text against the portal fallback prompt", () => {
+    const matchText = pendingSteerMatchText("", true)
+    expect(matchText).toBe("Please analyze the attached file(s).")
+    expect(findPendingSteerIndex([matchText], `Please analyze the attached file(s).${OCR_EVIDENCE}`)).toBe(0)
+  })
+
+  it("uses trimmed user text for pending steer matching", () => {
+    expect(pendingSteerMatchText("  hello  ", true)).toBe("hello")
+  })
+
+  it("does not synthesize a fallback prompt for text-only empty steer", () => {
+    expect(pendingSteerMatchText("", false)).toBe("")
+  })
+
+  it("strips OCR evidence from echoed user text", () => {
+    expect(extractUserMessageText(`这个能看到吗${OCR_EVIDENCE}`)).toBe("这个能看到吗")
+  })
+})

--- a/portal-web/src/hooks/steer-pending.ts
+++ b/portal-web/src/hooks/steer-pending.ts
@@ -4,6 +4,15 @@
  * Extracted so the logic can be unit-tested without React/jsdom.
  */
 
+import { stripAttachmentOcrEvidence } from "../components/chat/user-message-text"
+import { ATTACHMENT_ONLY_PROMPT } from "../components/chat/attachment-prompt"
+
+export function pendingSteerMatchText(text: string, hasAttachments: boolean): string {
+  const trimmed = text.trim()
+  if (trimmed) return trimmed
+  return hasAttachments ? ATTACHMENT_ONLY_PROMPT : text
+}
+
 /**
  * Match an incoming steer message (from SSE message_start) against the pending queue.
  * Returns the index of the matched pending message, or -1 if not found.
@@ -12,16 +21,16 @@
  * what the frontend sent and what pi-agent echoes back.
  */
 export function findPendingSteerIndex(pending: readonly string[], incomingText: string): number {
-  const trimmed = incomingText.trim()
+  const trimmed = stripAttachmentOcrEvidence(incomingText).trim()
   if (!trimmed) return -1
-  return pending.findIndex((p) => p.trim() === trimmed)
+  return pending.findIndex((p) => stripAttachmentOcrEvidence(p).trim() === trimmed)
 }
 
 /**
  * Remove a pending message by index, returning the new array.
  * Returns the original array unchanged if index is out of bounds.
  */
-export function removePendingAt(pending: readonly string[], index: number): string[] {
+export function removePendingAt<T>(pending: readonly T[], index: number): T[] {
   if (index < 0 || index >= pending.length) return [...pending]
   return [...pending.slice(0, index), ...pending.slice(index + 1)]
 }
@@ -31,10 +40,11 @@ export function removePendingAt(pending: readonly string[], index: number): stri
  * content can be a plain string or an array of TextContent/ImageContent blocks.
  */
 export function extractUserMessageText(content: unknown): string {
-  if (typeof content === "string") return content
+  if (typeof content === "string") return stripAttachmentOcrEvidence(content)
   if (!Array.isArray(content)) return ""
-  return (content as Array<{ type: string; text?: string }>)
+  const text = (content as Array<{ type: string; text?: string }>)
     .filter((c) => c.type === "text")
     .map((c) => c.text ?? "")
     .join("")
+  return stripAttachmentOcrEvidence(text)
 }

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -6,14 +6,16 @@
  * and chatAbort for cancellation.
  */
 
-import { useState, useCallback, useEffect, useRef } from "react"
+import { useState, useCallback, useEffect, useMemo, useRef } from "react"
 import { api, chatSteer, chatAbort } from "../api"
 import type {
   PilotMessage,
   ContextUsage,
   ErrorDetail,
+  ChatAttachment,
 } from "../components/chat/types"
-import { findPendingSteerIndex, removePendingAt, extractUserMessageText } from "./steer-pending"
+import { stripAttachmentOcrEvidence } from "../components/chat/user-message-text"
+import { findPendingSteerIndex, removePendingAt, extractUserMessageText, pendingSteerMatchText } from "./steer-pending"
 
 /** Parse an unknown payload into an ErrorDetail with backward-compat fallbacks.
  *  See docs/design/error-envelope.md §4. */
@@ -93,13 +95,19 @@ interface UsePilotChatReturn {
   pendingMessages: string[]
   hasMore: boolean
   loadingMore: boolean
-  send: (text: string) => void
-  steer: (text: string) => void
+  send: (text: string, attachments?: ChatAttachment[]) => void
+  steer: (text: string, attachments?: ChatAttachment[]) => void
   abort: () => void
   loadMore: () => void
   setDpActive: (active: boolean) => void
   removePending: (index: number) => void
   exitDp: () => void
+}
+
+interface PendingSteer {
+  text: string
+  matchText: string
+  attachments?: ChatAttachment[]
 }
 
 const DELEGATED_TOOL_STALE_MS = 4 * 60 * 1000
@@ -311,7 +319,7 @@ function toPilotMessage(m: ChatMessage): PilotMessage {
       ? (toolIsDelegation
           ? "Delegated investigation did not finish before the recovery window. It may have timed out or been interrupted."
           : "Tool execution did not finish before the recovery window. It may have timed out or been interrupted.")
-      : m.content,
+      : m.role === "user" ? stripAttachmentOcrEvidence(m.content) : m.content,
     toolName: m.tool_name,
     toolArgs,
     toolInput: toolArgs ? formatToolInput(m.tool_name ?? "", toolArgs) : undefined,
@@ -457,7 +465,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const [streamText, setStreamText] = useState("")
   const [dpActive, setDpActive] = useState(false)
   const [contextUsage, setContextUsage] = useState<ContextUsage | null>(null)
-  const [pendingMessages, setPendingMessages] = useState<string[]>([])
+  const [pendingSteers, setPendingSteers] = useState<PendingSteer[]>([])
   const [hasMore, setHasMore] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const pageRef = useRef(1)
@@ -629,7 +637,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           recoveredStreamingRef.current = false
           setStreaming(false)
           streamingRef.current = false
-          setPendingMessages([])
+          setPendingSteers([])
           return
         }
       } catch (err) {
@@ -838,21 +846,23 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
 
           // Show steer (user) messages injected mid-conversation.
           // The initial prompt's user message is already displayed by send(),
-          // so only create a PilotMessage if the text is in pendingMessages (= steer).
+          // so only create a PilotMessage if the text is in pendingSteers (= steer).
           if (msg?.role === "user") {
             const text = extractUserMessageText(msg.content)
             if (text) {
-              setPendingMessages((prev) => {
-                const idx = findPendingSteerIndex(prev, text)
+              setPendingSteers((prev) => {
+                const idx = findPendingSteerIndex(prev.map((pending) => pending.matchText), text)
                 if (idx < 0) return prev // not a steer — already displayed
+                const pending = prev[idx]
                 // Steer message: add to chat and remove from pending
                 setMessages((msgs) => [
                   ...msgs,
                   {
                     id: `msg-${Date.now()}`,
                     role: "user" as const,
-                    content: text,
+                    content: pending.text.trim() ? text : pending.text,
                     timestamp: timeNow(),
+                    ...(pending.attachments?.length ? { attachments: pending.attachments } : {}),
                   },
                 ])
                 return removePendingAt(prev, idx)
@@ -934,7 +944,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
             streamingRef.current = false
             recoveredStreamingRef.current = false
           }
-          setPendingMessages([])
+          setPendingSteers([])
           break
 
         // --- Agent start (agent started processing) ---
@@ -951,7 +961,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           setStreaming(false)
           streamingRef.current = false
           recoveredStreamingRef.current = false
-          setPendingMessages([])
+          setPendingSteers([])
           // Update context usage from agent_end event
           const cu = evt.contextUsage as ContextUsage | undefined
           if (cu) {
@@ -994,13 +1004,32 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     }
   }, [agentId, sessionId, hasMore, loadingMore])
 
+  const handleSteerFailure = useCallback((err: unknown, pending: PendingSteer) => {
+    console.error("[usePilotChat] steer error:", err)
+    setPendingSteers((prev) => prev.filter((item) => item !== pending))
+    const body = (err as { body?: unknown }).body
+    const detail = body !== undefined
+      ? parseErrorDetail(body)
+      : {
+          code: "INTERNAL_ERROR",
+          message: err instanceof Error ? err.message : "Failed to steer",
+          retriable: true,
+        }
+    setMessages((prev) => [...prev, makeErrorMessage(detail)])
+  }, [])
+
   // --- Send a message ---
   const send = useCallback(
-    (text: string) => {
+    (text: string, attachments?: ChatAttachment[]) => {
       if ((streamingRef.current || hasPendingDelegationSynthesis(messages)) && sessionId) {
         // While streaming, send as steer
-        chatSteer(agentId, sessionId, text).catch((err) => console.error("[usePilotChat] steer error:", err))
-        setPendingMessages((prev) => [...prev, text])
+        const pending: PendingSteer = {
+          text,
+          matchText: pendingSteerMatchText(text, !!attachments?.length),
+          ...(attachments?.length ? { attachments } : {}),
+        }
+        chatSteer(agentId, sessionId, text, attachments).catch((err) => handleSteerFailure(err, pending))
+        setPendingSteers((prev) => [...prev, pending])
         return
       }
 
@@ -1010,6 +1039,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         role: "user",
         content: text,
         timestamp: timeNow(),
+        ...(attachments?.length ? { attachments } : {}),
       }
       setMessages((prev) => [...prev, userMsg])
       setStreaming(true)
@@ -1031,7 +1061,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
               "Content-Type": "application/json",
               ...(token ? { Authorization: `Bearer ${token}` } : {}),
             },
-            body: JSON.stringify({ text, session_id: sessionId }),
+            body: JSON.stringify({ text, session_id: sessionId, attachments }),
             signal: controller.signal,
           })
 
@@ -1107,7 +1137,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
                     setStreaming(false)
                     streamingRef.current = false
                     recoveredStreamingRef.current = false
-                    setPendingMessages([])
+                    setPendingSteers([])
                   }
                   // Update cache: mark stream as finished so switching back shows final state
                   if (streamSessionId) { const cached = messagesCacheRef.current.get(streamSessionId); if (cached) cached.streaming = false }
@@ -1173,35 +1203,29 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         }
       })()
     },
-    [agentId, sessionId, messages, handleChatEvent],
+    [agentId, sessionId, messages, handleChatEvent, handleSteerFailure],
   )
 
   // --- Steer ---
   const steer = useCallback(
-    (text: string) => {
+    (text: string, attachments?: ChatAttachment[]) => {
       if (!sessionId) return
-      chatSteer(agentId, sessionId, text).catch((err) => {
-        console.error("[usePilotChat] steer error:", err)
-        const body = (err as { body?: unknown }).body
-        const detail = body !== undefined
-          ? parseErrorDetail(body)
-          : {
-              code: "INTERNAL_ERROR",
-              message: err instanceof Error ? err.message : "Failed to steer",
-              retriable: true,
-            }
-        setMessages((prev) => [...prev, makeErrorMessage(detail)])
-      })
-      setPendingMessages((prev) => [...prev, text])
+      const pending: PendingSteer = {
+        text,
+        matchText: pendingSteerMatchText(text, !!attachments?.length),
+        ...(attachments?.length ? { attachments } : {}),
+      }
+      chatSteer(agentId, sessionId, text, attachments).catch((err) => handleSteerFailure(err, pending))
+      setPendingSteers((prev) => [...prev, pending])
     },
-    [agentId, sessionId],
+    [agentId, sessionId, handleSteerFailure],
   )
 
   // --- Abort ---
   const abort = useCallback(async () => {
     if (!sessionId) return
     isAbortingRef.current = true
-    setPendingMessages([])
+    setPendingSteers([])
     // Mark all streaming messages as complete visually
     setMessages((prev) =>
       prev.map((m) =>
@@ -1225,7 +1249,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
 
   // --- Remove pending ---
   const removePending = useCallback((index: number) => {
-    setPendingMessages((prev) => [...prev.slice(0, index), ...prev.slice(index + 1)])
+    setPendingSteers((prev) => removePendingAt(prev, index))
   }, [])
 
   // --- Exit DP ---
@@ -1235,6 +1259,11 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     }
     resetDpState()
   }, [agentId, sessionId, resetDpState])
+
+  const pendingMessages = useMemo(
+    () => pendingSteers.map((pending) => pending.text || "(No content)"),
+    [pendingSteers],
+  )
 
   return {
     messages,

--- a/portal-web/src/pages/Chat.tsx
+++ b/portal-web/src/pages/Chat.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from "react"
 import { useSearchParams, useLocation } from "react-router-dom"
-import { Bot, Loader2, MessageSquare } from "lucide-react"
+import { Bot, Loader2, MessageSquare, PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { api } from "../api"
 import { AgentChat } from "../components/AgentChat"
+
+const AGENT_SELECTOR_COLLAPSED_KEY = "siclaw.agentSelector.collapsed"
 
 interface Agent {
   id: string; name: string; status: string; model_id: string; is_production: boolean
@@ -14,6 +16,13 @@ export function Chat() {
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedAgentId, setSelectedAgentId] = useState<string>(searchParams.get("agent") || "")
+  const [agentSelectorCollapsed, setAgentSelectorCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(AGENT_SELECTOR_COLLAPSED_KEY) === "true"
+    } catch {
+      return false
+    }
+  })
 
   // Sync agent selection when the URL's ?agent= param changes (e.g. deep link
   // navigation while the component is always mounted in Layout).
@@ -39,12 +48,22 @@ export function Chat() {
       .finally(() => setLoading(false))
   }, [])
 
+  useEffect(() => {
+    try {
+      localStorage.setItem(AGENT_SELECTOR_COLLAPSED_KEY, String(agentSelectorCollapsed))
+    } catch {
+      // Ignore storage failures in private browsing or locked-down environments.
+    }
+  }, [agentSelectorCollapsed])
+
   const handleSelectAgent = (agentId: string) => {
     setSelectedAgentId(agentId)
     if (location.pathname.startsWith("/chat")) {
       setSearchParams({ agent: agentId })
     }
   }
+
+  const agentStatusClass = (status: string) => (status === "active" ? "bg-green-500" : "bg-gray-500")
 
   if (loading) {
     return (
@@ -67,35 +86,86 @@ export function Chat() {
   return (
     <div className="flex h-full overflow-hidden">
       {/* Agent selector sidebar */}
-      <div className="w-[200px] border-r border-border flex flex-col shrink-0">
-        <div className="px-3 py-2 border-b border-border">
-          <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
-            Select Agent
-          </span>
-        </div>
-        <div className="flex-1 overflow-y-auto py-1">
-          {agents.map((a) => (
+      <aside
+        className={`border-r border-border flex flex-col shrink-0 bg-background/30 transition-[width] duration-200 ease-out ${
+          agentSelectorCollapsed ? "w-14" : "w-[200px]"
+        }`}
+      >
+        <div
+          className={`border-b border-border ${
+            agentSelectorCollapsed
+              ? "h-12 flex items-center justify-center"
+              : "px-3 py-2 flex items-center justify-between gap-2"
+          }`}
+        >
+          {agentSelectorCollapsed ? (
             <button
-              key={a.id}
-              onClick={() => handleSelectAgent(a.id)}
-              className={`flex items-center gap-2 w-full px-3 py-2 text-left transition-colors ${
-                selectedAgentId === a.id
-                  ? "bg-secondary text-foreground"
-                  : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
-              }`}
+              type="button"
+              onClick={() => setAgentSelectorCollapsed(false)}
+              className="h-8 w-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
+              aria-label="Expand agent selector"
+              title="Expand agent selector"
             >
-              <Bot className="h-3.5 w-3.5 shrink-0" />
-              <div className="flex-1 min-w-0">
-                <p className="text-[12px] font-mono truncate">{a.name}</p>
-                <p className="text-[10px] text-muted-foreground truncate">{a.model_id || "No model"}</p>
-              </div>
-              <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${
-                a.status === "active" ? "bg-green-500" : "bg-gray-500"
-              }`} />
+              <PanelLeftOpen className="h-4 w-4" />
             </button>
+          ) : (
+            <>
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Select Agent
+              </span>
+              <button
+                type="button"
+                onClick={() => setAgentSelectorCollapsed(true)}
+                className="h-7 w-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
+                aria-label="Collapse agent selector"
+                title="Collapse agent selector"
+              >
+                <PanelLeftClose className="h-4 w-4" />
+              </button>
+            </>
+          )}
+        </div>
+        <div className={`flex-1 overflow-y-auto overflow-x-hidden ${agentSelectorCollapsed ? "py-2 px-1.5 space-y-1" : "py-1"}`}>
+          {agents.map((a) => (
+            agentSelectorCollapsed ? (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => handleSelectAgent(a.id)}
+                className={`relative mx-auto flex h-10 w-10 items-center justify-center rounded-lg transition-colors ${
+                  selectedAgentId === a.id
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+                }`}
+                aria-label={`Select agent ${a.name}`}
+                title={`${a.name}${a.model_id ? ` · ${a.model_id}` : ""}`}
+              >
+                <Bot className="h-4 w-4" />
+                <span className={`absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full ${agentStatusClass(a.status)}`} />
+              </button>
+            ) : (
+              <button
+                key={a.id}
+                type="button"
+                onClick={() => handleSelectAgent(a.id)}
+                className={`flex items-center gap-2 w-full px-3 py-2 text-left transition-colors ${
+                  selectedAgentId === a.id
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+                }`}
+                title={`${a.name}${a.model_id ? ` · ${a.model_id}` : ""}`}
+              >
+                <Bot className="h-3.5 w-3.5 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-[12px] font-mono truncate">{a.name}</p>
+                  <p className="text-[10px] text-muted-foreground truncate">{a.model_id || "No model"}</p>
+                </div>
+                <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${agentStatusClass(a.status)}`} />
+              </button>
+            )
           ))}
         </div>
-      </div>
+      </aside>
 
       {/* Chat area */}
       <div className="flex-1 overflow-hidden">

--- a/services/ocr-backend/README.md
+++ b/services/ocr-backend/README.md
@@ -1,0 +1,195 @@
+# Siclaw OCR backend
+
+Independent PaddleOCR HTTP service used by Portal attachment preprocessing.
+This is the product OCR path for pasted images and PDFs; it does not require an
+MCP server or MCP environment variables.
+
+P0 scope:
+
+- English terminal screenshots.
+- Chinese/bilingual table screenshots.
+- Text-heavy image or PDF attachments.
+
+The goal is reliable text evidence extraction for the agent, not full visual
+reasoning. Monitoring dashboards should still be handled through dashboard URLs
+or metrics tools when exact values matter.
+
+## Contract
+
+`POST /parse` with JSON. Callers can pass `x-request-id` as a header or
+`request_id` in the JSON body for log correlation:
+
+```json
+{
+  "request_id": "optional-caller-request-id",
+  "input": "terminal.png",
+  "kind_hint": "terminal",
+  "language_hint": "auto",
+  "source": {
+    "type": "file_base64",
+    "filename": "terminal.png",
+    "mime_type": "image/png",
+    "data": "..."
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "kind": "terminal",
+  "language": "en",
+  "route": "text",
+  "text": "recognized text",
+  "confidence": 0.91,
+  "blocks": [{ "type": "ocr_text", "text": "..." }],
+  "tables": [],
+  "warnings": []
+}
+```
+
+Health checks:
+
+- `GET /healthz`
+- `GET /health`
+
+## Routing
+
+Default routing is plain `PaddleOCR` text extraction for every image/PDF. This
+keeps latency and dependency risk lower than document-structure parsing.
+
+`PPStructureV3` can be enabled for experiments:
+
+```bash
+export SICLAW_OCR_ENABLE_STRUCTURE=1
+```
+
+Keep it disabled for the default Portal path until table reconstruction is both
+stable and faster on the target cluster.
+
+## Run locally
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python server.py
+```
+
+Useful environment variables:
+
+```bash
+export PADDLEOCR_BACKEND_HOST=0.0.0.0
+export PADDLEOCR_BACKEND_PORT=8088
+export PADDLEOCR_DEVICE=cpu
+export PADDLEOCR_PRELOAD=1
+export PADDLEOCR_MAX_REQUEST_BYTES=10485760
+export SICLAW_OCR_MAX_CONCURRENCY=1
+export SICLAW_OCR_HARD_TIMEOUT_MS=150000
+export SICLAW_OCR_MAX_PDF_PAGES=10
+export SICLAW_OCR_MAX_IMAGE_PIXELS=50000000
+```
+
+The service disables Paddle's MKLDNN/oneDNN path by default because PP-OCRv5 CPU
+inference can fail with oneDNN attribute-conversion errors on some nodes.
+`SICLAW_OCR_MAX_CONCURRENCY` is a per-Pod admitted in-flight request guard.
+PaddleOCR prediction remains serialized inside each backend process; when all
+slots are busy, the service returns HTTP 503 with `Retry-After: 1` instead of
+letting OCR inference saturate the Pod CPU.
+`SICLAW_OCR_HARD_TIMEOUT_MS` is a process-level watchdog for pathological OCR
+hangs. If one request exceeds this window, the backend logs metadata only and
+exits so Kubernetes can restart a clean container. Set it to `0` only for local
+debugging. Keep `SICLAW_OCR_MAX_CONCURRENCY=1` while the hard watchdog is
+enabled; scale with more OCR replicas instead of multiple in-flight requests in
+one process.
+`SICLAW_OCR_MAX_PDF_PAGES` caps PDF inputs before PaddleOCR runs. The default
+is 10 pages; larger PDFs are truncated to the first 10 pages and the response
+includes a warning. Set it to `0` to disable the page cap.
+`SICLAW_OCR_MAX_IMAGE_PIXELS` caps decoded image size before OCR runs. The
+default is 50 million pixels; set it to `0` to disable the decoded-pixel cap.
+
+Siclaw's Helm chart defaults to PaddleOCR's mobile CPU profile:
+
+```bash
+export PADDLEOCR_TEXT_DETECTION_MODEL_NAME=PP-OCRv5_mobile_det
+export PADDLEOCR_TEXT_RECOGNITION_MODEL_NAME=PP-OCRv5_mobile_rec
+```
+
+The mobile profile is much faster on terminal screenshots and simple PDFs. For
+a quality-first server profile, leave both variables unset.
+
+## Build
+
+Build from the repository root:
+
+```bash
+docker buildx build \
+  --platform linux/amd64 \
+  -f Dockerfile.ocr \
+  -t registry-cn-shanghai.siflow.cn/k8s/siclaw-ocr:<tag> \
+  --push \
+  .
+```
+
+The Dockerfile defaults `PIP_INDEX_URL` to the Tsinghua PyPI mirror. Override it
+with `--build-arg PIP_INDEX_URL=https://pypi.org/simple` if that is better for
+your network.
+
+## Deploy
+
+The Helm chart creates an independent OCR Deployment and Service when
+`ocr.enabled=true`. Portal receives the service URL through
+`SICLAW_OCR_BACKEND_URL` when Portal is enabled.
+
+For an OCR-only addon release, use:
+
+```yaml
+runtime:
+  enabled: false
+portal:
+  enabled: false
+ocr:
+  enabled: true
+```
+
+The repository includes `helm/siclaw/values-ocr-only.yaml` for this profile.
+
+The chart uses a `startupProbe` for slow first-time model loading and mounts
+emptyDir caches at `/root/.paddlex` and `/root/.paddleocr` by default. These
+caches store PaddleOCR model artifacts only; user uploads and extracted OCR text
+are request-scoped and are not written there.
+
+For an external or replacement OCR service, set:
+
+```yaml
+ocr:
+  enabled: false
+  externalUrl: "http://your-ocr-service:8088/parse"
+```
+
+Portal and Runtime do not need to change when the OCR implementation is swapped.
+External systems can reuse the same service contract by calling `/parse`
+directly, or by configuring their Siclaw-facing layer to use the same
+`externalUrl` style boundary.
+
+Request logs are intentionally metadata-only. Successful and failed `/parse`
+requests include `request_id`, `status`, `status_code`, `kind`, `mime`,
+`route`, `elapsed_ms`, and request size; raw OCR input and extracted text are
+not logged.
+
+## Known limits
+
+- It extracts OCR text; it does not provide general image understanding.
+- Exact table structure is best-effort unless `SICLAW_OCR_ENABLE_STRUCTURE=1`.
+- PDFs are capped to the first `SICLAW_OCR_MAX_PDF_PAGES` pages by default so
+  long papers do not monopolize OCR workers. Upload a smaller excerpt when
+  later pages matter.
+- Decoded image pixels are capped by `SICLAW_OCR_MAX_IMAGE_PIXELS`, which
+  prevents small compressed images from expanding into very large rasters.
+- The Helm chart can render an optional NetworkPolicy for the OCR service.
+  Enable `ocr.networkPolicy.enabled=true` and add `ocr.networkPolicy.ingressFrom`
+  entries for shared OCR deployments. Without a NetworkPolicy, any in-cluster
+  Pod that can reach the ClusterIP can call `/parse`.
+- Low-resolution, skewed, or cropped screenshots may return incomplete text or
+  warnings. The agent should treat OCR evidence as evidence, not ground truth.

--- a/services/ocr-backend/parse_once.py
+++ b/services/ocr-backend/parse_once.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Command-mode entrypoint for the Siclaw PaddleOCR backend.
+
+It reads one JSON request from stdin and prints one JSON response to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+
+from server import parse_request
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+        result = parse_request(payload)
+        print(json.dumps(result, ensure_ascii=False))
+        return 0
+    except Exception as exc:  # noqa: BLE001 - command mode returns JSON errors.
+        print(
+            json.dumps(
+                {
+                    "error": str(exc),
+                    "warnings": ["Siclaw OCR command backend failed."],
+                    "trace": traceback.format_exc().splitlines()[-8:],
+                },
+                ensure_ascii=False,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/ocr-backend/requirements.txt
+++ b/services/ocr-backend/requirements.txt
@@ -1,0 +1,5 @@
+paddlepaddle>=3.0.0,<4.0.0
+paddleocr>=3.0.0,<4.0.0
+opencv-python-headless>=4.8.0,<5.0.0
+Pillow>=10.0.0,<12.0.0
+pypdf>=4.0.0,<7.0.0

--- a/services/ocr-backend/server.py
+++ b/services/ocr-backend/server.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+"""Siclaw attachment OCR backend.
+
+This service intentionally uses only the Python standard library for HTTP so the
+production image stays small and easy to replace. Portal sends pasted image/PDF
+attachments here and forwards the extracted text evidence to the Siclaw agent.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+import tempfile
+import threading
+import time
+import traceback
+import uuid
+import warnings
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+OCR_PIPELINE: Any | None = None
+STRUCTURE_PIPELINE: Any | None = None
+OCR_LOCK = threading.Lock()
+STRUCTURE_LOCK = threading.Lock()
+REQUEST_SEMAPHORE: threading.BoundedSemaphore | None = None
+REQUEST_SEMAPHORE_LOCK = threading.Lock()
+
+# PaddleOCR 3.x CPU inference can select oneDNN/MKLDNN paths that fail for
+# PP-OCRv5 on some nodes. Keep the stable Paddle static path unless explicitly
+# overridden by the operator.
+os.environ.setdefault("PADDLE_PDX_ENABLE_MKLDNN_BYDEFAULT", "0")
+os.environ.setdefault("FLAGS_use_mkldnn", "0")
+
+
+def bool_env(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def int_env(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return int(float(value))
+
+
+def max_concurrency() -> int:
+    return max(1, int_env("SICLAW_OCR_MAX_CONCURRENCY", 1))
+
+
+def hard_timeout_ms() -> int:
+    return max(0, int_env("SICLAW_OCR_HARD_TIMEOUT_MS", 150_000))
+
+
+def max_pdf_pages() -> int:
+    return max(0, int_env("SICLAW_OCR_MAX_PDF_PAGES", 10))
+
+
+def max_image_pixels() -> int:
+    return max(0, int_env("SICLAW_OCR_MAX_IMAGE_PIXELS", 50_000_000))
+
+
+def request_semaphore() -> threading.BoundedSemaphore:
+    global REQUEST_SEMAPHORE
+    if REQUEST_SEMAPHORE is None:
+        with REQUEST_SEMAPHORE_LOCK:
+            if REQUEST_SEMAPHORE is None:
+                REQUEST_SEMAPHORE = threading.BoundedSemaphore(max_concurrency())
+    return REQUEST_SEMAPHORE
+
+
+def device() -> str:
+    return os.environ.get("PADDLEOCR_DEVICE", "cpu")
+
+
+def get_ocr_pipeline() -> Any:
+    global OCR_PIPELINE
+    if OCR_PIPELINE is None:
+        with OCR_LOCK:
+            if OCR_PIPELINE is None:
+                OCR_PIPELINE = build_ocr_pipeline()
+    return OCR_PIPELINE
+
+
+def build_ocr_pipeline() -> Any:
+    from paddleocr import PaddleOCR
+
+    kwargs: dict[str, Any] = {
+        "use_doc_orientation_classify": False,
+        "use_doc_unwarping": False,
+        "use_textline_orientation": False,
+        "device": device(),
+    }
+    if bool_env("PADDLEOCR_ENABLE_HPI", False):
+        kwargs["enable_hpi"] = True
+    if os.environ.get("PADDLEOCR_TEXT_DETECTION_MODEL_NAME"):
+        kwargs["text_detection_model_name"] = os.environ["PADDLEOCR_TEXT_DETECTION_MODEL_NAME"]
+    if os.environ.get("PADDLEOCR_TEXT_RECOGNITION_MODEL_NAME"):
+        kwargs["text_recognition_model_name"] = os.environ["PADDLEOCR_TEXT_RECOGNITION_MODEL_NAME"]
+    if os.environ.get("PADDLEOCR_TEXT_DET_LIMIT_SIDE_LEN"):
+        kwargs["text_det_limit_side_len"] = int(os.environ["PADDLEOCR_TEXT_DET_LIMIT_SIDE_LEN"])
+    if os.environ.get("PADDLEOCR_LANG"):
+        kwargs["lang"] = os.environ["PADDLEOCR_LANG"]
+    return PaddleOCR(**kwargs)
+
+
+def structure_enabled() -> bool:
+    return bool_env("SICLAW_OCR_ENABLE_STRUCTURE", False)
+
+
+def get_structure_pipeline() -> Any:
+    global STRUCTURE_PIPELINE
+    if STRUCTURE_PIPELINE is None:
+        with STRUCTURE_LOCK:
+            if STRUCTURE_PIPELINE is None:
+                from paddleocr import PPStructureV3
+
+                STRUCTURE_PIPELINE = PPStructureV3(device=device())
+    return STRUCTURE_PIPELINE
+
+
+def main() -> None:
+    host = os.environ.get("PADDLEOCR_BACKEND_HOST", "127.0.0.1")
+    port = int(os.environ.get("PADDLEOCR_BACKEND_PORT", "8088"))
+    if os.environ.get("PADDLEOCR_PRELOAD", "1") != "0":
+        started = time.perf_counter()
+        get_ocr_pipeline()
+        print(f"[paddleocr-backend] preloaded text OCR in {elapsed_ms(started)}ms", flush=True)
+        if structure_enabled():
+            started = time.perf_counter()
+            get_structure_pipeline()
+            print(f"[paddleocr-backend] preloaded structure OCR in {elapsed_ms(started)}ms", flush=True)
+    server = ThreadingHTTPServer((host, port), Handler)
+    print(f"[paddleocr-backend] listening on http://{host}:{port}", flush=True)
+    server.serve_forever()
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "siclaw-paddleocr-backend/0.1"
+
+    def do_GET(self) -> None:
+        if self.path in {"/healthz", "/health"}:
+            self.send_json(200, {"ok": True})
+            return
+        self.send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if urlparse(self.path).path != "/parse":
+            self.send_json(404, {"error": "not found"})
+            return
+
+        started = time.perf_counter()
+        request_id = request_id_from_headers(self.headers)
+        kind_hint = "-"
+        mime_type = "-"
+        route = "-"
+        try:
+            size = int(self.headers.get("content-length", "0"))
+            max_size = int_env("PADDLEOCR_MAX_REQUEST_BYTES", 10 * 1024 * 1024)
+            if size <= 0:
+                self.log_parse(request_id, "failed", 400, "-", "-", "-", started)
+                self.send_json(400, {"error": "empty request body"}, request_id=request_id)
+                return
+            if size > max_size:
+                self.log_parse(request_id, "failed", 413, "-", "-", "-", started, size=size)
+                self.send_json(
+                    413,
+                    {"error": f"request body too large; limit is {max_size} bytes"},
+                    request_id=request_id,
+                )
+                return
+            payload = json.loads(self.rfile.read(size).decode("utf-8"))
+            request_id = request_id_from_payload(payload, request_id)
+            kind_hint, mime_type = payload_metadata(payload)
+            semaphore = request_semaphore()
+            if not semaphore.acquire(blocking=False):
+                self.log_parse(request_id, "busy", 503, kind_hint, mime_type, "-", started, size=size)
+                self.send_json(
+                    503,
+                    {"error": f"OCR backend is busy; max concurrency is {max_concurrency()}"},
+                    request_id=request_id,
+                    headers={"Retry-After": "1"},
+                )
+                return
+            watchdog = RequestWatchdog(request_id, kind_hint, mime_type, started)
+            try:
+                watchdog.arm()
+                result = parse_request(payload)
+            finally:
+                watchdog.cancel()
+                semaphore.release()
+            route = str(result.get("route") or "-")
+            self.log_parse(
+                request_id,
+                "ok",
+                200,
+                str(result.get("kind") or kind_hint),
+                mime_type,
+                route,
+                started,
+                size=size,
+            )
+            self.send_json(200, result, request_id=request_id)
+        except json.JSONDecodeError as exc:
+            self.log_parse(request_id, "failed", 400, kind_hint, mime_type, route, started)
+            self.send_json(400, {"error": f"invalid JSON: {exc}"}, request_id=request_id)
+        except ValueError as exc:
+            self.log_parse(request_id, "failed", 400, kind_hint, mime_type, route, started)
+            self.send_json(400, {"error": str(exc)}, request_id=request_id)
+        except Exception as exc:  # noqa: BLE001 - return service errors as JSON.
+            self.log_parse(request_id, "failed", 500, kind_hint, mime_type, route, started)
+            body: dict[str, Any] = {"error": "OCR parse failed"}
+            if bool_env("SICLAW_OCR_DEBUG", False):
+                body["detail"] = str(exc)
+                body["trace"] = traceback.format_exc().splitlines()[-8:]
+            self.send_json(
+                500,
+                body,
+                request_id=request_id,
+            )
+            print(f"[paddleocr-backend] parse failed request_id={request_id}: {exc}", flush=True)
+            traceback.print_exc()
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        print(f"[paddleocr-backend] {self.address_string()} {fmt % args}", flush=True)
+
+    def log_parse(
+        self,
+        request_id: str,
+        status: str,
+        status_code: int,
+        kind: str,
+        mime: str,
+        route: str,
+        started: float,
+        *,
+        size: int | None = None,
+    ) -> None:
+        size_field = f" size={size}" if size is not None else ""
+        print(
+            "[paddleocr-backend] parse "
+            f"request_id={request_id} "
+            f"status={status} "
+            f"status_code={status_code} "
+            f"kind={safe_log_value(kind)} "
+            f"mime={safe_log_value(mime)} "
+            f"route={safe_log_value(route)} "
+            f"elapsed_ms={elapsed_ms(started)}"
+            f"{size_field}",
+            flush=True,
+        )
+
+    def send_json(
+        self,
+        status: int,
+        body: dict[str, Any],
+        *,
+        request_id: str | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+        try:
+            self.send_response(status)
+            self.send_header("content-type", "application/json; charset=utf-8")
+            if request_id:
+                self.send_header("x-request-id", request_id)
+            for key, value in (headers or {}).items():
+                self.send_header(key, value)
+            self.send_header("content-length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        except BrokenPipeError:
+            print("[paddleocr-backend] client disconnected before response completed", flush=True)
+
+
+def request_id_from_headers(headers: Any) -> str:
+    return normalize_request_id(headers.get("x-request-id"))
+
+
+def request_id_from_payload(payload: dict[str, Any], fallback: str) -> str:
+    return normalize_request_id(payload.get("request_id") or payload.get("requestId") or fallback)
+
+
+def normalize_request_id(value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        return safe_log_value(value.strip())[:128]
+    return uuid.uuid4().hex
+
+
+def payload_metadata(payload: dict[str, Any]) -> tuple[str, str]:
+    kind_hint = str(payload.get("kind_hint") or "auto")
+    source = payload.get("source")
+    mime_type = "-"
+    if isinstance(source, dict):
+        mime_type = str(source.get("mime_type") or source.get("mimeType") or "-")
+    return kind_hint, mime_type
+
+
+def safe_log_value(value: Any) -> str:
+    text = str(value or "-").strip() or "-"
+    safe = []
+    for char in text[:128]:
+        if char.isalnum() or char in {"-", "_", ".", "/", ":", "@"}:
+            safe.append(char)
+        else:
+            safe.append("_")
+    return "".join(safe) or "-"
+
+
+class RequestWatchdog:
+    def __init__(self, request_id: str, kind: str, mime: str, started: float) -> None:
+        self.request_id = request_id
+        self.kind = kind
+        self.mime = mime
+        self.started = started
+        self.timeout_ms = hard_timeout_ms()
+        self._timer: threading.Timer | None = None
+
+    def arm(self) -> None:
+        if self.timeout_ms <= 0:
+            return
+        self._timer = threading.Timer(self.timeout_ms / 1000, self._expire)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def cancel(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+
+    def _expire(self) -> None:
+        print(
+            "[paddleocr-backend] hard_timeout "
+            f"request_id={safe_log_value(self.request_id)} "
+            f"kind={safe_log_value(self.kind)} "
+            f"mime={safe_log_value(self.mime)} "
+            f"timeout_ms={self.timeout_ms} "
+            f"elapsed_ms={elapsed_ms(self.started)} "
+            "action=exit_process",
+            flush=True,
+        )
+        os._exit(124)
+
+
+def parse_request(payload: dict[str, Any]) -> dict[str, Any]:
+    kind_hint = str(payload.get("kind_hint") or "auto")
+    language_hint = str(payload.get("language_hint") or "auto")
+
+    with tempfile.TemporaryDirectory(prefix="siclaw-ocr-") as tmp:
+        input_path = materialize_source(payload, Path(tmp))
+        input_path, preflight_warnings = preflight_source(input_path, Path(tmp))
+        route = choose_route(input_path, kind_hint)
+        if route == "text":
+            result = parse_with_ocr(input_path, kind_hint, language_hint, Path(tmp))
+            result["route"] = "text"
+            if kind_hint == "auto":
+                result["kind"] = "mixed_ui"
+            prepend_warnings(result, preflight_warnings)
+            return result
+        try:
+            result = parse_with_structure(input_path, kind_hint, language_hint, Path(tmp))
+            result["route"] = "structure"
+            prepend_warnings(result, preflight_warnings)
+            return result
+        except MemoryError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - structure OCR is best-effort.
+            print(
+                "[paddleocr-backend] structure fallback "
+                f"kind={safe_log_value(kind_hint)} "
+                f"error={safe_log_value(exc)}",
+                flush=True,
+            )
+            result = parse_with_ocr(input_path, kind_hint, language_hint, Path(tmp))
+            if kind_hint == "auto":
+                result["kind"] = "mixed_ui"
+            result["route"] = "structure_fallback_text"
+            result.setdefault("warnings", [])
+            prepend_warnings(result, [f"Structured OCR failed; fell back to text OCR: {exc}"])
+            prepend_warnings(result, preflight_warnings)
+            return result
+
+
+def choose_route(input_path: str, kind_hint: str) -> str:
+    if not structure_enabled():
+        return "text"
+    if kind_hint in {"table", "ticket", "document", "pdf", "monitoring_chart"}:
+        return "structure"
+    if kind_hint in {"terminal", "log", "screenshot", "mixed_ui"}:
+        return "text"
+    suffix = Path(input_path).suffix.lower()
+    if suffix == ".pdf":
+        return "structure"
+    return "text"
+
+
+def materialize_source(payload: dict[str, Any], tmp: Path) -> str:
+    source = payload.get("source")
+    if not isinstance(source, dict):
+        raise ValueError("source must be an object")
+
+    source_type = source.get("type")
+    if source_type != "file_base64":
+        raise ValueError(f"unsupported source.type: {source_type!r}")
+
+    data = source.get("data")
+    filename = str(source.get("filename") or "upload.bin")
+    if not isinstance(data, str) or not data:
+        raise ValueError("source.data is required")
+    safe_name = Path(filename).name or "upload.bin"
+    tmp_root = tmp.resolve()
+    path = (tmp / safe_name).resolve()
+    if path == tmp_root or not path.is_relative_to(tmp_root):
+        raise ValueError("unsafe filename")
+    try:
+        decoded = base64.b64decode(data, validate=True)
+    except binascii.Error as exc:
+        raise ValueError("invalid base64 data") from exc
+    path.write_bytes(decoded)
+    return str(path)
+
+
+def preflight_source(input_path: str, tmp: Path) -> tuple[str, list[str]]:
+    input_path, warnings_ = enforce_pdf_page_limit(input_path, tmp)
+    warnings_.extend(enforce_image_pixel_limit(input_path))
+    return input_path, warnings_
+
+
+def enforce_pdf_page_limit(input_path: str, tmp: Path) -> tuple[str, list[str]]:
+    if Path(input_path).suffix.lower() != ".pdf":
+        return input_path, []
+    limit = max_pdf_pages()
+    if limit <= 0:
+        return input_path, []
+
+    from pypdf import PdfReader, PdfWriter
+
+    reader = PdfReader(input_path)
+    total_pages = len(reader.pages)
+    if total_pages <= limit:
+        return input_path, []
+
+    limited_path = tmp / "limited-input.pdf"
+    writer = PdfWriter()
+    for index in range(limit):
+        writer.add_page(reader.pages[index])
+    with limited_path.open("wb") as f:
+        writer.write(f)
+
+    warning = (
+        f"PDF has {total_pages} pages; OCR parsed the first {limit} pages only. "
+        "Upload a smaller excerpt if later pages matter."
+    )
+    return str(limited_path), [warning]
+
+
+def enforce_image_pixel_limit(input_path: str) -> list[str]:
+    if Path(input_path).suffix.lower() == ".pdf":
+        return []
+    limit = max_image_pixels()
+    if limit <= 0:
+        return []
+
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except ImportError:
+        print("[paddleocr-backend] image pixel preflight skipped because Pillow is unavailable", flush=True)
+        return []
+
+    bomb_exceptions = tuple(
+        item
+        for item in (
+            getattr(Image, "DecompressionBombWarning", None),
+            getattr(Image, "DecompressionBombError", None),
+        )
+        if isinstance(item, type)
+    )
+    try:
+        Image.MAX_IMAGE_PIXELS = limit
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(input_path) as image:
+                width, height = image.size
+    except UnidentifiedImageError:
+        return []
+    except bomb_exceptions as exc:
+        raise ValueError(f"image is too large; maximum decoded pixels is {limit}") from exc
+
+    pixels = width * height
+    if pixels > limit:
+        raise ValueError(f"image is too large; maximum decoded pixels is {limit}")
+    return []
+
+
+def prepend_warnings(result: dict[str, Any], warnings: list[str]) -> None:
+    if not warnings:
+        return
+    existing = result.get("warnings")
+    if not isinstance(existing, list):
+        existing = []
+    result["warnings"] = warnings + existing
+
+
+def parse_with_ocr(input_path: str, kind_hint: str, language_hint: str, tmp: Path) -> dict[str, Any]:
+    ocr = get_ocr_pipeline()
+    with OCR_LOCK:
+        output = ocr.predict(input_path)
+
+    json_records = save_and_load_json(output, tmp)
+    texts: list[str] = []
+    blocks: list[dict[str, Any]] = []
+    scores: list[float] = []
+
+    for record in json_records:
+        res = record.get("res", record)
+        rec_texts = as_list(res.get("rec_texts"))
+        rec_scores = [to_float(v) for v in as_list(res.get("rec_scores"))]
+        rec_boxes = as_list(res.get("rec_boxes"))
+
+        for idx, text in enumerate(rec_texts):
+            if not isinstance(text, str) or not text.strip():
+                continue
+            score = rec_scores[idx] if idx < len(rec_scores) else None
+            box = rec_boxes[idx] if idx < len(rec_boxes) else None
+            texts.append(text)
+            block: dict[str, Any] = {"type": "ocr_text", "text": text}
+            if score is not None:
+                block["confidence"] = score
+                scores.append(score)
+            if isinstance(box, list):
+                block["bbox"] = flatten_numbers(box)
+            blocks.append(block)
+
+    return {
+        "kind": kind_hint if kind_hint != "auto" else "terminal",
+        "language": normalize_language(language_hint, "\n".join(texts)),
+        "text": "\n".join(texts),
+        "blocks": blocks,
+        "tables": [],
+        "confidence": average(scores),
+        "warnings": warnings_for_text(texts, scores),
+    }
+
+
+def parse_with_structure(input_path: str, kind_hint: str, language_hint: str, tmp: Path) -> dict[str, Any]:
+    pipeline = get_structure_pipeline()
+    with STRUCTURE_LOCK:
+        output = pipeline.predict(input=input_path)
+
+    markdown_pages: list[dict[str, Any]] = []
+    for res in output:
+        md_info = getattr(res, "markdown", None)
+        if isinstance(md_info, dict):
+            markdown_pages.append(md_info)
+
+    markdown_text = ""
+    if markdown_pages:
+        try:
+            markdown_text = pipeline.concatenate_markdown_pages(markdown_pages)
+        except MemoryError:
+            raise
+        except Exception as exc:
+            print(
+                "[paddleocr-backend] markdown concat failed "
+                f"error={safe_log_value(exc)}",
+                flush=True,
+            )
+            markdown_text = "\n\n".join(str(page.get("markdown_text", "")) for page in markdown_pages)
+
+    json_records = save_and_load_json(output, tmp)
+    text = markdown_text or extract_text_from_records(json_records)
+    tables = markdown_tables(text)
+
+    return {
+        "kind": kind_hint if kind_hint != "auto" else ("table" if tables else "mixed_ui"),
+        "language": normalize_language(language_hint, text),
+        "text": text,
+        "blocks": [{"type": "ocr_text", "text": text}] if text else [],
+        "tables": tables,
+        "confidence": confidence_from_records(json_records),
+        "warnings": warnings_for_text(text.splitlines(), []),
+    }
+
+
+def save_and_load_json(output: Any, tmp: Path) -> list[dict[str, Any]]:
+    out_dir = tmp / "json"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for res in output:
+        res.save_to_json(save_path=str(out_dir), ensure_ascii=False)
+
+    records: list[dict[str, Any]] = []
+    for path in sorted(out_dir.glob("*.json")):
+        with path.open("r", encoding="utf-8") as f:
+            records.append(json.load(f))
+    return records
+
+
+def extract_text_from_records(records: list[dict[str, Any]]) -> str:
+    texts: list[str] = []
+    for record in records:
+        res = record.get("res", record)
+        for text in as_list(res.get("rec_texts")):
+            if isinstance(text, str) and text.strip():
+                texts.append(text)
+    return "\n".join(texts)
+
+
+def markdown_tables(text: str) -> list[dict[str, Any]]:
+    tables: list[dict[str, Any]] = []
+    current: list[str] = []
+    for line in text.splitlines() + [""]:
+        if "|" in line and line.count("|") >= 2:
+            current.append(line.strip())
+            continue
+        if current:
+            table = parse_markdown_table(current)
+            if table:
+                tables.append(table)
+            current = []
+    return tables
+
+
+def parse_markdown_table(lines: list[str]) -> dict[str, Any] | None:
+    normalized = [line.strip().strip("|") for line in lines if line.strip()]
+    rows = [[cell.strip() for cell in line.split("|")] for line in normalized]
+    rows = [row for row in rows if not all(set(cell) <= {"-", ":"} for cell in row)]
+    if len(rows) < 2:
+        return None
+    headers = rows[0]
+    body = rows[1:]
+    return {"headers": headers, "rows": body, "markdown": "\n".join(lines)}
+
+
+def confidence_from_records(records: list[dict[str, Any]]) -> float | None:
+    scores: list[float] = []
+    for record in records:
+        res = record.get("res", record)
+        scores.extend(v for v in (to_float(x) for x in as_list(res.get("rec_scores"))) if v is not None)
+    return average(scores)
+
+
+def warnings_for_text(texts: list[str], scores: list[float]) -> list[str]:
+    warnings: list[str] = []
+    if not any(t.strip() for t in texts):
+        warnings.append("No readable OCR text was extracted.")
+    if scores and average(scores) is not None and average(scores) < 0.8:
+        warnings.append("Average OCR confidence is below 0.8.")
+    return warnings
+
+
+def normalize_language(language_hint: str, text: str) -> str:
+    if language_hint in {"zh", "en"}:
+        return language_hint
+    if any("\u3400" <= ch <= "\u9fff" for ch in text):
+        return "zh"
+    if any(("a" <= ch.lower() <= "z") for ch in text):
+        return "en"
+    return "unknown"
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    try:
+        return value.tolist()
+    except AttributeError:
+        return []
+
+
+def to_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def average(values: list[float]) -> float | None:
+    clean = [v for v in values if v is not None]
+    if not clean:
+        return None
+    return round(sum(clean) / len(clean), 4)
+
+
+def flatten_numbers(value: Any) -> list[float]:
+    if isinstance(value, list):
+        out: list[float] = []
+        for item in value:
+            out.extend(flatten_numbers(item))
+        return out
+    number = to_float(value)
+    return [] if number is None else [number]
+
+
+def elapsed_ms(started: float) -> int:
+    return round((time.perf_counter() - started) * 1000)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/ocr-backend/server_test.py
+++ b/services/ocr-backend/server_test.py
@@ -1,0 +1,169 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import server
+
+
+class RouteTests(unittest.TestCase):
+    def test_routes_everything_to_text_when_structure_is_disabled(self) -> None:
+        with patch.dict(os.environ, {"SICLAW_OCR_ENABLE_STRUCTURE": "0"}):
+            self.assertEqual(server.choose_route("/tmp/receipt.pdf", "pdf"), "text")
+            self.assertEqual(server.choose_route("/tmp/terminal.png", "terminal"), "text")
+
+    def test_routes_document_inputs_to_structure_when_enabled(self) -> None:
+        with patch.dict(os.environ, {"SICLAW_OCR_ENABLE_STRUCTURE": "1"}):
+            self.assertEqual(server.choose_route("/tmp/receipt.pdf", "auto"), "structure")
+            self.assertEqual(server.choose_route("/tmp/table.png", "table"), "structure")
+            self.assertEqual(server.choose_route("/tmp/terminal.png", "terminal"), "text")
+
+
+class MarkdownTableTests(unittest.TestCase):
+    def test_parses_basic_markdown_table(self) -> None:
+        table = server.parse_markdown_table([
+            "| Name | CPU | MEM |",
+            "| --- | ---: | ---: |",
+            "| node-a | 8 | 32Gi |",
+            "| node-b | 16 | 64Gi |",
+        ])
+
+        self.assertEqual(table, {
+            "headers": ["Name", "CPU", "MEM"],
+            "rows": [
+                ["node-a", "8", "32Gi"],
+                ["node-b", "16", "64Gi"],
+            ],
+            "markdown": "| Name | CPU | MEM |\n| --- | ---: | ---: |\n| node-a | 8 | 32Gi |\n| node-b | 16 | 64Gi |",
+        })
+
+    def test_rejects_single_row_table(self) -> None:
+        self.assertIsNone(server.parse_markdown_table(["| only | header |"]))
+
+
+class LanguageTests(unittest.TestCase):
+    def test_respects_explicit_language_hint(self) -> None:
+        self.assertEqual(server.normalize_language("zh", "plain english"), "zh")
+        self.assertEqual(server.normalize_language("en", "中文"), "en")
+
+    def test_detects_language_when_hint_is_auto(self) -> None:
+        self.assertEqual(server.normalize_language("auto", "节点状态正常"), "zh")
+        self.assertEqual(server.normalize_language("auto", "kubectl get pods"), "en")
+        self.assertEqual(server.normalize_language("auto", "12345"), "unknown")
+
+
+class SafetyHelpersTests(unittest.TestCase):
+    def test_safe_log_value_strips_control_characters(self) -> None:
+        self.assertEqual(server.safe_log_value("foo\nbar\tbaz"), "foo_bar_baz")
+
+    def test_hard_timeout_ms_can_be_disabled_for_local_debugging(self) -> None:
+        with patch.dict(os.environ, {"SICLAW_OCR_HARD_TIMEOUT_MS": "0"}):
+            self.assertEqual(server.hard_timeout_ms(), 0)
+
+    def test_max_pdf_pages_defaults_to_ten_and_can_be_disabled(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(server.max_pdf_pages(), 10)
+        with patch.dict(os.environ, {"SICLAW_OCR_MAX_PDF_PAGES": "0"}):
+            self.assertEqual(server.max_pdf_pages(), 0)
+
+    def test_max_image_pixels_defaults_and_can_be_disabled(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(server.max_image_pixels(), 50_000_000)
+        with patch.dict(os.environ, {"SICLAW_OCR_MAX_IMAGE_PIXELS": "0"}):
+            self.assertEqual(server.max_image_pixels(), 0)
+
+    def test_prepend_warnings_preserves_backend_warnings(self) -> None:
+        result = {"warnings": ["backend warning"]}
+
+        server.prepend_warnings(result, ["pdf warning"])
+
+        self.assertEqual(result["warnings"], ["pdf warning", "backend warning"])
+
+    def test_enforce_pdf_page_limit_writes_limited_pdf(self) -> None:
+        class FakeReader:
+            def __init__(self, _path: str) -> None:
+                self.pages = list(range(12))
+
+        class FakeWriter:
+            def __init__(self) -> None:
+                self.pages: list[int] = []
+
+            def add_page(self, page: int) -> None:
+                self.pages.append(page)
+
+            def write(self, stream) -> None:
+                stream.write(("pages:" + ",".join(str(p) for p in self.pages)).encode("utf-8"))
+
+        fake_pypdf = types.ModuleType("pypdf")
+        fake_pypdf.PdfReader = FakeReader
+        fake_pypdf.PdfWriter = FakeWriter
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pdf_path = Path(tmp_dir) / "paper.pdf"
+            pdf_path.write_bytes(b"%PDF")
+            with patch.dict(os.environ, {"SICLAW_OCR_MAX_PDF_PAGES": "10"}), patch.dict(sys.modules, {"pypdf": fake_pypdf}):
+                limited_path, warnings = server.enforce_pdf_page_limit(str(pdf_path), Path(tmp_dir))
+
+            self.assertNotEqual(limited_path, str(pdf_path))
+            self.assertEqual(Path(limited_path).read_text(), "pages:0,1,2,3,4,5,6,7,8,9")
+            self.assertEqual(len(warnings), 1)
+            self.assertIn("PDF has 12 pages", warnings[0])
+            self.assertIn("first 10 pages", warnings[0])
+
+    def test_materialize_source_rejects_parent_directory_filename(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaisesRegex(ValueError, "unsafe filename"):
+                server.materialize_source({
+                    "source": {
+                        "type": "file_base64",
+                        "filename": "..",
+                        "data": "aGVsbG8=",
+                    },
+                }, Path(tmp_dir))
+
+    def test_materialize_source_rejects_invalid_base64(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaisesRegex(ValueError, "invalid base64 data"):
+                server.materialize_source({
+                    "source": {
+                        "type": "file_base64",
+                        "filename": "image.png",
+                        "data": "not base64 !!!",
+                    },
+                }, Path(tmp_dir))
+
+    def test_enforce_image_pixel_limit_rejects_large_decoded_image(self) -> None:
+        class FakeImageObject:
+            size = (100, 100)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, _exc_type, _exc, _tb) -> None:
+                return None
+
+        class FakeImage:
+            MAX_IMAGE_PIXELS = None
+            DecompressionBombWarning = UserWarning
+
+            @staticmethod
+            def open(_path: str) -> FakeImageObject:
+                return FakeImageObject()
+
+        fake_pil = types.ModuleType("PIL")
+        fake_pil.Image = FakeImage
+        fake_pil.UnidentifiedImageError = ValueError
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            image_path = Path(tmp_dir) / "large.png"
+            image_path.write_bytes(b"png")
+            with patch.dict(os.environ, {"SICLAW_OCR_MAX_IMAGE_PIXELS": "9999"}), patch.dict(sys.modules, {"PIL": fake_pil}):
+                with self.assertRaisesRegex(ValueError, "image is too large"):
+                    server.enforce_image_pixel_limit(str(image_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/gateway/rest-router.test.ts
+++ b/src/gateway/rest-router.test.ts
@@ -7,6 +7,7 @@ import {
   sendJson,
   parseBody,
   parseQuery,
+  RequestBodyTooLargeError,
   requireAuth,
   requireAdmin,
 } from "./rest-router.js";
@@ -180,6 +181,14 @@ describe("parseBody", () => {
     const p = parseBody(req);
     req.emit("error", new Error("socket hangup"));
     await expect(p).rejects.toThrow("socket hangup");
+  });
+
+  it("rejects when body exceeds the configured size limit", async () => {
+    const req = new FakeReq() as any;
+    const p = parseBody(req, { maxBytes: 4 });
+    req.emit("data", Buffer.from("12345"));
+    req.emit("end");
+    await expect(p).rejects.toBeInstanceOf(RequestBodyTooLargeError);
   });
 });
 

--- a/src/gateway/rest-router.ts
+++ b/src/gateway/rest-router.ts
@@ -94,11 +94,40 @@ export function sendJson(res: http.ServerResponse, status: number, data: unknown
   res.end(body);
 }
 
-export async function parseBody<T>(req: http.IncomingMessage): Promise<T> {
+export class RequestBodyTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} byte limit`);
+    this.name = "RequestBodyTooLargeError";
+  }
+}
+
+export async function parseBody<T>(
+  req: http.IncomingMessage,
+  options: { maxBytes?: number } = {},
+): Promise<T> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    let bytes = 0;
+    let settled = false;
+
+    function fail(err: Error): void {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    }
+
+    req.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      bytes += chunk.length;
+      if (options.maxBytes != null && bytes > options.maxBytes) {
+        fail(new RequestBodyTooLargeError(options.maxBytes));
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on("end", () => {
+      if (settled) return;
+      settled = true;
       try {
         const body = Buffer.concat(chunks).toString("utf-8");
         resolve(body ? JSON.parse(body) as T : {} as T);
@@ -106,7 +135,7 @@ export async function parseBody<T>(req: http.IncomingMessage): Promise<T> {
         reject(new Error("Invalid JSON body"));
       }
     });
-    req.on("error", reject);
+    req.on("error", (err) => fail(err instanceof Error ? err : new Error(String(err))));
   });
 }
 

--- a/src/portal/chat-gateway.test.ts
+++ b/src/portal/chat-gateway.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import crypto from "node:crypto";
 
@@ -74,6 +74,10 @@ function makeConnMap(overrides: Partial<RuntimeConnectionMap> = {}): RuntimeConn
 }
 
 beforeEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
 
 describe("chat-gateway routes", () => {
   let router: ReturnType<typeof createRestRouter>;
@@ -175,6 +179,265 @@ describe("chat-gateway routes", () => {
         text: "hi",
         sessionId: "s1",
       }));
+    });
+
+    it("calls OCR backend for chat attachments and forwards extracted evidence", async () => {
+      vi.stubEnv("SICLAW_OCR_BACKEND_URL", "http://siclaw-ocr-backend:8088/parse");
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({
+          kind: "terminal",
+          language: "en",
+          route: "text",
+          confidence: 0.93,
+          text: "kubectl get pods\npod-a Running",
+          warnings: [],
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4", name: "GPT-4", reasoning: 0, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "这个终端截图是什么问题",
+          session_id: "s1",
+          attachments: [{
+            kind: "image",
+            filename: "terminal.png",
+            mimeType: "image/png",
+            data: "aGVsbG8=",
+          }],
+        },
+      });
+
+      router.handle(req, res);
+
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://siclaw-ocr-backend:8088/parse",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "content-type": "application/json",
+            "x-request-id": expect.any(String),
+          }),
+        }),
+      );
+      const ocrBody = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(ocrBody.request_id).toBe(fetchMock.mock.calls[0][1].headers["x-request-id"]);
+      expect(ocrBody.kind_hint).toBe("auto");
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      expect(command.text).toContain("这个终端截图是什么问题");
+      expect(command.text).toContain("OCR evidence extracted by Siclaw");
+      expect(command.text).toContain("kubectl get pods");
+    });
+
+    it("truncates OCR evidence before injecting it into the prompt", async () => {
+      vi.stubEnv("SICLAW_OCR_BACKEND_URL", "http://siclaw-ocr-backend:8088/parse");
+      vi.stubEnv("SICLAW_OCR_MAX_EVIDENCE_TEXT_CHARS", "12");
+      vi.stubEnv("SICLAW_OCR_MAX_TOTAL_EVIDENCE_TEXT_CHARS", "2000");
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({
+          kind: "document",
+          language: "en",
+          route: "text",
+          confidence: 0.95,
+          text: "abcdefghijklmnopqrstuvwxyz",
+          warnings: [],
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4", name: "GPT-4", reasoning: 0, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "read this",
+          session_id: "s1",
+          attachments: [{
+            kind: "pdf",
+            filename: "long.pdf",
+            mimeType: "application/pdf",
+            data: "aGVsbG8=",
+          }],
+        },
+      });
+
+      router.handle(req, res);
+
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      expect(command.text).toContain("abcdefghijkl");
+      expect(command.text).toContain("OCR text truncated after 12 characters; original length 26 characters.");
+      expect(command.text).not.toContain("mnopqrstuvwxyz");
+    });
+
+    it("truncates aggregate OCR evidence before injecting it into the prompt", async () => {
+      vi.stubEnv("SICLAW_OCR_BACKEND_URL", "http://siclaw-ocr-backend:8088/parse");
+      vi.stubEnv("SICLAW_OCR_MAX_EVIDENCE_TEXT_CHARS", "2000");
+      vi.stubEnv("SICLAW_OCR_MAX_TOTAL_EVIDENCE_TEXT_CHARS", "180");
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({
+          kind: "document",
+          language: "en",
+          route: "text",
+          confidence: 0.95,
+          text: "x".repeat(500),
+          warnings: [],
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4", name: "GPT-4", reasoning: 0, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "read this",
+          session_id: "s1",
+          attachments: [{
+            kind: "pdf",
+            filename: "long.pdf",
+            mimeType: "application/pdf",
+            data: "aGVsbG8=",
+          }],
+        },
+      });
+
+      router.handle(req, res);
+
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      expect(command.text).toContain("OCR evidence truncated after 180 total characters");
+      expect(command.text.length).toBeLessThan(600);
+    });
+
+    it("starts the SSE response before waiting for OCR", async () => {
+      vi.stubEnv("SICLAW_OCR_BACKEND_URL", "http://siclaw-ocr-backend:8088/parse");
+      let resolveFetch: ((value: unknown) => void) | undefined;
+      const fetchMock = vi.fn(() => new Promise((resolve) => { resolveFetch = resolve; }));
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4", name: "GPT-4", reasoning: 0, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "read this",
+          session_id: "s1",
+          attachments: [{
+            kind: "image",
+            filename: "terminal.png",
+            mimeType: "image/png",
+            data: "aGVsbG8=",
+          }],
+        },
+      });
+
+      router.handle(req, res);
+
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({
+        "Content-Type": "text/event-stream",
+      }));
+      expect(connMap.sendCommand).not.toHaveBeenCalled();
+
+      resolveFetch?.({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({
+          kind: "terminal",
+          language: "en",
+          route: "text",
+          confidence: 0.95,
+          text: "kubectl get pods",
+          warnings: [],
+        }),
+      });
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      expect(connMap.sendCommand).toHaveBeenCalled();
+    });
+
+    it("keeps attachment sends recoverable when OCR backend is not configured", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4", name: "GPT-4", reasoning: 0, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "",
+          session_id: "s1",
+          attachments: [{
+            kind: "image",
+            filename: "terminal.png",
+            mimeType: "image/png",
+            data: "aGVsbG8=",
+          }],
+        },
+      });
+
+      router.handle(req, res);
+
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      expect(command.text).toContain("Please analyze the attached file(s).");
+      expect(command.text).toContain("OCR unavailable: OCR backend is not configured");
     });
 
     it("forwards model compatibility for OpenAI-compatible gateway chat sends", async () => {

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -10,6 +10,7 @@ import http from "node:http";
 import {
   sendJson,
   parseBody,
+  RequestBodyTooLargeError,
   requireAuth,
   type RestRouter,
 } from "../gateway/rest-router.js";
@@ -22,6 +23,255 @@ import {
   type ErrorDetail,
 } from "../lib/error-envelope.js";
 import { defaultProviderModelCompat } from "../core/model-compat.js";
+
+interface ChatAttachment {
+  kind?: string;
+  filename?: string;
+  mimeType?: string;
+  mime_type?: string;
+  data?: string;
+}
+
+interface ChatRequestBody {
+  text?: string;
+  session_id?: string;
+  attachments?: ChatAttachment[];
+}
+
+const MAX_CHAT_ATTACHMENTS = 4;
+const MAX_ATTACHMENT_BASE64_CHARS = 8 * 1024 * 1024;
+const MAX_CHAT_REQUEST_BODY_BYTES = MAX_CHAT_ATTACHMENTS * MAX_ATTACHMENT_BASE64_CHARS + 512 * 1024;
+const OCR_DEFAULT_TIMEOUT_MS = 120_000;
+const OCR_DEFAULT_MAX_EVIDENCE_TEXT_CHARS = 32 * 1024;
+const OCR_DEFAULT_MAX_TOTAL_EVIDENCE_TEXT_CHARS = 64 * 1024;
+const ATTACHMENT_ONLY_PROMPT = "Please analyze the attached file(s).";
+const SUPPORTED_IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+function ocrBackendUrl(): string | undefined {
+  return process.env.SICLAW_OCR_BACKEND_URL?.trim() || undefined;
+}
+
+function ocrTimeoutMs(): number {
+  const raw = process.env.SICLAW_OCR_TIMEOUT_MS?.trim();
+  if (!raw) return OCR_DEFAULT_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : OCR_DEFAULT_TIMEOUT_MS;
+}
+
+function ocrMaxEvidenceTextChars(): number {
+  const raw = process.env.SICLAW_OCR_MAX_EVIDENCE_TEXT_CHARS?.trim();
+  if (!raw) return OCR_DEFAULT_MAX_EVIDENCE_TEXT_CHARS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : OCR_DEFAULT_MAX_EVIDENCE_TEXT_CHARS;
+}
+
+function ocrMaxTotalEvidenceTextChars(): number {
+  const raw = process.env.SICLAW_OCR_MAX_TOTAL_EVIDENCE_TEXT_CHARS?.trim();
+  if (!raw) return OCR_DEFAULT_MAX_TOTAL_EVIDENCE_TEXT_CHARS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : OCR_DEFAULT_MAX_TOTAL_EVIDENCE_TEXT_CHARS;
+}
+
+function normalizeChatAttachments(raw: unknown): ChatAttachment[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.slice(0, MAX_CHAT_ATTACHMENTS).filter((item): item is ChatAttachment => {
+    if (!item || typeof item !== "object") return false;
+    const candidate = item as ChatAttachment;
+    const mimeType = normalizeMimeType(candidate.mimeType ?? candidate.mime_type, candidate.filename);
+    const isImage = candidate.kind === "image" && SUPPORTED_IMAGE_MIME_TYPES.has(mimeType);
+    const isPdf = candidate.kind === "pdf" && mimeType === "application/pdf";
+    return (isImage || isPdf)
+      && typeof candidate.filename === "string"
+      && typeof candidate.data === "string"
+      && candidate.data.length > 0
+      && candidate.data.length <= MAX_ATTACHMENT_BASE64_CHARS;
+  }).map((attachment) => ({
+    ...attachment,
+    filename: safeAttachmentFilename(attachment.filename),
+  }));
+}
+
+function normalizeMimeType(raw: string | undefined, filename: string | undefined): string {
+  const mimeType = (raw ?? "").trim().toLowerCase();
+  if (mimeType === "application/pdf") return mimeType;
+  if (SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) return mimeType;
+
+  const lowerName = (filename ?? "").toLowerCase();
+  if (lowerName.endsWith(".pdf")) return "application/pdf";
+  if (lowerName.endsWith(".png")) return "image/png";
+  if (lowerName.endsWith(".jpg") || lowerName.endsWith(".jpeg")) return "image/jpeg";
+  if (lowerName.endsWith(".webp")) return "image/webp";
+  return mimeType;
+}
+
+function safeAttachmentFilename(value: string | undefined): string {
+  const basename = (value ?? "attachment")
+    .split(/[\\/]/)
+    .filter(Boolean)
+    .pop() ?? "attachment";
+  const cleaned = basename.replace(/[\r\n\t]/g, "_").trim();
+  return cleaned.slice(0, 160) || "attachment";
+}
+
+function safeLogValue(value: unknown): string {
+  const text = String(value ?? "-").trim() || "-";
+  return text
+    .slice(0, 160)
+    .replace(/[^\p{L}\p{N}._:/@-]+/gu, "_");
+}
+
+async function appendOcrEvidence(text: string, attachments: ChatAttachment[] | undefined): Promise<string> {
+  const normalizedAttachments = normalizeChatAttachments(attachments);
+  if (normalizedAttachments.length === 0) return text;
+
+  const backendUrl = ocrBackendUrl();
+  const sections = await Promise.all(normalizedAttachments.map(async (attachment) => {
+    const mimeType = normalizeMimeType(attachment.mimeType ?? attachment.mime_type, attachment.filename);
+    const kindHint = ocrKindHint(attachment, mimeType);
+    const started = Date.now();
+    const requestId = crypto.randomUUID();
+    if (!backendUrl) {
+      return `### ${attachment.filename}\nOCR unavailable: OCR backend is not configured`;
+    }
+    try {
+      const res = await fetch(backendUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": requestId,
+        },
+        body: JSON.stringify({
+          request_id: requestId,
+          input: attachment.filename,
+          kind_hint: kindHint,
+          language_hint: "auto",
+          expected_output: "siclaw_screenshot_evidence_v1",
+          source: {
+            type: "file_base64",
+            data: attachment.data,
+            filename: attachment.filename,
+            mime_type: mimeType,
+          },
+        }),
+        signal: AbortSignal.timeout(ocrTimeoutMs()),
+      });
+
+      const responseText = await res.text();
+      const elapsedMs = Date.now() - started;
+      if (!res.ok) {
+        const reason = summarizeOcrError(responseText);
+        console.warn(`[portal-chat] OCR failed for ${safeLogValue(attachment.filename)}: HTTP ${res.status} request_id=${requestId} kind_hint=${safeLogValue(kindHint)} elapsed_ms=${elapsedMs}${reason ? ` ${reason}` : ""}`);
+        return `### ${attachment.filename}\nOCR failed: HTTP ${res.status}${reason ? ` - ${reason}` : ""}`;
+      }
+
+      let evidence: Record<string, unknown>;
+      try {
+        evidence = responseText ? JSON.parse(responseText) as Record<string, unknown> : {};
+      } catch (err) {
+        console.warn(
+          `[portal-chat] OCR malformed response for ${safeLogValue(attachment.filename)}: request_id=${requestId} `
+          + `kind_hint=${safeLogValue(kindHint)} elapsed_ms=${elapsedMs} error=${safeLogValue(errorMessage(err))}`,
+        );
+        return `### ${attachment.filename}\nOCR failed: malformed backend response`;
+      }
+      console.log(
+        `[portal-chat] OCR parsed ${safeLogValue(attachment.filename)}: request_id=${requestId} kind_hint=${safeLogValue(kindHint)} `
+        + `kind=${String(evidence.kind ?? "unknown")} route=${String(evidence.route ?? "unknown")} `
+        + `elapsed_ms=${elapsedMs}`,
+      );
+      const warnings = Array.isArray(evidence.warnings)
+        ? evidence.warnings.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+        : [];
+      const boundedText = boundedOcrEvidenceText(evidence.text);
+      const warningLines = boundedText.warning ? [...warnings, boundedText.warning] : warnings;
+      return [
+        `### ${attachment.filename}`,
+        `kind: ${String(evidence.kind ?? "unknown")}`,
+        `route: ${String(evidence.route ?? "unknown")}`,
+        `language: ${String(evidence.language ?? "unknown")}`,
+        `confidence: ${String(evidence.confidence ?? "unknown")}`,
+        `elapsed_ms: ${elapsedMs}`,
+        warningLines.length ? `warnings: ${warningLines.join("; ")}` : "",
+        "",
+        boundedText.text,
+      ].filter((line) => line !== "").join("\n");
+    } catch (err) {
+      const elapsedMs = Date.now() - started;
+      console.warn(
+        `[portal-chat] OCR exception for ${safeLogValue(attachment.filename)}: request_id=${requestId} `
+        + `kind_hint=${safeLogValue(kindHint)} elapsed_ms=${elapsedMs} error=${safeLogValue(errorMessage(err))}`,
+      );
+      return `### ${attachment.filename}\nOCR failed: ${errorMessage(err)}`;
+    }
+  }));
+
+  return [
+    text.trim() || ATTACHMENT_ONLY_PROMPT,
+    "",
+    "[System: The user pasted image or PDF attachment(s). OCR evidence extracted by Siclaw is below. Use it as evidence, preserve exact command/table text when possible, and mention if OCR appears incomplete or uncertain.]",
+    "",
+    boundedOcrEvidenceSections(sections),
+  ].join("\n");
+}
+
+function ocrKindHint(attachment: ChatAttachment, mimeType: string): string {
+  const filename = (attachment.filename ?? "").toLowerCase();
+  if (mimeType === "application/pdf" || filename.endsWith(".pdf")) return "pdf";
+  return "auto";
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name;
+  return String(err);
+}
+
+function summarizeOcrError(raw: string): string {
+  if (!raw.trim()) return "";
+  try {
+    const parsed = JSON.parse(raw) as { error?: unknown };
+    if (typeof parsed.error === "string") return parsed.error.slice(0, 500);
+  } catch {
+    // Fall through to plain text summary.
+  }
+  return raw.replace(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function boundedOcrEvidenceText(raw: unknown): { text: string; warning?: string } {
+  const text = String(raw ?? "").trim();
+  if (!text) return { text: "(no OCR text extracted)" };
+
+  const maxChars = ocrMaxEvidenceTextChars();
+  if (text.length <= maxChars) return { text };
+
+  return {
+    text: `${text.slice(0, maxChars).trimEnd()}\n\n[OCR evidence truncated after ${maxChars} characters; original length ${text.length} characters.]`,
+    warning: `OCR text truncated after ${maxChars} characters; original length ${text.length} characters.`,
+  };
+}
+
+function boundedOcrEvidenceSections(sections: string[]): string {
+  const evidence = sections.join("\n\n");
+  const maxChars = ocrMaxTotalEvidenceTextChars();
+  if (evidence.length <= maxChars) return evidence;
+  return `${evidence.slice(0, maxChars).trimEnd()}\n\n[OCR evidence truncated after ${maxChars} total characters; original length ${evidence.length} characters.]`;
+}
+
+async function parseChatRequestBody(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<ChatRequestBody | null> {
+  try {
+    return await parseBody<ChatRequestBody>(req, { maxBytes: MAX_CHAT_REQUEST_BODY_BYTES });
+  } catch (err) {
+    const tooLarge = err instanceof RequestBodyTooLargeError;
+    sendJson(res, tooLarge ? 413 : 400, errorBody({
+      code: ErrorCodes.BAD_REQUEST,
+      message: tooLarge ? err.message : "Invalid JSON body",
+      retriable: false,
+    }));
+    return null;
+  }
+}
 
 /** Resolve model binding directly from Portal's own DB. */
 async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelBinding | null> {
@@ -130,9 +380,10 @@ export function registerChatRoutes(
       return;
     }
 
-    const body = await parseBody<{ text?: string; session_id?: string }>(req);
-    if (!body.text) {
-      sendJson(res, 400, errorBody({ code: ErrorCodes.BAD_REQUEST, message: "text is required", retriable: false }));
+    const body = await parseChatRequestBody(req, res);
+    if (!body) return;
+    if (!body.text && !normalizeChatAttachments(body.attachments).length) {
+      sendJson(res, 400, errorBody({ code: ErrorCodes.BAD_REQUEST, message: "text or supported attachment is required", retriable: false }));
       return;
     }
 
@@ -209,11 +460,13 @@ export function registerChatRoutes(
       }
     });
 
+    const promptText = await appendOcrEvidence(body.text ?? "", body.attachments);
+
     // Send chat.send command
     const result = await connectionMap.sendCommand(agentId, "chat.send", {
       agentId,
       userId: auth.userId,
-      text: body.text,
+      text: promptText,
       sessionId,
       modelProvider: modelBinding.modelProvider,
       modelId: modelBinding.modelId,
@@ -241,14 +494,16 @@ export function registerChatRoutes(
     const auth = requireAuth(req, jwtSecret);
     if (!auth) { sendJson(res, 401, { error: "Authentication required" }); return; }
 
-    const body = await parseBody<{ session_id?: string; text?: string }>(req);
-    if (!body.session_id || !body.text) { sendJson(res, 400, { error: "session_id and text are required" }); return; }
+    const body = await parseChatRequestBody(req, res);
+    if (!body) return;
+    if (!body.session_id || (!body.text && !normalizeChatAttachments(body.attachments).length)) { sendJson(res, 400, { error: "session_id and text or attachments are required" }); return; }
+    const promptText = await appendOcrEvidence(body.text ?? "", body.attachments);
 
     const result = await connectionMap.sendCommand(params.id, "chat.steer", {
       agentId: params.id,
       userId: auth.userId,
       sessionId: body.session_id,
-      text: body.text,
+      text: promptText,
     });
 
     sendJson(res, result.ok ? 200 : 502, result);


### PR DESCRIPTION
## Summary
- Add image/PDF attachment upload and preview support in the Portal chat input and user bubbles.
- Preprocess supported attachments in the Portal chat gateway through an independent PaddleOCR backend service, then append extracted OCR evidence to the agent prompt.
- Add a Helm-managed OCR Deployment/Service with mobile PP-OCRv5 defaults, Portal env wiring, and design/backend docs.

## Notes
- This PR is based directly on `origin/main` and intentionally does not include PR286 / `feat/codex-style-steer` changes.
- This is not an MCP flow; raw image/PDF bytes stop at Portal -> OCR backend, and Runtime/AgentBox receive text evidence only.
- OCR backend accepts only `file_base64` sources to avoid URL/path read behavior.

## Validation
- `npm test -- src/portal/chat-gateway.test.ts`
- `npm run build -- --pretty false`
- `npm run build` in `portal-web/`
- `python3 -m py_compile services/ocr-backend/server.py services/ocr-backend/parse_once.py`
- `helm lint helm/siclaw`
- `helm template siclaw helm/siclaw --namespace sdliu-siclaw`
- `helm template siclaw helm/siclaw --namespace sdliu-siclaw -f helm/siclaw/values-standalone.yaml`
- `git diff --check`