### PR TITLE
feat(tools): host_list query + pagination

### DIFF
--- a/src/agentbox/credential-broker.test.ts
+++ b/src/agentbox/credential-broker.test.ts
@@ -8,6 +8,7 @@ import type {
   ClusterMeta,
   HostMeta,
   CredentialPayload,
+  HostListResult,
 } from "./credential-transport.js";
 
 /**
@@ -36,6 +37,12 @@ class FakeTransport implements CredentialTransport {
     const p = this.hostPayloads.get(name);
     if (!p) throw new Error(`no host payload for ${name}`);
     return Promise.resolve(p);
+  }
+  queryResult: HostListResult = { hosts: [], total: 0, next_cursor: null };
+  queryHostsCalls: Array<{ query: string; opts?: { limit?: number; cursor?: string } }> = [];
+  queryHosts(query: string, opts?: { limit?: number; cursor?: string }): Promise<HostListResult> {
+    this.queryHostsCalls.push({ query, opts });
+    return Promise.resolve(this.queryResult);
   }
 }
 
@@ -348,5 +355,20 @@ describe("CredentialBroker — sync read + refresh API", () => {
     await broker.refreshHosts();
     await broker.refreshHosts();
     expect(transport.listHostsCalls - baseline).toBe(2);
+  });
+
+  it("queryHosts passes through to the transport without touching the registry (no reconcile)", async () => {
+    transport.queryResult = {
+      hosts: [{ name: "gpu-1", ip: "10.0.0.9", port: 22, username: "root", auth_type: "key", is_production: true }],
+      total: 1,
+      next_cursor: null,
+    };
+    const result = await broker.queryHosts("gpu", { limit: 10 });
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].name).toBe("gpu-1");
+    expect(result.total).toBe(1);
+    expect(transport.queryHostsCalls).toEqual([{ query: "gpu", opts: { limit: 10 } }]);
+    // No reconcile / no caching — the registry stays empty (full-snapshot contract intact).
+    expect(broker.listHostsLocalInfo()).toHaveLength(0);
   });
 });

--- a/src/agentbox/credential-broker.ts
+++ b/src/agentbox/credential-broker.ts
@@ -34,9 +34,10 @@ import type {
   ClusterMeta,
   HostMeta,
   CredentialPayload,
+  HostListResult,
 } from "./credential-transport.js";
 
-export type { ClusterMeta, HostMeta, CredentialPayload };
+export type { ClusterMeta, HostMeta, CredentialPayload, HostListResult };
 
 export interface CredentialFile {
   name: string;
@@ -431,6 +432,16 @@ export class CredentialBroker {
   /** Synchronous read of the host metadata Map. Empty if never refreshed. */
   getHostsLocal(): HostMeta[] {
     return this.hosts.list().map((info) => info.meta);
+  }
+
+  /**
+   * Filtered + paginated host_list (name/ip/description). Bypasses the registry
+   * entirely — does NOT reconcile or cache — so it can't violate the full-snapshot
+   * contract of refreshHosts/reconcileFullList. Used by the host_list tool
+   * (metadata only, no credentials).
+   */
+  async queryHosts(query: string, opts?: { limit?: number; cursor?: string }): Promise<HostListResult> {
+    return this.transport.queryHosts(query, opts);
   }
 
   /** true once refreshHosts() has succeeded at least once. */

--- a/src/agentbox/credential-transport.ts
+++ b/src/agentbox/credential-transport.ts
@@ -12,13 +12,21 @@ import type {
   ClusterMeta,
   HostMeta,
   CredentialPayload,
+  HostListResult,
 } from "../shared/credential-types.js";
 
-export type { ClusterMeta, HostMeta, CredentialPayload };
+export type { ClusterMeta, HostMeta, CredentialPayload, HostListResult };
 
 export interface CredentialTransport {
   listClusters(): Promise<ClusterMeta[]>;
   listHosts(): Promise<HostMeta[]>;
+  /**
+   * Filtered + paginated host_list (name/ip/description), agent-scoped. Distinct
+   * from listHosts: returns a FILTERED subset, so the broker must NOT feed it to
+   * reconcileFullList (which requires a full snapshot). Hits the same
+   * `credential-list` RPC as listHosts, with a `query`.
+   */
+  queryHosts(query: string, opts?: { limit?: number; cursor?: string }): Promise<HostListResult>;
   getClusterCredential(name: string, purpose: string): Promise<CredentialPayload>;
   getHostCredential(name: string, purpose: string): Promise<CredentialPayload>;
 }
@@ -56,6 +64,27 @@ export class HttpTransport implements CredentialTransport {
       throw new Error("Gateway returned malformed credential-list (host) response");
     }
     return res.hosts;
+  }
+
+  async queryHosts(query: string, opts?: { limit?: number; cursor?: string }): Promise<HostListResult> {
+    const res = await this.client.request(
+      "/api/internal/credential-list",
+      "POST",
+      {
+        kind: "host",
+        query,
+        ...(opts?.limit != null ? { limit: opts.limit } : {}),
+        ...(opts?.cursor != null ? { cursor: opts.cursor } : {}),
+      },
+    ) as Partial<HostListResult>;
+    if (!Array.isArray(res.hosts)) {
+      throw new Error("Gateway returned malformed credential-list (host search) response");
+    }
+    return {
+      hosts: res.hosts,
+      total: typeof res.total === "number" ? res.total : res.hosts.length,
+      next_cursor: res.next_cursor ?? null,
+    };
   }
 
   async getClusterCredential(name: string, purpose: string): Promise<CredentialPayload> {

--- a/src/gateway/credential-proxy.test.ts
+++ b/src/gateway/credential-proxy.test.ts
@@ -53,6 +53,7 @@ class FakeService {
   getHostCredential = vi.fn();
   listClusters = vi.fn();
   listHosts = vi.fn();
+  queryHosts = vi.fn();
 }
 
 let service: FakeService;
@@ -176,6 +177,28 @@ describe("handleCredentialList", () => {
     await handleCredentialList(asHttpReq(req), asHttpRes(res), goodIdentity, service as unknown as CredentialService);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).hosts).toHaveLength(1);
+  });
+
+  it("routes a host list WITH a query to queryHosts (filtered path), not listHosts", async () => {
+    service.queryHosts.mockResolvedValue({ hosts: [{ name: "gpu-1", ip: "10.0.0.9", port: 22, username: "root", auth_type: "key", is_production: true }], total: 1, next_cursor: null });
+    const req = new FakeReq(JSON.stringify({ kind: "host", query: "gpu", limit: 10 }));
+    const res = new FakeRes();
+    await handleCredentialList(asHttpReq(req), asHttpRes(res), goodIdentity, service as unknown as CredentialService);
+    expect(res.statusCode).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.hosts).toHaveLength(1);
+    expect(parsed.total).toBe(1);
+    expect(service.queryHosts).toHaveBeenCalledWith(expect.objectContaining({ agentId: "a1" }), "gpu", expect.objectContaining({ limit: 10 }));
+    expect(service.listHosts).not.toHaveBeenCalled();
+  });
+
+  it("routes a host list WITHOUT a query to the full listHosts path", async () => {
+    service.listHosts.mockResolvedValue([]);
+    const req = new FakeReq(JSON.stringify({ kind: "host" }));
+    const res = new FakeRes();
+    await handleCredentialList(asHttpReq(req), asHttpRes(res), goodIdentity, service as unknown as CredentialService);
+    expect(service.listHosts).toHaveBeenCalled();
+    expect(service.queryHosts).not.toHaveBeenCalled();
   });
 
   it("400 when kind is unsupported", async () => {

--- a/src/gateway/credential-proxy.ts
+++ b/src/gateway/credential-proxy.ts
@@ -25,6 +25,10 @@ interface CredentialRequestBody {
 interface CredentialListBody {
   kind?: string;
   session_id?: string;
+  /** Host search (kind="host"): server-side filter + pagination. Absent = full list. */
+  query?: string;
+  limit?: number;
+  cursor?: string;
 }
 
 // Keep identity fields to a safe charset before they land in SQL params or
@@ -144,8 +148,16 @@ export async function handleCredentialList(
       const clusters = await service.listClusters(id);
       sendJson(res, 200, { clusters });
     } else {
-      const hosts = await service.listHosts(id);
-      sendJson(res, 200, { hosts });
+      // A `query` (even "") routes to the filtered/paginated search (no full
+      // snapshot); its absence keeps the full-list path the broker's reconcile
+      // depends on.
+      if (typeof body.query === "string") {
+        const result = await service.queryHosts(id, body.query, { limit: body.limit, cursor: body.cursor });
+        sendJson(res, 200, result);
+      } else {
+        const hosts = await service.listHosts(id);
+        sendJson(res, 200, { hosts });
+      }
     }
   } catch (err) {
     if (err instanceof SessionOwnershipError) {

--- a/src/gateway/credential-service.ts
+++ b/src/gateway/credential-service.ts
@@ -12,6 +12,7 @@ import type {
   ClusterMeta,
   HostMeta,
   CredentialPayload,
+  HostListResult,
 } from "../shared/credential-types.js";
 import { sessionRegistry, type SessionRegistry } from "./session-registry.js";
 
@@ -73,6 +74,29 @@ export class CredentialService {
       throw new Error("Adapter credential-list returned malformed host list response");
     }
     return data.hosts;
+  }
+
+  /** Filtered + paginated host_list (name/ip/description), agent-scoped. Hits the
+   *  same `credential.list` RPC as listHosts, with a `query` — returns a FILTERED
+   *  subset, not a full snapshot. */
+  async queryHosts(identity: Identity, query: string, opts?: { limit?: number; cursor?: string }): Promise<HostListResult> {
+    const data = await this.frontendClient.request(
+      "credential.list",
+      await this.rpcParams(identity, {
+        kind: "host",
+        query,
+        ...(opts?.limit != null ? { limit: opts.limit } : {}),
+        ...(opts?.cursor != null ? { cursor: opts.cursor } : {}),
+      }),
+    ) as Partial<HostListResult>;
+    if (!Array.isArray(data.hosts)) {
+      throw new Error("Adapter credential-list returned malformed host search response");
+    }
+    return {
+      hosts: data.hosts,
+      total: typeof data.total === "number" ? data.total : data.hosts.length,
+      next_cursor: data.next_cursor ?? null,
+    };
   }
 
   async getClusterCredential(identity: Identity, clusterName: string, purpose: string): Promise<CredentialPayload> {

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -428,6 +428,55 @@ describe("credential.list", () => {
       getHandler("credential.list")({}, ""),
     ).rejects.toThrow("agentId required");
   });
+
+  // ── host query path (host_list with a query) ──
+  it("host query: filters, paginates, returns id + total + next_cursor", async () => {
+    const q = mockQuery(
+      [{ n: 137 }], // COUNT(*)
+      [{ id: "h1", name: "gpu-1", ip: "10.0.0.9", port: 22, username: "root", auth_type: "key", is_production: 1, description: "x", jump_host_name: "bastion" }],
+    );
+    const result = await getHandler("credential.list")({ kind: "host", query: "gpu", limit: 1 }, "agent-1");
+    expect(result.hosts).toEqual([
+      { id: "h1", name: "gpu-1", ip: "10.0.0.9", port: 22, username: "root", auth_type: "key", is_production: true, description: "x", jump_host: "bastion" },
+    ]);
+    expect(result.total).toBe(137);
+    expect(result.next_cursor).toBe("1"); // offset 0 + limit 1 < 137
+    const selectSql = q.mock.calls[1][0];
+    expect(selectSql).toContain("LIMIT 1 OFFSET 0");
+    expect(selectSql).toContain("LIKE");
+  });
+
+  it("host query: limit defaults to 20 and caps at 100", async () => {
+    const q1 = mockQuery([{ n: 0 }], []);
+    await getHandler("credential.list")({ kind: "host", query: "x" }, "a1");
+    expect(q1.mock.calls[1][0]).toContain("LIMIT 20 OFFSET 0");
+    const q2 = mockQuery([{ n: 0 }], []);
+    await getHandler("credential.list")({ kind: "host", query: "x", limit: 9999 }, "a1");
+    expect(q2.mock.calls[1][0]).toContain("LIMIT 100");
+  });
+
+  it("host query: an IPv4 query matches ip exactly (no LIKE)", async () => {
+    const q = mockQuery([{ n: 1 }], [{ id: "h1", name: "n", ip: "10.0.0.5", port: 22, username: "root", auth_type: "key", is_production: 1, description: null, jump_host_name: null }]);
+    await getHandler("credential.list")({ kind: "host", query: "10.0.0.5" }, "a1");
+    const selectSql = q.mock.calls[1][0];
+    expect(selectSql).toContain("h.ip = ?");
+    expect(selectSql).not.toContain("LIKE");
+    expect(q.mock.calls[1][1]).toEqual(["a1", "10.0.0.5"]); // agentId + exact ip
+  });
+
+  it("host query: an empty query browses (paginated, no filter)", async () => {
+    const q = mockQuery([{ n: 2 }], [
+      { id: "h1", name: "a", ip: "10.0.0.1", port: 22, username: "root", auth_type: "key", is_production: 1, description: null, jump_host_name: null },
+      { id: "h2", name: "b", ip: "10.0.0.2", port: 22, username: "root", auth_type: "key", is_production: 0, description: null, jump_host_name: null },
+    ]);
+    const result = await getHandler("credential.list")({ kind: "host", query: "" }, "a1");
+    expect(result.hosts).toHaveLength(2);
+    expect(result.total).toBe(2);
+    expect(result.next_cursor).toBeNull(); // 0 + 2 == total
+    const selectSql = q.mock.calls[1][0];
+    expect(selectSql).not.toContain("LIKE");
+    expect(selectSql).toContain("WHERE ah.agent_id = ?");
+  });
 });
 
 describe("credential.get", () => {
@@ -690,6 +739,7 @@ describe("credential.hostSearch", () => {
     expect(query.mock.calls[0][0]).toContain("FROM hosts");
     expect(query.mock.calls[0][0]).not.toContain("agent_hosts");
   });
+
 });
 
 // ================================================================

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1787,21 +1787,64 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     if (!agentId) throw new Error("agentId required");
     const db = getDb();
     if (params.kind === "host" || params.kind === "hosts") {
+      const fromHost = "FROM agent_hosts ah JOIN hosts h ON ah.host_id = h.id LEFT JOIN hosts hj ON h.jump_host_id = hj.id";
+      // No `query` field → full snapshot (the broker's reconcileFullList depends
+      // on this). A `query` (even "") → server-side filtered + paginated browse.
+      if (typeof params.query !== "string") {
+        const [rows] = await db.query(
+          `SELECT h.name, h.ip, h.port, h.username, h.auth_type, h.is_production, h.description, hj.name AS jump_host_name
+           ${fromHost} WHERE ah.agent_id = ?`,
+          [agentId],
+        ) as any;
+        return {
+          hosts: rows.map((r: any) => ({
+            name: r.name, ip: r.ip, port: r.port, username: r.username,
+            auth_type: r.auth_type, is_production: !!r.is_production,
+            ...(r.description ? { description: r.description } : {}),
+            ...(r.jump_host_name ? { jump_host: r.jump_host_name } : {}),
+          })),
+        };
+      }
+
+      // Filtered + paginated host_list (metadata only; never secrets). limit
+      // default 20 / max 100; offset from an opaque numeric cursor. Both are
+      // clamped integers → safe to inline (avoids a bound-param-in-LIMIT quirk).
+      const q = (params.query as string).trim();
+      const rawLimit = Number(params.limit);
+      const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.floor(rawLimit), 100) : 20;
+      const rawOffset = Number(params.cursor);
+      const offset = Number.isFinite(rawOffset) && rawOffset > 0 ? Math.floor(rawOffset) : 0;
+      // IP smart-match: an IPv4-looking query matches h.ip exactly (so "10.0.0.5"
+      // doesn't substring-hit "10.0.0.51"); else substring over name/ip/description.
+      const isIpv4 = /^\d{1,3}(?:\.\d{1,3}){3}$/.test(q);
+      const conds = ["ah.agent_id = ?"];
+      const whereParams: unknown[] = [agentId];
+      if (q) {
+        if (isIpv4) {
+          conds.push("h.ip = ?");
+          whereParams.push(q);
+        } else {
+          conds.push("(h.name LIKE ? OR h.ip LIKE ? OR h.description LIKE ?)");
+          whereParams.push(`%${q}%`, `%${q}%`, `%${q}%`);
+        }
+      }
+      const where = ` WHERE ${conds.join(" AND ")}`;
+      const [countRows] = await db.query(`SELECT COUNT(*) AS n ${fromHost}${where}`, whereParams) as any;
+      const total = Number((countRows as any[])?.[0]?.n ?? 0);
       const [rows] = await db.query(
-        `SELECT h.name, h.ip, h.port, h.username, h.auth_type, h.is_production, h.description, hj.name AS jump_host_name
-         FROM agent_hosts ah JOIN hosts h ON ah.host_id = h.id
-         LEFT JOIN hosts hj ON h.jump_host_id = hj.id
-         WHERE ah.agent_id = ?`,
-        [agentId],
+        `SELECT h.id, h.name, h.ip, h.port, h.username, h.auth_type, h.is_production, h.description, hj.name AS jump_host_name
+         ${fromHost}${where} ORDER BY h.name LIMIT ${limit} OFFSET ${offset}`,
+        whereParams,
       ) as any;
-      return {
-        hosts: rows.map((r: any) => ({
-          name: r.name, ip: r.ip, port: r.port, username: r.username,
-          auth_type: r.auth_type, is_production: !!r.is_production,
-          ...(r.description ? { description: r.description } : {}),
-          ...(r.jump_host_name ? { jump_host: r.jump_host_name } : {}),
-        })),
-      };
+      const hosts = (rows as any[]).map((r) => ({
+        id: r.id,
+        name: r.name, ip: r.ip, port: r.port, username: r.username,
+        auth_type: r.auth_type, is_production: !!r.is_production,
+        ...(r.description ? { description: r.description } : {}),
+        ...(r.jump_host_name ? { jump_host: r.jump_host_name } : {}),
+      }));
+      const next_cursor = offset + hosts.length < total ? String(offset + limit) : null;
+      return { hosts, total, next_cursor };
     }
     // Default: clusters
     const [rows] = await db.query(

--- a/src/shared/credential-types.ts
+++ b/src/shared/credential-types.ts
@@ -34,6 +34,9 @@ export interface ClusterMeta {
 }
 
 export interface HostMeta {
+  /** Stable host id. Populated by host search as a selection handle; absent on
+   *  the dial path (credential.get) where the broker keys by name. */
+  id?: string;
   name: string;
   description?: string;
   ip: string;
@@ -59,6 +62,18 @@ export interface CredentialFile {
   name: string;
   content: string;
   mode?: number;
+}
+
+/**
+ * A page of `host_list` results (when a query / pagination is supplied).
+ * Metadata only — never secrets. `total` is the full match count (for "narrow
+ * your query" hints); `next_cursor` is an opaque pagination cursor, null when
+ * exhausted.
+ */
+export interface HostListResult {
+  hosts: HostMeta[];
+  total: number;
+  next_cursor: string | null;
 }
 
 export interface CredentialPayload {

--- a/src/tools/query/host-list.test.ts
+++ b/src/tools/query/host-list.test.ts
@@ -2,20 +2,17 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createHostListTool } from "./host-list.js";
 import type { KubeconfigRef } from "../../core/types.js";
 
+// host_list always goes through the broker's server-side queryHosts (a blank
+// query = browse). The fake records the call and returns a settable result.
 function makeFakeBroker(overrides: Partial<any> = {}) {
   return {
-    hostsReady: false,
-    refreshCount: 0,
-    hosts: [] as any[],
-    isHostsReady() {
-      return this.hostsReady;
-    },
-    async refreshHosts() {
-      this.refreshCount++;
-      this.hostsReady = true;
-    },
-    getHostsLocal() {
-      return this.hosts;
+    queryCount: 0,
+    lastQuery: null as null | { query: string; opts?: { limit?: number; cursor?: string } },
+    result: { hosts: [] as any[], total: 0, next_cursor: null as string | null },
+    async queryHosts(query: string, opts?: { limit?: number; cursor?: string }) {
+      this.queryCount++;
+      this.lastQuery = { query, opts };
+      return this.result;
     },
     ...overrides,
   };
@@ -42,60 +39,81 @@ describe("host_list tool", () => {
     expect(parsed.error).toContain("Credential broker not initialized");
   });
 
-  it("refreshes hosts on first call, serves cache after", async () => {
-    broker.hosts = [
-      {
-        name: "h1", ip: "10.0.0.1", port: 22, username: "root",
-        auth_type: "key", is_production: true,
-      },
-    ];
-    const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
-    await tool.execute("id-1", {});
-    await tool.execute("id-2", {});
-    expect(broker.refreshCount).toBe(1);
-  });
-
-  it("returns hosts list JSON with key metadata fields", async () => {
-    broker.hosts = [
-      {
-        name: "h1", ip: "10.0.0.1", port: 22, username: "root",
-        auth_type: "key", is_production: true, description: "ctrl plane",
-        password: "SECRET", // must be omitted
-      },
-    ];
+  it("browses via queryHosts with an empty query when no args are given", async () => {
+    broker.result = {
+      hosts: [{ name: "h1", ip: "10.0.0.1", port: 22, username: "root", auth_type: "key", is_production: true }],
+      total: 1, next_cursor: null,
+    };
     const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
     const result = await tool.execute("id", {});
-    const text = (result.content[0] as any).text;
-    const parsed = JSON.parse(text.split("\n\n")[0]);
+    const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
     expect(parsed.hosts).toHaveLength(1);
+    expect(broker.queryCount).toBe(1);
+    expect(broker.lastQuery?.query).toBe(""); // browse, not a filter
+  });
+
+  it("returns key metadata fields (id surfaced; never password/private_key)", async () => {
+    broker.result = {
+      hosts: [{ id: "h1-uuid", name: "h1", ip: "10.0.0.1", port: 22, username: "root", auth_type: "key", is_production: true, description: "ctrl plane", password: "SECRET" }],
+      total: 1, next_cursor: null,
+    };
+    const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
+    const result = await tool.execute("id", { query: "h1" });
+    const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
+    expect(parsed.hosts[0].id).toBe("h1-uuid");
     expect(parsed.hosts[0].name).toBe("h1");
-    expect(parsed.hosts[0].ip).toBe("10.0.0.1");
-    expect(parsed.hosts[0].auth_type).toBe("key");
     expect(parsed.hosts[0].description).toBe("ctrl plane");
     expect(parsed.hosts[0].password).toBeUndefined();
   });
 
-  it("omits description field when absent", async () => {
-    broker.hosts = [{
-      name: "h1", ip: "10.0.0.1", port: 22, username: "root",
-      auth_type: "password", is_production: false,
-    }];
+  it("omits id and description when absent", async () => {
+    broker.result = {
+      hosts: [{ name: "h1", ip: "10.0.0.1", port: 22, username: "root", auth_type: "password", is_production: false }],
+      total: 1, next_cursor: null,
+    };
     const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
     const result = await tool.execute("id", {});
     const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
+    expect(parsed.hosts[0].id).toBeUndefined();
     expect(parsed.hosts[0].description).toBeUndefined();
   });
 
-  it("returns helper hint when no hosts bound", async () => {
-    broker.hosts = [];
+  it("surfaces total + next_cursor and a paging hint when truncated", async () => {
+    broker.result = {
+      hosts: [{ name: "h1", ip: "10.0.0.1", port: 22, username: "root", auth_type: "key", is_production: true }],
+      total: 137, next_cursor: "20",
+    };
     const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
-    const result = await tool.execute("id", {});
+    const result = await tool.execute("id", { query: "node" });
     const text = (result.content[0] as any).text;
-    expect(text).toContain("No hosts are bound");
+    const parsed = JSON.parse(text.split("\n\n")[0]);
+    expect(parsed.total).toBe(137);
+    expect(parsed.next_cursor).toBe("20");
+    expect(text).toContain('cursor="20"');
   });
 
-  it("returns error when refresh throws", async () => {
-    broker.refreshHosts = async () => { throw new Error("gateway down"); };
+  it("passes limit + cursor through to queryHosts", async () => {
+    const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
+    await tool.execute("id", { query: "gpu", limit: 10, cursor: "40" });
+    expect(broker.lastQuery).toEqual({ query: "gpu", opts: { limit: 10, cursor: "40" } });
+  });
+
+  it("returns helper hint when no hosts bound (empty browse)", async () => {
+    broker.result = { hosts: [], total: 0, next_cursor: null };
+    const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
+    const result = await tool.execute("id", {});
+    expect((result.content[0] as any).text).toContain("No hosts are bound");
+  });
+
+  it("query with no matches returns a 'No hosts match' hint", async () => {
+    broker.result = { hosts: [], total: 0, next_cursor: null };
+    const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
+    const result = await tool.execute("id", { query: "nope" });
+    expect((result.content[0] as any).text).toContain('No hosts match "nope"');
+  });
+
+  it("returns error when queryHosts throws", async () => {
+    broker.queryHosts = async () => { throw new Error("gateway down"); };
     const tool = createHostListTool({ credentialsDir: "/tmp", credentialBroker: broker as any });
     const result = await tool.execute("id", {});
     const parsed = JSON.parse((result.content[0] as any).text);

--- a/src/tools/query/host-list.ts
+++ b/src/tools/query/host-list.ts
@@ -22,12 +22,23 @@ export function createHostListTool(kubeconfigRef: KubeconfigRef): ToolDefinition
       return new Text(theme.fg("toolTitle", theme.bold("host_list")), 0, 0);
     },
     renderResult: renderTextResult,
-    description: `List SSH-reachable hosts bound to the current agent.
-Returns host names, IPs, ports, usernames, auth_type ("password" or "key"), is_production, and jump_host (the bastion name when the host is reached via ProxyJump — host_exec/host_script tunnel through it automatically).
+    description: `List SSH-reachable hosts bound to the current agent (server-side search; results are capped).
+Returns id, name, IP, port, username, auth_type ("password"/"key"/"managed"), is_production, and jump_host (the bastion name when the host is reached via ProxyJump — host_exec/host_script tunnel through it automatically).
 Does NOT return password or private_key — those are materialized to disk only when an SSH-using tool actually runs.
-Use this to discover hosts that the agent can reach via SSH (for node-level diagnostics outside the K8s API).`,
-    parameters: Type.Object({}),
-    async execute(_toolCallId, _rawParams) {
+Pass "query" to filter by name / IP / description (an IP-looking query matches the IP exactly); omit it to browse all bound hosts (still capped).
+The response includes "total" (full match count) and "next_cursor": if total exceeds what's shown, narrow the query or page with cursor.`,
+    parameters: Type.Object({
+      query: Type.Optional(Type.String({
+        description: "Filter by name / IP / description (server-side; an IP-looking value matches the IP exactly). Omit to browse all bound hosts.",
+      })),
+      limit: Type.Optional(Type.Number({
+        description: "Max results per page (default 20, max 100).",
+      })),
+      cursor: Type.Optional(Type.String({
+        description: "Opaque pagination cursor from a previous response's next_cursor.",
+      })),
+    }),
+    async execute(_toolCallId, rawParams) {
       const broker = kubeconfigRef.credentialBroker;
       if (!broker) {
         return {
@@ -36,22 +47,24 @@ Use this to discover hosts that the agent can reach via SSH (for node-level diag
         };
       }
 
-      // Lazy fill: pay one transport round-trip only on first access.
-      // Subsequent calls serve the cached Map synchronously; the Map is
-      // kept fresh by notify-driven refresh (POST /api/reload-host).
-      if (!broker.isHostsReady()) {
-        try {
-          await broker.refreshHosts();
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          return {
-            content: [{ type: "text", text: JSON.stringify({ error: `Failed to list hosts: ${message}` }) }],
-            details: {},
-          };
-        }
+      const params = (rawParams ?? {}) as { query?: string; limit?: number; cursor?: string };
+      const query = typeof params.query === "string" ? params.query.trim() : "";
+
+      // Always go through the server-side search (a blank query = browse). This
+      // keeps results capped and never loads the full host list into the broker.
+      let result;
+      try {
+        result = await broker.queryHosts(query, { limit: params.limit, cursor: params.cursor });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ error: `Failed to list hosts: ${message}` }) }],
+          details: {},
+        };
       }
 
-      const entries = broker.getHostsLocal().map((meta) => ({
+      const entries = result.hosts.map((meta) => ({
+        ...(meta.id ? { id: meta.id } : {}),
         name: meta.name,
         ip: meta.ip,
         port: meta.port,
@@ -66,11 +79,15 @@ Use this to discover hosts that the agent can reach via SSH (for node-level diag
 
       let hint = "";
       if (entries.length === 0) {
-        hint = "\n\nNo hosts are bound to this agent. Ask the user to bind hosts in the Portal (Agent detail page).";
+        hint = query
+          ? `\n\nNo hosts match "${query}".`
+          : "\n\nNo hosts are bound to this agent. Ask the user to bind hosts in the Portal (Agent detail page).";
+      } else if (result.next_cursor) {
+        hint = `\n\nShowing ${entries.length} of ${result.total}. Narrow the query, or pass cursor="${result.next_cursor}" for the next page.`;
       }
 
       return {
-        content: [{ type: "text", text: JSON.stringify({ hosts: entries }, null, 2) + hint }],
+        content: [{ type: "text", text: JSON.stringify({ hosts: entries, total: result.total, next_cursor: result.next_cursor }, null, 2) + hint }],
         details: {},
       };
     },


### PR DESCRIPTION
## What
`host_list` gains an optional `query` (+ `limit`/`cursor`) for **server-side, agent-scoped** filtering over name/ip/description — so the agent can *find* a host instead of dumping every bound host into context.

- **No separate tool or RPC.** Per design §12.2 the query **folds into the existing `credential.list(kind=host)`**; there is no `host_search` tool, and the path does not use the (pre-existing, untouched) `credential.hostSearch` RPC.
- **IPv4-exact smart-match** (so `10.0.0.5` doesn't substring-hit `10.0.0.51`); otherwise substring.
- **Pagination**: default limit 20 (max 100), opaque `cursor`, response `total` + `next_cursor`.
- **`id`** surfaced as a stable selection handle; **metadata only — never secrets**.
- **No-arg is capped too**: host_list always goes through the filtered path (blank query = browse), so it's no longer an unbounded dump.
- **Contract-safe**: the filtered path (`broker.queryHosts`) bypasses the broker registry — no reconcile — preserving `reconcileFullList`'s full-snapshot requirement; the full-list path (no query) is untouched and still feeds the broker.

Implements `docs/design/agent-host-jump-chain.md` §12 (siclaw v1: query + pagination; filters / facets / by-id deferred).

## Chain
`host_list` → `broker.queryHosts` → `transport.queryHosts` → `POST /api/internal/credential-list {query,limit,cursor}` → proxy → `service.queryHosts` → `credential.list` (kind=host, query).

## Test
- `npx tsc --noEmit` clean; `npm test` → **3191 passed / 2 skipped**.
- credential.list host-query (filter / paginate / IP-smart / limit-clamp / total), proxy query-vs-list dispatch, broker passthrough (no reconcile), tool query / browse / paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)