### PR TITLE
[codex] Set non-empty default Helm image registry

### DIFF
--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -1,6 +1,6 @@
 # -- Container images
 image:
-  registry: ""          # e.g. "siclaw" -> siclaw/siclaw-runtime:latest
+  registry: "siclaw"    # e.g. "siclaw" -> siclaw/siclaw-runtime:latest
   pullPolicy: Always
   tag: "latest"
 


### PR DESCRIPTION
## Summary

- Set the default Helm image registry namespace to `siclaw`.
- Keep the existing image tag and pull policy defaults unchanged.

## Why

The chart defaults should render concrete image references out of the box. A non-empty registry namespace makes the default rendered manifests easier to inspect and validate without requiring extra values.

## Validation

- `helm lint helm/siclaw`
- `helm template siclaw helm/siclaw | rg -n "image:"`
- `git diff --check`
