### PR TITLE
feat(skills): support skill directory packages

### DIFF
--- a/docs/design/skills.md
+++ b/docs/design/skills.md
@@ -8,7 +8,7 @@
 4. **Per-user toggles**: skill enable/disable and skill space enable/disable are per-user, keyed by `skillId` (not `skillName`).
 5. **Submit and Contribute are independent**: two separate approval flows, each with its own staging tag, review handler, and withdraw operation.
 6. **No cross-origin name collisions**: skills with the same name but different `originId` are rejected at all entry points (create, fork, rename, move, contribute). Only fork from the same source is allowed to create a same-name copy.
-7. **Content hash for change detection**: SHA-256 of specs + sorted scripts determines whether content has changed. Used by `canSubmit`, `canContribute`, `hasUnpublishedChanges`, and builtin sync.
+7. **Content hash for change detection**: SHA-256 of the normalized skill package files determines whether content has changed. Used by `canSubmit`, `canContribute`, `hasUnpublishedChanges`, and builtin sync.
 8. **Skill preview in conversation**: the `skill_preview` tool reads skill draft files from disk and renders a side panel with copy buttons. Agent writes files first via file I/O tools, then calls `skill_preview` with the directory path. Does not persist to DB.
 
 ### The Security-Flexibility Trade-off
@@ -53,10 +53,17 @@ snapshots.
 ```
 {skillName}/
 ├── SKILL.md              # Specification (YAML frontmatter + Markdown body)
-└── scripts/
-    ├── main-script.sh    # One or more executable scripts
-    └── helper.py
+├── scripts/              # Optional executable scripts; direct .sh/.py files remain executable
+│   ├── main-script.sh
+│   └── helper.py
+├── references/           # Optional markdown/source material for the agent to read
+├── examples/             # Optional examples, fixtures, expected outputs
+└── assets/               # Optional small binary/text assets
 ```
+
+A single skill is always a directory package. The smallest valid skill is
+`{skillName}/SKILL.md`; a bundle is a collection of skill directories, not a
+skill itself. The directory name and `SKILL.md` frontmatter `name` must match.
 
 ### SKILL.md Frontmatter
 
@@ -247,7 +254,7 @@ skill.contribute -> contributionStatus: pending -> staging-contribution snapshot
 
 Before publish, submit, or contribute, the UI shows a GitHub-style diff dialog:
 
-- **File diffs**: collapsible sections per file (SKILL.md, scripts/*), 3 lines context, hidden unchanged regions
+- **File diffs**: collapsible sections per package file (`SKILL.md`, `scripts/*`, `references/*`, assets), with text diffs where possible and binary file summaries otherwise
 - **Metadata diff**: type and labels shown as colored tag pills (+green, -red, unchanged gray)
 - **Commit message**: optional text input, stored on skill record for version history
 - **Origin fallback**: for first-time operations on forked skills, diffs against the fork source
@@ -256,7 +263,7 @@ Before publish, submit, or contribute, the UI shows a GitHub-style diff dialog:
 
 Each publish/approve creates a version record with:
 - `tag: "published"` for dev versions, `tag: "approved"` for prod versions
-- Inline specs + scriptsJson + metadata snapshot
+- Full package `files` plus compatibility `specs` / `scriptsJson` and metadata snapshot
 - commitMessage from the user
 
 The UI provides a version history drawer with tag filter (Dev / Prod) and rollback button.
@@ -362,7 +369,7 @@ Personal skills use `published` as a diff baseline (set during fork). Dev bundle
 
 ## Content Hash
 
-SHA-256 of `specs + sorted scripts` (scripts sorted by name for order-independence). Stored in `skill_contents.content_hash`, auto-computed on every save.
+SHA-256 of normalized skill package files, including `SKILL.md`, scripts, references, examples, and assets. Legacy `specs + scripts` payloads are first converted into the same package-file representation. Stored in `skill_contents.content_hash`, auto-computed on every save.
 
 Used by:
 - `hasUnpublishedSkillChanges`: working hash vs published/approved hash
@@ -406,7 +413,7 @@ Gateway (buildSkillBundle)
   -> dedup by dirName (first wins), logs warning on collision
   -> skips per-user disabled skills and disabled skill spaces
   -> generates dirName slug from name at runtime
-  -> builds SkillBundlePayload { skills: [{ dirName, scope, specs, scripts }] }
+  -> builds SkillBundlePayload { skills: [{ dirName, scope, specs, scripts, files }] }
 
 AgentBox (materialize)
   -> builds resolved/ directory with priority-based merging (first dirName wins):
@@ -448,8 +455,8 @@ Gateway startup executes `syncBuiltinSkills()`:
 
 ```
 Scans skills/core/ + skills/extension/
-  -> parses SKILL.md + scripts + meta.json labels for each skill
-  -> computes content hash (SHA-256)
+  -> parses the full skill directory package + meta.json labels for each skill
+  -> computes content hash (SHA-256 of normalized files)
   -> compares with DB:
     - new -> INSERT (id = "builtin:<dirName>"), creates base version record
     - content hash changed -> UPDATE, creates version record
@@ -528,9 +535,9 @@ See `docs/design/invariants.md` §1.4 for the enclosing Portal-as-SoT contract.
 
 | Table | Purpose |
 |-------|---------|
-| `skills` | Skill metadata: name, scope, dirName, authorId, skillSpaceId, originId, forkedFromId, contentHash, labelsJson, publishedVersion, approvedVersion, stagingVersion, reviewStatus, contributionStatus, commitMessage, globalSourceSkillId, globalPinnedVersion |
-| `skill_contents` | File content (specs + scriptsJson + contentHash) by tag (working / staging / staging-contribution / published / approved). Unique index on (skillId, tag). CHECK constraint enforces valid tags. |
-| `skill_versions` | Version history: version number, specs, scriptsJson, tag (published/approved), commitMessage, authorId |
+| `skills` | Skill metadata and working content: name, scope, dirName, authorId, skillSpaceId, originId, forkedFromId, files, compatibility specs/scriptsJson, contentHash, labelsJson, publishedVersion, approvedVersion, stagingVersion, reviewStatus, contributionStatus, commitMessage, globalSourceSkillId, globalPinnedVersion |
+| `skill_contents` | Historical content-tag model for working / staging / staging-contribution / published / approved snapshots where present. New package content should use normalized files and derive compatibility specs/scriptsJson. |
+| `skill_versions` | Version history: version number, files, compatibility specs/scriptsJson, tag (published/approved), commitMessage, authorId |
 | `skill_reviews` | AI + admin review records: reviewerType (ai/admin), riskLevel, summary, findings[], decision (approve/reject/info) |
 | `skill_votes` | User upvotes/downvotes on global skills |
 | `skill_spaces` | Skill space metadata: name, description, ownerId |

--- a/docs/features/portal-cli-integration.mdx
+++ b/docs/features/portal-cli-integration.mdx
@@ -122,7 +122,7 @@ Portal-paired TUI adds an **ephemeral** subtree that gets wiped on exit:
 ```
 .siclaw/
 ├── .portal-snapshot/           ephemeral — source of truth is Portal
-│   ├── skills/<name>/          SKILL.md + scripts/ per skill
+│   ├── skills/<name>/          full skill package per skill
 │   ├── knowledge/<repo>/       knowledge pages, per repo
 │   └── credentials/
 │       ├── manifest.json       { name, type, metadata } per entry

--- a/portal-web/src/api.ts
+++ b/portal-web/src/api.ts
@@ -51,6 +51,28 @@ export async function api<T>(path: string, options?: ApiOptions): Promise<T> {
   return res.json()
 }
 
+export async function apiRaw<T>(path: string, options: RequestInit): Promise<T> {
+  const token = getToken()
+  const res = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers: {
+      ...(token ? { "Authorization": `Bearer ${token}` } : {}),
+      ...(options.headers as Record<string, string> | undefined),
+    },
+  })
+
+  if (res.status === 401) {
+    clearToken()
+    window.location.href = "/login"
+    throw new Error("Unauthorized")
+  }
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(body.error || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
 // SSE helper for chat
 export function chatSSE(
   agentId: string,

--- a/portal-web/src/components/SimpleDiff.tsx
+++ b/portal-web/src/components/SimpleDiff.tsx
@@ -9,8 +9,8 @@
  * Dark-theme compatible (uses Tailwind CSS variable colors).
  */
 
-import { useState, type ReactNode } from "react"
-import { ChevronDown, ChevronRight, FileText } from "lucide-react"
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react"
+import { ChevronDown, ChevronRight, FileText, Folder, Search } from "lucide-react"
 
 // ── Diff algorithm ──────────────────────────────────────────────
 
@@ -21,7 +21,7 @@ interface DiffLine {
   lineNew?: number
 }
 
-function computeDiff(oldText: string, newText: string): DiffLine[] {
+export function computeDiff(oldText: string, newText: string): DiffLine[] {
   const oldLines = oldText ? oldText.split("\n") : []
   const newLines = newText ? newText.split("\n") : []
 
@@ -76,22 +76,23 @@ function DiffLineRow({ line }: { line: DiffLine }) {
         {line.type === "remove" ? "" : line.lineNew}
       </span>
       <span className={`w-5 shrink-0 text-center select-none ${
-        line.type === "add" ? "text-green-400" :
-        line.type === "remove" ? "text-red-400" : "text-muted-foreground/20"
+        line.type === "add" ? "text-green-700 dark:text-green-300" :
+        line.type === "remove" ? "text-red-700 dark:text-red-300" : "text-muted-foreground/20"
       }`}>
         {line.type === "add" ? "+" : line.type === "remove" ? "-" : " "}
       </span>
       <span className={`flex-1 whitespace-pre-wrap break-all pr-2 ${
-        line.type === "add" ? "text-green-300" :
-        line.type === "remove" ? "text-red-300" : ""
+        line.type === "add" ? "text-green-800 dark:text-green-200" :
+        line.type === "remove" ? "text-red-800 dark:text-red-200" : ""
       }`}>{line.content || "\u00A0"}</span>
     </div>
   )
 }
 
-export function DiffBlock({ oldText, newText }: { oldText: string; newText: string }) {
+export function DiffBlock({ oldText, newText, maxHeightClassName = "max-h-80" }: { oldText: string; newText: string; maxHeightClassName?: string }) {
   const diffLines = computeDiff(oldText, newText)
   const [expandedRanges, setExpandedRanges] = useState<Set<number>>(new Set())
+  const containerClassName = `text-[11px] font-mono ${maxHeightClassName} ${maxHeightClassName ? "overflow-y-auto" : ""}`
 
   // Find changed line indices
   const changedSet = new Set<number>()
@@ -102,7 +103,7 @@ export function DiffBlock({ oldText, newText }: { oldText: string; newText: stri
   // If few lines or mostly changed, show everything
   if (diffLines.length <= 20 || changedSet.size === 0) {
     return (
-      <div className="text-[11px] font-mono max-h-80 overflow-y-auto">
+      <div className={containerClassName}>
         {diffLines.map((line, i) => <DiffLineRow key={i} line={line} />)}
       </div>
     )
@@ -141,7 +142,7 @@ export function DiffBlock({ oldText, newText }: { oldText: string; newText: stri
   }
 
   return (
-    <div className="text-[11px] font-mono max-h-80 overflow-y-auto">
+    <div className={containerClassName}>
       {chunks.map((chunk, ci) => {
         if (chunk.type === "collapsed") {
           const count = chunk.end - chunk.start
@@ -167,11 +168,14 @@ export function DiffBlock({ oldText, newText }: { oldText: string; newText: stri
 // ── Collapsible file section ────────────────────────────────────
 
 interface CollapsibleFileSectionProps {
+  id?: string
   title: string
   badge: "added" | "modified" | "removed" | "unchanged"
   defaultOpen?: boolean
   additions?: number
   removals?: number
+  stickyHeader?: boolean
+  bodyClassName?: string
   children: ReactNode
 }
 
@@ -182,14 +186,16 @@ const BADGE_STYLES: Record<string, string> = {
   unchanged: "text-muted-foreground bg-secondary",
 }
 
-export function CollapsibleFileSection({ title, badge, defaultOpen, additions, removals, children }: CollapsibleFileSectionProps) {
+export function CollapsibleFileSection({ id, title, badge, defaultOpen, additions, removals, stickyHeader, bodyClassName, children }: CollapsibleFileSectionProps) {
   const [open, setOpen] = useState(defaultOpen ?? false)
 
   return (
-    <div className="border border-border rounded-md overflow-hidden">
+    <div id={id} className="border border-border rounded-md overflow-hidden bg-card">
       <button
         onClick={() => setOpen(!open)}
         className={`w-full flex items-center gap-2 px-3 py-2 text-[12px] font-medium transition-colors ${
+          stickyHeader ? "sticky top-0 z-10" : ""
+        } ${
           open ? "bg-secondary/50" : "hover:bg-secondary/30"
         }`}
       >
@@ -206,17 +212,32 @@ export function CollapsibleFileSection({ title, badge, defaultOpen, additions, r
           </span>
         )}
       </button>
-      {open && <div className="border-t border-border">{children}</div>}
+      {open && <div className={`border-t border-border ${bodyClassName ?? ""}`}>{children}</div>}
     </div>
   )
 }
 
 // ── Top-level SkillDiffView ─────────────────────────────────────
 
+type FileDiffBadge = "added" | "modified" | "removed" | "unchanged"
+
+interface FileDiffValue {
+  old: string | null
+  new: string | null
+  encoding?: string
+}
+
+export interface SkillDiffPayload {
+  specs_diff?: { old: string | null; new: string | null }
+  scripts_diff?: { old: string | null; new: string | null }
+  files_diff?: Record<string, FileDiffValue>
+}
+
 interface SkillDiffViewProps {
   diff: {
     specs_diff?: { old: string | null; new: string | null }
     scripts_diff?: { old: string | null; new: string | null }
+    files_diff?: Record<string, { old: string | null; new: string | null; encoding?: string }>
   } | string | null
 }
 
@@ -231,7 +252,7 @@ function parseScriptsList(raw: string | null): { name: string; content: string }
 }
 
 /** Decode a string that may have been double-JSON-encoded */
-function decodeStr(raw: string | null): string {
+export function decodeStr(raw: string | null): string {
   if (!raw) return ""
   let s = raw
   // Unwrap double-encoding: "\"---\\nname:...\"" → "---\nname:..."
@@ -239,80 +260,324 @@ function decodeStr(raw: string | null): string {
   return s
 }
 
-export function SkillDiffView({ diff: rawDiff }: SkillDiffViewProps) {
-  if (!rawDiff) return null
+interface FileDiffSection {
+  path: string
+  badge: FileDiffBadge
+  oldContent: string
+  newContent: string
+  additions: number
+  removals: number
+  binary: boolean
+}
 
-  const diff = typeof rawDiff === "string" ? JSON.parse(rawDiff) : rawDiff
+interface DiffTreeNode {
+  name: string
+  path: string
+  type: "file" | "dir"
+  section?: FileDiffSection
+  children: DiffTreeNode[]
+}
+
+function parseDiff(rawDiff: SkillDiffViewProps["diff"]): SkillDiffPayload | null {
+  if (!rawDiff) return null
+  if (typeof rawDiff !== "string") return rawDiff
+  try { return JSON.parse(rawDiff) } catch { return null }
+}
+
+function badgeForValue(value: FileDiffValue, oldContent: string, newContent: string): FileDiffBadge {
+  if (value.old === null || value.old === undefined) return "added"
+  if (value.new === null || value.new === undefined) return "removed"
+  return oldContent !== newContent ? "modified" : "unchanged"
+}
+
+function sectionFromTexts(path: string, oldContent: string, newContent: string, badge: FileDiffBadge, binary = false): FileDiffSection {
+  if (binary) return { path, badge, oldContent: "", newContent: "", additions: 0, removals: 0, binary }
+  const lines = computeDiff(oldContent, newContent)
+  return {
+    path,
+    badge,
+    oldContent,
+    newContent,
+    additions: lines.filter(l => l.type === "add").length,
+    removals: lines.filter(l => l.type === "remove").length,
+    binary,
+  }
+}
+
+function fileSectionsFromDiff(diff: SkillDiffPayload): FileDiffSection[] {
+  const filesDiff = diff?.files_diff
+  if (filesDiff) {
+    return (Object.entries(filesDiff) as Array<[string, FileDiffValue]>)
+      .map(([path, value]) => {
+        const binary = value.encoding === "base64"
+        const oldContent = binary ? "" : decodeStr(value.old)
+        const newContent = binary ? "" : decodeStr(value.new)
+        const badge = badgeForValue(value, oldContent, newContent)
+        return sectionFromTexts(path, oldContent, newContent, badge, binary)
+      })
+      .filter(s => s.badge !== "unchanged")
+  }
+
   const specsDiff = diff?.specs_diff
   const scriptsDiff = diff?.scripts_diff
+  const sections: FileDiffSection[] = []
 
-  const hasSpecs = specsDiff && (specsDiff.old || specsDiff.new)
-  const hasScripts = scriptsDiff && (scriptsDiff.old || scriptsDiff.new)
-  if (!hasSpecs && !hasScripts) return null
+  if (specsDiff && (specsDiff.old || specsDiff.new)) {
+    const oldContent = decodeStr(specsDiff.old)
+    const newContent = decodeStr(specsDiff.new)
+    const badge: FileDiffBadge = !specsDiff.old ? "added" : !specsDiff.new ? "removed" : oldContent !== newContent ? "modified" : "unchanged"
+    if (badge !== "unchanged") sections.push(sectionFromTexts("SKILL.md", oldContent, newContent, badge))
+  }
 
-  // Parse old/new scripts for per-file diffing
-  const oldScripts = parseScriptsList(scriptsDiff?.old)
-  const newScripts = parseScriptsList(scriptsDiff?.new)
+  if (scriptsDiff && (scriptsDiff.old || scriptsDiff.new)) {
+    const oldScripts = parseScriptsList(scriptsDiff.old)
+    const newScripts = parseScriptsList(scriptsDiff.new)
+    const allScriptNames = [...new Set([...oldScripts.map(s => s.name), ...newScripts.map(s => s.name)])]
+    for (const name of allScriptNames) {
+      const oldScript = oldScripts.find(s => s.name === name)
+      const newScript = newScripts.find(s => s.name === name)
+      const oldContent = oldScript?.content || ""
+      const newContent = newScript?.content || ""
+      const badge: FileDiffBadge = !oldScript ? "added" : !newScript ? "removed" : oldContent !== newContent ? "modified" : "unchanged"
+      if (badge !== "unchanged") sections.push(sectionFromTexts(`scripts/${name}`, oldContent, newContent, badge))
+    }
+  }
 
-  // Build per-script diff sections
-  const allScriptNames = [...new Set([...oldScripts.map(s => s.name), ...newScripts.map(s => s.name)])]
-  const scriptSections = allScriptNames.map(name => {
-    const oldScript = oldScripts.find(s => s.name === name)
-    const newScript = newScripts.find(s => s.name === name)
-    const oldContent = oldScript?.content || ""
-    const newContent = newScript?.content || ""
-    const badge: "added" | "removed" | "modified" | "unchanged" =
-      !oldScript ? "added" : !newScript ? "removed" : oldContent !== newContent ? "modified" : "unchanged"
+  return sections
+}
 
-    const lines = computeDiff(oldContent, newContent)
-    const additions = lines.filter(l => l.type === "add").length
-    const removals = lines.filter(l => l.type === "remove").length
+function buildDiffTree(sections: FileDiffSection[]): DiffTreeNode[] {
+  const root: DiffTreeNode = { name: "", path: "", type: "dir", children: [] }
+  const dirMap = new Map<string, DiffTreeNode>([["", root]])
+  const ensureDir = (dirPath: string) => {
+    if (!dirPath) return root
+    const parts = dirPath.split("/")
+    let current = root
+    let currentPath = ""
+    for (const part of parts) {
+      currentPath = currentPath ? `${currentPath}/${part}` : part
+      let dir = dirMap.get(currentPath)
+      if (!dir) {
+        dir = { name: part, path: currentPath, type: "dir", children: [] }
+        dirMap.set(currentPath, dir)
+        current.children.push(dir)
+      }
+      current = dir
+    }
+    return current
+  }
 
-    return { name, badge, oldContent, newContent, additions, removals }
-  }).filter(s => s.badge !== "unchanged")
+  for (const section of sections) {
+    const idx = section.path.lastIndexOf("/")
+    const dir = ensureDir(idx >= 0 ? section.path.slice(0, idx) : "")
+    dir.children.push({
+      name: idx >= 0 ? section.path.slice(idx + 1) : section.path,
+      path: section.path,
+      type: "file",
+      section,
+      children: [],
+    })
+  }
 
-  // Specs diff stats — decode double-encoded strings
-  const specsOld = decodeStr(specsDiff?.old)
-  const specsNew = decodeStr(specsDiff?.new)
-  const specsLines = hasSpecs ? computeDiff(specsOld, specsNew) : []
-  const specsAdded = specsLines.filter(l => l.type === "add").length
-  const specsRemoved = specsLines.filter(l => l.type === "remove").length
-  const specsBadge: "added" | "modified" | "removed" = !specsDiff?.old ? "added" : !specsDiff?.new ? "removed" : "modified"
+  const sortNodes = (nodes: DiffTreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.path === "SKILL.md") return -1
+      if (b.path === "SKILL.md") return 1
+      if (a.type !== b.type) return a.type === "dir" ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+    nodes.forEach(n => sortNodes(n.children))
+  }
+  sortNodes(root.children)
+  return root.children
+}
 
-  const totalFiles = (hasSpecs ? 1 : 0) + scriptSections.length
+const STATUS_LABELS: Record<FileDiffBadge, string> = {
+  added: "A",
+  modified: "M",
+  removed: "D",
+  unchanged: "U",
+}
 
+const STATUS_TEXT: Record<FileDiffBadge, string> = {
+  added: "Added",
+  modified: "Modified",
+  removed: "Deleted",
+  unchanged: "Unchanged",
+}
+
+function statusClassName(badge: FileDiffBadge) {
+  if (badge === "added") return "text-green-700 bg-green-500/10 border-green-500/20 dark:text-green-300"
+  if (badge === "removed") return "text-red-700 bg-red-500/10 border-red-500/20 dark:text-red-300"
+  if (badge === "modified") return "text-blue-700 bg-blue-500/10 border-blue-500/20 dark:text-blue-300"
+  return "text-muted-foreground bg-secondary border-border"
+}
+
+function DiffSummary({ sections }: { sections: FileDiffSection[] }) {
+  const additions = sections.reduce((sum, s) => sum + s.additions, 0)
+  const removals = sections.reduce((sum, s) => sum + s.removals, 0)
   return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
-        <span>{totalFiles} file{totalFiles > 1 ? "s" : ""} changed</span>
-      </div>
-
-      {hasSpecs && (
-        <CollapsibleFileSection
-          title="SKILL.md"
-          badge={specsBadge}
-          defaultOpen={totalFiles <= 3}
-          additions={specsAdded}
-          removals={specsRemoved}
-        >
-          <DiffBlock oldText={specsOld} newText={specsNew} />
-        </CollapsibleFileSection>
-      )}
-
-      {scriptSections.map((s, i) => (
-        <CollapsibleFileSection
-          key={s.name}
-          title={`scripts/${s.name}`}
-          badge={s.badge}
-          defaultOpen={i === 0 && !hasSpecs}
-          additions={s.additions}
-          removals={s.removals}
-        >
-          <DiffBlock oldText={s.oldContent} newText={s.newContent} />
-        </CollapsibleFileSection>
-      ))}
+    <div className="h-10 px-3 border-b border-border flex items-center gap-3 shrink-0 bg-card">
+      <span className="text-[12px] font-medium">{sections.length} file{sections.length === 1 ? "" : "s"} changed</span>
+      <span className="text-[11px] text-green-700 dark:text-green-300">+{additions}</span>
+      <span className="text-[11px] text-red-700 dark:text-red-300">-{removals}</span>
+      <span className="ml-auto hidden sm:inline text-[11px] text-muted-foreground">Unified diff</span>
     </div>
   )
+}
+
+function BinaryDiffNotice({ section }: { section: FileDiffSection }) {
+  return (
+    <div className="px-4 py-8 text-center text-[12px] text-muted-foreground bg-secondary/20">
+      Binary file {STATUS_TEXT[section.badge].toLowerCase()}.
+    </div>
+  )
+}
+
+interface PackageDiffViewProps {
+  diff: SkillDiffViewProps["diff"]
+  compact?: boolean
+  className?: string
+  emptyMessage?: string
+}
+
+export function PackageDiffView({ diff: rawDiff, compact = false, className = "", emptyMessage = "No file changes to show." }: PackageDiffViewProps) {
+  const parsedDiff = useMemo(() => parseDiff(rawDiff), [rawDiff])
+  const sections = useMemo(() => parsedDiff ? fileSectionsFromDiff(parsedDiff) : [], [parsedDiff])
+  const [query, setQuery] = useState("")
+  const [activePath, setActivePath] = useState("")
+  const idPrefix = useId().replace(/[^a-zA-Z0-9_-]/g, "")
+
+  useEffect(() => {
+    if (!sections.some(s => s.path === activePath)) {
+      setActivePath(sections[0]?.path ?? "")
+    }
+  }, [sections, activePath])
+
+  const filteredSections = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return sections
+    return sections.filter(s => s.path.toLowerCase().includes(q))
+  }, [sections, query])
+  const tree = useMemo(() => buildDiffTree(filteredSections), [filteredSections])
+
+  const sectionId = (path: string) => `${idPrefix}-${path.replace(/[^a-zA-Z0-9_-]/g, "-")}`
+  const jumpToFile = (path: string) => {
+    setActivePath(path)
+    requestAnimationFrame(() => document.getElementById(sectionId(path))?.scrollIntoView({ block: "start", behavior: "smooth" }))
+  }
+
+  const renderTree = (nodes: DiffTreeNode[], depth = 0): ReactNode => nodes.map(node => {
+    if (node.type === "dir") {
+      return (
+        <div key={node.path}>
+          <div className="h-7 flex items-center gap-1.5 text-[12px] text-muted-foreground font-mono" style={{ paddingLeft: `${depth * 14 + 8}px` }}>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+            <Folder className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+            <span className="truncate">{node.name}</span>
+          </div>
+          {renderTree(node.children, depth + 1)}
+        </div>
+      )
+    }
+    const section = node.section!
+    const active = activePath === section.path
+    return (
+      <button
+        key={node.path}
+        type="button"
+        onClick={() => jumpToFile(section.path)}
+        className={`w-full h-7 flex items-center gap-1.5 rounded px-1.5 text-left text-[12px] font-mono transition-colors ${
+          active ? "bg-primary/10 text-foreground ring-1 ring-primary/20" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+        }`}
+        style={{ paddingLeft: `${depth * 14 + 8}px` }}
+        title={section.path}
+      >
+        <FileText className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">{node.name}</span>
+        <span className={`ml-auto shrink-0 rounded border px-1 py-0.5 text-[9px] leading-none ${statusClassName(section.badge)}`}>
+          {STATUS_LABELS[section.badge]}
+        </span>
+      </button>
+    )
+  })
+
+  if (sections.length === 0) {
+    return (
+      <div className={`rounded-lg border border-border bg-card px-4 py-8 text-center text-[12px] text-muted-foreground ${className}`}>
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  const renderSection = (section: FileDiffSection, i: number, full = false) => (
+    <CollapsibleFileSection
+      key={section.path}
+      id={full ? sectionId(section.path) : undefined}
+      title={section.path}
+      badge={section.badge}
+      defaultOpen={i === 0 || sections.length <= 3}
+      additions={section.additions}
+      removals={section.removals}
+      stickyHeader={full}
+    >
+      {section.binary ? (
+        <BinaryDiffNotice section={section} />
+      ) : (
+        <DiffBlock oldText={section.oldContent} newText={section.newContent} maxHeightClassName={full ? "" : "max-h-80"} />
+      )}
+    </CollapsibleFileSection>
+  )
+
+  if (compact) {
+    return (
+      <div className={`space-y-3 ${className}`}>
+        <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+          <span>{sections.length} file{sections.length > 1 ? "s" : ""} changed</span>
+          <span className="text-green-700 dark:text-green-300">+{sections.reduce((sum, s) => sum + s.additions, 0)}</span>
+          <span className="text-red-700 dark:text-red-300">-{sections.reduce((sum, s) => sum + s.removals, 0)}</span>
+        </div>
+        {sections.map((section, i) => renderSection(section, i))}
+      </div>
+    )
+  }
+
+  return (
+    <div className={`h-full min-h-0 flex flex-col overflow-hidden rounded-lg border border-border bg-card ${className}`}>
+      <DiffSummary sections={sections} />
+      <div className="flex flex-1 min-h-0">
+        <aside className="hidden md:flex md:w-72 shrink-0 border-r border-border flex-col min-h-0 bg-card">
+          <div className="p-3 border-b border-border">
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+              <input
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder="Filter files..."
+                className="w-full h-8 rounded-md border border-border bg-background pl-7 pr-2 text-[12px] outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2">
+            {filteredSections.length === 0 ? (
+              <p className="px-2 py-6 text-center text-[12px] text-muted-foreground">No matching files.</p>
+            ) : (
+              <div className="space-y-0.5">{renderTree(tree)}</div>
+            )}
+          </div>
+        </aside>
+        <main className="flex-1 min-w-0 overflow-y-auto bg-background">
+          <div className="p-3 space-y-3">
+            {filteredSections.map((section, i) => renderSection(section, i, true))}
+          </div>
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export function SkillDiffView({ diff: rawDiff }: SkillDiffViewProps) {
+  return <PackageDiffView diff={rawDiff} compact />
 }
 
 // Keep backward compat export

--- a/portal-web/src/components/chat/SkillPanel.tsx
+++ b/portal-web/src/components/chat/SkillPanel.tsx
@@ -9,6 +9,7 @@ interface SkillData {
   type: string
   specs: string
   scripts: Array<{ name: string; content: string }>
+  files?: Array<{ path: string; content: string; encoding?: "utf8" | "base64"; size?: number }>
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -44,16 +45,19 @@ function CopyButton({ text }: { text: string }) {
 function getFileIcon(name: string) {
   if (name === "SKILL.md") return <FileText className="w-3.5 h-3.5 text-indigo-500 shrink-0" />
   if (name.endsWith(".py")) return <FileCode className="w-3.5 h-3.5 text-blue-500 shrink-0" />
-  return <Terminal className="w-3.5 h-3.5 text-green-500 shrink-0" />
+  if (name.endsWith(".sh")) return <Terminal className="w-3.5 h-3.5 text-green-500 shrink-0" />
+  return <FileText className="w-3.5 h-3.5 text-slate-500 shrink-0" />
 }
 
 function FileEntry({
   name,
   content,
+  meta,
   defaultExpanded,
 }: {
   name: string
   content: string
+  meta?: string
   defaultExpanded?: boolean
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded ?? false)
@@ -73,6 +77,7 @@ function FileEntry({
         />
         {getFileIcon(name)}
         <span className="text-xs font-mono text-foreground truncate">{name}</span>
+        {meta && <span className="text-[10px] text-muted-foreground shrink-0">{meta}</span>}
         <span className="ml-auto shrink-0">
           <CopyButton text={content} />
         </span>
@@ -86,6 +91,16 @@ function FileEntry({
       )}
     </div>
   )
+}
+
+function decodeSkillPanelFile(file: NonNullable<SkillData["files"]>[number]): { content: string; meta?: string } {
+  if (file.encoding === "base64") {
+    return {
+      content: `[binary file${file.size ? `, ${file.size} bytes` : ""}]`,
+      meta: "binary",
+    }
+  }
+  return { content: file.content, meta: file.size ? `${file.size}B` : undefined }
 }
 
 export interface SkillPanelProps {
@@ -116,12 +131,21 @@ export function SkillPanel({ message, onClose }: SkillPanelProps) {
     )
   }
 
-  // Flat file list: SKILL.md first, then scripts
-  const files: Array<{ name: string; content: string }> = []
-  if (skill.specs) files.push({ name: "SKILL.md", content: skill.specs })
-  for (const s of skill.scripts ?? []) {
-    if (s.content) files.push({ name: s.name, content: s.content })
-  }
+  const files: Array<{ name: string; content: string; meta?: string }> = Array.isArray(skill.files) && skill.files.length > 0
+    ? skill.files
+      .map(file => {
+        const decoded = decodeSkillPanelFile(file)
+        return { name: file.path, content: decoded.content, meta: decoded.meta }
+      })
+      .sort((a, b) => {
+        if (a.name === "SKILL.md") return -1
+        if (b.name === "SKILL.md") return 1
+        return a.name.localeCompare(b.name)
+      })
+    : [
+      ...(skill.specs ? [{ name: "SKILL.md", content: skill.specs }] : []),
+      ...(skill.scripts ?? []).filter(s => s.content).map(s => ({ name: `scripts/${s.name}`, content: s.content })),
+    ]
 
   return (
     <div className="w-[480px] border-l border-border bg-card flex flex-col shrink-0 h-full">
@@ -149,7 +173,7 @@ export function SkillPanel({ message, onClose }: SkillPanelProps) {
       {/* File list */}
       <div className="overflow-y-auto flex-1">
         {files.map((f, i) => (
-          <FileEntry key={f.name} name={f.name} content={f.content} defaultExpanded={i === 0} />
+          <FileEntry key={f.name} name={f.name} content={f.content} meta={f.meta} defaultExpanded={i === 0} />
         ))}
       </div>
     </div>

--- a/portal-web/src/pages/SkillDetail.tsx
+++ b/portal-web/src/pages/SkillDetail.tsx
@@ -1,14 +1,16 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from "react"
+import { useState, useEffect, useRef, useMemo, useCallback, type ReactNode } from "react"
 import { useParams, useNavigate } from "react-router-dom"
-import { ArrowLeft, Loader2, Save, Send, Undo2, Plus, Trash2, RotateCcw, Terminal, FileCode, X, History, ShieldAlert, Code2, FileUp } from "lucide-react"
-import { api } from "../api"
+import { ArrowLeft, Loader2, Save, Send, Undo2, Trash2, RotateCcw, Terminal, FileCode, X, History, ShieldAlert, Code2, FileUp, FolderUp, Archive, ChevronDown, ChevronRight, Folder, FileText, FilePlus2, FolderPlus, Pencil, MoreHorizontal } from "lucide-react"
+import { api, apiRaw } from "../api"
 import { useToast } from "../components/toast"
-import { SkillDiffView } from "../components/SimpleDiff"
+import { PackageDiffView } from "../components/SimpleDiff"
 import { useConfirm } from "../components/confirm-dialog"
 import Editor from "react-simple-code-editor"
 import Prism from "prismjs"
 import "prismjs/components/prism-python"
 import "prismjs/components/prism-bash"
+import "prismjs/components/prism-json"
+import "prismjs/components/prism-markdown"
 import "prismjs/themes/prism-dark.css"
 
 // ── Types ───────────────────────────────────────────────────────
@@ -18,14 +20,38 @@ interface Skill {
   author_id: string; status: "draft" | "pending_review" | "installed"
   version: number; specs: string
   scripts: { name: string; content: string }[] | string | null
+  files?: SkillPackageFile[] | string | null
   created_at: string; updated_at: string
   is_builtin?: boolean; overlay_of?: string | null
 }
 
 interface SkillVersion {
   id: string; version: number; specs: string; scripts: string
+  files?: SkillPackageFile[] | string | null
   commit_message: string; author_id: string
   is_approved: number; created_at: string
+  diff?: unknown
+}
+
+interface SkillPackageFile {
+  path: string
+  content: string
+  encoding?: "utf8" | "base64"
+  size?: number
+  sha256?: string
+  executable?: boolean
+}
+
+type NewPackageEntryKind = "file" | "folder"
+type RenameTarget = { type: "file" | "dir"; path: string }
+
+interface FileTreeNode {
+  name: string
+  path: string
+  type: "file" | "dir"
+  file?: SkillPackageFile
+  virtual?: boolean
+  children: FileTreeNode[]
 }
 
 interface SkillReview {
@@ -76,6 +102,202 @@ function parseScripts(raw: Skill["scripts"]): { name: string; content: string }[
   return raw
 }
 
+function parseFiles(raw: Skill["files"]): SkillPackageFile[] {
+  if (!raw) return []
+  if (typeof raw === "string") { try { return JSON.parse(raw) } catch { return [] } }
+  return Array.isArray(raw) ? raw : []
+}
+
+function byteSize(content: string, encoding: "utf8" | "base64" = "utf8") {
+  if (encoding === "base64") return Math.ceil(content.length * 3 / 4)
+  return new TextEncoder().encode(content).length
+}
+
+function textFile(path: string, content: string, executable = false): SkillPackageFile {
+  return { path, content, encoding: "utf8", size: byteSize(content), executable }
+}
+
+function normalizePackagePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+/g, "/").trim()
+}
+
+function isDirectScriptPath(path: string): boolean {
+  return /^scripts\/[^/]+\.(sh|py)$/.test(path)
+}
+
+function decodeFile(file: SkillPackageFile): string {
+  if (file.encoding === "base64") {
+    try { return atob(file.content) } catch { return "" }
+  }
+  return file.content
+}
+
+function fileDirectory(path: string): string {
+  const idx = path.lastIndexOf("/")
+  return idx >= 0 ? path.slice(0, idx) : ""
+}
+
+function validatePackagePath(path: string, allowSkillMd = false): string | null {
+  const normalized = normalizePackagePath(path)
+  if (!normalized) return "Path is required"
+  if (normalized.endsWith("/")) return "Use a file path, not a directory path"
+  if (!allowSkillMd && normalized === "SKILL.md") return "SKILL.md already exists"
+  const parts = normalized.split("/")
+  if (parts.some(p => !p || p === "." || p === "..")) return "Path cannot contain empty, . or .. segments"
+  if (parts.some(p => p.startsWith("."))) return "Hidden package paths are not supported"
+  if (parts.some(p => p === ".git" || p === "node_modules")) return ".git and node_modules are not allowed"
+  return null
+}
+
+function validateDirectoryPath(path: string): string | null {
+  const normalized = normalizePackagePath(path)
+  if (!normalized) return "Directory path is required"
+  const parts = normalized.split("/")
+  if (parts.some(p => !p || p === "." || p === "..")) return "Path cannot contain empty, . or .. segments"
+  if (parts.some(p => p.startsWith("."))) return "Hidden package paths are not supported"
+  if (parts.some(p => p === ".git" || p === "node_modules")) return ".git and node_modules are not allowed"
+  return null
+}
+
+function shouldSkipFolderUploadPath(path: string): boolean {
+  const normalized = normalizePackagePath(path)
+  if (!normalized) return true
+  return normalized.split("/").some(p => p.startsWith(".") || p === "__MACOSX" || p === "node_modules")
+}
+
+function packageFileKind(path: string): string {
+  if (path === "SKILL.md") return "Entrypoint"
+  if (path.endsWith(".py")) return "Python"
+  if (path.endsWith(".sh")) return "Bash"
+  if (path.endsWith(".json")) return "JSON"
+  if (path.endsWith(".md")) return "Markdown"
+  if (path.endsWith(".csv")) return "CSV"
+  if (path.endsWith(".txt")) return "Text"
+  return "File"
+}
+
+function prismLanguageForPath(path: string) {
+  if (path.endsWith(".py")) return { grammar: Prism.languages.python, language: "python" }
+  if (path.endsWith(".sh")) return { grammar: Prism.languages.bash, language: "bash" }
+  if (path.endsWith(".json")) return { grammar: Prism.languages.json, language: "json" }
+  if (path.endsWith(".md")) return { grammar: Prism.languages.markdown, language: "markdown" }
+  return { grammar: Prism.languages.markdown || Prism.languages.bash, language: "markdown" }
+}
+
+function packageFileIcon(path: string, className = "h-4 w-4") {
+  if (path === "SKILL.md") return <FileText className={`${className} text-purple-400`} />
+  if (path.endsWith(".py")) return <FileCode className={`${className} text-blue-400`} />
+  if (path.endsWith(".sh")) return <Terminal className={`${className} text-green-400`} />
+  return <FileCode className={`${className} text-slate-400`} />
+}
+
+function buildFileTree(files: SkillPackageFile[], virtualDirs: string[] = []): FileTreeNode[] {
+  const root: FileTreeNode = { name: "", path: "", type: "dir", children: [] }
+  const dirMap = new Map<string, FileTreeNode>([["", root]])
+
+  const ensureDir = (dirPath: string, virtual = false) => {
+    const normalized = normalizePackagePath(dirPath)
+    if (!normalized) return root
+    const parts = normalized.split("/")
+    let current = root
+    let currentPath = ""
+    for (const part of parts) {
+      currentPath = currentPath ? `${currentPath}/${part}` : part
+      let dir = dirMap.get(currentPath)
+      if (!dir) {
+        dir = { name: part, path: currentPath, type: "dir", children: [], virtual }
+        dirMap.set(currentPath, dir)
+        current.children.push(dir)
+      } else if (virtual) {
+        dir.virtual = true
+      }
+      current = dir
+    }
+    return current
+  }
+
+  for (const dir of virtualDirs) ensureDir(dir, true)
+
+  for (const file of files) {
+    const parts = file.path.split("/")
+    let current = root
+    let currentPath = ""
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]
+      currentPath = currentPath ? `${currentPath}/${part}` : part
+      const isFile = i === parts.length - 1
+      if (isFile) {
+        current.children.push({ name: part, path: file.path, type: "file", file, children: [] })
+      } else {
+        current = ensureDir(currentPath)
+      }
+    }
+  }
+
+  const sortNodes = (nodes: FileTreeNode[]) => {
+    nodes.sort((a, b) => {
+      if (a.path === "SKILL.md") return -1
+      if (b.path === "SKILL.md") return 1
+      if (a.type !== b.type) return a.type === "dir" ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+    nodes.forEach(n => sortNodes(n.children))
+  }
+  sortNodes(root.children)
+  return root.children
+}
+
+function filesDiffPayload(oldFiles: SkillPackageFile[], newFiles: SkillPackageFile[]) {
+  const oldMap = new Map(oldFiles.map(f => [f.path, f]))
+  const newMap = new Map(newFiles.map(f => [f.path, f]))
+  return Object.fromEntries([...new Set([...oldMap.keys(), ...newMap.keys()])].sort().map(path => {
+    const oldFile = oldMap.get(path)
+    const newFile = newMap.get(path)
+    return [path, {
+      old: oldFile ? decodeFile(oldFile) : null,
+      new: newFile ? decodeFile(newFile) : null,
+      encoding: newFile?.encoding ?? oldFile?.encoding ?? "utf8",
+    }]
+  }))
+}
+
+function decodeMaybeJsonString(raw: string | null | undefined): string {
+  if (!raw) return ""
+  if (raw.startsWith('"')) { try { return JSON.parse(raw) } catch { return raw } }
+  return raw
+}
+
+function skillPackageFilesFromSkill(skill: Skill | null): SkillPackageFile[] {
+  if (!skill) return []
+  const files = parseFiles(skill.files)
+  if (files.length > 0) return files
+  const legacySpecs = decodeMaybeJsonString(skill.specs)
+  return [
+    ...(legacySpecs ? [textFile("SKILL.md", legacySpecs)] : []),
+    ...parseScripts(skill.scripts).map(s => textFile(`scripts/${s.name}`, s.content, s.name.endsWith(".sh") || s.name.endsWith(".py"))),
+  ]
+}
+
+async function browserFileToPackageFile(file: File, packagePath: string): Promise<SkillPackageFile> {
+  const buffer = await file.arrayBuffer()
+  const executable = isDirectScriptPath(packagePath)
+  try {
+    const content = new TextDecoder("utf-8", { fatal: true }).decode(buffer).replace(/\r\n/g, "\n")
+    return textFile(packagePath, content, executable)
+  } catch {
+    let binary = ""
+    const bytes = new Uint8Array(buffer)
+    for (const b of bytes) binary += String.fromCharCode(b)
+    return {
+      path: packagePath,
+      content: btoa(binary),
+      encoding: "base64",
+      size: bytes.byteLength,
+      executable,
+    }
+  }
+}
+
 // ── Component ───────────────────────────────────────────────────
 
 export function SkillDetail() {
@@ -96,14 +318,20 @@ export function SkillDetail() {
   const [labels, setLabels] = useState<string[]>([])
   const [specs, setSpecs] = useState(DEFAULT_SPEC)
   const [scripts, setScripts] = useState<{ name: string; content: string }[]>([])
+  const [extraFiles, setExtraFiles] = useState<SkillPackageFile[]>([])
   const [commitMessage, setCommitMessage] = useState("")
 
-  // Active script editor
-  const [activeScriptIdx, setActiveScriptIdx] = useState<number | null>(null)
+  // Active package file editor
+  const [selectedFilePath, setSelectedFilePath] = useState("SKILL.md")
+  const [selectedNodePath, setSelectedNodePath] = useState("SKILL.md")
+  const [selectedDirPath, setSelectedDirPath] = useState("")
+  const [virtualDirs, setVirtualDirs] = useState<string[]>([])
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set())
 
   // Versions
   const [versions, setVersions] = useState<SkillVersion[]>([])
   const [showHistory, setShowHistory] = useState(false)
+  const [versionDiffDialog, setVersionDiffDialog] = useState<{ title: string; diff: any } | null>(null)
 
   // Label input + autocomplete
   const labelInputRef = useRef<HTMLInputElement>(null)
@@ -133,7 +361,22 @@ export function SkillDetail() {
         try { specsVal = JSON.parse(specsVal) } catch { /* keep as-is */ }
       }
       setSpecs(specsVal)
-      setScripts(parseScripts(s.scripts))
+      const loadedFiles = parseFiles(s.files)
+      if (loadedFiles.length > 0) {
+        const skillFile = loadedFiles.find(f => f.path === "SKILL.md")
+        if (skillFile) setSpecs(decodeFile(skillFile))
+        setScripts(loadedFiles
+          .filter(f => /^scripts\/[^/]+\.(sh|py)$/.test(f.path))
+          .map(f => ({ name: f.path.slice("scripts/".length), content: decodeFile(f) })))
+        setExtraFiles(loadedFiles.filter(f => f.path !== "SKILL.md" && !/^scripts\/[^/]+\.(sh|py)$/.test(f.path)))
+      } else {
+        setScripts(parseScripts(s.scripts))
+        setExtraFiles([])
+      }
+      setVirtualDirs([])
+      setSelectedFilePath("SKILL.md")
+      setSelectedNodePath("SKILL.md")
+      setSelectedDirPath("")
       setEditing(false)
     } catch (err: any) { toast.error(err.message) }
     finally { setLoading(false) }
@@ -148,16 +391,62 @@ export function SkillDetail() {
       .catch(() => setVersions([]))
   }, [id, skill?.version])
 
+  const disabled = !editing && !isCreate
+
+  const packageFiles = useMemo<SkillPackageFile[]>(() => {
+    const scriptFiles = scripts.map(s => textFile(`scripts/${s.name}`, s.content, s.name.endsWith(".sh") || s.name.endsWith(".py")))
+    const extras = extraFiles
+      .filter(f => f.path !== "SKILL.md" && !/^scripts\/[^/]+\.(sh|py)$/.test(f.path))
+      .map(f => ({ ...f, encoding: f.encoding ?? "utf8", size: f.size ?? byteSize(f.content, f.encoding ?? "utf8") }))
+    return [textFile("SKILL.md", specs), ...scriptFiles, ...extras].sort((a, b) => a.path.localeCompare(b.path))
+  }, [specs, scripts, extraFiles])
+
+  const fileTree = useMemo(() => buildFileTree(packageFiles, virtualDirs), [packageFiles, virtualDirs])
+  const selectedFile = packageFiles.find(f => f.path === selectedFilePath) ?? packageFiles.find(f => f.path === "SKILL.md") ?? packageFiles[0]
+  const selectedFileContent = selectedFile ? decodeFile(selectedFile) : ""
+  const selectedFileReadOnly = disabled || selectedFile?.encoding === "base64"
+
+  useEffect(() => {
+    if (packageFiles.length === 0) return
+    if (!packageFiles.some(f => f.path === selectedFilePath)) {
+      setSelectedFilePath(packageFiles.find(f => f.path === "SKILL.md")?.path ?? packageFiles[0].path)
+      setSelectedNodePath(packageFiles.find(f => f.path === "SKILL.md")?.path ?? packageFiles[0].path)
+      setSelectedDirPath("")
+    }
+    setExpandedDirs(prev => {
+      const next = new Set(prev)
+      for (const dirPath of virtualDirs) {
+        const parts = dirPath.split("/")
+        let dir = ""
+        for (const part of parts) {
+          dir = dir ? `${dir}/${part}` : part
+          next.add(dir)
+        }
+      }
+      for (const file of packageFiles) {
+        const parts = file.path.split("/")
+        let dir = ""
+        for (let i = 0; i < parts.length - 1; i++) {
+          dir = dir ? `${dir}/${parts[i]}` : parts[i]
+          next.add(dir)
+        }
+      }
+      return next
+    })
+  }, [packageFiles, selectedFilePath, virtualDirs])
+
   // ── Dirty detection ───────────────────────────────────────────
 
   const isDirty = useMemo(() => {
     if (!skill) return isCreate && name.trim().length > 0
+    const originalFiles = parseFiles(skill.files)
     return name !== skill.name ||
       description !== (skill.description || "") ||
       specs !== (typeof skill.specs === "string" ? skill.specs : "") ||
       JSON.stringify(scripts) !== JSON.stringify(parseScripts(skill.scripts)) ||
+      (originalFiles.length > 0 ? JSON.stringify(packageFiles) !== JSON.stringify(originalFiles) : extraFiles.length > 0) ||
       JSON.stringify(labels) !== JSON.stringify(Array.isArray(skill.labels) ? skill.labels : [])
-  }, [skill, name, description, specs, scripts, labels, isCreate])
+  }, [skill, name, description, specs, scripts, extraFiles, packageFiles, labels, isCreate])
 
   // ── Actions ───────────────────────────────────────────────────
 
@@ -166,7 +455,7 @@ export function SkillDetail() {
     setSaving(true)
     try {
       const created = await api<Skill>("/siclaw/skills", {
-        method: "POST", body: { name: name.trim(), description: description.trim(), labels, specs, scripts },
+        method: "POST", body: { name: name.trim(), description: description.trim(), labels, specs, scripts, files: packageFiles },
       })
       toast.success("Skill created")
       navigate(`/skills/${created.id}`, { replace: true })
@@ -174,12 +463,25 @@ export function SkillDetail() {
     finally { setSaving(false) }
   }
 
-  const handleSave = async () => {
+  const [showSaveDiffDialog, setShowSaveDiffDialog] = useState(false)
+  const [saveDiff, setSaveDiff] = useState<any>(null)
+
+  const buildSaveDiff = () => ({
+    files_diff: filesDiffPayload(skillPackageFilesFromSkill(skill), packageFiles),
+  })
+
+  const handleSaveClick = () => {
+    if (!skill || !isDirty) return
+    setSaveDiff(buildSaveDiff())
+    setShowSaveDiffDialog(true)
+  }
+
+  const performSave = async () => {
     if (!skill) return
     setSaving(true)
     try {
       const updated = await api<Skill>(`/siclaw/skills/${id}`, {
-        method: "PUT", body: { name: name.trim(), description: description.trim(), labels, specs, scripts, commit_message: commitMessage || undefined },
+        method: "PUT", body: { name: name.trim(), description: description.trim(), labels, specs, scripts, files: packageFiles, commit_message: commitMessage || undefined },
       })
       // If the backend created an overlay (response has overlay_of set), redirect to the new overlay
       if (updated.overlay_of) {
@@ -190,6 +492,7 @@ export function SkillDetail() {
       setSkill(updated)
       setEditing(false)
       setCommitMessage("")
+      setShowSaveDiffDialog(false)
       toast.success("Saved")
     } catch (err: any) { toast.error(err.message) }
     finally { setSaving(false) }
@@ -210,6 +513,7 @@ export function SkillDetail() {
       // Decode baseline — may be double-encoded from old DB data
       let baselineSpecs = ""
       let baselineScripts: { name: string; content: string }[] = []
+      let baselineFiles: SkillPackageFile[] = []
       if (lastApproved) {
         const vDetail = await api<SkillVersion>(`/siclaw/skills/${id}/versions/${lastApproved.version}`)
         baselineSpecs = vDetail.specs || ""
@@ -218,11 +522,19 @@ export function SkillDetail() {
           const raw = vDetail.scripts || "[]"
           baselineScripts = typeof raw === "string" ? JSON.parse(raw) : raw
         } catch { baselineScripts = [] }
+        baselineFiles = parseFiles(vDetail.files)
+        if (baselineFiles.length === 0) {
+          baselineFiles = [
+            ...(baselineSpecs ? [textFile("SKILL.md", baselineSpecs)] : []),
+            ...baselineScripts.map(s => textFile(`scripts/${s.name}`, s.content, s.name.endsWith(".sh") || s.name.endsWith(".py"))),
+          ]
+        }
       }
 
       setSubmitDiff({
         specs_diff: { old: baselineSpecs || null, new: specs },
         scripts_diff: { old: JSON.stringify(baselineScripts), new: JSON.stringify(scripts) },
+        files_diff: filesDiffPayload(baselineFiles, packageFiles),
       })
       setShowSubmitDialog(true)
     } catch {
@@ -269,62 +581,413 @@ export function SkillDetail() {
     } catch (err: any) { toast.error(err.message) }
   }
 
-  // ── Script management ─────────────────────────────────────────
+  // ── Package tree management ───────────────────────────────────
 
-  const [showAddMenu, setShowAddMenu] = useState(false)
   const [showNameDialog, setShowNameDialog] = useState(false)
-  const [newScriptType, setNewScriptType] = useState<"shell" | "python">("shell")
-  const [newScriptName, setNewScriptName] = useState("")
+  const [newEntryKind, setNewEntryKind] = useState<NewPackageEntryKind>("file")
+  const [newFilePath, setNewFilePath] = useState("")
+  const [renameTarget, setRenameTarget] = useState<RenameTarget | null>(null)
+  const [renamePath, setRenamePath] = useState("")
+  const [showPackageMenu, setShowPackageMenu] = useState(false)
   const fileInputRef2 = useRef<HTMLInputElement>(null)
+  const folderInputRef = useRef<HTMLInputElement>(null)
+  const archiveInputRef = useRef<HTMLInputElement>(null)
 
-  const initiateAddScript = (type: "shell" | "python") => {
-    setNewScriptType(type)
-    setNewScriptName(type === "python" ? "script.py" : "script.sh")
-    setShowAddMenu(false)
+  const defaultPathForKind = (kind: NewPackageEntryKind) => {
+    const base = selectedDirPath
+    return kind === "folder"
+      ? (base ? `${base}/new-folder` : "new-folder")
+      : (base ? `${base}/new-file.md` : "new-file.md")
+  }
+
+  const newEntryTitle = (kind: NewPackageEntryKind) => {
+    return kind === "folder" ? "Folder" : "File"
+  }
+
+  const selectPackageFile = (path: string) => {
+    const normalized = normalizePackagePath(path)
+    setSelectedFilePath(normalized)
+    setSelectedNodePath(normalized)
+    setSelectedDirPath(fileDirectory(normalized))
+  }
+
+  const selectPackageDirectory = (path: string) => {
+    const normalized = normalizePackagePath(path)
+    setSelectedNodePath(normalized)
+    setSelectedDirPath(normalized)
+  }
+
+  const initiateAddEntry = (kind: NewPackageEntryKind, baseDir = selectedDirPath) => {
+    setNewEntryKind(kind)
+    setNewFilePath(kind === "folder"
+      ? (baseDir ? `${baseDir}/new-folder` : "new-folder")
+      : (baseDir ? `${baseDir}/new-file.md` : "new-file.md"))
     setShowNameDialog(true)
   }
 
-  const confirmAddScript = () => {
-    const trimmed = newScriptName.trim()
-    if (!trimmed) return
-    if (scripts.some(s => s.name === trimmed)) {
-      toast.error(`Script "${trimmed}" already exists`)
-      return
-    }
-    const template = newScriptType === "python" ? '#!/usr/bin/env python3\n\nprint("Hello")' : '#!/bin/bash\n\necho "Hello"'
-    setScripts([...scripts, { name: trimmed, content: template }])
-    setActiveScriptIdx(scripts.length)
-    setShowNameDialog(false)
+  const normalizeUiPackageFile = (file: SkillPackageFile): SkillPackageFile => ({
+    ...file,
+    path: normalizePackagePath(file.path),
+    encoding: file.encoding ?? "utf8",
+    size: file.size ?? byteSize(file.content, file.encoding ?? "utf8"),
+  })
+
+  const setPackageFilesFromUi = (files: SkillPackageFile[], nextSelectedPath = "SKILL.md") => {
+    const normalized = files.map(normalizeUiPackageFile).sort((a, b) => a.path.localeCompare(b.path))
+    const skillFile = normalized.find(f => f.path === "SKILL.md")
+    if (skillFile) setSpecs(decodeFile(skillFile))
+    setScripts(normalized
+      .filter(f => isDirectScriptPath(f.path))
+      .map(f => ({ name: f.path.slice("scripts/".length), content: decodeFile(f) })))
+    setExtraFiles(normalized.filter(f => f.path !== "SKILL.md" && !isDirectScriptPath(f.path)))
+    setSelectedFilePath(nextSelectedPath)
+    setSelectedNodePath(nextSelectedPath)
+    setSelectedDirPath(fileDirectory(nextSelectedPath))
   }
 
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    if (scripts.some(s => s.name === file.name)) {
-      toast.error(`Script "${file.name}" already exists`)
-      e.target.value = ""
+  const packageDirectoryExists = (path: string) => {
+    const normalized = normalizePackagePath(path)
+    return packageFiles.some(f => f.path.startsWith(`${normalized}/`)) ||
+      virtualDirs.some(d => d === normalized || d.startsWith(`${normalized}/`))
+  }
+
+  const addPackageTextFile = (path: string, content: string, executable = false) => {
+    const normalized = normalizePackagePath(path)
+    if (normalized === "SKILL.md") {
+      setSpecs(content)
+      selectPackageFile("SKILL.md")
+      return true
+    }
+    if (isDirectScriptPath(normalized)) {
+      const scriptName = normalized.slice("scripts/".length)
+      if (scripts.some(s => s.name === scriptName)) return false
+      setScripts(prev => [...prev, { name: scriptName, content }])
+      selectPackageFile(normalized)
+      return true
+    }
+    if (extraFiles.some(f => f.path === normalized)) return false
+    setExtraFiles(prev => [...prev, textFile(normalized, content, executable)])
+    selectPackageFile(normalized)
+    return true
+  }
+
+  const confirmAddFile = () => {
+    const normalized = normalizePackagePath(newFilePath)
+    if (newEntryKind === "folder") {
+      const dirError = validateDirectoryPath(normalized)
+      if (dirError) {
+        toast.error(dirError)
+        return
+      }
+      if (packageFiles.some(f => f.path === normalized || f.path.startsWith(`${normalized}/`)) ||
+          virtualDirs.some(d => d === normalized || d.startsWith(`${normalized}/`))) {
+        toast.error(`Directory "${normalized}" already exists`)
+        return
+      }
+      setVirtualDirs(prev => [...prev, normalized].sort())
+      setExpandedDirs(prev => {
+        const next = new Set(prev)
+        const parts = normalized.split("/")
+        let dir = ""
+        for (const part of parts) {
+          dir = dir ? `${dir}/${part}` : part
+          next.add(dir)
+        }
+        return next
+      })
+      selectPackageDirectory(normalized)
+      setShowNameDialog(false)
+      setNewFilePath("")
       return
     }
-    const reader = new FileReader()
-    reader.onload = (event) => {
-      const content = event.target?.result as string
-      setScripts([...scripts, { name: file.name, content }])
-      setActiveScriptIdx(scripts.length)
+
+    const pathError = validatePackagePath(normalized)
+    if (pathError) {
+      toast.error(pathError)
+      return
     }
-    reader.readAsText(file)
-    e.target.value = ""
+    if (packageFiles.some(f => f.path === normalized)) {
+      toast.error(`File "${normalized}" already exists`)
+      return
+    }
+    if (packageDirectoryExists(normalized)) {
+      toast.error(`Directory "${normalized}" already exists`)
+      return
+    }
+    const template = normalized.endsWith(".py")
+      ? '#!/usr/bin/env python3\n\n'
+      : normalized.endsWith(".sh")
+        ? '#!/usr/bin/env bash\nset -euo pipefail\n\n'
+        : normalized.endsWith(".json")
+          ? "{\n  \n}\n"
+          : normalized.endsWith(".md")
+            ? "# New File\n\n"
+            : ""
+    const added = addPackageTextFile(normalized, template, isDirectScriptPath(normalized))
+    if (!added) {
+      toast.error(`File "${normalized}" already exists`)
+      return
+    }
+    setShowNameDialog(false)
+    setNewFilePath("")
+  }
+
+  const activeUploadDir = () => selectedDirPath
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const picked = Array.from(e.target.files ?? [])
+    if (picked.length === 0) return
+    try {
+      const baseDir = activeUploadDir()
+      const nextScripts = [...scripts]
+      const nextExtras = [...extraFiles]
+      const existing = new Set(packageFiles.map(f => f.path))
+      let firstAdded: string | null = null
+      for (const file of picked) {
+        const normalized = normalizePackagePath(baseDir ? `${baseDir}/${file.name}` : file.name)
+        const pathError = validatePackagePath(normalized)
+        if (pathError) throw new Error(`${normalized}: ${pathError}`)
+        if (existing.has(normalized)) throw new Error(`File "${normalized}" already exists`)
+        if (packageDirectoryExists(normalized)) throw new Error(`Directory "${normalized}" already exists`)
+        const packageFile = await browserFileToPackageFile(file, normalized)
+        existing.add(normalized)
+        if (!firstAdded) firstAdded = normalized
+        if (isDirectScriptPath(normalized)) {
+          nextScripts.push({ name: normalized.slice("scripts/".length), content: decodeFile(packageFile) })
+        } else {
+          nextExtras.push(packageFile)
+        }
+      }
+      setScripts(nextScripts)
+      setExtraFiles(nextExtras)
+      if (firstAdded) selectPackageFile(firstAdded)
+      toast.success(`${picked.length} file${picked.length > 1 ? "s" : ""} uploaded`)
+    } catch (err: any) {
+      toast.error(err.message)
+    } finally {
+      e.target.value = ""
+    }
+  }
+
+  const applyPackage = (files: SkillPackageFile[], parsedName?: string, parsedDescription?: string) => {
+    const skillFile = files.find(f => f.path === "SKILL.md")
+    if (!skillFile) {
+      toast.error("Package must include SKILL.md")
+      return
+    }
+    const nextSpecs = decodeFile(skillFile)
+    setSpecs(nextSpecs)
+    const fmMatch = nextSpecs.match(/^---\n([\s\S]*?)\n---/)
+    const nameMatch = fmMatch?.[1]?.match(/^name:\s*(.+)$/m)
+    const descMatch = fmMatch?.[1]?.match(/^description:\s*(.+)$/m)
+    setName(parsedName || nameMatch?.[1]?.trim() || name)
+    setDescription(parsedDescription || descMatch?.[1]?.trim() || description)
+    setScripts(files
+      .filter(f => /^scripts\/[^/]+\.(sh|py)$/.test(f.path))
+      .map(f => ({ name: f.path.slice("scripts/".length), content: decodeFile(f) })))
+    setExtraFiles(files.filter(f => f.path !== "SKILL.md" && !/^scripts\/[^/]+\.(sh|py)$/.test(f.path)))
+    setVirtualDirs([])
+    selectPackageFile("SKILL.md")
+  }
+
+  const handleFolderUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const picked = Array.from(e.target.files ?? [])
+    if (picked.length === 0) return
+    try {
+      const uploadable = picked
+        .map(file => ({
+          file,
+          path: (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name,
+        }))
+        .filter(({ path }) => !shouldSkipFolderUploadPath(path))
+      if (uploadable.length === 0) {
+        toast.error("No supported package files selected")
+        return
+      }
+      const files = await Promise.all(uploadable.map(({ file, path }) => browserFileToPackageFile(file, path)))
+      const preview = await api<{ skill: { name: string; description: string; files: SkillPackageFile[] } }>("/siclaw/skills/package/preview", {
+        method: "POST",
+        body: { files },
+      })
+      applyPackage(preview.skill.files, preview.skill.name, preview.skill.description)
+      toast.success("Package loaded")
+    } catch (err: any) {
+      toast.error(err.message)
+    } finally {
+      e.target.value = ""
+    }
+  }
+
+  const handleArchiveUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      const preview = await apiRaw<{ skill: { name: string; description: string; files: SkillPackageFile[] } }>("/siclaw/skills/package/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: await file.arrayBuffer(),
+      })
+      applyPackage(preview.skill.files, preview.skill.name, preview.skill.description)
+      toast.success("Archive loaded")
+    } catch (err: any) {
+      toast.error(err.message)
+    } finally {
+      e.target.value = ""
+    }
   }
 
   const removeScript = (i: number) => {
     setScripts(scripts.filter((_, idx) => idx !== i))
-    if (activeScriptIdx === i) setActiveScriptIdx(null)
-    else if (activeScriptIdx !== null && activeScriptIdx > i) setActiveScriptIdx(activeScriptIdx - 1)
+    selectPackageFile("SKILL.md")
   }
 
   const updateScriptContent = (i: number, content: string) => {
     const next = [...scripts]
     next[i] = { ...next[i], content }
     setScripts(next)
+  }
+
+  const removeExtraFile = (i: number) => {
+    setExtraFiles(extraFiles.filter((_, idx) => idx !== i))
+    selectPackageFile("SKILL.md")
+  }
+
+  const updateExtraFileContent = (i: number, content: string) => {
+    const next = [...extraFiles]
+    next[i] = { ...next[i], content, encoding: "utf8", size: byteSize(content) }
+    setExtraFiles(next)
+  }
+
+  const updateSkillFileContent = (content: string) => {
+    setSpecs(content)
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/)
+    const nameMatch = fmMatch?.[1]?.match(/^name:\s*(.+)$/m)
+    if (nameMatch) setName(nameMatch[1].trim())
+    const descMatch = fmMatch?.[1]?.match(/^description:\s*(.+)$/m)
+    if (descMatch) setDescription(descMatch[1].trim())
+  }
+
+  const updatePackageFileContent = (path: string, content: string) => {
+    if (path === "SKILL.md") {
+      updateSkillFileContent(content)
+      return
+    }
+    if (isDirectScriptPath(path)) {
+      const scriptName = path.slice("scripts/".length)
+      const idx = scripts.findIndex(s => s.name === scriptName)
+      if (idx >= 0) updateScriptContent(idx, content)
+      return
+    }
+    const idx = extraFiles.findIndex(f => f.path === path)
+    if (idx >= 0) updateExtraFileContent(idx, content)
+  }
+
+  const removePackageFile = (path: string) => {
+    if (path === "SKILL.md") {
+      toast.error("SKILL.md is required")
+      return
+    }
+    if (isDirectScriptPath(path)) {
+      const scriptName = path.slice("scripts/".length)
+      const idx = scripts.findIndex(s => s.name === scriptName)
+      if (idx >= 0) removeScript(idx)
+      return
+    }
+    const idx = extraFiles.findIndex(f => f.path === path)
+    if (idx >= 0) removeExtraFile(idx)
+  }
+
+  const removePackageDirectory = async (path: string) => {
+    const normalized = normalizePackagePath(path)
+    const containedFiles = packageFiles.filter(f => f.path.startsWith(`${normalized}/`))
+    if (containedFiles.length > 0) {
+      const ok = await confirmDialog({
+        title: "Delete Folder",
+        message: `Delete "${normalized}" and ${containedFiles.length} file${containedFiles.length > 1 ? "s" : ""}?`,
+        confirmLabel: "Delete",
+        destructive: true,
+      })
+      if (!ok) return
+    }
+    const remainingFiles = packageFiles.filter(f => !f.path.startsWith(`${normalized}/`))
+    setPackageFilesFromUi(remainingFiles, "SKILL.md")
+    setVirtualDirs(prev => prev.filter(d => d !== normalized && !d.startsWith(`${normalized}/`)))
+    selectPackageFile("SKILL.md")
+  }
+
+  const startRename = (target: RenameTarget) => {
+    if (target.type === "file" && target.path === "SKILL.md") {
+      toast.error("SKILL.md filename is required")
+      return
+    }
+    setRenameTarget(target)
+    setRenamePath(target.path)
+  }
+
+  const confirmRename = () => {
+    if (!renameTarget) return
+    const nextPath = normalizePackagePath(renamePath)
+
+    if (renameTarget.type === "dir") {
+      const oldPath = normalizePackagePath(renameTarget.path)
+      const dirError = validateDirectoryPath(nextPath)
+      if (dirError) { toast.error(dirError); return }
+      if (nextPath === oldPath) { setRenameTarget(null); return }
+      if (nextPath.startsWith(`${oldPath}/`)) {
+        toast.error("Cannot move a folder inside itself")
+        return
+      }
+      if (packageFiles.some(f => f.path === nextPath || (f.path.startsWith(`${nextPath}/`) && !f.path.startsWith(`${oldPath}/`))) ||
+          virtualDirs.some(d => d === nextPath || (d.startsWith(`${nextPath}/`) && !d.startsWith(`${oldPath}/`)))) {
+        toast.error(`Directory "${nextPath}" already exists`)
+        return
+      }
+      const movedFiles = packageFiles.map(f => f.path.startsWith(`${oldPath}/`)
+        ? { ...f, path: `${nextPath}/${f.path.slice(oldPath.length + 1)}` }
+        : f)
+      const selectedAfterMove = selectedFilePath.startsWith(`${oldPath}/`)
+        ? `${nextPath}/${selectedFilePath.slice(oldPath.length + 1)}`
+        : selectedFilePath
+      setPackageFilesFromUi(movedFiles, selectedAfterMove)
+      setVirtualDirs(prev => prev.map(d => d === oldPath || d.startsWith(`${oldPath}/`)
+        ? `${nextPath}${d.slice(oldPath.length)}`
+        : d).sort())
+      setExpandedDirs(prev => {
+        const next = new Set(prev)
+        next.delete(oldPath)
+        next.add(nextPath)
+        return next
+      })
+      setSelectedDirPath(nextPath)
+      setSelectedNodePath(nextPath)
+      setRenameTarget(null)
+      return
+    }
+
+    const oldPath = normalizePackagePath(renameTarget.path)
+    const pathError = validatePackagePath(nextPath)
+    if (pathError) { toast.error(pathError); return }
+    if (nextPath === oldPath) { setRenameTarget(null); return }
+    if (packageFiles.some(f => f.path === nextPath)) {
+      toast.error(`File "${nextPath}" already exists`)
+      return
+    }
+    if (packageDirectoryExists(nextPath)) {
+      toast.error(`Directory "${nextPath}" already exists`)
+      return
+    }
+    const movedFiles = packageFiles.map(f => f.path === oldPath ? { ...f, path: nextPath } : f)
+    setPackageFilesFromUi(movedFiles, nextPath)
+    setRenameTarget(null)
+  }
+
+  const toggleDir = (path: string) => {
+    setExpandedDirs(prev => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
   }
 
   // ── Label management ──────────────────────────────────────────
@@ -363,13 +1026,126 @@ export function SkillDetail() {
     })
   }
 
+  const renderFileTree = (nodes: FileTreeNode[], depth = 0): ReactNode => nodes.map(node => {
+    if (node.type === "dir") {
+      const expanded = expandedDirs.has(node.path)
+      const active = selectedNodePath === node.path
+      return (
+        <div key={node.path}
+          className={`group rounded ${active ? "bg-primary/10 text-foreground ring-1 ring-primary/20" : ""}`}
+        >
+          <div className={`flex items-center rounded ${active ? "text-foreground" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}`}>
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedNodePath(node.path)
+                setSelectedDirPath(node.path)
+                toggleDir(node.path)
+              }}
+              className="min-w-0 flex-1 h-7 flex items-center gap-1.5 rounded px-1.5 text-left text-[12px] font-mono"
+              style={{ paddingLeft: `${depth * 14 + 6}px` }}
+              title={node.path}
+            >
+              {expanded ? <ChevronDown className="h-3.5 w-3.5 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0" />}
+              <Folder className="h-3.5 w-3.5 shrink-0 text-amber-400" />
+              <span className="truncate">{node.name}</span>
+              {node.virtual && node.children.length === 0 && <span className="ml-auto text-[10px] text-muted-foreground/50">empty</span>}
+            </button>
+            {(editing || isCreate) && (
+              <div className="mr-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                <button
+                  type="button"
+                  onClick={e => { e.stopPropagation(); selectPackageDirectory(node.path); initiateAddEntry("file", node.path) }}
+                  title="New file in this folder"
+                  className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground"
+                >
+                  <FilePlus2 className="h-3 w-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={e => { e.stopPropagation(); selectPackageDirectory(node.path); initiateAddEntry("folder", node.path) }}
+                  title="New folder in this folder"
+                  className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground"
+                >
+                  <FolderPlus className="h-3 w-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={e => { e.stopPropagation(); startRename({ type: "dir", path: node.path }) }}
+                  title="Rename folder"
+                  className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground"
+                >
+                  <Pencil className="h-3 w-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={e => { e.stopPropagation(); void removePackageDirectory(node.path) }}
+                  title="Delete folder"
+                  className="p-1 rounded hover:bg-red-500/10 text-muted-foreground hover:text-red-400"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </div>
+            )}
+          </div>
+          {expanded && renderFileTree(node.children, depth + 1)}
+        </div>
+      )
+    }
+
+    const active = selectedNodePath === node.path
+    const size = node.file ? (node.file.size ?? byteSize(node.file.content, node.file.encoding ?? "utf8")) : 0
+    return (
+      <div key={node.path}
+        className={`group flex items-center gap-1 rounded ${
+          active ? "bg-primary/10 text-foreground ring-1 ring-primary/20" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+        }`}
+        style={{ marginLeft: `${depth * 14}px` }}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            setSelectedFilePath(node.path)
+            setSelectedNodePath(node.path)
+            setSelectedDirPath(fileDirectory(node.path))
+          }}
+          className="min-w-0 flex-1 h-8 flex items-center gap-2 rounded px-1.5 text-left"
+          title={node.path}
+        >
+          <span className="w-3.5 shrink-0" />
+          {packageFileIcon(node.path, "h-3.5 w-3.5 shrink-0")}
+          <span className="truncate text-[12px] font-mono">{node.name}</span>
+          <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/60">{size}B</span>
+        </button>
+        {(editing || isCreate) && node.path !== "SKILL.md" && (
+          <div className="mr-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); startRename({ type: "file", path: node.path }) }}
+              title="Rename file"
+              className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground"
+            >
+              <Pencil className="h-3 w-3" />
+            </button>
+            <button
+              type="button"
+              onClick={e => { e.stopPropagation(); removePackageFile(node.path) }}
+              title="Delete file"
+              className="p-1 rounded hover:bg-red-500/10 text-muted-foreground hover:text-red-400"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          </div>
+        )}
+      </div>
+    )
+  })
+
   // ── Render ────────────────────────────────────────────────────
 
   if (loading) return <div className="flex items-center justify-center h-full"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>
 
   const st = STATUS_STYLES[skill?.status || "draft"] || STATUS_STYLES.draft
-  const disabled = !editing && !isCreate
-
   return (
     <div className="flex flex-col h-full">
       {/* ── Header ──────────────────────────────────────────── */}
@@ -427,7 +1203,7 @@ export function SkillDetail() {
           {!isCreate && editing && (
             <>
               <button onClick={() => { setEditing(false); loadSkill() }} className="h-8 px-3 text-sm rounded-md border border-border text-muted-foreground">Discard</button>
-              <button onClick={handleSave} disabled={saving || !isDirty} className="flex items-center gap-1.5 h-8 px-3 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">
+              <button onClick={handleSaveClick} disabled={saving || !isDirty} className="flex items-center gap-1.5 h-8 px-3 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">
                 {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />} Save
               </button>
             </>
@@ -462,7 +1238,7 @@ export function SkillDetail() {
       <div className="flex flex-1 overflow-hidden min-h-0">
 
         {/* LEFT PANEL: metadata + specs */}
-        <div className={`flex flex-col border-r border-border ${scripts.length > 0 || editing || isCreate ? "w-[65%]" : "w-full"}`}>
+        <div className={`flex flex-col border-r border-border ${packageFiles.length > 1 || editing || isCreate ? "w-[65%]" : "w-full"}`}>
           <div className="flex-1 overflow-y-auto flex flex-col">
             {/* Metadata bar: labels + description (compact, always visible) */}
             <div className="px-6 py-3 border-b border-border/50 space-y-2.5 shrink-0">
@@ -511,159 +1287,139 @@ export function SkillDetail() {
               )}
             </div>
 
-            {/* Specs (SKILL.md) — fills remaining space */}
+            {/* Selected package file editor */}
             <div className="flex-1 flex flex-col min-h-0">
-              <textarea
-                value={specs} onChange={e => {
-                  if (disabled) return
-                  const newSpecs = e.target.value
-                  setSpecs(newSpecs)
-                  // Sync frontmatter name → header name
-                  const fmMatch = newSpecs.match(/^---\n([\s\S]*?)\n---/)
-                  const nameMatch = fmMatch?.[1]?.match(/^name:\s*(.+)$/m)
-                  if (nameMatch) setName(nameMatch[1].trim())
-                  // Sync frontmatter description
-                  const descMatch = fmMatch?.[1]?.match(/^description:\s*(.+)$/m)
-                  if (descMatch) setDescription(descMatch[1].trim())
-                }}
-                readOnly={disabled} spellCheck={false}
-                className={`flex-1 px-5 py-4 text-[12px] font-mono leading-relaxed resize-none border-none outline-none ${
-                  disabled ? "bg-transparent text-foreground" : "bg-background focus:ring-0"
-                }`}
-              />
+              <div className="h-10 px-5 border-b border-border/50 flex items-center justify-between bg-background/60 shrink-0">
+                <div className="min-w-0 flex items-center gap-2">
+                  {selectedFile ? packageFileIcon(selectedFile.path, "h-4 w-4 shrink-0") : <FileCode className="h-4 w-4 text-muted-foreground" />}
+                  <span className="text-[12px] font-mono font-medium truncate">{selectedFile?.path ?? "No file selected"}</span>
+                  {selectedFile && (
+                    <span className="text-[10px] text-muted-foreground">
+                      {packageFileKind(selectedFile.path)} · {selectedFile.size ?? byteSize(selectedFile.content, selectedFile.encoding ?? "utf8")}B
+                    </span>
+                  )}
+                </div>
+                {selectedFile?.path === "SKILL.md" && (
+                  <span className="text-[10px] text-muted-foreground">package entrypoint</span>
+                )}
+              </div>
+              <div className="flex-1 overflow-auto min-h-0">
+                {!selectedFile ? (
+                  <div className="h-full flex items-center justify-center text-sm text-muted-foreground">No file selected</div>
+                ) : selectedFile.encoding === "base64" ? (
+                  <div className="h-full flex flex-col items-center justify-center text-sm text-muted-foreground">
+                    <FileCode className="h-8 w-8 mb-3 text-muted-foreground/40" />
+                    <p>Binary file preview only</p>
+                    <p className="mt-1 text-[11px] text-muted-foreground/50">{selectedFile.path}</p>
+                  </div>
+                ) : (
+                  <Editor
+                    value={selectedFileContent}
+                    onValueChange={(code: string) => {
+                      if (selectedFileReadOnly || !selectedFile) return
+                      updatePackageFileContent(selectedFile.path, code)
+                    }}
+                    highlight={(code: string) => {
+                      if (!selectedFile) return code
+                      const lang = prismLanguageForPath(selectedFile.path)
+                      return lang.grammar ? Prism.highlight(code, lang.grammar, lang.language) : code
+                    }}
+                    readOnly={selectedFileReadOnly}
+                    padding={20}
+                    style={{
+                      fontFamily: '"JetBrains Mono", "Fira Code", "SF Mono", monospace',
+                      fontSize: 12,
+                      lineHeight: 1.65,
+                      minHeight: "100%",
+                      backgroundColor: disabled ? "transparent" : "hsl(var(--background))",
+                      color: "hsl(var(--foreground))",
+                    }}
+                    textareaClassName="outline-none"
+                  />
+                )}
+              </div>
             </div>
           </div>
         </div>
 
-        {/* RIGHT PANEL: scripts */}
-        {(scripts.length > 0 || editing || isCreate) && (
-          <div className="flex-1 flex flex-col min-w-0 relative">
-            {/* Scripts header */}
-            <div className="px-4 py-3 flex items-center justify-between border-b border-border shrink-0">
-              <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-                Scripts ({scripts.length})
-              </span>
-              {(editing || isCreate) && (
-                <div className="flex items-center gap-1">
-                  <button onClick={() => fileInputRef2.current?.click()} title="Upload Script"
-                    className="p-1.5 rounded hover:bg-secondary text-muted-foreground">
-                    <FileUp className="h-3.5 w-3.5" />
-                  </button>
-                  <input type="file" ref={fileInputRef2} className="hidden" accept=".sh,.py,.txt" onChange={handleFileUpload} />
-                  <div className="relative">
-                    <button onClick={() => setShowAddMenu(!showAddMenu)} title="New Script"
-                      className="p-1.5 rounded hover:bg-secondary text-muted-foreground hover:text-foreground">
-                      <Plus className="h-3.5 w-3.5" />
+        {/* RIGHT PANEL: skill package tree */}
+        {(packageFiles.length > 1 || editing || isCreate) && (
+          <div className="flex-1 flex flex-col min-w-0 bg-background">
+            <div className="px-4 py-3 border-b border-border shrink-0 space-y-2">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                  Package ({packageFiles.length})
+                </span>
+                {(editing || isCreate) && (
+                  <div className="flex items-center gap-1">
+                    <input
+                      type="file"
+                      ref={folderInputRef}
+                      className="hidden"
+                      multiple
+                      onChange={handleFolderUpload}
+                      {...({ webkitdirectory: "", directory: "" } as any)}
+                    />
+                    <input type="file" ref={archiveInputRef} className="hidden" accept=".zip,.tar,.tgz,.tar.gz,.gz" onChange={handleArchiveUpload} />
+                    <input type="file" ref={fileInputRef2} className="hidden" multiple onChange={handleFileUpload} />
+                    <button onClick={() => initiateAddEntry("file")} title={`New file in ${selectedDirPath || "package root"}`} aria-label={`New file in ${selectedDirPath || "package root"}`}
+                      className="h-7 w-7 rounded bg-secondary hover:bg-secondary/80 text-foreground inline-flex items-center justify-center">
+                      <FilePlus2 className="h-3.5 w-3.5" />
                     </button>
-                    {showAddMenu && (
-                      <>
-                        <div className="fixed inset-0 z-10" onClick={() => setShowAddMenu(false)} />
-                        <div className="absolute right-0 top-full mt-1 w-36 bg-card border border-border rounded-lg shadow-lg z-20 py-1">
-                          <button onClick={() => initiateAddScript("shell")}
-                            className="w-full flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-secondary/50 transition-colors">
-                            <Terminal className="h-3.5 w-3.5 text-green-400" /> Shell Script
-                          </button>
-                          <button onClick={() => initiateAddScript("python")}
-                            className="w-full flex items-center gap-2 px-3 py-2 text-[12px] hover:bg-secondary/50 transition-colors">
-                            <FileCode className="h-3.5 w-3.5 text-blue-400" /> Python Script
-                          </button>
-                        </div>
-                      </>
-                    )}
+                    <button onClick={() => initiateAddEntry("folder")} title={`New folder in ${selectedDirPath || "package root"}`} aria-label={`New folder in ${selectedDirPath || "package root"}`}
+                      className="h-7 w-7 rounded bg-secondary hover:bg-secondary/80 text-foreground inline-flex items-center justify-center">
+                      <FolderPlus className="h-3.5 w-3.5" />
+                    </button>
+                    <button onClick={() => fileInputRef2.current?.click()} title={`Add files into ${activeUploadDir() || "package root"}`} aria-label={`Add files into ${activeUploadDir() || "package root"}`}
+                      className="h-7 w-7 rounded border border-border/60 hover:bg-secondary text-muted-foreground hover:text-foreground inline-flex items-center justify-center">
+                      <FileUp className="h-3.5 w-3.5" />
+                    </button>
+                    <div className="relative">
+                      <button onClick={() => setShowPackageMenu(!showPackageMenu)} title="More package actions" aria-label="More package actions"
+                        className="h-7 w-7 rounded border border-border/60 hover:bg-secondary text-muted-foreground hover:text-foreground inline-flex items-center justify-center">
+                        <MoreHorizontal className="h-3.5 w-3.5" />
+                      </button>
+                      {showPackageMenu && (
+                        <>
+                          <div className="fixed inset-0 z-10" onClick={() => setShowPackageMenu(false)} />
+                          <div className="absolute right-0 top-full mt-1 w-52 bg-card border border-border rounded-lg shadow-lg z-20 py-1">
+                            <button
+                              type="button"
+                              onClick={() => { setShowPackageMenu(false); folderInputRef.current?.click() }}
+                              className="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-left hover:bg-secondary/50 transition-colors"
+                            >
+                              <FolderUp className="h-3.5 w-3.5 text-muted-foreground" />
+                              Replace from Folder
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => { setShowPackageMenu(false); archiveInputRef.current?.click() }}
+                              className="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-left hover:bg-secondary/50 transition-colors"
+                            >
+                              <Archive className="h-3.5 w-3.5 text-muted-foreground" />
+                              Replace from Archive
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
 
-            {/* Script list */}
-            <div className="flex-1 overflow-y-auto">
-              {scripts.length === 0 ? (
+            <div className="flex-1 overflow-y-auto p-2">
+              {packageFiles.length === 0 ? (
                 <div className="h-full flex flex-col items-center justify-center">
                   <div className="p-3 bg-secondary/30 rounded-full mb-3">
                     <Code2 className="h-6 w-6 text-muted-foreground/30" />
                   </div>
-                  <p className="text-[12px] text-muted-foreground/50">No scripts yet</p>
-                  <p className="text-[10px] text-muted-foreground/30 mt-1">Add or upload a script to get started</p>
+                  <p className="text-[12px] text-muted-foreground/50">No package files</p>
                 </div>
               ) : (
-                <div className="p-3 space-y-1.5">
-                  {scripts.map((s, i) => {
-                    const isPy = s.name.endsWith(".py")
-                    return (
-                      <div key={i} onClick={() => setActiveScriptIdx(i)}
-                        className="flex items-center justify-between p-3 rounded-md border border-border/50 hover:border-border hover:bg-secondary/20 cursor-pointer group transition-colors">
-                        <div className="flex items-center gap-3">
-                          <div className={`w-8 h-8 rounded-md flex items-center justify-center shrink-0 ${isPy ? "bg-blue-500/10 text-blue-400" : "bg-green-500/10 text-green-400"}`}>
-                            {isPy ? <FileCode className="h-4 w-4" /> : <Terminal className="h-4 w-4" />}
-                          </div>
-                          <div>
-                            <p className="text-[13px] font-medium font-mono group-hover:text-foreground transition-colors">{s.name}</p>
-                            <p className="text-[10px] text-muted-foreground font-mono">{isPy ? "Python" : "Bash"} · {s.content.length}B</p>
-                          </div>
-                        </div>
-                        {(editing || isCreate) && (
-                          <button onClick={e => { e.stopPropagation(); removeScript(i) }} title="Delete"
-                            className="p-1.5 rounded opacity-0 group-hover:opacity-100 hover:bg-red-500/10 text-muted-foreground hover:text-red-400 transition-all">
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </button>
-                        )}
-                      </div>
-                    )
-                  })}
-                </div>
+                <div className="space-y-0.5">{renderFileTree(fileTree)}</div>
               )}
             </div>
-
-            {/* OVERLAY EDITOR — full-screen dark editor when a script is active */}
-            {activeScriptIdx !== null && scripts[activeScriptIdx] && (
-              <div className="absolute inset-0 z-40 bg-[#1e1e1e] flex flex-col">
-                {/* Editor header */}
-                <div className="flex items-center justify-between px-4 py-3 bg-[#252526] border-b border-[#1e1e1e]">
-                  <div className="flex items-center gap-3">
-                    <div className={`w-8 h-8 rounded flex items-center justify-center ${
-                      scripts[activeScriptIdx].name.endsWith(".py") ? "bg-[#37373d] text-yellow-400" : "bg-[#37373d] text-green-400"
-                    }`}>
-                      {scripts[activeScriptIdx].name.endsWith(".py") ? <FileCode className="h-4 w-4" /> : <Terminal className="h-4 w-4" />}
-                    </div>
-                    <span className="text-sm font-medium text-gray-200 font-mono">
-                      {scripts[activeScriptIdx].name}
-                    </span>
-                  </div>
-                  <button onClick={() => setActiveScriptIdx(null)} title="Close Editor"
-                    className="p-1.5 text-gray-400 hover:text-white hover:bg-[#333] rounded transition-colors">
-                    <X className="h-5 w-5" />
-                  </button>
-                </div>
-
-                {/* Editor content with syntax highlighting */}
-                <div className="flex-1 overflow-auto">
-                  <Editor
-                    value={scripts[activeScriptIdx].content}
-                    onValueChange={code => {
-                      if (disabled) return
-                      updateScriptContent(activeScriptIdx, code)
-                    }}
-                    highlight={code => {
-                      const isPy = scripts[activeScriptIdx].name.endsWith(".py")
-                      const grammar = isPy ? Prism.languages.python : Prism.languages.bash
-                      if (!grammar) return code
-                      return Prism.highlight(code, grammar, isPy ? "python" : "bash")
-                    }}
-                    readOnly={disabled}
-                    padding={24}
-                    style={{
-                      fontFamily: '"JetBrains Mono", "Fira Code", "SF Mono", monospace',
-                      fontSize: 13,
-                      lineHeight: 1.6,
-                      backgroundColor: "#1e1e1e",
-                      color: "#d4d4d4",
-                      minHeight: "100%",
-                    }}
-                    textareaClassName="outline-none"
-                  />
-                </div>
-              </div>
-            )}
           </div>
         )}
 
@@ -693,14 +1449,22 @@ export function SkillDetail() {
                     )}
                   </div>
                   <p className="text-[11px] text-muted-foreground truncate">{v.commit_message || "No message"}</p>
-                  <div className="flex items-center justify-between">
+                  <div className="flex items-center justify-between gap-2">
                     <span className="text-[10px] text-muted-foreground/60">{new Date(v.created_at).toLocaleDateString()}</span>
-                    {skill?.status !== "pending_review" && (
-                      <button onClick={() => handleRollback(v.version)} title="Rollback"
-                        className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground">
-                        <RotateCcw className="h-3 w-3" />
-                      </button>
-                    )}
+                    <div className="flex items-center gap-0.5">
+                      {!!v.diff && (
+                        <button onClick={() => setVersionDiffDialog({ title: `v${v.version} changes`, diff: v.diff })} title="View diff"
+                          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground">
+                          <FileText className="h-3 w-3" />
+                        </button>
+                      )}
+                      {skill?.status !== "pending_review" && (
+                        <button onClick={() => handleRollback(v.version)} title="Rollback"
+                          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground">
+                          <RotateCcw className="h-3 w-3" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
               ))}
@@ -709,25 +1473,88 @@ export function SkillDetail() {
         )}
       </div>
 
-      {/* ── New Script Name Dialog ────────────────────────────── */}
+      {/* ── New Package Entry Dialog ──────────────────────────── */}
       {showNameDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div className="absolute inset-0 bg-black/50" onClick={() => setShowNameDialog(false)} />
           <div className="relative bg-card rounded-xl shadow-xl border border-border p-5 w-80 space-y-4">
             <div>
-              <h3 className="text-sm font-semibold">New {newScriptType === "python" ? "Python" : "Shell"} Script</h3>
-              <p className="text-[11px] text-muted-foreground mt-1">Enter a filename for your script.</p>
+              <h3 className="text-sm font-semibold">New {newEntryTitle(newEntryKind)}</h3>
             </div>
-            <input autoFocus type="text" value={newScriptName}
-              onChange={e => setNewScriptName(e.target.value)}
-              onKeyDown={e => e.key === "Enter" && confirmAddScript()}
-              placeholder={newScriptType === "python" ? "script.py" : "script.sh"}
+            <input autoFocus type="text" value={newFilePath}
+              onChange={e => setNewFilePath(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && confirmAddFile()}
+              placeholder={defaultPathForKind(newEntryKind)}
               className="w-full h-9 px-3 text-sm rounded-md border border-border bg-background font-mono focus:outline-none focus:ring-1 focus:ring-ring" />
             <div className="flex justify-end gap-2">
               <button onClick={() => setShowNameDialog(false)}
                 className="h-8 px-3 text-[12px] text-muted-foreground hover:text-foreground rounded-md">Cancel</button>
-              <button onClick={confirmAddScript} disabled={!newScriptName.trim()}
-                className="h-8 px-3 text-[12px] rounded-md bg-primary text-primary-foreground disabled:opacity-50">Create Script</button>
+              <button onClick={confirmAddFile} disabled={!newFilePath.trim()}
+                className="h-8 px-3 text-[12px] rounded-md bg-primary text-primary-foreground disabled:opacity-50">Create {newEntryTitle(newEntryKind)}</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Rename Package Entry Dialog ───────────────────────── */}
+      {renameTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setRenameTarget(null)} />
+          <div className="relative bg-card rounded-xl shadow-xl border border-border p-5 w-96 space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold">Rename {renameTarget.type === "dir" ? "Folder" : "File"}</h3>
+            </div>
+            <input autoFocus type="text" value={renamePath}
+              onChange={e => setRenamePath(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && confirmRename()}
+              className="w-full h-9 px-3 text-sm rounded-md border border-border bg-background font-mono focus:outline-none focus:ring-1 focus:ring-ring" />
+            <div className="flex justify-end gap-2">
+              <button onClick={() => setRenameTarget(null)}
+                className="h-8 px-3 text-[12px] text-muted-foreground hover:text-foreground rounded-md">Cancel</button>
+              <button onClick={confirmRename} disabled={!renamePath.trim()}
+                className="h-8 px-3 text-[12px] rounded-md bg-primary text-primary-foreground disabled:opacity-50">Rename</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Save Diff Preview Dialog ────────────────────────── */}
+      {showSaveDiffDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/50" onClick={() => !saving && setShowSaveDiffDialog(false)} />
+          <div className="relative w-full max-w-[92vw] h-[86vh] bg-card rounded-xl shadow-xl border border-border overflow-hidden flex flex-col">
+            <div className="px-6 py-4 border-b border-border shrink-0 flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-[14px] font-semibold">Review Changes</h3>
+                <p className="text-[12px] text-muted-foreground mt-1">Check the package diff before saving this skill.</p>
+              </div>
+              <button onClick={() => setShowSaveDiffDialog(false)} disabled={saving}
+                className="p-1.5 rounded hover:bg-secondary text-muted-foreground disabled:opacity-50">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 p-4">
+              <PackageDiffView
+                diff={saveDiff}
+                className="h-full"
+                emptyMessage="No package file changes. Metadata changes will still be saved."
+              />
+            </div>
+            <div className="border-t border-border px-6 py-3 space-y-2 shrink-0">
+              <input
+                value={commitMessage} onChange={e => setCommitMessage(e.target.value)}
+                placeholder="Commit message (optional) — describe what changed and why"
+                className="w-full h-8 px-3 text-[13px] rounded-md border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              <div className="flex items-center justify-end gap-2">
+                <button onClick={() => setShowSaveDiffDialog(false)} disabled={saving}
+                  className="h-8 px-3 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50">Cancel</button>
+                <button onClick={performSave} disabled={saving}
+                  className="flex items-center gap-1.5 h-8 px-4 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50">
+                  {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                  {saving ? "Saving..." : "Save Changes"}
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -737,14 +1564,14 @@ export function SkillDetail() {
       {showSubmitDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div className="absolute inset-0 bg-black/50" onClick={() => setShowSubmitDialog(false)} />
-          <div className="relative w-full max-w-2xl bg-card rounded-xl shadow-xl border border-border overflow-hidden flex flex-col max-h-[80vh]">
-            <div className="px-6 py-4 border-b border-border">
+          <div className="relative w-full max-w-[92vw] h-[86vh] bg-card rounded-xl shadow-xl border border-border overflow-hidden flex flex-col">
+            <div className="px-6 py-4 border-b border-border shrink-0">
               <h3 className="text-[14px] font-semibold">Submit for Review</h3>
               <p className="text-[12px] text-muted-foreground mt-1">Review your changes before submitting.</p>
             </div>
-            <div className="flex-1 overflow-y-auto px-6 py-4 min-h-0">
+            <div className="flex-1 min-h-0 p-4">
               {submitDiff ? (
-                <SkillDiffView diff={submitDiff} />
+                <PackageDiffView diff={submitDiff} className="h-full" />
               ) : (
                 <p className="text-[12px] text-muted-foreground">First submission — all content will be reviewed.</p>
               )}
@@ -764,6 +1591,28 @@ export function SkillDetail() {
                   {submitConfirming ? "Submitting..." : "Confirm Submit"}
                 </button>
               </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Version Diff Dialog ─────────────────────────────── */}
+      {versionDiffDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setVersionDiffDialog(null)} />
+          <div className="relative w-full max-w-[92vw] h-[86vh] bg-card rounded-xl shadow-xl border border-border overflow-hidden flex flex-col">
+            <div className="px-6 py-4 border-b border-border shrink-0 flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-[14px] font-semibold">{versionDiffDialog.title}</h3>
+                <p className="text-[12px] text-muted-foreground mt-1">File-level changes recorded for this version.</p>
+              </div>
+              <button onClick={() => setVersionDiffDialog(null)}
+                className="p-1.5 rounded hover:bg-secondary text-muted-foreground">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 p-4">
+              <PackageDiffView diff={versionDiffDialog.diff} className="h-full" />
             </div>
           </div>
         </div>

--- a/portal-web/src/pages/Skills.tsx
+++ b/portal-web/src/pages/Skills.tsx
@@ -4,7 +4,7 @@ import { Plus, Zap, Trash2, Loader2, Search, ClipboardCheck, ShieldCheck, Tag, C
 import { api } from "../api"
 import { useToast } from "../components/toast"
 import { useConfirm } from "../components/confirm-dialog"
-import { SkillDiffView } from "../components/SimpleDiff"
+import { PackageDiffView } from "../components/SimpleDiff"
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -515,7 +515,7 @@ function ReviewApprovalCard({ review: r, onDecision }: { review: PendingReview; 
       {expanded && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div className="absolute inset-0 bg-black/50" onClick={() => setExpanded(false)} />
-          <div className="relative w-full max-w-3xl bg-card rounded-xl shadow-xl border border-border overflow-hidden flex flex-col max-h-[85vh]">
+          <div className="relative w-full max-w-[92vw] h-[88vh] bg-card rounded-xl shadow-xl border border-border overflow-hidden flex flex-col">
             {/* Modal header */}
             <div className="px-6 py-4 border-b border-border flex items-center justify-between shrink-0">
               <div>
@@ -600,7 +600,7 @@ function ReviewApprovalCard({ review: r, onDecision }: { review: PendingReview; 
                   {reviewDetail?.diff && (
                     <div className="space-y-2">
                       <span className="text-[12px] font-medium text-muted-foreground">Changes</span>
-                      <SkillDiffView diff={reviewDetail.diff} />
+                      <PackageDiffView diff={reviewDetail.diff} className="h-[54vh]" />
                     </div>
                   )}
                 </>

--- a/skills/platform/skill-authoring/SKILL.md
+++ b/skills/platform/skill-authoring/SKILL.md
@@ -2,13 +2,36 @@
 name: skill-authoring
 description: >-
   Guide for writing and improving Siclaw skills. Read this when creating or
-  modifying a skill. Covers SKILL.md format, script execution modes, and
-  best practices.
+  modifying a skill. Covers skill directory layout, SKILL.md format, script
+  execution modes, and best practices.
 ---
 
 # Skill Authoring Guide
 
 Read this guide before creating a new skill or improving an existing one.
+
+## Directory Layout
+
+A skill is a directory package, not a single file. The smallest valid skill is:
+
+```text
+<skill-name>/
+└── SKILL.md
+```
+
+Optional package files can live beside `SKILL.md`:
+
+```text
+<skill-name>/
+├── SKILL.md
+├── scripts/        # executable .sh/.py helpers
+├── references/     # markdown docs the agent can read
+├── examples/       # example inputs/outputs
+└── assets/         # small images or other package assets
+```
+
+The directory name must match the `name` field in `SKILL.md`. Use uppercase
+`SKILL.md`; lowercase `skill.md` is not canonical.
 
 ## SKILL.md Format
 

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -253,6 +253,62 @@ describe("skillsHandler", () => {
     expect(fs.readFileSync(path.join(scriptsDir, "analyze.py"), "utf8")).toBe("print('ok')");
   });
 
+  it("materializes complete skill package files when files[] is present", async () => {
+    const payload = {
+      version: new Date().toISOString(),
+      skills: [
+        {
+          dirName: "packaged",
+          scope: "global" as const,
+          specs: "---\nname: packaged\n---\n",
+          scripts: [],
+          files: [
+            { path: "SKILL.md", content: "---\nname: packaged\n---\n", encoding: "utf8" as const, size: 23, sha256: "a" },
+            { path: "references/runbook.md", content: "# runbook", encoding: "utf8" as const, size: 9, sha256: "b" },
+            { path: "scripts/run.sh", content: "echo ok", encoding: "utf8" as const, size: 7, sha256: "c", executable: true },
+          ],
+        },
+      ],
+    };
+
+    await skillsHandler.materialize(payload);
+
+    expect(fs.readFileSync(path.join(resolvedDir(), "packaged", "references", "runbook.md"), "utf8")).toBe("# runbook");
+    expect(fs.readFileSync(path.join(resolvedDir(), "packaged", "scripts", "run.sh"), "utf8")).toBe("echo ok");
+  });
+
+  it("skips one invalid skill package instead of aborting the whole bundle", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const payload = {
+        version: "v1",
+        skills: [
+          {
+            dirName: "../bad",
+            scope: "global" as const,
+            specs: "---\nname: bad\n---\n",
+            scripts: [],
+            files: [{ path: "SKILL.md", content: "---\nname: bad\n---\n", encoding: "utf8" as const, size: 18, sha256: "bad" }],
+          },
+          {
+            dirName: "good",
+            scope: "global" as const,
+            specs: "---\nname: good\n---\n",
+            scripts: [],
+          },
+        ],
+      };
+
+      const count = await skillsHandler.materialize(payload);
+
+      expect(count).toBe(1);
+      expect(readResolved("good")).toBe("---\nname: good\n---\n");
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to materialize skill ../bad"));
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   // ── 3. global overrides builtin ──────────────────────────────────
   it("global scope takes priority over builtin with the same dirName", async () => {
     const payload = {

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -25,6 +25,7 @@ import type {
 } from "../shared/gateway-sync.js";
 import { GATEWAY_SYNC_DESCRIPTORS } from "../shared/gateway-sync.js";
 import { resolveUnderDir } from "../shared/path-utils.js";
+import { decodeSkillFileContent, normalizeSkillFiles, type SkillPackageFile } from "../shared/skill-package.js";
 
 // ── MCP handler ───────────────────────────────────────────────────────
 
@@ -81,10 +82,26 @@ export const mcpHandler: AgentBoxSyncHandler<McpPayload> = {
 /** Write a single skill (specs + scripts) into the resolved directory */
 function writeSkillToDir(
   resolvedDir: string,
-  skill: { dirName: string; specs: string; scripts: Array<{ name: string; content: string }> | null | undefined },
+  skill: {
+    dirName: string;
+    specs: string;
+    scripts: Array<{ name: string; content: string }> | null | undefined;
+    files?: SkillPackageFile[] | null;
+  },
 ): void {
   const skillDir = resolveUnderDir(resolvedDir, skill.dirName);
   fs.mkdirSync(skillDir, { recursive: true });
+  if (Array.isArray(skill.files) && skill.files.length > 0) {
+    for (const file of normalizeSkillFiles(skill.files)) {
+      const filePath = resolveUnderDir(skillDir, file.path);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, file.encoding === "base64" ? Buffer.from(file.content, "base64") : decodeSkillFileContent(file));
+      if (file.executable || /^scripts\/[^/]+\.(sh|py)$/.test(file.path)) {
+        try { fs.chmodSync(filePath, 0o755); } catch { /* non-POSIX */ }
+      }
+    }
+    return;
+  }
   if (skill.specs) {
     fs.writeFileSync(path.join(skillDir, "SKILL.md"), skill.specs);
   }
@@ -114,6 +131,7 @@ interface SkillBundlePayload {
     scope: "builtin" | "global";
     specs: string;
     scripts: Array<{ name: string; content: string }>;
+    files?: SkillPackageFile[] | null;
     skillSpaceId?: string;
   }>;
 }
@@ -184,8 +202,18 @@ export const skillsHandler: AgentBoxSyncHandler<SkillBundlePayload> = {
     for (const skill of sortedSkills) {
       if (!skill?.dirName) continue;
       if (seen.has(skill.dirName)) continue;
-      seen.add(skill.dirName);
-      writeSkillToDir(resolvedDir, skill);
+      try {
+        writeSkillToDir(resolvedDir, skill);
+        seen.add(skill.dirName);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[sync-handlers.skills] Failed to materialize skill ${skill.dirName}: ${msg}`);
+        try {
+          fs.rmSync(resolveUnderDir(resolvedDir, skill.dirName), { recursive: true, force: true });
+        } catch {
+          // If dirName itself was unsafe, there is no in-bounds path to clean up.
+        }
+      }
     }
 
     return seen.size;

--- a/src/gateway/skills/builtin-sync.test.ts
+++ b/src/gateway/skills/builtin-sync.test.ts
@@ -63,10 +63,10 @@ describe("parseSkillsDir", () => {
 
   // ── 3. basic frontmatter ────────────────────────────────────────────
   it("parses name from basic frontmatter", () => {
-    writeSkill("my-skill", "---\nname: foo\n---\nBody text");
+    writeSkill("foo", "---\nname: foo\n---\nBody text");
     const [skill] = parseSkillsDir(tmpDir);
     expect(skill.name).toBe("foo");
-    expect(skill.dirName).toBe("my-skill");
+    expect(skill.dirName).toBe("foo");
   });
 
   // ── 4. block scalar description (>-) ────────────────────────────────
@@ -80,21 +80,21 @@ describe("parseSkillsDir", () => {
       "---",
       "Body",
     ].join("\n");
-    writeSkill("block", specs);
+    writeSkill("blocker", specs);
     const [skill] = parseSkillsDir(tmpDir);
     expect(skill.description).toBe("line1 line2");
   });
 
   // ── 5. inline description ──────────────────────────────────────────
   it("parses inline description", () => {
-    writeSkill("inline", "---\nname: inl\ndescription: simple desc\n---\n");
+    writeSkill("inl", "---\nname: inl\ndescription: simple desc\n---\n");
     const [skill] = parseSkillsDir(tmpDir);
     expect(skill.description).toBe("simple desc");
   });
 
   // ── 6. skill without description ───────────────────────────────────
   it("returns empty description when not present in frontmatter", () => {
-    writeSkill("no-desc", "---\nname: nd\n---\n");
+    writeSkill("nd", "---\nname: nd\n---\n");
     const [skill] = parseSkillsDir(tmpDir);
     expect(skill.description).toBe("");
   });
@@ -116,7 +116,7 @@ describe("parseSkillsDir", () => {
 
   // ── 8. skill without scripts dir ──────────────────────────────────
   it("returns empty scripts array when scripts/ does not exist", () => {
-    writeSkill("no-scripts", "---\nname: ns\n---\n");
+    writeSkill("ns", "---\nname: ns\n---\n");
     const [skill] = parseSkillsDir(tmpDir);
     expect(skill.scripts).toEqual([]);
   });
@@ -148,10 +148,9 @@ describe("parseSkillsDir", () => {
   });
 
   // ── 12. SKILL.md without name ──────────────────────────────────────
-  it("skips skills whose SKILL.md lacks a name field", () => {
+  it("rejects skills whose SKILL.md lacks a name field", () => {
     writeSkill("nameless", "---\ndescription: something\n---\n");
-    const result = parseSkillsDir(tmpDir);
-    expect(result).toEqual([]);
+    expect(() => parseSkillsDir(tmpDir)).toThrow(/name field/);
   });
 
   // ── 13. multiple skills ───────────────────────────────────────────
@@ -178,7 +177,7 @@ describe("parseSkillsDir", () => {
   // ── additional edge cases ─────────────────────────────────────────
 
   it("ignores non-.sh/.py files in scripts/", () => {
-    writeSkill("filtered-scripts", "---\nname: fs\n---\n", {
+    writeSkill("fs", "---\nname: fs\n---\n", {
       "run.sh": "echo hi",
       "helper.py": "pass",
       "readme.md": "# doc",
@@ -189,10 +188,9 @@ describe("parseSkillsDir", () => {
     expect(skill.scripts.map((s) => s.name)).toEqual(["helper.py", "run.sh"]);
   });
 
-  it("handles SKILL.md with no frontmatter block — skips it", () => {
+  it("rejects SKILL.md with no frontmatter block", () => {
     writeSkill("no-front", "Just some markdown without frontmatter");
-    const result = parseSkillsDir(tmpDir);
-    expect(result).toEqual([]);
+    expect(() => parseSkillsDir(tmpDir)).toThrow(/name field/);
   });
 
   it("handles meta.json with invalid JSON gracefully", () => {
@@ -213,16 +211,44 @@ describe("parseSkillsDir", () => {
       "  literal line2",
       "---",
     ].join("\n");
-    writeSkill("literal", specs);
+    writeSkill("lit", specs);
     const [skill] = parseSkillsDir(tmpDir);
     expect(skill.description).toBe("literal line1 literal line2");
   });
 
   it("includes the full raw specs content (frontmatter + body)", () => {
     const specs = "---\nname: full\n---\n# Body\nSome content here";
-    writeSkill("full-specs", specs);
+    writeSkill("full", specs);
     const [skill] = parseSkillsDir(tmpDir);
     expect(skill.specs).toBe(specs);
+  });
+
+  it("preserves non-script package files in files[]", () => {
+    writeSkill("packaged", "---\nname: packaged\n---\n", { "run.sh": "echo ok" });
+    fs.mkdirSync(path.join(tmpDir, "packaged", "references"));
+    fs.writeFileSync(path.join(tmpDir, "packaged", "references", "runbook.md"), "# Runbook\n");
+    fs.mkdirSync(path.join(tmpDir, "packaged", "examples"));
+    fs.writeFileSync(path.join(tmpDir, "packaged", "examples", "input.json"), "{}");
+
+    const [skill] = parseSkillsDir(tmpDir);
+    expect(skill.files.map(f => f.path).sort()).toEqual([
+      "SKILL.md",
+      "examples/input.json",
+      "references/runbook.md",
+      "scripts/run.sh",
+    ]);
+  });
+
+  it("rejects lowercase skill.md", () => {
+    const dir = path.join(tmpDir, "lowercase");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "skill.md"), "---\nname: lowercase\n---\n");
+    expect(() => parseSkillsDir(tmpDir)).toThrow(/uppercase SKILL\.md/);
+  });
+
+  it("rejects directory/name mismatch", () => {
+    writeSkill("folder-name", "---\nname: frontmatter-name\n---\n");
+    expect(() => parseSkillsDir(tmpDir)).toThrow(/does not match/);
   });
 
   // ── platform skill isolation ──────────────────────────────────────────

--- a/src/gateway/skills/builtin-sync.ts
+++ b/src/gateway/skills/builtin-sync.ts
@@ -12,15 +12,22 @@
  *   - Existing, user has edited     SKIP
  *     (current hash != v1 hash):
  *
- * "Hash" is SHA-256 of (specs + JSON-sorted scripts), providing a stable
- * content fingerprint independent of insertion order.
+ * "Hash" is SHA-256 of the normalized skill package file list, providing a
+ * stable content fingerprint independent of insertion order.
  */
 
-import { createHash } from "node:crypto";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getDb } from "../db.js";
+import {
+  computeSkillFilesHash,
+  parseFrontmatter,
+  parseSkillDirectory,
+  safeParseSkillFiles,
+  type SkillPackageFile,
+  type SkillScriptEntry,
+} from "../../shared/skill-package.js";
 
 /**
  * Resolve skills/core/ relative to the installed package, not process.cwd().
@@ -31,17 +38,13 @@ import { getDb } from "../db.js";
  */
 export const SKILLS_CORE_DIR = fileURLToPath(new URL("../../../skills/core", import.meta.url));
 
-interface ScriptEntry {
-  name: string;
-  content: string;
-}
-
 interface BuiltinSkillData {
   dirName: string;
   name: string;
   description: string;
   specs: string;
-  scripts: ScriptEntry[];
+  scripts: SkillScriptEntry[];
+  files: SkillPackageFile[];
   labels: string[];
 }
 
@@ -56,84 +59,18 @@ export interface ParsedSkill {
   labels: string[];
   specs: string;
   scripts: Array<{ name: string; content: string }>;
+  files: SkillPackageFile[];
 }
 
 // ---------------------------------------------------------------------------
 // Filesystem helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Parse a skill's YAML frontmatter and return its `name` and `description`.
- * Handles inline values and block scalars (`>-`, `>`, `|`, `|-`) — built-in
- * skills rely on `description: >-` for multi-line text.
- */
-export function parseFrontmatter(md: string): { name: string; description: string } {
-  const match = md.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) return { name: "", description: "" };
-
-  const block = match[1];
-
-  // name: single-line value
-  const nameMatch = block.match(/^name:\s*(.+)$/m);
-  const name = nameMatch ? nameMatch[1].trim() : "";
-
-  // description: may be a YAML block scalar (>-, >, |) or inline
-  let description = "";
-  const lines = block.split("\n");
-  const descIdx = lines.findIndex(l => l.match(/^description:\s/));
-  if (descIdx >= 0) {
-    const firstLine = lines[descIdx].replace(/^description:\s*/, "").trim();
-    if (firstLine === ">-" || firstLine === ">" || firstLine === "|" || firstLine === "|-") {
-      // Block scalar: collect indented continuation lines
-      const contLines: string[] = [];
-      for (let i = descIdx + 1; i < lines.length; i++) {
-        if (lines[i].match(/^\s+/)) {
-          contLines.push(lines[i].trim());
-        } else {
-          break;
-        }
-      }
-      description = contLines.join(" ");
-    } else {
-      // Inline scalar
-      description = firstLine;
-    }
-  }
-
-  return { name, description };
-}
-
 function readSkillDir(dirName: string, dirPath: string, labelsMap: Record<string, string[]>): BuiltinSkillData | null {
-  const skillMdPath = join(dirPath, "SKILL.md");
-  if (!existsSync(skillMdPath)) return null;
-
-  const specs = readFileSync(skillMdPath, "utf8");
-  const { name, description } = parseFrontmatter(specs);
-  if (!name) return null;
-
-  // Collect scripts (sorted by name for deterministic hashing)
-  const scripts: ScriptEntry[] = [];
-  const scriptsDir = join(dirPath, "scripts");
-  if (existsSync(scriptsDir)) {
-    const files = readdirSync(scriptsDir).filter((f) => f.endsWith(".sh") || f.endsWith(".py")).sort();
-    for (const file of files) {
-      const content = readFileSync(join(scriptsDir, file), "utf8");
-      scripts.push({ name: file, content });
-    }
-  }
-
-  const labels = labelsMap[dirName] ?? [];
-
-  return { dirName, name, description, specs, scripts, labels };
+  return parseSkillDirectory(dirName, dirPath, labelsMap);
 }
 
-function computeHash(specs: string, scripts: ScriptEntry[]): string {
-  const h = createHash("sha256");
-  h.update(specs);
-  // Scripts are already sorted by name; stringify produces a stable string
-  h.update(JSON.stringify(scripts));
-  return h.digest("hex");
-}
+export { parseFrontmatter };
 
 // ---------------------------------------------------------------------------
 // Public API — parsing
@@ -205,15 +142,16 @@ export async function syncBuiltinSkills(
   let skipped = 0;
 
   for (const skill of entries) {
-    const hash = computeHash(skill.specs, skill.scripts);
+    const hash = computeSkillFilesHash(skill.files);
     // specs is MEDIUMTEXT — store raw string, not JSON-encoded
     const specsRaw = skill.specs;
     const scriptsJson = JSON.stringify(skill.scripts);
+    const filesJson = JSON.stringify(skill.files);
     const labelsJson = JSON.stringify(skill.labels);
 
     // Look up existing skill row
     const [rows] = await db.query<any[]>(
-      `SELECT id, version, specs, scripts FROM skills WHERE org_id = ? AND name = ? LIMIT 1`,
+      `SELECT id, version, specs, scripts, files FROM skills WHERE org_id = ? AND name = ? LIMIT 1`,
       [orgId, skill.name],
     );
 
@@ -223,15 +161,15 @@ export async function syncBuiltinSkills(
       const versionId = crypto.randomUUID();
 
       await db.query(
-        `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, created_by)
-         VALUES (?, ?, ?, ?, ?, 'system', 'installed', 1, ?, ?, 'system')`,
-        [skillId, orgId, skill.name, skill.description, labelsJson, specsRaw, scriptsJson],
+        `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, files, created_by)
+         VALUES (?, ?, ?, ?, ?, 'system', 'installed', 1, ?, ?, ?, 'system')`,
+        [skillId, orgId, skill.name, skill.description, labelsJson, specsRaw, scriptsJson, filesJson],
       );
 
       await db.query(
-        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, commit_message, author_id, is_approved)
-         VALUES (?, ?, 1, ?, ?, 'Initial builtin import', 'system', 1)`,
-        [versionId, skillId, specsRaw, scriptsJson],
+        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, commit_message, author_id, is_approved)
+         VALUES (?, ?, 1, ?, ?, ?, 'Initial builtin import', 'system', 1)`,
+        [versionId, skillId, specsRaw, scriptsJson, filesJson],
       );
 
       inserted++;
@@ -239,12 +177,12 @@ export async function syncBuiltinSkills(
     }
 
     // ── Existing skill ────────────────────────────────────
-    const existing = rows[0] as { id: string; version: number; specs: any; scripts: any };
+    const existing = rows[0] as { id: string; version: number; specs: any; scripts: any; files: any };
     // specs is MEDIUMTEXT — should be a raw string, but may be double-encoded from old bug
     let existingSpecs: string = typeof existing.specs === "string" ? existing.specs : String(existing.specs || "");
     if (existingSpecs.startsWith('"')) { try { existingSpecs = JSON.parse(existingSpecs); } catch { /* keep */ } }
     // scripts is JSON column — MySQL driver may return string or parsed object
-    let existingScripts: ScriptEntry[];
+    let existingScripts: SkillScriptEntry[];
     if (Array.isArray(existing.scripts)) {
       existingScripts = existing.scripts;
     } else if (typeof existing.scripts === "string") {
@@ -252,7 +190,7 @@ export async function syncBuiltinSkills(
     } else {
       existingScripts = [];
     }
-    const currentHash = computeHash(existingSpecs, existingScripts);
+    const currentHash = computeSkillFilesHash(safeParseSkillFiles(existing.files, existingSpecs, existingScripts));
 
     if (currentHash === hash) {
       // Content identical — nothing to do
@@ -262,19 +200,19 @@ export async function syncBuiltinSkills(
 
     // Check v1 hash to detect user edits
     const [v1Rows] = await db.query<any[]>(
-      `SELECT specs, scripts FROM skill_versions WHERE skill_id = ? AND version = 1 LIMIT 1`,
+      `SELECT specs, scripts, files FROM skill_versions WHERE skill_id = ? AND version = 1 LIMIT 1`,
       [existing.id],
     );
 
     if (v1Rows.length > 0) {
-      const v1 = v1Rows[0] as { specs: any; scripts: any };
+      const v1 = v1Rows[0] as { specs: any; scripts: any; files: any };
       let v1Specs: string = typeof v1.specs === "string" ? v1.specs : String(v1.specs || "");
       if (v1Specs.startsWith('"')) { try { v1Specs = JSON.parse(v1Specs); } catch { /* keep */ } }
-      let v1Scripts: ScriptEntry[];
+      let v1Scripts: SkillScriptEntry[];
       if (Array.isArray(v1.scripts)) { v1Scripts = v1.scripts; }
       else if (typeof v1.scripts === "string") { try { v1Scripts = JSON.parse(v1.scripts); } catch { v1Scripts = []; } }
       else { v1Scripts = []; }
-      const v1Hash = computeHash(v1Specs, v1Scripts);
+      const v1Hash = computeSkillFilesHash(safeParseSkillFiles(v1.files, v1Specs, v1Scripts));
 
       if (v1Hash !== currentHash) {
         // User has edited since v1 — leave their version alone
@@ -289,15 +227,15 @@ export async function syncBuiltinSkills(
     const versionId = crypto.randomUUID();
 
     await db.query(
-      `UPDATE skills SET description = ?, labels = ?, version = ?, specs = ?, scripts = ?, status = 'installed', updated_at = CURRENT_TIMESTAMP
+      `UPDATE skills SET description = ?, labels = ?, version = ?, specs = ?, scripts = ?, files = ?, status = 'installed', updated_at = CURRENT_TIMESTAMP
        WHERE id = ?`,
-      [skill.description, labelsJson, newVersion, specsRaw, scriptsJson, existing.id],
+      [skill.description, labelsJson, newVersion, specsRaw, scriptsJson, filesJson, existing.id],
     );
 
     await db.query(
-      `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, commit_message, author_id, is_approved)
-       VALUES (?, ?, ?, ?, ?, 'Builtin update from image', 'system', 1)`,
-      [versionId, existing.id, newVersion, specsRaw, scriptsJson],
+      `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, commit_message, author_id, is_approved)
+       VALUES (?, ?, ?, ?, ?, ?, 'Builtin update from image', 'system', 1)`,
+      [versionId, existing.id, newVersion, specsRaw, scriptsJson, filesJson],
     );
 
     updated++;

--- a/src/lib/portal-skill-materializer.test.ts
+++ b/src/lib/portal-skill-materializer.test.ts
@@ -45,6 +45,28 @@ describe("materializePortalSkills", () => {
     expect(mode & 0o100).toBe(0o100);  // owner-executable at minimum
   });
 
+  it("writes complete skill package files when files[] is present", () => {
+    const out = path.join(tmpRoot, "skills");
+    materializePortalSkills(
+      [{
+        name: "packaged",
+        description: "desc",
+        labels: [],
+        specs: "# fallback",
+        scripts: [],
+        files: [
+          { path: "SKILL.md", content: "# packaged", encoding: "utf8", size: 10, sha256: "x" },
+          { path: "references/runbook.md", content: "# runbook", encoding: "utf8", size: 9, sha256: "y" },
+          { path: "scripts/run.sh", content: "echo ok", encoding: "utf8", size: 7, sha256: "z", executable: true },
+        ],
+      }],
+      out,
+    );
+    expect(fs.readFileSync(path.join(out, "packaged", "SKILL.md"), "utf-8")).toBe("# packaged");
+    expect(fs.readFileSync(path.join(out, "packaged", "references", "runbook.md"), "utf-8")).toBe("# runbook");
+    expect(fs.readFileSync(path.join(out, "packaged", "scripts", "run.sh"), "utf-8")).toBe("echo ok");
+  });
+
   it("skips skills with directory-traversal names", () => {
     const out = path.join(tmpRoot, "skills");
     const result = materializePortalSkills(

--- a/src/lib/portal-skill-materializer.ts
+++ b/src/lib/portal-skill-materializer.ts
@@ -20,6 +20,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { CliSnapshotSkill } from "../portal/cli-snapshot-api.js";
+import { decodeSkillFileContent, normalizeSkillFiles } from "../shared/skill-package.js";
 
 /**
  * Reject names that would land outside `rootDir` when joined with it.
@@ -79,9 +80,30 @@ export function materializePortalSkills(
     }
     const skillDir = path.join(outDir, skill.name);
     fs.mkdirSync(skillDir, { recursive: true });
-    fs.writeFileSync(path.join(skillDir, "SKILL.md"), skill.specs, "utf-8");
+    if (Array.isArray(skill.files) && skill.files.length > 0) {
+      try {
+        for (const file of normalizeSkillFiles(skill.files)) {
+          const filePath = path.resolve(skillDir, file.path);
+          const rel = path.relative(skillDir, filePath);
+          if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+            throw new Error(`unsafe file path: ${file.path}`);
+          }
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          fs.writeFileSync(filePath, file.encoding === "base64" ? Buffer.from(file.content, "base64") : decodeSkillFileContent(file));
+          if (file.executable || /^scripts\/[^/]+\.(sh|py)$/.test(file.path)) {
+            try { fs.chmodSync(filePath, 0o755); } catch { /* non-POSIX */ }
+          }
+        }
+      } catch {
+        fs.rmSync(skillDir, { recursive: true, force: true });
+        skipped.push(skill.name || "(empty)");
+        continue;
+      }
+    } else {
+      fs.writeFileSync(path.join(skillDir, "SKILL.md"), skill.specs, "utf-8");
+    }
 
-    if (Array.isArray(skill.scripts) && skill.scripts.length > 0) {
+    if (!Array.isArray(skill.files) && Array.isArray(skill.scripts) && skill.scripts.length > 0) {
       const scriptsDir = path.join(skillDir, "scripts");
       fs.mkdirSync(scriptsDir, { recursive: true });
       for (const script of skill.scripts) {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -17,6 +17,7 @@ import {
 } from "../gateway/rest-router.js";
 import { defaultProviderModelCompat } from "../core/model-compat.js";
 import { normalizeChatSessionPreview, normalizeChatSessionTitle } from "./chat-session-fields.js";
+import { safeParseSkillFiles } from "../shared/skill-package.js";
 
 function requireInternalAuth(req: http.IncomingMessage, internalSecret: string): boolean {
   const token = req.headers["x-auth-token"] as string | undefined;
@@ -139,6 +140,23 @@ async function isJumpOfBoundHost(db: Db, agentId: string, hostId: string, prodMa
     }
   }
   return false;
+}
+
+function parseSkillScripts(raw: unknown): Array<{ name: string; content: string }> {
+  if (Array.isArray(raw)) return raw as Array<{ name: string; content: string }>;
+  if (typeof raw === "string") return safeParseJson<Array<{ name: string; content: string }>>(raw, []);
+  return [];
+}
+
+function skillBundleEntry(row: any) {
+  const scripts = parseSkillScripts(row.scripts);
+  return {
+    dirName: row.name.replace(/[^a-zA-Z0-9_-]/g, "_"),
+    scope: "global",
+    specs: row.specs || "",
+    scripts,
+    files: safeParseSkillFiles(row.files, row.specs || "", scripts),
+  };
 }
 
 export function registerAdapterRoutes(router: RestRouter, internalSecret: string): void {
@@ -814,7 +832,8 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
            COALESCE(o.name, s.name) AS name,
            COALESCE(o.labels, s.labels) AS labels,
            COALESCE(ov.specs, sv.specs) AS specs,
-           COALESCE(ov.scripts, sv.scripts) AS scripts
+           COALESCE(ov.scripts, sv.scripts) AS scripts,
+           COALESCE(ov.files, sv.files, o.files, s.files) AS files
          FROM skills s
          LEFT JOIN skills o ON o.overlay_of = s.id
          LEFT JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_approved = 1
@@ -833,7 +852,8 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
            COALESCE(o.name, s.name) AS name,
            COALESCE(o.labels, s.labels) AS labels,
            COALESCE(o.specs, s.specs) AS specs,
-           COALESCE(o.scripts, s.scripts) AS scripts
+           COALESCE(o.scripts, s.scripts) AS scripts,
+           COALESCE(o.files, s.files) AS files
          FROM skills s
          LEFT JOIN skills o ON o.overlay_of = s.id
          WHERE s.id IN (${placeholders})`,
@@ -843,12 +863,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     }
     const skills = rows
       .filter((row: any) => row.specs != null)
-      .map((row: any) => ({
-        dirName: row.name.replace(/[^a-zA-Z0-9_-]/g, "_"),
-        scope: "global",
-        specs: row.specs || "",
-        scripts: safeParseJson(row.scripts, []),
-      }));
+      .map(skillBundleEntry);
     sendJson(res, 200, { version: new Date().toISOString(), skills });
   });
 
@@ -1643,7 +1658,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     if (isProduction) {
       const placeholders = skillIds.map(() => "?").join(",");
       const [result] = await db.query(
-        `SELECT s.id, s.name, s.labels, sv.specs, sv.scripts
+        `SELECT s.id, s.name, s.labels, sv.specs, sv.scripts, COALESCE(sv.files, s.files) AS files
          FROM skills s
          JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_approved = 1
          WHERE s.id IN (${placeholders})
@@ -1657,17 +1672,12 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     } else {
       const placeholders = skillIds.map(() => "?").join(",");
       const [result] = await db.query(
-        `SELECT id, name, labels, specs, scripts FROM skills WHERE id IN (${placeholders})`,
+        `SELECT id, name, labels, specs, scripts, files FROM skills WHERE id IN (${placeholders})`,
         skillIds,
       ) as any;
       rows = result;
     }
-    const skills = rows.map((row: any) => ({
-      dirName: row.name.replace(/[^a-zA-Z0-9_-]/g, "_"),
-      scope: "global",
-      specs: row.specs || "",
-      scripts: safeParseJson(row.scripts, []),
-    }));
+    const skills = rows.map(skillBundleEntry);
     return { version: new Date().toISOString(), skills };
   });
 

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -40,6 +40,7 @@ import type {
   CliSnapshotActiveAgent,
   CliSnapshotSkill,
 } from "./cli-snapshot-types.js";
+import { safeParseSkillFiles } from "../shared/skill-package.js";
 
 export type {
   CliSnapshotKnowledgeRepo,
@@ -117,6 +118,7 @@ interface SkillRow {
   labels: string | null;
   specs: string | null;
   scripts: string | null;
+  files: string | null;
 }
 
 interface KnowledgeRow {
@@ -304,7 +306,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
     // both paths — an overlay always wins over the base builtin.
     const [skills] = activeAgentId
       ? await db.query<SkillRow[]>(
-          `SELECT s.name, s.description, s.labels, s.specs, s.scripts
+          `SELECT s.name, s.description, s.labels, s.specs, s.scripts, s.files
            FROM skills s
            JOIN agent_skills ask ON ask.skill_id = s.id
            WHERE s.org_id = ? AND ask.agent_id = ?
@@ -316,7 +318,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
           ["default", activeAgentId, "default"],
         )
       : await db.query<SkillRow[]>(
-          `SELECT s.name, s.description, s.labels, s.specs, s.scripts
+          `SELECT s.name, s.description, s.labels, s.specs, s.scripts, s.files
            FROM skills s
            WHERE s.org_id = ?
              AND (s.is_builtin = 0 OR s.id NOT IN (
@@ -443,6 +445,11 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
         labels: safeJson<string[]>(s.labels ?? "", []),
         specs: s.specs!,
         scripts: safeJson<Array<{ name: string; content: string }>>(s.scripts ?? "", []),
+        files: safeParseSkillFiles(
+          s.files,
+          s.specs ?? "",
+          safeJson<Array<{ name: string; content: string }>>(s.scripts ?? "", []),
+        ),
       }));
 
     const knowledgeOut: CliSnapshotKnowledgeRepo[] = knowledge.map((k) => {

--- a/src/portal/cli-snapshot-types.ts
+++ b/src/portal/cli-snapshot-types.ts
@@ -6,6 +6,8 @@
  * the types without pulling Portal runtime code into its tsconfig graph.
  */
 
+import type { SkillPackageFile } from "../shared/skill-package.js";
+
 export interface CliSnapshotKnowledgeRepo {
   name: string;
   version: number;
@@ -76,4 +78,6 @@ export interface CliSnapshotSkill {
   specs: string;
   /** Companion scripts (shell / python) referenced by SKILL.md. */
   scripts: Array<{ name: string; content: string }>;
+  /** Complete skill directory package, rooted at the skill directory. */
+  files?: SkillPackageFile[];
 }

--- a/src/portal/migrate-sqlite.test.ts
+++ b/src/portal/migrate-sqlite.test.ts
@@ -171,6 +171,16 @@ describe("runPortalMigrations on SQLite :memory:", () => {
     expect(cols).toContain("updated_at");
   });
 
+  it("skills and skill_versions files columns exist after migration", async () => {
+    await runPortalMigrations();
+    const db = getDb();
+    const [skillRows] = await db.query<Array<{ name: string }>>("PRAGMA table_info(skills)");
+    const [versionRows] = await db.query<Array<{ name: string }>>("PRAGMA table_info(skill_versions)");
+
+    expect(skillRows.map((r) => r.name)).toContain("files");
+    expect(versionRows.map((r) => r.name)).toContain("files");
+  });
+
   it("hosts.jump_host_id and hosts.passphrase columns exist after migration", async () => {
     await runPortalMigrations();
     const db = getDb();

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -108,6 +108,7 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     version INT NOT NULL DEFAULT 1,
     specs MEDIUMTEXT,
     scripts TEXT,
+    files MEDIUMTEXT,
     created_by CHAR(36) NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -119,6 +120,7 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     version INT NOT NULL,
     specs MEDIUMTEXT,
     scripts TEXT,
+    files MEDIUMTEXT,
     diff TEXT,
     commit_message VARCHAR(500),
     author_id CHAR(36) NOT NULL,
@@ -499,12 +501,14 @@ export async function runPortalMigrations(): Promise<void> {
   await safeAlterTable(db, "agent_tasks", "last_manual_run_at", "TIMESTAMP NULL DEFAULT NULL");
   await safeAlterTable(db, "skills", "is_builtin", "TINYINT(1) NOT NULL DEFAULT 0");
   await safeAlterTable(db, "skills", "overlay_of", "CHAR(36) DEFAULT NULL");
+  await safeAlterTable(db, "skills", "files", "MEDIUMTEXT DEFAULT NULL");
   // Hosts: self-referencing jump host chain (ProxyJump) + private-key passphrase.
   // No FK on jump_host_id — mirrors chat_sessions.parent_session_id; integrity is
   // enforced in app code (validateJumpChain) and acquire-time tolerates dangling refs.
   await safeAlterTable(db, "hosts", "jump_host_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "hosts", "passphrase", "VARCHAR(500) DEFAULT NULL");
   await safeAlterTable(db, "skill_versions", "labels", "TEXT DEFAULT NULL");
+  await safeAlterTable(db, "skill_versions", "files", "MEDIUMTEXT DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "parent_session_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "parent_agent_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "delegation_id", "CHAR(36) DEFAULT NULL");

--- a/src/portal/siclaw-api.skills.test.ts
+++ b/src/portal/siclaw-api.skills.test.ts
@@ -254,6 +254,36 @@ describe("siclaw-api skills", () => {
       const skillInsertArgs = query.mock.calls[0][1];
       expect(skillInsertArgs).toContain(JSON.stringify(["demo"]));
     });
+
+    it("creates a skill from files[] and derives specs/scripts", async () => {
+      const files = [
+        { path: "SKILL.md", content: "---\nname: package-skill\ndescription: packaged\n---\nbody", encoding: "utf8", size: 55, sha256: "a" },
+        { path: "scripts/run.sh", content: "echo ok", encoding: "utf8", size: 7, sha256: "b", executable: true },
+        { path: "references/runbook.md", content: "# runbook", encoding: "utf8", size: 9, sha256: "c" },
+      ];
+      query
+        .mockResolvedValueOnce([undefined, []])
+        .mockResolvedValueOnce([undefined, []])
+        .mockResolvedValueOnce([[{ id: "s-new", name: "package-skill", status: "draft", labels: "[]", scripts: JSON.stringify([{ name: "run.sh", content: "echo ok" }]), files: JSON.stringify(files) }], []]);
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/skills",
+        method: "POST",
+        body: { files },
+      }));
+
+      expect(status).toBe(201);
+      expect(body.name).toBe("package-skill");
+      const insertArgs = query.mock.calls[0][1];
+      expect(insertArgs).toContain("package-skill");
+      expect(insertArgs).toContain(JSON.stringify([{ name: "run.sh", content: "echo ok" }]));
+      const filesArg = insertArgs.find((arg: unknown) => typeof arg === "string" && arg.includes("references/runbook.md"));
+      expect(JSON.parse(filesArg)).toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: "SKILL.md" }),
+        expect.objectContaining({ path: "scripts/run.sh" }),
+        expect.objectContaining({ path: "references/runbook.md" }),
+      ]));
+    });
   });
 
   // ── GET /skills/:id ──────────────────────────────────────
@@ -306,6 +336,107 @@ describe("siclaw-api skills", () => {
 
       expect(status).toBe(201);
       expect(body.overlay_of).toBe("s-builtin");
+    });
+
+    it("preserves package extras when legacy scripts are updated", async () => {
+      const specs = "---\nname: package-skill\ndescription: packaged\n---\nbody";
+      const existingFiles = [
+        { path: "SKILL.md", content: specs, encoding: "utf8", size: 55, sha256: "a" },
+        { path: "scripts/old.sh", content: "echo old", encoding: "utf8", size: 8, sha256: "b", executable: true },
+        { path: "references/runbook.md", content: "# runbook", encoding: "utf8", size: 9, sha256: "c" },
+      ];
+      query
+        .mockResolvedValueOnce([[{
+          id: "s1",
+          name: "package-skill",
+          description: "packaged",
+          labels: "[]",
+          status: "draft",
+          is_builtin: 0,
+          specs,
+          scripts: JSON.stringify([{ name: "old.sh", content: "echo old" }]),
+          files: JSON.stringify(existingFiles),
+        }], []])
+        .mockResolvedValueOnce([undefined, []])
+        .mockImplementationOnce(async () => {
+          const updateArgs = query.mock.calls[1][1];
+          return [[{
+            id: "s1",
+            name: "package-skill",
+            labels: "[]",
+            status: "draft",
+            specs,
+            scripts: updateArgs[4],
+            files: updateArgs[5],
+          }], []];
+        });
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/skills/s1",
+        method: "PUT",
+        body: { scripts: [{ name: "new.sh", content: "echo new" }] },
+      }));
+
+      expect(status).toBe(200);
+      expect(body.files).toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: "SKILL.md" }),
+        expect.objectContaining({ path: "scripts/new.sh" }),
+        expect.objectContaining({ path: "references/runbook.md" }),
+      ]));
+      expect(body.files).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: "scripts/old.sh" }),
+      ]));
+    });
+
+    it("stores binary package diffs without UTF-8 decoded payloads", async () => {
+      const specs = "---\nname: package-skill\ndescription: packaged\n---\nbody";
+      const oldFiles = [
+        { path: "SKILL.md", content: specs, encoding: "utf8" },
+        { path: "assets/blob.bin", content: Buffer.from([1, 2, 3]).toString("base64"), encoding: "base64" },
+      ];
+      const newFiles = [
+        { path: "SKILL.md", content: specs, encoding: "utf8" },
+        { path: "assets/blob.bin", content: Buffer.from([4, 5, 6]).toString("base64"), encoding: "base64" },
+      ];
+      query
+        .mockResolvedValueOnce([[{
+          id: "s1",
+          name: "package-skill",
+          description: "packaged",
+          labels: "[]",
+          status: "installed",
+          version: 1,
+          is_builtin: 0,
+          specs,
+          scripts: "[]",
+          files: JSON.stringify(oldFiles),
+        }], []])
+        .mockResolvedValueOnce([undefined, []])
+        .mockResolvedValueOnce([undefined, []])
+        .mockResolvedValueOnce([[{
+          id: "s1",
+          name: "package-skill",
+          labels: "[]",
+          status: "draft",
+          specs,
+          scripts: "[]",
+          files: JSON.stringify(newFiles),
+        }], []]);
+
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/skills/s1",
+        method: "PUT",
+        body: { files: newFiles },
+      }));
+
+      expect(status).toBe(200);
+      const versionInsertArgs = query.mock.calls[1][1];
+      const diff = JSON.parse(versionInsertArgs[6]);
+      expect(diff.files_diff["assets/blob.bin"]).toEqual({
+        old: null,
+        new: null,
+        encoding: "base64",
+      });
     });
 
     it("returns 409 when builtin already has an overlay", async () => {

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -40,6 +40,16 @@ import { parseFrontmatter } from "../gateway/skills/builtin-sync.js";
 import { validateSchedule } from "../cron/cron-limits.js";
 import { validateKnowledgePackage } from "../shared/knowledge-package.js";
 import {
+  decodeSkillFileContent,
+  normalizeSkillFiles,
+  parseSingleSkillPackage,
+  safeParseSkillFiles,
+  scriptsFromSkillFiles,
+  skillFilesFromLegacy,
+  type SkillPackageFile,
+  type SkillScriptEntry,
+} from "../shared/skill-package.js";
+import {
   normalizeChatSessionPreview,
   normalizeChatSessionTitle,
   truncateChatSessionTitle,
@@ -309,10 +319,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       db.query(listSql, [...params, pageSize, offset]),
     ]) as [any, any];
 
-    for (const row of listRows as any[]) {
-      if (row.labels !== undefined) row.labels = safeParseJson(row.labels, []);
-      if (row.scripts !== undefined) row.scripts = safeParseJson(row.scripts, []);
-    }
+    for (const row of listRows as any[]) hydrateSkillRow(row);
 
     sendJson(res, 200, {
       data: listRows,
@@ -349,6 +356,172 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     return { valid: true, name: nameMatch[1].trim(), description };
   }
 
+  function decodeSpecs(raw: string | null | undefined): string | null {
+    if (!raw) return null;
+    if (raw.startsWith('"')) { try { return JSON.parse(raw); } catch {} }
+    return raw;
+  }
+
+  function parseScripts(raw: unknown): SkillScriptEntry[] {
+    if (Array.isArray(raw)) return raw as SkillScriptEntry[];
+    if (typeof raw === "string") return safeParseJson<SkillScriptEntry[]>(raw, []);
+    return [];
+  }
+
+  function parseFiles(raw: unknown, specs?: string | null, scripts?: SkillScriptEntry[] | null): SkillPackageFile[] {
+    return safeParseSkillFiles(raw, specs, scripts);
+  }
+
+  function mergeLegacyPackageFiles(
+    baseFiles: SkillPackageFile[],
+    specs: string,
+    scripts: SkillScriptEntry[],
+    opts: { replaceSpecs: boolean; replaceScripts: boolean },
+  ): SkillPackageFile[] {
+    if (baseFiles.length === 0) return skillFilesFromLegacy(specs, scripts);
+    const kept = baseFiles.filter((file) => {
+      if (opts.replaceSpecs && file.path === "SKILL.md") return false;
+      if (opts.replaceScripts && /^scripts\/[^/]+\.(sh|py)$/.test(file.path)) return false;
+      return true;
+    });
+    const replacements = skillFilesFromLegacy(
+      opts.replaceSpecs ? specs : null,
+      opts.replaceScripts ? scripts : [],
+    );
+    return normalizeSkillFiles([...kept, ...replacements]);
+  }
+
+  function hydrateSkillRow(row: any): any {
+    if (!row) return row;
+    row.labels = safeParseJson(row.labels, []);
+    row.scripts = parseScripts(row.scripts);
+    row.files = parseFiles(row.files, decodeSpecs(row.specs) ?? "", row.scripts);
+    return row;
+  }
+
+  function buildSkillPackageFromBody(
+    body: Record<string, unknown>,
+    fallback?: { name?: string; description?: string | null; labels?: unknown; specs?: unknown; scripts?: unknown; files?: unknown },
+  ): {
+    name: string;
+    description: string;
+    labels: string[];
+    specs: string;
+    scripts: SkillScriptEntry[];
+    files: SkillPackageFile[];
+    labelsJson: string;
+    scriptsJson: string;
+    filesJson: string;
+  } {
+    const labels = Array.isArray(body.labels)
+      ? body.labels.map(String)
+      : safeParseJson<string[]>(fallback?.labels as any, []);
+
+    if (Array.isArray(body.files)) {
+      const parsed = parseSingleSkillPackage(body.files, { labels });
+      const explicitName = typeof body.name === "string" ? body.name.trim() : "";
+      if (explicitName && explicitName !== parsed.name) {
+        throw new Error(`name "${explicitName}" does not match SKILL.md name "${parsed.name}"`);
+      }
+      const explicitDescription = typeof body.description === "string" ? body.description.trim() : "";
+      const description = explicitDescription || parsed.description || "";
+      return {
+        name: parsed.name,
+        description,
+        labels,
+        specs: parsed.specs,
+        scripts: parsed.scripts,
+        files: parsed.files,
+        labelsJson: JSON.stringify(labels),
+        scriptsJson: JSON.stringify(parsed.scripts),
+        filesJson: JSON.stringify(parsed.files),
+      };
+    }
+
+    const fallbackSpecs = decodeSpecs(fallback?.specs as any) ?? "";
+    const specs = typeof body.specs === "string" ? body.specs : fallbackSpecs;
+    const specsCheck = validateSpecs(specs);
+    if (!specsCheck.valid) throw new Error(specsCheck.error);
+    const bodyHasSpecs = typeof body.specs === "string";
+    const bodyHasScripts = Array.isArray(body.scripts);
+    const fallbackScripts = parseScripts(fallback?.scripts);
+    const scripts = bodyHasScripts ? body.scripts as SkillScriptEntry[] : fallbackScripts;
+    const fallbackFiles = parseFiles(fallback?.files, fallbackSpecs, fallbackScripts);
+    const files = !bodyHasSpecs && !bodyHasScripts && fallbackFiles.length > 0
+      ? fallbackFiles
+      : mergeLegacyPackageFiles(fallbackFiles, specs, scripts, {
+        replaceSpecs: bodyHasSpecs,
+        replaceScripts: bodyHasScripts,
+      });
+    const derivedScripts = !bodyHasScripts && files.length > 0 ? scriptsFromSkillFiles(files) : scripts;
+    const explicitName = typeof body.name === "string" ? body.name.trim() : "";
+    const explicitDescription = typeof body.description === "string" ? body.description.trim() : "";
+    return {
+      name: explicitName || specsCheck.name || fallback?.name || "untitled",
+      description: explicitDescription || specsCheck.description || String(fallback?.description ?? ""),
+      labels,
+      specs,
+      scripts: derivedScripts,
+      files,
+      labelsJson: JSON.stringify(labels),
+      scriptsJson: JSON.stringify(derivedScripts),
+      filesJson: JSON.stringify(files),
+    };
+  }
+
+  function buildFilesDiff(
+    oldFiles: SkillPackageFile[] | null,
+    newFiles: SkillPackageFile[] | null,
+  ): Record<string, { old: string | null; new: string | null; encoding?: string }> {
+    const diff: Record<string, { old: string | null; new: string | null; encoding?: string }> = {};
+    const oldMap = new Map((oldFiles ?? []).map((file) => [file.path, file]));
+    const newMap = new Map((newFiles ?? []).map((file) => [file.path, file]));
+    for (const filePath of [...new Set([...oldMap.keys(), ...newMap.keys()])].sort()) {
+      const oldFile = oldMap.get(filePath);
+      const newFile = newMap.get(filePath);
+      if (oldFile?.sha256 === newFile?.sha256 && oldFile?.encoding === newFile?.encoding) continue;
+      const encoding = newFile?.encoding ?? oldFile?.encoding;
+      diff[filePath] = encoding === "base64"
+        ? { old: null, new: null, encoding }
+        : {
+          old: oldFile ? decodeSkillFileContent(oldFile) : null,
+          new: newFile ? decodeSkillFileContent(newFile) : null,
+          encoding,
+        };
+    }
+    return diff;
+  }
+
+  function evaluateInstructionFilesStatic(files: SkillPackageFile[]) {
+    const findings: ReturnType<typeof evaluateScriptsStatic> = [];
+    const patterns = [
+      { category: "prompt_injection", severity: "medium" as const, pattern: /ignore (all )?(previous|prior) instructions/i, label: "Instruction override" },
+      { category: "prompt_injection", severity: "medium" as const, pattern: /system prompt/i, label: "System prompt reference" },
+      { category: "data_exfiltration", severity: "high" as const, pattern: /(secret|token|credential).*(send|upload|exfiltrate|post)/i, label: "Credential exfiltration instruction" },
+    ];
+    for (const file of files) {
+      if (file.path !== "SKILL.md" && !file.path.startsWith("references/")) continue;
+      if (file.encoding !== "utf8") continue;
+      const lines = decodeSkillFileContent(file).split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        for (const p of patterns) {
+          const match = lines[i].match(p.pattern);
+          if (match) {
+            findings.push({
+              category: p.category,
+              severity: p.severity,
+              pattern: p.label,
+              match: match[0],
+              scriptName: file.path,
+              line: i + 1,
+            });
+          }
+        }
+      }
+    }
+    return findings;
+  }
+
   // Create skill
   router.post(`${P}/skills`, async (req, res) => {
     const auth = requireAuth(req, config.jwtSecret);
@@ -357,52 +530,44 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (await guardAccess(res, config, auth, "write")) return;
     const body = await parseBody<Record<string, unknown>>(req);
 
-    // Validate specs format
-    const specsCheck = validateSpecs(body.specs as string);
-    if (!specsCheck.valid) {
-      sendJson(res, 400, { error: specsCheck.error });
+    let pkg: ReturnType<typeof buildSkillPackageFromBody>;
+    try {
+      pkg = buildSkillPackageFromBody(body);
+    } catch (err: any) {
+      sendJson(res, 400, { error: err.message });
       return;
     }
 
     const id = crypto.randomUUID();
     const version = 1;
-
     const db = getDb();
 
-    // Use name/description from frontmatter if not explicitly provided
-    const skillName = (body.name as string)?.trim() || specsCheck.name || "untitled";
-    const skillDescription = (body.description as string)?.trim() || specsCheck.description || "";
-
     await db.query(
-      `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, created_by)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, files, created_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
-        id, auth.orgId, skillName, skillDescription || null,
-        JSON.stringify(body.labels || []),
+        id, auth.orgId, pkg.name, pkg.description || null,
+        pkg.labelsJson,
         auth.userId, "draft", version,
-        body.specs || "", JSON.stringify(body.scripts || []),
+        pkg.specs, pkg.scriptsJson, pkg.filesJson,
         auth.userId,
       ],
     );
 
     // Insert initial version
     await db.query(
-      `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, commit_message, author_id, labels)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, commit_message, author_id, labels)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         crypto.randomUUID(), id, version,
-        body.specs || "", JSON.stringify(body.scripts || []),
+        pkg.specs, pkg.scriptsJson, pkg.filesJson,
         body.commit_message || "Initial version", auth.userId,
-        JSON.stringify(body.labels || []),
+        pkg.labelsJson,
       ],
     );
 
     const [rows] = await db.query("SELECT * FROM skills WHERE id = ?", [id]) as any;
-    const created = rows[0];
-    if (created) {
-      created.labels = safeParseJson(created.labels, []);
-      created.scripts = safeParseJson(created.scripts, []);
-    }
+    const created = hydrateSkillRow(rows[0]);
     sendJson(res, 201, created);
   });
 
@@ -577,6 +742,38 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
   // Skills CRUD (continues — parameterized resource routes)
   // ================================================================
 
+  // Preview a single skill package from archive bytes or JSON { files }.
+  router.post(`${P}/skills/package/preview`, async (req, res) => {
+    const auth = requireAuth(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
+
+    if (await guardAccess(res, config, auth, "write")) return;
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+    const raw = Buffer.concat(chunks);
+    const contentType = req.headers["content-type"] || "";
+
+    try {
+      let parsed;
+      if (contentType.includes("application/json")) {
+        const body = JSON.parse(raw.toString("utf8"));
+        parsed = parseSingleSkillPackage(body.files ?? [], { labels: Array.isArray(body.labels) ? body.labels : [] });
+      } else {
+        const { parseSkillPack } = await import("./skill-import.js");
+        const skills = await parseSkillPack(raw);
+        if (skills.length !== 1) {
+          sendJson(res, 400, { error: "Single-skill package upload must contain exactly one skill directory" });
+          return;
+        }
+        parsed = skills[0];
+      }
+      sendJson(res, 200, { skill: parsed });
+    } catch (err: any) {
+      sendJson(res, 400, { error: err.message || "Failed to parse skill package" });
+    }
+  });
+
   // Get skill
   router.get(`${P}/skills/:id`, async (req, res, params) => {
     const auth = requireAuth(req, config.jwtSecret);
@@ -592,9 +789,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       sendJson(res, 404, { error: "Skill not found" });
       return;
     }
-    const row = rows[0];
-    row.labels = safeParseJson(row.labels, []);
-    row.scripts = safeParseJson(row.scripts, []);
+    const row = hydrateSkillRow(rows[0]);
     sendJson(res, 200, row);
   });
 
@@ -626,29 +821,28 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
         return;
       }
       // Create overlay — full copy with user's edits applied
+      let pkg: ReturnType<typeof buildSkillPackageFromBody>;
+      try {
+        pkg = buildSkillPackageFromBody(body, targetSkill);
+      } catch (err: any) {
+        sendJson(res, 400, { error: err.message });
+        return;
+      }
       const overlayId = crypto.randomUUID();
-      const newSpecs = (body.specs as string) ?? targetSkill.specs;
-      const newScripts = body.scripts ? JSON.stringify(body.scripts) : targetSkill.scripts;
-      const newLabels = body.labels ? JSON.stringify(body.labels) : targetSkill.labels;
-      const newDesc = (body.description as string) ?? targetSkill.description;
 
       await db.query(
-        `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, created_by, is_builtin, overlay_of)
-         VALUES (?, ?, ?, ?, ?, ?, 'draft', 1, ?, ?, ?, 0, ?)`,
-        [overlayId, auth.orgId, targetSkill.name, newDesc, newLabels, auth.userId, newSpecs, newScripts, auth.userId, params.id],
+        `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, files, created_by, is_builtin, overlay_of)
+         VALUES (?, ?, ?, ?, ?, ?, 'draft', 1, ?, ?, ?, ?, 0, ?)`,
+        [overlayId, auth.orgId, pkg.name, pkg.description, pkg.labelsJson, auth.userId, pkg.specs, pkg.scriptsJson, pkg.filesJson, auth.userId, params.id],
       );
       await db.query(
-        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, author_id, is_approved, labels)
-         VALUES (?, ?, 1, ?, ?, ?, 0, ?)`,
-        [crypto.randomUUID(), overlayId, newSpecs, newScripts, auth.userId, newLabels],
+        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, author_id, is_approved, labels)
+         VALUES (?, ?, 1, ?, ?, ?, ?, 0, ?)`,
+        [crypto.randomUUID(), overlayId, pkg.specs, pkg.scriptsJson, pkg.filesJson, auth.userId, pkg.labelsJson],
       );
 
       const [created] = await db.query("SELECT * FROM skills WHERE id = ?", [overlayId]) as any;
-      const overlay = created[0];
-      if (overlay) {
-        overlay.labels = safeParseJson(overlay.labels, []);
-        overlay.scripts = safeParseJson(overlay.scripts, []);
-      }
+      const overlay = hydrateSkillRow(created[0]);
       sendJson(res, 201, overlay);
       return;
     }
@@ -664,69 +858,79 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (skill.status === "installed") {
       // Bump version, create version record, reset to draft
       const newVersion = (skill.version || 0) + 1;
-      // specs is MEDIUMTEXT (raw string), scripts is JSON
-      const newSpecs = body.specs ?? skill.specs ?? "";
-      const newScripts = body.scripts ? JSON.stringify(body.scripts) : (typeof skill.scripts === "string" ? skill.scripts : JSON.stringify(skill.scripts || []));
-      const oldSpecs = skill.specs ?? "";
-      const oldScripts = typeof skill.scripts === "string" ? skill.scripts : JSON.stringify(skill.scripts || []);
+      let pkg: ReturnType<typeof buildSkillPackageFromBody>;
+      try {
+        pkg = buildSkillPackageFromBody(body, skill);
+      } catch (err: any) {
+        sendJson(res, 400, { error: err.message });
+        return;
+      }
+      const oldSpecs = decodeSpecs(skill.specs) ?? "";
+      const oldScripts = parseScripts(skill.scripts);
+      const oldFiles = parseFiles(skill.files, oldSpecs, oldScripts);
 
       // Create version record with diff between old and new
-      const newLabels = body.labels ? JSON.stringify(body.labels) : targetSkill.labels;
       await db.query(
-        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, diff, commit_message, author_id, is_approved, labels)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, diff, commit_message, author_id, is_approved, labels)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
         [
           crypto.randomUUID(), params.id, newVersion,
-          newSpecs, newScripts,
+          pkg.specs, pkg.scriptsJson, pkg.filesJson,
           JSON.stringify({
-            specs_diff: { old: oldSpecs, new: newSpecs },
-            scripts_diff: { old: oldScripts, new: newScripts },
+            specs_diff: { old: oldSpecs, new: pkg.specs },
+            scripts_diff: { old: JSON.stringify(oldScripts), new: pkg.scriptsJson },
+            files_diff: buildFilesDiff(oldFiles, pkg.files),
           }),
           body.commit_message || `Version ${newVersion}`,
           auth.userId,
-          newLabels,
+          pkg.labelsJson,
         ],
       );
 
       await db.query(
         `UPDATE skills SET name = COALESCE(?, name), description = COALESCE(?, description),
          labels = COALESCE(?, labels), status = 'draft',
-         version = ?, specs = COALESCE(?, specs), scripts = COALESCE(?, scripts),
+         version = ?, specs = COALESCE(?, specs), scripts = COALESCE(?, scripts), files = COALESCE(?, files),
          updated_at = CURRENT_TIMESTAMP
          WHERE id = ?`,
         [
-          body.name ?? null, body.description ?? null,
-          body.labels ? JSON.stringify(body.labels) : null,
+          pkg.name, pkg.description,
+          pkg.labelsJson,
           newVersion,
-          body.specs ?? null,
-          body.scripts ? JSON.stringify(body.scripts) : null,
+          pkg.specs,
+          pkg.scriptsJson,
+          pkg.filesJson,
           params.id,
         ],
       );
     } else {
       // Draft: in-place update, no version bump
+      let pkg: ReturnType<typeof buildSkillPackageFromBody>;
+      try {
+        pkg = buildSkillPackageFromBody(body, skill);
+      } catch (err: any) {
+        sendJson(res, 400, { error: err.message });
+        return;
+      }
       await db.query(
         `UPDATE skills SET name = COALESCE(?, name), description = COALESCE(?, description),
          labels = COALESCE(?, labels),
-         specs = COALESCE(?, specs), scripts = COALESCE(?, scripts),
+         specs = COALESCE(?, specs), scripts = COALESCE(?, scripts), files = COALESCE(?, files),
          updated_at = CURRENT_TIMESTAMP
          WHERE id = ?`,
         [
-          body.name ?? null, body.description ?? null,
-          body.labels ? JSON.stringify(body.labels) : null,
-          body.specs ?? null,
-          body.scripts ? JSON.stringify(body.scripts) : null,
+          pkg.name, pkg.description,
+          pkg.labelsJson,
+          pkg.specs,
+          pkg.scriptsJson,
+          pkg.filesJson,
           params.id,
         ],
       );
     }
 
     const [rows] = await db.query("SELECT * FROM skills WHERE id = ?", [params.id]) as any;
-    const updated = rows[0];
-    if (updated) {
-      updated.labels = safeParseJson(updated.labels, []);
-      updated.scripts = safeParseJson(updated.scripts, []);
-    }
+    const updated = hydrateSkillRow(rows[0]);
     sendJson(res, 200, updated);
 
     // Draft update: notify dev agents to reload skills
@@ -792,7 +996,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       [params.id],
     ) as any;
     for (const row of rows as any[]) {
-      if (row.scripts !== undefined) row.scripts = safeParseJson(row.scripts, []);
+      const scripts = parseScripts(row.scripts);
+      if (row.scripts !== undefined) row.scripts = scripts;
+      row.files = parseFiles(row.files, decodeSpecs(row.specs) ?? "", scripts);
       if (row.labels !== undefined) row.labels = safeParseJson(row.labels, []);
       if (row.diff !== undefined) row.diff = safeParseJson(row.diff, null);
     }
@@ -825,7 +1031,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       return;
     }
     const versionRow = rows[0];
-    versionRow.scripts = safeParseJson(versionRow.scripts, []);
+    const versionScripts = parseScripts(versionRow.scripts);
+    versionRow.scripts = versionScripts;
+    versionRow.files = parseFiles(versionRow.files, decodeSpecs(versionRow.specs) ?? "", versionScripts);
     versionRow.labels = safeParseJson(versionRow.labels, []);
     versionRow.diff = safeParseJson(versionRow.diff, null);
     sendJson(res, 200, versionRow);
@@ -866,21 +1074,22 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
 
     // Find last approved version for diff baseline
     const [baselineRows] = await db.query(
-      "SELECT specs, scripts FROM skill_versions WHERE skill_id = ? AND is_approved = 1 ORDER BY version DESC LIMIT 1",
+      "SELECT specs, scripts, files FROM skill_versions WHERE skill_id = ? AND is_approved = 1 ORDER BY version DESC LIMIT 1",
       [params.id],
     ) as any;
     const baseline = baselineRows.length > 0 ? baselineRows[0] : null;
 
-    // Decode specs — may be double-encoded from earlier bug
-    function decodeSpecs(raw: string | null): string | null {
-      if (!raw) return null;
-      if (raw.startsWith('"')) { try { return JSON.parse(raw); } catch {} }
-      return raw;
-    }
+    const baselineSpecs = decodeSpecs(baseline?.specs) || null;
+    const baselineScripts = parseScripts(baseline?.scripts);
+    const baselineFiles = baseline ? parseFiles(baseline.files, baselineSpecs, baselineScripts) : null;
+    const currentSpecs = decodeSpecs(skill.specs) || "";
+    const currentScripts = parseScripts(skill.scripts);
+    const currentFiles = parseFiles(skill.files, currentSpecs, currentScripts);
 
     const diff = JSON.stringify({
-      specs_diff: { old: decodeSpecs(baseline?.specs) || null, new: decodeSpecs(skill.specs) },
-      scripts_diff: { old: baseline?.scripts || null, new: skill.scripts },
+      specs_diff: { old: baselineSpecs, new: currentSpecs },
+      scripts_diff: { old: baseline ? JSON.stringify(baselineScripts) : null, new: JSON.stringify(currentScripts) },
+      files_diff: buildFilesDiff(baselineFiles, currentFiles),
       ...(body.comment ? { comment: body.comment } : {}),
     });
 
@@ -900,12 +1109,15 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     sendJson(res, 200, { review_id: reviewId, status: "pending_review" });
 
     // Security assessment runs entirely in background — reviewer sees results when they open the review
-    const scriptsArr: { name: string; content: string }[] = safeParseJson(skill.scripts, []);
+    const scriptsArr = scriptsFromSkillFiles(currentFiles);
 
     (async () => {
       try {
         // Phase 1: static
-        const staticFindings = evaluateScriptsStatic(scriptsArr);
+        const staticFindings = [
+          ...evaluateScriptsStatic(scriptsArr),
+          ...evaluateInstructionFilesStatic(currentFiles),
+        ];
         const staticAssessment = buildAssessment(staticFindings);
 
         // Phase 2: AI (may take 10-30s)
@@ -921,6 +1133,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
         // Fallback: at least store static assessment
         try {
           const staticFindings = evaluateScriptsStatic(scriptsArr);
+          staticFindings.push(...evaluateInstructionFilesStatic(currentFiles));
           await db.query(
             "UPDATE skill_reviews SET security_assessment = ? WHERE id = ?",
             [JSON.stringify(buildAssessment(staticFindings)), reviewId],
@@ -1005,14 +1218,18 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     ) as any;
 
     if (versionRows.length === 0) {
+      const approvedScripts = parseScripts(skill.scripts);
+      const approvedSpecs = typeof skill.specs === "string" ? skill.specs : JSON.stringify(skill.specs);
+      const approvedFiles = JSON.stringify(parseFiles(skill.files, decodeSpecs(approvedSpecs) ?? "", approvedScripts));
       // Create one with current skill content, is_approved=1
       await db.query(
-        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, commit_message, author_id, is_approved, labels)
-         VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)`,
+        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, commit_message, author_id, is_approved, labels)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
         [
           crypto.randomUUID(), params.id, skill.version,
-          typeof skill.specs === "string" ? skill.specs : JSON.stringify(skill.specs),
-          typeof skill.scripts === "string" ? skill.scripts : JSON.stringify(skill.scripts),
+          approvedSpecs,
+          JSON.stringify(approvedScripts),
+          approvedFiles,
           `Approved version ${skill.version}`,
           skill.author_id,
           typeof skill.labels === "string" ? skill.labels : JSON.stringify(skill.labels || []),
@@ -1186,18 +1403,24 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const currentScripts = typeof skill.scripts === "string" ? skill.scripts : JSON.stringify(skill.scripts);
     const targetSpecs = typeof target.specs === "string" ? target.specs : JSON.stringify(target.specs);
     const targetScripts = typeof target.scripts === "string" ? target.scripts : JSON.stringify(target.scripts);
+    const currentScriptsArr = parseScripts(currentScripts);
+    const targetScriptsArr = parseScripts(targetScripts);
+    const currentFiles = parseFiles(skill.files, decodeSpecs(currentSpecs) ?? "", currentScriptsArr);
+    const targetFiles = parseFiles(target.files, decodeSpecs(targetSpecs) ?? "", targetScriptsArr);
+    const targetFilesJson = JSON.stringify(targetFiles);
 
     // Create new version record with target's content and diff vs current
     const targetLabels = target.labels ?? skill.labels;
     await db.query(
-      `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, diff, commit_message, author_id, is_approved, labels)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+      `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, diff, commit_message, author_id, is_approved, labels)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
       [
         crypto.randomUUID(), params.id, newVersion,
-        targetSpecs, targetScripts,
+        targetSpecs, targetScripts, targetFilesJson,
         JSON.stringify({
           specs_diff: { old: currentSpecs, new: targetSpecs },
           scripts_diff: { old: currentScripts, new: targetScripts },
+          files_diff: buildFilesDiff(currentFiles, targetFiles),
         }),
         `Rollback to version ${body.version}`,
         auth.userId,
@@ -1217,17 +1440,14 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (rollbackName) { setClauses.push("name = ?"); setValues.push(rollbackName); }
     if (rollbackDesc) { setClauses.push("description = ?"); setValues.push(rollbackDesc); }
     if (rollbackLabels) { setClauses.push("labels = ?"); setValues.push(typeof rollbackLabels === "string" ? rollbackLabels : JSON.stringify(rollbackLabels)); }
+    setClauses.push("files = ?"); setValues.push(targetFilesJson);
     setClauses.push("updated_at = CURRENT_TIMESTAMP");
     setValues.push(params.id);
     await db.query(`UPDATE skills SET ${setClauses.join(", ")} WHERE id = ?`, setValues);
 
     const [rows] = await db.query("SELECT * FROM skills WHERE id = ?", [params.id]) as any;
     const row = rows[0];
-    if (row) {
-      row.labels = safeParseJson(row.labels, []);
-      row.scripts = safeParseJson(row.scripts, []);
-    }
-    sendJson(res, 200, row);
+    sendJson(res, 200, hydrateSkillRow(row));
   });
 
   // ================================================================

--- a/src/portal/skill-import.test.ts
+++ b/src/portal/skill-import.test.ts
@@ -418,17 +418,12 @@ describe("parseSkillPack", () => {
     expect(buf[0]).toBe(0x1f);
     expect(buf[1]).toBe(0x8b);
 
-    let extractedFiles: string[] = [];
-    (parseSkillsDir as any).mockImplementation((dir: string) => {
-      extractedFiles = fs.readdirSync(dir);
-      return [];
-    });
+    const skills = await parseSkillPack(buf);
 
-    await parseSkillPack(buf);
-
-    // Single wrapper subdir (no meta.json at root) → parseSkillPack descends
-    // into it, so the dir we observed lists SKILL.md directly.
-    expect(extractedFiles).toContain("SKILL.md");
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("my-skill");
+    expect(skills[0].files.map(f => f.path)).toContain("SKILL.md");
+    expect(parseSkillsDir).not.toHaveBeenCalled();
   });
 
   it("rejects buffers that are neither zip nor tar", async () => {

--- a/src/portal/skill-import.ts
+++ b/src/portal/skill-import.ts
@@ -17,6 +17,7 @@ import AdmZip from "adm-zip";
 import * as tar from "tar";
 import { getDb } from "../gateway/db.js";
 import { parseSkillsDir, type ParsedSkill } from "../gateway/skills/builtin-sync.js";
+import { computeSkillFilesHash, parseSingleSkillPackage, collectSkillDirectoryFiles, parseSkillDirectory, safeParseSkillFiles } from "../shared/skill-package.js";
 
 export type { ParsedSkill };
 
@@ -47,6 +48,10 @@ export interface ImportResult extends ImportDiff {
  *   - "upsert" — leave them untouched (additive upload; used by admin pack upload)
  */
 export type ImportMode = "sync" | "upsert";
+
+function packageFilesFor(skill: ParsedSkill) {
+  return safeParseSkillFiles((skill as any).files, skill.specs, skill.scripts);
+}
 
 // ---------------------------------------------------------------------------
 // 1. Parse a skill pack archive into structured skill objects
@@ -137,9 +142,15 @@ export async function parseSkillPack(archiveBuffer: Buffer): Promise<ParsedSkill
     // the archive likely has a wrapper directory — descend into it.
     const entries = fs.readdirSync(extractDir, { withFileTypes: true });
     const dirs = entries.filter(e => e.isDirectory());
+    if (entries.some(e => e.name === "SKILL.md")) {
+      return [parseSingleSkillPackage(collectSkillDirectoryFiles(extractDir))];
+    }
     let skillsRoot = extractDir;
     if (dirs.length === 1 && !entries.some(e => e.name === "meta.json")) {
-      skillsRoot = path.join(extractDir, dirs[0].name);
+      const singleDir = path.join(extractDir, dirs[0].name);
+      const singleSkill = parseSkillDirectory(dirs[0].name, singleDir);
+      if (singleSkill) return [singleSkill];
+      skillsRoot = singleDir;
     }
 
     return parseSkillsDir(skillsRoot);
@@ -164,10 +175,10 @@ export async function computeImportDiff(
 
   // Current builtin skills
   const [builtinRows] = await db.query(
-    "SELECT id, name, description, specs, scripts FROM skills WHERE org_id = ? AND is_builtin = 1",
+    "SELECT id, name, description, specs, scripts, files FROM skills WHERE org_id = ? AND is_builtin = 1",
     [orgId],
   ) as any;
-  const builtinMap = new Map<string, { id: string; description: string; specs: string; scripts: string }>();
+  const builtinMap = new Map<string, { id: string; description: string; specs: string; scripts: string; files?: string | null }>();
   for (const row of builtinRows) {
     builtinMap.set(row.name, row);
   }
@@ -183,11 +194,13 @@ export async function computeImportDiff(
     if (!existing) {
       added.push(entry);
     } else {
-      // Normalize scripts — DB may store as JSON string or parsed object
       const existingScripts = typeof existing.scripts === "string"
-        ? existing.scripts : JSON.stringify(existing.scripts);
-      const incomingScripts = JSON.stringify(skill.scripts);
-      if (existing.specs !== skill.specs || existingScripts !== incomingScripts) {
+        ? existing.scripts : JSON.stringify(existing.scripts ?? []);
+      let parsedExistingScripts: Array<{ name: string; content: string }> = [];
+      try { parsedExistingScripts = JSON.parse(existingScripts || "[]"); } catch { parsedExistingScripts = []; }
+      const existingHash = computeSkillFilesHash(safeParseSkillFiles(existing.files, existing.specs, parsedExistingScripts));
+      const incomingHash = computeSkillFilesHash(packageFilesFor(skill));
+      if (existingHash !== incomingHash) {
         updated.push(entry);
       } else {
         unchanged.push(entry);
@@ -265,15 +278,16 @@ export async function executeImport(
     for (const entry of diff.added) {
       const skill = incoming.find(s => s.name === entry.name)!;
       const id = crypto.randomUUID();
+      const filesJson = JSON.stringify(packageFilesFor(skill));
       await conn.query(
-        `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, created_by, is_builtin)
-         VALUES (?, ?, ?, ?, ?, 'system', 'installed', 1, ?, ?, 'system', 1)`,
-        [id, orgId, skill.name, skill.description, JSON.stringify(skill.labels), skill.specs, JSON.stringify(skill.scripts)],
+        `INSERT INTO skills (id, org_id, name, description, labels, author_id, status, version, specs, scripts, files, created_by, is_builtin)
+         VALUES (?, ?, ?, ?, ?, 'system', 'installed', 1, ?, ?, ?, 'system', 1)`,
+        [id, orgId, skill.name, skill.description, JSON.stringify(skill.labels), skill.specs, JSON.stringify(skill.scripts), filesJson],
       );
       await conn.query(
-        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, author_id, is_approved, commit_message)
-         VALUES (?, ?, 1, ?, ?, 'system', 1, ?)`,
-        [crypto.randomUUID(), id, skill.specs, JSON.stringify(skill.scripts), comment || "Builtin import"],
+        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, author_id, is_approved, commit_message)
+         VALUES (?, ?, 1, ?, ?, ?, 'system', 1, ?)`,
+        [crypto.randomUUID(), id, skill.specs, JSON.stringify(skill.scripts), filesJson, comment || "Builtin import"],
       );
     }
 
@@ -281,6 +295,7 @@ export async function executeImport(
     for (const entry of diff.updated) {
       const skill = incoming.find(s => s.name === entry.name)!;
       const existingId = builtinByName.get(entry.name)!;
+      const filesJson = JSON.stringify(packageFilesFor(skill));
       // Get next version number
       const [vRows] = await conn.query(
         "SELECT MAX(version) AS v FROM skill_versions WHERE skill_id = ?",
@@ -289,15 +304,15 @@ export async function executeImport(
       const nextVersion = (vRows[0]?.v ?? 0) + 1;
       // Update skills row
       await conn.query(
-        `UPDATE skills SET description = ?, labels = ?, specs = ?, scripts = ?, version = ?, updated_at = CURRENT_TIMESTAMP
+        `UPDATE skills SET description = ?, labels = ?, specs = ?, scripts = ?, files = ?, version = ?, updated_at = CURRENT_TIMESTAMP
          WHERE id = ?`,
-        [skill.description, JSON.stringify(skill.labels), skill.specs, JSON.stringify(skill.scripts), nextVersion, existingId],
+        [skill.description, JSON.stringify(skill.labels), skill.specs, JSON.stringify(skill.scripts), filesJson, nextVersion, existingId],
       );
       // Create approved version row
       await conn.query(
-        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, author_id, is_approved, commit_message)
-         VALUES (?, ?, ?, ?, ?, 'system', 1, ?)`,
-        [crypto.randomUUID(), existingId, nextVersion, skill.specs, JSON.stringify(skill.scripts), comment || "Builtin update"],
+        `INSERT INTO skill_versions (id, skill_id, version, specs, scripts, files, author_id, is_approved, commit_message)
+         VALUES (?, ?, ?, ?, ?, ?, 'system', 1, ?)`,
+        [crypto.randomUUID(), existingId, nextVersion, skill.specs, JSON.stringify(skill.scripts), filesJson, comment || "Builtin update"],
       );
     }
 

--- a/src/shared/skill-package.test.ts
+++ b/src/shared/skill-package.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, afterEach } from "vitest";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  collectSkillDirectoryFiles,
+  normalizeSkillFiles,
+  parseSingleSkillPackage,
+} from "./skill-package.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function skillMd(name = "demo-skill") {
+  return `---
+name: ${name}
+description: Demo skill
+---
+
+# ${name}
+`;
+}
+
+function text(path: string, content = "x") {
+  return { path, content, encoding: "utf8" as const };
+}
+
+function tempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "siclaw-skill-package-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+describe("skill package normalization", () => {
+  it("computes size and sha256 from content instead of trusting client metadata", () => {
+    const content = skillMd();
+    const [file] = normalizeSkillFiles([{
+      path: "SKILL.md",
+      content,
+      encoding: "utf8",
+      size: 1,
+      sha256: "client-controlled",
+    }]);
+
+    expect(file.size).toBe(Buffer.byteLength(content, "utf8"));
+    expect(file.sha256).toBe(crypto.createHash("sha256").update(content).digest("hex"));
+  });
+
+  it("computes binary size and sha256 from decoded base64 bytes", () => {
+    const bytes = Buffer.from([0, 255, 1, 2]);
+    const [file] = normalizeSkillFiles([{
+      path: "assets/blob.bin",
+      content: bytes.toString("base64"),
+      encoding: "base64",
+      size: 1,
+      sha256: "client-controlled",
+    }]);
+
+    expect(file.size).toBe(bytes.length);
+    expect(file.sha256).toBe(crypto.createHash("sha256").update(bytes).digest("hex"));
+  });
+
+  it("rejects unsafe or unsupported paths", () => {
+    for (const badPath of [
+      "../SKILL.md",
+      "/SKILL.md",
+      "references/../SKILL.md",
+      ".DS_Store",
+      ".git/config",
+      "node_modules/pkg/index.js",
+    ]) {
+      expect(() => normalizeSkillFiles([text(badPath)])).toThrow();
+    }
+  });
+
+  it("rejects duplicate package paths", () => {
+    expect(() => normalizeSkillFiles([
+      text("SKILL.md", skillMd()),
+      text("SKILL.md", skillMd()),
+    ])).toThrow(/Duplicate/);
+  });
+});
+
+describe("single skill package parsing", () => {
+  it("parses a wrapped skill directory and strips the wrapper", () => {
+    const parsed = parseSingleSkillPackage([
+      text("demo-skill/SKILL.md", skillMd("demo-skill")),
+      text("demo-skill/references/runbook.md", "# Runbook\n"),
+      text("demo-skill/scripts/check.sh", "echo ok\n"),
+    ]);
+
+    expect(parsed.name).toBe("demo-skill");
+    expect(parsed.files.map(file => file.path).sort()).toEqual([
+      "SKILL.md",
+      "references/runbook.md",
+      "scripts/check.sh",
+    ].sort());
+    expect(parsed.scripts).toEqual([{ name: "check.sh", content: "echo ok\n" }]);
+  });
+
+  it("requires uppercase SKILL.md", () => {
+    expect(() => parseSingleSkillPackage([
+      text("demo-skill/skill.md", skillMd("demo-skill")),
+    ])).toThrow(/uppercase SKILL\.md/);
+  });
+
+  it("rejects a directory name that does not match frontmatter name", () => {
+    expect(() => parseSingleSkillPackage([
+      text("demo-skill/SKILL.md", skillMd("other-skill")),
+    ])).toThrow(/does not match/);
+  });
+
+  it("rejects a multi-skill bundle when parsing a single skill package", () => {
+    expect(() => parseSingleSkillPackage([
+      text("alpha/SKILL.md", skillMd("alpha")),
+      text("beta/SKILL.md", skillMd("beta")),
+    ])).toThrow(/SKILL\.md/);
+  });
+});
+
+describe("skill directory collection", () => {
+  it("collects nested package files", () => {
+    const dir = tempDir();
+    fs.mkdirSync(path.join(dir, "references"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "SKILL.md"), skillMd("demo-skill"));
+    fs.writeFileSync(path.join(dir, "references", "runbook.md"), "# Runbook\n");
+
+    expect(collectSkillDirectoryFiles(dir).map(file => file.path).sort()).toEqual([
+      "SKILL.md",
+      "references/runbook.md",
+    ].sort());
+  });
+
+  it("rejects symlinks and hidden path segments", () => {
+    const symlinkDir = tempDir();
+    fs.writeFileSync(path.join(symlinkDir, "SKILL.md"), skillMd("demo-skill"));
+    fs.writeFileSync(path.join(symlinkDir, "target.txt"), "target");
+    fs.symlinkSync(path.join(symlinkDir, "target.txt"), path.join(symlinkDir, "link.txt"));
+    expect(() => collectSkillDirectoryFiles(symlinkDir)).toThrow(/Symlink/);
+
+    const hiddenDir = tempDir();
+    fs.writeFileSync(path.join(hiddenDir, "SKILL.md"), skillMd("demo-skill"));
+    fs.writeFileSync(path.join(hiddenDir, ".DS_Store"), "");
+    expect(() => collectSkillDirectoryFiles(hiddenDir)).toThrow(/Unsupported/);
+  });
+
+  it("rejects excessive file counts while walking the directory", () => {
+    const dir = tempDir();
+    fs.writeFileSync(path.join(dir, "SKILL.md"), skillMd("demo-skill"));
+    for (let i = 0; i < 200; i++) {
+      fs.writeFileSync(path.join(dir, `file-${i}.txt`), "x");
+    }
+
+    expect(() => collectSkillDirectoryFiles(dir)).toThrow(/exceeds 200 files/);
+  });
+
+  it("rejects excessive total bytes while walking the directory", () => {
+    const dir = tempDir();
+    fs.mkdirSync(path.join(dir, "assets"));
+    fs.writeFileSync(path.join(dir, "SKILL.md"), skillMd("demo-skill"));
+    const chunk = Buffer.alloc(2 * 1024 * 1024 - 1, "x");
+    for (let i = 0; i < 6; i++) {
+      fs.writeFileSync(path.join(dir, "assets", `blob-${i}.bin`), chunk);
+    }
+
+    expect(() => collectSkillDirectoryFiles(dir)).toThrow(/exceeds 10485760 total bytes/);
+  });
+});

--- a/src/shared/skill-package.ts
+++ b/src/shared/skill-package.ts
@@ -1,0 +1,316 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export type SkillFileEncoding = "utf8" | "base64";
+
+export interface SkillPackageFile {
+  path: string;
+  content: string;
+  encoding: SkillFileEncoding;
+  size: number;
+  sha256: string;
+  executable?: boolean;
+}
+
+export interface SkillScriptEntry {
+  name: string;
+  content: string;
+}
+
+export interface ParsedSkillPackage {
+  dirName: string;
+  name: string;
+  description: string;
+  labels: string[];
+  specs: string;
+  scripts: SkillScriptEntry[];
+  files: SkillPackageFile[];
+}
+
+export const SKILL_FILE_NAME = "SKILL.md";
+
+const MAX_SKILL_FILES = 200;
+const MAX_SKILL_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_SKILL_TOTAL_BYTES = 10 * 1024 * 1024;
+const FORBIDDEN_SEGMENTS = new Set([".git", "node_modules"]);
+
+export function parseFrontmatter(md: string): { name: string; description: string } {
+  const match = md.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return { name: "", description: "" };
+
+  const block = match[1];
+  const nameMatch = block.match(/^name:\s*(.+)$/m);
+  const name = nameMatch ? nameMatch[1].trim().replace(/^["']|["']$/g, "") : "";
+
+  let description = "";
+  const lines = block.split("\n");
+  const descIdx = lines.findIndex((line) => line.match(/^description:\s/));
+  if (descIdx >= 0) {
+    const firstLine = lines[descIdx].replace(/^description:\s*/, "").trim();
+    if (firstLine === ">-" || firstLine === ">" || firstLine === "|" || firstLine === "|-") {
+      const contLines: string[] = [];
+      for (let i = descIdx + 1; i < lines.length; i++) {
+        if (lines[i].match(/^\s+/)) contLines.push(lines[i].trim());
+        else break;
+      }
+      description = contLines.join(" ");
+    } else {
+      description = firstLine.replace(/^["']|["']$/g, "");
+    }
+  }
+
+  return { name, description };
+}
+
+export function decodeSkillFileContent(file: Pick<SkillPackageFile, "content" | "encoding">): string {
+  if (file.encoding === "base64") return Buffer.from(file.content, "base64").toString("utf8");
+  return file.content;
+}
+
+function encodeBuffer(buffer: Buffer): Pick<SkillPackageFile, "content" | "encoding" | "size" | "sha256"> {
+  const utf8 = buffer.toString("utf8");
+  const roundTrip = Buffer.from(utf8, "utf8");
+  const encoding: SkillFileEncoding = roundTrip.equals(buffer) ? "utf8" : "base64";
+  const content = encoding === "utf8" ? utf8.replace(/\r\n/g, "\n") : buffer.toString("base64");
+  const contentBytes = encoding === "utf8" ? Buffer.from(content, "utf8") : buffer;
+  return {
+    content,
+    encoding,
+    size: contentBytes.length,
+    sha256: createHash("sha256").update(contentBytes).digest("hex"),
+  };
+}
+
+function normalizePath(rawPath: string): string {
+  const normalized = String(rawPath || "").replace(/\\/g, "/").replace(/^\.\/+/, "");
+  if (!normalized || normalized.startsWith("/") || normalized.includes("\0")) {
+    throw new Error(`Unsafe skill file path: ${rawPath}`);
+  }
+  const parts = normalized.split("/");
+  if (parts.some((segment) => !segment || segment === "." || segment === "..")) {
+    throw new Error(`Unsafe skill file path: ${rawPath}`);
+  }
+  for (const segment of parts) {
+    if (FORBIDDEN_SEGMENTS.has(segment) || segment.startsWith(".")) {
+      throw new Error(`Unsupported skill file path segment: ${segment}`);
+    }
+  }
+  return parts.join("/");
+}
+
+function normalizeFileObject(raw: any): SkillPackageFile {
+  const filePath = normalizePath(raw?.path ?? raw?.name);
+  const encoding: SkillFileEncoding = raw?.encoding === "base64" ? "base64" : "utf8";
+  if (typeof raw?.content !== "string") {
+    throw new Error(`Skill file ${filePath} content must be a string`);
+  }
+  const bytes = encoding === "base64"
+    ? Buffer.from(raw.content, "base64")
+    : Buffer.from(raw.content.replace(/\r\n/g, "\n"), "utf8");
+  if (bytes.length > MAX_SKILL_FILE_BYTES) {
+    throw new Error(`Skill file ${filePath} exceeds ${MAX_SKILL_FILE_BYTES} bytes`);
+  }
+  return {
+    path: filePath,
+    content: encoding === "utf8" ? bytes.toString("utf8") : raw.content,
+    encoding,
+    size: bytes.length,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    ...(raw?.executable ? { executable: true } : {}),
+  };
+}
+
+export function normalizeSkillFiles(rawFiles: unknown): SkillPackageFile[] {
+  if (!Array.isArray(rawFiles)) throw new Error("files must be an array");
+  if (rawFiles.length > MAX_SKILL_FILES) {
+    throw new Error(`Skill package exceeds ${MAX_SKILL_FILES} files`);
+  }
+  const seen = new Set<string>();
+  let total = 0;
+  const files = rawFiles.map(normalizeFileObject).sort((a, b) => a.path.localeCompare(b.path));
+  for (const file of files) {
+    if (seen.has(file.path)) throw new Error(`Duplicate skill file path: ${file.path}`);
+    seen.add(file.path);
+    total += file.size;
+  }
+  if (total > MAX_SKILL_TOTAL_BYTES) {
+    throw new Error(`Skill package exceeds ${MAX_SKILL_TOTAL_BYTES} total bytes`);
+  }
+  return files;
+}
+
+function stripSingleWrapper(files: SkillPackageFile[]): SkillPackageFile[] {
+  if (files.some((file) => file.path === SKILL_FILE_NAME)) return files;
+
+  const skillMdRoots = files
+    .filter((file) => file.path.endsWith(`/${SKILL_FILE_NAME}`))
+    .map((file) => file.path.slice(0, -(`/${SKILL_FILE_NAME}`).length));
+  const lowerCaseRoots = files
+    .filter((file) => file.path.toLowerCase().endsWith("/skill.md") || file.path.toLowerCase() === "skill.md")
+    .map((file) => file.path);
+
+  if (skillMdRoots.length === 0 && lowerCaseRoots.length > 0) {
+    throw new Error("Skill package must use uppercase SKILL.md");
+  }
+  const roots = [...new Set(skillMdRoots)];
+  if (roots.length !== 1) return files;
+
+  const root = `${roots[0]}/`;
+  if (!files.every((file) => file.path.startsWith(root))) return files;
+  return files.map((file) => ({ ...file, path: file.path.slice(root.length) }));
+}
+
+export function scriptsFromSkillFiles(files: SkillPackageFile[]): SkillScriptEntry[] {
+  return files
+    .filter((file) => /^scripts\/[^/]+\.(sh|py)$/.test(file.path))
+    .map((file) => ({ name: file.path.slice("scripts/".length), content: decodeSkillFileContent(file) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function skillFilesFromLegacy(
+  specs: string | null | undefined,
+  scripts: SkillScriptEntry[] | null | undefined,
+): SkillPackageFile[] {
+  const rawFiles: Array<Pick<SkillPackageFile, "path" | "content" | "encoding" | "executable">> = [];
+  if (specs) rawFiles.push({ path: SKILL_FILE_NAME, content: specs, encoding: "utf8" });
+  for (const script of Array.isArray(scripts) ? scripts : []) {
+    rawFiles.push({
+      path: `scripts/${script.name}`,
+      content: script.content,
+      encoding: "utf8",
+      executable: script.name.endsWith(".sh") || script.name.endsWith(".py"),
+    });
+  }
+  return normalizeSkillFiles(rawFiles);
+}
+
+export function parseSingleSkillPackage(
+  rawFiles: unknown,
+  opts: { labels?: string[]; expectedDirName?: string } = {},
+): ParsedSkillPackage {
+  const normalized = normalizeSkillFiles(rawFiles);
+  const wrapperRoot = (() => {
+    if (normalized.some((file) => file.path === SKILL_FILE_NAME)) return undefined;
+    const roots = [...new Set(normalized
+      .filter((file) => file.path.endsWith(`/${SKILL_FILE_NAME}`))
+      .map((file) => file.path.slice(0, -(`/${SKILL_FILE_NAME}`).length)))];
+    return roots.length === 1 && normalized.every((file) => file.path.startsWith(`${roots[0]}/`))
+      ? roots[0]
+      : undefined;
+  })();
+  const files = stripSingleWrapper(normalized);
+  const skillMd = files.find((file) => file.path === SKILL_FILE_NAME);
+  if (!skillMd) {
+    if (files.some((file) => file.path.toLowerCase() === "skill.md")) {
+      throw new Error("Skill package must use uppercase SKILL.md");
+    }
+    throw new Error("Skill package must include SKILL.md");
+  }
+
+  const specs = decodeSkillFileContent(skillMd);
+  const { name, description } = parseFrontmatter(specs);
+  if (!name) throw new Error("SKILL.md frontmatter must include a name field");
+  const expectedDirName = opts.expectedDirName ?? wrapperRoot;
+  if (expectedDirName && expectedDirName !== name) {
+    throw new Error(`Skill directory "${expectedDirName}" does not match SKILL.md name "${name}"`);
+  }
+
+  return {
+    dirName: expectedDirName ?? name,
+    name,
+    description,
+    labels: opts.labels ?? [],
+    specs,
+    scripts: scriptsFromSkillFiles(files),
+    files,
+  };
+}
+
+export function collectSkillDirectoryFiles(dirPath: string): SkillPackageFile[] {
+  const files: SkillPackageFile[] = [];
+  let fileCount = 0;
+  let totalBytes = 0;
+
+  function walk(currentDir: string, relDir: string): void {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      if (entry.name.startsWith(".") || FORBIDDEN_SEGMENTS.has(entry.name)) {
+        throw new Error(`Unsupported skill file path segment: ${entry.name}`);
+      }
+      const abs = path.join(currentDir, entry.name);
+      const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
+      const stat = fs.lstatSync(abs);
+      if (stat.isSymbolicLink()) throw new Error(`Symlink is not allowed in skill package: ${rel}`);
+      if (stat.isDirectory()) {
+        walk(abs, rel);
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      if (stat.size > MAX_SKILL_FILE_BYTES) {
+        throw new Error(`Skill file ${rel} exceeds ${MAX_SKILL_FILE_BYTES} bytes`);
+      }
+      fileCount += 1;
+      if (fileCount > MAX_SKILL_FILES) {
+        throw new Error(`Skill package exceeds ${MAX_SKILL_FILES} files`);
+      }
+      const encoded = encodeBuffer(fs.readFileSync(abs));
+      totalBytes += encoded.size;
+      if (totalBytes > MAX_SKILL_TOTAL_BYTES) {
+        throw new Error(`Skill package exceeds ${MAX_SKILL_TOTAL_BYTES} total bytes`);
+      }
+      files.push({
+        path: normalizePath(rel),
+        ...encoded,
+        ...(stat.mode & 0o111 ? { executable: true } : {}),
+      });
+    }
+  }
+
+  walk(dirPath, "");
+  return normalizeSkillFiles(files);
+}
+
+export function parseSkillDirectory(
+  dirName: string,
+  dirPath: string,
+  labelsMap: Record<string, string[]> = {},
+): ParsedSkillPackage | null {
+  const skillMdPath = path.join(dirPath, SKILL_FILE_NAME);
+  if (!fs.existsSync(skillMdPath)) {
+    if (fs.existsSync(path.join(dirPath, "skill.md"))) {
+      throw new Error(`Skill directory "${dirName}" must use uppercase SKILL.md`);
+    }
+    return null;
+  }
+  return parseSingleSkillPackage(collectSkillDirectoryFiles(dirPath), {
+    expectedDirName: dirName,
+    labels: labelsMap[dirName] ?? [],
+  });
+}
+
+export function computeSkillFilesHash(files: SkillPackageFile[]): string {
+  const h = createHash("sha256");
+  for (const file of normalizeSkillFiles(files)) {
+    h.update(file.path);
+    h.update("\0");
+    h.update(file.encoding);
+    h.update("\0");
+    h.update(file.content);
+    h.update("\0");
+    h.update(file.executable ? "1" : "0");
+    h.update("\0");
+  }
+  return h.digest("hex");
+}
+
+export function safeParseSkillFiles(raw: unknown, specs?: string | null, scripts?: SkillScriptEntry[] | null): SkillPackageFile[] {
+  if (Array.isArray(raw)) return normalizeSkillFiles(raw);
+  if (typeof raw === "string" && raw.trim()) {
+    try {
+      return normalizeSkillFiles(JSON.parse(raw));
+    } catch {
+      return skillFilesFromLegacy(specs, scripts);
+    }
+  }
+  return skillFilesFromLegacy(specs, scripts);
+}

--- a/src/tools/cmd-exec/restricted-bash.test.ts
+++ b/src/tools/cmd-exec/restricted-bash.test.ts
@@ -14,6 +14,16 @@ import {
 import { extractPipeline } from "../infra/command-validator.js";
 import { preExecSecurity } from "../infra/security-pipeline.js";
 
+function expectAllowedByRestrictedBashGate(command: string) {
+  const pre = preExecSecurity(command, {
+    context: "local",
+    extraAllowed: new Set(["kubectl"]),
+    isAllowed: isSkillScript,
+    pipelineValidators: [validateKubectlInPipeline],
+  });
+  expect(pre.error).toBeNull();
+}
+
 describe("extractCommands", () => {
   it("splits pipe", () => {
     expect(extractCommands("kubectl get pods | grep Error")).toEqual([
@@ -1149,14 +1159,8 @@ describe("createRestrictedBashTool — new DevOps command restrictions", () => {
   });
 
   // ctr
-  it("allows ctr images ls", async () => {
-    const result = await tool.execute(
-      "test-id",
-      { command: "ctr images ls" },
-      undefined,
-      {} as any
-    );
-    expect((result.details as any).blocked).toBeFalsy();
+  it("allows ctr images ls", () => {
+    expectAllowedByRestrictedBashGate("ctr images ls");
   });
 
   it("blocks ctr images pull", async () => {
@@ -1333,15 +1337,8 @@ describe("createRestrictedBashTool — pipe-only text command enforcement", () =
   ];
 
   for (const cmd of allowedPiped) {
-    it(`allows piped: ${cmd}`, async () => {
-      const result = await tool.execute(
-        "test-id",
-        { command: cmd },
-        undefined,
-        {} as any
-      );
-      expect(result.content[0].text).not.toContain("can only be used after a pipe");
-      expect((result.details as any).blocked).toBeFalsy();
+    it(`allows piped: ${cmd}`, () => {
+      expectAllowedByRestrictedBashGate(cmd);
     });
   }
 

--- a/src/tools/workflow/skill-preview.test.ts
+++ b/src/tools/workflow/skill-preview.test.ts
@@ -133,7 +133,7 @@ description: "A skill that does X"
     expect(parsed.skill.description).toBe("A skill that does X");
   });
 
-  it("falls back to directory name when frontmatter has no name", async () => {
+  it("returns error when frontmatter has no name", async () => {
     const dir = writeSkill(`---
 description: Some skill
 ---
@@ -141,17 +141,16 @@ description: Some skill
 `);
     const result = await exec({ dir });
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.skill.name).toBe(path.basename(testSkillDir));
+    expect(parsed.error).toMatch(/name field/);
+    expect(result.details.error).toBe(true);
   });
 
-  it("handles SKILL.md without frontmatter", async () => {
+  it("returns error for SKILL.md without frontmatter", async () => {
     const dir = writeSkill("# Just a title\n\nSome content");
     const result = await exec({ dir });
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.skill.name).toBe(path.basename(testSkillDir));
-    expect(parsed.skill.description).toBe("");
-    expect(parsed.skill.type).toBe("Custom");
-    expect(parsed.skill.specs).toBe("# Just a title\n\nSome content");
+    expect(parsed.error).toMatch(/name field/);
+    expect(result.details.error).toBe(true);
   });
 
   // --- Scripts ---

--- a/src/tools/workflow/skill-preview.ts
+++ b/src/tools/workflow/skill-preview.ts
@@ -4,6 +4,7 @@ import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveUnderDir } from "../../shared/path-utils.js";
+import { collectSkillDirectoryFiles, parseSingleSkillPackage } from "../../shared/skill-package.js";
 
 const DRAFTS_BASE = path.resolve(process.cwd(), ".siclaw/user-data/skill-drafts");
 
@@ -99,45 +100,26 @@ description: >-
             details: { error: true },
           };
         }
-        const specs = fs.readFileSync(specPath, "utf-8").replace(/\r\n/g, "\n");
-
-        // Parse name and description from YAML frontmatter
-        let name = path.basename(safeDir);
-        let description = "";
+        let parsed;
+        try {
+          parsed = parseSingleSkillPackage(collectSkillDirectoryFiles(safeDir));
+        } catch (err: unknown) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: err instanceof Error ? err.message : String(err) }) }],
+            details: { error: true },
+          };
+        }
         let type = "Custom";
-        const fmMatch = specs.match(/^---\n([\s\S]*?)\n---/);
+        const fmMatch = parsed.specs.match(/^---\n([\s\S]*?)\n---/);
         if (fmMatch) {
           const fm = fmMatch[1];
-          const nameMatch = fm.match(/^name:\s*(.+)$/m);
-          if (nameMatch) name = nameMatch[1].trim();
-          // Multiline: "description: >-\n  line1\n  line2" or inline: "description: one line"
-          const descMulti = fm.match(/^description:\s*>-?\s*\n((?:[ \t]+.+\n?)+)/m);
-          if (descMulti) {
-            description = descMulti[1].trim().replace(/\n\s*/g, " ");
-          } else {
-            const descInline = fm.match(/^description:\s*(?!>)(.+)$/m);
-            if (descInline) description = descInline[1].trim().replace(/^["']|["']$/g, "");
-          }
           const typeMatch = fm.match(/^type:\s*(.+)$/m);
           if (typeMatch) type = typeMatch[1].trim();
         }
 
-        // Read scripts (skip symlinks to prevent exfiltration)
-        const scripts: Array<{ name: string; content: string }> = [];
-        const scriptsDir = path.join(safeDir, "scripts");
-        if (fs.existsSync(scriptsDir) && fs.statSync(scriptsDir).isDirectory()) {
-          for (const f of fs.readdirSync(scriptsDir).sort()) {
-            const fp = path.join(scriptsDir, f);
-            const stat = fs.lstatSync(fp);
-            if (stat.isFile() && !stat.isSymbolicLink()) {
-              scripts.push({ name: f, content: fs.readFileSync(fp, "utf-8") });
-            }
-          }
-        }
-
         const result = {
-          skill: { name, description, type, specs, scripts },
-          summary: `Skill preview for '${name}'. Click View to inspect and copy.`,
+          skill: { ...parsed, type },
+          summary: `Skill preview for '${parsed.name}'. Click View to inspect and copy.`,
         };
 
         return {


### PR DESCRIPTION
## Summary

Treat each skill as a self-contained **directory package** instead of a `specs` + `scripts[]` pair:

- A skill is a directory with a canonical `SKILL.md` plus arbitrary package files (`scripts/`, `references/`, `examples/`, `assets/`); a bundle is a collection of such directories.
- New shared module `src/shared/skill-package.ts` is the single source of truth for package parsing, validation, and content hashing.
- `files` support threads through every read/write path — built-in sync, Portal CRUD APIs, CLI snapshots, agentbox sync, materialization, and the `skill_preview` tool — while preserving legacy `specs`/`scripts`.
- Portal skill editor reworked into an explorer-style package tree: file/folder create / rename / delete, package upload / replace, per-file editing, and GitHub-style package diffs before Save / Submit / review / version comparison.
- Security review extended from scripts-only to file-level package diffs plus lightweight prompt-injection / exfiltration scanning of `SKILL.md` and `references/`.

## Schema

- Adds `files MEDIUMTEXT` to `skills` and `skill_versions` (idempotent `safeAlterTable` backfill on existing DBs).
- Content hash changes from `SHA-256(specs + sorted scripts)` to `SHA-256(normalized package files)`. Legacy rows fall back to the synthesized package representation, so builtin sync does **not** churn skills that only carry `SKILL.md` + scripts.

## Compatibility

- Existing legacy skill rows are synthesized into package files **on read**, not eagerly backfilled.
- Every read path (adapter, CLI snapshot, agentbox sync, materializer) falls back to `specs`/`scripts` when `files` is absent.
- Binary package files are preserved (base64) and rendered as binary changes in diffs.

## Security

The shared validator rejects: hidden paths (`.`-prefixed segments), `.git`, `node_modules`, symlinks, path traversal (`..` / absolute / `\0`), non-uppercase `SKILL.md`, dirName ↔ `name` mismatch, and oversize packages (2 MB/file, 10 MB total, 200 files). Defense-in-depth: gateway validates → agentbox re-normalizes + path-containment check → materializer re-checks paths and cleans up on failure.

## Validation

- `npm run build`
- `npm run build:web`
- `npm test`
- Targeted package tests after the final preview fix:
  `npm test -- src/tools/workflow/skill-preview.test.ts src/portal/siclaw-api.skills.test.ts src/portal/skill-import.test.ts src/gateway/skills/builtin-sync.test.ts src/lib/portal-skill-materializer.test.ts src/agentbox/sync-handlers.test.ts`
- `git diff --check`
- Playwright visual QA for desktop/mobile Save diff modal.
- Deployed standalone Siclaw test namespace `sdliu-siclaw` with portal image `registry-cn-shanghai.siflow.cn/k8s/siclaw-portal:skill-dir-closed-661b1e5-20260601190500`; rollout and `/health` passed.
