### PR TITLE
fix(memory): disable Siclaw memory by default

### DIFF
--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: {{ include "siclaw.agentboxImage" . }}
             - name: SICLAW_GATEWAY_HOSTNAME
               value: "{{ include "siclaw.fullname" . }}-runtime.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: SICLAW_MEMORY_ENABLED
+              value: {{ ternary "true" "false" .Values.runtime.memory.enabled | quote }}
             {{- if .Values.agentbox.persistence.enabled }}
             - name: SICLAW_PERSISTENCE_ENABLED
               value: "true"

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -57,6 +57,10 @@ runtime:
     limits:
       cpu: "2"
       memory: "2Gi"
+  memory:
+    # Disabled by default for Sicore-integrated production deployments. Enabling
+    # this re-exposes memory_search/memory_get and session memory auto-save.
+    enabled: false
   env: {}
 
 # -- Portal (standalone web UI, replaces Upstream)

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -48,6 +48,7 @@ vi.mock("../core/config.js", () => ({
       },
     },
   }),
+  isMemoryEnabled: () => true,
 }));
 
 // Make sync-handlers a no-op registry.

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -11,7 +11,7 @@ import https from "node:https";
 import type { TLSSocket } from "node:tls";
 import type { AgentBoxSessionManager } from "./session.js";
 import type { SessionMode } from "../core/types.js";
-import { loadConfig } from "../core/config.js";
+import { isMemoryEnabled, loadConfig } from "../core/config.js";
 import { emitDiagnostic } from "../shared/diagnostic-events.js";
 import { checkMetricsAuth } from "../shared/metrics.js"; // also registers metrics subscriber (side-effect)
 import { GatewayClient } from "./gateway-client.js";
@@ -414,7 +414,7 @@ export function createHttpServer(
     // Prepending would break marker detection in pi-agent extension input handlers
     // (e.g., [System: respond in Chinese]\n[Deep Investigation]\n... fails startsWith check).
     const detectedLang = detectLanguage(body.text);
-    if (detectedLang !== "English") {
+    if (detectedLang !== "English" && isMemoryEnabled()) {
       // Only two DP markers remain after the refactor: activation and exit.
       const dpMarkers = [DP_ACTIVATION_MARKER, `${DP_EXIT_MARKER}\n`];
       const matchedMarker = dpMarkers.find(m => promptText.startsWith(m));

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -780,13 +780,20 @@ describe("AgentBoxSessionManager — resetMemory", () => {
     await expect(mgr.resetMemory()).resolves.toBeUndefined();
   });
 
-  it("calls sync + clearInvestigations on the shared indexer after init", async () => {
+  it("closes and rebuilds the shared indexer after Gateway deletes the memory dir", async () => {
     const mgr = new AgentBoxSessionManager();
     // Trigger shared init via getOrCreate
     await mgr.getOrCreate("sess-1");
+
+    const firstIndexer = await (createMemoryIndexer as any).mock.results[0].value;
+
     await mgr.resetMemory();
-    // We can't directly observe through the mock without exposing it, but
-    // we can verify no throw and activeCount is preserved.
+
+    expect(firstIndexer.close).toHaveBeenCalledTimes(1);
+    expect(createMemoryIndexer).toHaveBeenCalledTimes(2);
+    const secondIndexer = await (createMemoryIndexer as any).mock.results[1].value;
+    expect(secondIndexer.sync).toHaveBeenCalledTimes(1);
+    expect(secondIndexer.startWatching).toHaveBeenCalledTimes(1);
     expect(mgr.activeCount()).toBe(1);
   });
 });

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -108,6 +108,7 @@ vi.mock("../memory/session-summarizer.js", () => ({
 // Scoped config mock — points paths to the per-test temp dir.
 let _cfgUserDataDir = "";
 let _cfgCredentialsDir = ".siclaw/credentials";
+let _memoryEnabled = true;
 
 vi.mock("../core/config.js", () => ({
   loadConfig: () => ({
@@ -120,10 +121,13 @@ vi.mock("../core/config.js", () => ({
     providers: {},
   }),
   getEmbeddingConfig: () => null,
+  isMemoryEnabled: () => _memoryEnabled,
 }));
 
 // Import SUT after mocks
 import { AgentBoxSessionManager } from "./session.js";
+import { createMemoryIndexer } from "../memory/index.js";
+import { saveSessionKnowledge } from "../memory/session-summarizer.js";
 
 function installDelegationPersistenceRecorder(mgr: AgentBoxSessionManager): void {
   const g = globalThis as any;
@@ -145,6 +149,7 @@ let origCwd: string;
 let tmpDir: string;
 
 beforeEach(() => {
+  vi.clearAllMocks();
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -154,6 +159,7 @@ beforeEach(() => {
   process.chdir(tmpDir);
   _cfgUserDataDir = path.join(tmpDir, "user-data");
   _cfgCredentialsDir = path.join(tmpDir, ".siclaw/credentials");
+  _memoryEnabled = true;
   (globalThis as any).__frameworkEntriesState.entries = []; // default: new session
   (globalThis as any).__createSessionCalls.length = 0;
   (globalThis as any).__fakeBrainFactories.length = 0;
@@ -218,6 +224,17 @@ describe("AgentBoxSessionManager — getOrCreate", () => {
     const mgr = new AgentBoxSessionManager();
     await mgr.getOrCreate("sess-1");
     expect(lastCreateSiclawSession.calls[0].mode).toBe("web");
+  });
+
+  it("does not initialize memory or create memory dir when memory is disabled", async () => {
+    _memoryEnabled = false;
+    const mgr = new AgentBoxSessionManager();
+
+    await mgr.getOrCreate("sess-1");
+
+    expect(createMemoryIndexer).not.toHaveBeenCalled();
+    expect(lastCreateSiclawSession.calls[0].memoryIndexer).toBeUndefined();
+    expect(fs.existsSync(path.join(_cfgUserDataDir, "memory"))).toBe(false);
   });
 
   it("hides delegation tools by default", async () => {
@@ -586,6 +603,16 @@ describe("AgentBoxSessionManager — release", () => {
     await mgr.getOrCreate("sess-1");
     await mgr.release("sess-1");
     expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-save session memory when memory is disabled", async () => {
+    _memoryEnabled = false;
+    const mgr = new AgentBoxSessionManager();
+
+    await mgr.getOrCreate("sess-1");
+    await mgr.release("sess-1");
+
+    expect(saveSessionKnowledge).not.toHaveBeenCalled();
   });
 
   it("release skips delete when a new getOrCreate has replaced the session mid-release", async () => {

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -415,6 +415,17 @@ export class AgentBoxSessionManager {
     return path.join(userDataDir, "memory");
   }
 
+  private async createSharedMemoryIndexer(memoryDir: string): Promise<MemoryIndexer> {
+    if (!fs.existsSync(memoryDir)) {
+      fs.mkdirSync(memoryDir, { recursive: true });
+    }
+    const embeddingOpts = getEmbeddingConfig() ?? undefined;
+    const indexer = await createMemoryIndexer(memoryDir, embeddingOpts);
+    await indexer.sync();
+    indexer.startWatching();
+    return indexer;
+  }
+
   /**
    * Lazily initialize shared components (memory indexer, MCP manager).
    * Called on first getOrCreate(). Idempotent.
@@ -433,13 +444,7 @@ export class AgentBoxSessionManager {
 
     // ── Memory indexer ──
     try {
-      if (!fs.existsSync(memoryDir)) {
-        fs.mkdirSync(memoryDir, { recursive: true });
-      }
-      const embeddingOpts = getEmbeddingConfig() ?? undefined;
-      this._sharedMemoryIndexer = await createMemoryIndexer(memoryDir, embeddingOpts);
-      await this._sharedMemoryIndexer.sync();
-      this._sharedMemoryIndexer.startWatching();
+      this._sharedMemoryIndexer = await this.createSharedMemoryIndexer(memoryDir);
       console.log(`[agentbox-session] Shared memory indexer initialized for ${memoryDir}`);
     } catch (err) {
       console.warn(`[agentbox-session] Shared memory indexer init failed:`, err);
@@ -1964,9 +1969,8 @@ Always end with a final report even if evidence is incomplete.`;
   /**
    * Reset the shared memory indexer.
    * Called after Gateway has cleared memory files on PVC.
-   * Triggers a sync so the existing indexer detects deleted files and
-   * cleans up its DB records. We keep the same indexer instance alive
-   * because active sessions hold direct references to it via tool closures.
+   * Gateway deletes the full memory/ directory, including .memory.db, so a
+   * live AgentBox must close the old sqlite handle and build a fresh indexer.
    */
   async resetMemory(): Promise<void> {
     if (!isMemoryEnabled()) {
@@ -1988,13 +1992,18 @@ Always end with a final report even if evidence is incomplete.`;
     }
 
     try {
-      // sync() detects deleted .md files and cleans up files/chunks tables
-      await this._sharedMemoryIndexer.sync();
-      // investigations table is NOT cleaned by sync — clear it explicitly
-      this._sharedMemoryIndexer.clearInvestigations();
-      console.log(`[agentbox-session] Memory indexer re-synced after PVC cleanup`);
+      this._sharedMemoryIndexer.close();
     } catch (err) {
-      console.warn(`[agentbox-session] Memory indexer sync after reset failed:`, err);
+      console.warn(`[agentbox-session] Memory indexer close before reset failed:`, err);
+    }
+    this._sharedMemoryIndexer = null;
+
+    try {
+      const memoryDir = this.getMemoryDir();
+      this._sharedMemoryIndexer = await this.createSharedMemoryIndexer(memoryDir);
+      console.log(`[agentbox-session] Memory indexer rebuilt after PVC cleanup`);
+    } catch (err) {
+      console.warn(`[agentbox-session] Memory indexer rebuild after reset failed:`, err);
     }
   }
 }

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -33,7 +33,7 @@ import type { BrainSession } from "../core/brain-session.js";
 import type { McpClientManager } from "../core/mcp-client.js";
 import { createMemoryIndexer, type MemoryIndexer } from "../memory/index.js";
 import { saveSessionKnowledge } from "../memory/session-summarizer.js";
-import { loadConfig, getEmbeddingConfig } from "../core/config.js";
+import { loadConfig, getEmbeddingConfig, isMemoryEnabled } from "../core/config.js";
 import { emitDiagnostic } from "../shared/diagnostic-events.js";
 import { buildRedactionConfigForModelConfig, redactText, type RedactionConfig } from "../shared/output-redactor.js";
 import type {
@@ -422,6 +422,12 @@ export class AgentBoxSessionManager {
   private async ensureSharedComponents(): Promise<void> {
     if (this._sharedInitialized) return;
     this._sharedInitialized = true;
+
+    if (!isMemoryEnabled()) {
+      this._sharedMemoryIndexer = null;
+      console.log(`[agentbox-session] Memory disabled by SICLAW_MEMORY_ENABLED`);
+      return;
+    }
 
     const memoryDir = this.getMemoryDir();
 
@@ -1458,10 +1464,11 @@ Always end with a final report even if evidence is incomplete.`;
     const sessionDir = this.getSessionDir(id);
     console.log(`[agentbox-session] Creating session: ${id} in ${sessionDir}`);
 
-    // Ensure memory directory exists
-    const memoryDir = this.getMemoryDir();
-    if (!fs.existsSync(memoryDir)) {
-      fs.mkdirSync(memoryDir, { recursive: true });
+    if (isMemoryEnabled()) {
+      const memoryDir = this.getMemoryDir();
+      if (!fs.existsSync(memoryDir)) {
+        fs.mkdirSync(memoryDir, { recursive: true });
+      }
     }
 
     // continueRecent with proper cwd + sessionDir — restores the correct
@@ -1527,7 +1534,7 @@ Always end with a final report even if evidence is incomplete.`;
     result.sessionIdRef.current = id;
 
     // New session: sync memory index, then purge stale investigations (chained to avoid race)
-    if (isNewSession && this._sharedMemoryIndexer) {
+    if (isMemoryEnabled() && isNewSession && this._sharedMemoryIndexer) {
       const memDir = this.getMemoryDir();
       this._sharedMemoryIndexer.sync()
         .then(() => this._sharedMemoryIndexer!.purgeStaleInvestigations(memDir, { skipSync: true }))
@@ -1774,8 +1781,9 @@ Always end with a final report even if evidence is incomplete.`;
   /**
    * Release a session after prompt completion.
    *
-   * Performs memory auto-save (if new messages since last save), syncs the
-   * shared memory index, then removes the session from the in-memory map.
+   * When memory is enabled, performs memory auto-save (if new messages since
+   * last save) and syncs the shared memory index, then removes the session
+   * from the in-memory map.
    * Shared components (memory indexer, MCP) are NOT destroyed.
    *
    * The session can be transparently restored from JSONL on the next getOrCreate().
@@ -1787,22 +1795,26 @@ Always end with a final report even if evidence is incomplete.`;
     console.log(`[agentbox-session] Releasing session: ${sessionId}`);
 
     // 1. Auto-save session memory (dedup: only if new messages since last save)
-    try {
-      const sessionDir = this.getSessionDir(sessionId);
-      const memoryDir = this.getMemoryDir();
-      const currentMessageCount = this.countJsonlMessages(sessionDir);
+    if (isMemoryEnabled()) {
+      try {
+        const sessionDir = this.getSessionDir(sessionId);
+        const memoryDir = this.getMemoryDir();
+        const currentMessageCount = this.countJsonlMessages(sessionDir);
 
-      if (currentMessageCount > managed._lastSavedMessageCount) {
-        const saved = await saveSessionKnowledge({ sessionDir, memoryDir });
-        if (saved) {
-          managed._lastSavedMessageCount = currentMessageCount;
-          console.log(`[agentbox-session] Memory auto-saved for ${sessionId}: ${saved.map(f => path.basename(f)).join(", ")}`);
+        if (currentMessageCount > managed._lastSavedMessageCount) {
+          const saved = await saveSessionKnowledge({ sessionDir, memoryDir });
+          if (saved) {
+            managed._lastSavedMessageCount = currentMessageCount;
+            console.log(`[agentbox-session] Memory auto-saved for ${sessionId}: ${saved.map(f => path.basename(f)).join(", ")}`);
+          }
+        } else {
+          console.log(`[agentbox-session] Skipping memory auto-save for ${sessionId} (no new messages)`);
         }
-      } else {
-        console.log(`[agentbox-session] Skipping memory auto-save for ${sessionId} (no new messages)`);
+      } catch (err) {
+        console.warn(`[agentbox-session] Memory auto-save failed for ${sessionId}:`, err);
       }
-    } catch (err) {
-      console.warn(`[agentbox-session] Memory auto-save failed for ${sessionId}:`, err);
+    } else {
+      console.log(`[agentbox-session] Skipping memory auto-save for ${sessionId} (memory disabled)`);
     }
 
     // 2. Shutdown per-session MCP connections
@@ -1815,7 +1827,7 @@ Always end with a final report even if evidence is incomplete.`;
     }
 
     // 3. Sync shared memory index to pick up the new summary file
-    if (this._sharedMemoryIndexer) {
+    if (isMemoryEnabled() && this._sharedMemoryIndexer) {
       await this._sharedMemoryIndexer.sync().catch((err) => {
         console.warn(`[agentbox-session] Memory sync on release failed:`, err);
       });
@@ -1957,6 +1969,19 @@ Always end with a final report even if evidence is incomplete.`;
    * because active sessions hold direct references to it via tool closures.
    */
   async resetMemory(): Promise<void> {
+    if (!isMemoryEnabled()) {
+      if (this._sharedMemoryIndexer) {
+        try {
+          this._sharedMemoryIndexer.close();
+        } catch (err) {
+          console.warn(`[agentbox-session] Memory indexer close during disabled reset failed:`, err);
+        }
+        this._sharedMemoryIndexer = null;
+      }
+      console.log(`[agentbox-session] Memory disabled; resetMemory is a no-op`);
+      return;
+    }
+
     if (!this._sharedMemoryIndexer) {
       console.log(`[agentbox-session] No memory indexer to reset`);
       return;

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -6,7 +6,7 @@ import {
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
 import { createSiclawSession } from "./core/agent-factory.js";
-import { loadConfig, getDefaultLlm, setPortalSnapshot, validateLlmConfig } from "./core/config.js";
+import { isMemoryEnabled, loadConfig, getDefaultLlm, setPortalSnapshot, validateLlmConfig } from "./core/config.js";
 import { needsSetup } from "./cli-setup.js";
 import { runFirstRunSetup } from "./cli-first-run.js";
 import { saveSessionKnowledge } from "./memory/session-summarizer.js";
@@ -218,7 +218,7 @@ const { brain, session, modelFallbackMessage, customTools, skillsDirs, memoryInd
         .filter((e) => (e.isDirectory() || e.isSymbolicLink()) && !e.name.startsWith("_")).length;
     } catch { /* skip */ }
   }
-  const memoryActive = fs.existsSync(path.resolve(process.cwd(), loadConfig().paths.userDataDir, "memory"));
+  const memoryActive = isMemoryEnabled() && fs.existsSync(path.resolve(process.cwd(), loadConfig().paths.userDataDir, "memory"));
 
   // Count credentials
   let credCount = 0;
@@ -353,7 +353,7 @@ if (isPrintMode && initialMessage) {
 
 // -- Cleanup on exit --
 // Auto-save session memory (mirrors AgentBox release flow)
-if (session.sessionFile) {
+if (isMemoryEnabled() && session.sessionFile) {
   const sessionDir = path.dirname(session.sessionFile);
   const memoryDir = path.resolve(process.cwd(), config.paths.userDataDir, "memory");
   try {

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -34,7 +34,7 @@ import agentExtension from "./extensions/agent.js";
 import { PiAgentBrain } from "./brains/pi-agent-brain.js";
 import type { BrainSession } from "./brain-session.js";
 import { McpClientManager } from "./mcp-client.js";
-import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm } from "./config.js";
+import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryEnabled } from "./config.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
 
 import type { SessionMode, KubeconfigRef, MemoryRef, DpStateRef, MutableDpStateRef } from "./types.js";
@@ -173,13 +173,13 @@ function truncateWithBudget(content: string, maxChars: number): string {
  * lazy index (name + description + path) and the model reads SKILL.md on demand.
  */
 function buildAppendSystemPrompt(
-  memoryDir: string,
+  memoryDir: string | null,
 ): string[] {
   const parts: string[] = [];
 
   // Load PROFILE.md (user profile for personalized interactions)
-  const profileFile = path.join(memoryDir, "PROFILE.md");
-  if (fs.existsSync(profileFile)) {
+  const profileFile = memoryDir ? path.join(memoryDir, "PROFILE.md") : null;
+  if (profileFile && fs.existsSync(profileFile)) {
     let profileContent = fs.readFileSync(profileFile, "utf-8").trim();
     if (profileContent) {
       profileContent = truncateWithBudget(profileContent, 5_000);
@@ -231,7 +231,7 @@ When the user does provide identifying info, IMMEDIATELY update \`${memoryDir}/P
   const config_ = loadConfig();
   const reposDir_ = path.resolve(process.cwd(), config_.paths.reposDir);
   const docsDir_ = path.resolve(process.cwd(), config_.paths.docsDir);
-  const overview = buildKnowledgeOverview({ reposDir: reposDir_, docsDir: docsDir_ });
+  const overview = buildKnowledgeOverview({ reposDir: reposDir_, docsDir: docsDir_, memoryEnabled: !!memoryDir });
   if (overview) {
     parts.push(overview);
   }
@@ -248,6 +248,24 @@ function assertPathAllowed(absolutePath: string, allowedDirs: string[], operatio
       `${operation} blocked: "${absolutePath}" is outside allowed directories. ` +
       `Allowed: ${allowedDirs.join(", ")}`
     );
+  }
+}
+
+function isPathInsideDir(absolutePath: string, dir: string): boolean {
+  const resolved = path.resolve(absolutePath);
+  const resolvedDir = path.resolve(dir);
+  return resolved === resolvedDir || resolved.startsWith(resolvedDir + path.sep);
+}
+
+function assertToolPathAllowed(
+  absolutePath: string,
+  allowedDirs: string[],
+  operation: string,
+  blockedMemoryDir: string | null,
+): void {
+  assertPathAllowed(absolutePath, allowedDirs, operation);
+  if (blockedMemoryDir && isPathInsideDir(absolutePath, blockedMemoryDir)) {
+    throw new Error(`${operation} blocked: Siclaw memory is disabled.`);
   }
 }
 
@@ -283,6 +301,7 @@ export async function createSiclawSession(
   const agentId: string | null = opts?.agentId ?? null;
   const sessionIdRef: { current: string } = { current: "" };
   const mode = opts?.mode ?? "web";
+  const memoryEnabled = isMemoryEnabled();
   // Mutable ref — populated after memoryIndexer is created (below) so memory-
   // consuming tools can retrieve past investigations and persist new ones.
   const memoryRef: MemoryRef = {};
@@ -299,40 +318,46 @@ export async function createSiclawSession(
   const userDataDir = path.resolve(cwd, config.paths.userDataDir);
   const memoryDir = path.join(userDataDir, "memory");
 
-  // Ensure memoryDir and skeleton PROFILE.md exist before the memory indexer
-  // opens its sqlite DB inside memoryDir, and before buildAppendSystemPrompt
-  // reads PROFILE.md below. Previously the mkdir happened later in the function,
-  // so a fresh install saw ERR_SQLITE_ERROR on first run and lost memory tools
-  // for that session.
-  if (!fs.existsSync(memoryDir)) {
-    fs.mkdirSync(memoryDir, { recursive: true });
-  }
-  const skeletonProfilePath = path.join(memoryDir, "PROFILE.md");
-  if (!fs.existsSync(skeletonProfilePath)) {
-    fs.writeFileSync(skeletonProfilePath, `# User Profile\n- **Name**: TBD\n- **Role**: TBD\n- **Infrastructure**: TBD\n- **Preferences**: TBD\n- **Language**: English\n`);
+  if (memoryEnabled) {
+    // Ensure memoryDir and skeleton PROFILE.md exist before the memory indexer
+    // opens its sqlite DB inside memoryDir, and before buildAppendSystemPrompt
+    // reads PROFILE.md below. Previously the mkdir happened later in the function,
+    // so a fresh install saw ERR_SQLITE_ERROR on first run and lost memory tools
+    // for that session.
+    if (!fs.existsSync(memoryDir)) {
+      fs.mkdirSync(memoryDir, { recursive: true });
+    }
+    const skeletonProfilePath = path.join(memoryDir, "PROFILE.md");
+    if (!fs.existsSync(skeletonProfilePath)) {
+      fs.writeFileSync(skeletonProfilePath, `# User Profile\n- **Name**: TBD\n- **Role**: TBD\n- **Infrastructure**: TBD\n- **Preferences**: TBD\n- **Language**: English\n`);
+    }
   }
 
   // ── Memory indexer init (before resolve — memory tools use `available` guard) ──
   // TIMING: must run before DefaultResourceLoader construction (L~478) so that
   // the memoryFlushExtension lambda captures the initialized .current value.
   const memoryIndexerRef: { current: MemoryIndexer | undefined } = { current: undefined };
-  let memoryIndexer: MemoryIndexer | undefined = opts?.memoryIndexer;
-  try {
-    if (memoryIndexer) {
-      memoryIndexerRef.current = memoryIndexer;
-      console.log(`[agent-factory] Reusing shared memory indexer for ${memoryDir}`);
-    } else {
-      const embeddingOpts = resolveEmbeddingConfig();
-      memoryIndexer = await createMemoryIndexer(memoryDir, embeddingOpts);
-      memoryIndexerRef.current = memoryIndexer;
-      await memoryIndexer.sync();
-      memoryIndexer.startWatching();
-      console.log(`[agent-factory] Memory indexer initialized for ${memoryDir}`);
+  let memoryIndexer: MemoryIndexer | undefined = memoryEnabled ? opts?.memoryIndexer : undefined;
+  if (memoryEnabled) {
+    try {
+      if (memoryIndexer) {
+        memoryIndexerRef.current = memoryIndexer;
+        console.log(`[agent-factory] Reusing shared memory indexer for ${memoryDir}`);
+      } else {
+        const embeddingOpts = resolveEmbeddingConfig();
+        memoryIndexer = await createMemoryIndexer(memoryDir, embeddingOpts);
+        memoryIndexerRef.current = memoryIndexer;
+        await memoryIndexer.sync();
+        memoryIndexer.startWatching();
+        console.log(`[agent-factory] Memory indexer initialized for ${memoryDir}`);
+      }
+      memoryRef.indexer = memoryIndexer;
+      memoryRef.dir = memoryDir;
+    } catch (err) {
+      console.warn(`[agent-factory] Memory indexer init failed, continuing without:`, err);
     }
-    memoryRef.indexer = memoryIndexer;
-    memoryRef.dir = memoryDir;
-  } catch (err) {
-    console.warn(`[agent-factory] Memory indexer init failed, continuing without:`, err);
+  } else {
+    console.log(`[agent-factory] Memory disabled by SICLAW_MEMORY_ENABLED`);
   }
 
   // ── Tool Registry: declarative resolution ──
@@ -347,8 +372,8 @@ export async function createSiclawSession(
       kubeconfigRef, userId, agentId, sessionIdRef,
       memoryRef, dpStateRef,
       knowledgeIndexer: opts?.knowledgeIndexer,
-      memoryIndexer,
-      memoryDir,
+      memoryIndexer: memoryEnabled ? memoryIndexer : undefined,
+      memoryDir: memoryEnabled ? memoryDir : undefined,
       sessionEventEmitter: opts?.sessionEventEmitter,
       delegateToAgentExecutor: opts?.enableDelegationTools ? opts?.delegateToAgentExecutor : undefined,
       delegateToAgentsExecutor: opts?.enableDelegationTools ? opts?.delegateToAgentsExecutor : undefined,
@@ -414,47 +439,53 @@ export async function createSiclawSession(
     ...(opts?.portalSkillsDir ? [opts.portalSkillsDir] : []),
   ];
   const writeAllowedDirs = [userDataDir];
+  const blockedMemoryDir = memoryEnabled ? null : memoryDir;
 
   const restrictedFileTools = [
     createReadTool(cwd, {
       operations: {
-        readFile: async (p) => { assertPathAllowed(p, readAllowedDirs, "read"); return fsReadFile(p); },
-        access: async (p) => { assertPathAllowed(p, readAllowedDirs, "read"); return fsAccess(p, fs.constants.R_OK); },
+        readFile: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir); return fsReadFile(p); },
+        access: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir); return fsAccess(p, fs.constants.R_OK); },
       },
     }),
     createEditTool(cwd, {
       operations: {
-        readFile: async (p) => { assertPathAllowed(p, writeAllowedDirs, "edit"); return fsReadFile(p); },
-        writeFile: async (p, c) => { assertPathAllowed(p, writeAllowedDirs, "edit"); return fsWriteFile(p, c, "utf-8"); },
-        access: async (p) => { assertPathAllowed(p, writeAllowedDirs, "edit"); return fsAccess(p, fs.constants.R_OK | fs.constants.W_OK); },
+        readFile: async (p) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedMemoryDir); return fsReadFile(p); },
+        writeFile: async (p, c) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedMemoryDir); return fsWriteFile(p, c, "utf-8"); },
+        access: async (p) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedMemoryDir); return fsAccess(p, fs.constants.R_OK | fs.constants.W_OK); },
       },
     }),
     createWriteTool(cwd, {
       operations: {
-        writeFile: async (p, c) => { assertPathAllowed(p, writeAllowedDirs, "write"); return fsWriteFile(p, c, "utf-8"); },
-        mkdir: async (d) => { assertPathAllowed(d, writeAllowedDirs, "write"); await fsMkdir(d, { recursive: true }); },
+        writeFile: async (p, c) => { assertToolPathAllowed(p, writeAllowedDirs, "write", blockedMemoryDir); return fsWriteFile(p, c, "utf-8"); },
+        mkdir: async (d) => { assertToolPathAllowed(d, writeAllowedDirs, "write", blockedMemoryDir); await fsMkdir(d, { recursive: true }); },
       },
     }),
     createGrepTool(cwd, {
       operations: {
-        isDirectory: (p) => { assertPathAllowed(p, readAllowedDirs, "grep"); return fs.statSync(p).isDirectory(); },
-        readFile: (p) => { assertPathAllowed(p, readAllowedDirs, "grep"); return fs.readFileSync(p, "utf-8"); },
+        isDirectory: (p) => { assertToolPathAllowed(p, readAllowedDirs, "grep", blockedMemoryDir); return fs.statSync(p).isDirectory(); },
+        readFile: (p) => { assertToolPathAllowed(p, readAllowedDirs, "grep", blockedMemoryDir); return fs.readFileSync(p, "utf-8"); },
       },
     }),
     createFindTool(cwd, {
       operations: {
-        exists: (p) => { assertPathAllowed(p, readAllowedDirs, "find"); return fs.existsSync(p); },
+        exists: (p) => { assertToolPathAllowed(p, readAllowedDirs, "find", blockedMemoryDir); return fs.existsSync(p); },
         glob: (pattern, searchCwd, options) => {
-          assertPathAllowed(searchCwd, readAllowedDirs, "find");
-          return globSync(pattern, { cwd: searchCwd, absolute: true, dot: true, ignore: options.ignore }).slice(0, options.limit);
+          assertToolPathAllowed(searchCwd, readAllowedDirs, "find", blockedMemoryDir);
+          return globSync(pattern, { cwd: searchCwd, absolute: true, dot: true, ignore: options.ignore })
+            .filter((p) => !blockedMemoryDir || !isPathInsideDir(p, blockedMemoryDir))
+            .slice(0, options.limit);
         },
       },
     }),
     createLsTool(cwd, {
       operations: {
-        exists: (p) => { assertPathAllowed(p, readAllowedDirs, "ls"); return fs.existsSync(p); },
-        stat: (p) => { assertPathAllowed(p, readAllowedDirs, "ls"); return fs.statSync(p); },
-        readdir: (p) => { assertPathAllowed(p, readAllowedDirs, "ls"); return fs.readdirSync(p); },
+        exists: (p) => { assertToolPathAllowed(p, readAllowedDirs, "ls", blockedMemoryDir); return fs.existsSync(p); },
+        stat: (p) => { assertToolPathAllowed(p, readAllowedDirs, "ls", blockedMemoryDir); return fs.statSync(p); },
+        readdir: (p) => {
+          assertToolPathAllowed(p, readAllowedDirs, "ls", blockedMemoryDir);
+          return fs.readdirSync(p).filter((entry) => !blockedMemoryDir || !isPathInsideDir(path.join(p, entry), blockedMemoryDir));
+        },
       },
     }),
   ];
@@ -538,7 +569,7 @@ export async function createSiclawSession(
     cwd,
     systemPromptOverride: () => buildSreSystemPrompt(mode, opts?.systemPromptTemplate),
     appendSystemPromptOverride: () => {
-      const parts = buildAppendSystemPrompt(memoryDir);
+      const parts = buildAppendSystemPrompt(memoryEnabled ? memoryDir : null);
       if (agentSystemPromptAppend) {
         parts.push("\n\n" + agentSystemPromptAppend);
       }
@@ -548,7 +579,7 @@ export async function createSiclawSession(
     extensionFactories: [
       contextPruningExtension,
       compactionSafeguardExtension,
-      (api) => memoryFlushExtension(api, memoryIndexerRef.current),
+      ...(memoryEnabled ? [(api: ExtensionAPI) => memoryFlushExtension(api, memoryIndexerRef.current)] : []),
       (api) => deepInvestigationExtension(api, memoryRef, mutableDpStateRef),
       (api) => setupExtension(api, credentialsDir, { portalUrl: opts?.portalUrl ?? null }),
       ...cliOnlyFactories,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -66,6 +66,21 @@ export interface SiclawConfig {
   userId: string;
 }
 
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
+
+function parseBooleanEnv(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value.trim() === "") return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+  return defaultValue;
+}
+
+export function isMemoryEnabled(): boolean {
+  return parseBooleanEnv(process.env.SICLAW_MEMORY_ENABLED, true);
+}
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------

--- a/src/core/prompt.test.ts
+++ b/src/core/prompt.test.ts
@@ -20,6 +20,9 @@ describe("buildSreSystemPrompt memory flag", () => {
     expect(prompt).toContain("memory_search");
     expect(prompt).toContain("memory_get");
     expect(prompt).toContain("remember context from previous sessions");
+    expect(prompt).toContain("## Environment & Configuration");
+    expect(prompt).not.toContain("{{memoryIntro}}");
+    expect(prompt).not.toContain("{{memorySection}}");
   });
 
   it("removes bundled memory instructions when memory is disabled", () => {
@@ -30,5 +33,8 @@ describe("buildSreSystemPrompt memory flag", () => {
     expect(prompt).not.toContain("memory_search");
     expect(prompt).not.toContain("memory_get");
     expect(prompt).not.toContain("remember context from previous sessions");
+    expect(prompt).toContain("## Environment & Configuration");
+    expect(prompt).not.toContain("{{memoryIntro}}");
+    expect(prompt).not.toContain("{{memorySection}}");
   });
 });

--- a/src/core/prompt.test.ts
+++ b/src/core/prompt.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSreSystemPrompt } from "./prompt.js";
+
+const ORIGINAL_MEMORY_ENABLED = process.env.SICLAW_MEMORY_ENABLED;
+
+afterEach(() => {
+  if (ORIGINAL_MEMORY_ENABLED === undefined) {
+    delete process.env.SICLAW_MEMORY_ENABLED;
+  } else {
+    process.env.SICLAW_MEMORY_ENABLED = ORIGINAL_MEMORY_ENABLED;
+  }
+});
+
+describe("buildSreSystemPrompt memory flag", () => {
+  it("keeps bundled memory instructions when memory is enabled", () => {
+    delete process.env.SICLAW_MEMORY_ENABLED;
+
+    const prompt = buildSreSystemPrompt("web");
+
+    expect(prompt).toContain("memory_search");
+    expect(prompt).toContain("memory_get");
+    expect(prompt).toContain("remember context from previous sessions");
+  });
+
+  it("removes bundled memory instructions when memory is disabled", () => {
+    process.env.SICLAW_MEMORY_ENABLED = "false";
+
+    const prompt = buildSreSystemPrompt("web");
+
+    expect(prompt).not.toContain("memory_search");
+    expect(prompt).not.toContain("memory_get");
+    expect(prompt).not.toContain("remember context from previous sessions");
+  });
+});

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -27,12 +27,15 @@ export function buildSreSystemPrompt(mode?: "cli" | "web" | "channel" | "task", 
   const modeLabel = MODE_LABELS[mode ?? "cli"] ?? "Web UI";
   const settingsPath = mode === "cli" ? "`/setup`" : "sidebar **Settings**";
   const credentialsPath = mode === "cli" ? "`/setup` → Credentials" : "**Settings → Credentials**";
+  const memoryEnabled = isMemoryEnabled();
 
   // Variable substitution
   let prompt = template
     .replace(/\{\{mode\}\}/g, modeLabel)
     .replace(/\{\{settingsPath\}\}/g, settingsPath)
-    .replace(/\{\{credentialsPath\}\}/g, credentialsPath);
+    .replace(/\{\{credentialsPath\}\}/g, credentialsPath)
+    .replace(/\{\{memoryIntro\}\}/g, memoryEnabled ? MEMORY_INTRO : "")
+    .replace(/\{\{memorySection\}\}/g, memoryEnabled ? MEMORY_SECTION : "");
 
   // Mode-conditional blocks: strip the non-matching mode block
   const keepMode = mode === "web" ? "web" : "cli";
@@ -49,12 +52,6 @@ export function buildSreSystemPrompt(mode?: "cli" | "web" | "channel" | "task", 
 
   // Append hardcoded safety section — NOT overridable by agent templates
   prompt += SAFETY_SECTION(credentialsPath);
-
-  if (!isMemoryEnabled()) {
-    prompt = prompt
-      .replace(" You remember context from previous sessions and grow more helpful over time.", "")
-      .replace(/\n### Memory — Search On Demand\n\nUse `memory_search`[\s\S]*?(?=\n## Environment & Configuration)/, "");
-  }
 
   return prompt;
 }
@@ -95,7 +92,15 @@ Respond in the user's language. \`[System: respond in X]\` overrides to language
 // ---------------------------------------------------------------------------
 // Bundled default template — overridable via agent settings
 // ---------------------------------------------------------------------------
-const DEFAULT_TEMPLATE = `You are Siclaw, a personal SRE AI assistant. You help your user manage and troubleshoot their infrastructure — Kubernetes clusters, cloud resources, and DevOps workflows. You are competent, direct, and warm. You remember context from previous sessions and grow more helpful over time.
+const MEMORY_INTRO = " You remember context from previous sessions and grow more helpful over time.";
+
+const MEMORY_SECTION = `
+
+### Memory — Search On Demand
+
+Use \`memory_search\` **on demand** when symptoms suggest a previously-seen issue — search for past investigations, what was tried, what the root cause was. Use \`memory_get\` to pull details when a match looks relevant. Don't search reflexively — search purposefully.`;
+
+const DEFAULT_TEMPLATE = `You are Siclaw, a personal SRE AI assistant. You help your user manage and troubleshoot their infrastructure — Kubernetes clusters, cloud resources, and DevOps workflows. You are competent, direct, and warm.{{memoryIntro}}
 
 ## Core Behavior
 
@@ -172,10 +177,7 @@ Internal infrastructure knowledge lives as a flat markdown wiki at \`.siclaw/kno
 
 Pages are semantic — they describe what components are and how they fail, not the commands to run. Translate what you learn into concrete checks using skills (preferred) and bash.
 
-### Memory — Search On Demand
-
-Use \`memory_search\` **on demand** when symptoms suggest a previously-seen issue — search for past investigations, what was tried, what the root cause was. Use \`memory_get\` to pull details when a match looks relevant. Don't search reflexively — search purposefully.
-
+{{memorySection}}
 ## Environment & Configuration
 
 Siclaw {{mode}} session. All configuration via {{settingsPath}} (Models, Credentials). Config file \`.siclaw/config/settings.json\` is auto-managed — don't edit manually.

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -1,3 +1,5 @@
+import { isMemoryEnabled } from "./config.js";
+
 const MODE_LABELS: Record<string, string> = {
   cli: "TUI",
   web: "Web UI",
@@ -47,6 +49,12 @@ export function buildSreSystemPrompt(mode?: "cli" | "web" | "channel" | "task", 
 
   // Append hardcoded safety section — NOT overridable by agent templates
   prompt += SAFETY_SECTION(credentialsPath);
+
+  if (!isMemoryEnabled()) {
+    prompt = prompt
+      .replace(" You remember context from previous sessions and grow more helpful over time.", "")
+      .replace(/\n### Memory — Search On Demand\n\nUse `memory_search`[\s\S]*?(?=\n## Environment & Configuration)/, "");
+  }
 
   return prompt;
 }

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -83,6 +83,7 @@ const originalGatewayEnv = {
   SICLAW_GATEWAY_INTERNAL_URL: process.env.SICLAW_GATEWAY_INTERNAL_URL,
   SICLAW_GATEWAY_HOSTNAME: process.env.SICLAW_GATEWAY_HOSTNAME,
   SICLAW_INTERNAL_PORT: process.env.SICLAW_INTERNAL_PORT,
+  SICLAW_MEMORY_ENABLED: process.env.SICLAW_MEMORY_ENABLED,
 };
 
 // Import SUT after mocks.
@@ -241,6 +242,29 @@ describe("K8sSpawner — spawn branches", () => {
     expect(env).toContainEqual({
       name: "SICLAW_GATEWAY_URL",
       value: "https://custom-runtime.svc:3002",
+    });
+  });
+
+  it("passes the runtime memory flag into AgentBox pods", async () => {
+    process.env.SICLAW_MEMORY_ENABLED = "false";
+
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "10.0.0.10", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    await s.spawn({ agentId: "default" });
+
+    const env = calls.createNamespacedPod[0].body.spec.containers[0].env;
+    expect(env).toContainEqual({
+      name: "SICLAW_MEMORY_ENABLED",
+      value: "false",
     });
   });
 

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -172,6 +172,9 @@ export class K8sSpawner implements BoxSpawner {
       { name: "SICLAW_GATEWAY_URL", value: this.gatewayUrl(namespace) },
       { name: "SICLAW_AGENT_ID", value: agentId },
     ];
+    if (process.env.SICLAW_MEMORY_ENABLED !== undefined) {
+      env.push({ name: "SICLAW_MEMORY_ENABLED", value: process.env.SICLAW_MEMORY_ENABLED });
+    }
 
     // Add custom environment variables
     if (boxConfig.env) {

--- a/src/gateway/memory-cleanup.test.ts
+++ b/src/gateway/memory-cleanup.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { clearAgentMemory } from "./memory-cleanup.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "memory-cleanup-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("clearAgentMemory", () => {
+  it("deletes the complete memory directory including profile, db, and nested files", () => {
+    const memoryDir = path.join(tmpDir, "agents", "a1", "memory");
+    fs.mkdirSync(path.join(memoryDir, "investigations"), { recursive: true });
+    fs.mkdirSync(path.join(memoryDir, "topics"), { recursive: true });
+    fs.writeFileSync(path.join(memoryDir, "PROFILE.md"), "profile");
+    fs.writeFileSync(path.join(memoryDir, ".memory.db"), "db");
+    fs.writeFileSync(path.join(memoryDir, "2026-05-26-0502.md"), "longmen");
+    fs.writeFileSync(path.join(memoryDir, "investigations", "case.md"), "case");
+    fs.writeFileSync(path.join(memoryDir, "topics", "cilium.md"), "topic");
+
+    const result = clearAgentMemory("a1", tmpDir);
+
+    expect(result.deletedFiles).toBe(5);
+    expect(result.memoryDir).toBe(memoryDir);
+    expect(fs.existsSync(memoryDir)).toBe(false);
+  });
+
+  it("is idempotent when the memory directory is already absent", () => {
+    const first = clearAgentMemory("missing", tmpDir);
+    const second = clearAgentMemory("missing", tmpDir);
+
+    expect(first.deletedFiles).toBe(0);
+    expect(second.deletedFiles).toBe(0);
+  });
+});

--- a/src/gateway/memory-cleanup.ts
+++ b/src/gateway/memory-cleanup.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function sanitizeAgentId(agentId: string): string {
+  return agentId.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 63);
+}
+
+function countFiles(dir: string): number {
+  let count = 0;
+  if (!fs.existsSync(dir)) return count;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      count += countFiles(fullPath);
+    } else if (entry.isFile()) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+export function clearAgentMemory(agentId: string, userDataBase = "/app/.siclaw/user-data"): { memoryDir: string; deletedFiles: number } {
+  const base = path.resolve(userDataBase);
+  const memoryDir = path.resolve(base, "agents", sanitizeAgentId(agentId), "memory");
+
+  if (!memoryDir.startsWith(base + path.sep)) {
+    throw new Error(`Refusing to clear memory outside user data base: ${memoryDir}`);
+  }
+
+  const deletedFiles = countFiles(memoryDir);
+  fs.rmSync(memoryDir, { recursive: true, force: true });
+  return { memoryDir, deletedFiles };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -19,8 +19,6 @@
  */
 
 import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
 import http from "node:http";
 import https from "node:https";
 import type { RuntimeConfig } from "./config.js";
@@ -38,6 +36,7 @@ import type { FrontendWsClient } from "./frontend-ws-client.js";
 import { createMtlsMiddleware } from "./security/mtls-middleware.js";
 import type { BoxSpawner } from "./agentbox/spawner.js";
 import { checkMetricsAuth } from "../shared/metrics.js";
+import { clearAgentMemory } from "./memory-cleanup.js";
 import {
   handleSettings,
   handleMcpServers,
@@ -313,30 +312,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const agentId = params.agentId as string;
     if (!agentId) throw new Error("agentId required");
 
-    // Memory is agent-scoped (one pod per agent). Path mirrors the k8s-spawner
-    // subPath layout: `/app/.siclaw/user-data/agents/{agentId}/memory`.
-    const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 63);
-    const userDataBase = "/app/.siclaw/user-data";
-    const memoryDir = path.resolve(userDataBase, "agents", sanitize(agentId), "memory");
-
-    // Delete memory files
-    let deletedFiles = 0;
-    if (fs.existsSync(memoryDir)) {
-      const investigationsDir = path.join(memoryDir, "investigations");
-      if (fs.existsSync(investigationsDir)) {
-        const invFiles = fs.readdirSync(investigationsDir).filter((f: string) => f.endsWith(".md"));
-        deletedFiles += invFiles.length;
-        fs.rmSync(investigationsDir, { recursive: true });
-      }
-      for (const entry of fs.readdirSync(memoryDir)) {
-        if (entry === "PROFILE.md") continue;
-        const fullPath = path.join(memoryDir, entry);
-        if (fs.statSync(fullPath).isFile() && !entry.startsWith(".memory.db")) {
-          fs.unlinkSync(fullPath);
-          if (entry.endsWith(".md")) deletedFiles++;
-        }
-      }
-    }
+    const { memoryDir, deletedFiles } = clearAgentMemory(agentId);
 
     console.log(`[rpc] agent.clearMemory: deleted ${deletedFiles} files in ${memoryDir}`);
 

--- a/src/memory/overview-generator.ts
+++ b/src/memory/overview-generator.ts
@@ -8,18 +8,20 @@ import path from "node:path";
 export interface OverviewOpts {
   reposDir?: string;
   docsDir?: string;
+  memoryEnabled?: boolean;
 }
 
 /**
  * Build a concise knowledge overview from content directories.
  * Scans repos/ and docs/ only. Past investigations live under
  * memory/investigations/ but are intentionally NOT auto-injected into the
- * prompt — the agent pulls them on demand via the `memory_search` tool.
+ * prompt; when memory is enabled the agent can pull them on demand via
+ * `memory_search`.
  * Pure sync filesystem scan — no DB dependency.
  * Returns empty string if no knowledge files exist.
  */
 export function buildKnowledgeOverview(opts: OverviewOpts): string {
-  const { reposDir, docsDir } = opts;
+  const { reposDir, docsDir, memoryEnabled = true } = opts;
   const TOTAL_BUDGET = 1200;
 
   const repoEntries = reposDir ? scanRepos(reposDir) : [];
@@ -72,7 +74,9 @@ export function buildKnowledgeOverview(opts: OverviewOpts): string {
   }
 
   // --- Footer ---
-  parts.push('\n\nUse `read` to view files in repos/ or docs/, or `memory_search` to find specific facts.');
+  parts.push(memoryEnabled
+    ? '\n\nUse `read` to view files in repos/ or docs/, or `memory_search` to find specific facts.'
+    : '\n\nUse `read` to view files in repos/ or docs/.');
 
   return parts.join("");
 }
@@ -210,4 +214,3 @@ function scanDocs(docsDir: string): DocEntry[] {
   entries.sort((a, b) => b.fileCount - a.fileCount || (a.category === "(root)" ? 1 : -1));
   return entries;
 }
-

--- a/src/tools/query/memory-get.test.ts
+++ b/src/tools/query/memory-get.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createMemoryGetTool } from "./memory-get.js";
+import { createMemoryGetTool, registration } from "./memory-get.js";
 
 let dir: string;
+const ORIGINAL_MEMORY_ENABLED = process.env.SICLAW_MEMORY_ENABLED;
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "memory-get-test-"));
@@ -12,6 +13,11 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(dir, { recursive: true, force: true });
+  if (ORIGINAL_MEMORY_ENABLED === undefined) {
+    delete process.env.SICLAW_MEMORY_ENABLED;
+  } else {
+    process.env.SICLAW_MEMORY_ENABLED = ORIGINAL_MEMORY_ENABLED;
+  }
 });
 
 describe("memory_get tool", () => {
@@ -19,6 +25,11 @@ describe("memory_get tool", () => {
     const tool = createMemoryGetTool(dir);
     expect(tool.name).toBe("memory_get");
     expect(tool.label).toBe("Memory Get");
+  });
+
+  it("is unavailable when memory is disabled", () => {
+    process.env.SICLAW_MEMORY_ENABLED = "false";
+    expect(registration.available?.({ memoryIndexer: {}, memoryDir: dir } as any)).toBe(false);
   });
 
   it("returns error on empty path", async () => {

--- a/src/tools/query/memory-get.ts
+++ b/src/tools/query/memory-get.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { renderTextResult } from "../infra/tool-render.js";
+import { isMemoryEnabled } from "../../core/config.js";
 
 interface MemoryGetParams {
   path: string;
@@ -117,5 +118,5 @@ export const registration: ToolEntry = {
   category: "query",
   create: (refs) => createMemoryGetTool(refs.memoryDir!),
   platform: true,
-  available: (refs) => !!refs.memoryIndexer && !!refs.memoryDir,
+  available: (refs) => isMemoryEnabled() && !!refs.memoryIndexer && !!refs.memoryDir,
 };

--- a/src/tools/query/memory-search.test.ts
+++ b/src/tools/query/memory-search.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { createMemorySearchTool } from "./memory-search.js";
+import { afterEach, describe, it, expect } from "vitest";
+import { createMemorySearchTool, registration } from "./memory-search.js";
+
+const ORIGINAL_MEMORY_ENABLED = process.env.SICLAW_MEMORY_ENABLED;
+
+afterEach(() => {
+  if (ORIGINAL_MEMORY_ENABLED === undefined) {
+    delete process.env.SICLAW_MEMORY_ENABLED;
+  } else {
+    process.env.SICLAW_MEMORY_ENABLED = ORIGINAL_MEMORY_ENABLED;
+  }
+});
 
 function makeIndexer(result: any) {
   return {
@@ -12,6 +22,11 @@ describe("memory_search tool", () => {
     const tool = createMemorySearchTool(makeIndexer({ chunks: [], totalFiles: 0, totalChunks: 0 }));
     expect(tool.name).toBe("memory_search");
     expect(tool.label).toBe("Memory Search");
+  });
+
+  it("is unavailable when memory is disabled", () => {
+    process.env.SICLAW_MEMORY_ENABLED = "false";
+    expect(registration.available?.({ memoryIndexer: makeIndexer({}) } as any)).toBe(false);
   });
 
   it("returns empty query error", async () => {

--- a/src/tools/query/memory-search.ts
+++ b/src/tools/query/memory-search.ts
@@ -4,6 +4,7 @@ import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { renderTextResult } from "../infra/tool-render.js";
 import type { MemoryIndexer } from "../../memory/index.js";
+import { isMemoryEnabled } from "../../core/config.js";
 
 interface MemorySearchParams {
   query: string;
@@ -111,5 +112,5 @@ export const registration: ToolEntry = {
   category: "query",
   create: (refs) => createMemorySearchTool(refs.memoryIndexer!),
   platform: true,
-  available: (refs) => !!refs.memoryIndexer,
+  available: (refs) => isMemoryEnabled() && !!refs.memoryIndexer,
 };


### PR DESCRIPTION
## Summary
- add `SICLAW_MEMORY_ENABLED` as a global runtime/agentbox memory kill switch
- disable memory tools, memory prompt injection, PROFILE updates, and session memory auto-save when the flag is off
- default the Helm runtime deployment to `SICLAW_MEMORY_ENABLED=false` and pass the flag through to spawned AgentBox pods
- make `agent.clearMemory` remove the complete agent `memory/` directory, including `.memory.db`, `PROFILE.md`, topics, investigations, and historical markdown files

## Verification
- `npm run build`
- `npm test -- src/core/prompt.test.ts src/tools/query/memory-search.test.ts src/tools/query/memory-get.test.ts src/gateway/memory-cleanup.test.ts src/agentbox/session.test.ts src/gateway/agentbox/k8s-spawner.test.ts src/agentbox/http-server.test.ts`
- `helm template siclaw ./helm/siclaw >/tmp/siclaw-memory-mr-helm.yaml && rg -n "SICLAW_MEMORY_ENABLED|value: \"false\"" /tmp/siclaw-memory-mr-helm.yaml`
- `npm test`