### PR TITLE
Keep Siclaw chat stable when agent selector expands

### DIFF
--- a/portal-web/src/pages/Chat.tsx
+++ b/portal-web/src/pages/Chat.tsx
@@ -58,6 +58,7 @@ export function Chat() {
 
   const handleSelectAgent = (agentId: string) => {
     setSelectedAgentId(agentId)
+    setAgentSelectorCollapsed(true)
     if (location.pathname.startsWith("/chat")) {
       setSearchParams({ agent: agentId })
     }
@@ -84,66 +85,61 @@ export function Chat() {
   }
 
   return (
-    <div className="flex h-full overflow-hidden">
+    <div className="relative flex h-full overflow-hidden">
       {/* Agent selector sidebar */}
       <aside
-        className={`border-r border-border flex flex-col shrink-0 bg-background/30 transition-[width] duration-200 ease-out ${
-          agentSelectorCollapsed ? "w-14" : "w-[200px]"
-        }`}
+        className="w-14 border-r border-border flex flex-col shrink-0 bg-background/30"
       >
-        <div
-          className={`border-b border-border ${
-            agentSelectorCollapsed
-              ? "h-12 flex items-center justify-center"
-              : "px-3 py-2 flex items-center justify-between gap-2"
-          }`}
-        >
-          {agentSelectorCollapsed ? (
+        <div className="h-12 border-b border-border flex items-center justify-center">
+          <button
+            type="button"
+            onClick={() => setAgentSelectorCollapsed(false)}
+            className="h-8 w-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
+            aria-label="Expand agent selector"
+            title="Expand agent selector"
+          >
+            <PanelLeftOpen className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto overflow-x-hidden py-2 px-1.5 space-y-1">
+          {agents.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              onClick={() => handleSelectAgent(a.id)}
+              className={`relative mx-auto flex h-10 w-10 items-center justify-center rounded-lg transition-colors ${
+                selectedAgentId === a.id
+                  ? "bg-secondary text-foreground"
+                  : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+              }`}
+              aria-label={`Select agent ${a.name}`}
+              title={`${a.name}${a.model_id ? ` · ${a.model_id}` : ""}`}
+            >
+              <Bot className="h-4 w-4" />
+              <span className={`absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full ${agentStatusClass(a.status)}`} />
+            </button>
+          ))}
+        </div>
+      </aside>
+
+      {!agentSelectorCollapsed && (
+        <div className="absolute left-0 top-0 bottom-0 z-40 w-[220px] border-r border-border bg-background/95 shadow-xl shadow-black/10">
+          <div className="px-3 py-2 border-b border-border flex items-center justify-between gap-2">
+            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+              Select Agent
+            </span>
             <button
               type="button"
-              onClick={() => setAgentSelectorCollapsed(false)}
-              className="h-8 w-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
-              aria-label="Expand agent selector"
-              title="Expand agent selector"
+              onClick={() => setAgentSelectorCollapsed(true)}
+              className="h-7 w-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
+              aria-label="Collapse agent selector"
+              title="Collapse agent selector"
             >
-              <PanelLeftOpen className="h-4 w-4" />
+              <PanelLeftClose className="h-4 w-4" />
             </button>
-          ) : (
-            <>
-              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
-                Select Agent
-              </span>
-              <button
-                type="button"
-                onClick={() => setAgentSelectorCollapsed(true)}
-                className="h-7 w-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
-                aria-label="Collapse agent selector"
-                title="Collapse agent selector"
-              >
-                <PanelLeftClose className="h-4 w-4" />
-              </button>
-            </>
-          )}
-        </div>
-        <div className={`flex-1 overflow-y-auto overflow-x-hidden ${agentSelectorCollapsed ? "py-2 px-1.5 space-y-1" : "py-1"}`}>
-          {agents.map((a) => (
-            agentSelectorCollapsed ? (
-              <button
-                key={a.id}
-                type="button"
-                onClick={() => handleSelectAgent(a.id)}
-                className={`relative mx-auto flex h-10 w-10 items-center justify-center rounded-lg transition-colors ${
-                  selectedAgentId === a.id
-                    ? "bg-secondary text-foreground"
-                    : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
-                }`}
-                aria-label={`Select agent ${a.name}`}
-                title={`${a.name}${a.model_id ? ` · ${a.model_id}` : ""}`}
-              >
-                <Bot className="h-4 w-4" />
-                <span className={`absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full ${agentStatusClass(a.status)}`} />
-              </button>
-            ) : (
+          </div>
+          <div className="h-[calc(100%-45px)] overflow-y-auto overflow-x-hidden py-1">
+            {agents.map((a) => (
               <button
                 key={a.id}
                 type="button"
@@ -162,13 +158,13 @@ export function Chat() {
                 </div>
                 <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${agentStatusClass(a.status)}`} />
               </button>
-            )
-          ))}
+            ))}
+          </div>
         </div>
-      </aside>
+      )}
 
       {/* Chat area */}
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 min-w-0 overflow-hidden">
         {selectedAgentId ? (
           <AgentChat key={selectedAgentId} agentId={selectedAgentId} />
         ) : (

--- a/portal-web/src/pages/Chat.tsx
+++ b/portal-web/src/pages/Chat.tsx
@@ -16,6 +16,7 @@ export function Chat() {
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedAgentId, setSelectedAgentId] = useState<string>(searchParams.get("agent") || "")
+  const [agentPreview, setAgentPreview] = useState<{ agentId: string; left: number; top: number } | null>(null)
   const [agentSelectorCollapsed, setAgentSelectorCollapsed] = useState<boolean>(() => {
     try {
       return localStorage.getItem(AGENT_SELECTOR_COLLAPSED_KEY) === "true"
@@ -59,12 +60,26 @@ export function Chat() {
   const handleSelectAgent = (agentId: string) => {
     setSelectedAgentId(agentId)
     setAgentSelectorCollapsed(true)
+    setAgentPreview(null)
     if (location.pathname.startsWith("/chat")) {
       setSearchParams({ agent: agentId })
     }
   }
 
+  const handleShowAgentPreview = (agentId: string, element: HTMLElement) => {
+    if (!agentSelectorCollapsed) return
+    const rect = element.getBoundingClientRect()
+    const previewWidth = 224
+    const previewHeight = 64
+    setAgentPreview({
+      agentId,
+      left: Math.max(8, Math.min(rect.right + 10, window.innerWidth - previewWidth - 8)),
+      top: Math.max(8, Math.min(rect.top, window.innerHeight - previewHeight - 8)),
+    })
+  }
+
   const agentStatusClass = (status: string) => (status === "active" ? "bg-green-500" : "bg-gray-500")
+  const previewAgent = agentPreview ? agents.find((a) => a.id === agentPreview.agentId) : undefined
 
   if (loading) {
     return (
@@ -107,6 +122,10 @@ export function Chat() {
               key={a.id}
               type="button"
               onClick={() => handleSelectAgent(a.id)}
+              onFocus={(e) => handleShowAgentPreview(a.id, e.currentTarget)}
+              onMouseEnter={(e) => handleShowAgentPreview(a.id, e.currentTarget)}
+              onBlur={() => setAgentPreview(null)}
+              onMouseLeave={() => setAgentPreview(null)}
               className={`relative mx-auto flex h-10 w-10 items-center justify-center rounded-lg transition-colors ${
                 selectedAgentId === a.id
                   ? "bg-secondary text-foreground"
@@ -123,42 +142,70 @@ export function Chat() {
       </aside>
 
       {!agentSelectorCollapsed && (
-        <div className="absolute left-0 top-0 bottom-0 z-40 w-[220px] border-r border-border bg-background/95 shadow-xl shadow-black/10">
-          <div className="px-3 py-2 border-b border-border flex items-center justify-between gap-2">
-            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
-              Select Agent
-            </span>
-            <button
-              type="button"
-              onClick={() => setAgentSelectorCollapsed(true)}
-              className="h-7 w-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
-              aria-label="Collapse agent selector"
-              title="Collapse agent selector"
-            >
-              <PanelLeftClose className="h-4 w-4" />
-            </button>
-          </div>
-          <div className="h-[calc(100%-45px)] overflow-y-auto overflow-x-hidden py-1">
-            {agents.map((a) => (
+        <>
+          <div
+            className="absolute left-[220px] right-0 top-0 bottom-0 z-30"
+            onClick={() => setAgentSelectorCollapsed(true)}
+            aria-hidden="true"
+          />
+          <div className="absolute left-0 top-0 bottom-0 z-40 w-[220px] border-r border-border bg-background/95 shadow-xl shadow-black/10">
+            <div className="px-3 py-2 border-b border-border flex items-center justify-between gap-2">
+              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                Select Agent
+              </span>
               <button
-                key={a.id}
                 type="button"
-                onClick={() => handleSelectAgent(a.id)}
-                className={`flex items-center gap-2 w-full px-3 py-2 text-left transition-colors ${
-                  selectedAgentId === a.id
-                    ? "bg-secondary text-foreground"
-                    : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
-                }`}
-                title={`${a.name}${a.model_id ? ` · ${a.model_id}` : ""}`}
+                onClick={() => setAgentSelectorCollapsed(true)}
+                className="h-7 w-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
+                aria-label="Collapse agent selector"
+                title="Collapse agent selector"
               >
-                <Bot className="h-3.5 w-3.5 shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <p className="text-[12px] font-mono truncate">{a.name}</p>
-                  <p className="text-[10px] text-muted-foreground truncate">{a.model_id || "No model"}</p>
-                </div>
-                <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${agentStatusClass(a.status)}`} />
+                <PanelLeftClose className="h-4 w-4" />
               </button>
-            ))}
+            </div>
+            <div className="h-[calc(100%-45px)] overflow-y-auto overflow-x-hidden py-1">
+              {agents.map((a) => (
+                <button
+                  key={a.id}
+                  type="button"
+                  onClick={() => handleSelectAgent(a.id)}
+                  className={`flex items-center gap-2 w-full px-3 py-2 text-left transition-colors ${
+                    selectedAgentId === a.id
+                      ? "bg-secondary text-foreground"
+                      : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+                  }`}
+                  title={`${a.name}${a.model_id ? ` · ${a.model_id}` : ""}`}
+                >
+                  <Bot className="h-3.5 w-3.5 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-[12px] font-mono truncate">{a.name}</p>
+                    <p className="text-[10px] text-muted-foreground truncate">{a.model_id || "No model"}</p>
+                  </div>
+                  <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${agentStatusClass(a.status)}`} />
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {agentSelectorCollapsed && agentPreview && previewAgent && (
+        <div
+          className="fixed z-50 w-56 rounded-md border border-border bg-background/95 p-2 shadow-lg shadow-black/10 pointer-events-none"
+          style={{ left: agentPreview.left, top: agentPreview.top }}
+          aria-hidden="true"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-secondary text-foreground">
+              <Bot className="h-3.5 w-3.5" />
+              <span className={`absolute right-1 top-1 h-1.5 w-1.5 rounded-full ${agentStatusClass(previewAgent.status)}`} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-[12px] font-medium text-foreground">{previewAgent.name}</p>
+              <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                {previewAgent.model_id || "No model"}
+              </p>
+            </div>
           </div>
         </div>
       )}

--- a/portal-web/src/pages/Chat.tsx
+++ b/portal-web/src/pages/Chat.tsx
@@ -5,6 +5,7 @@ import { api } from "../api"
 import { AgentChat } from "../components/AgentChat"
 
 const AGENT_SELECTOR_COLLAPSED_KEY = "siclaw.agentSelector.collapsed"
+const AGENT_SELECTOR_OVERLAY_WIDTH = 220
 
 interface Agent {
   id: string; name: string; status: string; model_id: string; is_production: boolean
@@ -57,10 +58,41 @@ export function Chat() {
     }
   }, [agentSelectorCollapsed])
 
-  const handleSelectAgent = (agentId: string) => {
-    setSelectedAgentId(agentId)
+  useEffect(() => {
+    if (agentSelectorCollapsed) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setAgentSelectorCollapsed(true)
+        setAgentPreview(null)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [agentSelectorCollapsed])
+
+  useEffect(() => {
+    if (!agentPreview) return
+
+    const hideAgentPreview = () => setAgentPreview(null)
+
+    window.addEventListener("resize", hideAgentPreview)
+    document.addEventListener("scroll", hideAgentPreview, true)
+    return () => {
+      window.removeEventListener("resize", hideAgentPreview)
+      document.removeEventListener("scroll", hideAgentPreview, true)
+    }
+  }, [agentPreview])
+
+  const collapseAgentSelector = () => {
     setAgentSelectorCollapsed(true)
     setAgentPreview(null)
+  }
+
+  const handleSelectAgent = (agentId: string) => {
+    setSelectedAgentId(agentId)
+    collapseAgentSelector()
     if (location.pathname.startsWith("/chat")) {
       setSearchParams({ agent: agentId })
     }
@@ -108,7 +140,10 @@ export function Chat() {
         <div className="h-12 border-b border-border flex items-center justify-center">
           <button
             type="button"
-            onClick={() => setAgentSelectorCollapsed(false)}
+            onClick={() => {
+              setAgentSelectorCollapsed(false)
+              setAgentPreview(null)
+            }}
             className="h-8 w-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
             aria-label="Expand agent selector"
             title="Expand agent selector"
@@ -144,18 +179,22 @@ export function Chat() {
       {!agentSelectorCollapsed && (
         <>
           <div
-            className="absolute left-[220px] right-0 top-0 bottom-0 z-30"
-            onClick={() => setAgentSelectorCollapsed(true)}
+            className="absolute right-0 top-0 bottom-0 z-30"
+            style={{ left: AGENT_SELECTOR_OVERLAY_WIDTH }}
+            onClick={collapseAgentSelector}
             aria-hidden="true"
           />
-          <div className="absolute left-0 top-0 bottom-0 z-40 w-[220px] border-r border-border bg-background/95 shadow-xl shadow-black/10">
-            <div className="px-3 py-2 border-b border-border flex items-center justify-between gap-2">
+          <div
+            className="absolute left-0 top-0 bottom-0 z-40 flex flex-col border-r border-border bg-background/95 shadow-xl shadow-black/10"
+            style={{ width: AGENT_SELECTOR_OVERLAY_WIDTH }}
+          >
+            <div className="shrink-0 px-3 py-2 border-b border-border flex items-center justify-between gap-2">
               <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
                 Select Agent
               </span>
               <button
                 type="button"
-                onClick={() => setAgentSelectorCollapsed(true)}
+                onClick={collapseAgentSelector}
                 className="h-7 w-7 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/70 transition-colors"
                 aria-label="Collapse agent selector"
                 title="Collapse agent selector"
@@ -163,7 +202,7 @@ export function Chat() {
                 <PanelLeftClose className="h-4 w-4" />
               </button>
             </div>
-            <div className="h-[calc(100%-45px)] overflow-y-auto overflow-x-hidden py-1">
+            <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden py-1">
               {agents.map((a) => (
                 <button
                   key={a.id}


### PR DESCRIPTION
## Summary

- Keep the Siclaw chat agent rail at a fixed narrow width.
- Render the expanded agent selector as an overlay instead of resizing the chat layout.
- Collapse the overlay after selecting an agent or clicking the blank area outside the selector.
- Add a compact hover/focus preview for collapsed rail agent icons, matching Sicore's lighter preview affordance.

## Why

Expanding or collapsing the agent selector changed the flex width of the chat area, which caused the message column and reply box to shift horizontally. Sicore's Siclaw integration keeps the chat stable by treating the selector as a rail/overlay style control, and also exposes enough agent detail from the collapsed rail without forcing the full list open.

## Testing

- `npm run build` in `portal-web`
- `git diff --check`
- Local visual QA with Vite + mock API + headless Chrome: verified the compact preview appears on rail hover, the reply box and session controls keep the same x coordinates before/after expansion, and a blank-area click collapses the overlay.
