### PR TITLE
chore(skills): drop dead extension tier and align governance docs with current model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,14 @@ snapshot, K8s/Docker/Helm, or user-facing workflows.
 ## Stable Boundaries
 
 - `LocalSpawner` runs all local AgentBox instances in one process with a shared
-  filesystem. Local skill sync must stay user-scoped and must not wipe shared
-  skill directories such as global/skillset/user trees.
-- Core skills are baked into the Docker image. Workspace skill bundles should
-  include only selected global/dev/personal skills.
+  filesystem. Local mode intentionally **skips** skill materialize (which would
+  wipe the shared `.siclaw/skills/resolved/` directory and clobber other users);
+  the agent reads from `skills/core/` and `skills/platform/` directly.
+- Skills live in a single flat per-org pool (`skills` table, `is_builtin` flag).
+  Bundles deliver the skills bound to the requesting agent via `agent_skills`,
+  filtered by the agent's `is_production` flag — prod agents only see versions
+  where `skill_versions.is_approved = 1`. Builtin skills (`skills/core/`) are
+  synced into the same DB pool at Gateway startup.
 - TUI plus local Portal uses Portal as a read-only snapshot source. TUI startup
   must tolerate missing or unauthorized Portal snapshot access.
 - Shell execution security is layered: OS-level isolation first, whitelist-only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,17 @@ Gateway + K8sSpawner  (production — one isolated pod per user)
 ### 🔴 Local Mode: Shared Filesystem
 
 `LocalSpawner` runs ALL AgentBox instances **in-process**, sharing one filesystem.
-- `skillsHandler.materialize()` **must NOT be called in local mode** — wipes all users' skills
-- Local skills sync writes only to `skills/user/{userId}/` scoped paths
+- `skillsHandler.materialize()` **must NOT be called in local mode** — would wipe the shared `.siclaw/skills/resolved/` and clobber every other user
+- LocalSpawner intentionally **skips** skill sync entirely (see `local-spawner.ts:113-117`); local agents read directly from `skills/core/` + `skills/platform/`
+- Knowledge sync IS called in LocalSpawner (its handler merges instead of wiping); MCP is also skipped for the same shared-state reason
 
 ### 🔴 Skill Bundle Contract
 
-`buildSkillBundle()` packages **only global + skillset (dev only) + personal skills** selected for the current workspace. Core skills are baked into the Docker image. `materialize()` does NOT restore core skills.
+The skill bundle endpoint (`/api/internal/siclaw/skills/bundle`) delivers **the skills bound to the requesting agent** via `agent_skills`, filtered by the agent's `is_production` flag:
+- **Prod agent**: only the latest `skill_versions` row where `is_approved = 1` (status-gated; draft skills are silently excluded)
+- **Dev agent**: current `skills.specs` / `skills.scripts` (draft + installed both delivered)
+
+Builtin skills (`is_builtin = 1`) flow through the same pipeline — synced from `skills/core/` into the DB at Gateway startup. `materialize()` writes everything into `.siclaw/skills/resolved/` (flat, no per-user segment). The on-disk `skills/core/` directory is the **fallback** when `resolved/` doesn't exist (TUI mode, first boot). The full design lives in `docs/design/2026-04-13-skill-governance-design.md`.
 
 ### 🔴 TUI + Local Portal: Read-Only Snapshot Contract
 

--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -68,7 +68,6 @@ RUN npm ci --omit=dev
 # Copy compiled JS + skills + entrypoint (knowledge synced at runtime via bundle API)
 COPY --from=builder /app/dist/ ./dist/
 COPY skills/core/ ./skills/core/
-COPY skills/extension/ ./skills/extension/
 COPY skills/platform/ ./skills/platform/
 COPY docker/agentbox-entrypoint.sh /usr/local/bin/agentbox-entrypoint.sh
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -33,7 +33,6 @@ COPY --from=builder /app/dist/ ./dist/
 
 # Copy builtin skills
 COPY skills/core/ ./skills/core/
-COPY skills/extension/ ./skills/extension/
 
 RUN mkdir -p .siclaw
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -69,22 +69,26 @@ LocalSpawner runs AgentBox HTTP servers in-process, one per user, on ports 4000+
 **Status**: Active
 
 **Context**:
-The skill bundle API (`/api/internal/skills/bundle`) delivers skills to AgentBox instances. Should it include core (built-in) skills?
+The skill bundle API (`/api/internal/siclaw/skills/bundle`) delivers skills to AgentBox instances. How are core (built-in) skills delivered, and how are draft vs approved versions separated?
 
 Options:
-- **Include all**: Bundle contains core + global + personal. Simple for AgentBox (one source of truth). Expensive: Gateway must serialize all core skill files on every request.
-- **Exclude core**: Bundle contains only global + personal. Core skills are baked into the Docker image / repo checkout. AgentBox reads them from disk directly.
+- **Disk-only core**: Bundle excludes builtins; AgentBox reads core from `skills/core/` baked into the image. Two execution sources (disk + bundle) to merge at runtime. Forces a separate "disabled builtins" channel for opt-out.
+- **DB-backed core (current)**: Builtins are synced from `skills/core/` into the DB at Gateway startup (with `is_builtin=1` flag) and flow through the same bundle pipeline as user skills. One source of truth at runtime; per-agent binding and version history work uniformly.
 
 **Decision**:
-Bundles contain **only global + skillset (dev only) + personal skills**. Core skills are baked into the AgentBox Docker image at build time and read from `skills/core/` at runtime. Skillset skills (from Skill Spaces) are included only in dev bundles — they must be promoted to global scope before reaching production.
+Builtins are synced into the DB at Gateway startup and delivered through the unified bundle pipeline. The bundle endpoint filters by `agent_skills` membership and `is_production` flag:
+- **Prod agent** → only `skill_versions` rows where `is_approved = 1` (status-gated)
+- **Dev agent** → current `skills.specs` / `skills.scripts` (draft + installed both delivered)
+
+Overlays (`overlay_of` FK) let a user-created skill replace a builtin's content while sharing the name. The on-disk `skills/core/` directory is only used as the **runtime fallback** when `.siclaw/skills/resolved/` is absent (TUI mode, first boot).
 
 **Consequences**:
-- ✅ Bundle requests are small and fast (no large static skill content)
-- ✅ Core skills are versioned with the code, not the database
-- ⚠️ `skillsHandler.materialize()` does NOT restore core skills — it only writes what's in the bundle
-- ⚠️ In local mode, `materialize()` wipes `skills/global/`, `skills/skillset/`, and `skills/user/` subdirectories, destroying ALL users' personal skills on the shared filesystem — see ADR-002 for why local mode cannot safely call `materialize()`
-- ⚠️ If a user disables a core skill, the `disabledBuiltins` list in the bundle tells AgentBox which core skills to skip
-- ⚠️ Skillset skills are dev-only — untested collaborative work cannot reach production without promotion to global
+- ✅ One pipeline, one schema — builtins, user skills, and overlays all use the same `skills` / `skill_versions` / `skill_reviews` tables and the same review gate
+- ✅ Per-agent binding via `agent_skills` — admins explicitly attach skills to each agent
+- ✅ Prod safety: draft skills cannot reach prod agents (filter at the bundle query)
+- ⚠️ `skillsHandler.materialize()` wipes `.siclaw/skills/resolved/` and rebuilds it from the bundle — destructive when called against a shared filesystem; LocalSpawner explicitly **skips** the skills handler (see `local-spawner.ts:113-117`)
+- ⚠️ In local mode, agents see only `skills/core/` + `skills/platform/` — DB-managed skills are not delivered. This is a known limitation of the multi-user-shared-FS model; multi-tenant skill delivery requires K8s mode
+- ⚠️ Empty-bundle protection: `materialize()` refuses to wipe `resolved/` if the incoming payload is empty but existing content is non-empty (guards against transient Gateway errors)
 
 ---
 

--- a/docs/design/invariants.md
+++ b/docs/design/invariants.md
@@ -35,20 +35,20 @@ TUI has two sub-modes: **standalone** (no Portal in the cwd) and **Portal-paired
 **Invariant**: In local mode (`LocalSpawner`), every AgentBox instance runs in the same Node.js process as Gateway and shares the same working directory and filesystem.
 
 **Consequences**:
-- Any code that writes/deletes files in `./skills/` affects ALL users simultaneously
-- `skillsHandler.materialize()` is **NOT safe** in local mode — it wipes `skills/global/`, `skills/skillset/`, and `skills/user/` subdirectories (not `core/`), which in a shared filesystem destroys ALL users' personal skills. This is designed for K8s pods with isolated filesystems.
-- Per-user skill sync in local mode must write only to `skills/user/<userId>/` without touching `skills/core/` (global + personal skills from the bundle are both written into the user's directory)
+- Any code that writes/deletes files in `.siclaw/skills/` affects ALL users simultaneously
+- `skillsHandler.materialize()` is **NOT safe** in local mode — it wipes and rebuilds `.siclaw/skills/resolved/`, a single shared directory. LocalSpawner therefore explicitly **skips** the skills handler (see `local-spawner.ts:113-117`) — knowledge sync runs (its handler merges instead of wiping), but skills and MCP sync are intentionally not called.
+- Consequence: in local mode, agents only see skills from `skills/core/` + `skills/platform/` baked into the repo. DB-managed skills (user-created or admin-bound) are **not delivered to local agents**. Multi-tenant skill delivery requires K8s mode (one pod per user with its own emptyDir).
 - Local SQLite (via `node:sqlite`) uses WAL mode with a shared process — local mode is single-process by design; production K8s uses MySQL and has no such constraint
 
-**Source**: `src/gateway/agentbox/local-spawner.ts`, `src/agentbox/resource-handlers.ts:82-97`
+**Source**: `src/gateway/agentbox/local-spawner.ts:113-133`, `src/agentbox/sync-handlers.ts` (skillsHandler.materialize)
 
 ### 1.3 K8s Pod Isolation
 
 **Invariant**: Each K8s AgentBox pod is fully isolated: its own emptyDir volume for skills, its own mTLS client certificate, its own process. Skills sync via `skillsHandler.materialize()` is safe here because there is no shared filesystem.
 
 **Consequences**:
-- The `global/`, `skillset/`, and `user/` skill subdirectories in a pod are managed by resource sync — wiped and rebuilt on every sync. `core/` and `extension/` are baked into the image.
-- Core skills ARE baked into the Docker image (`COPY skills/core/ ./skills/core/` in Dockerfile.agentbox). They are NOT delivered via the skill bundle — see §2.1.
+- The pod's `.siclaw/skills/resolved/` directory is managed by resource sync — wiped and rebuilt by `skillsHandler.materialize()` on every reload. `skills/core/` and `skills/platform/` are baked into the image and read-only.
+- Builtin skills ARE baked into the Docker image (`COPY skills/core/` + `COPY skills/platform/` in Dockerfile.agentbox). Core builtins are also synced into the DB at Gateway startup and flow through the same bundle pipeline as user skills — see §2.1. `skills/core/` on disk is the runtime fallback when `resolved/` doesn't exist (TUI / first-boot).
 - Pod self-destructs after 5 minutes of idle (no SSE connections, no sessions)
 
 **Source**: `src/gateway/agentbox/k8s-spawner.ts`, `src/agentbox/http-server.ts` (IDLE_TIMEOUT_MS)
@@ -105,7 +105,7 @@ The trust boundary remains "whoever can read `.siclaw/local-secrets.json` in the
 ```
 
 - The directory is **ephemeral**: TUI wipes it on `SIGINT` / `SIGTERM` / normal exit.
-- These materializers are **distinct from** `skillsHandler.materialize()` (§1.2). The canonical handler mutates `skills/{global,skillset,user}/` and is unsafe in LocalSpawner's shared filesystem; the Portal-snapshot materializers write only to `.siclaw/.portal-snapshot/` inside the cwd and are scoped to the TUI process. Do not consolidate the two without redesigning the skill-bundle contract.
+- These materializers are **distinct from** `skillsHandler.materialize()` (§1.2). The canonical handler wipes and rebuilds `.siclaw/skills/resolved/` (a single shared path, unsafe in LocalSpawner); the Portal-snapshot materializers write only to `.siclaw/.portal-snapshot/` inside the cwd and are scoped to the TUI process. Do not consolidate the two without redesigning the skill-bundle contract.
 - `agent-factory.ts` picks up these paths via new `portalSkillsDir` / `portalKnowledgeDir` / `portalCredentialsDir` opts; when set, they override `config.paths.*` so the agent's Read tool, `local_script`, and kubectl use Portal content.
 
 **Skill filter** (`src/core/agent-factory.ts`):
@@ -119,42 +119,64 @@ When a Portal snapshot is active, pi-coding-agent's `DefaultResourceLoader` auto
 
 ### 2.1 What a Bundle Contains
 
-**Invariant**: `buildSkillBundle()` packages **only global + skillset (dev only) + personal skills** from the database. When a workspace composer is present, each scope is filtered to the workspace selection. Core (builtin) skills are NEVER included in bundles.
+**Invariant**: The skill bundle endpoint (`POST /api/internal/siclaw/skills/bundle`) packages **the skills bound to the requesting agent** via `agent_skills`, filtered by the agent's `is_production` flag. Builtins flow through the same pipeline — they were synced from `skills/core/` into the DB at Gateway startup with `is_builtin=1`.
 
 ```
-Bundle = selected global skills (DB, published tag) + selected skillset skills (DB, dev only) + selected personal skills (DB)
-Bundle ≠ core skills (baked into image/repo checkout)
+Prod agent → SELECT FROM skill_versions WHERE is_approved=1 AND version=MAX(...)
+              JOIN agent_skills ON ... WHERE agent_id = ?
+              ──────────────────────────────────────────────────
+              Draft / pending_review skills are silently excluded.
+
+Dev agent  → SELECT current specs/scripts FROM skills s
+              JOIN agent_skills ON ... WHERE agent_id = ?
+              ──────────────────────────────────────────────────
+              Draft + installed both delivered.
+
+Overlay    → When an overlay (overlay_of != NULL) exists for a builtin,
+              the bundle returns the overlay's content under the same id/name,
+              and the base builtin is suppressed.
 ```
 
-**Source**: `src/gateway/skills/skill-bundle.ts:1-10`
+**Disk runtime fallback**: when `.siclaw/skills/resolved/` is absent (TUI mode, first boot), the agent reads directly from `skills/core/` on disk. `skills/platform/` is **always** loaded on top — those are platform meta-skills, not in the DB.
 
-### 2.2 Skill Directory Tiers
+**Source**: `src/portal/adapter.ts` (POST /api/internal/siclaw/skills/bundle), `src/agentbox/sync-handlers.ts` (skillsHandler.materialize)
 
-```
-skills/
-├── core/              ← Built-in, read-only, baked into image. Never overwritten by sync.
-├── extension/         ← Builtin overlay (inner projects). Baked into image.
-├── global/            ← Global skills, synced from DB. Supplements/overrides builtin.
-├── skillset/{spaceId}/ ← Skill Space skills, synced from DB. Dev only.
-└── user/{userId}/     ← Personal skills, synced from DB per user.
-```
-
-**Loading priority** (highest wins): `personal` > `skillset` > `global` > `builtin`
-
-### 2.3 Skill Activation Gate
-
-Scripts in a skill follow this workflow before execution is permitted:
+### 2.2 Skill Directory Layout
 
 ```
-draft → (request review) → pending → (AI + static analysis) → approved/rejected
+skills/                          ← Repo / Docker image, read-only at runtime
+├── core/                         ← Builtin diagnostic skills (Docker-baked); synced into DB at Gateway startup
+└── platform/                     ← Platform meta-skills (skill-authoring, manage-skill); never in DB, always loaded
+
+.siclaw/skills/                  ← Runtime working directory
+└── resolved/                     ← Flat dir written by skillsHandler.materialize() from the bundle; single shared path (no per-user segment)
+
+.siclaw/.portal-snapshot/        ← TUI + local Portal only (ephemeral)
+└── skills/                       ← Written by portal-skill-materializer; wiped on TUI exit
 ```
 
-- **Static analysis**: 22 `DANGER_PATTERNS` (Critical 8 / High 8 / Medium 6) in `ScriptEvaluator`
-- **AI analysis**: LLM semantic review with mandatory rule — "Skills MUST be strictly read-only"
-- **Human gate**: `skill_reviewer` role must approve before `published` status
-- Skills with unapproved scripts **cannot** be executed via `local_script`
+There is **no scope-based directory tier**. Skill identity is `(org_id, name)` in the database; `dirName` is derived from `name` at materialize time. The execution chain sees a single flat `resolved/` directory.
 
-**Source**: `src/gateway/skills/script-evaluator.ts`
+### 2.3 Skill Status Lifecycle
+
+A skill has a single `status` column gating its execution eligibility:
+
+```
+draft ──submit──▶ pending_review ──approve──▶ installed
+  ▲                     │                          │
+  │                   reject                      edit
+  │                     │                          │
+  └─────── withdraw ────┘                          ▼
+  └────────────────────────────────────────── (creates new version,
+                                                status → draft)
+```
+
+- **Edit on `installed`** creates a new `skill_versions` row and resets status to `draft` — re-submit required before prod agents see it again
+- **Approve** sets the current version's `is_approved = 1` and `status = installed`
+- **Rollback** copies a target historical version's content into a new version with `status = draft` (must re-review)
+- **Security review** runs on submit: two-phase (static pattern scan + AI semantic analysis) → stored in `skill_reviews`
+
+**Source**: `src/gateway/skills/script-evaluator.ts`, `src/gateway/skills/ai-security-reviewer.ts`, `docs/design/2026-04-13-skill-governance-design.md`
 
 ### 2.4 Skill Script Execution
 
@@ -306,17 +328,18 @@ postReload(context)  Notify active sessions to pick up changes
 ```
 
 - `fetch` is network I/O with retry (3 attempts, exponential backoff: 1s, 2s, 4s)
-- `materialize` is local filesystem write — **idempotent but destructive for skills** (wipes `global/` + `skillset/` + `user/` subdirs then rebuilds)
+- `materialize` is local filesystem write — **idempotent but destructive for skills** (wipes `.siclaw/skills/resolved/` then rebuilds from the bundle). Empty-bundle protection: if the incoming payload is empty but `resolved/` already has skills, the wipe is skipped.
 - `postReload` calls `brain.reload()` on active sessions
 
 ### 6.2 When to Use Each Handler
 
 | Handler | Safe in LocalSpawner? | Safe in K8s pod? | Notes |
 |---------|----------------------|------------------|-------|
-| `mcpHandler.materialize()` | ✅ Yes | ✅ Yes | Merges, does not wipe |
-| `skillsHandler.materialize()` | ❌ No | ✅ Yes | Wipes `global/` + `skillset/` + `user/` subdirs (not `core/`) |
+| `knowledgeHandler.materialize()` | ✅ Yes | ✅ Yes | Merges, does not wipe |
+| `mcpHandler.materialize()` | ❌ No (skipped) | ✅ Yes | Wipes shared MCP config — LocalSpawner skips |
+| `skillsHandler.materialize()` | ❌ No (skipped) | ✅ Yes | Wipes `.siclaw/skills/resolved/` — LocalSpawner skips |
 
-For local mode skills sync, write directly to `skills/user/<userId>/` without delegating to `skillsHandler.materialize()`. Global and personal skills from the bundle are both placed under the user's directory.
+LocalSpawner explicitly calls only `knowledgeHandler` (see `local-spawner.ts:113-133`); the skills and MCP handlers are not invoked. Local-mode agents therefore see only baked builtins (`skills/core/` + `skills/platform/`) for skills and the static MCP config for MCP servers. Multi-tenant skill / MCP delivery requires K8s mode.
 
 ---
 

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -130,13 +130,12 @@ the correct access boundaries.
 
 | Path | Owner | Mode | Volume | agentbox | sandbox | Notes |
 |------|-------|------|--------|----------|---------|-------|
-| `skills/core/` | agentbox:agentbox | 0755/0644 | rootfs (baked) | rwx/rw | r-x/r- | Built-in diagnostic skills. Baked into image. |
-| `.siclaw/skills/` | agentbox:agentbox | 0755/0644 | emptyDir | rwx/rw | r-x/r- | Global + skillset + personal skills synced from DB via `skillsHandler.materialize()`. |
+| `skills/core/` | agentbox:agentbox | 0755/0644 | rootfs (baked) | rwx/rw | r-x/r- | Built-in diagnostic skills. Baked into image, synced into DB at Gateway startup. |
+| `skills/platform/` | agentbox:agentbox | 0755/0644 | rootfs (baked) | rwx/rw | r-x/r- | Platform meta-skills (skill-authoring, manage-skill). Baked into image, always loaded, not in DB. |
+| `.siclaw/skills/resolved/` | agentbox:agentbox | 0755/0644 | emptyDir | rwx/rw | r-x/r- | Flat materialized skill set for this agent — written by `skillsHandler.materialize()` from the bundle. |
 | `/app/` (application code) | agentbox:agentbox | 0755/0644 | rootfs | rwx/rw | r-x/r- | Node.js dist, package.json, etc. |
 
-**Skills write flow in K8s mode**: `skill.create` → DB → `notifySkillReload` → AgentBox main
-process (agentbox user) calls `skillsHandler.materialize()` → writes to emptyDir at
-`.siclaw/skills/`. The sandbox user (child processes) only reads from this directory.
+**Skills write flow in K8s mode**: skill edited / approved in Portal → DB updated → Gateway notifies bound AgentBoxes → AgentBox main process (agentbox user) re-fetches the bundle and calls `skillsHandler.materialize()` → writes to emptyDir at `.siclaw/skills/resolved/`. The sandbox user (child processes) only reads from this directory.
 
 Agent needs to **read** skills (SKILL.md, scripts/) to understand and execute them.
 Agent must **never write** to skills — that goes through the skill review gate

--- a/docs/design/skills.md
+++ b/docs/design/skills.md
@@ -1,64 +1,49 @@
 # Skills Architecture
 
+> Canonical model: `docs/design/2026-04-13-skill-governance-design.md` (flat-pool + status-gate + agent-binding). This file summarises the runtime contract and how the agent sees skills. For governance flow, review state machine, and migration rationale, read the governance doc.
+
 ## Design Principles
 
-1. **Management and execution chains are separated**: Gateway API + DB handle skill CRUD, sharing, review, and approval using only `id` + `name`. Disk directories (`dirName`) are generated from `name` at materialize time and are implementation details of the execution chain.
-2. **Skill space is a collaborative development space**: maintainers edit space skills directly, publish to dev, submit + approve for production.
-3. **Builtins are unified in the database**: Gateway startup scans Docker-baked builtin skills and syncs them to DB. After that, everything goes through DB -- no special handling.
-4. **Per-user toggles**: skill enable/disable and skill space enable/disable are per-user, keyed by `skillId` (not `skillName`).
-5. **Submit and Contribute are independent**: two separate approval flows, each with its own staging tag, review handler, and withdraw operation.
-6. **No cross-origin name collisions**: skills with the same name but different `originId` are rejected at all entry points (create, fork, rename, move, contribute). Only fork from the same source is allowed to create a same-name copy.
-7. **Content hash for change detection**: SHA-256 of specs + sorted scripts determines whether content has changed. Used by `canSubmit`, `canContribute`, `hasUnpublishedChanges`, and builtin sync.
-8. **Skill preview in conversation**: the `skill_preview` tool reads skill draft files from disk and renders a side panel with copy buttons. Agent writes files first via file I/O tools, then calls `skill_preview` with the directory path. Does not persist to DB.
-
-### The Security-Flexibility Trade-off
-
-Siclaw's command whitelist (`ALLOWED_COMMANDS` in `command-sets.ts`) restricts the agent to a set of
-safe, read-only binaries (e.g. `kubectl get`, `ip`, `ethtool`). This protects production environments
-from accidental mutations but limits what the agent can do -- many real-world SRE tasks require
-commands that go beyond read-only operations (restarting services, modifying configs, running
-performance tests, etc.).
-
-**Skill scripts are the escape hatch.** The command whitelist does *not* filter commands inside skill
-scripts -- a script can use any binary, any flag, any pipeline. This gives users full flexibility to
-encode arbitrary operational procedures as skills. The trade-off is managed through the approval
-workflow:
-
-- **Dev environment**: users can freely create, edit, and test skills with no restrictions.
-  All personal skills (including drafts) are immediately available to the agent.
-- **Prod environment**: only reviewer-approved skills are loaded. Before a skill reaches
-  production, it goes through static pattern analysis + AI semantic review + human reviewer
-  approval. This ensures scripts are safe and intentional before they can run against live
-  infrastructure.
-
-In effect, skills should be treated as **read-only at runtime** -- they are executed as-is, not
-modified on the fly. The editing and iteration happen in dev; production gets immutable, approved
-snapshots.
-
-### Why skills instead of ad-hoc commands?
-
-1. **Flexibility** -- skill scripts bypass the command whitelist, enabling operations that the
-   agent cannot perform through ad-hoc commands alone.
-2. **Reliability** -- tested scripts avoid the trial-and-error of ad-hoc command generation.
-3. **Safety** -- the dev/prod split and approval workflow ensure only reviewed scripts run in
-   production, even though the scripts themselves are unrestricted.
-4. **Reusability** -- investigation patterns are encoded once, used by all users.
-5. **Governance** -- the approval workflow ensures scripts meet the team's quality and security
-   bar before they enter the shared pool.
+1. **Single flat pool per org.** All skills (builtin, user-created, overlays) live in one `skills` table — no scope hierarchy, no skill-spaces, no per-user fork tree. `is_builtin` and `overlay_of` are flags, not tiers.
+2. **Status gates execution eligibility.** `draft → pending_review → installed`. Prod agents see only `is_approved = 1` versions; dev agents see current `skills.specs/scripts`.
+3. **Explicit agent binding.** `agent_skills` is the only delivery channel — an agent only receives skills explicitly bound to it. There is no implicit "everything global" bundle.
+4. **One execution surface.** AgentBox writes the active bundle into a single flat `.siclaw/skills/resolved/` directory. The agent reads only from there (plus the always-loaded `skills/platform/`); the on-disk `skills/core/` is the fallback when `resolved/` doesn't exist.
+5. **Builtins flow through the same pipeline.** Gateway startup scans `skills/core/` and upserts each into the DB with `is_builtin=1`, `status=installed`, `is_approved=1`. After that, builtins are normal DB rows that can be overlaid, re-reviewed, or rolled back.
 
 ---
 
-## Skill Format
+## The Security-Flexibility Trade-off
+
+Siclaw's command whitelist (`ALLOWED_COMMANDS` in `command-sets.ts`) restricts ad-hoc agent commands to a safe read-only set (`kubectl get`, `ip`, `ethtool`, etc.). **Skill scripts are the escape hatch** — the whitelist does not filter inside skill scripts, so a script can use any binary, flag, or pipeline.
+
+This makes skills a **privilege escalation channel**. The trade-off is managed through the status gate:
+
+- **Dev environment**: latest content (draft + installed) is delivered, so authors can iterate freely
+- **Prod environment**: only `is_approved = 1` snapshots are delivered — every script in production has been through static pattern scan + AI semantic review + a human reviewer approval
+
+Editing an `installed` skill creates a new version and resets `status = draft` — the next prod fetch will not see the change until it is re-approved.
+
+### Why skills instead of ad-hoc commands?
+
+1. **Flexibility** — bypass the command whitelist for legitimate operational procedures
+2. **Reliability** — tested scripts vs trial-and-error command generation
+3. **Safety** — the dev/prod split + approval workflow gates production
+4. **Reusability** — encode investigation patterns once, reuse across agents
+5. **Governance** — review audit trail in `skill_reviews`
+
+---
+
+## Skill Format on Disk
+
+Builtins under `skills/core/` follow this layout:
 
 ```
 {skillName}/
-├── SKILL.md              # Specification (YAML frontmatter + Markdown body)
+├── SKILL.md              # YAML frontmatter + Markdown body
 └── scripts/
-    ├── main-script.sh    # One or more executable scripts
+    ├── main.sh
     └── helper.py
 ```
-
-### SKILL.md Frontmatter
 
 ```yaml
 ---
@@ -69,458 +54,9 @@ description: >-
 ---
 ```
 
-The `name` and `description` fields are parsed by `SkillFileWriter.parseFrontmatter()` and surfaced
-in the agent's system prompt for skill discovery.
+`name` and `description` are surfaced in the agent's system prompt. `meta.json` next to the skill dirs supplies `labels` (`{ "find-node": ["kubernetes", "general"] }`) used for filtering in the UI.
 
-### Labels (`meta.json`)
-
-Each tier directory (`skills/core/`, `skills/extension/`) may contain a `meta.json`:
-
-```json
-{
-  "labels": {
-    "find-node":      ["kubernetes", "general", "diagnostic"],
-    "dns-debug":      ["kubernetes", "network", "diagnostic"]
-  }
-}
-```
-
-Labels are loaded at startup by `builtin-sync.ts` and stored in the `labelsJson` column of the
-`skills` table. Used for filtering in the UI. Core and extension labels are unified under the
-`builtin` scope.
-
----
-
-## Scope Model
-
-| Scope | Owner | Editable by | Storage | How it gets there |
-|-------|-------|-------------|---------|-------------------|
-| **builtin** | Docker image | No (can only be disabled) | DB (synced from disk at startup) | `builtin-sync.ts` scans `skills/core/` + `skills/extension/` and upserts DB |
-| **global** | System (admin) | No | DB | Personal/skillset skill contributed, reviewed, and promoted |
-| **personal** | Individual user | Author | DB | User creates or forks from builtin/global |
-| **skillset** | Skill space (team) | Space maintainers | DB | Fork from global/builtin, or move from personal |
-
-## Skill Identity
-
-### id
-
-- Builtin skills: `builtin:<dirName>` (deterministic id, backward-compatible with forkedFromId chains and workspace composer refs)
-- DB skills (global/personal/skillset): UUID
-
-### originId
-
-Each skill records an `originId` pointing to the **original source**. All forks inherit this value.
-
-```
-Global g1 (originId: g1)
-  -> fork to personal: p1 (originId: g1)
-  -> fork to skillset: ss1 (originId: g1)
-
-Builtin "cluster-events" (originId: "builtin:cluster-events")
-  -> fork to personal: p2 (originId: "builtin:cluster-events")
-```
-
-Uses:
-- `resolveRelatedGlobalSkill`: query `WHERE originId=x AND scope='global'` to find related global skill
-- `promoteToGlobal`: find existing global skill via originId and update (no duplicates)
-- `rejectCrossOriginNameConflict`: reject same-name skills with different originId at all entry points
-- Rename does not break the chain (originId is immutable)
-
-### forkedFromId
-
-Records the **direct parent** (one hop). Used for:
-- Fork conflict detection: reject if target already has skill with same `forkedFromId`
-- UI display "forked from xxx"
-- On delete, chain relay (`relinkForkedFrom`)
-
-### Name Conflict Rules
-
-All entry points enforce: **same name + different originId = rejected**.
-
-| Entry point | Same name, same origin | Same name, different origin |
-|-------------|----------------------|---------------------------|
-| `skill.create` | Allowed (fork) | Rejected |
-| `skill.fork` | Rejected (already exists) | Rejected |
-| `skill.update` (rename) | N/A | Rejected |
-| `skill.moveToSpace` | Rejected (already in space) | Rejected |
-| `skill.contribute` | Update existing global | Rejected |
-
----
-
-## Skill Lifecycle
-
-### Create & Edit
-
-```
-User creates skill -> scope: personal, editable
-User edits skill   -> personal or skillset (maintainer)
-```
-
-### Fork (builtin/global only)
-
-```
-Fork to personal:   builtin/global -> personal copy (editable, inherits approved state)
-Fork to skill space: builtin/global -> skillset copy (batch supported via sourceIds[])
-```
-
-Forks inherit `originId` and set `forkedFromId`. The forked skill starts with:
-- `approvedVersion: 1`, `publishedVersion: 1`, `reviewStatus: "approved"`
-- Content saved to `working`, `published`, and `approved` tags
-- A version record with `tag: "approved"` is created
-
-This means forked skills are **immediately available in production** -- no need to re-submit.
-
-If the target (personal or skillset) already has a skill from the same source, fork is **rejected** (not updated). User must edit the existing copy directly.
-
-### Move to Space (from personal)
-
-```
-Personal skill -> skill.moveToSpace(id, skillSpaceId) -> scope changes to skillset
-```
-
-- Destructive operation: personal copy no longer exists
-- Only skill author + space maintainer can operate
-- Rejected if space already has skill with same originId or same name
-- Rejected if global/builtin has same name with different originId
-- Resets lifecycle: `publishedVersion: null`, `approvedVersion: null`, `reviewStatus: draft`
-- Clears all content tags except `working` (`published`, `approved`, `staging`, `staging-contribution`)
-
-### Edit & Publish in Space
-
-```
-Space skill -> skill.update (edit working) -> skill.publishInSpace (working -> published + version)
-```
-
-- Maintainer edits directly, saves to working
-- Publish: working -> published, creates version record, no approval needed
-- Publish takes effect in **dev environment** (for all space members)
-- **Production** requires additional `skill.submit` -> admin `skill.approveSubmit`
-- Last-write-wins (sufficient for small teams)
-
-### Submit (production review)
-
-```
-skill.submit -> reviewStatus: pending -> staging snapshot
-  -> skill.approveSubmit -> approved (prod effective)
-  -> skill.rejectSubmit  -> draft
-  -> skill.withdrawSubmit -> withdraw
-```
-
-- Personal skill: copies working -> `staging`
-- Skillset skill: copies published -> `staging` (must publishInSpace first)
-- While pending, can re-submit to update staging (no need to withdraw first)
-- Batch support: `ids[]`
-
-#### Script Security Review
-
-When a skill is submitted (`skill.submit`), `triggerScriptReview()` performs two-phase analysis:
-
-**Phase 1 -- Static pattern matching** (`DANGER_PATTERNS` in `script-evaluator.ts`):
-- Regex rules categorized by risk: `destructive_command`, `privilege_escalation`,
-  `data_exfiltration`, `env_mutation`, etc.
-- Severity levels: `critical`, `high`, `medium`, `low`
-- Examples: `rm -rf` -> critical, `kubectl delete` -> high, `curl -d` -> high
-
-**Phase 2 -- AI semantic analysis**:
-- Calls LLM with script content + Phase 1 findings as context
-- Returns structured risk assessment: `{ riskLevel, findings[], summary }`
-- Falls back to static-only if AI is unavailable
-
-Review results are stored in the `skill_reviews` table for audit.
-
-### Contribute (promote to Global)
-
-```
-skill.contribute -> contributionStatus: pending -> staging-contribution snapshot
-  -> skill.approveContribute -> promoted to global
-  -> skill.rejectContribute  -> contribution reverted
-  -> skill.withdrawContribute -> withdraw
-```
-
-- Requirement: already approved + no unpublished changes
-- Copies approved -> `staging-contribution` (independent from submit's staging)
-- **Submit and Contribute can be pending simultaneously**, they do not interfere
-- Conflict check: same-name global skill with different originId -> rejected
-- Batch support: `ids[]`
-
-### Diff Preview
-
-Before publish, submit, or contribute, the UI shows a GitHub-style diff dialog:
-
-- **File diffs**: collapsible sections per file (SKILL.md, scripts/*), 3 lines context, hidden unchanged regions
-- **Metadata diff**: type and labels shown as colored tag pills (+green, -red, unchanged gray)
-- **Commit message**: optional text input, stored on skill record for version history
-- **Origin fallback**: for first-time operations on forked skills, diffs against the fork source
-
-### Version History
-
-Each publish/approve creates a version record with:
-- `tag: "published"` for dev versions, `tag: "approved"` for prod versions
-- Inline specs + scriptsJson + metadata snapshot
-- commitMessage from the user
-
-The UI provides a version history drawer with tag filter (Dev / Prod) and rollback button.
-
-### Rollback
-
-```
-skill.rollback(id, version, target: "dev" | "prod")
-```
-
-- Restores content from the selected version to the target content tag (`published` or `approved`)
-- Restores metadata (name, description, type, labels) from the version snapshot
-- Cleans up `staging` and `staging-contribution` content tags
-- Resets `reviewStatus` and `contributionStatus` if they were pending
-- Creates a new version record documenting the rollback
-
-### Export / Download
-
-```
-skill.export(ids[]) -> { filename, data (base64), size }
-```
-
-- Exports selected skills as a tar.gz archive
-- Single skill: `{name}-{timestamp}.tar.gz`
-- Multiple skills: `skills-export-{timestamp}.tar.gz`
-- UI provides a batch picker dialog in skill space (same pattern as submit/contribute)
-
-### Delete
-
-- **Builtin**: cannot delete, only disable (`skill.setEnabled(id, false)`)
-- **Global**: after deletion, builtin skill with same name automatically "surfaces"
-- **Personal/Skillset**: normal deletion. `relinkForkedFrom` ensures child skill chains are not broken.
-
-### Per-user Enable/Disable
-
-All skill and skill space toggles are per-user, effective across all of that user's workspaces:
-
-| Operation | Table | Primary key |
-|-----------|-------|-------------|
-| `skill.setEnabled(id, enabled)` | `user_disabled_skills` | `(userId, skillId)` |
-| `skillSpace.setEnabled(skillSpaceId, enabled)` | `user_disabled_skill_spaces` | `(userId, skillSpaceId)` |
-
----
-
-## Skill Space
-
-A skill space is a **shared collaboration space** for team development:
-
-- Fork builtin/global skills into the space (batch supported)
-- Move mature personal skills into the space
-- Maintainers directly edit space skills
-- Publish makes changes effective for space members (dev env)
-- Submit + approve gates production deployment
-- Contribute to global for organization-wide sharing
-- Per-user enable/disable (each member independently controls whether to load)
-
-### Membership
-
-| Role | Can view | Can fork global to space | Can edit | Can publish | Can submit | Can contribute | Can add members | Can delete skills | Can delete space |
-|------|---------|------------------------|---------|------------|-----------|---------------|----------------|------------------|-----------------|
-| Owner | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes (if empty) |
-| Maintainer | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No |
-
-### Typical workflow
-
-```
-Alice creates "pod-health-check" in My Skills
-  -> edits and tests it
-  -> moves to team space "SRE Tools" (skill.moveToSpace)
-
-Carol adds 5 global skills to "SRE Tools"
-  -> multi-selects from global list -> batch fork
-
-Bob edits "pod-health-check" directly in "SRE Tools"
-  -> changes saved to working copy
-  -> clicks Publish -> effective for all space members in dev
-
-Space maintainer batch-submits published skills -> admin approves -> production
-Space maintainer batch-contributes approved skills -> admin approves -> Global
-```
-
----
-
-## Content Tags
-
-| Tag | Purpose | Written by |
-|-----|---------|-----------|
-| `working` | Author's latest edits | `skill.update` |
-| `published` | Dev published version (skillset); diff baseline (personal) | `skill.publishInSpace`, fork baseline |
-| `approved` | Prod approved version (all scopes) | `skill.approveSubmit`, fork baseline |
-| `staging` | Submit review snapshot | `skill.submit` |
-| `staging-contribution` | Contribute review snapshot | `skill.contribute` |
-
-Personal skills use `published` as a diff baseline (set during fork). Dev bundle uses `working` directly.
-
-## Version Fields
-
-| Field | Purpose | Set by |
-|-------|---------|--------|
-| `publishedVersion` | Dev published version (skillset); fork baseline version (personal) | `skill.publishInSpace`, fork |
-| `approvedVersion` | Prod approved version (all scopes) | `skill.approveSubmit`, fork |
-| `stagingVersion` | Optimistic concurrency for reviews | `skill.submit`, `skill.contribute` |
-
-## Content Hash
-
-SHA-256 of `specs + sorted scripts` (scripts sorted by name for order-independence). Stored in `skill_contents.content_hash`, auto-computed on every save.
-
-Used by:
-- `hasUnpublishedSkillChanges`: working hash vs published/approved hash
-- `computeCanSubmit`: published hash vs approved hash + metadata comparison
-- `computeCanContribute`: approved hash vs global published hash + metadata comparison
-- `builtin-sync.ts`: detect content changes on startup
-
----
-
-## Two Separate Chains
-
-### Management Chain (Gateway API + DB)
-
-Handles skill CRUD, sharing, and review. **No filesystem directories involved.**
-
-```
-skills table
-  id, name, scope, authorId, skillSpaceId,
-  originId, forkedFromId, contentHash, labelsJson,
-  publishedVersion, approvedVersion, stagingVersion,
-  reviewStatus, contributionStatus, commitMessage, ...
-
-skill_contents table
-  skillId, tag ("working"|"staging"|"staging-contribution"|"published"|"approved"),
-  specs, scriptsJson, contentHash
-  Unique index on (skillId, tag)
-
-user_disabled_skills table
-  userId, skillId (per-user skill enable/disable)
-
-user_disabled_skill_spaces table
-  userId, skillSpaceId (per-user space enable/disable)
-```
-
-### Execution Chain (AgentBox materialize -> disk -> agent)
-
-```
-Gateway (buildSkillBundle)
-  -> reads skill_contents for all scopes from DB (including builtin)
-  -> priority order: personal > skillset > global > builtin
-  -> dedup by dirName (first wins), logs warning on collision
-  -> skips per-user disabled skills and disabled skill spaces
-  -> generates dirName slug from name at runtime
-  -> builds SkillBundlePayload { skills: [{ dirName, scope, specs, scripts }] }
-
-AgentBox (materialize)
-  -> builds resolved/ directory with priority-based merging (first dirName wins):
-      1. Personal skills
-      2. Skillset skills
-      3. Global skills
-      4. Builtin skills
-  -> Agent loads all skills from the single resolved/ directory
-```
-
-### K8s vs Local vs TUI-with-Portal
-
-| Mode | Skills path | Written by |
-|------|-------------|-----------|
-| K8s (single-user pod) | `.siclaw/skills/resolved/` | `resource-handlers.ts materialize()` |
-| Local (multi-user process) | `.siclaw/skills/user/{userId}/resolved/` | `local-spawner.ts syncSkills()` |
-| TUI with local Portal | `.siclaw/.portal-snapshot/skills/` (**ephemeral**, cleaned on SIGINT/SIGTERM) | `src/lib/portal-skill-materializer.ts` on TUI startup |
-
-The TUI-with-Portal path is a separate write target from the other two. It never touches `skills/{core,extension,global,skillset,user}/` on disk — see `docs/design/invariants.md` §1.4 for the full snapshot contract.
-
----
-
-## Bundle Inclusion Rules
-
-| Scope | Dev bundle | Prod bundle | Content tag |
-|-------|-----------|-------------|-------------|
-| Personal | Yes (working) | Only if `approvedVersion` exists | dev: working, prod: approved |
-| Skillset | Only if `publishedVersion` exists | Only if `approvedVersion` exists | dev: published, prod: approved |
-| Global | Yes | Yes | published |
-| Builtin | Yes (unless disabled) | Yes (unless disabled) | published |
-
-Per-user disabled skills and disabled skill spaces are excluded from all bundles.
-
----
-
-## Builtin Skill Sync
-
-Gateway startup executes `syncBuiltinSkills()`:
-
-```
-Scans skills/core/ + skills/extension/
-  -> parses SKILL.md + scripts + meta.json labels for each skill
-  -> computes content hash (SHA-256)
-  -> compares with DB:
-    - new -> INSERT (id = "builtin:<dirName>"), creates base version record
-    - content hash changed -> UPDATE, creates version record
-    - unchanged -> skip
-    - in DB but not on disk -> DELETE
-```
-
-Startup fix-ups:
-- Backfills null `originId` on global skills (inherits from forkedFromId chain)
-- Backfills null `tag` on version records (infers from commitMessage)
-- Creates missing version records for builtins and globals
-
----
-
-## Skill Execution
-
-### local_script Tool
-
-The `local_script` tool (`src/tools/script-exec/local-script.ts`) is the primary execution path:
-
-1. **Path resolution**: `resolveSkillScript(skill, script)` searches scope directories
-   in priority order (personal > skillset > global > builtin)
-2. **Interpreter selection**: `.py` -> `python3`, `.sh` -> `bash`
-3. **Execution**: `child_process.spawn()` with args array (no shell interpolation)
-4. **Security**: runs as `sandbox` user (OS-level isolation), inherits sanitized environment
-5. **Limits**: 300s max timeout, 10 MB max output
-
-### Bash Fallback
-
-The `restricted-bash` tool also allows skill script execution. `isSkillScript()` resolves the
-target path and allows scripts rooted under the repo `skills/` tree or the configured dynamic
-`skillsDir`, including materialized `skillset` scripts.
-This is a secondary path -- `local_script` is preferred.
-
----
-
-## Skill Discovery by Agent
-
-### How the Agent Sees Skills
-
-`agent-factory.ts` loads skills from a single `resolved/` directory built by materialize (K8s)
-or syncSkills (local). The directory contains all skills flattened with priority:
-personal > skillset > global > builtin.
-
-```typescript
-// Local mode: per-user resolved dir at {skillsBase}/user/{userId}/resolved/
-// K8s mode: {skillsBase}/resolved/
-const resolvedSkillsDir = opts?.userId
-  ? path.join(skillsBase, "user", opts.userId, "resolved")
-  : path.join(skillsBase, "resolved");
-
-// Fallback: if resolved/ doesn't exist yet (first boot, TUI mode),
-// load builtin directories directly (skills/core/ + skills/extension/)
-```
-
-The resolved directory is passed to `DefaultResourceLoader` via `additionalSkillPaths`.
-The loader auto-discovers skills by scanning for `SKILL.md` files, parsing frontmatter,
-and injecting descriptions into the system prompt. The agent then knows which skills are
-available and can invoke them via `local_script`.
-
-### TUI with Local Portal — skillsOverride Filter
-
-When a TUI session has a local Portal snapshot active (`portalSkillsDir` set), the agent
-factory passes a `skillsOverride` to `DefaultResourceLoader` that **restricts** the visible
-skill set to paths rooted under either the Portal-materialized dir or the repo's
-`skills/platform/`. This filter removes user-global skills that the loader would otherwise
-auto-discover from `~/.pi/agent/skills/` or similar — they are invisible from the Portal
-operator's perspective and must not leak into the agent's tool inventory.
-
-Without the override, the agent could invoke skills the Portal operator never opted into.
-See `docs/design/invariants.md` §1.4 for the enclosing Portal-as-SoT contract.
+The bundle delivers the same structure (one directory per skill, `SKILL.md` + `scripts/*`) but unpacked into `.siclaw/skills/resolved/` at runtime — there are no scope subdirectories.
 
 ---
 
@@ -528,139 +64,266 @@ See `docs/design/invariants.md` §1.4 for the enclosing Portal-as-SoT contract.
 
 | Table | Purpose |
 |-------|---------|
-| `skills` | Skill metadata: name, scope, dirName, authorId, skillSpaceId, originId, forkedFromId, contentHash, labelsJson, publishedVersion, approvedVersion, stagingVersion, reviewStatus, contributionStatus, commitMessage, globalSourceSkillId, globalPinnedVersion |
-| `skill_contents` | File content (specs + scriptsJson + contentHash) by tag (working / staging / staging-contribution / published / approved). Unique index on (skillId, tag). CHECK constraint enforces valid tags. |
-| `skill_versions` | Version history: version number, specs, scriptsJson, tag (published/approved), commitMessage, authorId |
-| `skill_reviews` | AI + admin review records: reviewerType (ai/admin), riskLevel, summary, findings[], decision (approve/reject/info) |
-| `skill_votes` | User upvotes/downvotes on global skills |
-| `skill_spaces` | Skill space metadata: name, description, ownerId |
-| `skill_space_members` | Space membership: userId, skillSpaceId, role (owner/maintainer) |
-| `user_disabled_skills` | Per-user skill disabling: userId, skillId |
-| `user_disabled_skill_spaces` | Per-user skill space disabling: userId, skillSpaceId |
-| `workspace_skills` | Workspace-scoped skill assignments (schema exists, not yet enforced) |
+| `skills` | Skill rows: `id`, `org_id`, `name`, `description`, `labels`, `author_id`, `status`, `version`, `specs`, `scripts`, `created_by`, `is_builtin`, `overlay_of` |
+| `skill_versions` | Immutable history: `id`, `skill_id`, `version`, `specs`, `scripts`, `diff`, `commit_message`, `author_id`, `is_approved`, `labels`. UNIQUE `(skill_id, version)` |
+| `skill_reviews` | Submit / approve / reject audit: `id`, `skill_id`, `version`, `diff`, `security_assessment`, `submitted_by`, `reviewed_by`, `decision`, `reject_reason` |
+| `agent_skills` | Binding junction: `(agent_id, skill_id)` |
+
+Status values: `draft`, `pending_review`, `installed`.
+
+Indexes:
+- `idx_skills_org_name (org_id, name)` — **non-unique** (relaxed so a builtin and its overlay can share a name)
+- `idx_skills_overlay (overlay_of)`
 
 ---
 
-## API Reference
-
-### Skill CRUD
-
-| RPC Method | Purpose |
-|-----------|---------|
-| `skill.create` | Create personal skill (cross-origin name conflict check) |
-| `skill.update` | Edit personal or skillset skill (cross-origin name conflict on rename) |
-| `skill.delete` | Delete personal or skillset skill (builtin cannot be deleted) |
-| `skill.get` | Get skill details (any scope) |
-| `skill.list` | List skills (with scope/workspace filtering, enriched with canSubmit/canContribute/hasUnpublishedChanges) |
-| `skill.setEnabled` | Per-user enable/disable a skill (by skillId, resolves name to id for backward compat) |
-| `skill.updateLabels` | Update skill labels |
-
-### Fork & Share
-
-| RPC Method | Purpose |
-|-----------|---------|
-| `skill.fork` | Fork builtin/global to personal or skillset. Batch via `sourceIds[]`. Inherits approved state. Rejects if same-source skill already exists. |
-| `skill.moveToSpace` | Move personal skill to skill space (destructive, resets lifecycle, rejects same-origin/name conflicts) |
-| `skill.publishInSpace` | Publish skillset skill: working -> published + version (dev only) |
-| `skill.forkDiff` | Preview diff before forking into a skill space |
-
-### Submit (production review)
-
-| RPC Method | Purpose |
-|-----------|---------|
-| `skill.submit` | Submit for production review. Batch via `ids[]` |
-| `skill.approveSubmit` | Approve submit -> production |
-| `skill.rejectSubmit` | Reject submit -> back to draft |
-| `skill.withdrawSubmit` | Withdraw pending submit |
-
-### Contribute (promote to Global)
-
-| RPC Method | Purpose |
-|-----------|---------|
-| `skill.contribute` | Contribute to global (cross-origin conflict check). Batch via `ids[]` |
-| `skill.approveContribute` | Approve contribution -> promote to global |
-| `skill.rejectContribute` | Reject contribution |
-| `skill.withdrawContribute` | Withdraw pending contribution |
-
-### Diff, History & Rollback
-
-| RPC Method | Purpose |
-|-----------|---------|
-| `skill.previewDiff` | Preview diff before publish/submit/contribute (metadata + file diffs) |
-| `skill.diff` | View diff between versions |
-| `skill.history` | List version history with optional tag filter (published/approved) |
-| `skill.rollback` | Rollback to previous version (restores content + metadata, cleans staging) |
-| `skill.export` | Download skills as tar.gz (batch via `ids[]`) |
-
-### Other
-
-| RPC Method | Purpose |
-|-----------|---------|
-| `skill.vote` | Upvote/downvote global skills |
-| `skill.revert` | Revert global skill to builtin version |
-| `skill.getReview` | Get AI/admin review results |
-| `skill.review` | Backward-compat dispatcher -> routes to approveSubmit/rejectSubmit/approveContribute/rejectContribute |
-| `skill.withdraw` | Backward-compat dispatcher -> routes to withdrawSubmit/withdrawContribute |
-
-### Skill Space
-
-| RPC Method | Purpose |
-|-----------|---------|
-| `skillSpace.create` | Create skill space |
-| `skillSpace.get` | Get space with members and skills (enriched with canSubmit/canContribute/hasUnpublishedChanges) |
-| `skillSpace.list` | List all spaces for user |
-| `skillSpace.update` | Update space name/description (owner only) |
-| `skillSpace.delete` | Delete empty space (owner only) |
-| `skillSpace.addMember` | Add maintainer to space |
-| `skillSpace.removeMember` | Remove member (owner) or leave (self) |
-| `skillSpace.listMembers` | List space members |
-| `skillSpace.setEnabled` | Per-user enable/disable a skill space |
-
----
-
-## Key Files
+## Status Lifecycle
 
 ```
-Execution & Resolution
-  src/tools/script-exec/local-script.ts      local_script tool (primary execution path)
-  src/tools/script-exec/node-script.ts       node_script tool (K8s node execution)
-  src/tools/script-exec/pod-script.ts        pod_script tool (K8s pod execution)
-  src/tools/infra/script-resolver.ts         Skill path resolution, scope priority
-  src/tools/cmd-exec/restricted-bash.ts      Bash whitelist (isSkillScript)
+       ┌─────── withdraw ───────┐
+       ▼                        │
+    [draft] ───submit───▶ [pending_review] ───approve───▶ [installed]
+       ▲                        │                              │
+       │                      reject                         edit
+       │                        │                              │
+       └────────────────────────┘                              │
+       └───────────────────────────────────────────────────────┘
+                                   (edit on installed →
+                                    new version, status=draft)
+```
 
-Gateway Skills Management
-  src/gateway/skills/file-writer.ts          Disk I/O: read, write, scan, snapshot
-  src/gateway/skills/skill-bundle.ts         buildSkillBundle() -- priority-ordered packaging with dedup
-  src/gateway/skills/script-evaluator.ts     Security review (static + AI)
-  src/gateway/skills/builtin-sync.ts         Builtin skill sync + label loading + startup fix-ups
-  src/gateway/rpc-methods.ts                 All skill.* and skillSpace.* RPC handlers
+| Status | Edit behavior |
+|---|---|
+| `draft` | In-place update, no version bump |
+| `pending_review` | Blocked — must withdraw first |
+| `installed` | Creates new `skill_versions` row, resets `status = draft` |
 
-DB Repositories
-  src/gateway/db/repositories/skill-repo.ts          Skill metadata CRUD
-  src/gateway/db/repositories/skill-content-repo.ts  Content by tag, content hash
-  src/gateway/db/repositories/skill-version-repo.ts  Version history
-  src/gateway/db/repositories/skill-space-repo.ts    Space membership, per-user toggles
+### Review
 
-Agent Integration
-  src/core/agent-factory.ts                  Skill directory setup, resolved/ loading, additionalSkillPaths
+Submit triggers two-phase analysis stored on `skill_reviews.security_assessment`:
 
-Sync & Materialization
-  src/agentbox/resource-handlers.ts          skillsHandler.materialize() (K8s)
-  src/gateway/agentbox/local-spawner.ts      syncSkills() (local mode)
+1. **Static pattern scan** (`script-evaluator.ts`): regex rules categorized by risk (`destructive_command`, `privilege_escalation`, `data_exfiltration`, …) with severities (critical / high / medium / low). `rm -rf` → critical, `kubectl delete` → high, `curl -d` → high.
+2. **AI semantic review** (`ai-security-reviewer.ts`): LLM receives scripts + Phase 1 findings; returns structured `{ riskLevel, findings[], summary }`. Falls back to static-only when AI is unavailable.
 
-Frontend
-  portal-web/src/pages/Skills.tsx          My Skills + Global tab
-  portal-web/src/pages/SkillDetail.tsx     Skill space / editor / diff / history
-  portal-web/src/pages/SkillImport.tsx     Skill import flow
-  portal-web/src/components/chat/SkillPanel.tsx  Skill selector in chat
-  portal-web/src/components/chat/SkillCard.tsx   Skill card presentation
+Approve sets `is_approved=1` on the current version and `status=installed`. Reject sets `status=draft` and stores `reject_reason`.
 
-Tests
-  src/gateway/skills/skill-lifecycle.test.ts  91 comprehensive RPC handler tests
+### Rollback
 
-Filesystem Layout
-  skills/core/                               Builtin core skills (Docker-baked)
-  skills/extension/                          Builtin extension skills (inner project overlay)
-  .siclaw/skills/resolved/                   Materialized skills -- all scopes merged (K8s)
-  .siclaw/skills/user/{userId}/resolved/     Materialized skills -- per-user (local mode)
+Copies a target version's content into a new version with `status=draft` (must re-review):
+
+```
+v1 ✓ approved  "Initial version"
+v2 ✓ approved  "Add timeout retry"
+v3   draft     "Refactor"          ← broken
+v4   draft     "Rollback to v1"    ← content equals v1, fresh version number
+```
+
+Rollback is blocked while `status=pending_review` (withdraw first).
+
+---
+
+## Overlays
+
+`overlay_of` lets a user-created skill replace a builtin's content while keeping the same `name`. Bundle queries skip the base skill when an overlay exists for it. Used to customize a builtin without losing the ability to roll back to the original Docker-shipped content (which lives in v1 of the base row).
+
+```
+skills/core/find-node       → DB row A (is_builtin=1, status=installed, v1 approved)
+User edits "find-node"      → New DB row B (is_builtin=0, overlay_of=A)
+Bundle for agents bound to A → returns B's content; A is suppressed
+```
+
+---
+
+## Builtin Sync at Startup
+
+Gateway startup runs `syncBuiltinSkills()`:
+
+```
+For each directory under skills/core/:
+  Parse SKILL.md frontmatter + scripts/* + meta.json labels
+  Compute contentHash = SHA-256(specs + sorted scripts)
+
+  Not in DB:
+    INSERT with is_builtin=1, status=installed, version=1, is_approved=1
+    Create skill_versions(v1, is_approved=1)
+
+  In DB, hash matches:    SKIP
+  In DB, user not edited: UPDATE content, version+1, status=installed,
+                          create skill_versions(is_approved=1)
+                          (image upgrade auto-applies to untouched builtins)
+  In DB, user has edited: SKIP (user's edits win; they can rollback to v1
+                          to restore the original Docker-shipped version)
+```
+
+`skills/platform/` is **never** synced — those skills (skill-authoring, manage-skill) are platform meta-skills, kept on disk, and always loaded by `agent-factory.ts` regardless of bundle state.
+
+---
+
+## Bundle Delivery
+
+### Endpoint
+
+`POST /api/internal/siclaw/skills/bundle` — see `src/portal/adapter.ts`.
+
+Request body:
+```json
+{ "skill_ids": ["<id>", ...], "is_production": true }
+```
+
+Skill IDs come from the `agent_skills` join for the requesting agent.
+
+### Query logic
+
+```sql
+-- Production: latest approved version snapshot
+SELECT COALESCE(o.id, s.id) AS id, COALESCE(o.name, s.name) AS name,
+       COALESCE(o.labels, s.labels) AS labels,
+       COALESCE(ov.specs, sv.specs) AS specs,
+       COALESCE(ov.scripts, sv.scripts) AS scripts
+FROM skills s
+LEFT JOIN skills o ON o.overlay_of = s.id              -- overlay wins
+LEFT JOIN skill_versions sv ON sv.skill_id = s.id AND sv.is_approved = 1
+  AND sv.version = (SELECT MAX(v2.version) FROM skill_versions v2
+                    WHERE v2.skill_id = s.id AND v2.is_approved = 1)
+LEFT JOIN skill_versions ov ON ov.skill_id = o.id AND ov.is_approved = 1
+  AND ov.version = (SELECT MAX(v3.version) FROM skill_versions v3
+                    WHERE v3.skill_id = o.id AND v3.is_approved = 1)
+WHERE s.id IN (?)
+
+-- Dev: current content (no version filter)
+SELECT COALESCE(o.id, s.id), COALESCE(o.name, s.name),
+       COALESCE(o.labels, s.labels),
+       COALESCE(o.specs, s.specs),
+       COALESCE(o.scripts, s.scripts)
+FROM skills s
+LEFT JOIN skills o ON o.overlay_of = s.id
+WHERE s.id IN (?)
+```
+
+A prod agent bound to a skill that has never been approved gets an empty row — silently excluded from the bundle until it passes review.
+
+### Response shape
+
+```typescript
+{
+  version: string,                     // ISO timestamp
+  skills: Array<{
+    dirName: string,                   // name.replace(/[^a-zA-Z0-9_-]/g, "_")
+    scope: "global",                   // legacy field, hardcoded; only used for
+                                       // dirName collision priority
+    specs: string,                     // SKILL.md content
+    scripts: Array<{ name, content }>
+  }>
+}
+```
+
+The `scope` field is a vestige of the old multi-tier model. The bundle always sends `"global"`; AgentBox's `SkillBundlePayload` declares `"builtin" | "global"` only so `skillsHandler.materialize()` can use it as a dirName-collision tie-breaker (global > builtin > other). It carries no scope semantics beyond that.
+
+---
+
+## Materialize → resolved/
+
+`skillsHandler.materialize()` in `src/agentbox/sync-handlers.ts`:
+
+```
+Bundle payload → .siclaw/skills/resolved/<dirName>/{SKILL.md, scripts/*}
+
+Rules:
+  - Wipe and recreate resolved/ before writing
+  - Empty-bundle protection: if incoming.skills is empty AND resolved/
+    already has skills, SKIP the wipe (transient Gateway failure guard)
+  - Dedup by dirName; priority order global > builtin > other
+  - First write wins
+```
+
+There is **no per-user segment**. K8s pods are isolated by emptyDir; LocalSpawner shares the cwd, so materialize is unsafe there and is **skipped entirely** by `local-spawner.ts` (only `knowledgeHandler` runs in local mode).
+
+---
+
+## Runtime Modes
+
+| Mode | What the agent sees | Materialize target |
+|------|---------------------|--------------------|
+| **K8s pod** | bundle skills + `skills/platform/` | `.siclaw/skills/resolved/` (per-pod emptyDir) |
+| **LocalSpawner** | `skills/core/` + `skills/platform/` only | not written (handler skipped) |
+| **TUI standalone** | `skills/core/` + `skills/platform/` only | not written |
+| **TUI + local Portal** | Portal snapshot + `skills/platform/` | `.siclaw/.portal-snapshot/skills/` (ephemeral, cleaned on TUI exit) |
+
+In K8s mode the bundle is the source of truth — `skills/core/` on disk is only a fallback when `resolved/` doesn't yet exist (first boot before the first sync).
+
+In local mode (LocalSpawner or standalone TUI), DB-managed skills are **not delivered** to agents. This is a deliberate limitation of the shared-filesystem multi-user model — see `docs/design/invariants.md` §1.2 and §6.2.
+
+In TUI + local Portal mode, `agent-factory.ts` installs a `skillsOverride` filter on `DefaultResourceLoader` that restricts the visible skill set to paths rooted under either `portalSkillsDir` or `skills/platform/`. Without this filter, the loader would auto-discover user-global skills from `~/.pi/agent/skills/`, which would bypass the Portal-as-SoT contract — see `docs/design/invariants.md` §1.4.
+
+---
+
+## Skill Execution
+
+### Path resolution
+
+`resolveSkillScript(skill, script)` in `src/tools/infra/script-resolver.ts` walks (in order):
+
+1. `.siclaw/skills/resolved/<skill>/scripts/<script>` (materialize output)
+2. `.siclaw/skills/<skill>/scripts/<script>` (legacy flat layout)
+3. `.siclaw/skills/<global|core>/<skill>/scripts/<script>` (legacy scope subdirs)
+4. `skills/core/<skill>/scripts/<script>` (Docker-baked fallback) — unless `.disabled-builtins.json` lists the skill
+
+Path 1 is what current K8s flow produces. Paths 2–3 are kept for legacy on-disk layouts that may exist in older deployments. Path 4 is the TUI / first-boot fallback.
+
+### local_script tool
+
+`src/tools/script-exec/local-script.ts`:
+
+1. Resolve script path (above)
+2. Pick interpreter: `.sh` → `bash`, `.py` → `python3`
+3. `spawn()` with args array (no shell interpolation)
+4. Run as `sandbox` user (OS-level isolation, no credential access)
+5. 300 s max timeout, 10 MB max combined output
+
+### restricted-bash skill bypass
+
+`restricted-bash` accepts a command if `isSkillScript()` resolves the target to a path under `skills/` (or `config.paths.skillsDir`). This is the secondary execution path — `local_script` is preferred because it goes straight through the path resolver with no shell intermediary.
+
+---
+
+## Agent Discovery
+
+`agent-factory.ts` assembles `skillsDirs` in this order:
+
+```
+1. opts.portalSkillsDir (when TUI + Portal active)         → exclusive
+2. .siclaw/skills/resolved/ (when present)                  → bundle output
+3. skills/core/ (fallback when neither above exists)        → TUI / first boot
++ skills/platform/ (always appended, never an exclusive)
+```
+
+`DefaultResourceLoader` (from pi-coding-agent) scans these dirs for `SKILL.md`, parses frontmatter, and injects each skill's `description` into the agent's system prompt. The agent invokes a skill by calling `local_script(skill, script)`.
+
+---
+
+## File Reference
+
+```
+Code
+  src/portal/adapter.ts                      Bundle endpoint (POST /api/internal/siclaw/skills/bundle)
+  src/portal/migrate.ts                      Schema (skills / skill_versions / skill_reviews)
+  src/gateway/skills/builtin-sync.ts         Startup sync of skills/core/ into DB
+  src/gateway/skills/script-evaluator.ts     Static pattern scan (Phase 1 review)
+  src/gateway/skills/ai-security-reviewer.ts AI semantic analysis (Phase 2 review)
+  src/agentbox/sync-handlers.ts              skillsHandler: fetch + materialize
+  src/core/agent-factory.ts                  skillsDirs assembly, skillsOverride for TUI+Portal
+  src/tools/infra/script-resolver.ts         resolveSkillScript path search
+  src/tools/script-exec/local-script.ts      Skill execution tool
+  src/lib/portal-skill-materializer.ts       TUI Portal-snapshot materialize (distinct from skillsHandler)
+
+Disk layout
+  skills/core/                               Builtin skills (Docker-baked, synced into DB)
+  skills/platform/                           Platform meta-skills (always loaded, never in DB)
+  .siclaw/skills/resolved/                   Runtime materialize target (K8s)
+  .siclaw/.portal-snapshot/skills/           TUI + Portal ephemeral materialize target
+
+Reference
+  docs/design/2026-04-13-skill-governance-design.md   Canonical governance design
+  docs/design/invariants.md §1.2, §1.3, §2, §6        Bundle / materialize / mode contracts
+  docs/design/decisions.md ADR-003                    Bundle delivery decision rationale
 ```

--- a/src/agentbox-main.ts
+++ b/src/agentbox-main.ts
@@ -62,13 +62,13 @@ async function main() {
   console.log(`[agentbox] cwd: ${process.cwd()}`);
   console.log(`[agentbox] userDataDir=${userDataDir}`);
   console.log(`[agentbox] skillsDir=${skillsDir}`);
-  for (const tier of ["core", "extension"]) {
-    const dir = path.join(skillsDir, tier);
-    if (fs.existsSync(dir)) {
-      const entries = fs.readdirSync(dir).filter(e => !e.startsWith("."));
-      console.log(`[agentbox] skills/${tier}: ${entries.length} entries${entries.length ? ` (${entries.join(", ")})` : ""}`);
+  {
+    const coreDir = path.join(skillsDir, "core");
+    if (fs.existsSync(coreDir)) {
+      const entries = fs.readdirSync(coreDir).filter(e => !e.startsWith("."));
+      console.log(`[agentbox] skills/core: ${entries.length} entries${entries.length ? ` (${entries.join(", ")})` : ""}`);
     } else {
-      console.warn(`[agentbox] WARNING: skills/${tier} NOT found at ${dir}`);
+      console.warn(`[agentbox] WARNING: skills/core NOT found at ${coreDir}`);
     }
   }
 

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -631,16 +631,13 @@ describe("skill directory resolution", () => {
   function resolveSkillDirs(cwd: string, skillsBase: string): string[] {
     const resolvedSkillsDir = path.join(skillsBase, "resolved");
     const builtinPath = path.resolve(cwd, "skills", "core");
-    const extensionPath = path.resolve(cwd, "skills", "extension");
     const platformPath = path.resolve(cwd, "skills", "platform");
 
     const skillsDirs: string[] = [];
     if (fs.existsSync(resolvedSkillsDir)) {
       skillsDirs.push(resolvedSkillsDir);
-    } else {
-      for (const bDir of [builtinPath, extensionPath]) {
-        if (fs.existsSync(bDir)) skillsDirs.push(bDir);
-      }
+    } else if (fs.existsSync(builtinPath)) {
+      skillsDirs.push(builtinPath);
     }
     if (fs.existsSync(platformPath)) skillsDirs.push(platformPath);
     return skillsDirs;
@@ -660,19 +657,17 @@ describe("skill directory resolution", () => {
   });
 
   // ── 1. server mode: resolved/ exists → use resolved/ + platform/ ──────
-  it("server mode: resolved/ takes priority over core/ and extension/ when it exists", () => {
+  it("server mode: resolved/ takes priority over core/ when it exists", () => {
     const resolvedDir = path.join(skillsBase, "resolved");
     const platformDir = path.join(tmpDir, "skills", "platform");
     fs.mkdirSync(resolvedDir, { recursive: true });
     fs.mkdirSync(platformDir, { recursive: true });
-    // Also create core/ and extension/ to confirm they are NOT included
+    // Also create core/ to confirm it is NOT included
     fs.mkdirSync(path.join(tmpDir, "skills", "core"), { recursive: true });
-    fs.mkdirSync(path.join(tmpDir, "skills", "extension"), { recursive: true });
 
     const result = resolveSkillDirs(tmpDir, skillsBase);
     expect(result).toEqual([resolvedDir, platformDir]);
     expect(result).not.toContain(path.join(tmpDir, "skills", "core"));
-    expect(result).not.toContain(path.join(tmpDir, "skills", "extension"));
   });
 
   // ── 2. server mode: resolved/ exists, no platform/ → use resolved/ only
@@ -684,21 +679,8 @@ describe("skill directory resolution", () => {
     expect(result).toEqual([resolvedDir]);
   });
 
-  // ── 3. TUI mode: no resolved/ → fallback to core/ + extension/ + platform/
-  it("TUI mode: no resolved/ → falls back to core/ + extension/ + platform/", () => {
-    const coreDir = path.join(tmpDir, "skills", "core");
-    const extensionDir = path.join(tmpDir, "skills", "extension");
-    const platformDir = path.join(tmpDir, "skills", "platform");
-    fs.mkdirSync(coreDir, { recursive: true });
-    fs.mkdirSync(extensionDir, { recursive: true });
-    fs.mkdirSync(platformDir, { recursive: true });
-
-    const result = resolveSkillDirs(tmpDir, skillsBase);
-    expect(result).toEqual([coreDir, extensionDir, platformDir]);
-  });
-
-  // ── 4. TUI mode: no resolved/, no extension/ → core/ + platform/ ──────
-  it("TUI mode: no resolved/, no extension/ → core/ + platform/ only", () => {
+  // ── 3. TUI mode: no resolved/ → fallback to core/ + platform/ ─────────
+  it("TUI mode: no resolved/ → falls back to core/ + platform/", () => {
     const coreDir = path.join(tmpDir, "skills", "core");
     const platformDir = path.join(tmpDir, "skills", "platform");
     fs.mkdirSync(coreDir, { recursive: true });
@@ -706,7 +688,6 @@ describe("skill directory resolution", () => {
 
     const result = resolveSkillDirs(tmpDir, skillsBase);
     expect(result).toEqual([coreDir, platformDir]);
-    expect(result).not.toContain(path.join(tmpDir, "skills", "extension"));
   });
 
   // ── 5. platform always loaded: present in both server and TUI modes ───

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -114,7 +114,6 @@ interface SkillBundlePayload {
     scope: "builtin" | "global";
     specs: string;
     scripts: Array<{ name: string; content: string }>;
-    skillSpaceId?: string;
   }>;
 }
 

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -525,7 +525,6 @@ export async function createSiclawSession(
   // Fallback: only when resolved/ doesn't exist (TUI mode where Gateway sync
   // never runs). Server modes always have resolved/ created by materialize.
   const builtinPath = path.resolve(cwd, "skills", "core");
-  const extensionPath = path.resolve(cwd, "skills", "extension");
   const platformPath = path.resolve(cwd, "skills", "platform");
 
   const skillsDirs: string[] = [];
@@ -535,10 +534,8 @@ export async function createSiclawSession(
     skillsDirs.push(opts.portalSkillsDir);
   } else if (fs.existsSync(resolvedSkillsDir)) {
     skillsDirs.push(resolvedSkillsDir);
-  } else {
-    for (const bDir of [builtinPath, extensionPath]) {
-      if (fs.existsSync(bDir)) skillsDirs.push(bDir);
-    }
+  } else if (fs.existsSync(builtinPath)) {
+    skillsDirs.push(builtinPath);
   }
   // Platform skills are always loaded (system-level, not user-managed)
   if (fs.existsSync(platformPath)) skillsDirs.push(platformPath);

--- a/src/tools/cmd-exec/restricted-bash.test.ts
+++ b/src/tools/cmd-exec/restricted-bash.test.ts
@@ -456,16 +456,16 @@ describe("createRestrictedBashTool", () => {
 });
 
 describe("isSkillScript", () => {
-  const extSkillsDir = path.join(process.cwd(), "skills", "extension");
+  const coreSkillsDir = path.join(process.cwd(), "skills", "core");
   const mockScript = path.join(
-    extSkillsDir,
-    "roce-perftest-pod",
+    coreSkillsDir,
+    "_test-perftest-pod",
     "scripts",
     "_mock-test.sh"
   );
   const mockPyScript = path.join(
-    extSkillsDir,
-    "roce-check-node-config",
+    coreSkillsDir,
+    "_test-check-node-config",
     "scripts",
     "_mock-test.py"
   );
@@ -478,43 +478,43 @@ describe("isSkillScript", () => {
   });
 
   afterAll(() => {
-    try { fs.rmSync(path.join(extSkillsDir, "roce-perftest-pod"), { recursive: true }); } catch {}
-    try { fs.rmSync(path.join(extSkillsDir, "roce-check-node-config"), { recursive: true }); } catch {}
+    try { fs.rmSync(path.join(coreSkillsDir, "_test-perftest-pod"), { recursive: true }); } catch {}
+    try { fs.rmSync(path.join(coreSkillsDir, "_test-check-node-config"), { recursive: true }); } catch {}
   });
 
   // bash/sh prefix
-  it("allows bash skills/extension/ script", () => {
-    expect(isSkillScript("bash skills/extension/roce-perftest-pod/scripts/_mock-test.sh --help")).toBe(true);
+  it("allows bash skills/core/ script", () => {
+    expect(isSkillScript("bash skills/core/_test-perftest-pod/scripts/_mock-test.sh --help")).toBe(true);
   });
 
-  it("allows sh skills/extension/ script", () => {
-    expect(isSkillScript("sh skills/extension/roce-perftest-pod/scripts/_mock-test.sh")).toBe(true);
+  it("allows sh skills/core/ script", () => {
+    expect(isSkillScript("sh skills/core/_test-perftest-pod/scripts/_mock-test.sh")).toBe(true);
   });
 
   it("allows bash with flags before script path", () => {
-    expect(isSkillScript("bash -e skills/extension/roce-perftest-pod/scripts/_mock-test.sh")).toBe(true);
+    expect(isSkillScript("bash -e skills/core/_test-perftest-pod/scripts/_mock-test.sh")).toBe(true);
   });
 
   // direct invocation
-  it("allows direct skills/extension/ script invocation", () => {
-    expect(isSkillScript("skills/extension/roce-perftest-pod/scripts/_mock-test.sh --server-pod pod-a")).toBe(true);
+  it("allows direct skills/core/ script invocation", () => {
+    expect(isSkillScript("skills/core/_test-perftest-pod/scripts/_mock-test.sh --server-pod pod-a")).toBe(true);
   });
 
   it("allows direct invocation with env var prefix", () => {
-    expect(isSkillScript("FOO=1 skills/extension/roce-perftest-pod/scripts/_mock-test.sh")).toBe(true);
+    expect(isSkillScript("FOO=1 skills/core/_test-perftest-pod/scripts/_mock-test.sh")).toBe(true);
   });
 
   // python3 prefix
-  it("allows python3 skills/extension/ script", () => {
-    expect(isSkillScript("python3 skills/extension/roce-check-node-config/scripts/_mock-test.py")).toBe(true);
+  it("allows python3 skills/core/ script", () => {
+    expect(isSkillScript("python3 skills/core/_test-check-node-config/scripts/_mock-test.py")).toBe(true);
   });
 
-  it("allows python skills/extension/ script", () => {
-    expect(isSkillScript("python skills/extension/roce-check-node-config/scripts/_mock-test.py --node x")).toBe(true);
+  it("allows python skills/core/ script", () => {
+    expect(isSkillScript("python skills/core/_test-check-node-config/scripts/_mock-test.py --node x")).toBe(true);
   });
 
   it("allows python3 with flags before script path", () => {
-    expect(isSkillScript("python3 -u skills/extension/roce-check-node-config/scripts/_mock-test.py")).toBe(true);
+    expect(isSkillScript("python3 -u skills/core/_test-check-node-config/scripts/_mock-test.py")).toBe(true);
   });
 
   // blocked
@@ -532,8 +532,8 @@ describe("isSkillScript", () => {
   });
 
   it("blocks path traversal", () => {
-    expect(isSkillScript("bash skills/extension/../../etc/passwd")).toBe(false);
-    expect(isSkillScript("skills/extension/../../etc/passwd")).toBe(false);
+    expect(isSkillScript("bash skills/core/../../etc/passwd")).toBe(false);
+    expect(isSkillScript("skills/core/../../etc/passwd")).toBe(false);
   });
 
   it("blocks bash with no arguments", () => {
@@ -776,16 +776,16 @@ describe("createRestrictedBashTool — find validation", () => {
 
 describe("createRestrictedBashTool — skill script whitelist", () => {
   const tool = createRestrictedBashTool();
-  const extSkillsDir = path.join(process.cwd(), "skills", "extension");
+  const coreSkillsDir = path.join(process.cwd(), "skills", "core");
   const mockScript = path.join(
-    extSkillsDir,
-    "roce-perftest-pod",
+    coreSkillsDir,
+    "_test-perftest-pod",
     "scripts",
     "_mock-test.sh"
   );
   const mockPyScript = path.join(
-    extSkillsDir,
-    "roce-check-node-config",
+    coreSkillsDir,
+    "_test-check-node-config",
     "scripts",
     "_mock-test.py"
   );
@@ -800,24 +800,24 @@ describe("createRestrictedBashTool — skill script whitelist", () => {
   });
 
   afterAll(() => {
-    try { fs.rmSync(path.join(extSkillsDir, "roce-perftest-pod"), { recursive: true }); } catch {}
-    try { fs.rmSync(path.join(extSkillsDir, "roce-check-node-config"), { recursive: true }); } catch {}
+    try { fs.rmSync(path.join(coreSkillsDir, "_test-perftest-pod"), { recursive: true }); } catch {}
+    try { fs.rmSync(path.join(coreSkillsDir, "_test-check-node-config"), { recursive: true }); } catch {}
   });
 
-  it("allows bash skills/extension/ script", async () => {
+  it("allows bash skills/core/ script", async () => {
     const result = await tool.execute(
       "test-id",
-      { command: "bash skills/extension/roce-perftest-pod/scripts/_mock-test.sh --help" },
+      { command: "bash skills/core/_test-perftest-pod/scripts/_mock-test.sh --help" },
       undefined,
       {} as any
     );
     expect(result.content[0].text).not.toContain("Blocked");
   });
 
-  it("allows direct skills/extension/ script invocation", async () => {
+  it("allows direct skills/core/ script invocation", async () => {
     const result = await tool.execute(
       "test-id",
-      { command: "skills/extension/roce-perftest-pod/scripts/_mock-test.sh --server-pod pod-a" },
+      { command: "skills/core/_test-perftest-pod/scripts/_mock-test.sh --server-pod pod-a" },
       undefined,
       {} as any
     );
@@ -848,7 +848,7 @@ describe("createRestrictedBashTool — skill script whitelist", () => {
   it("blocks path traversal", async () => {
     const result = await tool.execute(
       "test-id",
-      { command: "bash skills/extension/../../etc/passwd" },
+      { command: "bash skills/core/../../etc/passwd" },
       undefined,
       {} as any
     );
@@ -865,10 +865,10 @@ describe("createRestrictedBashTool — skill script whitelist", () => {
     expect(result.content[0].text).toContain("Blocked");
   });
 
-  it("allows python3 skills/extension/ script", async () => {
+  it("allows python3 skills/core/ script", async () => {
     const result = await tool.execute(
       "test-id",
-      { command: "python3 skills/extension/roce-check-node-config/scripts/_mock-test.py --node x" },
+      { command: "python3 skills/core/_test-check-node-config/scripts/_mock-test.py --node x" },
       undefined,
       {} as any
     );

--- a/src/tools/infra/script-resolver.test.ts
+++ b/src/tools/infra/script-resolver.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./script-resolver.js";
 
 // script-resolver reads from process.cwd() + config.paths.skillsDir (".siclaw/skills")
-// and process.cwd() + "skills/{core,extension}" for builtins.
+// and process.cwd() + "skills/core" for builtins.
 // We use cwd + temp dirs to avoid polluting the real repo.
 
 let tmpRoot: string;
@@ -115,13 +115,6 @@ describe("resolveSkillScript — path search precedence", () => {
     expect(res!.content).toBe("core-script");
   });
 
-  it("falls back to skills/extension builtin", () => {
-    mkFile(path.join(tmpRoot, "skills/extension/ext-skill/scripts/b.sh"), "ext-script");
-    const res = resolveSkillScript("ext-skill", "b.sh");
-    expect(res).not.toBeNull();
-    expect(res!.scope).toBe("builtin");
-  });
-
   it("respects .disabled-builtins.json", () => {
     mkFile(path.join(tmpRoot, "skills/core/disabled-one/scripts/a.sh"), "x");
     fs.mkdirSync(path.join(tmpRoot, ".siclaw/skills"), { recursive: true });
@@ -155,7 +148,7 @@ describe("listSkillScripts", () => {
 describe("listAllSkillsWithScripts", () => {
   it("returns all skills + their scripts", () => {
     mkFile(path.join(tmpRoot, ".siclaw/skills/global/sk1/scripts/a.sh"));
-    mkFile(path.join(tmpRoot, ".siclaw/skills/extension/sk2/scripts/b.sh"));
+    mkFile(path.join(tmpRoot, "skills/core/sk2/scripts/b.sh"));
     const all = listAllSkillsWithScripts();
     const names = all.map(s => s.skill).sort();
     expect(names).toContain("sk1");

--- a/src/tools/infra/script-resolver.ts
+++ b/src/tools/infra/script-resolver.ts
@@ -7,15 +7,13 @@ function skillsBase(): string {
   return path.resolve(process.cwd(), config.paths.skillsDir);
 }
 
-/** Builtin skills directories (baked into Docker image at skills/core/ and skills/extension/) */
-const BUILTIN_TIERS = ["core", "extension"] as const;
-
+/** Builtin skills directory (baked into Docker image at skills/core/) */
 function builtinCoreDir(): string {
   return path.resolve(process.cwd(), "skills", "core");
 }
 
 function builtinDirs(): string[] {
-  return BUILTIN_TIERS.map(t => path.resolve(process.cwd(), "skills", t));
+  return [builtinCoreDir()];
 }
 
 /** Load disabled builtins list (written by agentbox startup from bundle API) */
@@ -33,7 +31,7 @@ function loadDisabledBuiltins(): Set<string> {
  * Skill scope directories to search (in priority order, CLI fallback).
  * Higher-specificity scopes first: global > builtin.
  */
-const SKILL_SCOPES = ["extension", "global", "core"];
+const SKILL_SCOPES = ["global", "core"];
 
 /** Directory entry with associated scope */
 interface ScopeDir {
@@ -43,7 +41,6 @@ interface ScopeDir {
 
 /** Map scope directory names to SkillScope values */
 const SCOPE_MAP: Record<string, SkillScope> = {
-  extension: "builtin",
   global: "global",
   core: "builtin",
 };
@@ -54,7 +51,7 @@ const SCOPE_MAP: Record<string, SkillScope> = {
  * Priority: global (bundle) > builtin (Docker image).
  * 1. Bundle-materialized resolved/ directory (built by materialize with priority merging)
  * 2. Legacy flat layout (bundle-materialized without scope subdirs)
- * 3. Scope subdirectories (extension > global > core)
+ * 3. Scope subdirectories (global > core)
  * 4. Builtin fallback (skills/core/) — unless disabled
  */
 function getSkillScriptDirs(skill: string): ScopeDir[] {
@@ -69,7 +66,7 @@ function getSkillScriptDirs(skill: string): ScopeDir[] {
   const directPath = path.join(base, skill, "scripts");
   if (fs.existsSync(directPath)) return [{ dir: directPath, scope: "global" }];
 
-  // 3. Scope subdirectories (extension > global > core)
+  // 3. Scope subdirectories (global > core)
   const dirs: ScopeDir[] = [];
   for (const scopeName of SKILL_SCOPES) {
     const dir = path.join(base, scopeName, skill, "scripts");
@@ -77,7 +74,7 @@ function getSkillScriptDirs(skill: string): ScopeDir[] {
   }
   if (dirs.length > 0) return dirs;
 
-  // 4. Builtin fallback (skills/{core,extension}/) — for skills not in the bundle
+  // 4. Builtin fallback (skills/core/) — for skills not in the bundle
   const disabled = loadDisabledBuiltins();
   if (!disabled.has(skill)) {
     for (const bDir of builtinDirs()) {
@@ -111,14 +108,14 @@ function getSkillBaseDirs(): string[] {
     return dirs;
   }
 
-  // 2. Scope subdirectories (extension > global > core)
+  // 2. Scope subdirectories (global > core)
   const dirs: string[] = [];
   for (const scope of SKILL_SCOPES) {
     const dir = path.join(base, scope);
     if (fs.existsSync(dir)) dirs.push(dir);
   }
 
-  // 3. Builtin fallback (skills/{core,extension}/ from Docker image)
+  // 3. Builtin fallback (skills/core/ from Docker image)
   for (const bDir of builtinDirs()) {
     if (fs.existsSync(bDir) && !dirs.includes(bDir)) dirs.push(bDir);
   }
@@ -133,14 +130,12 @@ export function skillExistsInBundle(skillName: string): boolean {
   const directDir = path.join(base, skillName);
   if (fs.existsSync(directDir) && fs.statSync(directDir).isDirectory()) return true;
   // Scope subdirectory layout
-  for (const scopeDir of ["extension", "global"]) {
-    const dir = path.join(base, scopeDir, skillName);
-    if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) return true;
-  }
+  const dir = path.join(base, "global", skillName);
+  if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) return true;
   return false;
 }
 
-/** Check if a skill exists as a non-disabled builtin (skills/{core,extension}/) */
+/** Check if a skill exists as a non-disabled builtin (skills/core/) */
 export function skillExistsAsBuiltin(skillName: string): boolean {
   const disabled = loadDisabledBuiltins();
   if (disabled.has(skillName)) return false;


### PR DESCRIPTION
## Summary

The `extension` skill tier has been empty since the initial commit — it added nothing but dead code paths. Separately, the skill-governance docs still described the pre-2026-04-13 four-scope model (`personal`/`skillset`/`global`/`builtin`, `skill_spaces`, content tags, `originId`) that no longer exists in the schema. This PR removes the dead tier and rewrites the docs against the current flat-pool + status-gate + agent-binding model.

Pure cleanup + docs — **no behavior change** (net −339 lines).

## Remove the dead extension tier

- Delete empty `skills/extension/` (and its `.gitkeep`)
- Strip `COPY skills/extension/` from `Dockerfile.agentbox` + `Dockerfile.runtime`
- Collapse `BUILTIN_TIERS` / `SKILL_SCOPES` / `SCOPE_MAP` in `script-resolver.ts` to drop the extension branch (the existing "return SKILL.md on unknown script name" behavior is preserved)
- Simplify the tier loop in `agentbox-main.ts`; remove the `extensionPath` fallback in `agent-factory.ts`
- Drop the dead `SkillBundlePayload.skillSpaceId?` field
- Migrate test fixtures from `skills/extension/` to `skills/core/`

## Align skill docs with the current model

- Rewrite `docs/design/skills.md` against the current schema (`is_builtin`, `overlay_of`, status lifecycle, `agent_skills` binding) and bundle code
- Update `invariants.md` (§1.2 LocalSpawner skips the skills handler; §1.3 K8s `resolved/` contract; §2.1–2.3 bundle / layout / lifecycle; §6 sync table)
- Update `decisions.md` ADR-003 bundle rationale, `security.md` file-permission table, `CLAUDE.md` §1.2 Skill Bundle Contract, and the `AGENTS.md` skill mention

## Verification

- No new type errors versus `main` (verified by diffing `tsc --noEmit` output before/after)
- Targeted tests for every touched file pass — `script-resolver`, `restricted-bash`, `sync-handlers` (630 tests)
