### PR TITLE
feat(chat): scroll-to-select copy, image-safe copy & Markdown export

### DIFF
--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useCallback, useMemo, useLayoutEffect, Fragment } from "react"
+import { useRef, useEffect, useState, useCallback, useMemo, useLayoutEffect } from "react"
 import type { KeyboardEvent } from "react"
 import { formatToolInput } from "../../hooks/usePilotChat"
 import {
@@ -20,13 +20,25 @@ import {
   ArrowRight,
   PencilLine,
   FileText,
+  ListChecks,
+  Square,
+  X,
+  Download,
 } from "lucide-react"
 import { cn } from "./cn"
 import { Markdown } from "./Markdown"
-import { tryParseChartSpec } from "./ChartRenderer"
-import { validateMermaidSource } from "./MermaidRenderer"
-import { svgToPngDataUrl } from "./svg-export"
-import { useCopyFeedback } from "./clipboard"
+import { useCopyFeedback, copyTextToClipboard } from "./clipboard"
+import { copyElementsAsRichText, buildCopyHtml } from "./rich-copy"
+import { downloadBlob } from "./svg-export"
+import { serializeMessagesToText, serializeMessagesToMarkdown, stripVisualizationFences, stripImageData } from "./transcript"
+import {
+  EMPTY_SELECTION,
+  selectVisible,
+  toggleMessage,
+  selectAll as selectAllMessages,
+  selectedIds as computeSelectedIds,
+  type SelectionState,
+} from "./selection-model"
 import { InputArea } from "./InputArea"
 import { ImageAttachmentPreview } from "./ImageAttachmentPreview"
 import { SkillCard } from "./SkillCard"
@@ -34,6 +46,33 @@ import { ScheduleCard } from "./ScheduleCard"
 import { ErrorBubble } from "./ErrorBubble"
 import { stripAttachmentOcrEvidence } from "./user-message-text"
 import type { ChatAttachment, PilotMessage, ContextUsage, ActionChip, PrefixActionChip, MessageTiming } from "./types"
+
+// Wrap copy-ready message HTML in a minimal self-contained document for the
+// Markdown-export's companion .html file. Charts are inline PNG <img>, which
+// browsers always render (unlike data: images in many Markdown viewers).
+function wrapChatHtml(inner: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Siclaw chat export</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Microsoft YaHei", sans-serif; max-width: 880px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; color: #1a1a1a; }
+  img { max-width: 100%; height: auto; }
+  pre { background: #f4f4f5; padding: .75rem 1rem; border-radius: 8px; overflow-x: auto; }
+  code { background: #f0f0f1; padding: .1rem .3rem; border-radius: 4px; }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; margin: .5rem 0; }
+  th, td { border: 1px solid #ddd; padding: .4rem .7rem; }
+  blockquote { border-left: 3px solid #ddd; margin: .5rem 0; padding-left: 1rem; color: #555; }
+  hr { border: none; border-top: 1px solid #e5e5e5; margin: 1.5rem 0; }
+</style>
+</head>
+<body>${inner}</body>
+</html>
+`
+}
 
 /**
  * Format a millisecond duration into a compact human-readable string.
@@ -71,7 +110,7 @@ function ModelTimeLabel({ timing }: { timing: MessageTiming | undefined }) {
   const total = combinedModelMs(timing)
   if (total == null) return null
   return (
-    <span className="text-xs text-muted-foreground/70 tabular-nums select-text cursor-text">
+    <span data-copy-ignore className="text-xs text-muted-foreground/70 tabular-nums select-text cursor-text">
       thinking {formatTimingMs(total)}
     </span>
   )
@@ -293,6 +332,9 @@ export function PilotArea({
       .some((m) => m.role === "assistant" && !m.isStreaming && (m.content?.trim().length ?? 0) > 0)
   }, [messages, isLoading, dpActive])
   const renderMessages = useMemo(() => withDelegationStatusNotices(messages), [messages])
+  // The exact list rendered as rows, in order. Scroll-selection indexes into
+  // this same list, so a row's data-msg-idx always maps back to the right message.
+  const selectableMessages = useMemo(() => renderMessages.filter((m) => !m.hidden), [renderMessages])
   const latestEditableUserMessageId = useMemo(() => {
     for (let i = renderMessages.length - 1; i >= 0; i--) {
       const message = renderMessages[i]
@@ -326,8 +368,114 @@ export function PilotArea({
     setEditingDraft("")
   }, [editingDraft, isLoading, wrappedSendMessage])
 
+  // --- Scroll-to-select copy ---
+  // Click a message to anchor, scroll to paint a contiguous band over the
+  // messages you pass, fine-tune with checkboxes, then copy the lot (images and
+  // all). See selection-model.ts for the pure state rules.
+  const [selectMode, setSelectMode] = useState(false)
+  const [selection, setSelection] = useState<SelectionState>(EMPTY_SELECTION)
+  const selectModeRef = useRef(false)
+  const [selectionCopied, , flashSelectionCopied] = useCopyFeedback()
+  useEffect(() => {
+    selectModeRef.current = selectMode
+  }, [selectMode])
+  // Drop any in-progress selection when the session changes.
+  useEffect(() => {
+    setSelectMode(false)
+    setSelection(EMPTY_SELECTION)
+  }, [sessionKey])
+
+  const enterSelectMode = useCallback(() => {
+    setSelection(EMPTY_SELECTION)
+    setSelectMode(true)
+  }, [])
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false)
+    setSelection(EMPTY_SELECTION)
+  }, [])
+  const handleToggleMessage = useCallback((id: string) => {
+    setSelection((s) => toggleMessage(s, id))
+  }, [])
+
+  // Scroll-to-select via IntersectionObserver: while in select mode, every
+  // message row that enters the viewport is auto-checked (accumulating, either
+  // scroll direction). The observer fires only on actual visibility changes —
+  // no per-scroll-event layout scans of the whole list — and its initial
+  // callback covers whatever is already on screen when select mode turns on.
+  useEffect(() => {
+    if (!selectMode) return
+    const container = scrollContainerRef.current
+    if (!container) return
+    const visible = new Set<string>()
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const id = (entry.target as HTMLElement).getAttribute("data-msg-id")
+          if (!id) continue
+          if (entry.isIntersecting) visible.add(id)
+          else visible.delete(id)
+        }
+        setSelection((s) => selectVisible(s, [...visible]))
+      },
+      { root: container, threshold: 0 },
+    )
+    container.querySelectorAll<HTMLElement>("[data-msg-id]").forEach((row) => io.observe(row))
+    return () => io.disconnect()
+    // Re-observe when the rendered list changes so new rows are tracked too.
+  }, [selectMode, selectableMessages])
+
+  const selectedIdSet = useMemo(() => computeSelectedIds(selection), [selection])
+  const selectedCount = selectedIdSet.size
+
+  const copySelection = useCallback(async () => {
+    if (selectedIdSet.size === 0) return
+    const selected = selectableMessages.filter((m) => selectedIdSet.has(m.id))
+    const plain = serializeMessagesToText(selected)
+    const container = scrollContainerRef.current
+    let ok = false
+    if (container) {
+      const els = Array.from(container.querySelectorAll<HTMLElement>("[data-msg-id]")).filter((el) => {
+        const id = el.getAttribute("data-msg-id")
+        return id != null && selectedIdSet.has(id)
+      })
+      ok = await copyElementsAsRichText(els, plain)
+    }
+    if (!ok) ok = await copyTextToClipboard(plain)
+    if (ok) flashSelectionCopied()
+  }, [selectedIdSet, selectableMessages, flashSelectionCopied])
+
+  const downloadSelection = useCallback(async () => {
+    if (selectedIdSet.size === 0) return
+    const selected = selectableMessages.filter((m) => selectedIdSet.has(m.id))
+    const base = `siclaw-chat-${selected.length}-messages`
+
+    // 1) Markdown — content verbatim, charts kept as ```chart spec blocks
+    //    (compact chart data; the HTML carries the rendered colour image).
+    const md = serializeMessagesToMarkdown(selected)
+    downloadBlob(new Blob([md], { type: "text/markdown;charset=utf-8" }), `${base}.md`)
+
+    // 2) Self-contained HTML — buildCopyHtml rasterizes charts/Mermaid to <img>,
+    //    which browsers always render, so double-clicking the .html shows them.
+    const container = scrollContainerRef.current
+    if (container) {
+      const rowById = new Map(
+        Array.from(container.querySelectorAll<HTMLElement>("[data-msg-id]")).map(
+          (r) => [r.getAttribute("data-msg-id"), r] as const,
+        ),
+      )
+      const els = selected.map((m) => rowById.get(m.id)).filter((r): r is HTMLElement => !!r)
+      const { html } = await buildCopyHtml(els)
+      downloadBlob(new Blob([wrapChatHtml(html)], { type: "text/html;charset=utf-8" }), `${base}.html`)
+    }
+  }, [selectedIdSet, selectableMessages])
+
   // Auto-scroll logic
   useEffect(() => {
+    // While selecting, the user is scrolling on purpose — never yank them.
+    if (selectModeRef.current) {
+      prevMsgCountRef.current = messages.length
+      return
+    }
     if (needsScrollOnLoadRef.current && messages.length > 0) {
       needsScrollOnLoadRef.current = false
       userScrolledAwayRef.current = false
@@ -349,7 +497,8 @@ export function PilotArea({
     prevMsgCountRef.current = messages.length
   }, [messages, scrollToBottom])
 
-  // Detect user scrolling away
+  // Detect user scrolling away (scroll-to-select is handled by the
+  // IntersectionObserver above, not here).
   const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current
     if (!container) return
@@ -364,7 +513,68 @@ export function PilotArea({
     <div className="flex-1 flex flex-col h-full bg-card relative">
       {visibleForCopy.length > 0 && (
         <div className="absolute top-2 left-3 z-10">
-          <CopySessionButton messages={visibleForCopy} containerRef={scrollContainerRef} />
+          <button
+            type="button"
+            onClick={selectMode ? exitSelectMode : enterSelectMode}
+            title={selectMode ? "Exit selection" : "Select messages to copy"}
+            className={cn(
+              "p-1.5 rounded-md transition-colors",
+              selectMode
+                ? "bg-blue-500/15 text-blue-400"
+                : "text-muted-foreground hover:text-foreground hover:bg-secondary/50",
+            )}
+          >
+            <ListChecks className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+      {selectMode && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 rounded-full border border-border bg-card/95 px-3 py-1.5 shadow-md shadow-black/10 backdrop-blur">
+          <span className="text-xs font-medium text-foreground whitespace-nowrap">
+            {selectedCount > 0 ? `${selectedCount} selected` : "Scroll to select on-screen messages"}
+          </span>
+          <div className="h-3.5 w-px bg-border" />
+          <button
+            type="button"
+            onClick={() => setSelection(selectAllMessages(selectableMessages.map((m) => m.id)))}
+            className="px-2 py-0.5 rounded-md border border-border bg-secondary/40 text-xs font-medium text-foreground hover:bg-secondary transition-colors"
+          >
+            All
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelection(EMPTY_SELECTION)}
+            disabled={selectedCount === 0}
+            className="px-2 py-0.5 rounded-md border border-border bg-secondary/40 text-xs font-medium text-foreground hover:bg-secondary transition-colors disabled:opacity-40 disabled:hover:bg-secondary/40"
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={downloadSelection}
+            disabled={selectedCount === 0}
+            title="Download selected as Markdown + HTML"
+            className="flex items-center rounded-md border border-border bg-secondary/40 p-1 text-foreground hover:bg-secondary transition-colors disabled:opacity-40 disabled:hover:bg-secondary/40"
+          >
+            <Download className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={copySelection}
+            disabled={selectedCount === 0}
+            className="flex items-center gap-1 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 transition-colors disabled:opacity-40 disabled:hover:bg-blue-600"
+          >
+            {selectionCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+            {selectionCopied ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            onClick={exitSelectMode}
+            title="Exit selection"
+            className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       )}
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-4 lg:px-8 py-8" onScroll={handleScroll}>
@@ -402,54 +612,85 @@ export function PilotArea({
                 </div>
               )}
 
-              {renderMessages
-                .filter((m) => !m.hidden)
-                .map((msg) => {
+              {selectableMessages.map((msg) => {
                 const childSessionId = msg.metadata?.kind === "delegation_event"
                   ? (msg.metadata as Record<string, unknown>).child_session_id
                   : undefined
                 const subStatus = (msg.metadata as Record<string, unknown> | undefined)?.status
+                const selected = selectMode && selectedIdSet.has(msg.id)
                 return (
-                <Fragment key={msg.id}>
-                  <MessageItem
-                    message={msg}
-                    sendMessage={wrappedSendMessage}
-                    showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
-                    dpActive={dpActive}
-                    canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
-                    editingContent={editingMessageId === msg.id ? editingDraft : null}
-                    onStartEditMessage={startEditingMessage}
-                    onEditMessageChange={setEditingDraft}
-                    onCancelEditMessage={cancelEditingMessage}
-                    onSubmitEditMessage={submitEditedMessage}
-                    onChipClick={(chip, meta) => {
-                      if (meta.isDpCheckpoint) {
-                        const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
-                        if (prefixChip) {
-                          setActivePrefix(prefixChip)
-                          setChipDraft(null)
-                          return
-                        }
-                      }
-                      setChipSeq((s) => s + 1)
-                      setChipDraft(chip.insertText + " ")
-                    }}
-                    onOpenSkillPanel={onOpenSkillPanel}
-                    onOpenSchedulePanel={onOpenSchedulePanel}
-                    agentId={agentId}
-                  />
-                  {typeof childSessionId === "string" && onOpenSubagent && (
-                    <div className="pl-12 -mt-1 mb-2">
-                      <button
-                        type="button"
-                        onClick={() => onOpenSubagent(childSessionId as string, typeof subStatus === "string" ? subStatus : undefined, "Sub-agent")}
-                        className="text-[11px] text-blue-400 hover:text-blue-300 hover:underline underline-offset-2"
-                      >
-                        View sub-agent transcript →
-                      </button>
-                    </div>
+                <div
+                  key={msg.id}
+                  data-msg-id={msg.id}
+                  data-msg-role={msg.role}
+                  onClick={selectMode ? () => handleToggleMessage(msg.id) : undefined}
+                  className={cn(
+                    "relative rounded-xl transition-colors",
+                    // No row-level highlight — the checkbox alone signals selection.
+                    selectMode && "cursor-pointer px-2 -mx-2 py-1 hover:bg-secondary/30",
                   )}
-                </Fragment>
+                >
+                  {selectMode && (
+                    <button
+                      type="button"
+                      data-copy-ignore
+                      title={selected ? "Deselect" : "Select"}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        handleToggleMessage(msg.id)
+                      }}
+                      className="absolute left-1.5 top-1.5 z-10 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {selected ? (
+                        <span className="flex h-3.5 w-3.5 items-center justify-center rounded-[4px] bg-blue-500 text-white">
+                          <Check className="h-2.5 w-2.5" strokeWidth={3} />
+                        </span>
+                      ) : (
+                        <Square className="h-3.5 w-3.5" />
+                      )}
+                    </button>
+                  )}
+                  <div className={cn(selectMode && "pl-8 pointer-events-none select-none")}>
+                    <MessageItem
+                      message={msg}
+                      sendMessage={wrappedSendMessage}
+                      showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
+                      dpActive={dpActive}
+                      canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
+                      editingContent={editingMessageId === msg.id ? editingDraft : null}
+                      onStartEditMessage={startEditingMessage}
+                      onEditMessageChange={setEditingDraft}
+                      onCancelEditMessage={cancelEditingMessage}
+                      onSubmitEditMessage={submitEditedMessage}
+                      onChipClick={(chip, meta) => {
+                        if (meta.isDpCheckpoint) {
+                          const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
+                          if (prefixChip) {
+                            setActivePrefix(prefixChip)
+                            setChipDraft(null)
+                            return
+                          }
+                        }
+                        setChipSeq((s) => s + 1)
+                        setChipDraft(chip.insertText + " ")
+                      }}
+                      onOpenSkillPanel={onOpenSkillPanel}
+                      onOpenSchedulePanel={onOpenSchedulePanel}
+                      agentId={agentId}
+                    />
+                    {typeof childSessionId === "string" && onOpenSubagent && (
+                      <div className="pl-12 -mt-1 mb-2">
+                        <button
+                          type="button"
+                          onClick={() => onOpenSubagent(childSessionId as string, typeof subStatus === "string" ? subStatus : undefined, "Sub-agent")}
+                          className="text-[11px] text-blue-400 hover:text-blue-300 hover:underline underline-offset-2"
+                        >
+                          View sub-agent transcript →
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
                 )
                 })}
 
@@ -1190,6 +1431,7 @@ function MessageItem({
     <div className={cn("flex gap-4 group", isUser ? "flex-row-reverse" : "flex-row")}>
       {/* Avatar */}
       <div
+        data-copy-ignore
         className={cn(
           "w-8 h-8 rounded-full flex items-center justify-center shrink-0 shadow-sm shadow-black/10 border",
           isUser ? "bg-blue-600 border-blue-600 text-white" : "bg-card border-border text-blue-400",
@@ -1244,11 +1486,16 @@ function MessageItem({
         )}
 
         {isUser && message.attachments && message.attachments.length > 0 && (
-          <ImageAttachmentPreview
-            attachments={message.attachments}
-            className="mb-2 max-w-[560px] justify-end"
-            tileClassName="h-32 w-56"
-          />
+          // data-copy-ignore: pasted/uploaded attachments are transient OCR
+          // inputs, so the scroll-select copy/export skips them (the copy helper
+          // strips [data-copy-ignore]).
+          <div data-copy-ignore>
+            <ImageAttachmentPreview
+              attachments={message.attachments}
+              className="mb-2 max-w-[560px] justify-end"
+              tileClassName="h-32 w-56"
+            />
+          </div>
         )}
 
         {isUser && editingContent != null && canRenderEditor ? (
@@ -1305,150 +1552,6 @@ function DelegationStatusNotice({ content }: { content: string }) {
   )
 }
 
-function serializeSessionToText(messages: PilotMessage[]): string {
-  const lines: string[] = []
-  for (const m of messages) {
-    if (m.hidden) continue
-    if (m.metadata?.kind === "delegation_status_notice") continue
-    if (m.role === "user") {
-      lines.push(`You:\n${m.content.trim()}`)
-    } else if (m.role === "assistant") {
-      const body = stripVisualizationFences(m.content ?? "")
-      if (body) lines.push(`Assistant:\n${body}`)
-    } else if (m.role === "tool") {
-      const name = m.toolName ?? "tool"
-      const input = m.toolInput ? `\n$ ${m.toolInput}` : ""
-      const out = (m.content ?? "").trim()
-      lines.push(`[${name}]${input}${out ? `\n${out}` : ""}`)
-    } else if (m.role === "error") {
-      lines.push(`Error: ${(m.content ?? "").trim()}`)
-    }
-  }
-  return lines.join("\n\n")
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-}
-
-// Build a text/html rendition of the whole session with each visual fenced
-// block swapped for its rasterised PNG. The PNGs are passed in DOM order; an
-// assistant message's fences are mapped to them left-to-right, skipping fences
-// whose source failed validation.
-//
-// KNOWN LIMITATION — this PNG↔fence mapping is best-effort, not exact. It
-// assumes `tryParseChartSpec` / `validateMermaidSource` succeeding here implies
-// the fence rendered a real `.chart-host svg` / `.mermaid-host svg` in the DOM.
-// That can drift if a fence parsed but the visual did not actually mount (e.g.
-// it was still in the streaming/loading state, or future render-gating changes),
-// in which case later images attach to the wrong message. Acceptable for a
-// copy-to-clipboard convenience; if it ever needs to be exact, walk per-message
-// DOM nodes instead of re-parsing text.
-function serializeSessionToHtml(messages: PilotMessage[], visualUrls: string[]): string {
-  const fenceRe = /```(chart|mermaid)\s*([\s\S]*?)```/g
-  let visualIdx = 0
-  const parts: string[] = []
-  for (const m of messages) {
-    if (m.hidden) continue
-    if (m.metadata?.kind === "delegation_status_notice") continue
-    if (m.role === "user") {
-      parts.push(`<p><strong>You:</strong></p><p>${escapeHtml(m.content.trim()).replace(/\n/g, "<br/>")}</p>`)
-    } else if (m.role === "assistant") {
-      const body = (m.content ?? "").trim()
-      if (!body) continue
-      let html = "<p><strong>Assistant:</strong></p>"
-      let last = 0
-      let match: RegExpExecArray | null
-      fenceRe.lastIndex = 0
-      while ((match = fenceRe.exec(body)) !== null) {
-        const before = body.slice(last, match.index).trim()
-        if (before) html += `<p>${escapeHtml(before).replace(/\n/g, "<br/>")}</p>`
-        const lang = match[1]
-        const raw = match[2].trim()
-        const parsed = lang === "chart" ? Boolean(tryParseChartSpec(raw)) : validateMermaidSource(raw).ok
-        if (parsed && visualIdx < visualUrls.length) {
-          html += `<p><img src="${visualUrls[visualIdx++]}" alt="${lang}" style="max-width:100%;height:auto"/></p>`
-        } else if (lang === "mermaid") {
-          html += "<p>[diagram]</p>"
-        } else {
-          html += `<p>[${lang}]</p>`
-        }
-        last = match.index + match[0].length
-      }
-      const tail = body.slice(last).trim()
-      if (tail) html += `<p>${escapeHtml(tail).replace(/\n/g, "<br/>")}</p>`
-      parts.push(html)
-    } else if (m.role === "tool") {
-      const name = m.toolName ?? "tool"
-      const out = (m.content ?? "").trim()
-      parts.push(
-        `<p><strong>[${escapeHtml(name)}]</strong></p>` +
-          (out ? `<pre>${escapeHtml(out)}</pre>` : ""),
-      )
-    } else if (m.role === "error") {
-      parts.push(`<p><strong>Error:</strong> ${escapeHtml((m.content ?? "").trim())}</p>`)
-    }
-  }
-  return `<div>${parts.join("")}</div>`
-}
-
-async function copySessionWithCharts(
-  container: HTMLElement,
-  messages: PilotMessage[],
-): Promise<boolean> {
-  const svgs = Array.from(container.querySelectorAll<SVGSVGElement>(
-    '.chart-host svg[role="img"], .mermaid-host svg[role="img"]',
-  ))
-  if (svgs.length === 0) return false
-  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false
-  try {
-    const visualUrls = await Promise.all(svgs.map((svg) => svgToPngDataUrl(svg)))
-    const html = serializeSessionToHtml(messages, visualUrls)
-    const plain = serializeSessionToText(messages)
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        "text/html": new Blob([html], { type: "text/html" }),
-        "text/plain": new Blob([plain], { type: "text/plain" }),
-      }),
-    ])
-    return true
-  } catch (err) {
-    console.warn("[copy] rich session copy failed, falling back to text:", err)
-    return false
-  }
-}
-
-function CopySessionButton({
-  messages,
-  containerRef,
-}: {
-  messages: PilotMessage[]
-  containerRef: React.RefObject<HTMLDivElement | null>
-}) {
-  const [copied, copy, flashCopied] = useCopyFeedback()
-  const handleCopy = async () => {
-    const container = containerRef.current
-    if (container && (await copySessionWithCharts(container, messages))) {
-      flashCopied()
-      return
-    }
-    void copy(serializeSessionToText(messages))
-  }
-  return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      title="Copy entire session"
-      className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
-    >
-      {copied ? <Check className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-    </button>
-  )
-}
-
 function CopyIconButton({
   text,
   title,
@@ -1478,55 +1581,6 @@ function CopyIconButton({
   )
 }
 
-// Plain-text fallback for the clipboard: a ```chart fenced JSON block is noise
-// when pasted as text, so swap it for a readable placeholder.
-function stripVisualizationFences(markdown: string): string {
-  return markdown
-    .replace(/```chart\s*[\s\S]*?```/g, "[chart]")
-    .replace(/```mermaid\s*[\s\S]*?```/g, "[diagram]")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim()
-}
-
-// Copy a rendered message bubble as rich text/html with visualisations rasterised to
-// inline PNGs, plus a text/plain fallback. Returns false when there are no
-// visualisations or the browser can't do a rich clipboard write, so the caller can
-// fall back to a plain markdown copy. Without this, "copy answer" yielded the
-// raw chart JSON spec or Mermaid source instead of the picture the user sees.
-async function copyBubbleWithCharts(bubble: HTMLElement, content: string): Promise<boolean> {
-  const visuals = Array.from(bubble.querySelectorAll<SVGSVGElement>(
-    '.chart-host svg[role="img"], .mermaid-host svg[role="img"]',
-  ))
-  if (visuals.length === 0) return false
-  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false
-  try {
-    const dataUrls = await Promise.all(visuals.map((svg) => svgToPngDataUrl(svg)))
-    const clone = bubble.cloneNode(true) as HTMLElement
-    const cloneHosts = Array.from(clone.querySelectorAll<HTMLElement>(".chart-host, .mermaid-host"))
-    cloneHosts.forEach((host, i) => {
-      const img = document.createElement("img")
-      img.src = dataUrls[i] ?? ""
-      img.style.maxWidth = "100%"
-      img.style.height = "auto"
-      host.replaceWith(img)
-    })
-    // Drop any leftover interactive controls (chart toolbars etc.).
-    clone.querySelectorAll("button").forEach((b) => b.remove())
-    const html = `<div>${clone.innerHTML}</div>`
-    const plain = stripVisualizationFences(content)
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        "text/html": new Blob([html], { type: "text/html" }),
-        "text/plain": new Blob([plain], { type: "text/plain" }),
-      }),
-    ])
-    return true
-  } catch (err) {
-    console.warn("[copy] rich chart copy failed, falling back to text:", err)
-    return false
-  }
-}
-
 function CopyableMessage({
   isUser,
   content,
@@ -1543,7 +1597,8 @@ function CopyableMessage({
 
   const handleCopy = async () => {
     const bubble = bubbleRef.current
-    if (bubble && (await copyBubbleWithCharts(bubble, content))) {
+    const plain = stripImageData(stripVisualizationFences(content))
+    if (bubble && (await copyElementsAsRichText([bubble], plain))) {
       flashCopied()
       return
     }

--- a/portal-web/src/components/chat/rich-copy.ts
+++ b/portal-web/src/components/chat/rich-copy.ts
@@ -1,0 +1,109 @@
+/**
+ * DOM-based rich clipboard copy for chat messages.
+ *
+ * The earlier "copy entire session" path re-serialised message *text* to HTML,
+ * which turned an inline markdown image `![](data:image/png;base64,…)` into the
+ * escaped base64 string — pasting "the data that generates the image" instead of
+ * the picture. Walking the rendered DOM instead (as the per-message copy already
+ * did) keeps real <img> elements intact and rasterises chart/Mermaid SVGs to
+ * PNG, so charts, diagrams, generated images and uploaded attachments all copy
+ * as pictures. This is the approach the old code's KNOWN LIMITATION comment
+ * recommended ("walk per-message DOM nodes instead of re-parsing text").
+ */
+
+import { svgToPngDataUrl } from "./svg-export"
+
+const VISUAL_SVG_SELECTOR = '.chart-host svg[role="img"], .mermaid-host svg[role="img"]'
+const VISUAL_HOST_SELECTOR = ".chart-host, .mermaid-host"
+
+// Clone one rendered element into copy-ready HTML: chart/Mermaid hosts become
+// rasterised PNG <img>s, interactive chrome is dropped, and real <img>s survive.
+// Rasterisation reads the *live* SVG (computed styles are lost on a detached
+// clone), so this is async. `hasVisual` tells the caller whether anything worth
+// a rich-HTML copy was found — a pure-text bubble copies better as plain markdown.
+async function cloneElementForCopy(el: HTMLElement): Promise<{ html: string; hasVisual: boolean }> {
+  const liveSvgs = Array.from(el.querySelectorAll<SVGSVGElement>(VISUAL_SVG_SELECTOR))
+  const dataUrls = await Promise.all(
+    liveSvgs.map((svg) =>
+      svgToPngDataUrl(svg).catch((err): string | null => {
+        console.warn("[copy] svg rasterisation failed:", err)
+        return null
+      }),
+    ),
+  )
+
+  const clone = el.cloneNode(true) as HTMLElement
+  // Strip chrome that should never land in a transcript (avatars, checkboxes,
+  // timing badges — tagged at the render site).
+  clone.querySelectorAll("[data-copy-ignore]").forEach((n) => n.remove())
+  // Drop interactive controls, but unwrap any button that wraps an image (e.g.
+  // the click-to-zoom button around an uploaded image) so the picture survives.
+  clone.querySelectorAll("button").forEach((b) => {
+    if (b.querySelector("img")) b.replaceWith(...Array.from(b.childNodes))
+    else b.remove()
+  })
+
+  // Swap each chart/Mermaid host for its PNG, matched by document order. A host
+  // with no rasterised URL (still loading, or rasterisation failed) falls back
+  // to a text placeholder so nothing half-rendered ships.
+  const hosts = Array.from(clone.querySelectorAll<HTMLElement>(VISUAL_HOST_SELECTOR))
+  let hasVisual = false
+  hosts.forEach((host, i) => {
+    const url = i < dataUrls.length ? dataUrls[i] : null
+    if (!url) {
+      const placeholder = document.createElement("span")
+      placeholder.textContent = host.classList.contains("mermaid-host") ? "[diagram]" : "[chart]"
+      host.replaceWith(placeholder)
+      return
+    }
+    const img = document.createElement("img")
+    img.src = url
+    img.style.maxWidth = "100%"
+    img.style.height = "auto"
+    host.replaceWith(img)
+    hasVisual = true
+  })
+
+  if (clone.querySelector("img")) hasVisual = true
+  return { html: clone.innerHTML, hasVisual }
+}
+
+/**
+ * Build the copy-ready HTML for a set of rendered message elements, with each
+ * visual turned into an image. Exposed separately from the clipboard write so it
+ * can be exercised without a real clipboard. `hasVisual` is false when there is
+ * nothing worth a rich-HTML copy.
+ */
+export async function buildCopyHtml(els: HTMLElement[]): Promise<{ html: string; hasVisual: boolean }> {
+  const parts = await Promise.all(els.map((el) => cloneElementForCopy(el)))
+  const hasVisual = parts.some((p) => p.hasVisual)
+  return { html: `<div>${parts.map((p) => p.html).join("")}</div>`, hasVisual }
+}
+
+/**
+ * Copy one or more rendered message elements as rich text/html (visuals as
+ * images) with a plain-text fallback in the same clipboard write.
+ *
+ * Returns false — so the caller can fall back to a plain-text copy — when there
+ * is nothing visual to preserve (a plain-text transcript reads better in an
+ * editor) or the browser can't do a rich clipboard write (e.g. insecure origin,
+ * no ClipboardItem).
+ */
+export async function copyElementsAsRichText(els: HTMLElement[], plainText: string): Promise<boolean> {
+  if (els.length === 0) return false
+  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) return false
+  try {
+    const { html, hasVisual } = await buildCopyHtml(els)
+    if (!hasVisual) return false
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        "text/html": new Blob([html], { type: "text/html" }),
+        "text/plain": new Blob([plainText], { type: "text/plain" }),
+      }),
+    ])
+    return true
+  } catch (err) {
+    console.warn("[copy] rich copy failed, falling back to text:", err)
+    return false
+  }
+}

--- a/portal-web/src/components/chat/selection-model.test.ts
+++ b/portal-web/src/components/chat/selection-model.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest"
+import {
+  EMPTY_SELECTION,
+  isSelected,
+  selectVisible,
+  toggleMessage,
+  selectAll,
+  selectedIds,
+  selectedCount,
+} from "./selection-model"
+
+const ids = (s: Parameters<typeof selectedIds>[0]) => [...selectedIds(s)].sort()
+
+describe("selection-model (visibility accumulate)", () => {
+  it("selects nothing by default", () => {
+    expect(selectedCount(EMPTY_SELECTION)).toBe(0)
+  })
+
+  it("auto-selects whatever is currently visible", () => {
+    const s = selectVisible(EMPTY_SELECTION, ["b", "c"])
+    expect(ids(s)).toEqual(["b", "c"])
+  })
+
+  it("accumulates as new messages scroll into view (up or down)", () => {
+    let s = selectVisible(EMPTY_SELECTION, ["c", "d"]) // initial screenful
+    s = selectVisible(s, ["d", "e"]) // scroll down
+    s = selectVisible(s, ["a", "b"]) // scroll up past the start
+    expect(ids(s)).toEqual(["a", "b", "c", "d", "e"])
+  })
+
+  it("returns the same state object when nothing new becomes visible", () => {
+    const s = selectVisible(EMPTY_SELECTION, ["a", "b"])
+    expect(selectVisible(s, ["a", "b"])).toBe(s)
+  })
+
+  it("un-checking excludes a message and scrolling past it won't re-select it", () => {
+    let s = selectVisible(EMPTY_SELECTION, ["a", "b", "c"])
+    s = toggleMessage(s, "b") // user un-checks b
+    expect(ids(s)).toEqual(["a", "c"])
+    s = selectVisible(s, ["a", "b", "c"]) // scroll past b again
+    expect(ids(s)).toEqual(["a", "c"]) // stays excluded
+  })
+
+  it("re-checking clears the exclusion", () => {
+    let s = selectVisible(EMPTY_SELECTION, ["a"])
+    s = toggleMessage(s, "a") // off
+    expect(isSelected(s, "a")).toBe(false)
+    s = toggleMessage(s, "a") // on again
+    expect(isSelected(s, "a")).toBe(true)
+    s = selectVisible(s, ["a"]) // and stays on while visible
+    expect(isSelected(s, "a")).toBe(true)
+  })
+
+  it("toggle works on a not-yet-seen message", () => {
+    const s = toggleMessage(EMPTY_SELECTION, "z")
+    expect(ids(s)).toEqual(["z"])
+  })
+
+  it("selectAll selects all and resets exclusions", () => {
+    let s = selectVisible(EMPTY_SELECTION, ["a"])
+    s = toggleMessage(s, "a") // exclude a
+    s = selectAll(["a", "b", "c"])
+    expect(ids(s)).toEqual(["a", "b", "c"])
+    // exclusion cleared: scrolling keeps everything
+    expect(selectVisible(s, ["a", "b", "c"])).toBe(s)
+  })
+})

--- a/portal-web/src/components/chat/selection-model.ts
+++ b/portal-web/src/components/chat/selection-model.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure state model for scroll-to-select message copying.
+ *
+ * Auto-select by visibility: in select mode, every message that is (or scrolls)
+ * into the viewport is selected automatically — no clicking. Selection
+ * accumulates as you scroll up or down, so you "paint" a range just by scrolling
+ * through it (mouse wheel or scrollbar, either direction). Checkboxes still let
+ * you fine-tune: un-checking a message records it in `excluded` so a later scroll
+ * past it won't re-select it.
+ */
+
+export interface SelectionState {
+  /** Currently selected message ids. */
+  selected: ReadonlySet<string>
+  /** Ids the user explicitly un-checked — never auto-re-selected on scroll. */
+  excluded: ReadonlySet<string>
+}
+
+export const EMPTY_SELECTION: SelectionState = { selected: new Set(), excluded: new Set() }
+
+export function isSelected(state: SelectionState, id: string): boolean {
+  return state.selected.has(id)
+}
+
+/**
+ * Auto-select every currently-visible id, skipping ones the user un-checked.
+ * Returns the SAME state object when nothing changed, so React skips the
+ * re-render — cheap to call on every scroll tick.
+ */
+export function selectVisible(state: SelectionState, visibleIds: readonly string[]): SelectionState {
+  let added = false
+  const selected = new Set(state.selected)
+  for (const id of visibleIds) {
+    if (state.excluded.has(id) || selected.has(id)) continue
+    selected.add(id)
+    added = true
+  }
+  return added ? { selected, excluded: state.excluded } : state
+}
+
+/**
+ * Toggle one message via its checkbox (or a click on the bubble). Un-checking
+ * records the id in `excluded` so scrolling past it again won't re-select it;
+ * re-checking clears that.
+ */
+export function toggleMessage(state: SelectionState, id: string): SelectionState {
+  const selected = new Set(state.selected)
+  const excluded = new Set(state.excluded)
+  if (selected.has(id)) {
+    selected.delete(id)
+    excluded.add(id)
+  } else {
+    selected.add(id)
+    excluded.delete(id)
+  }
+  return { selected, excluded }
+}
+
+/** Select every message (toolbar "All"); clears any manual exclusions. */
+export function selectAll(ids: readonly string[]): SelectionState {
+  return { selected: new Set(ids), excluded: new Set() }
+}
+
+export function selectedIds(state: SelectionState): Set<string> {
+  return new Set(state.selected)
+}
+
+export function selectedCount(state: SelectionState): number {
+  return state.selected.size
+}

--- a/portal-web/src/components/chat/transcript.test.ts
+++ b/portal-web/src/components/chat/transcript.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest"
+import {
+  stripImageData,
+  stripVisualizationFences,
+  serializeMessagesToText,
+  serializeMessagesToMarkdown,
+} from "./transcript"
+import type { PilotMessage } from "./types"
+
+function msg(partial: Partial<PilotMessage> & Pick<PilotMessage, "role">): PilotMessage {
+  return { id: Math.random().toString(36), content: "", timestamp: "12:00", ...partial }
+}
+
+describe("stripImageData", () => {
+  it("collapses a base64 data-URL image to a short placeholder", () => {
+    const big = "data:image/png;base64," + "A".repeat(5000)
+    const out = stripImageData(`before ![a diagram](${big}) after`)
+    expect(out).toBe("before [image: a diagram] after")
+    expect(out).not.toContain("base64")
+  })
+
+  it("uses a bare placeholder when the image has no alt text", () => {
+    expect(stripImageData("x ![](https://e/i.png) y")).toBe("x [image] y")
+  })
+
+  it("leaves non-image text untouched", () => {
+    expect(stripImageData("just [a link](https://e)")).toBe("just [a link](https://e)")
+  })
+})
+
+describe("stripVisualizationFences", () => {
+  it("replaces chart and mermaid fences with placeholders", () => {
+    const md = "intro\n\n```chart\n{\"x\":1}\n```\n\nmid\n\n```mermaid\ngraph TD\n```\n\nend"
+    const out = stripVisualizationFences(md)
+    expect(out).toContain("[chart]")
+    expect(out).toContain("[diagram]")
+    expect(out).not.toContain("graph TD")
+  })
+})
+
+describe("serializeMessagesToText", () => {
+  it("labels roles and skips hidden / status-notice messages", () => {
+    const out = serializeMessagesToText([
+      msg({ role: "user", content: "hello" }),
+      msg({ role: "assistant", content: "hi there" }),
+      msg({ role: "tool", toolName: "kubectl", toolInput: "get pods", content: "pod-1 Running" }),
+      msg({ role: "user", content: "secret", hidden: true }),
+      msg({ role: "assistant", content: "notice", metadata: { kind: "delegation_status_notice" } }),
+    ])
+    expect(out).toContain("You:\nhello")
+    expect(out).toContain("Assistant:\nhi there")
+    expect(out).toContain("[kubectl]\n$ get pods\npod-1 Running")
+    expect(out).not.toContain("secret")
+    expect(out).not.toContain("notice")
+  })
+
+  it("markdown export keeps content, bold role headers, fenced tool output, and rules", () => {
+    const md = serializeMessagesToMarkdown([
+      msg({ role: "user", content: "hello" }),
+      msg({ role: "assistant", content: "see ![pic](https://e/i.png)" }),
+      msg({ role: "tool", toolName: "kubectl", toolInput: "get pods", content: "pod-1 Running" }),
+    ])
+    expect(md).toContain("**You** · 12:00\n\nhello")
+    expect(md).toContain("**Siclaw**")
+    expect(md).toContain("![pic](https://e/i.png)") // images kept so they render in a viewer
+    expect(md).toContain("**[kubectl]**")
+    expect(md).toContain("```\npod-1 Running\n```")
+    expect(md).toContain("\n---\n") // messages separated by horizontal rules
+  })
+
+  it("markdown export keeps chart spec blocks verbatim (HTML export carries the rendered image)", () => {
+    const content = 'intro\n\n```chart\n{"type":"bar"}\n```\n\nmore'
+    const md = serializeMessagesToMarkdown([msg({ id: "a1", role: "assistant", content })])
+    expect(md).toContain("```chart")
+    expect(md).toContain('"type":"bar"')
+    expect(md).toContain("intro")
+    expect(md).toContain("more")
+  })
+
+  it("markdown export omits user attachments (transient OCR inputs)", () => {
+    const md = serializeMessagesToMarkdown([
+      msg({
+        role: "user",
+        content: "look at this",
+        attachments: [
+          { kind: "image", filename: "shot.png", mimeType: "image/png", data: "AAAB" },
+          { kind: "pdf", filename: "report.pdf", mimeType: "application/pdf", data: "ZZZ" },
+        ],
+      }),
+    ])
+    expect(md).toContain("look at this") // persisted content kept
+    expect(md).not.toContain("data:image/png;base64,AAAB") // attachment image omitted
+    expect(md).not.toContain("report.pdf") // attachment file omitted
+  })
+
+  it("does not dump raw base64 image data in assistant or user text", () => {
+    const big = "data:image/png;base64," + "Z".repeat(4000)
+    const out = serializeMessagesToText([
+      msg({ role: "user", content: `look ![shot](${big})` }),
+      msg({ role: "assistant", content: `here ![result](${big})` }),
+    ])
+    expect(out).not.toContain("base64")
+    expect(out).toContain("[image: shot]")
+    expect(out).toContain("[image: result]")
+  })
+})

--- a/portal-web/src/components/chat/transcript.ts
+++ b/portal-web/src/components/chat/transcript.ts
@@ -1,0 +1,80 @@
+/** Plain-text serialisation of chat messages for the clipboard. */
+
+import type { PilotMessage } from "./types"
+
+// A ```chart / ```mermaid fenced block is a JSON/diagram spec — useful as a
+// rendered picture, but noise when pasted as text. Swap each for a readable
+// placeholder. The rich text/html clipboard payload carries the actual image.
+export function stripVisualizationFences(markdown: string): string {
+  return markdown
+    .replace(/```chart\s*[\s\S]*?```/g, "[chart]")
+    .replace(/```mermaid\s*[\s\S]*?```/g, "[diagram]")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+// Markdown image syntax `![alt](src)` embeds the whole source inline. For data:
+// URLs that source is a multi-kilobyte base64 blob — pasting it as text dumps
+// "the data that generates the image" instead of the picture. Collapse it to a
+// short placeholder for the text/plain payload; the rich text/html payload keeps
+// the real <img>.
+export function stripImageData(markdown: string): string {
+  return markdown.replace(/!\[([^\]]*)\]\([^)]*\)/g, (_match, alt: string) => {
+    const label = (alt ?? "").trim()
+    return label ? `[image: ${label}]` : "[image]"
+  })
+}
+
+// Serialise a list of messages to a Markdown document for download. Content is
+// kept verbatim — chart/Mermaid stay as their ```chart / ```mermaid spec blocks
+// (compact, diff-friendly chart data); the companion HTML export carries the
+// rendered colour image. Role headers are bold, tool output is fenced, and
+// messages are separated by horizontal rules. User-pasted attachments
+// (message.attachments) are omitted — transient OCR inputs, not persisted.
+export function serializeMessagesToMarkdown(messages: PilotMessage[]): string {
+  const blocks: string[] = []
+  for (const m of messages) {
+    if (m.hidden) continue
+    if (m.metadata?.kind === "delegation_status_notice") continue
+    const ts = m.timestamp ? ` · ${m.timestamp}` : ""
+    if (m.role === "user") {
+      blocks.push(`**You**${ts}\n\n${(m.content ?? "").trim()}`)
+    } else if (m.role === "assistant") {
+      const body = (m.content ?? "").trim()
+      if (body) blocks.push(`**Siclaw**${ts}\n\n${body}`)
+    } else if (m.role === "tool") {
+      const name = m.toolName ?? "tool"
+      const cmd = m.toolInput ? `\`${m.toolInput}\`\n\n` : ""
+      const out = (m.content ?? "").trim()
+      blocks.push(`**[${name}]**${ts}\n\n${cmd}${out ? "```\n" + out + "\n```" : ""}`.trim())
+    } else if (m.role === "error") {
+      blocks.push(`**Error**${ts}\n\n${(m.content ?? "").trim()}`)
+    }
+  }
+  return blocks.join("\n\n---\n\n") + "\n"
+}
+
+// Serialise a list of messages to a plain-text transcript. Used both for the
+// "copy entire session" button and the scroll-selection "copy selected" action,
+// so it takes whatever subset of messages the caller hands it.
+export function serializeMessagesToText(messages: PilotMessage[]): string {
+  const lines: string[] = []
+  for (const m of messages) {
+    if (m.hidden) continue
+    if (m.metadata?.kind === "delegation_status_notice") continue
+    if (m.role === "user") {
+      lines.push(`You:\n${stripImageData((m.content ?? "").trim())}`)
+    } else if (m.role === "assistant") {
+      const body = stripImageData(stripVisualizationFences(m.content ?? ""))
+      if (body) lines.push(`Assistant:\n${body}`)
+    } else if (m.role === "tool") {
+      const name = m.toolName ?? "tool"
+      const input = m.toolInput ? `\n$ ${m.toolInput}` : ""
+      const out = (m.content ?? "").trim()
+      lines.push(`[${name}]${input}${out ? `\n${out}` : ""}`)
+    } else if (m.role === "error") {
+      lines.push(`Error: ${(m.content ?? "").trim()}`)
+    }
+  }
+  return lines.join("\n\n")
+}


### PR DESCRIPTION
Adds a select mode to the chat for exporting parts of a conversation.
Toggle it, then scroll — every message that enters the viewport is
auto-checked as you go (wheel or scrollbar, either direction), so you
build a selection without clicking. A floating toolbar offers All, Clear,
Copy, and Download; per-row checkboxes fine-tune.

Copy is also fixed: it now walks the rendered DOM, rasterizing
chart/Mermaid SVGs to PNG and keeping real <img> elements, so charts,
diagrams, generated images, and attachments copy as pictures instead of
raw markdown/base64. Download exports the selected messages as a Markdown
file, with images and mermaid preserved so they render in a viewer.