### PR TITLE
feat: managed (bastion-key) jump-host auth + host connection testing

### DIFF
--- a/docs/design/2026-04-24-dp-mode-refactor-design.md
+++ b/docs/design/2026-04-24-dp-mode-refactor-design.md
@@ -529,7 +529,7 @@ Delegation tools are hidden in ordinary chat: `delegate_to_agent` and `delegate_
 ## 8. Migration Plan
 
 ### Pre-work
-- Verify current DP persistence PR (the three commits on `feat/portal-port-from-sicore`) is merged to main.
+- Verify current DP persistence PR (the three commits on the DP-persistence port branch) is merged to main.
 - Snapshot user preferences / settings that might reference DP features (there aren't many; main one is the `[Deep Investigation]` prefix).
 
 ### Step 1 — Land ActionChip unification (no behavior change)

--- a/docs/design/attachment-ocr.md
+++ b/docs/design/attachment-ocr.md
@@ -108,10 +108,10 @@ attachments for chat-history replay. Model caches, when enabled, store only
 PaddleOCR/PaddleX model artifacts.
 
 The OCR service is safe to reuse from another API gateway as long as that system
-uses the same `/parse` contract. For example, Sicore can call a shared OCR
+uses the same `/parse` contract. For example, another service can call a shared OCR
 service from its siclaw proxy layer, or point to an externally managed service
 with the same request/response shape, then forward only text evidence to
-Siclaw. Sicore-specific proxy code should live in Sicore, not in this Siclaw
+Siclaw. Caller-specific proxy code should live in the caller, not in this Siclaw
 standalone OCR change.
 
 ## Deployment
@@ -123,7 +123,7 @@ The Helm chart supports three deployment profiles:
   `helm/siclaw/values-no-ocr.yaml`.
 - OCR-only addon: OCR Deployment + Service only, using
   `helm/siclaw/values-ocr-only.yaml`. This is intended for external callers
-  such as Sicore's Siclaw proxy.
+  such as a caller's Siclaw proxy.
 
 The chart creates the OCR Deployment and Service whenever:
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -478,9 +478,6 @@ scheme:
 - Binding an agent to a target transitively authorizes transit through its jump
   chain; the agent never receives a bastion's credential material, only
   reachability.
-- "Managed" auth (reading the last-hop key off the bastion) is intentionally NOT
-  implemented — a community anti-pattern (keys on the bastion).
-
 **Consequences**:
 - ✅ Standard, portable model — the same inventory works standalone or driven by
   an external management server
@@ -491,3 +488,14 @@ scheme:
   inherit reachability (a test bastion may front a prod target)
 
 **Files**: `src/tools/infra/ssh-dial.ts`, `src/tools/infra/ssh-client.ts`, `src/portal/adapter.ts`, `src/portal/host-api.ts`, `src/portal/migrate.ts`; full contract in `docs/design/ssh-jump-host.md`
+
+**Update (2026-06, feat/ssh-managed-jump): managed auth now supported.**
+The original decision excluded "managed" target auth (last-hop key read off the
+bastion) as a community anti-pattern. Reversed by product decision to align with
+sicore, which supports it as a first-class form. siclaw now supports
+`auth_type="managed"`: the target stores no credential; `ssh-dial` reads the first
+readable `~/.ssh/id_*` off the bastion at dial time and uses it for the final hop
+(target username + optional passphrase from the host record). Constraints: a managed
+host **requires a jump host**; the key is **not** broker-materialized (it lives on
+the bastion and transits agentbox memory) — an explicit, documented tradeoff vs.
+explicit per-hop credentials. Mechanism mirrors sicore `internal/connector/managed_jump.go`.

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -491,11 +491,10 @@ scheme:
 
 **Update (2026-06, feat/ssh-managed-jump): managed auth now supported.**
 The original decision excluded "managed" target auth (last-hop key read off the
-bastion) as a community anti-pattern. Reversed by product decision to align with
-sicore, which supports it as a first-class form. siclaw now supports
+bastion) as a community anti-pattern. Reversed by product decision to support a credential-on-bastion form. siclaw now supports
 `auth_type="managed"`: the target stores no credential; `ssh-dial` reads the first
 readable `~/.ssh/id_*` off the bastion at dial time and uses it for the final hop
 (target username + optional passphrase from the host record). Constraints: a managed
 host **requires a jump host**; the key is **not** broker-materialized (it lives on
 the bastion and transits agentbox memory) — an explicit, documented tradeoff vs.
-explicit per-hop credentials. Mechanism mirrors sicore `internal/connector/managed_jump.go`.
+explicit per-hop credentials. Mechanism: read the first readable `~/.ssh/id_*` off the bastion for the final hop.

--- a/docs/design/error-envelope.md
+++ b/docs/design/error-envelope.md
@@ -1,6 +1,6 @@
-# Error Envelope (siclaw + sicore)
+# Error Envelope (siclaw + management server)
 
-> **Goal**: Whenever something fails along the chat flow (browser ↔ sicore-web ↔ sicore-apiserver ↔ siclaw-runtime ↔ agentbox ↔ model/tool), the user sees a clear in-line error bubble — not a silent stop. We do **not** exhaustively classify every failure; we ensure errors are never swallowed, and we tag the few we know how to handle specifically.
+> **Goal**: Whenever something fails along the chat flow (browser ↔ management web ↔ management API server ↔ siclaw-runtime ↔ agentbox ↔ model/tool), the user sees a clear in-line error bubble — not a silent stop. We do **not** exhaustively classify every failure; we ensure errors are never swallowed, and we tag the few we know how to handle specifically.
 
 ---
 
@@ -12,7 +12,7 @@ One canonical shape, shared by REST bodies and SSE error frames.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `code` | string | ✅ | Identifier. Reuse sicore `ErrCode*` values where possible (`INTERNAL_ERROR`, `CONNECTION_FAILED`, `CONNECTION_TIMEOUT`, `TOO_MANY_REQUESTS`, etc.). Default to `INTERNAL_ERROR` when nothing better is known. |
+| `code` | string | ✅ | Identifier. Reuse the management server's `ErrCode*` values where possible (`INTERNAL_ERROR`, `CONNECTION_FAILED`, `CONNECTION_TIMEOUT`, `TOO_MANY_REQUESTS`, etc.). Default to `INTERNAL_ERROR` when nothing better is known. |
 | `message` | string | ✅ | One-line, user-facing. English fine for v1; i18n later. |
 | `retriable` | bool | ✅ | Whether the UI should show a retry button. Default to `true` when wrapping unknown errors (be optimistic). |
 | `retryAfterMs` | number | ❌ | Hint for rate-limit/overload backoff. UI uses for retry button countdown. |
@@ -23,9 +23,9 @@ One canonical shape, shared by REST bodies and SSE error frames.
 
 | Channel | Body shape |
 |---|---|
-| **REST 4xx/5xx** | `{ "error": ErrorDetail }` (matches sicore's existing `ErrorResponse`) |
+| **REST 4xx/5xx** | `{ "error": ErrorDetail }` (matches the management server's existing `ErrorResponse`) |
 | **SSE error event** | `event: error\ndata: <ErrorDetail>\n\n` (data is `ErrorDetail` directly — the event name discriminates, no extra wrapping) |
-| **WS RPC error** (sicore↔runtime) | `{ ok: false, error: ErrorDetail }` — replaces today's `{OK, Error: string}` shape gradually (see §5 migration) |
+| **WS RPC error** (management server↔runtime) | `{ ok: false, error: ErrorDetail }` — replaces today's `{OK, Error: string}` shape gradually (see §5 migration) |
 
 ---
 
@@ -35,10 +35,10 @@ Hard rule: **start small, add only when we actually emit one in code**. No specu
 
 ### Generic / fallback
 - `INTERNAL_ERROR` — anything we couldn't classify. Always default.
-- `BAD_REQUEST` — caller sent garbage (matches sicore `ErrCodeBadRequest`).
+- `BAD_REQUEST` — caller sent garbage (matches the management server's `ErrCodeBadRequest`).
 
 ### Connectivity & infra
-- `CONNECTION_FAILED` — sicore can't reach siclaw runtime ("no Runtime connected for agent X"). Maps to existing `ErrCodeConnectionFailed`.
+- `CONNECTION_FAILED` — the management server can't reach the siclaw runtime ("no Runtime connected for agent X"). Maps to existing `ErrCodeConnectionFailed`.
 - `CONNECTION_TIMEOUT` — WS RPC timed out. Maps to existing `ErrCodeConnectionTimeout`.
 - `STREAM_INTERRUPTED` — SSE / WS connection broke mid-stream.
 
@@ -75,7 +75,7 @@ That's it.
 
 ## 4. Front-end rendering
 
-Two frontends — `siclaw/portal-web` and `sicore/web` — both implement the same rules.
+Two frontends — `siclaw/portal-web` and the management server's web UI — both implement the same rules.
 
 ### `<ErrorBubble>` component
 - Inline red-toned bubble in the chat message stream (same column as agent messages, not a toast)
@@ -119,7 +119,7 @@ The frontend handles both old and new shapes during migration. After all backend
 
 ## 5. Migration & scope
 
-We are **not** rewriting all 402 catch blocks in siclaw or all 15+ `gin.H{"error": ...}` in sicore. Scope for v1:
+We are **not** rewriting all 402 catch blocks in siclaw or all 15+ `gin.H{"error": ...}` in the management server. Scope for v1:
 
 ### Required (chat-flow user-visible)
 
@@ -132,7 +132,7 @@ We are **not** rewriting all 402 catch blocks in siclaw or all 15+ `gin.H{"error
 - `portal-web/src/hooks/usePilotChat.ts` — SSE error + fetch error handling
 - `portal-web/src/components/chat/PilotArea.tsx` (or message renderer) — render error type
 
-**sicore** (Go + React):
+**Management server** (Go + React):
 - `pkg/model/response.go` — extend `ErrorDetail` with `Retriable`, `RetryAfterMs`, `RequestId`; new `RespondErrorEnvelope()` and `WriteSSEError()` helpers
 - `internal/siclaw/proxy/handler.go` — replace `gin.H{"error": ...}` with envelope helpers; map `"no Runtime connected"` → `CONNECTION_FAILED`, RPC timeout → `CONNECTION_TIMEOUT`
 - `web/components/siclaw/chat/error-bubble.tsx` (new)
@@ -141,7 +141,7 @@ We are **not** rewriting all 402 catch blocks in siclaw or all 15+ `gin.H{"error
 
 ### Not in scope (v1)
 - 400 other siclaw catches that are not on the user-visible chat path
-- Other sicore handlers (host, cluster, credential, etc.) — they use proper `RespondError` already; the gap was siclaw proxy bypassing it
+- Other management-server handlers (host, cluster, credential, etc.) — they use proper `RespondError` already; the gap was siclaw proxy bypassing it
 - Auto-classification of every model/tool error subtype — handled per-call as we encounter need
 
 ### Future (v2+, when actual UX gaps surface)
@@ -157,7 +157,7 @@ We are **not** rewriting all 402 catch blocks in siclaw or all 15+ `gin.H{"error
 | Property | Pass? | Why |
 |---|---|---|
 | Single source of truth for shape | ✅ | One `ErrorDetail`, two transports |
-| Wire-compatible with existing sicore `ErrorResponse` | ✅ | `{error: ErrorDetail}` matches; only adds optional fields |
+| Wire-compatible with the management server's existing `ErrorResponse` | ✅ | `{error: ErrorDetail}` matches; only adds optional fields |
 | Frontend renders without per-code branching | ✅ | One bubble + `retriable` flag drives all UX; code only used for optional friendlier copy via i18n later |
 | New code added without UI change | ✅ | Default render uses `message` directly |
 | Backward-compatible during migration | ✅ | `parseErrorDetail()` handles both `{error: string}` and `{error: ErrorDetail}` |

--- a/docs/design/ssh-jump-host.md
+++ b/docs/design/ssh-jump-host.md
@@ -55,11 +55,28 @@ reachability through the bastion. The `is_production` constraint applies to the
 directly-bound entry host only; bastions inherit reachability (so a test bastion
 may legitimately front a prod target).
 
+## Managed target auth (`auth_type=managed`)
+
+Supported (see ADR-013). A managed host stores **no credential of its own**; the
+final hop authenticates with a private key discovered on the bastion
+(`~/.ssh/id_{ed25519,rsa,ecdsa,dsa}`, first readable), the target username comes
+from the host record, and an optional `passphrase` decrypts an encrypted bastion
+key. Contract:
+
+- A managed host **requires a jump host** (the bastion to source the key from) —
+  enforced on write (`host-api`), at the boundary (`adapter` emits no key/password
+  file, only `auth_type:"managed"` + `jump_host`), at acquire (`acquireSshTarget`),
+  and at dial (`dialSshChain` rejects a managed first hop).
+- `ssh-dial` sources the key by running a `cat` of the candidate paths over the
+  already-connected bastion session, then dials the target through the tunnel with
+  it (`MANAGED_KEY_FETCH_CMD`).
+- **Security tradeoff (deliberate):** the key lives on the bastion and is read into
+  agentbox memory at dial time — it is **not** broker-materialized/0600/agent-scoped.
+  This is the cost of the convenience (one credential on the bastion fronting many
+  targets). Use explicit per-hop credentials when you want full broker governance.
+
 ## Out of scope (intentional)
 
-- **Managed target auth** (reading the last-hop key *from* the bastion): a
-  community anti-pattern (keys on the bastion) and a sicore product convention.
-  Not implemented here; lives in sicore's internal integration if needed.
 - Identity-layer access (SSM/EICE/Teleport-style short-lived certs): future.
 - The legacy `.ssh_config` (`ssh`-via-restricted-bash) path does not consume
   ProxyJump or passphrases yet; only `host_exec`/`host_script` and the Portal

--- a/docs/design/ssh-jump-host.md
+++ b/docs/design/ssh-jump-host.md
@@ -18,7 +18,7 @@ external management server.
   bastion. Each bastion is itself a managed host row with its own credentials —
   equivalent to ssh_config `ProxyJump <named-host>`. Multi-level = a chain of
   references.
-- **Depth is capped at 3** (`MAX_JUMP_DEPTH`), mirroring sicore's connector.
+- **Depth is capped at 3** (`MAX_JUMP_DEPTH`).
   Cycles are rejected. The cap and cycle guard are enforced both on write
   (`validateJumpChain` in `host-api.ts`) and at acquire/dial time, because a row
   can be edited into a cycle after a child already references it.
@@ -31,8 +31,8 @@ The credential boundaries (`adapter.ts` WS-RPC + REST mirrors, `cli-snapshot-api
 carry the bastion's **host name**, never an internal id. The management server
 resolves `jump_host_id → name` at the boundary; the broker stores it as
 `HostMeta.jump_host` and `acquireSshTarget` recurses by name. This keeps the
-execution layer (`ssh-dial.ts`, broker-free) ignorant of any source system, so a
-sicore-style id model never leaks into siclaw's standard SSH layer.
+execution layer (`ssh-dial.ts`, broker-free) ignorant of any source system, so an
+upstream id model never leaks into siclaw's standard SSH layer.
 
 ## Execution contract
 

--- a/helm/siclaw/values-ocr-only.yaml
+++ b/helm/siclaw/values-ocr-only.yaml
@@ -1,7 +1,7 @@
 # OCR-only deployment profile.
 #
 # Use this when Siclaw provides the shared OCR addon service for another
-# caller, such as Sicore's Siclaw proxy. It deploys only the OCR backend and
+# caller, such as a caller's Siclaw proxy. It deploys only the OCR backend and
 # its ClusterIP Service; no Portal, Runtime, Runtime RBAC, Runtime CA, or
 # Runtime test hook is rendered.
 

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -18,7 +18,7 @@ database:
 
 # -- Agent Runtime
 # NOTE: Runtime is a singleton — exactly one replica per Helm release.
-# Phone-home WS registration on the upstream (Portal or SiCore) is keyed by
+# Phone-home WS registration on the upstream (Portal or an external management server) is keyed by
 # runtime identity and a second connection with the same identity evicts the
 # first, so multiple replicas of the same release would continuously fight.
 # Scale horizontally by deploying multiple releases with distinct identities.
@@ -58,7 +58,7 @@ runtime:
       cpu: "2"
       memory: "2Gi"
   memory:
-    # Disabled by default for Sicore-integrated production deployments. Enabling
+    # Disabled by default for integrated production deployments. Enabling
     # this re-exposes memory_search/memory_get and session memory auto-save.
     enabled: false
   # Max sub-agent child sessions a single AgentBox runs concurrently. A wide
@@ -143,10 +143,10 @@ ocr:
     # ingressFrom:
     #   - namespaceSelector:
     #       matchLabels:
-    #         kubernetes.io/metadata.name: sicore
+    #         kubernetes.io/metadata.name: management-server
     #     podSelector:
     #       matchLabels:
-    #         app.kubernetes.io/name: sicore-apiserver
+    #         app.kubernetes.io/name: management-apiserver
     ingressFrom: []
 
 # -- AgentBox (spawned at runtime by K8s spawner)

--- a/portal-web/src/components/chat/types.ts
+++ b/portal-web/src/components/chat/types.ts
@@ -30,7 +30,7 @@ export interface MessageTiming {
 }
 
 /** Wire-compatible with siclaw's ErrorDetail (src/lib/error-envelope.ts) and
- *  sicore's pkg/model ErrorDetail. See docs/design/error-envelope.md. */
+ *  the management server's ErrorDetail. See docs/design/error-envelope.md. */
 export interface ErrorDetail {
   code: string
   message: string

--- a/portal-web/src/pages/Hosts.tsx
+++ b/portal-web/src/pages/Hosts.tsx
@@ -36,7 +36,7 @@ export function Hosts() {
       }
       if (form.auth_type === "password" && form.password) body.password = form.password
       if (form.auth_type === "key" && form.private_key) body.private_key = form.private_key
-      if (form.auth_type === "key" && form.passphrase) body.passphrase = form.passphrase
+      if ((form.auth_type === "key" || form.auth_type === "managed") && form.passphrase) body.passphrase = form.passphrase
       const h = await api<Host>("/hosts", { method: "POST", body })
       setHosts((prev) => [...prev, h])
       setShowCreate(false)
@@ -76,7 +76,7 @@ export function Hosts() {
       }
       if (editForm.auth_type === "password" && editForm.password) body.password = editForm.password
       if (editForm.auth_type === "key" && editForm.private_key) body.private_key = editForm.private_key
-      if (editForm.auth_type === "key" && editForm.passphrase) body.passphrase = editForm.passphrase
+      if ((editForm.auth_type === "key" || editForm.auth_type === "managed") && editForm.passphrase) body.passphrase = editForm.passphrase
       const updated = await api<Host>(`/hosts/${editingId}`, { method: "PUT", body })
       setHosts((prev) => prev.map((h) => h.id === editingId ? updated : h))
       setEditingId(null)
@@ -131,14 +131,18 @@ export function Hosts() {
               <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
                 <input type="radio" name="auth" checked={form.auth_type === "key"} onChange={() => setForm({ ...form, auth_type: "key" })} /> SSH Key
               </label>
+              <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                <input type="radio" name="auth" checked={form.auth_type === "managed"} onChange={() => setForm({ ...form, auth_type: "managed" })} /> Managed (key on jump host)
+              </label>
             </div>
           </div>
-          {form.auth_type === "password" ? (
+          {form.auth_type === "password" && (
             <div>
               <label className="block text-sm font-medium mb-1">Password</label>
               <input type="password" placeholder="SSH password" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background" />
             </div>
-          ) : (
+          )}
+          {form.auth_type === "key" && (
             <>
               <div>
                 <label className="block text-sm font-medium mb-1">Private Key</label>
@@ -150,8 +154,17 @@ export function Hosts() {
               </div>
             </>
           )}
+          {form.auth_type === "managed" && (
+            <div className="rounded-md border border-border bg-secondary/20 p-3 space-y-2">
+              <p className="text-xs text-muted-foreground">Authenticates with a private key found on the selected jump host (<span className="font-mono">~/.ssh/id_*</span>). No credential is stored for this host — <span className="font-medium">a Jump Host is required</span>.</p>
+              <div>
+                <label className="block text-sm font-medium mb-1">Key Passphrase</label>
+                <input type="password" placeholder="Optional — only if the jump host's key is encrypted" value={form.passphrase} onChange={(e) => setForm({ ...form, passphrase: e.target.value })} className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background" />
+              </div>
+            </div>
+          )}
           <div>
-            <label className="block text-sm font-medium mb-1">Jump Host <span className="text-muted-foreground font-normal">(ProxyJump bastion, optional)</span></label>
+            <label className="block text-sm font-medium mb-1">Jump Host <span className="text-muted-foreground font-normal">{form.auth_type === "managed" ? "(required — bastion holding the key)" : "(ProxyJump bastion, optional)"}</span></label>
             <select value={form.jump_host_id} onChange={(e) => setForm({ ...form, jump_host_id: e.target.value })} className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background">
               <option value="">None (direct connection)</option>
               {hosts.map((j) => <option key={j.id} value={j.id}>{j.name} ({j.ip})</option>)}
@@ -171,7 +184,7 @@ export function Hosts() {
             </div>
           </div>
           <div className="flex gap-2">
-            <button onClick={handleCreate} disabled={creating || !form.name || !form.ip} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">{creating ? "Creating..." : "Create"}</button>
+            <button onClick={handleCreate} disabled={creating || !form.name || !form.ip || (form.auth_type === "managed" && !form.jump_host_id)} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">{creating ? "Creating..." : "Create"}</button>
             <button onClick={() => setShowCreate(false)} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground hover:text-foreground">Cancel</button>
           </div>
         </div>
@@ -235,14 +248,18 @@ export function Hosts() {
                         <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
                           <input type="radio" name="edit-auth" checked={editForm.auth_type === "key"} onChange={() => setEditForm({ ...editForm, auth_type: "key" })} /> SSH Key
                         </label>
+                        <label className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                          <input type="radio" name="edit-auth" checked={editForm.auth_type === "managed"} onChange={() => setEditForm({ ...editForm, auth_type: "managed" })} /> Managed (key on jump host)
+                        </label>
                       </div>
                     </div>
-                    {editForm.auth_type === "password" ? (
+                    {editForm.auth_type === "password" && (
                       <div>
                         <label className="block text-sm font-medium mb-1">Password</label>
                         <input type="password" placeholder="Leave empty to keep current" value={editForm.password} onChange={(e) => setEditForm({ ...editForm, password: e.target.value })} className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background" />
                       </div>
-                    ) : (
+                    )}
+                    {editForm.auth_type === "key" && (
                       <>
                         <div>
                           <label className="block text-sm font-medium mb-1">Private Key</label>
@@ -254,8 +271,17 @@ export function Hosts() {
                         </div>
                       </>
                     )}
+                    {editForm.auth_type === "managed" && (
+                      <div className="rounded-md border border-border bg-secondary/20 p-3 space-y-2">
+                        <p className="text-xs text-muted-foreground">Authenticates with a private key found on the selected jump host (<span className="font-mono">~/.ssh/id_*</span>). No credential is stored for this host — <span className="font-medium">a Jump Host is required</span>.</p>
+                        <div>
+                          <label className="block text-sm font-medium mb-1">Key Passphrase</label>
+                          <input type="password" placeholder="Leave empty to keep current" value={editForm.passphrase} onChange={(e) => setEditForm({ ...editForm, passphrase: e.target.value })} className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background" />
+                        </div>
+                      </div>
+                    )}
                     <div>
-                      <label className="block text-sm font-medium mb-1">Jump Host <span className="text-muted-foreground font-normal">(ProxyJump bastion, optional)</span></label>
+                      <label className="block text-sm font-medium mb-1">Jump Host <span className="text-muted-foreground font-normal">{editForm.auth_type === "managed" ? "(required — bastion holding the key)" : "(ProxyJump bastion, optional)"}</span></label>
                       <select value={editForm.jump_host_id} onChange={(e) => setEditForm({ ...editForm, jump_host_id: e.target.value })} className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background">
                         <option value="">None (direct connection)</option>
                         {hosts.filter((j) => j.id !== h.id).map((j) => <option key={j.id} value={j.id}>{j.name} ({j.ip})</option>)}
@@ -275,7 +301,7 @@ export function Hosts() {
                       </div>
                     </div>
                     <div className="flex gap-2">
-                      <button onClick={handleSaveEdit} disabled={saving || !editForm.name || !editForm.ip} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">{saving ? "Saving..." : "Save"}</button>
+                      <button onClick={handleSaveEdit} disabled={saving || !editForm.name || !editForm.ip || (editForm.auth_type === "managed" && !editForm.jump_host_id)} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">{saving ? "Saving..." : "Save"}</button>
                       <button onClick={() => setEditingId(null)} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground hover:text-foreground">Cancel</button>
                     </div>
                   </div>

--- a/portal-web/src/pages/Hosts.tsx
+++ b/portal-web/src/pages/Hosts.tsx
@@ -19,8 +19,32 @@ export function Hosts() {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editForm, setEditForm] = useState({ ...emptyForm })
   const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
   const toast = useToast()
   const confirmDialog = useConfirm()
+
+  // Test a connection using the (possibly unsaved) form values, so the operator
+  // can validate what they typed before saving. The jump chain is resolved
+  // server-side from saved hosts; the target hop uses these inline credentials.
+  const handleTestConnection = async (f: typeof emptyForm) => {
+    setTesting(true)
+    try {
+      const body: Record<string, unknown> = {
+        ip: f.ip, port: parseInt(f.port), username: f.username,
+        auth_type: f.auth_type, jump_host_id: f.jump_host_id || null,
+      }
+      if (f.auth_type === "password" && f.password) body.password = f.password
+      if (f.auth_type === "key" && f.private_key) body.private_key = f.private_key
+      if ((f.auth_type === "key" || f.auth_type === "managed") && f.passphrase) body.passphrase = f.passphrase
+      const r = await api<{ ok: boolean; message: string }>("/hosts/test-connection", { method: "POST", body })
+      if (r.ok) toast.success(r.message || "SSH connection OK")
+      else toast.error(r.message || "Connection failed")
+    } catch (err: any) {
+      toast.error(err.message)
+    } finally {
+      setTesting(false)
+    }
+  }
 
   useEffect(() => {
     api<{ data: Host[] }>("/hosts").then((r) => setHosts(Array.isArray(r.data) ? r.data : Array.isArray(r) ? r as any : [])).catch(() => setHosts([])).finally(() => setLoading(false))
@@ -185,6 +209,7 @@ export function Hosts() {
           </div>
           <div className="flex gap-2">
             <button onClick={handleCreate} disabled={creating || !form.name || !form.ip || (form.auth_type === "managed" && !form.jump_host_id)} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">{creating ? "Creating..." : "Create"}</button>
+            <button onClick={() => handleTestConnection(form)} disabled={testing || !form.ip || (form.auth_type === "managed" && !form.jump_host_id)} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground hover:text-foreground disabled:opacity-50">{testing ? "Testing..." : "Test Connection"}</button>
             <button onClick={() => setShowCreate(false)} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground hover:text-foreground">Cancel</button>
           </div>
         </div>
@@ -302,6 +327,7 @@ export function Hosts() {
                     </div>
                     <div className="flex gap-2">
                       <button onClick={handleSaveEdit} disabled={saving || !editForm.name || !editForm.ip || (editForm.auth_type === "managed" && !editForm.jump_host_id)} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">{saving ? "Saving..." : "Save"}</button>
+                      <button onClick={() => handleTestConnection(editForm)} disabled={testing || !editForm.ip || (editForm.auth_type === "managed" && !editForm.jump_host_id)} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground hover:text-foreground disabled:opacity-50">{testing ? "Testing..." : "Test Connection"}</button>
                       <button onClick={() => setEditingId(null)} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground hover:text-foreground">Cancel</button>
                     </div>
                   </div>

--- a/src/agentbox/credential-broker.test.ts
+++ b/src/agentbox/credential-broker.test.ts
@@ -138,6 +138,35 @@ describe("CredentialBroker — host pipeline", () => {
     expect(broker.getHostLocalInfo("no-jump")?.meta.jump_host).toBeUndefined();
   });
 
+  it("acquireHost accepts a managed host (no files) with jump_host", async () => {
+    transport.hostPayloads.set("managed-t", {
+      credential: {
+        name: "managed-t",
+        type: "ssh",
+        files: [],
+        metadata: { ip: "10.0.0.9", port: 22, username: "ops", auth_type: "managed", is_production: false, jump_host: "bastion" },
+        ttl_seconds: 300,
+      },
+    });
+    await broker.acquireHost("managed-t", "test");
+    const info = broker.getHostLocalInfo("managed-t");
+    expect(info?.meta.auth_type).toBe("managed");
+    expect(info?.meta.jump_host).toBe("bastion");
+  });
+
+  it("rejects a managed host with no jump_host", async () => {
+    transport.hostPayloads.set("bad-managed", {
+      credential: {
+        name: "bad-managed",
+        type: "ssh",
+        files: [],
+        metadata: { ip: "10.0.0.9", port: 22, username: "ops", auth_type: "managed", is_production: false },
+        ttl_seconds: 300,
+      },
+    });
+    await expect(broker.acquireHost("bad-managed", "test")).rejects.toThrow(/managed.*no metadata\.jump_host/);
+  });
+
   it("acquireHost (password) writes <name>.password", async () => {
     transport.hostPayloads.set("node-b", {
       credential: {

--- a/src/agentbox/credential-broker.ts
+++ b/src/agentbox/credential-broker.ts
@@ -478,13 +478,20 @@ export class CredentialBroker {
    */
   async ensureHost(hostName: string, purpose = "ensure"): Promise<HostLocalInfo> {
     const existing = this.hosts.get(hostName);
+    // Managed hosts have no key/password file (the key is sourced from the
+    // bastion at dial time), so file existence isn't a freshness/materialization
+    // requirement for them — TTL alone governs.
+    const existingManaged = existing?.meta?.auth_type === "managed";
     const fresh = existing?.expiresAt !== undefined
       && existing.expiresAt > Date.now()
-      && (existing.filePaths?.every((fp) => fs.existsSync(fp)) ?? false);
+      && (existingManaged || (existing.filePaths?.every((fp) => fs.existsSync(fp)) ?? false));
     if (existing && fresh) return existing;
     await this.acquireHost(hostName, purpose);
     const refreshed = this.hosts.get(hostName);
-    if (!refreshed?.filePaths || refreshed.filePaths.length === 0) {
+    if (!refreshed) {
+      throw new Error(`Broker.ensureHost(${hostName}) completed but host not in registry`);
+    }
+    if (refreshed.meta?.auth_type !== "managed" && (!refreshed.filePaths || refreshed.filePaths.length === 0)) {
       throw new Error(`Broker.ensureHost(${hostName}) completed but no files materialized`);
     }
     return refreshed;
@@ -590,8 +597,13 @@ function inferHostMetaFromResponse(response: CredentialResponse, fallbackName: s
   if (typeof username !== "string" || username.length === 0) {
     throw new Error(`Host "${name}" credential payload missing required metadata.username`);
   }
-  if (authType !== "password" && authType !== "key") {
-    throw new Error(`Host "${name}" credential payload metadata.auth_type must be "password" or "key", got ${JSON.stringify(authType)}`);
+  if (authType !== "password" && authType !== "key" && authType !== "managed") {
+    throw new Error(`Host "${name}" credential payload metadata.auth_type must be "password", "key", or "managed", got ${JSON.stringify(authType)}`);
+  }
+  // Managed hosts carry no key/password file (the key is sourced from the
+  // bastion at dial time); they require a jump_host instead.
+  if (authType === "managed" && (typeof metadata.jump_host !== "string" || metadata.jump_host.length === 0)) {
+    throw new Error(`Host "${name}" has auth_type="managed" but no metadata.jump_host`);
   }
   if (typeof isProduction !== "boolean") {
     throw new Error(`Host "${name}" credential payload missing required metadata.is_production`);

--- a/src/gateway/config.ts
+++ b/src/gateway/config.ts
@@ -9,9 +9,9 @@ export interface RuntimeConfig {
   internalPort: number;
   /** Bind host */
   host: string;
-  /** Management server URL (Portal or SiCore) — provides Agent info, credentials, permissions */
+  /** Management server URL (Portal or an external management server) — provides Agent info, credentials, permissions */
   serverUrl: string;
-  /** Portal/SiCore's secret — Runtime presents this when phone-homing to the management server */
+  /** The management server's secret — Runtime presents this when phone-homing to the management server */
   portalSecret: string;
 }
 

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -205,7 +205,7 @@ export async function handleMcpServers(
 
     const data = await frontendClient.request("config.getMcpServers", {
       // Upstream uses agentId to resolve the caller's org and reject
-      // cross-org id requests. Without it, sicore falls back to the WS
+      // cross-org id requests. Without it, the management server falls back to the WS
       // runtime_id and the org lookup fails ("agent <runtime_id> not found").
       agentId: identity.agentId,
       ids: mcpServerIds,
@@ -233,7 +233,7 @@ export async function handleSkillsBundle(
 
     const data = await frontendClient.request("config.getSkillBundle", {
       // Upstream uses agentId to resolve the caller's org and reject
-      // cross-org skill_id requests. Without it, sicore falls back to the
+      // cross-org skill_id requests. Without it, the management server falls back to the
       // WS runtime_id and the org lookup fails ("agent <runtime_id> not
       // found"), which manifests as repeated `skills/bundle error` in
       // Runtime logs and a fresh AgentBox with no skills materialised.

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -177,12 +177,12 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // the background and stream events back to Portal via the chat.event
     // WS channel.
     //
-    // Why: sicore's WS RPC carries a fixed 30s timeout. Coupling the ack
+    // Why: the management server's WS RPC carries a fixed 30s timeout. Coupling the ack
     // to "agentbox is ready and prompt() returned" forced that timeout to
     // cover worst-case cold-start (image pull, container start, ready
     // probe), which routinely exceeds 30s and produced spurious
     // CONNECTION_TIMEOUT bubbles even when the runtime was healthy. Once
-    // the bubble fires, sicore tears down the SSE response and the
+    // the bubble fires, the management server tears down the SSE response and the
     // delayed reply (which still arrives later) is dropped — leaving a
     // ghost session in DB and a confused user.
     //
@@ -510,7 +510,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     res.end(JSON.stringify({ error: "Not found" }));
   });
 
-  // Runtime no longer accepts inbound WS connections — Portal/SiCore drive
+  // Runtime no longer accepts inbound WS connections — Portal / the management server drive
   // RPCs over the phone-home WS owned by FrontendWsClient. The HTTP server
   // here serves only /api/health and the internal mTLS endpoints.
   httpServer.keepAliveTimeout = 500;

--- a/src/lib/error-envelope.ts
+++ b/src/lib/error-envelope.ts
@@ -1,5 +1,5 @@
 // Error envelope — see docs/design/error-envelope.md.
-// Wire-compatible with sicore's pkg/model/response.go ErrorDetail.
+// Wire-compatible with the management server's ErrorDetail (pkg/model/response.go).
 
 export type ErrorDetail = {
   code: string;
@@ -13,7 +13,7 @@ export type ErrorDetail = {
 // REST body wrapper. SSE error frames carry ErrorDetail directly (event name discriminates).
 export type ErrorEnvelope = { error: ErrorDetail };
 
-// Codes mirror sicore ErrCode* where applicable, plus a few siclaw-specific ones.
+// Codes mirror the management server's ErrCode* where applicable, plus a few siclaw-specific ones.
 // Add new codes here only when actually emitted from code; see design doc §2.
 export const ErrorCodes = {
   INTERNAL: "INTERNAL_ERROR",

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -516,6 +516,19 @@ describe("credential.get", () => {
     ]);
   });
 
+  it("returns a managed credential: auth_type=managed + jump_host, no key/password file", async () => {
+    mockQuery(
+      [{ id: "t1", name: "target", ip: "10.0.0.9", port: 22, username: "ops", auth_type: "managed", password: null, private_key: null, passphrase: null, is_production: 1, description: null, jump_host_id: "b1" }],
+      [{ "1": 1 }],         // binding ok
+      [{ name: "bastion" }], // resolveJumpHostName
+    );
+    const result = await getHandler("credential.get")({ source: "host", source_id: "target" }, "agent-1");
+    expect(result.credential.type).toBe("ssh");
+    expect(result.credential.metadata.auth_type).toBe("managed");
+    expect(result.credential.metadata.jump_host).toBe("bastion");
+    expect(result.credential.files).toEqual([]);
+  });
+
   it("authorizes a jump host transitively when the agent is bound to a host that uses it", async () => {
     mockQuery(
       // 1) resolve the requested bastion host

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -65,7 +65,18 @@ async function resolveJumpHostName(db: Db, jumpHostId: string | null | undefined
  */
 async function buildHostSshCredential(db: Db, host: HostCredentialRow) {
   const files: { name: string; content: string; mode?: number }[] = [];
-  if (host.auth_type === "key") {
+  const jumpName = await resolveJumpHostName(db, host.jump_host_id);
+  if (host.auth_type === "managed") {
+    // Managed: no stored key/password — the key is sourced from the bastion at
+    // dial time. Requires a jump host. Optionally ship a passphrase for an
+    // encrypted bastion key.
+    if (!jumpName) {
+      throw new Error(`Host "${host.name}" has auth_type="managed" but no jump host configured`);
+    }
+    if (host.passphrase) {
+      files.push({ name: "host.passphrase", content: host.passphrase, mode: 0o600 });
+    }
+  } else if (host.auth_type === "key") {
     if (!host.private_key) {
       throw new Error(`Host "${host.name}" has auth_type="key" but private_key is empty`);
     }
@@ -81,7 +92,6 @@ async function buildHostSshCredential(db: Db, host: HostCredentialRow) {
   } else {
     throw new Error(`Host "${host.name}" has unknown auth_type=${JSON.stringify(host.auth_type)}`);
   }
-  const jumpName = await resolveJumpHostName(db, host.jump_host_id);
   return {
     name: host.name,
     type: "ssh" as const,

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -32,7 +32,7 @@ function jsonParam(value: unknown): string | null {
 // Shared by the HTTP routes (registerAdapterRoutes) and the WS-RPC handlers
 // (buildAdapterRpcHandlers) so the two transports can't drift.
 
-/** Mirrors sicore connector maxJumpDepth + ssh-client MAX_JUMP_DEPTH. */
+/** Matches ssh-client MAX_JUMP_DEPTH (target + up to 3 bastions). */
 const ADAPTER_MAX_JUMP_DEPTH = 3;
 
 interface HostCredentialRow {

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -474,7 +474,10 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
       hosts: hostRows
         .filter((h) =>
           (h.auth_type === "password" && typeof h.password === "string" && h.password.length > 0) ||
-          (h.auth_type === "key" && typeof h.private_key === "string" && h.private_key.length > 0),
+          (h.auth_type === "key" && typeof h.private_key === "string" && h.private_key.length > 0) ||
+          // Managed hosts carry no key/password of their own; they're usable as
+          // long as they have a jump host to source the key from.
+          (h.auth_type === "managed" && typeof h.jump_host_name === "string" && h.jump_host_name.length > 0),
         )
         .map((h) => ({
           name: h.name,
@@ -484,7 +487,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
           authType: h.auth_type,
           password: h.auth_type === "password" ? h.password : null,
           privateKey: h.auth_type === "key" ? h.private_key : null,
-          passphrase: h.auth_type === "key" ? h.passphrase : null,
+          passphrase: (h.auth_type === "key" || h.auth_type === "managed") ? h.passphrase : null,
           description: h.description,
           jumpHost: h.jump_host_name,
         })),

--- a/src/portal/host-api.test.ts
+++ b/src/portal/host-api.test.ts
@@ -279,6 +279,40 @@ describe("registerHostRoutes", () => {
     });
   });
 
+  describe("POST /api/v1/hosts/test-connection (unsaved form data)", () => {
+    it("tests a direct host from submitted form data", async () => {
+      dialSshChainMock.mockResolvedValueOnce({ client: {}, teardown: vi.fn() });
+      runCommandMock.mockResolvedValueOnce({ stdout: "ok\n", stderr: "", exitCode: 0 });
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/hosts/test-connection",
+        method: "POST",
+        body: { ip: "10.0.0.1", port: 22, username: "root", auth_type: "password", password: "pw" },
+      }));
+      expect(status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+
+    it("returns 400 without ip", async () => {
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/hosts/test-connection",
+        method: "POST",
+        body: { auth_type: "password", password: "pw" },
+      }));
+      expect(status).toBe(400);
+    });
+
+    it("rejects a managed test with no jump host", async () => {
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/hosts/test-connection",
+        method: "POST",
+        body: { ip: "10.0.0.9", auth_type: "managed" },
+      }));
+      expect(status).toBe(200);
+      expect(body.ok).toBe(false);
+      expect(body.message).toMatch(/managed.*requires a jump host/i);
+    });
+  });
+
   describe("validateJumpChain", () => {
     // Minimal fake db: each host id maps to its jump_host_id (or absent = not found).
     const chainDb = (map: Record<string, string | null>): any => ({

--- a/src/portal/host-api.test.ts
+++ b/src/portal/host-api.test.ts
@@ -139,6 +139,34 @@ describe("registerHostRoutes", () => {
       expect(insertArgs[11]).toBeNull(); // jump_host_id defaults to null
     });
 
+    it("rejects auth_type=managed without a jump_host_id (400)", async () => {
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/hosts",
+        method: "POST",
+        body: { name: "m", ip: "10.0.0.9", auth_type: "managed" },
+      }));
+      expect(status).toBe(400);
+      expect(body.error).toMatch(/managed.*requires a jump_host_id/i);
+    });
+
+    it("creates a managed host with a jump host (no secrets stored)", async () => {
+      query
+        .mockResolvedValueOnce([[{ jump_host_id: null }], []]) // validateJumpChain: bastion exists, no further jump
+        .mockResolvedValueOnce([undefined, []])                // INSERT
+        .mockResolvedValueOnce([[{ id: "h-m", name: "m" }], []]); // SELECT back
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/hosts",
+        method: "POST",
+        body: { name: "m", ip: "10.0.0.9", auth_type: "managed", jump_host_id: "bastion-id" },
+      }));
+      expect(status).toBe(201);
+      const insertArgs = query.mock.calls[1][1]; // calls[0] = validateJumpChain SELECT
+      expect(insertArgs[5]).toBe("managed");      // auth_type
+      expect(insertArgs[6]).toBeNull();           // password
+      expect(insertArgs[7]).toBeNull();           // private_key
+      expect(insertArgs[11]).toBe("bastion-id");  // jump_host_id
+    });
+
     it("never returns password or private_key in response", async () => {
       query
         .mockResolvedValueOnce([undefined, []])

--- a/src/portal/host-api.ts
+++ b/src/portal/host-api.ts
@@ -117,6 +117,59 @@ async function resolveHostDialChain(db: Db, startId: string): Promise<DialHop[]>
   return targetFirst.reverse();
 }
 
+interface HostFormBody {
+  ip?: string;
+  port?: number;
+  username?: string;
+  auth_type?: string;
+  password?: string;
+  private_key?: string;
+  passphrase?: string;
+  jump_host_id?: string | null;
+}
+
+/** Build the target DialHop from submitted (unsaved) form data. */
+function hopFromForm(b: HostFormBody): DialHop {
+  const host = b.ip ?? "";
+  const port = b.port ?? 22;
+  const username = b.username || "root";
+  const authType = b.auth_type || "password";
+  if (authType === "managed") {
+    return { host, port, username, auth: { managed: true, ...(b.passphrase ? { passphrase: b.passphrase } : {}) } };
+  }
+  if (authType === "key") {
+    if (!b.private_key) throw new Error('auth_type="key" requires a private_key to test');
+    return { host, port, username, auth: { privateKey: b.private_key, ...(b.passphrase ? { passphrase: b.passphrase } : {}) } };
+  }
+  if (!b.password) throw new Error('auth_type="password" requires a password to test');
+  return { host, port, username, auth: { password: b.password } };
+}
+
+/** Dial a resolved hop chain and run `echo ok`; never throws. */
+async function runConnectionTest(hops: DialHop[]): Promise<{ ok: boolean; message: string }> {
+  const timeoutMs = 10000;
+  let dialed;
+  try {
+    dialed = await dialSshChain(hops, { timeoutMs });
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+  try {
+    const result = await runCommand(dialed.client, "echo ok", { timeoutMs });
+    const ok = result.exitCode === 0 && result.stdout.trim() === "ok";
+    return {
+      ok,
+      message: ok
+        ? `SSH connection OK${hops.length > 1 ? ` (via ${hops.length - 1} jump host(s))` : ""}`
+        : `Unexpected probe result (exit ${result.exitCode}): ${result.stdout}${result.stderr}`.trim(),
+    };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  } finally {
+    dialed.teardown();
+  }
+}
+
 export function registerHostRoutes(router: RestRouter, jwtSecret: string, connectionMap: RuntimeConnectionMap): void {
   // GET /api/v1/hosts — list all (no secrets)
   router.get("/api/v1/hosts", async (req, res) => {
@@ -314,28 +367,36 @@ export function registerHostRoutes(router: RestRouter, jwtSecret: string, connec
       sendJson(res, 200, { ok: false, message: err instanceof Error ? err.message : String(err) });
       return;
     }
+    sendJson(res, 200, await runConnectionTest(hops));
+  });
 
-    const timeoutMs = 10000;
-    let dialed;
+  // POST /api/v1/hosts/test-connection — test using submitted (unsaved) form
+  // data, so an operator can validate what they typed before saving. The jump
+  // chain is resolved from saved hosts (jump_host_id); the target hop uses the
+  // inline credentials in the request.
+  router.post("/api/v1/hosts/test-connection", async (req, res) => {
+    const auth = requireAdmin(req, res, jwtSecret);
+    if (!auth) return;
+
+    const body = await parseBody<HostFormBody>(req);
+    if (!body.ip) {
+      sendJson(res, 400, { error: "ip is required" });
+      return;
+    }
+    if (body.auth_type === "managed" && !body.jump_host_id) {
+      sendJson(res, 200, { ok: false, message: 'auth_type="managed" requires a jump host' });
+      return;
+    }
+
+    const db = getDb();
+    let hops: DialHop[];
     try {
-      dialed = await dialSshChain(hops, { timeoutMs });
+      const jumpChain = body.jump_host_id ? await resolveHostDialChain(db, body.jump_host_id) : [];
+      hops = [...jumpChain, hopFromForm(body)];
     } catch (err) {
       sendJson(res, 200, { ok: false, message: err instanceof Error ? err.message : String(err) });
       return;
     }
-    try {
-      const result = await runCommand(dialed.client, "echo ok", { timeoutMs });
-      const ok = result.exitCode === 0 && result.stdout.trim() === "ok";
-      sendJson(res, 200, {
-        ok,
-        message: ok
-          ? `SSH connection OK${hops.length > 1 ? ` (via ${hops.length - 1} jump host(s))` : ""}`
-          : `Unexpected probe result (exit ${result.exitCode}): ${result.stdout}${result.stderr}`.trim(),
-      });
-    } catch (err) {
-      sendJson(res, 200, { ok: false, message: err instanceof Error ? err.message : String(err) });
-    } finally {
-      dialed.teardown();
-    }
+    sendJson(res, 200, await runConnectionTest(hops));
   });
 }

--- a/src/portal/host-api.ts
+++ b/src/portal/host-api.ts
@@ -64,6 +64,10 @@ interface ChainHostRow {
 }
 
 function hopFromDbRow(h: ChainHostRow): DialHop {
+  if (h.auth_type === "managed") {
+    // No stored key — ssh-dial sources it from the preceding hop (the bastion).
+    return { host: h.ip, port: h.port, username: h.username, auth: { managed: true, ...(h.passphrase ? { passphrase: h.passphrase } : {}) } };
+  }
   if (h.auth_type === "key") {
     if (!h.private_key) {
       throw new Error(`Host ${h.ip} has auth_type="key" but private_key is empty`);
@@ -153,6 +157,11 @@ export function registerHostRoutes(router: RestRouter, jwtSecret: string, connec
     const id = crypto.randomUUID();
     const db = getDb();
 
+    if (body.auth_type === "managed" && !body.jump_host_id) {
+      sendJson(res, 400, { error: 'auth_type="managed" requires a jump_host_id (the bastion that holds the key)' });
+      return;
+    }
+
     try {
       await validateJumpChain(db, id, body.jump_host_id);
     } catch (err) {
@@ -206,6 +215,14 @@ export function registerHostRoutes(router: RestRouter, jwtSecret: string, connec
 
     const body = await parseBody<Record<string, unknown>>(req);
     const db = getDb();
+
+    // When switching a host to managed, it must end up with a jump host. Reject
+    // the obvious "managed + clear jump" case; the runtime layers fail closed on
+    // any managed-without-jump that slips through.
+    if (body.auth_type === "managed" && "jump_host_id" in body && !body.jump_host_id) {
+      sendJson(res, 400, { error: 'auth_type="managed" requires a jump_host_id (the bastion that holds the key)' });
+      return;
+    }
 
     if ("jump_host_id" in body) {
       try {

--- a/src/shared/credential-types.ts
+++ b/src/shared/credential-types.ts
@@ -39,7 +39,12 @@ export interface HostMeta {
   ip: string;
   port: number;
   username: string;
-  auth_type: "password" | "key";
+  /**
+   * "managed" = the target stores no credential of its own; the last hop
+   * authenticates with a private key discovered on the jump host (bastion).
+   * Requires jump_host. See ADR-013.
+   */
+  auth_type: "password" | "key" | "managed";
   is_production: boolean;
   /**
    * Name of the next-hop jump host (bastion), if this host is reached through a

--- a/src/tools/infra/ssh-client.test.ts
+++ b/src/tools/infra/ssh-client.test.ts
@@ -169,6 +169,13 @@ function keyInfo(name: string, ip: string, jumpHost?: string, extraFiles: string
   } as HostLocalInfo;
 }
 
+function managedInfo(name: string, ip: string, jumpHost?: string, filePaths: string[] = []): HostLocalInfo {
+  return {
+    meta: { name, ip, port: 22, username: "ops", auth_type: "managed", is_production: false, ...(jumpHost ? { jump_host: jumpHost } : {}) },
+    filePaths,
+  } as HostLocalInfo;
+}
+
 describe("acquireSshTarget", () => {
   it("throws when broker is undefined", async () => {
     await expect(acquireSshTarget(undefined, "host-1", "test"))
@@ -268,6 +275,30 @@ describe("acquireSshTarget", () => {
       e: keyInfo("e", "10.0.0.5"),
     });
     await expect(acquireSshTarget(broker, "a", "test")).rejects.toThrow(/max depth/);
+  });
+
+  it("builds a managed target (no files) with its bastion, skipping the no-files check", async () => {
+    const broker = makeMultiBrokerStub({
+      target: managedInfo("target", "10.0.0.9", "bastion"),  // zero files
+      bastion: keyInfo("bastion", "10.0.0.1"),
+    });
+    const t = await acquireSshTarget(broker, "target", "test");
+    expect(t.auth).toEqual({ type: "managed" });
+    expect(t.jumpHost?.host).toBe("10.0.0.1");
+  });
+
+  it("wires a passphrasePath for a managed target when a .passphrase file is shipped", async () => {
+    const broker = makeMultiBrokerStub({
+      target: managedInfo("target", "10.0.0.9", "bastion", ["/tmp/target.host.passphrase"]),
+      bastion: keyInfo("bastion", "10.0.0.1"),
+    });
+    const t = await acquireSshTarget(broker, "target", "test");
+    expect(t.auth).toEqual({ type: "managed", passphrasePath: "/tmp/target.host.passphrase" });
+  });
+
+  it("throws when a managed host has no jump host", async () => {
+    const broker = makeMultiBrokerStub({ target: managedInfo("target", "10.0.0.9") });
+    await expect(acquireSshTarget(broker, "target", "test")).rejects.toThrow(/requires a jump host/);
   });
 });
 

--- a/src/tools/infra/ssh-client.ts
+++ b/src/tools/infra/ssh-client.ts
@@ -41,7 +41,10 @@ export interface SshTarget {
   username: string;
   auth:
     | { type: "key"; privateKeyPath: string; passphrasePath?: string }
-    | { type: "password"; passwordPath: string };
+    | { type: "password"; passwordPath: string }
+    // "managed": no stored credential; the key is discovered on jumpHost at
+    // dial time. Requires jumpHost to be set.
+    | { type: "managed"; passphrasePath?: string };
   /** Next hop toward this target (the bastion), when reached via ProxyJump. */
   jumpHost?: SshTarget;
 }
@@ -89,23 +92,35 @@ async function acquireSshTargetInner(
   if (!info) {
     throw new Error(`Host "${hostName}" not loaded into broker registry after ensureHost`);
   }
-  if (!info.filePaths || info.filePaths.length === 0) {
-    throw new Error(`Host "${hostName}" has no materialized credential file`);
-  }
 
   const meta = info.meta;
-  const wantedSuffix = meta.auth_type === "key" ? ".key" : ".password";
-  const credPath = info.filePaths.find((p) => p.endsWith(wantedSuffix));
-  if (!credPath) {
-    throw new Error(`Host "${hostName}" credential file with suffix ${wantedSuffix} not found`);
-  }
+  const filePaths = info.filePaths ?? [];
 
   let auth: SshTarget["auth"];
-  if (meta.auth_type === "key") {
-    const passphrasePath = info.filePaths.find((p) => p.endsWith(".passphrase"));
-    auth = { type: "key", privateKeyPath: credPath, ...(passphrasePath ? { passphrasePath } : {}) };
+  if (meta.auth_type === "managed") {
+    // Managed hosts store no key/password of their own — the key is sourced
+    // from the bastion at dial time, so they require a jump host and may have
+    // zero materialized files (or just a .passphrase for the bastion key).
+    if (!meta.jump_host) {
+      throw new Error(`Managed host "${hostName}" requires a jump host`);
+    }
+    const passphrasePath = filePaths.find((p) => p.endsWith(".passphrase"));
+    auth = { type: "managed", ...(passphrasePath ? { passphrasePath } : {}) };
   } else {
-    auth = { type: "password", passwordPath: credPath };
+    if (filePaths.length === 0) {
+      throw new Error(`Host "${hostName}" has no materialized credential file`);
+    }
+    const wantedSuffix = meta.auth_type === "key" ? ".key" : ".password";
+    const credPath = filePaths.find((p) => p.endsWith(wantedSuffix));
+    if (!credPath) {
+      throw new Error(`Host "${hostName}" credential file with suffix ${wantedSuffix} not found`);
+    }
+    if (meta.auth_type === "key") {
+      const passphrasePath = filePaths.find((p) => p.endsWith(".passphrase"));
+      auth = { type: "key", privateKeyPath: credPath, ...(passphrasePath ? { passphrasePath } : {}) };
+    } else {
+      auth = { type: "password", passwordPath: credPath };
+    }
   }
 
   const target: SshTarget = { host: meta.ip, port: meta.port, username: meta.username, auth };
@@ -166,6 +181,16 @@ async function targetToHops(target: SshTarget): Promise<DialHop[]> {
 }
 
 async function hopFromTarget(t: SshTarget): Promise<DialHop> {
+  if (t.auth.type === "managed") {
+    let passphrase: string | undefined;
+    if (t.auth.passphrasePath) {
+      const buf = await fsp.readFile(t.auth.passphrasePath);
+      passphrase = buf.toString("utf8").replace(/\s+$/u, "");
+      buf.fill(0);
+    }
+    // No key/password read here — ssh-dial sources the key from the bastion.
+    return { host: t.host, port: t.port, username: t.username, auth: { managed: true, ...(passphrase ? { passphrase } : {}) } };
+  }
   if (t.auth.type === "key") {
     const privateKey = await fsp.readFile(t.auth.privateKeyPath);
     let passphrase: string | undefined;

--- a/src/tools/infra/ssh-client.ts
+++ b/src/tools/infra/ssh-client.ts
@@ -30,7 +30,7 @@ import {
   type SshRunOptions,
 } from "./ssh-dial.js";
 
-/** Mirrors sicore connector maxJumpDepth — caps a target + up to 3 bastions. */
+/** Caps a target + up to 3 bastions. */
 const MAX_JUMP_DEPTH = 3;
 
 // ── Types ───────────────────────────────────────────────────────────

--- a/src/tools/infra/ssh-dial.test.ts
+++ b/src/tools/infra/ssh-dial.test.ts
@@ -34,6 +34,8 @@ const { MockClient, mockState } = vi.hoisted(() => {
     endOrder: [] as string[],
     forwardFail: false,
     connectFailLabel: "" as string,
+    managedKey: "MANAGED-KEY-FROM-BASTION",
+    managedFetchExit: 0,
   };
 
   class MockStream extends TinyEmitter {
@@ -44,17 +46,27 @@ const { MockClient, mockState } = vi.hoisted(() => {
   class MockClient extends TinyEmitter {
     label = "";
     sock: any = undefined;
+    privateKey: any = undefined;
     end = () => { state.endOrder.push(this.label); };
     forwardOut(_sip: string, _sport: number, _dip: string, _dport: number, cb: (err: Error | null, stream?: any) => void): void {
       if (state.forwardFail) { cb(new Error("forward denied")); return; }
       cb(null, new TinyEmitter() as any);
     }
-    exec(_cmd: string, cb: (err: Error | null, stream?: MockStream) => void): void {
-      cb(null, new MockStream());
+    exec(cmd: string, cb: (err: Error | null, stream?: MockStream) => void): void {
+      const stream = new MockStream();
+      cb(null, stream);
+      // Auto-respond to the managed key-fetch one-liner.
+      if (cmd.includes("$HOME/.ssh")) {
+        setImmediate(() => {
+          if (state.managedFetchExit === 0) stream.emit("data", Buffer.from(state.managedKey));
+          stream.emit("close", state.managedFetchExit);
+        });
+      }
     }
     connect(config: any): void {
       this.label = `${config.host}:${config.port}`;
       this.sock = config.sock;
+      this.privateKey = config.privateKey;
       state.instances.push(this);
       setImmediate(() => {
         if (state.connectFailLabel && this.label === state.connectFailLabel) {
@@ -78,10 +90,16 @@ beforeEach(() => {
   mockState.endOrder = [];
   mockState.forwardFail = false;
   mockState.connectFailLabel = "";
+  mockState.managedKey = "MANAGED-KEY-FROM-BASTION";
+  mockState.managedFetchExit = 0;
 });
 
 function hop(host: string, port = 22): DialHop {
   return { host, port, username: "root", auth: { privateKey: "KEY" } };
+}
+
+function managedHop(host: string, port = 22): DialHop {
+  return { host, port, username: "root", auth: { managed: true } };
 }
 
 describe("dialSshChain", () => {
@@ -125,6 +143,32 @@ describe("dialSshChain", () => {
 
   it("rejects empty chains", async () => {
     await expect(dialSshChain([], { timeoutMs: 5000 })).rejects.toThrow(/empty hop chain/);
+  });
+});
+
+describe("dialSshChain — managed target", () => {
+  it("fetches the key off the bastion and dials the target with it", async () => {
+    const { client, teardown } = await dialSshChain(
+      [hop("10.0.0.1"), managedHop("10.0.0.9")],
+      { timeoutMs: 5000 },
+    );
+    expect(client.label).toBe("10.0.0.9:22");
+    // The target hop was connected with the key fetched from the bastion.
+    const target = mockState.instances.find((c) => c.label === "10.0.0.9:22");
+    expect(target.privateKey).toBeInstanceOf(Buffer);
+    expect(target.privateKey.toString()).toBe("MANAGED-KEY-FROM-BASTION");
+    teardown();
+  });
+
+  it("rejects a managed target with no jump host", async () => {
+    await expect(dialSshChain([managedHop("10.0.0.9")], { timeoutMs: 5000 }))
+      .rejects.toThrow(/managed target requires a jump host/);
+  });
+
+  it("rejects with an actionable error when no readable key is on the bastion", async () => {
+    mockState.managedFetchExit = 3;
+    await expect(dialSshChain([hop("10.0.0.1"), managedHop("10.0.0.9")], { timeoutMs: 5000 }))
+      .rejects.toThrow(/managed key fetch from 10\.0\.0\.1 failed: no readable SSH private key/);
   });
 });
 

--- a/src/tools/infra/ssh-dial.ts
+++ b/src/tools/infra/ssh-dial.ts
@@ -31,7 +31,11 @@ import { Client, type ConnectConfig } from "ssh2";
 
 export type DialHopAuth =
   | { privateKey: Buffer | string; passphrase?: string }
-  | { password: string };
+  | { password: string }
+  // "managed": this hop has no credential of its own; its private key is
+  // discovered on the PREVIOUS hop (the bastion) at dial time. Only valid for a
+  // hop that has a preceding hop. See ADR-013.
+  | { managed: true; passphrase?: string };
 
 export interface DialHop {
   host: string;
@@ -87,9 +91,55 @@ export function makeHostVerifier(host: string, port: number): (key: Buffer, cb: 
   };
 }
 
+// ── Managed-target key discovery (mirrors sicore managed_jump.go) ───
+
+/**
+ * Shell one-liner run on the bastion to emit the first readable standard SSH
+ * private key. Mirrors sicore's candidate list. Exits 3 if none is readable.
+ */
+const MANAGED_KEY_FETCH_CMD =
+  'for k in "$HOME/.ssh/id_ed25519" "$HOME/.ssh/id_rsa" "$HOME/.ssh/id_ecdsa" "$HOME/.ssh/id_dsa"; ' +
+  'do [ -r "$k" ] && { cat "$k"; exit 0; }; done; exit 3';
+
+/**
+ * Fetch a managed target's private key by reading it off the already-connected
+ * bastion client. The key bytes transit the agentbox memory (this is the
+ * inherent "managed" tradeoff — see ADR-013).
+ */
+function fetchManagedKeyFromJump(jump: Client, timeoutMs: number): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("timed out fetching managed key from jump host"));
+    }, timeoutMs);
+    jump.exec(MANAGED_KEY_FETCH_CMD, (err, stream) => {
+      if (err) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+        return;
+      }
+      const chunks: Buffer[] = [];
+      stream.on("data", (c: Buffer) => chunks.push(c));
+      stream.stderr.on("data", () => { /* discard */ });
+      stream.on("close", (code: number | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        const key = Buffer.concat(chunks);
+        if (code === 0 && key.length > 0) resolve(key);
+        else reject(new Error("no readable SSH private key found on jump host (~/.ssh/id_{ed25519,rsa,ecdsa,dsa})"));
+      });
+    });
+  });
+}
+
 // ── Internal: ssh2 ConnectConfig for one hop ────────────────────────
 
-function buildHopConfig(hop: DialHop, timeoutMs: number, sock?: Duplex): ConnectConfig {
+function buildHopConfig(hop: DialHop, timeoutMs: number, sock?: Duplex, managedKey?: Buffer): ConnectConfig {
   const config: ConnectConfig = {
     host: hop.host,
     port: hop.port,
@@ -100,7 +150,13 @@ function buildHopConfig(hop: DialHop, timeoutMs: number, sock?: Duplex): Connect
     hostVerifier: makeHostVerifier(hop.host, hop.port),
   };
   if (sock) config.sock = sock;
-  if ("privateKey" in hop.auth) {
+  if ("managed" in hop.auth) {
+    if (!managedKey) {
+      throw new Error(`managed hop ${hop.host}:${hop.port} has no key fetched from the jump host`);
+    }
+    config.privateKey = managedKey;
+    if (hop.auth.passphrase) config.passphrase = hop.auth.passphrase;
+  } else if ("privateKey" in hop.auth) {
     config.privateKey = hop.auth.privateKey;
     if (hop.auth.passphrase) config.passphrase = hop.auth.passphrase;
   } else {
@@ -129,6 +185,9 @@ export interface DialedChain {
 export function dialSshChain(hops: DialHop[], opts: { timeoutMs: number; signal?: AbortSignal }): Promise<DialedChain> {
   if (hops.length === 0) {
     return Promise.reject(new Error("dialSshChain: empty hop chain"));
+  }
+  if ("managed" in hops[0].auth) {
+    return Promise.reject(new Error("managed target requires a jump host (no bastion to source the key from)"));
   }
 
   const clients: Client[] = [];
@@ -169,7 +228,7 @@ export function dialSshChain(hops: DialHop[], opts: { timeoutMs: number; signal?
       opts.timeoutMs,
     );
 
-    const connectHop = (index: number, sock?: Duplex) => {
+    const connectHop = (index: number, sock?: Duplex, managedKey?: Buffer) => {
       const hop = hops[index];
       const client = new Client();
       clients.push(client);
@@ -188,13 +247,22 @@ export function dialSshChain(hops: DialHop[], opts: { timeoutMs: number; signal?
             fail(new Error(`forwardOut from ${hop.host} to ${next.host}:${next.port} failed: ${err.message}`));
             return;
           }
-          connectHop(index + 1, stream as unknown as Duplex);
+          const dialNext = (mk?: Buffer) => connectHop(index + 1, stream as unknown as Duplex, mk);
+          if ("managed" in next.auth) {
+            // Source the managed target's key from THIS hop (the bastion) before
+            // dialing it through the freshly-opened tunnel.
+            fetchManagedKeyFromJump(client, opts.timeoutMs)
+              .then(dialNext)
+              .catch((e) => fail(new Error(`managed key fetch from ${hop.host} failed: ${e instanceof Error ? e.message : String(e)}`)));
+          } else {
+            dialNext();
+          }
         });
       });
 
       let config: ConnectConfig;
       try {
-        config = buildHopConfig(hop, opts.timeoutMs, sock);
+        config = buildHopConfig(hop, opts.timeoutMs, sock, managedKey);
       } catch (err) {
         fail(err instanceof Error ? err : new Error(String(err)));
         return;

--- a/src/tools/infra/ssh-dial.ts
+++ b/src/tools/infra/ssh-dial.ts
@@ -91,11 +91,11 @@ export function makeHostVerifier(host: string, port: number): (key: Buffer, cb: 
   };
 }
 
-// ── Managed-target key discovery (mirrors sicore managed_jump.go) ───
+// ── Managed-target key discovery ───────────────────────────────────
 
 /**
  * Shell one-liner run on the bastion to emit the first readable standard SSH
- * private key. Mirrors sicore's candidate list. Exits 3 if none is readable.
+ * private key (standard SSH key locations). Exits 3 if none is readable.
  */
 const MANAGED_KEY_FETCH_CMD =
   'for k in "$HOME/.ssh/id_ed25519" "$HOME/.ssh/id_rsa" "$HOME/.ssh/id_ecdsa" "$HOME/.ssh/id_dsa"; ' +


### PR DESCRIPTION
## Summary

Stacked on #293. Adds the **managed** target-auth form (target stores no
credential; the final hop uses a key discovered on the bastion), a **Test
Connection** action for unsaved host forms, and removes all `sicore` references
from the public repo.

> Base is `feat/ssh-jump-host` (#293) — review/merge that first; this shows only
> the 3 commits on top.

### What's in it
- **`feat(tools)` managed jump-host auth** — `auth_type="managed"`: no stored
  credential; `ssh-dial` reads the first readable `~/.ssh/id_*` off the bastion
  and dials the target through the tunnel (target username + optional passphrase).
  Requires a jump host; fails closed without one at write/boundary/acquire/dial.
  Spans shared types, ssh-dial, ssh-client, broker, adapter + cli-snapshot, host-api,
  Hosts.tsx UI. **Tradeoff documented in ADR-013** (the key lives on the bastion and
  is not broker-materialized) — reverses ADR-013's earlier exclusion by product decision.
- **`feat(portal)` connection testing from unsaved form data** — `POST
  /api/v1/hosts/test-connection` dials using the submitted fields (jump chain
  resolved from saved hosts) so operators validate before saving; "Test Connection"
  button on the create/edit forms. Existing `/:id/test` refactored to share the path.
- **`chore` remove `sicore` references** — genericized ~40 mentions across docs,
  helm values, and comments to "management server"/"upstream". `git grep -i sicore` = 0.
  No behavior change.

## Test Plan
- [x] `npm test` 3157 passed; backend + portal-web `tsc` clean
- [x] New unit tests: ssh-dial managed (key fetch / no-bastion / unreadable-key),
      ssh-client managed acquire, host-api managed validation + test-connection,
      broker accepts/rejects managed, adapter emits managed
- [ ] Manual: create a managed host (jump = a bastion with a key in `~/.ssh`,
      pubkey in the target's `authorized_keys`), hit Test Connection → OK, then
      `host_exec` via a bound agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
