### PR TITLE
feat(tools): background execution for host_exec + all script tools (+ sub-agent completion fixes)

### DIFF
--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -161,8 +161,10 @@ Step 8: formatExecOutput()
 
 | Tool | Method | How |
 |------|--------|-----|
-| `node_script` | base64 inject | Encode script → echo + base64 -d inside nsenter. Supports `netns` param for pod network namespace. |
+| `node_script` | stdin pipe | `kubectl exec -i` → `nsenter … sh -c '<reader>'` with the script piped to stdin (`sh -s` / `python3 -`). Supports `netns` param for pod network namespace. |
 | `pod_script` | stdin pipe | `kubectl exec -i` with script piped to stdin |
+| `host_script` | stdin pipe | ssh2 channel with the script piped to the remote `sh -s` / `python3 -` |
+| `local_script` | argv | interpreter + scriptPath (+ args) spawned directly in the AgentBox |
 
 ---
 
@@ -177,7 +179,7 @@ The most complex tool. Handles full shell pipelines with:
 - Production mode: `sudo -E -u sandbox` user isolation
 - Skill script detection bypass (`isSkillScript`)
 - 3-layer output sanitization (see §6.2)
-- Optional `run_in_background` (see §9) — exposed only when a `backgroundBashExecutor` is injected
+- Optional `run_in_background` (see §9) — exposed only when a `backgroundExecExecutor` is injected
 
 **kubectl access**: There is no dedicated kubectl tool — all kubectl commands go
 through `restricted_bash` with pipeline validation. `validateKubectlInPipeline()`
@@ -480,27 +482,33 @@ than 2 new cmd-exec tools are added.
 ## 9. Background Jobs (`run_in_background`)
 
 Two background modes share one core, modeled on Claude Code's `run_in_background`:
-**background bash** (a detached shell command) and **background sub-agent**
-(`spawn_subagent run_in_background`). They are peers — background bash does NOT spawn a
-sub-agent. Master switches: `BACKGROUND_BASH_ENABLED` and `RUN_IN_BACKGROUND_ENABLED`
-(`src/core/subagent-registry.ts`).
+**background exec** (a detached command/stream) and **background sub-agent**
+(`spawn_subagent run_in_background`). They are peers — background exec does NOT spawn a
+sub-agent. Background exec is wired on the whole exec + script family: `bash`, `node_exec`,
+`pod_exec`, `host_exec`, and the `local_script` / `node_script` / `pod_script` / `host_script`
+tools. Master switches: `BACKGROUND_BASH_ENABLED` (the exec + script family) and
+`RUN_IN_BACKGROUND_ENABLED` (sub-agents) (`src/core/subagent-registry.ts`).
 
 ### 9.1 Shared pieces
 
-- **`JobRegistry`** (`src/core/job-registry.ts`) — one per runtime; `JobRecord{type:"subagent"|"bash"}`.
+- **`JobRegistry`** (`src/core/job-registry.ts`) — one per runtime; `JobRecord{type:"subagent"|"bash"|"node"|"pod"|"host"|"local"}`.
   `claimNotification(jobId)` is the atomic dedup latch (a completion notice is sent EXACTLY
   once, even when process-exit and `job_stop` race).
 - **`buildTaskNotificationText`** (`src/core/task-notification.ts`) — the `<task_notification>`
   XML (task_id / output_file / status / summary) injected back into the parent model.
-- **`spawnBackgroundBash`** (`src/core/background-bash-runner.ts`) — runtime-agnostic: spawns
-  detached, streams sanitized output to disk (`SanitizingLineBuffer`, §6b sanitization.md),
-  registers the job, fires `notify` once on exit.
+- **`spawnBackgroundBash`** (`src/core/background-bash-runner.ts`) — runtime-agnostic launcher
+  with **three exec modes** (exactly one per request): `command` (detached shell — bash),
+  `file`+`args` (detached argv, no shell — node/pod/local/scripts; optional `stdin` carries a
+  script body), and `streamFactory` (in-process ssh2 stream — host_exec/host_script: no child
+  process, the factory dials ssh and returns live stdout/stderr + a `done` promise and owns
+  connection teardown). All three stream sanitized output to disk (`SanitizingLineBuffer`,
+  §6b sanitization.md), register the job, and fire `notify` exactly once on settle.
 - **`job_stop`** — generalized to cancel either job type (bash → process-group SIGKILL).
 
 ### 9.2 The completion-notification injector
 
 Tools have no live brain handle, so background work is launched via injected executors
-(`ToolRefs.backgroundBashExecutor`, `spawnSubagentExecutor`) and notified back through the
+(`ToolRefs.backgroundExecExecutor`, `spawnSubagentExecutor`) and notified back through the
 runtime:
 
 - **Gateway/agentbox** (`AgentBoxSessionManager.notifyParent`): parent run in-flight
@@ -536,11 +544,12 @@ Background bash output streams to `<userDataDir>/agent/tasks/<jobId>.output` (wi
 built-in `read` tool (offset/limit) to inspect progress and is notified on completion — it
 must NOT poll. Output is sanitized on write (§6b sanitization.md).
 
-### 9.4 Background on remote tools (node_exec / pod_exec)
+### 9.4 Background on remote & script tools (node_exec / pod_exec / host_exec / scripts)
 
-`run_in_background` also works on `node_exec` and `pod_exec` (gated identically on the
-injected executor). This is how long node-side work — e.g. RDMA perftest打流, server on
-node A + client on node B — runs without a dedicated skill.
+`run_in_background` also works on `node_exec`, `pod_exec`, `host_exec`, and every script tool
+(`local_script` / `node_script` / `pod_script` / `host_script`), gated identically on the
+injected executor. This is how long node-/host-side work — e.g. RDMA perftest打流, server on
+node A + client on node B — runs, whether issued as a one-off command or a skill script.
 
 The mechanism reuses the same runner in **argv mode**: the agentbox spawns the
 `kubectl exec <pod> -- …` (node_exec: into a debug pod, `nsenter` into the host;
@@ -557,6 +566,14 @@ on-disk file the model reads. Differences from bash background:
   — longer runs need a shorter perftest duration or a raised `debugPodTTL`.
 - **pod_exec** has no debug pod / no pin; the process is bounded by the target pod's
   lifecycle. If stopped early, the in-pod process may keep running until the pod ends.
+- **host_exec / host_script** use the **stream mode** (ssh2, no child process). The remote
+  command is wrapped in **`timeout <ttl>`** (host_exec default 600s, cap 3600s; host_script
+  the same) so a dropped channel cannot orphan the remote process — `job_stop` closes the
+  channel and the remote is bounded by `timeout`. The script body (host_script) is piped via
+  the ssh channel's stdin. `sshExecStream` (`src/tools/infra/ssh-client.ts`) owns chain teardown.
+- **node_script / pod_script / local_script** reuse the argv mode with the script piped via
+  `stdin` (no temp files on the target). node_script pins a debug pod and records the remote
+  PGID exactly like node_exec; pod/local mirror pod_exec/bash.
 
 The per-session concurrency cap (`getBackgroundBashConcurrency`) counts ALL background
-exec jobs (bash + node + pod) together; over the cap, the tool falls back to foreground.
+exec jobs (bash + node + pod + host + local) together; over the cap, the tool falls back to foreground.

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -1250,6 +1250,16 @@ function agentWorkBatchSummary(message: PilotMessage): {
   }
 }
 
+// A spawn_subagent launched in the background — detectable from the launch itself (run_in_background
+// arg or the "launched" result), so the card shows the indicator/running state during the LIVE turn,
+// not only after annotateSubagentCompletions runs on a refetch.
+function isBackgroundSpawn(message: PilotMessage): boolean {
+  if (message.toolName !== "spawn_subagent") return false
+  if ((message.toolArgs as Record<string, unknown> | undefined)?.run_in_background === true) return true
+  const parsed = message.content ? parseJsonRecord(message.content) : null
+  return stringValue(parsed?.status) === "launched"
+}
+
 function agentWorkSummary(message: PilotMessage): {
   target: string
   targetLabel: string
@@ -1292,7 +1302,12 @@ function agentWorkSummary(message: PilotMessage): {
     targetLabel: isSelfDelegation ? "self sub-agent" : (targetName ? `${targetName} · ${rawTarget}` : rawTarget),
     isSelfDelegation,
     scope: stringValue(args.description) ?? stringValue(args.scope) ?? stringValue(args.prompt) ?? stringValue(metadata.scope) ?? message.toolInput,
-    summary: normalizeAgentWorkSummary(stringValue(result.summary) ?? stringValue(message.content)),
+    summary: normalizeAgentWorkSummary(
+      // Background spawn: the folded sub-agent report (subBgSummary), not the launch JSON.
+      stringValue(metadata.subBgSummary) ??
+      stringValue(result.summary) ??
+      (isBackgroundSpawn(message) ? undefined : stringValue(message.content)),
+    ),
     fullSummary: normalizeAgentWorkSummary(
       stringValue(details.full_summary) ??
       stringValue(metadata.full_summary) ??
@@ -1309,6 +1324,10 @@ function agentWorkSummary(message: PilotMessage): {
     duration: compactDuration(durationMs ?? message.metadata?.durationMs as number | undefined),
     toolTrace: toolTraceValue(result.tool_trace ?? result.toolTrace ?? details.tool_trace ?? details.toolTrace),
     status:
+      // Background spawn: folded completion status, else "running" until it folds — never the
+      // launch result's "launched" (which would show as the default "Ready").
+      stringValue(metadata.subBgStatus) ??
+      (isBackgroundSpawn(message) ? "running" : undefined) ??
       stringValue(result.status) ??
       stringValue(metadata.status) ??
       message.toolStatus ??
@@ -1786,7 +1805,12 @@ function AgentWorkCard({ message }: { message: PilotMessage }) {
   // "running" at once (one tool_execution_start each), so without this the queued
   // children would falsely show a spinner; the backend flips status to "queued".
   const isQueued = work.status === "queued"
-  const isRunning = !isQueued && (message.toolStatus === "running" || message.isStreaming)
+  // Background spawn_subagent: the launch tool returns immediately (toolStatus "success"), so it
+  // is "running in the background" until its completion folds in (subBgStatus). Treat that as
+  // running so the card shows a spinner + the background marker instead of a bare "Ready".
+  const isBgSubagent = isBackgroundSpawn(message)
+  const bgSubDone = Boolean(message.metadata?.subBgStatus)
+  const isRunning = !isQueued && (message.toolStatus === "running" || message.isStreaming || (isBgSubagent && !bgSubDone))
   const isSpawn = message.toolName === "spawn_subagent"
   // Collapsed by default — the user expands the card when they want to see the
   // execution. (Legacy delegate cards keep auto-opening while streaming.)
@@ -1819,6 +1843,15 @@ function AgentWorkCard({ message }: { message: PilotMessage }) {
                   sub-agent
                 </span>
               )}
+              {isBgSubagent && (
+                <span
+                  className="shrink-0 inline-flex text-muted-foreground/70"
+                  title="Runs in the background — returns immediately, notifies on completion"
+                  aria-label="Background execution"
+                >
+                  <Clock className="w-3.5 h-3.5" />
+                </span>
+              )}
               <span className={cn("shrink-0 px-2 py-0.5 rounded-full border text-[11px] font-medium", tone.className)}>
                 {tone.label}
               </span>
@@ -1842,7 +1875,9 @@ function AgentWorkCard({ message }: { message: PilotMessage }) {
               // The card is just the sub-agent's execution process; the conclusion is
               // surfaced by the parent in the main conversation, so no report here.
               <div>
-                <div className="text-[11px] uppercase tracking-wide text-muted-foreground mb-1">Execution</div>
+                <div className="text-[11px] uppercase tracking-wide text-muted-foreground mb-1">
+                  {isBgSubagent && bgSubDone ? "Result" : "Execution"}
+                </div>
                 {steps.length > 0 ? (
                   <SubagentSteps steps={steps} />
                 ) : isQueued ? (
@@ -1852,8 +1887,13 @@ function AgentWorkCard({ message }: { message: PilotMessage }) {
                   </div>
                 ) : isRunning ? (
                   <div className="text-xs text-muted-foreground flex items-center gap-2">
-                    <Loader2 className="w-3 h-3 animate-spin" /> Sub-agent working…
+                    <Loader2 className="w-3 h-3 animate-spin" />
+                    {isBgSubagent ? "Running in the background… (updates here when done)" : "Sub-agent working…"}
                   </div>
+                ) : isBgSubagent && work.summary ? (
+                  // Background sub-agent has no inline steps (it ran in its own session); show the
+                  // folded result report so the user sees the outcome on the card.
+                  <div className="text-sm text-foreground"><Markdown>{work.summary}</Markdown></div>
                 ) : (
                   <div className="text-xs text-muted-foreground/60">(no execution recorded)</div>
                 )}
@@ -2199,8 +2239,8 @@ function ToolItem({ message, nested }: { message: PilotMessage; nested?: boolean
           {isBackground && (
             <span
               className="shrink-0 inline-flex text-muted-foreground/70"
-              title="后台执行:立即返回,完成后自动通知"
-              aria-label="后台执行"
+              title="Runs in the background — returns immediately, notifies on completion"
+              aria-label="Background execution"
             >
               <Clock className="w-3.5 h-3.5" />
             </span>
@@ -2271,12 +2311,12 @@ function ToolItem({ message, nested }: { message: PilotMessage; nested?: boolean
               <pre className="text-xs font-mono leading-relaxed text-muted-foreground whitespace-pre-wrap pr-8">
                 {isBackground
                   ? (bgRunning
-                      ? "在后台运行中…(完成后此处更新)"
+                      ? "Running in the background… (updates here when done)"
                       : bgFailed
-                        ? `后台任务失败${bgExitLabel}`
+                        ? `Background task failed${bgExitLabel}`
                         : bgStopped
-                          ? "后台任务已停止"
-                          : `后台任务完成${bgExitLabel}`)
+                          ? "Background task stopped"
+                          : `Background task completed${bgExitLabel}`)
                   : (message.content || (message.toolStatus === "aborted" ? "Aborted." : "Running..."))}
               </pre>
               {/* Output copy only for a real captured output — a background box's body is a

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -319,7 +319,7 @@ async function fetchSessionPage1(
     `/siclaw/agents/${agentId}/chat/sessions/${sessionId}/messages?page=1&page_size=${PAGE_SIZE}`,
   )
   const items = Array.isArray(res.data) ? res.data : Array.isArray(res) ? (res as unknown as ChatMessage[]) : []
-  return { items, pilotMsgs: annotateExecJobCompletions(annotateDelegationSynthesis(items.map(toPilotMessage))) }
+  return { items, pilotMsgs: annotateSubagentCompletions(annotateExecJobCompletions(annotateDelegationSynthesis(items.map(toPilotMessage)))) }
 }
 
 function toPilotMessage(m: ChatMessage): PilotMessage {
@@ -516,6 +516,66 @@ function annotateExecJobCompletions(messages: PilotMessage[]): PilotMessage[] {
   })
 }
 
+/**
+ * Fold a BACKGROUND spawn_subagent's completion into its launch card. The launch tool row
+ * returns {status:"launched", job_id} immediately; the sub-agent's result lands later as a
+ * hidden delegation_event whose delegation_id === the launch job_id (spawnId). Mark the launch
+ * background (so the card shows the clock indicator + a running state) and, once the completion
+ * is present, attach subBgStatus/subBgSummary so the card folds running → done/failed with the
+ * report. Refresh-safe — it's all chat history. (Sync spawn cards already fold via streaming.)
+ */
+function annotateSubagentCompletions(messages: PilotMessage[]): PilotMessage[] {
+  const done = new Map<string, { status: string; summary?: string }>()
+  for (const m of messages) {
+    if (m.metadata?.kind !== "delegation_event") continue
+    const id = messageDelegationId(m)
+    if (!id) continue
+    const raw = (messageString(m.metadata?.event_type) ?? messageString(m.metadata?.status) ?? "done").toLowerCase()
+    if (/run|start|queue|pend|progress|synthes/.test(raw)) continue // not a terminal event
+    // Preserve timed_out / partial as their own (amber) statuses — collapsing them into "done"
+    // showed a truncated/timed-out background investigation as a clean green success. statusTone
+    // renders both amber, matching the foreground delegation path.
+    const status = /fail|error/.test(raw) ? "failed"
+      : /cancel|abort|stop/.test(raw) ? "cancelled"
+      : /timed?[-_ ]?out/.test(raw) ? "timed_out"
+      : /partial|truncat/.test(raw) ? "partial"
+      : "done"
+    done.set(id, { status, summary: typeof m.content === "string" ? m.content : undefined })
+  }
+  let changed = false
+  const next = messages.map((m) => {
+    if (!isBackgroundSpawnLaunch(m)) return m // foreground spawn already carries its final status
+    const parsed = m.content ? tryParseJson(m.content) : undefined
+    changed = true
+    const jobId = messageString(parsed?.job_id) ?? messageDelegationId(m) ?? m.id
+    const c = jobId ? done.get(jobId) : undefined
+    return {
+      ...m,
+      metadata: {
+        ...(m.metadata ?? {}),
+        subBackground: true,
+        ...(c ? { subBgStatus: c.status, subBgSummary: c.summary } : {}),
+      },
+    }
+  })
+  return changed ? next : messages
+}
+
+/** A spawn_subagent launched in the background — detectable from the launch itself (args /
+ * "launched" result), so it works during the LIVE turn too, not only after annotate runs on a
+ * refetch. */
+function isBackgroundSpawnLaunch(m: PilotMessage): boolean {
+  if (m.role !== "tool" || m.toolName !== "spawn_subagent") return false
+  if ((m.toolArgs as Record<string, unknown> | undefined)?.run_in_background === true) return true
+  const parsed = m.content ? tryParseJson(m.content) : undefined
+  return parsed?.status === "launched"
+}
+
+/** A background spawn_subagent that launched but whose completion hasn't folded in yet. */
+function hasActiveBackgroundSubagent(messages: PilotMessage[]): boolean {
+  return messages.some((m) => isBackgroundSpawnLaunch(m) && !m.metadata?.subBgStatus)
+}
+
 function hasPendingDelegationSynthesis(messages: PilotMessage[]): boolean {
   return messages.some((message) => message.metadata?.ui_state === "synthesizing")
 }
@@ -542,6 +602,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const activeSessionIdRef = useRef<string | undefined>(sessionId ?? undefined)
   const [isCompacting, setIsCompacting] = useState(false)
   const hasActiveAsyncDelegation = hasActiveAsyncDelegationSurface(messages)
+  const hasActiveBgSubagent = hasActiveBackgroundSubagent(messages)
 
   // Per-session state cache: preserves ALL state across session switches so each
   // agent's conversation feels independent — like browser tabs.
@@ -751,6 +812,32 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     }
   }, [agentId, sessionId, hasActiveAsyncDelegation])
 
+  // A background spawn_subagent isn't an async-delegation batch, so the poller above doesn't
+  // cover it, and its completion is a pure-ack synthetic turn (no background_turn_done). Poll
+  // history while one is running so its card folds running → done live (annotateSubagentCompletions
+  // does the fold); stop once folded. Never clobbers a live /send stream or paged-back scrollback.
+  useEffect(() => {
+    if (!sessionId || !hasActiveBgSubagent) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    async function poll() {
+      try {
+        const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
+        if (cancelled) return
+        if (pageRef.current === 1 && !streamingRef.current) {
+          setMessages(pilotMsgs)
+          setHasMore(items.length >= PAGE_SIZE)
+        }
+        if (!hasActiveBackgroundSubagent(pilotMsgs)) return // folded → stop polling
+      } catch (err) {
+        console.warn("[usePilotChat] background-subagent refresh failed:", err)
+      }
+      if (!cancelled) timer = setTimeout(poll, 2500)
+    }
+    timer = setTimeout(poll, 1500)
+    return () => { cancelled = true; if (timer) clearTimeout(timer) }
+  }, [agentId, sessionId, hasActiveBgSubagent])
+
   // Persistent per-session SSE: receives server-pushed turns that land while the user is
   // idle — e.g. a background job's completion turn, generated AFTER the /send stream closed.
   // We do NOT render events live off this channel (the synthetic turn's body isn't streamed
@@ -810,6 +897,23 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
                 ? { ...m, metadata: { ...(m.metadata ?? {}), bgStatus: status, bgExitCode: exitCode } }
                 : m,
             ),
+          )
+        } else if (evt?.type === "subagent_done" && typeof evt.job_id === "string") {
+          // Fold the background spawn_subagent card in place (running → done/failed/…), regardless
+          // of page/stream state — so a completion the model stays silent about doesn't leave the
+          // card stuck on "Running…". The refetch reconciles the full summary later.
+          const jobId = evt.job_id
+          const raw = (typeof evt.status === "string" ? evt.status : "completed").toLowerCase()
+          const status = raw === "completed" ? "done" : raw === "stopped" ? "cancelled" : raw // failed/timed_out/partial pass through
+          setMessages((prev) =>
+            prev.map((m) => {
+              if (!isBackgroundSpawnLaunch(m) || m.metadata?.subBgStatus) return m
+              const parsedJobId = (m.content ? tryParseJson(m.content) : undefined)?.job_id
+              const launchJobId = (typeof parsedJobId === "string" ? parsedJobId : undefined) ?? messageDelegationId(m) ?? m.id
+              return launchJobId === jobId
+                ? { ...m, metadata: { ...(m.metadata ?? {}), subBackground: true, subBgStatus: status } }
+                : m
+            }),
           )
         }
       } catch { /* ignore malformed frame */ }

--- a/scripts/smoke/bg-browser.mjs
+++ b/scripts/smoke/bg-browser.mjs
@@ -1,0 +1,98 @@
+// Real-browser full-chain smoke for background exec. Phase A: drive a real agent to launch a
+// background host_exec that completes, and (on completion) read+report its output. Phase B: open
+// that session in headless Chrome (CDP) and assert the RENDERED DOM shows the host_exec tool box
+// folded to the done state, the completion bubble with the output marker, and NO raw
+// <task_notification> bubble. Screenshots are written to /tmp for evidence.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import WebSocket from "ws";
+
+const baseUrl = process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080";
+const apiBase = `${baseUrl}/api/v1`;
+const chromeBin = process.env.CHROME_BIN ?? "/usr/bin/google-chrome";
+const HOST = process.env.HOST_NAME ?? "172.16.73.22";
+const MARKER = process.env.MARKER ?? `SMOKE_UI_${Date.now() % 100000}`;
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function jf(url, opts = {}) {
+  const res = await fetch(url, { ...opts, headers: { "Content-Type": "application/json", ...(opts.headers ?? {}) } });
+  const text = await res.text();
+  let body; try { body = text ? JSON.parse(text) : {}; } catch { body = text; }
+  if (!res.ok) throw new Error(`${opts.method ?? "GET"} ${url} ${res.status}: ${text.slice(0, 200)}`);
+  return body;
+}
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+async function freePort() { return new Promise((res, rej) => { const s = net.createServer(); s.once("error", rej); s.listen(0, "127.0.0.1", () => { const p = s.address().port; s.close(() => res(p)); }); }); }
+
+// ---------- Phase A: create a completed-background session ----------
+const token = (await jf(`${apiBase}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${apiBase}/agents`, { headers: auth })).data?.[0];
+const session = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: `bg ui ${Date.now()}` }) });
+console.log(JSON.stringify({ sessionId: session.id, marker: MARKER }));
+
+const prompt = `Use the host_exec tool with run_in_background set to true to run this exact command on host "${HOST}": sleep 5; echo ${MARKER} . After launching, immediately end your turn — do not read the output yet. When you are LATER notified that it completed, read its output_file with the read tool and report the exact line it printed.`;
+const res = await fetch(`${apiBase}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text: prompt, session_id: session.id }) });
+{ const rd = res.body.getReader(); const dec = new TextDecoder(); while (true) { const { done } = await rd.read(); if (done) break; } } // drain launch turn
+
+// wait until the completion turn (with MARKER) is persisted
+let ok = false;
+for (let i = 0; i < 60; i++) {
+  const rows = (await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions/${session.id}/messages?page=1&page_size=100`, { headers: auth })).data ?? [];
+  const ev = rows.find((m) => pj(m.metadata).kind === "exec_job_event" && String(pj(m.metadata).job_id || "").includes("host_exec"));
+  const marker = rows.some((m) => m.role === "assistant" && (m.content || "").includes(MARKER));
+  if (ev && pj(ev.metadata).status === "completed" && marker) { ok = true; break; }
+  await wait(3000);
+}
+if (!ok) { console.log("RESULT: FAIL — completion turn with marker not persisted (phase A)"); process.exit(1); }
+console.log("phase A done: exec_job_event completed + completion turn persisted");
+
+// ---------- Phase B: open in headless Chrome, inspect rendered DOM ----------
+const profile = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-bg-ui-"));
+const cdpPort = await freePort();
+const chrome = spawn(chromeBin, ["--headless=new", `--remote-debugging-port=${cdpPort}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", "--disable-gpu", "--disable-extensions", "about:blank"], { stdio: "ignore" });
+async function cdpWsUrl() { for (let i = 0; i < 50; i++) { try { const list = await (await fetch(`http://127.0.0.1:${cdpPort}/json/list`)).json(); const page = list.find((t) => t.type === "page") ?? list[0]; if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl; } catch {} await wait(100); } throw new Error("Chrome CDP did not start"); }
+let ws;
+try {
+  ws = new WebSocket(await cdpWsUrl());
+  let seq = 0; const pending = new Map();
+  ws.on("message", (buf) => { const m = JSON.parse(buf.toString()); if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); } });
+  await new Promise((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
+  const send = (method, params = {}) => { const id = ++seq; ws.send(JSON.stringify({ id, method, params })); return new Promise((resolve, reject) => { pending.set(id, (m) => (m.error ? reject(new Error(JSON.stringify(m.error))) : resolve(m.result))); setTimeout(() => reject(new Error(`CDP timeout ${method}`)), 15000); }); };
+  await send("Page.enable"); await send("Runtime.enable");
+  await send("Emulation.setDeviceMetricsOverride", { width: 1600, height: 1600, deviceScaleFactor: 1, mobile: false });
+  await send("Page.navigate", { url: `${baseUrl}/login` });
+  await wait(700);
+  await send("Runtime.evaluate", { expression: `localStorage.setItem('token', ${JSON.stringify(token)}); true`, awaitPromise: true });
+  await send("Page.navigate", { url: `${baseUrl}/chat?agent=${agent.id}&session=${session.id}` });
+  const bodyText = async () => (await send("Runtime.evaluate", { expression: "document.body.innerText", returnByValue: true })).result.value ?? "";
+  const waitForText = async (needle) => { for (let i = 0; i < 100; i++) { const t = await bodyText(); if (t.includes(needle)) return t; await wait(300); } throw new Error(`timeout waiting for "${needle}"`); };
+
+  // The completion bubble carries the marker — wait for it to render.
+  await waitForText(MARKER);
+  // Expand the host_exec tool box to reveal its body (lifecycle text).
+  await send("Runtime.evaluate", { expression: `
+    const btn = Array.from(document.querySelectorAll('[role=button],button')).find((b)=>/host_exec/.test(b.innerText||''));
+    btn?.scrollIntoView({block:'center'}); btn?.click(); true`, awaitPromise: true });
+  await wait(600);
+  const text = await bodyText();
+  await wait(200);
+  const shot = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: true });
+  const screenshot = `/tmp/siclaw-bg-ui-${session.id}.png`;
+  await fs.writeFile(screenshot, Buffer.from(shot.data, "base64"));
+
+  const checks = {
+    hostExecBoxRendered: text.includes("host_exec"),
+    completionBubbleHasMarker: text.includes(MARKER),
+    boxFoldedDone: text.includes("Background task completed") || /exit 0/.test(text),
+    stillRunningGone: !text.includes("Running in the background"),
+    noRawTaskNotification: !text.includes("<task_notification>") && !text.includes("task_notification"),
+  };
+  console.log(JSON.stringify({ checks, screenshot }, null, 2));
+  const fail = Object.entries(checks).filter(([, v]) => !v).map(([k]) => k);
+  if (fail.length) { console.log("RESULT: FAIL — " + fail.join(", ") + "\n--- body ---\n" + text.slice(0, 1500)); process.exit(1); }
+  console.log("RESULT: PASS — browser rendered: host_exec box folded to done, completion bubble shows output marker, no raw task_notification bubble");
+} finally { ws?.close(); chrome.kill("SIGTERM"); }

--- a/scripts/smoke/bg-exec.mjs
+++ b/scripts/smoke/bg-exec.mjs
@@ -1,0 +1,83 @@
+// Live smoke for background exec/script tools + completion-event handling.
+// Usage: SICLAW_PORTAL_URL=... PROMPT="..." MARKER="SMOKE_DONE_x" node bg-exec.mjs
+// Verifies: (1) the tool launched in background (task_id), (2) a hidden exec_job_event
+// completion row is persisted (the box-fold signal), (3) the model produced a follow-up
+// assistant turn AFTER the launch (the synthetic completion turn), (4) terminal status.
+const baseUrl = process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080";
+const apiBase = `${baseUrl}/api/v1`;
+const PROMPT = process.env.PROMPT;
+const MARKER = process.env.MARKER ?? "SMOKE_DONE";
+const TOOL = process.env.TOOL; // expected launch tool (e.g. node_script); verdict keys on this
+const timeoutMs = Number(process.env.BG_TIMEOUT_MS ?? 180_000);
+
+async function jf(url, opts = {}) {
+  const res = await fetch(url, { ...opts, headers: { "Content-Type": "application/json", ...(opts.headers ?? {}) } });
+  const text = await res.text();
+  let body; try { body = text ? JSON.parse(text) : {}; } catch { body = text; }
+  if (!res.ok) throw new Error(`${opts.method ?? "GET"} ${url} ${res.status}: ${text.slice(0, 300)}`);
+  return body;
+}
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const token = (await jf(`${apiBase}/auth/login`, { method: "POST", body: JSON.stringify({ username: process.env.SICLAW_SMOKE_USER ?? "admin", password: process.env.SICLAW_SMOKE_PASSWORD ?? "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${apiBase}/agents`, { headers: auth })).data?.[0];
+const session = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: `bg smoke ${Date.now()}` }) });
+console.log(JSON.stringify({ agent: agent.name, sessionId: session.id, marker: MARKER }));
+
+// Send + drain the SSE stream (the launch turn).
+const res = await fetch(`${apiBase}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text: PROMPT, session_id: session.id }) });
+if (!res.ok) throw new Error(`send ${res.status}: ${await res.text()}`);
+const reader = res.body.getReader(); const dec = new TextDecoder(); let buf = "";
+const toolEnds = []; const toolStarts = [];
+while (true) {
+  const { done, value } = await reader.read(); if (done) break;
+  buf += dec.decode(value, { stream: true });
+  const frames = buf.split("\n\n"); buf = frames.pop() ?? "";
+  for (const f of frames) {
+    let ev = "message", data = "";
+    for (const line of f.split("\n")) { if (line.startsWith("event: ")) ev = line.slice(7); else if (line.startsWith("data: ")) data += line.slice(6); }
+    if (ev === "chat.event") { let p = data; try { p = JSON.parse(data); } catch {} if (p.type === "tool_execution_start") toolStarts.push(p); if (p.type === "tool_execution_end") toolEnds.push(p); }
+  }
+}
+const launch = toolEnds.find((t) => /host_exec|host_script|local_script|node_script|pod_script|bash/.test(t.toolName || ""));
+const launchText = launch ? JSON.stringify(launch.result) : "";
+const launchedInBg = /task_id|output_file|backgroundTaskId|background/i.test(launchText);
+console.log(JSON.stringify({ launchTool: launch?.toolName, launchedInBg, launchHead: launchText.slice(0, 300) }));
+
+// Poll the DB for the completion-event chain.
+const startedAt = Date.now();
+let execJobEvent = null, assistantAfterLaunch = false, launchRow = null, rowsN = 0;
+while (Date.now() - startedAt < timeoutMs) {
+  const msgs = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions/${session.id}/messages?page=1&page_size=100`, { headers: auth });
+  const rows = msgs.data ?? []; rowsN = rows.length;
+  const launchRe = TOOL ? new RegExp(`^${TOOL}$`) : /host_exec|host_script|local_script|node_script|pod_script|bash/;
+  const launchIdx = rows.findIndex((m) => m.tool_name && launchRe.test(m.tool_name));
+  launchRow = launchIdx >= 0 ? rows[launchIdx] : null;
+  // Key the completion event on the TARGET tool's job_id (discovery calls may precede it).
+  execJobEvent = rows.find((m) => pj(m.metadata).kind === "exec_job_event" && (!TOOL || String(pj(m.metadata).job_id || "").includes(TOOL))) ?? null;
+  // a substantive assistant turn after the launch row (the synthetic completion turn)
+  assistantAfterLaunch = launchIdx >= 0 && rows.slice(launchIdx + 1).some((m) => m.role === "assistant" && (m.content || "").trim().length > 0);
+  if (execJobEvent && (execJobEvent && pj(execJobEvent.metadata).status)) break;
+  await sleep(3000);
+}
+
+const meta = pj(execJobEvent?.metadata);
+const result = {
+  rows: rowsN,
+  launchRow: launchRow ? { tool: launchRow.tool_name, backgroundTaskId: pj(launchRow.metadata).backgroundTaskId ?? null } : null,
+  execJobEvent: execJobEvent ? { kind: meta.kind, status: meta.status, exit_code: meta.exit_code, job_id: meta.job_id } : null,
+  assistantAfterLaunch,
+};
+console.log(JSON.stringify(result, null, 2));
+
+// Verdict keys on DB truth (the exec_job_event for the target tool), not the SSE heuristic:
+// a discovery bash/node_exec call may precede the real background launch.
+const problems = [];
+if (!execJobEvent) problems.push(`no exec_job_event completion row for ${TOOL ?? "the tool"} (box would not fold)`);
+else if (!meta.status) problems.push("exec_job_event has no terminal status");
+if (!assistantAfterLaunch) problems.push("no assistant follow-up after launch (completion turn missing)");
+if (TOOL && !launchRow) problems.push(`no persisted ${TOOL} launch row`);
+if (problems.length) { console.log("RESULT: FAIL — " + problems.join("; ")); process.exit(1); }
+console.log(`RESULT: PASS — launched bg, exec_job_event status=${meta.status} exit=${meta.exit_code}, model followed up`);

--- a/scripts/smoke/bg-fullchain.mjs
+++ b/scripts/smoke/bg-fullchain.mjs
@@ -1,0 +1,118 @@
+// Full-chain smoke: subscribes to the LIVE per-session SSE channel (not just DB polling)
+// and verifies the real-time completion events, the streamed output content, and (MODE=stop)
+// the job_stop / stopped path.
+//   MODE=completed : host_exec bg `sleep N; echo MARKER` → assert live exec_job_done +
+//                    background_turn_done, exec_job_event=completed, and the model's
+//                    follow-up turn surfaces MARKER (proves output streamed to disk + read).
+//   MODE=stop      : host_exec bg `sleep 60` → tell the model to job_stop it → assert
+//                    exec_job_event status=stopped.
+const baseUrl = process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080";
+const apiBase = `${baseUrl}/api/v1`;
+const HOST = process.env.HOST_NAME ?? "172.16.73.22";
+const MODE = process.env.MODE ?? "completed";
+const MARKER = process.env.MARKER ?? "SMOKE_FC";
+const timeoutMs = Number(process.env.BG_TIMEOUT_MS ?? 180_000);
+
+async function jf(url, opts = {}) {
+  const res = await fetch(url, { ...opts, headers: { "Content-Type": "application/json", ...(opts.headers ?? {}) } });
+  const text = await res.text();
+  let body; try { body = text ? JSON.parse(text) : {}; } catch { body = text; }
+  if (!res.ok) throw new Error(`${opts.method ?? "GET"} ${url} ${res.status}: ${text.slice(0, 300)}`);
+  return body;
+}
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const token = (await jf(`${apiBase}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${apiBase}/agents`, { headers: auth })).data?.[0];
+const session = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: `fullchain ${MODE} ${Date.now()}` }) });
+console.log(JSON.stringify({ mode: MODE, sessionId: session.id, marker: MARKER }));
+
+// --- subscribe to the LIVE persistent per-session SSE channel (query-token auth) ---
+const liveEvents = [];
+const sseAbort = new AbortController();
+(async () => {
+  try {
+    const r = await fetch(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions/${session.id}/events?token=${encodeURIComponent(token)}`, { signal: sseAbort.signal });
+    const rd = r.body.getReader(); const dec = new TextDecoder(); let b = "";
+    while (true) {
+      const { done, value } = await rd.read(); if (done) break;
+      b += dec.decode(value, { stream: true });
+      const frames = b.split("\n\n"); b = frames.pop() ?? "";
+      for (const f of frames) {
+        let data = "";
+        for (const line of f.split("\n")) if (line.startsWith("data: ")) data += line.slice(6);
+        const p = pj(data);
+        const inner = p.event ?? p; // chat.event wraps {type,...}
+        if (inner && inner.type) liveEvents.push(inner.type === "exec_job_done" ? { type: "exec_job_done", status: inner.status, job_id: inner.job_id } : { type: inner.type });
+      }
+    }
+  } catch { /* aborted at end */ }
+})();
+
+async function send(text) {
+  const res = await fetch(`${apiBase}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text, session_id: session.id }) });
+  if (!res.ok) throw new Error(`send ${res.status}: ${await res.text()}`);
+  const rd = res.body.getReader(); const dec = new TextDecoder(); let b = ""; const toolEnds = [];
+  while (true) {
+    const { done, value } = await rd.read(); if (done) break;
+    b += dec.decode(value, { stream: true });
+    const frames = b.split("\n\n"); b = frames.pop() ?? "";
+    for (const f of frames) {
+      let ev = "message", data = "";
+      for (const line of f.split("\n")) { if (line.startsWith("event: ")) ev = line.slice(7); else if (line.startsWith("data: ")) data += line.slice(6); }
+      if (ev === "chat.event") { const p = pj(data); if (p.type === "tool_execution_end") toolEnds.push(p); }
+    }
+  }
+  return toolEnds;
+}
+
+const cmd = MODE === "stop" ? "sleep 60" : `sleep 6; echo ${MARKER}`;
+const onDone = MODE === "stop"
+  ? ""
+  : ` When you are LATER notified that this background task has completed, read its output_file with the read tool and report the exact line it printed.`;
+const launchPrompt = `Use the host_exec tool with run_in_background set to true to run this exact command on host "${HOST}": ${cmd} . After launching, immediately end your turn — do not read the output file yet, do not call any other tool, do not wait.${onDone}`;
+const toolEnds = await send(launchPrompt);
+const launch = toolEnds.find((t) => t.toolName === "host_exec");
+const launchText = launch ? JSON.stringify(launch.result) : "";
+const taskId = (launchText.match(/functions\.host_exec:\d+/) || [])[0] || (launchText.match(/"task_id":\s*"([^"]+)"/) || [])[1];
+console.log(JSON.stringify({ launched: !!launch, taskId }));
+
+if (MODE === "stop") {
+  await sleep(2000);
+  await send(`Call the job_stop tool with task_id "${taskId}" to stop that background task. Then end your turn.`);
+}
+
+// poll DB for the terminal exec_job_event
+const startedAt = Date.now();
+let execJobEvent = null, followupMarker = false;
+while (Date.now() - startedAt < timeoutMs) {
+  const rows = (await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions/${session.id}/messages?page=1&page_size=100`, { headers: auth })).data ?? [];
+  execJobEvent = rows.find((m) => pj(m.metadata).kind === "exec_job_event" && String(pj(m.metadata).job_id || "").includes("host_exec")) ?? null;
+  followupMarker = rows.some((m) => m.role === "assistant" && (m.content || "").includes(MARKER));
+  const haveTerminal = execJobEvent && pj(execJobEvent.metadata).status;
+  // background_turn_done fires AFTER the synthetic completion turn persists — well after the
+  // exec_job_event row. So don't stop the instant the row appears; for completed mode wait
+  // until the live background_turn_done arrives too (or the overall timeout).
+  const haveBtd = MODE === "stop" || liveEvents.some((e) => e.type === "background_turn_done");
+  if (haveTerminal && haveBtd) break;
+  await sleep(2500);
+}
+await sleep(1500); // let any final live event arrive
+sseAbort.abort();
+
+const meta = pj(execJobEvent?.metadata);
+console.log(JSON.stringify({ liveEvents, execJobEvent: execJobEvent ? { status: meta.status, exit_code: meta.exit_code, job_id: meta.job_id } : null, followupMarker }, null, 2));
+
+const problems = [];
+const expected = MODE === "stop" ? "stopped" : "completed";
+if (!execJobEvent) problems.push("no exec_job_event persisted");
+else if (meta.status !== expected) problems.push(`exec_job_event status=${meta.status}, expected ${expected}`);
+if (!liveEvents.some((e) => e.type === "exec_job_done")) problems.push("no LIVE exec_job_done event received over SSE");
+if (MODE !== "stop") {
+  if (!liveEvents.some((e) => e.type === "background_turn_done")) problems.push("no LIVE background_turn_done event over SSE");
+  if (!followupMarker) problems.push(`model follow-up did not surface ${MARKER} (output not streamed/read)`);
+}
+if (problems.length) { console.log("RESULT: FAIL — " + problems.join("; ")); process.exit(1); }
+console.log(`RESULT: PASS — live exec_job_done${MODE !== "stop" ? "+background_turn_done" : ""} received, exec_job_event=${meta.status}${MODE !== "stop" ? `, output marker surfaced` : ""}`);

--- a/scripts/smoke/bg-subagent-browser.mjs
+++ b/scripts/smoke/bg-subagent-browser.mjs
@@ -1,0 +1,83 @@
+// Real-browser smoke for the BACKGROUND spawn_subagent card. Phase A: launch a background
+// sub-agent and wait until its completion delegation_event is persisted. Phase B: open the
+// session in headless Chrome and assert the card shows the background (clock) indicator, folded
+// to a done state (not the default "Ready"), with the result rendered.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import WebSocket from "ws";
+
+const baseUrl = process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080";
+const apiBase = `${baseUrl}/api/v1`;
+const chromeBin = process.env.CHROME_BIN ?? "/usr/bin/google-chrome";
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+async function jf(u, o = {}) { const r = await fetch(u, { ...o, headers: { "Content-Type": "application/json", ...(o.headers ?? {}) } }); const t = await r.text(); let b; try { b = t ? JSON.parse(t) : {}; } catch { b = t; } if (!r.ok) throw new Error(`${u} ${r.status}: ${t.slice(0,200)}`); return b; }
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+async function freePort() { return new Promise((res, rej) => { const s = net.createServer(); s.once("error", rej); s.listen(0, "127.0.0.1", () => { const p = s.address().port; s.close(() => res(p)); }); }); }
+
+const token = (await jf(`${apiBase}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${apiBase}/agents`, { headers: auth })).data?.[0];
+const session = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: `bg subagent ui ${Date.now()}` }) });
+console.log("session", session.id);
+const prompt = `Use spawn_subagent with run_in_background set to true to dispatch ONE sub-agent whose scope is exactly: "In one sentence, say why notify beats polling for background tasks." After launching, immediately end your turn.`;
+const res = await fetch(`${apiBase}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text: prompt, session_id: session.id }) });
+{ const rd = res.body.getReader(); while (true) { const { done } = await rd.read(); if (done) break; } }
+let ok = false;
+for (let i = 0; i < 60; i++) {
+  const rows = (await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions/${session.id}/messages?page=1&page_size=100`, { headers: auth })).data ?? [];
+  if (rows.some((m) => pj(m.metadata).kind === "delegation_event")) { ok = true; break; }
+  await wait(3000);
+}
+if (!ok) { console.log("RESULT: FAIL — sub-agent completion (delegation_event) not persisted"); process.exit(1); }
+console.log("phase A done: sub-agent completion persisted");
+
+const profile = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-bg-sa-ui-"));
+const cdpPort = await freePort();
+const chrome = spawn(chromeBin, ["--headless=new", `--remote-debugging-port=${cdpPort}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", "--disable-gpu", "--disable-extensions", "about:blank"], { stdio: "ignore" });
+async function cdpWsUrl() { for (let i = 0; i < 50; i++) { try { const list = await (await fetch(`http://127.0.0.1:${cdpPort}/json/list`)).json(); const page = list.find((t) => t.type === "page") ?? list[0]; if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl; } catch {} await wait(100); } throw new Error("Chrome CDP did not start"); }
+let ws;
+try {
+  ws = new WebSocket(await cdpWsUrl());
+  let seq = 0; const pending = new Map();
+  ws.on("message", (buf) => { const m = JSON.parse(buf.toString()); if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); } });
+  await new Promise((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
+  const send = (method, params = {}) => { const id = ++seq; ws.send(JSON.stringify({ id, method, params })); return new Promise((resolve, reject) => { pending.set(id, (m) => (m.error ? reject(new Error(JSON.stringify(m.error))) : resolve(m.result))); setTimeout(() => reject(new Error(`CDP timeout ${method}`)), 15000); }); };
+  await send("Page.enable"); await send("Runtime.enable");
+  await send("Emulation.setDeviceMetricsOverride", { width: 1600, height: 1600, deviceScaleFactor: 1, mobile: false });
+  await send("Page.navigate", { url: `${baseUrl}/login` });
+  await wait(700);
+  await send("Runtime.evaluate", { expression: `localStorage.setItem('token', ${JSON.stringify(token)}); true`, awaitPromise: true });
+  await send("Page.navigate", { url: `${baseUrl}/chat?agent=${agent.id}&session=${session.id}` });
+  const evalJs = async (expr) => (await send("Runtime.evaluate", { expression: expr, returnByValue: true })).result.value;
+  // wait until the sub-agent card has rendered + folded (not "Ready")
+  let probe = {};
+  for (let i = 0; i < 100; i++) {
+    probe = await evalJs(`(() => {
+      const bg = !!document.querySelector('[title="Runs in the background — returns immediately, notifies on completion"]');
+      const body = document.body.innerText || "";
+      return { bgIndicator: bg, hasSubAgentChip: body.includes("sub-agent"), hasDone: body.includes("Done"), hasReady: body.includes("Ready"), bodyLen: body.length };
+    })()`);
+    if (probe.hasSubAgentChip && (probe.hasDone || !probe.hasReady)) break;
+    await wait(400);
+  }
+  // expand the card to reveal the result
+  await send("Runtime.evaluate", { expression: `(() => { const b = Array.from(document.querySelectorAll('button')).find(x=>/sub-agent/.test(x.innerText||'')); b?.scrollIntoView({block:'center'}); b?.click(); return true; })()`, awaitPromise: true });
+  await wait(600);
+  const text = await evalJs("document.body.innerText");
+  const shot = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: true });
+  const screenshot = `/tmp/siclaw-bg-sa-ui-${session.id}.png`;
+  await fs.writeFile(screenshot, Buffer.from(shot.data, "base64"));
+  const checks = {
+    subAgentCardRendered: probe.hasSubAgentChip,
+    backgroundIndicatorShown: probe.bgIndicator,
+    foldedNotStuckReady: probe.hasDone === true, // card flipped to Done (not default Ready)
+    resultVisibleAfterExpand: /result/i.test(text) && /(notify|polling|poll)/i.test(text),
+  };
+  console.log(JSON.stringify({ checks, screenshot }, null, 2));
+  const fail = Object.entries(checks).filter(([, v]) => !v).map(([k]) => k);
+  if (fail.length) { console.log("RESULT: FAIL — " + fail.join(", ") + "\n--- body ---\n" + text.slice(0, 1200)); process.exit(1); }
+  console.log("RESULT: PASS — sub-agent card: background indicator shown, folded to Done, result rendered");
+} finally { ws?.close(); chrome.kill("SIGTERM"); }

--- a/scripts/smoke/bg-subagent-live.mjs
+++ b/scripts/smoke/bg-subagent-live.mjs
@@ -1,0 +1,83 @@
+// LIVE-path browser smoke for the background spawn_subagent card: sends the prompt FROM the UI
+// (Enter), so the card is built from the live stream (not a refetch), then asserts the background
+// (clock) indicator + a Running state appear immediately, and the card later folds to Done.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import WebSocket from "ws";
+
+const baseUrl = process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080";
+const apiBase = `${baseUrl}/api/v1`;
+const chromeBin = process.env.CHROME_BIN ?? "/usr/bin/google-chrome";
+const BG_TITLE = "Runs in the background — returns immediately, notifies on completion";
+const PROMPT = 'Use spawn_subagent with run_in_background set to true to dispatch ONE sub-agent whose scope is exactly: "In one sentence, say why notify beats polling for background tasks." After launching, immediately end your turn.';
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+async function jf(u, o = {}) { const r = await fetch(u, { ...o, headers: { "Content-Type": "application/json", ...(o.headers ?? {}) } }); const t = await r.text(); let b; try { b = t ? JSON.parse(t) : {}; } catch { b = t; } if (!r.ok) throw new Error(`${u} ${r.status}: ${t.slice(0,200)}`); return b; }
+async function freePort() { return new Promise((res, rej) => { const s = net.createServer(); s.once("error", rej); s.listen(0, "127.0.0.1", () => { const p = s.address().port; s.close(() => res(p)); }); }); }
+
+const token = (await jf(`${apiBase}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${apiBase}/agents`, { headers: auth })).data?.[0];
+const session = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: `bg subagent live ${Date.now()}` }) });
+console.log("session", session.id);
+
+const profile = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-bg-live-"));
+const cdpPort = await freePort();
+const chrome = spawn(chromeBin, ["--headless=new", `--remote-debugging-port=${cdpPort}`, `--user-data-dir=${profile}`, "--no-first-run", "--no-default-browser-check", "--disable-gpu", "--disable-extensions", "about:blank"], { stdio: "ignore" });
+async function cdpWsUrl() { for (let i = 0; i < 50; i++) { try { const list = await (await fetch(`http://127.0.0.1:${cdpPort}/json/list`)).json(); const page = list.find((t) => t.type === "page") ?? list[0]; if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl; } catch {} await wait(100); } throw new Error("Chrome CDP did not start"); }
+let ws;
+try {
+  ws = new WebSocket(await cdpWsUrl());
+  let seq = 0; const pending = new Map();
+  ws.on("message", (buf) => { const m = JSON.parse(buf.toString()); if (m.id && pending.has(m.id)) { pending.get(m.id)(m); pending.delete(m.id); } });
+  await new Promise((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
+  const send = (method, params = {}) => { const id = ++seq; ws.send(JSON.stringify({ id, method, params })); return new Promise((resolve, reject) => { pending.set(id, (m) => (m.error ? reject(new Error(JSON.stringify(m.error))) : resolve(m.result))); setTimeout(() => reject(new Error(`CDP timeout ${method}`)), 15000); }); };
+  const evalJs = async (expr) => (await send("Runtime.evaluate", { expression: expr, returnByValue: true, awaitPromise: true })).result.value;
+  await send("Page.enable"); await send("Runtime.enable");
+  await send("Emulation.setDeviceMetricsOverride", { width: 1600, height: 1600, deviceScaleFactor: 1, mobile: false });
+  await send("Page.navigate", { url: `${baseUrl}/login` });
+  await wait(700);
+  await evalJs(`localStorage.setItem('token', ${JSON.stringify(token)}); true`);
+  await send("Page.navigate", { url: `${baseUrl}/chat?agent=${agent.id}&session=${session.id}` });
+  // wait for the composer textarea
+  for (let i = 0; i < 60; i++) { if (await evalJs(`!!document.querySelector('textarea')`)) break; await wait(300); }
+  // type into the React-controlled textarea + press Enter to send (live turn streams into THIS page)
+  await evalJs(`(() => {
+    const ta = document.querySelector('textarea');
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+    setter.call(ta, ${JSON.stringify(PROMPT)});
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+    return true;
+  })()`);
+
+  const probe = async () => evalJs(`(() => {
+    const bg = !!document.querySelector('[title=${JSON.stringify(BG_TITLE)}]');
+    const body = document.body.innerText || "";
+    return { bg, sub: body.includes("sub-agent"), running: body.includes("Running"), done: body.includes("Done"), ready: body.includes("Ready") };
+  })()`);
+
+  // Phase 1 (LIVE): poll fast right after send — capture the indicator + Running before it folds.
+  let sawLiveRunning = false, cardAppeared = false;
+  for (let i = 0; i < 120; i++) { // ~36s
+    const p = await probe();
+    if (p.sub) cardAppeared = true;
+    if (p.bg && p.running && !p.done) sawLiveRunning = true;
+    if (p.done) break;
+    await wait(300);
+  }
+  // Phase 2: ensure it folds to Done
+  let reachedDone = false;
+  for (let i = 0; i < 120; i++) { const p = await probe(); if (p.done) { reachedDone = true; break; } await wait(500); }
+
+  const shot = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: true });
+  const screenshot = `/tmp/siclaw-bg-live-${session.id}.png`;
+  await fs.writeFile(screenshot, Buffer.from(shot.data, "base64"));
+  const checks = { cardAppeared, sawLiveRunningWithIndicator: sawLiveRunning, reachedDone };
+  console.log(JSON.stringify({ checks, screenshot }, null, 2));
+  const fail = Object.entries(checks).filter(([, v]) => !v).map(([k]) => k);
+  if (fail.length) { console.log("RESULT: FAIL — " + fail.join(", ")); process.exit(1); }
+  console.log("RESULT: PASS — live: card showed background indicator + Running immediately, then folded to Done");
+} finally { ws?.close(); chrome.kill("SIGTERM"); }

--- a/scripts/smoke/bg-subagent-noloop.mjs
+++ b/scripts/smoke/bg-subagent-noloop.mjs
@@ -1,0 +1,64 @@
+// Behavioral smoke for the background spawn_subagent guidance fix. Reproduces the exact user
+// prompt that previously made the model spawn a SECOND "Wait for notification" sub-agent instead
+// of just ending its turn and reporting the answer. Asserts: (1) exactly one background
+// spawn_subagent launch, (2) NO launch whose description is a "wait/poll/notify" placeholder,
+// (3) the model eventually reports the correct sum (34) to the user.
+import { setTimeout as wait } from "node:timers/promises";
+
+const baseUrl = process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080";
+const apiBase = `${baseUrl}/api/v1`;
+const PROMPT = process.env.PROMPT ?? "使用subagent后台计算一下1+2+3+8+9+11,告诉我结果";
+const ANSWER = process.env.ANSWER ?? "34";
+
+async function jf(u, o = {}) {
+  const r = await fetch(u, { ...o, headers: { "Content-Type": "application/json", ...(o.headers ?? {}) } });
+  const t = await r.text();
+  let b; try { b = t ? JSON.parse(t) : {}; } catch { b = t; }
+  if (!r.ok) throw new Error(`${u} ${r.status}: ${t.slice(0, 200)}`);
+  return b;
+}
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+
+const token = (await jf(`${apiBase}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${apiBase}/agents`, { headers: auth })).data?.[0];
+const session = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: `bg subagent noloop ${Date.now()}` }) });
+console.log("session", session.id);
+
+// Drain the launch turn's SSE so the request completes.
+const res = await fetch(`${apiBase}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text: PROMPT, session_id: session.id }) });
+{ const rd = res.body.getReader(); while (true) { const { done } = await rd.read(); if (done) break; } }
+
+// Poll until the model reports the answer OR we time out (~90s). The completion notification
+// fires a synthetic turn; the answer should appear there if the model behaves.
+let rows = [];
+let answered = false;
+for (let i = 0; i < 30; i++) {
+  rows = (await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions/${session.id}/messages?page=1&page_size=100`, { headers: auth })).data ?? [];
+  answered = rows.some((m) => m.role === "assistant" && (m.content || "").includes(ANSWER));
+  if (answered) break;
+  await wait(3000);
+}
+
+const launches = rows
+  .filter((m) => m.role === "tool" && m.tool_name === "spawn_subagent")
+  .map((m) => ({ args: pj(m.tool_input), meta: pj(m.metadata) }));
+const bgLaunches = launches.filter((l) => l.args.run_in_background === true);
+const descs = launches.map((l) => String(l.args.description ?? ""));
+const WAIT_RE = /(wait|poll|notif|sleep|standby|等待|轮询|通知|稍等|等候)/i;
+const waitLike = descs.filter((d) => WAIT_RE.test(d));
+
+const checks = {
+  reportedAnswer: answered,
+  exactlyOneBackgroundLaunch: bgLaunches.length === 1,
+  noWaitPlaceholderSubagent: waitLike.length === 0,
+};
+console.log(JSON.stringify({ checks, launchDescriptions: descs, bgLaunchCount: bgLaunches.length }, null, 2));
+const fail = Object.entries(checks).filter(([, v]) => !v).map(([k]) => k);
+if (fail.length) {
+  console.log("RESULT: FAIL — " + fail.join(", "));
+  console.log("--- assistant messages ---");
+  for (const m of rows.filter((r) => r.role === "assistant")) console.log("•", (m.content || "").slice(0, 200));
+  process.exit(1);
+}
+console.log("RESULT: PASS — one background sub-agent, no wait-placeholder sub-agent, answer reported");

--- a/scripts/smoke/bg-subagent-recon.mjs
+++ b/scripts/smoke/bg-subagent-recon.mjs
@@ -1,0 +1,25 @@
+// Recon: what does a BACKGROUND spawn_subagent produce in the DB? Dump the message rows
+// (tool_name / role / metadata.kind / status fields / content head) so we can see whether the
+// sub-agent completes + notifies the parent, and what event (if any) should update the card.
+const apiBase = (process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080") + "/api/v1";
+async function jf(u, o = {}) { const r = await fetch(u, { ...o, headers: { "Content-Type": "application/json", ...(o.headers ?? {}) } }); const t = await r.text(); let b; try { b = t ? JSON.parse(t) : {}; } catch { b = t; } if (!r.ok) throw new Error(`${u} ${r.status}: ${t.slice(0,200)}`); return b; }
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const token = (await jf(`${apiBase}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${apiBase}/agents`, { headers: auth })).data?.[0];
+const session = await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: `bg subagent recon ${Date.now()}` }) });
+console.log("session", session.id);
+const prompt = `Use spawn_subagent with run_in_background set to true to dispatch ONE sub-agent whose scope is: "In one sentence, say why notify beats polling for background tasks." After launching, immediately end your turn. When the sub-agent completes and notifies you, summarize its conclusion in one line.`;
+const res = await fetch(`${apiBase}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text: prompt, session_id: session.id }) });
+{ const rd = res.body.getReader(); while (true) { const { done } = await rd.read(); if (done) break; } }
+for (let i = 0; i < 50; i++) {
+  await wait(3000);
+  const rows = (await jf(`${apiBase}/siclaw/agents/${agent.id}/chat/sessions/${session.id}/messages?page=1&page_size=100`, { headers: auth })).data ?? [];
+  const dump = rows.map((m) => { const md = pj(m.metadata); return { role: m.role, tool: m.tool_name ?? null, kind: md.kind ?? null, status: m.outcome ?? md.status ?? md.event_type ?? null, head: (typeof m.content === "string" ? m.content : JSON.stringify(m.content) ?? "").slice(0, 90) }; });
+  console.log(`--- poll ${i} (${rows.length} rows) ---`);
+  console.log(JSON.stringify(dump, null, 1));
+  const parentFollowup = rows.some((m) => m.role === "assistant" && /notify|poll|background|轮询|通知/.test(m.content || ""));
+  const subagentDone = rows.some((m) => (m.tool_name === "spawn_subagent") && (pj(m.metadata).status === "done" || m.outcome === "done"));
+  if (parentFollowup && rows.length > 3) { console.log("STOP: parent follow-up present"); break; }
+}

--- a/scripts/smoke/host-stop-orphan.mjs
+++ b/scripts/smoke/host-stop-orphan.mjs
@@ -1,0 +1,42 @@
+// Verifies job_stop on a background host_exec actually KILLS the remote process group
+// (not just closes the channel). Launches `sleep 240; echo SENTINEL` in the background,
+// stops it, then uses a FOREGROUND host_exec to count surviving processes carrying the
+// sentinel. 0 survivors = the remote group was reaped.
+import { setTimeout as wait } from "node:timers/promises";
+const b = (process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080") + "/api/v1";
+const HOST = process.env.HOST_NAME ?? "172.16.73.22";
+const SENT = "SENTINEL_" + Math.floor(Date.now() % 1e7);
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+async function jf(u, o = {}) { const r = await fetch(u, { ...o, headers: { "Content-Type": "application/json", ...(o.headers ?? {}) } }); const t = await r.text(); let x; try { x = t ? JSON.parse(t) : {}; } catch { x = t; } if (!r.ok) throw new Error(`${u} ${r.status}: ${t.slice(0,200)}`); return x; }
+const token = (await jf(`${b}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${b}/agents`, { headers: auth })).data[0];
+const s = await jf(`${b}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: "host stop orphan " + Date.now() }) });
+console.log("session", s.id, "sentinel", SENT);
+const send = async (text) => { const r = await fetch(`${b}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text, session_id: s.id }) }); const rd = r.body.getReader(); while (true) { const { done } = await rd.read(); if (done) break; } };
+
+await send(`Use the host_exec tool with run_in_background set to true on host "${HOST}" to run this EXACT command: sleep 240; echo ${SENT} . After launching, END YOUR TURN immediately — do not call any other tool.`);
+await wait(7000); // let the remote process group start + write its pgid file
+await send(`Stop the background host command you just launched, using the job_stop tool with the job_id it returned. Then END YOUR TURN.`);
+await wait(12000); // kill propagation: fresh ssh dial + kill -TERM/-KILL + up to 3s retry
+await send(`Now use host_exec with run_in_background OMITTED (foreground) on host "${HOST}" to run this EXACT command (a pipeline, no other text): ps -ef | grep ${SENT} | grep -v grep | wc -l . Report ONLY the number it prints.`);
+await wait(3000);
+
+const rows = (await jf(`${b}/siclaw/agents/${agent.id}/chat/sessions/${s.id}/messages?page=1&page_size=100`, { headers: auth })).data ?? [];
+// Find the foreground host_exec tool result carrying ORPHANS=
+let orphans = null;
+for (const m of rows) {
+  if (m.role === "tool" && m.tool_name === "host_exec") {
+    const txt = (m.content || "").trim();
+    if (/^\d+$/.test(txt)) orphans = Number(txt); // the `wc -l` survivor count
+  }
+}
+// Fallback: assistant prose reporting a lone number.
+if (orphans === null) {
+  for (const m of rows) { const mm = /\bsurvivors?\b[^0-9]*(\d+)|^\s*(\d+)\s*$/m.exec(m.content || ""); if (mm) { orphans = Number(mm[1] ?? mm[2]); break; } }
+}
+const stopEvt = rows.find((m) => pj(m.metadata).kind === "exec_job_event" && String(pj(m.metadata).job_id || "").includes("host_exec"));
+console.log(JSON.stringify({ orphans, stopStatus: pj(stopEvt?.metadata).status ?? null }, null, 2));
+if (orphans === null) { console.log("RESULT: INCONCLUSIVE — could not read ORPHANS= (model may not have run the check)"); process.exit(2); }
+if (orphans === 0) { console.log("RESULT: PASS — remote process group reaped by job_stop (0 survivors)"); process.exit(0); }
+console.log(`RESULT: FAIL — ${orphans} remote process(es) survived job_stop (orphaned until timeout)`); process.exit(1);

--- a/scripts/smoke/pod-stop-orphan.mjs
+++ b/scripts/smoke/pod-stop-orphan.mjs
@@ -1,0 +1,33 @@
+// Verifies job_stop on a background pod_script reaps the in-pod process tree (not just the
+// local kubectl). Launches exec-smoke `sleep 240` in a pod, stops it, then uses a foreground
+// pod_exec to count surviving processes carrying the sentinel. 0 = the in-pod session reaped.
+import { setTimeout as wait } from "node:timers/promises";
+const b = (process.env.SICLAW_PORTAL_URL ?? "http://127.0.0.1:18080") + "/api/v1";
+const POD = process.env.POD_NAME ?? "managed-target";
+const NS = process.env.POD_NS ?? "siclaw-inner";
+const SENT = "PODSENT_" + Math.floor(Date.now() % 1e7);
+const pj = (v) => { if (!v) return {}; if (typeof v === "object") return v; try { return JSON.parse(v) ?? {}; } catch { return {}; } };
+async function jf(u, o = {}) { const r = await fetch(u, { ...o, headers: { "Content-Type": "application/json", ...(o.headers ?? {}) } }); const t = await r.text(); let x; try { x = t ? JSON.parse(t) : {}; } catch { x = t; } if (!r.ok) throw new Error(`${u} ${r.status}: ${t.slice(0,200)}`); return x; }
+const token = (await jf(`${b}/auth/login`, { method: "POST", body: JSON.stringify({ username: "admin", password: "admin" }) })).token;
+const auth = { Authorization: `Bearer ${token}` };
+const agent = (await jf(`${b}/agents`, { headers: auth })).data[0];
+const s = await jf(`${b}/siclaw/agents/${agent.id}/chat/sessions`, { method: "POST", headers: auth, body: JSON.stringify({ title: "pod stop orphan " + Date.now() }) });
+console.log("session", s.id, "sentinel", SENT);
+const send = async (text) => { const r = await fetch(`${b}/siclaw/agents/${agent.id}/chat/send`, { method: "POST", headers: { "Content-Type": "application/json", ...auth }, body: JSON.stringify({ text, session_id: s.id }) }); const rd = r.body.getReader(); while (true) { const { done } = await rd.read(); if (done) break; } };
+
+await send(`Use the pod_script tool with run_in_background set to true to run skill "exec-smoke" script "sleep-echo.sh" with args "--seconds 240 --marker ${SENT}" inside pod "${POD}" in namespace "${NS}". After launching, END YOUR TURN immediately.`);
+await wait(8000);
+await send(`Stop the background pod_script job you just launched, using the job_stop tool with its job_id. Then END YOUR TURN.`);
+await wait(12000);
+await send(`Now use pod_exec (foreground) inside pod "${POD}" namespace "${NS}" to run this EXACT single command (no pipes): pgrep -c sleep . Report ONLY the integer it prints (0 if none).`);
+await wait(3000);
+
+const rows = (await jf(`${b}/siclaw/agents/${agent.id}/chat/sessions/${s.id}/messages?page=1&page_size=100`, { headers: auth })).data ?? [];
+let orphans = null;
+for (const m of rows) {
+  if (m.role === "tool" && m.tool_name === "pod_exec") { const mm = /(?:^|\D)(\d+)/.exec((m.content || "").trim()); if (mm) orphans = Number(mm[1]); }
+}
+console.log(JSON.stringify({ orphans, stopStatus: pj(rows.find((m) => pj(m.metadata).kind === "exec_job_event" && String(pj(m.metadata).job_id||"").includes("pod_script"))?.metadata).status ?? null }, null, 2));
+if (orphans === null) { console.log("RESULT: INCONCLUSIVE — no count read"); process.exit(2); }
+if (orphans === 0) { console.log("RESULT: PASS — in-pod session reaped by job_stop (0 survivors)"); process.exit(0); }
+console.log(`RESULT: FAIL — ${orphans} in-pod process(es) survived job_stop`); process.exit(1);

--- a/skills/core/exec-smoke/SKILL.md
+++ b/skills/core/exec-smoke/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: exec-smoke
+description: >-
+  Reachability / execution smoke: sleep a few seconds then echo a marker line.
+  Runs identically locally, on an SSH host, inside a pod, or on a node — used to
+  validate that a target is reachable and that script execution (including
+  background execution) completes and reports back. Not a diagnostic of the
+  workload itself; it only proves the execution path works.
+---
+
+# Exec Smoke
+
+A trivial, side-effect-free script used to verify the execution path of the
+`*_script` tools (local / host / pod / node), including `run_in_background`.
+
+## Router
+
+| Need | Action |
+| --- | --- |
+| Prove a target can run a script and return output | `scripts/sleep-echo.sh` |
+
+## Script
+
+`scripts/sleep-echo.sh [--seconds N] [--marker TEXT]`
+
+- `--seconds N` — how long to sleep before echoing (default 2). Use a few
+  seconds when validating background execution so the launch/complete lifecycle
+  is observable.
+- `--marker TEXT` — the exact line to echo on completion (default
+  `EXEC_SMOKE_OK`). Useful as a correlation token.
+
+It prints a `sleeping …` line, sleeps, then echoes the marker. No mutation, no
+cluster calls.
+
+## Targets
+
+```
+local_script: skill="exec-smoke", script="sleep-echo.sh", args="--seconds 3 --marker OK"
+host_script:  host="<host>",        skill="exec-smoke", script="sleep-echo.sh", args="--seconds 3 --marker OK"
+pod_script:   pod="<pod>", namespace="<ns>", skill="exec-smoke", script="sleep-echo.sh", args="--seconds 3 --marker OK"
+node_script:  node="<node>",       skill="exec-smoke", script="sleep-echo.sh", args="--seconds 3 --marker OK"
+```

--- a/skills/core/exec-smoke/scripts/sleep-echo.sh
+++ b/skills/core/exec-smoke/scripts/sleep-echo.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Execution-path smoke: sleep a few seconds, then echo a marker line.
+# Side-effect-free — proves a target is reachable and that script execution
+# (incl. background execution) completes and reports back. No cluster calls.
+
+SLEEP_SECONDS=2
+MARKER="EXEC_SMOKE_OK"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --seconds) SLEEP_SECONDS="${2:-2}"; shift 2 ;;
+    --marker)  MARKER="${2:-EXEC_SMOKE_OK}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+echo "exec-smoke: sleeping ${SLEEP_SECONDS}s on $(hostname 2>/dev/null || echo unknown)"
+sleep "${SLEEP_SECONDS}"
+echo "${MARKER}"

--- a/src/agentbox/notify-parent.test.ts
+++ b/src/agentbox/notify-parent.test.ts
@@ -178,6 +178,106 @@ describe("notifyParent", () => {
     expect(nonExec).toHaveLength(0);
   });
 
+  it("a text-only synthetic turn for a SUB-AGENT (inline result, no output_file) persists the report + fires background_turn_done", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    // Brain that, on prompt(), emits one assistant text message (the inline result report) and no tool call.
+    let cb: ((e: any) => void) | undefined;
+    const brain = {
+      followUp: vi.fn(async () => {}),
+      subscribe: vi.fn((fn: (e: any) => void) => { cb = fn; return () => {}; }),
+      prompt: vi.fn(async () => {
+        cb?.({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "The sum is 34" }] } });
+      }),
+    };
+    const managed = fakeManaged("s1", brain as any, true);
+    mgr.sessions.set("s1", managed);
+    mgr.jobs.register({ jobId: "sa1", type: "subagent", parentSessionId: "s1", description: "compute", status: "completed", startedAt: 0, notified: false }); // no outputFile
+    const send = vi.fn(async () => ({ ok: true, id: "x" }));
+    mgr.gatewayClient = { sendDelegationPersistenceEvent: send };
+    mgr.agentId = "agent-1";
+    await mgr.notifyParent("s1", "sa1", { taskId: "sa1", status: "completed", summary: "result: 34" }); // no output_file → inline result
+    await flushCoalesce();
+    const events = send.mock.calls.map((c) => c[0]);
+    const report = events.filter((e: any) => e?.type === "delegation.append_message").find((e: any) => (e.message?.content || "").includes("34"));
+    expect(report).toBeTruthy(); // the text-only report is persisted (not dropped)
+    const btd = events.filter((e: any) => e?.type === "delegation.emit_chat_event" && e?.event?.type === "background_turn_done");
+    expect(btd).toHaveLength(1); // refetch trigger fired so the UI shows the report
+  });
+
+  it("a text-only synthetic turn for a BASH job (output_file present) is still dropped (pure ack)", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    let cb: ((e: any) => void) | undefined;
+    const brain = {
+      followUp: vi.fn(async () => {}),
+      subscribe: vi.fn((fn: (e: any) => void) => { cb = fn; return () => {}; }),
+      prompt: vi.fn(async () => {
+        cb?.({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "no new info" }] } });
+      }),
+    };
+    const managed = fakeManaged("s1", brain as any, true);
+    mgr.sessions.set("s1", managed);
+    mgr.jobs.register({ jobId: "j1", type: "bash", parentSessionId: "s1", description: "cmd", status: "completed", startedAt: 0, notified: false, outputFile: "/o" });
+    const send = vi.fn(async () => ({ ok: true, id: "x" }));
+    mgr.gatewayClient = { sendDelegationPersistenceEvent: send };
+    mgr.agentId = "agent-1";
+    await mgr.notifyParent("s1", "j1", { taskId: "j1", outputFile: "/o", status: "completed", summary: "done" }); // output_file → data in file, text-only ack is noise
+    await flushCoalesce();
+    const events = send.mock.calls.map((c) => c[0]);
+    const ack = events.filter((e: any) => e?.type === "delegation.append_message").find((e: any) => (e.message?.content || "").includes("no new info"));
+    expect(ack).toBeFalsy(); // the pure-ack text is NOT persisted
+    const btd = events.filter((e: any) => e?.type === "delegation.emit_chat_event" && e?.event?.type === "background_turn_done");
+    expect(btd).toHaveLength(0);
+  });
+
+  it("a MIXED batch (sub-agent + shell job) keeps the strict guard — text-only ack is dropped", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    let cb: ((e: any) => void) | undefined;
+    const brain = {
+      followUp: vi.fn(async () => {}),
+      subscribe: vi.fn((fn: (e: any) => void) => { cb = fn; return () => {}; }),
+      prompt: vi.fn(async () => {
+        cb?.({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "both done, nothing new" }] } });
+      }),
+    };
+    const managed = fakeManaged("s1", brain as any, true);
+    mgr.sessions.set("s1", managed);
+    mgr.jobs.register({ jobId: "sa1", type: "subagent", parentSessionId: "s1", description: "sub", status: "completed", startedAt: 0, notified: false }); // inline (no outputFile)
+    mgr.jobs.register({ jobId: "j1", type: "bash", parentSessionId: "s1", description: "cmd", status: "completed", startedAt: 0, notified: false, outputFile: "/o" });
+    const send = vi.fn(async () => ({ ok: true, id: "x" }));
+    mgr.gatewayClient = { sendDelegationPersistenceEvent: send };
+    mgr.agentId = "agent-1";
+    // Both complete within the coalesce window → ONE synthetic turn covering the mixed batch.
+    await mgr.notifyParent("s1", "sa1", { taskId: "sa1", status: "completed", summary: "sub result" });
+    await mgr.notifyParent("s1", "j1", { taskId: "j1", outputFile: "/o", status: "completed", summary: "done" });
+    await flushCoalesce();
+    const events = send.mock.calls.map((c) => c[0]);
+    // The shell job present in the batch flips off allowTextOnlyPersist, so a text-only reaction
+    // is NOT persisted as a bubble (the sub-agent result still shows via its own card fold).
+    const ack = events.filter((e: any) => e?.type === "delegation.append_message").find((e: any) => (e.message?.content || "").includes("nothing new"));
+    expect(ack).toBeFalsy();
+    const btd = events.filter((e: any) => e?.type === "delegation.emit_chat_event" && e?.event?.type === "background_turn_done");
+    expect(btd).toHaveLength(0);
+  });
+
+  it("emits a live subagent_done fold event when a background sub-agent completes", async () => {
+    const { mgr } = setup(true);
+    mgr.jobs.register({ jobId: "sa9", type: "subagent", parentSessionId: "s1", description: "sub", status: "completed", startedAt: 0, notified: false });
+    const send = vi.fn(async () => ({ ok: true, id: "x" }));
+    mgr.gatewayClient = { sendDelegationPersistenceEvent: send };
+    mgr.agentId = "agent-1";
+    await mgr.notifyParent("s1", "sa9", { taskId: "sa9", status: "completed", summary: "result: 42" });
+    await flushCoalesce();
+    const fold = send.mock.calls
+      .map((c) => c[0])
+      .filter((e: any) => e?.type === "delegation.emit_chat_event" && e?.event?.type === "subagent_done");
+    expect(fold).toHaveLength(1);
+    expect(fold[0].event.job_id).toBe("sa9");
+    expect(fold[0].event.status).toBe("completed");
+    // Sub-agents are NOT given an exec_job_event (that's for shell/exec jobs).
+    const execEvents = send.mock.calls.map((c) => c[0]).filter((e: any) => e?.message?.metadata?.kind === "exec_job_event");
+    expect(execEvents).toHaveLength(0);
+  });
+
   it("does NOT emit background_turn_done when not persistable (no gatewayClient)", async () => {
     const { mgr, brain } = setup(true);
     // No gatewayClient / agentId → canPersist is false.

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -506,6 +506,17 @@ export class AgentBoxSessionManager {
     const job = this.jobs.get(jobId);
     if (job && job.type !== "subagent") {
       void this.persistExecJobEvent(sessionId, jobId, n.status, job.exitCode);
+    } else if (job) {
+      // Background sub-agent: fold its launch card live (running → done/failed/timed_out)
+      // regardless of the model's synthetic-turn reaction. The persisted delegation_event still
+      // drives the refetch fold; this TARGETED live event (mirrors exec_job_done) makes it
+      // immediate and paged-back/streaming-safe — without it, a completion the model correctly
+      // stays silent about leaves the card stuck on "Running…" until a manual refresh.
+      void this.persistDelegationEvent({
+        type: "delegation.emit_chat_event",
+        sessionId,
+        event: { type: "subagent_done", sessionId, job_id: jobId, status: n.status },
+      }).catch(() => {});
     }
 
     // Buffer the model-facing notification and arm the coalescing window. We deliver it ONLY
@@ -547,7 +558,17 @@ export class AgentBoxSessionManager {
     }
     const batch = managed._pendingNotifications.splice(0);
     if (batch.length === 0) return;
-    await this.runSyntheticPrompt(managed, buildNotificationBatch(batch));
+    // A notification with NO output_file carries its result INLINE in the summary (sub-agents —
+    // see task-notification.ts). For those the model's report is pure text (no read tool call),
+    // so the turnHadTool persist guard below would wrongly drop it — allow a text-only reaction.
+    // Require EVERY notification in the batch to be inline-result (`.every`, not `.some`): a
+    // mixed batch (sub-agent + a shell/exec job whose data lives in output_file) must keep the
+    // STRICT guard, else the shell job's pure-ack ("nothing new") text gets persisted as a noise
+    // bubble — the exact thing turnHadTool suppresses. In that rare mixed case the sub-agent's
+    // result is still visible via its own card fold (annotateSubagentCompletions), so only the
+    // model's optional prose is dropped, never the result itself.
+    const allInlineResult = batch.every((n) => !n.outputFile);
+    await this.runSyntheticPrompt(managed, buildNotificationBatch(batch), allInlineResult);
   }
 
   /**
@@ -557,7 +578,7 @@ export class AgentBoxSessionManager {
    * already started (re-check degrades us to followUp) or hits the 409 guard. This closes
    * the TOCTOU documented at the _promptInflight declaration.
    */
-  private runSyntheticPrompt(managed: ManagedSession, text: string): Promise<void> {
+  private runSyntheticPrompt(managed: ManagedSession, text: string, allowTextOnlyPersist = false): Promise<void> {
     const run = (managed._syntheticPromptQueue ?? Promise.resolve())
       .catch(() => {})
       .then(async () => {
@@ -631,13 +652,23 @@ export class AgentBoxSessionManager {
           managed._promptInflight = null;
           release();
           if (managed._backgroundWorkCount === 0) this.scheduleRelease(managed.id);
-          // Show the model's reaction ONLY if it actually DID something (made a tool call).
-          // A reaction with no tool call is a pure acknowledgement ("nothing new") — drop it
-          // so it doesn't add a noise bubble; the completion is already surfaced in the
-          // launching tool's own box (exec_job_event). A data-bearing summary necessarily
-          // reads the output first (a tool call), so this never hides real information.
+          // Decide whether to keep the model's reaction. Normally we keep it ONLY if it made a
+          // tool call: for a bash/exec completion the data lives in output_file, so a data-bearing
+          // report necessarily reads that file first (a tool call), and a text-only reaction is a
+          // pure ack ("nothing new") we drop to avoid a noise bubble (the completion already shows
+          // in the launching tool's own box).
+          // EXCEPTION (allowTextOnlyPersist): a sub-agent's result is delivered INLINE in the
+          // notification summary — the model reports it as pure text with NO tool call. There the
+          // text IS the answer the user is waiting for, so keep a non-empty text-only reaction too.
+          const turnHadText = turnMessages.some((m) => {
+            if (m.role !== "assistant") return false;
+            const c = Array.isArray(m.content)
+              ? m.content.filter((x: any) => x?.type === "text").map((x: any) => x.text ?? "").join("")
+              : typeof m.content === "string" ? m.content : "";
+            return c.trim().length > 0;
+          });
           // When kept, persist the whole turn then fire a refetch so the frontend shows it.
-          if (canPersist && turnHadTool) {
+          if (canPersist && (turnHadTool || (allowTextOnlyPersist && turnHadText))) {
             void Promise.allSettled(
               turnMessages.map((m) => this.persistSyntheticMessage(sid, m).catch(() => {})),
             ).then(() =>

--- a/src/core/background-bash-runner.test.ts
+++ b/src/core/background-bash-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { PassThrough } from "node:stream";
 import { reloadConfig } from "./config.js";
 import { JobRegistry } from "./job-registry.js";
 import { spawnBackgroundBash } from "./background-bash-runner.js";
@@ -136,6 +137,115 @@ describe("spawnBackgroundBash — argv mode (node/pod)", () => {
     // onComplete fires exactly once (settle is latched)
     await new Promise((r) => setTimeout(r, 20));
     expect(onCompleteCalls).toBe(1);
+  });
+});
+
+describe("spawnBackgroundBash — stream mode (host_exec/host_script via ssh2)", () => {
+  it("streams from a factory, sanitizes to disk, settles on done (exit 0)", async () => {
+    const jobs = new JobRegistry();
+    const jobId = `js-${Math.random().toString(36).slice(2)}`;
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    let resolveDone!: (v: { exitCode: number | null }) => void;
+    const done = new Promise<{ exitCode: number | null }>((r) => { resolveDone = r; });
+    const settled = new Promise<{ status: string; outputFile: string }>((resolve) => {
+      spawnBackgroundBash(
+        {
+          streamFactory: async () => ({ stdout, stderr, done, abort: () => {} }),
+          env: {},
+          action: redactSecret,
+          hasSensitiveKubectl: false,
+          description: "host h: cmd",
+          parentSessionId: "s1",
+          jobId,
+          isProd: false,
+          jobType: "host",
+        },
+        jobs,
+        (_id, n) => resolve({ status: n.status, outputFile: n.outputFile! }),
+      );
+    });
+    // let the async factory resolve + wire data handlers, then push output and finish
+    await new Promise((r) => setTimeout(r, 20));
+    stdout.write("line1 SECRET\n");
+    stdout.write("line2 ok\n");
+    stdout.end();
+    stderr.end();
+    await new Promise((r) => setTimeout(r, 20));
+    resolveDone({ exitCode: 0 });
+
+    const { status, outputFile } = await settled;
+    expect(status).toBe("completed");
+    expect(jobs.get(jobId)?.type).toBe("host");
+    const content = fs.readFileSync(outputFile, "utf8");
+    expect(content).toContain("line1 **REDACTED**");
+    expect(content).toContain("line2 ok");
+    expect(content).not.toContain("SECRET");
+  });
+
+  it("stream mode: job_stop marks stopped, abort resolves done → status stopped", async () => {
+    const jobs = new JobRegistry();
+    const jobId = `js2-${Math.random().toString(36).slice(2)}`;
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    let resolveDone!: (v: { exitCode: number | null }) => void;
+    const done = new Promise<{ exitCode: number | null }>((r) => { resolveDone = r; });
+    let aborted = false;
+    const settled = new Promise<string>((resolve) => {
+      spawnBackgroundBash(
+        {
+          streamFactory: async () => ({
+            stdout, stderr, done,
+            abort: () => { aborted = true; resolveDone({ exitCode: null }); },
+          }),
+          env: {},
+          action: null,
+          hasSensitiveKubectl: false,
+          description: "host h: sleep",
+          parentSessionId: "s1",
+          jobId,
+          isProd: false,
+          jobType: "host",
+        },
+        jobs,
+        (_id, n) => resolve(n.status),
+      );
+    });
+    await new Promise((r) => setTimeout(r, 20)); // factory resolved + job registered
+    jobs.setStatus(jobId, "stopped");
+    jobs.get(jobId)!.abort!();
+    expect(await settled).toBe("stopped");
+    expect(aborted).toBe(true);
+  });
+});
+
+describe("spawnBackgroundBash — stdin (node/pod/local scripts)", () => {
+  it("pipes req.stdin (the script body) to the child", async () => {
+    const jobs = new JobRegistry();
+    const jobId = `jstdin-${Math.random().toString(36).slice(2)}`;
+    const done = new Promise<{ status: string; outputFile: string }>((resolve) => {
+      spawnBackgroundBash(
+        {
+          file: "/bin/cat", // echoes stdin to stdout
+          args: [],
+          stdin: "hello-from-stdin\n",
+          env: process.env as Record<string, string>,
+          action: null,
+          hasSensitiveKubectl: false,
+          description: "local: script",
+          parentSessionId: "s1",
+          jobId,
+          isProd: false,
+          jobType: "local",
+        },
+        jobs,
+        (_id, n) => resolve({ status: n.status, outputFile: n.outputFile! }),
+      );
+    });
+    const { status, outputFile } = await done;
+    expect(status).toBe("completed");
+    expect(jobs.get(jobId)?.type).toBe("local");
+    expect(fs.readFileSync(outputFile, "utf8")).toContain("hello-from-stdin");
   });
 });
 

--- a/src/core/background-bash-runner.ts
+++ b/src/core/background-bash-runner.ts
@@ -52,6 +52,87 @@ export function spawnBackgroundBash(
     }
   };
 
+  // Settle (notify + onSettled) runs EXACTLY once — shared by all three modes. Node can
+  // emit both 'error' and 'close' for a child; ssh can resolve done after an abort. Without
+  // this latch onSettled would double-decrement the parent's background-work count.
+  let settled = false;
+  const settle = async (status: "completed" | "failed" | "killed" | "stopped", code: number | null, summary: string) => {
+    if (settled) return;
+    settled = true;
+    await flushAll();
+    jobs.setStatus(req.jobId, status, code != null ? { exitCode: code } : undefined);
+    // Per-job cleanup (node_exec unpins its debug pod) — before notify so the pod is
+    // released even if notify throws. Independent of onSettled (parent work-count).
+    try { req.onComplete?.(); } catch { /* best-effort */ }
+    notify(req.jobId, { taskId: req.jobId, outputFile, status, summary });
+    onSettled?.();
+  };
+
+  // Map a terminal exit code to (status, summary), honouring a prior job_stop ("stopped").
+  const terminalStatus = (code: number | null) => {
+    const wasStopped = jobs.get(req.jobId)?.status === "stopped";
+    const status = wasStopped ? "stopped" : code === 0 ? "completed" : "failed";
+    const summary =
+      status === "completed"
+        ? `Background command "${req.description}" completed${code != null ? ` (exit ${code})` : ""}`
+        : status === "stopped"
+          ? `Background command "${req.description}" was stopped`
+          : `Background command "${req.description}" failed${code != null ? ` (exit ${code})` : ""}`;
+    return { status, summary } as const;
+  };
+
+  // ── Stream mode (host_exec / host_script via ssh2) ──────────────────
+  // No child process: an in-process factory dials ssh and hands back live streams. The
+  // job is registered immediately (so job_stop can abort the dial-in-flight), then the
+  // streams are wired once the async factory resolves.
+  if (req.streamFactory) {
+    let abortStream = () => {};
+    jobs.register({
+      jobId: req.jobId,
+      type: req.jobType ?? "bash",
+      parentSessionId: req.parentSessionId,
+      description: req.description,
+      status: "running",
+      startedAt: Date.now(),
+      notified: false,
+      outputFile,
+      abort: () => {
+        try { req.onAbort?.(); } catch { /* best-effort */ }
+        try { abortStream(); } catch { /* best-effort */ }
+      },
+    });
+    void (async () => {
+      let handle;
+      try {
+        handle = await req.streamFactory!();
+      } catch (err) {
+        await settle("failed", null, `Background command "${req.description}" failed to start: ${(err as Error).message}`);
+        return;
+      }
+      abortStream = handle.abort;
+      // Dial-race: a job_stop that fired while the stream factory was still dialing ran the
+      // registry abort() when abortStream was still a no-op, so the stop was lost. Now that
+      // the streams are live, honour a prior stop immediately (close the channel + re-run the
+      // remote kill — both idempotent) instead of letting the command run to completion.
+      if (jobs.get(req.jobId)?.status === "stopped") {
+        try { req.onAbort?.(); } catch { /* best-effort */ }
+        try { abortStream(); } catch { /* best-effort */ }
+      }
+      handle.stdout.setEncoding("utf8");
+      handle.stderr.setEncoding("utf8");
+      handle.stdout.on("data", (c: string) => outSink.append(c));
+      handle.stderr.on("data", (c: string) => errSink.append(c));
+      try {
+        const { exitCode } = await handle.done;
+        const { status, summary } = terminalStatus(exitCode);
+        await settle(status, exitCode, summary);
+      } catch (err) {
+        await settle("failed", null, `Background command "${req.description}" failed: ${(err as Error).message}`);
+      }
+    })();
+    return { jobId: req.jobId, outputFile };
+  }
+
   // spawn (not exec) so output streams to disk instead of buffering in memory — a long
   // background command can emit far more than exec's maxBuffer. detached:true makes the
   // child a process-group leader, so kill(-pid) reaps the whole tree (matches the
@@ -68,21 +149,15 @@ export function spawnBackgroundBash(
   child.stdout?.setEncoding("utf8");
   child.stderr?.setEncoding("utf8");
 
-  // Settle (notify + onSettled) runs EXACTLY once. Node can emit both 'error' and 'close'
-  // for one process; without this latch onSettled would double-decrement the parent's
-  // background-work count and release the session while a sibling job still runs.
-  let settled = false;
-  const settle = async (status: "completed" | "failed" | "killed" | "stopped", code: number | null, summary: string) => {
-    if (settled) return;
-    settled = true;
-    await flushAll();
-    jobs.setStatus(req.jobId, status, code != null ? { exitCode: code } : undefined);
-    // Per-job cleanup (e.g. node_exec unpins its debug pod) — before notify so the pod is
-    // released even if notify throws. Independent of onSettled (parent work-count).
-    try { req.onComplete?.(); } catch { /* best-effort */ }
-    notify(req.jobId, { taskId: req.jobId, outputFile, status, summary });
-    onSettled?.();
-  };
+  // Script body (node/pod/local scripts) is piped via stdin — the calling tool builds the
+  // argv (kubectl exec / interpreter) and hands the script here rather than as a temp file.
+  if (req.stdin !== undefined) {
+    // The child may close stdin early (interpreter errors out) → EPIPE on this writable,
+    // emitted asynchronously, which a try/catch around .end() cannot catch. Without an
+    // 'error' listener Node throws unhandled. Swallow it; close/error drives the settle.
+    child.stdin?.on("error", () => { /* EPIPE / broken pipe — ignore */ });
+    try { child.stdin?.end(req.stdin); } catch { /* child may have failed to start */ }
+  }
 
   jobs.register({
     jobId: req.jobId,
@@ -117,14 +192,7 @@ export function spawnBackgroundBash(
     // A "stopped" status was set by job_stop before the SIGKILL that produced this exit.
     // Keep it "stopped" (not "killed") so the terminal status + notification match the
     // sub-agent stop path (job-registry maps a stopped sub-agent to "stopped" too).
-    const wasStopped = jobs.get(req.jobId)?.status === "stopped";
-    const status = wasStopped ? "stopped" : code === 0 ? "completed" : "failed";
-    const summary =
-      status === "completed"
-        ? `Background command "${req.description}" completed${code != null ? ` (exit ${code})` : ""}`
-        : status === "stopped"
-          ? `Background command "${req.description}" was stopped`
-          : `Background command "${req.description}" failed${code != null ? ` (exit ${code})` : ""}`;
+    const { status, summary } = terminalStatus(code);
     void settle(status, code, summary);
   });
 

--- a/src/core/job-registry.ts
+++ b/src/core/job-registry.ts
@@ -16,7 +16,7 @@
 
 import type { JobStopResult } from "./tool-registry.js";
 
-export type JobType = "subagent" | "bash" | "node" | "pod";
+export type JobType = "subagent" | "bash" | "node" | "pod" | "host" | "local";
 
 /**
  * Terminal + live states a background job can be in. A superset of SpawnSubagentStatus's

--- a/src/core/task-notification.ts
+++ b/src/core/task-notification.ts
@@ -45,11 +45,14 @@ export function escapeXml(s: string): string {
  * it already gave, and stay terse (or silent) when the result is already covered.
  */
 const NOTIFICATION_INSTRUCTIONS =
-  "This is an automatic background-job result, NOT a new user request. " +
+  "This is an automatic background-job result, NOT a new user request. The job has ALREADY FINISHED and its " +
+  "result is FINAL — the <summary> below (and the output_file, for shell jobs) IS that result. Do NOT re-launch, " +
+  "re-run, or re-dispatch this work, and do NOT spawn another sub-agent or call another tool to redo, verify, " +
+  "wait for, or 'get' a result you have just been handed — simply relay it. " +
   "Read the output_file only if you still need this result. " +
   "If it adds nothing the user doesn't already know — e.g. it matches a result or issue you already reported — " +
   "END YOUR TURN WITH NO MESSAGE AT ALL. Do NOT post 'no new info', 'same as above', or a restated summary; silence is the correct response and avoids a noise bubble. " +
-  "Produce text ONLY when there is genuinely NEW, actionable information, and then keep it to a brief update — never a re-run of a full report. " +
+  "Produce text ONLY when there is genuinely NEW, actionable information (e.g. the answer the user was waiting for), and then keep it to a brief update — never a re-run of a full report. " +
   "If several jobs finish together, fold them into ONE concise update.";
 
 /** One `<task_notification>` block (no instructions — those are appended once per message). */

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -127,18 +127,27 @@ export type JobStopExecutor = (jobId: string) => Promise<JobStopResult>;
  * executor only spawns + streams + notifies, keeping all command/security construction
  * in the tool.
  *
- * Two spawn modes (exactly one set):
+ * Three exec modes (exactly one set):
  *  - `command` (shell mode): run via `bash -c` — used by the local `bash` tool, whose
  *    command may include `sudo -E -u sandbox …` wrapping.
- *  - `file` + `args` (argv mode, no shell): used by node_exec/pod_exec to spawn
- *    `kubectl exec … -- nsenter … <cmd>` without re-tokenizing/quoting the nested command.
+ *  - `file` + `args` (argv mode, no shell): used by node_exec/pod_exec and node/pod/local
+ *    scripts to spawn `kubectl exec … -- nsenter … <cmd>` (or an interpreter) without
+ *    re-tokenizing/quoting the nested command. `stdin` may carry the script body.
+ *  - `streamFactory` (in-process stream mode): used by host_exec/host_script — there is no
+ *    child process; the factory dials ssh2 and returns live stdout/stderr streams + done.
  */
 export interface BackgroundExecRequest {
-  /** Shell-mode command (bash). Mutually exclusive with file/args. */
+  /** Shell-mode command (bash). Mutually exclusive with file/args/streamFactory. */
   command?: string;
-  /** argv-mode binary (node/pod). Mutually exclusive with command. */
+  /** argv-mode binary (node/pod/scripts). Mutually exclusive with command/streamFactory. */
   file?: string;
   args?: string[];
+  /** Script body piped to the child's stdin (argv mode: node/pod/local scripts). */
+  stdin?: string;
+  /** In-process stream source (host_exec/host_script via ssh2). Mutually exclusive with
+   *  command/file. Called once by the runner; the handle's `done` settles the job and the
+   *  factory owns connection teardown. */
+  streamFactory?: () => Promise<BackgroundStreamHandle>;
   cwd?: string;
   env: Record<string, string>;
   /** Sanitizer from preExecSecurity. MUST be line-safe (caller rejects otherwise) or null. */
@@ -151,7 +160,7 @@ export interface BackgroundExecRequest {
   /** True in K8s prod where the command is sudo-wrapped (bash shell mode only). */
   isProd: boolean;
   /** Job kind for the registry + concurrency accounting. Defaults to "bash". */
-  jobType?: "bash" | "node" | "pod";
+  jobType?: "bash" | "node" | "pod" | "host" | "local";
   /** Called exactly once when the job settles (completed/failed/killed), before notify.
    *  node_exec uses it to unpin (release) the debug pod it acquired for the job. */
   onComplete?: () => void;
@@ -164,6 +173,17 @@ export interface BackgroundExecRequest {
 export interface BackgroundExecResult {
   jobId: string;
   outputFile: string;
+}
+
+/** Live stream handle for an in-process background job (e.g. ssh2 channel). Structurally
+ *  matches ssh-dial's SshStreamHandle so sshExecStream's result is assignable. */
+export interface BackgroundStreamHandle {
+  stdout: import("node:stream").Readable;
+  stderr: import("node:stream").Readable;
+  /** Resolves when the remote side closes (exitCode null = killed by signal). */
+  done: Promise<{ exitCode: number | null; signal?: string }>;
+  /** Best-effort: close/abort the stream. */
+  abort: () => void;
 }
 
 /**

--- a/src/tools/cmd-exec/host-exec-background.test.ts
+++ b/src/tools/cmd-exec/host-exec-background.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the ssh-client boundary so we can drive host_exec's background branch without a real
+// SSH dial and inspect the exact remote command + the job_stop (onAbort) kill path.
+vi.mock("../infra/ssh-client.js", () => ({
+  acquireSshTarget: vi.fn(async () => ({ host: "10.0.0.9", port: 22, username: "u", auth: { type: "password", password: "p" } })),
+  sshExecStream: vi.fn(async () => ({ stdout: { setEncoding() {}, on() {} }, stderr: { setEncoding() {}, on() {} }, done: new Promise(() => {}), abort() {} })),
+  sshExec: vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 })),
+}));
+
+import { createHostExecTool } from "./host-exec.js";
+import { sshExecStream, sshExec } from "../infra/ssh-client.js";
+import type { BackgroundExecExecutor } from "../../core/tool-registry.js";
+
+const fakeExecutor: BackgroundExecExecutor = vi.fn(() => ({ jobId: "j", outputFile: "/o" }));
+const wiring = { executor: fakeExecutor, sessionIdRef: { current: "s1" } };
+
+beforeEach(() => {
+  vi.mocked(sshExecStream).mockClear();
+  vi.mocked(sshExec).mockClear();
+  vi.mocked(fakeExecutor).mockClear();
+});
+
+describe("host_exec — run_in_background schema gating", () => {
+  it("exposes run_in_background ONLY when an executor is injected", () => {
+    const withExec = createHostExecTool(undefined, wiring);
+    const withoutExec = createHostExecTool(undefined);
+    expect((withExec.parameters as any).properties.run_in_background).toBeDefined();
+    expect((withoutExec.parameters as any).properties.run_in_background).toBeUndefined();
+  });
+
+  it("keeps its core params regardless of background wiring", () => {
+    const tool = createHostExecTool(undefined);
+    expect((tool.parameters as any).properties.host).toBeDefined();
+    expect((tool.parameters as any).properties.command).toBeDefined();
+  });
+});
+
+describe("host_exec — background remote lifecycle", () => {
+  it("wraps the remote command in setsid + timeout and records a PGID file", async () => {
+    const tool = createHostExecTool(undefined, wiring);
+    const res = await tool.execute("call-1", { host: "myhost", command: "uptime", run_in_background: true }, undefined, {} as any);
+    expect((res.details as any).backgroundTaskId).toBe("j");
+
+    const req = vi.mocked(fakeExecutor).mock.calls[0][0] as any;
+    expect(req.jobType).toBe("host");
+    expect(typeof req.streamFactory).toBe("function");
+    expect(typeof req.onAbort).toBe("function");
+
+    // Invoke the factory to capture the exact remote command handed to ssh.
+    await req.streamFactory();
+    const wrapped = vi.mocked(sshExecStream).mock.calls[0][1] as string;
+    expect(wrapped).toContain("setsid");      // own process-group leader
+    expect(wrapped).toMatch(/timeout \d+/);   // leak backstop
+    expect(wrapped).toContain(".pgid");        // PGID recorded for job_stop
+    expect(wrapped).toContain("uptime");       // the user command
+  });
+
+  it("job_stop (onAbort) kills the remote process group over a fresh ssh connection", async () => {
+    const tool = createHostExecTool(undefined, wiring);
+    await tool.execute("call-2", { host: "myhost", command: "uptime", run_in_background: true }, undefined, {} as any);
+    const req = vi.mocked(fakeExecutor).mock.calls[0][0] as any;
+
+    req.onAbort();
+    expect(sshExec).toHaveBeenCalledTimes(1);
+    const killScript = vi.mocked(sshExec).mock.calls[0][1] as string;
+    // Kill by SESSION (pkill -s) so timeout's own child process group is reaped too,
+    // with a process-group kill as the fallback when pkill is unavailable.
+    expect(killScript).toContain("pkill -TERM -s");
+    expect(killScript).toContain("pkill -KILL -s");
+    expect(killScript).toContain("kill -TERM -"); // group-kill fallback
+    expect(killScript).toContain(".pgid");
+  });
+});

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -1,19 +1,28 @@
-import type { ToolEntry } from "../../core/tool-registry.js";
+import type { ToolEntry, BackgroundExecWiring } from "../../core/tool-registry.js";
 import { Type } from "@sinclair/typebox";
 import { Text } from "@mariozechner/pi-tui";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { KubeconfigRef } from "../../core/types.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { CONTAINER_SENSITIVE_PATHS } from "../infra/command-sets.js";
+import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "../infra/bg-session.js";
 import { preExecSecurity, postExecSecurity } from "../infra/security-pipeline.js";
+import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
+import { backgroundNotLineSafeError, backgroundLaunchedResult } from "./background-launch.js";
 import { validateNodeName } from "../infra/exec-utils.js";
-import { acquireSshTarget, sshExec } from "../infra/ssh-client.js";
+import { acquireSshTarget, sshExec, sshExecStream } from "../infra/ssh-client.js";
 
 interface HostExecParams {
   host: string;
   command: string;
   timeout_seconds?: number;
+  run_in_background?: boolean;
 }
+
+// Background ssh: default leak-guard ttl and cap (s). A dropped channel can't orphan the
+// remote process — `timeout <ttl>` bounds it. Generous vs node/pod (no debug-pod lifetime).
+const HOST_BG_DEFAULT_TTL = 600;
+const HOST_BG_MAX_TTL = 3600;
 
 /**
  * host_exec — run a single shell command on a non-K8s host via SSH.
@@ -26,7 +35,13 @@ interface HostExecParams {
  * the COMMANDS registry has no ssh / scp / sftp / sshpass entries — those are
  * blocked at the local context whitelist (DESIGN risk #1).
  */
-export function createHostExecTool(kubeconfigRef?: KubeconfigRef): ToolDefinition {
+export function createHostExecTool(
+  kubeconfigRef?: KubeconfigRef,
+  bg?: BackgroundExecWiring,
+): ToolDefinition {
+  // run_in_background is exposed only when the switch is on AND a runtime executor was
+  // injected — otherwise the param stays out of the schema.
+  const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
   return {
     name: "host_exec",
     label: "Host Exec",
@@ -70,9 +85,25 @@ Examples (pass the id from host_list; names shown here for readability):
       }),
       timeout_seconds: Type.Optional(
         Type.Number({
-          description: "Timeout in seconds (default: 30, max: 120)",
+          description: "Timeout in seconds (default: 30, max: 120; in background: default 600, max 3600)",
         })
       ),
+      ...(backgroundEnabled
+        ? {
+            run_in_background: Type.Optional(
+              Type.Boolean({
+                description:
+                  "Run the command on the host in the background instead of waiting. Returns immediately " +
+                  "with a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read " +
+                  "the file or call any tool, and do NOT sleep/wait. You are notified automatically when it " +
+                  "completes; ONLY THEN read the output_file. Use for long host work like RDMA perftest over " +
+                  "SSH (start the server on host A in the background, then the client on host B). The command " +
+                  "is wrapped in `timeout` and capped (~3600s). Output needing structural (JSON) redaction " +
+                  "cannot run in background.",
+              })
+            ),
+          }
+        : {}),
     }),
     renderCall(args: any, theme: any) {
       const host = args?.host || "...";
@@ -86,7 +117,7 @@ Examples (pass the id from host_list; names shown here for readability):
       );
     },
     renderResult: renderTextResult,
-    async execute(_toolCallId, rawParams, signal) {
+    async execute(toolCallId, rawParams, signal) {
       const params = rawParams as HostExecParams;
 
       // Validate host name format (reuse node naming rules — RFC 1123)
@@ -121,6 +152,50 @@ Examples (pass the id from host_list; names shown here for readability):
           content: [{ type: "text", text: `Error: ${msg}\n\nCould not reach "${params.host}" over SSH (not bound / no credential — not a command error). If "${params.host}" is a Kubernetes node, retry this command with node_exec (debug pod, no SSH).` }],
           details: { error: true, reason: "host_acquire_failed" },
         };
+      }
+
+      // ── Background mode ──────────────────────────────────────────────
+      // No child process: hand the executor an ssh2 stream factory. The remote command runs
+      // under `setsid` (own process-group leader) wrapped in `timeout <ttl>`, and records its
+      // PGID to a pidfile so job_stop can kill the WHOLE remote tree over a fresh ssh channel —
+      // closing the streaming channel does NOT reliably SIGHUP a non-PTY remote process, so a
+      // "stopped" perftest would otherwise keep running to ttl. Mirrors node_exec/node_script.
+      // Validation already ran above; only line-safe sanitizers stream per-line.
+      if (backgroundEnabled && params.run_in_background === true) {
+        if (pre.action && !pre.action.lineSafe) {
+          return backgroundNotLineSafeError();
+        }
+        const ttl = Math.min(params.timeout_seconds ?? HOST_BG_DEFAULT_TTL, HOST_BG_MAX_TTL);
+        const esc = params.command.replace(/'/g, "'\\''");
+        const userCmd = `timeout ${ttl} sh -c '${esc}'`;
+        // Run as a killable session (setsid + recorded session id) so job_stop reaps the whole
+        // remote tree incl. timeout's own process group. See bg-session.ts for the rationale.
+        const pgidFile = backgroundPgidFile(toolCallId);
+        const wrapped = wrapBackgroundSession(userCmd, pgidFile);
+        const killScript = backgroundSessionKillScript(pgidFile);
+        // job_stop: kill the remote process group over a FRESH ssh connection (the streaming
+        // channel is being torn down). Best-effort, time-boxed; the runner closes the channel after.
+        const onAbort = () => { void sshExec(target, killScript, { timeoutMs: 20_000 }).catch(() => {}); };
+        try {
+          const { jobId, outputFile } = bg!.executor!({
+            // The job outlives this turn, so it is NOT tied to the turn's AbortSignal —
+            // job_stop drives the abort via the JobRegistry → onAbort + handle.abort.
+            streamFactory: () => sshExecStream(target, wrapped, {}),
+            env: {},
+            action: pre.action,
+            hasSensitiveKubectl: pre.hasSensitiveKubectl,
+            description: `host ${params.host}: ${params.command.length > 60 ? params.command.slice(0, 57) + "…" : params.command}`,
+            parentSessionId: bg!.sessionIdRef?.current ?? "",
+            jobId: toolCallId,
+            isProd: false,
+            jobType: "host",
+            onAbort,
+          });
+          return backgroundLaunchedResult(jobId, outputFile, "Running on the host in the background.");
+        } catch (err) {
+          // Concurrency cap (or executor failure): fall through to a foreground run.
+          console.warn(`[host-exec] background launch declined, running foreground:`, err);
+        }
       }
 
       const timeout = Math.min(params.timeout_seconds ?? 30, 120) * 1000;
@@ -171,5 +246,9 @@ Examples (pass the id from host_list; names shown here for readability):
 
 export const registration: ToolEntry = {
   category: "cmd-exec",
-  create: (refs) => createHostExecTool(refs.kubeconfigRef),
+  create: (refs) =>
+    createHostExecTool(refs.kubeconfigRef, {
+      executor: refs.backgroundExecExecutor,
+      sessionIdRef: refs.sessionIdRef,
+    }),
 };

--- a/src/tools/infra/bg-session.test.ts
+++ b/src/tools/infra/bg-session.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "./bg-session.js";
+
+describe("bg-session", () => {
+  it("builds a unique, sanitized pidfile path", () => {
+    const a = backgroundPgidFile("functions.host_exec:0");
+    const b = backgroundPgidFile("functions.host_exec:0");
+    expect(a).toMatch(/^\/tmp\/siclaw-bg-functions_host_exec_0-[0-9a-f]{8}\.pgid$/);
+    expect(a).not.toBe(b); // random suffix → no collision across jobs
+  });
+
+  it("wraps a command as a setsid session that records its session id and cleans up", () => {
+    const wrapped = wrapBackgroundSession("timeout 600 sh -c 'do work'", "/tmp/x.pgid");
+    expect(wrapped.startsWith("setsid -w sh -c ")).toBe(true);
+    expect(wrapped).toContain("echo $$ > /tmp/x.pgid");   // record session id
+    expect(wrapped).toContain("timeout 600 sh -c");        // inner command preserved
+    expect(wrapped).toContain("rm -f /tmp/x.pgid");        // cleanup on normal exit
+    // The inner single-quotes are escaped for the outer setsid `sh -c '…'` (one quoting level).
+    expect(wrapped).toContain(`'\\''`);
+  });
+
+  it("kills by SESSION (pkill -s) with a process-group fallback", () => {
+    const kill = backgroundSessionKillScript("/tmp/x.pgid");
+    expect(kill).toContain("cat /tmp/x.pgid");
+    expect(kill).toContain("pkill -TERM -s");
+    expect(kill).toContain("pkill -KILL -s");
+    expect(kill).toContain("kill -TERM -");  // group-kill fallback when pkill is absent
+    expect(kill).toContain("rm -f /tmp/x.pgid");
+  });
+});

--- a/src/tools/infra/bg-session.ts
+++ b/src/tools/infra/bg-session.ts
@@ -1,0 +1,40 @@
+import { randomBytes } from "node:crypto";
+import { shellEscape } from "./command-sets.js";
+
+/**
+ * Shared shell-string builders for background jobs that run a command on a REMOTE shell
+ * (host_exec / host_script over SSH, pod_script via kubectl-exec). The transport differs per
+ * tool, but the "run as a killable session + reap it on job_stop" shell logic is identical and
+ * quoting-sensitive, so it lives here once (and is covered by an e2e remote-reap smoke).
+ *
+ * Why a SESSION (setsid), not just a process group: GNU `timeout` puts its child in its OWN
+ * process group, so a single `kill -<pgid>` of the launcher's group misses timeout's subtree.
+ * setsid starts a new session whose id every descendant inherits (across timeout's sub-group),
+ * so `pkill -s <sid>` reaps them all.
+ */
+
+/** A unique pidfile path holding the setsid session id (`$$` of the leader) for one job. */
+export function backgroundPgidFile(toolCallId: string): string {
+  const safe = toolCallId.replace(/[^A-Za-z0-9_-]/g, "_");
+  return `/tmp/siclaw-bg-${safe}-${randomBytes(4).toString("hex")}.pgid`;
+}
+
+/**
+ * Wrap `innerCmd` so it runs as its own session leader (setsid), records the session id to
+ * `pgidFile`, and removes the pidfile on normal exit. Returns ONE remote-shell command string.
+ * `echo $$` consumes no stdin, so a piped script body flows through to `innerCmd` unchanged.
+ */
+export function wrapBackgroundSession(innerCmd: string, pgidFile: string): string {
+  const launch = `echo $$ > ${pgidFile}; ${innerCmd}; rc=$?; rm -f ${pgidFile}; exit $rc`;
+  return `setsid -w sh -c ${shellEscape(launch)}`;
+}
+
+/**
+ * Shell that reaps a job started with {@link wrapBackgroundSession}: read the recorded session
+ * id (retry briefly in case the file isn't written yet) and kill the whole session — `pkill -s`
+ * first (catches timeout's sub-group), process-group `kill -<sid>` as a fallback when pkill is
+ * absent. Idempotent; meant to run over a fresh connection on job_stop.
+ */
+export function backgroundSessionKillScript(pgidFile: string): string {
+  return `sid=""; for i in 1 2 3; do sid=$(cat ${pgidFile} 2>/dev/null); [ -n "$sid" ] && break; sleep 1; done; if [ -n "$sid" ]; then pkill -TERM -s "$sid" 2>/dev/null || kill -TERM -"$sid" 2>/dev/null; sleep 1; pkill -KILL -s "$sid" 2>/dev/null || kill -KILL -"$sid" 2>/dev/null; fi; rm -f ${pgidFile}`;
+}

--- a/src/tools/infra/ssh-client.test.ts
+++ b/src/tools/infra/ssh-client.test.ts
@@ -47,10 +47,10 @@ const { MockClient, mockState, mockStreams } = vi.hoisted(() => {
 
   class MockStream extends TinyEmitter {
     stderr = new TinyEmitter();
-    stdin: { end: ReturnType<typeof makeFn> };
+    stdin: { end: ReturnType<typeof makeFn>; on: () => void };
     constructor() {
       super();
-      this.stdin = { end: makeFn() };
+      this.stdin = { end: makeFn(), on: () => {} };
     }
   }
 
@@ -123,10 +123,10 @@ afterEach(() => {
 function nextStream() {
   const s = new EventEmitter() as EventEmitter & {
     stderr: EventEmitter;
-    stdin: { end: ReturnType<typeof vi.fn> };
+    stdin: { end: ReturnType<typeof vi.fn>; on: () => void };
   };
   s.stderr = new EventEmitter();
-  s.stdin = { end: vi.fn() };
+  s.stdin = { end: vi.fn(), on: () => {} };
   mockStreams.push(s as any);
   return s;
 }

--- a/src/tools/infra/ssh-client.ts
+++ b/src/tools/infra/ssh-client.ts
@@ -27,9 +27,11 @@ import { ensureHostForTool } from "./ensure-kubeconfigs.js";
 import {
   dialSshChain,
   runCommand,
+  runCommandStream,
   type DialHop,
   type SshRunResult,
   type SshRunOptions,
+  type SshStreamHandle,
 } from "./ssh-dial.js";
 
 /** Caps a target + up to 3 bastions. */
@@ -217,6 +219,38 @@ export async function sshExec(
     return await runCommand(client, command, options);
   } finally {
     teardown();
+  }
+}
+
+// ── sshExecStream (background) ──────────────────────────────────────
+
+/**
+ * Streaming counterpart to {@link sshExec} for background jobs: dials the chain,
+ * starts `command` on the final host, and returns live stdout/stderr streams plus
+ * a `done` promise — WITHOUT buffering. The chain is torn down automatically when
+ * the command finishes or is aborted (so the caller never leaks a connection).
+ * The command itself should be `timeout`-wrapped by the calling tool so a dropped
+ * channel cannot orphan the remote process.
+ */
+export async function sshExecStream(
+  target: SshTarget,
+  command: string,
+  options: { signal?: AbortSignal; stdin?: string } = {},
+): Promise<SshStreamHandle> {
+  const hops = await targetToHops(target);
+  const { client, teardown } = await dialSshChain(hops, {
+    timeoutMs: SSH_CONNECT_TIMEOUT_MS,
+    signal: options.signal,
+  });
+  try {
+    const handle = await runCommandStream(client, command, options);
+    // Tear the chain down once the remote command closes (or is aborted, which
+    // closes the channel → resolves done). finally so a rejected done still cleans up.
+    void handle.done.finally(() => { try { teardown(); } catch { /* already gone */ } });
+    return handle;
+  } catch (err) {
+    teardown();
+    throw err;
   }
 }
 

--- a/src/tools/infra/ssh-dial.test.ts
+++ b/src/tools/infra/ssh-dial.test.ts
@@ -83,7 +83,7 @@ const { MockClient, mockState } = vi.hoisted(() => {
 
 vi.mock("ssh2", () => ({ Client: MockClient }));
 
-import { dialSshChain, runCommand, makeHostVerifier, type DialHop } from "./ssh-dial.js";
+import { dialSshChain, runCommand, runCommandStream, makeHostVerifier, type DialHop } from "./ssh-dial.js";
 
 beforeEach(() => {
   mockState.instances = [];
@@ -195,6 +195,93 @@ describe("runCommand", () => {
     const { client, teardown } = await dialSshChain([hop("10.0.0.9")], { timeoutMs: 5000 });
     (client as any).exec = () => { /* never calls back */ };
     await expect(runCommand(client, "sleep", { timeoutMs: 30 })).rejects.toThrow(/SSH timeout after 30ms/);
+    teardown();
+  });
+});
+
+describe("runCommandStream (background)", () => {
+  it("exposes live streams, pipes stdin, resolves done with exitCode on close", async () => {
+    const { client, teardown } = await dialSshChain([hop("10.0.0.9")], { timeoutMs: 5000 });
+    const handlers: Record<string, (...a: any[]) => void> = {};
+    const stdinEnd = vi.fn();
+    const fakeStream: any = {
+      on(ev: string, fn: (...a: any[]) => void) { handlers[ev] = fn; return fakeStream; },
+      stderr: { on() { return fakeStream.stderr; } },
+      stdin: { end: stdinEnd, on() { /* error listener */ } },
+      close() { /* abort path */ },
+    };
+    (client as any).exec = (_cmd: string, cb: (e: Error | null, s: any) => void) => cb(null, fakeStream);
+
+    const handle = await runCommandStream(client, "echo ok", { stdin: "scriptbody" });
+    expect(stdinEnd).toHaveBeenCalledWith("scriptbody"); // script body piped to remote stdin
+
+    let out = "";
+    handle.stdout.on("data", (c: Buffer) => { out += c.toString(); });
+    handlers["data"](Buffer.from("hello\n"));
+    handlers["close"](0);
+
+    const res = await handle.done;
+    expect(out).toBe("hello\n");
+    expect(res.exitCode).toBe(0);
+    teardown();
+  });
+
+  it("resolves done as a failure on a channel 'error' (no crash, no hang)", async () => {
+    const { client, teardown } = await dialSshChain([hop("10.0.0.9")], { timeoutMs: 5000 });
+    const handlers: Record<string, (...a: any[]) => void> = {};
+    const destroy = vi.fn();
+    const fakeStream: any = {
+      on(ev: string, fn: (...a: any[]) => void) { handlers[ev] = fn; return fakeStream; },
+      stderr: { on() { return fakeStream.stderr; } },
+      stdin: { end() {}, on() {} },
+      close() {}, destroy,
+    };
+    (client as any).exec = (_cmd: string, cb: (e: Error | null, s: any) => void) => cb(null, fakeStream);
+
+    const handle = await runCommandStream(client, "x");
+    // A channel error must NOT throw unhandled, and `done` must settle (so the job ends + teardown runs).
+    expect(() => handlers["error"](new Error("connection reset"))).not.toThrow();
+    const res = await handle.done;
+    expect(res.exitCode).toBeNull();
+    expect(res.signal).toBe("ERROR");
+    expect(destroy).toHaveBeenCalled();
+    teardown();
+  });
+
+  it("swallows an EPIPE on stdin instead of throwing unhandled", async () => {
+    const { client, teardown } = await dialSshChain([hop("10.0.0.9")], { timeoutMs: 5000 });
+    const handlers: Record<string, (...a: any[]) => void> = {};
+    const stdinHandlers: Record<string, (...a: any[]) => void> = {};
+    const fakeStream: any = {
+      on(ev: string, fn: (...a: any[]) => void) { handlers[ev] = fn; return fakeStream; },
+      stderr: { on() { return fakeStream.stderr; } },
+      stdin: { end() {}, on(ev: string, fn: (...a: any[]) => void) { stdinHandlers[ev] = fn; } },
+      close() {},
+    };
+    (client as any).exec = (_cmd: string, cb: (e: Error | null, s: any) => void) => cb(null, fakeStream);
+
+    const handle = await runCommandStream(client, "x", { stdin: "body" });
+    expect(stdinHandlers["error"]).toBeTypeOf("function");
+    expect(() => stdinHandlers["error"](new Error("write EPIPE"))).not.toThrow();
+    handlers["close"](0);
+    expect((await handle.done).exitCode).toBe(0);
+    teardown();
+  });
+
+  it("closes the channel immediately when the signal is already aborted (lost-stop guard)", async () => {
+    const { client, teardown } = await dialSshChain([hop("10.0.0.9")], { timeoutMs: 5000 });
+    const close = vi.fn();
+    const fakeStream: any = {
+      on(_ev: string, _fn: (...a: any[]) => void) { return fakeStream; },
+      stderr: { on() { return fakeStream.stderr; } },
+      stdin: { end() {}, on() {} },
+      close,
+    };
+    (client as any).exec = (_cmd: string, cb: (e: Error | null, s: any) => void) => cb(null, fakeStream);
+    const ac = new AbortController();
+    ac.abort(); // already stopped before exec's callback fires
+    await runCommandStream(client, "x", { signal: ac.signal });
+    expect(close).toHaveBeenCalled();
     teardown();
   });
 });

--- a/src/tools/infra/ssh-dial.ts
+++ b/src/tools/infra/ssh-dial.ts
@@ -357,12 +357,96 @@ export function runCommand(client: Client, command: string, options: SshRunOptio
           ...(truncated ? { truncated: true } : {}),
         });
       });
+      // A channel 'error' with no listener throws an uncaught exception; the timeout would
+      // eventually settleReject but the process may already have crashed. Reject explicitly.
+      stream.on("error", (e: Error) => settleReject(e));
+      stream.stderr.on("error", () => { /* see main stream 'error' */ });
       stream.on("data", (chunk: Buffer) => append(stdoutChunks, chunk));
       stream.stderr.on("data", (chunk: Buffer) => append(stderrChunks, chunk));
 
       if (options.stdin !== undefined) {
+        // Swallow EPIPE if the remote closes stdin early (async — not catchable around .end()).
+        stream.stdin.on("error", () => { /* EPIPE / broken pipe — ignore */ });
         stream.stdin.end(options.stdin);
       }
+    });
+  });
+}
+
+// ── runCommandStream (background) ────────────────────────────────────
+
+/** Live handle to a streaming remote command, for background execution. */
+export interface SshStreamHandle {
+  /** stdout of the remote command (the ssh2 channel itself). */
+  stdout: import("node:stream").Readable;
+  /** stderr of the remote command. */
+  stderr: import("node:stream").Readable;
+  /** Resolves when the remote channel closes (exitCode null = killed by signal). */
+  done: Promise<{ exitCode: number | null; signal?: string }>;
+  /** Best-effort: close the channel. The caller tears down the client afterwards. */
+  abort: () => void;
+}
+
+/**
+ * Streaming counterpart to {@link runCommand}: does NOT buffer — exposes the raw
+ * stdout/stderr streams so a background launcher can pipe them line-by-line to disk.
+ * Pipes options.stdin (script body) and honours an AbortSignal. There is no overall
+ * timeout here: a background command is bounded by its own `timeout <ttl>` wrapper
+ * (added by the calling tool) and by job_stop's abort. The caller owns client teardown.
+ */
+export function runCommandStream(
+  client: Client,
+  command: string,
+  options: { signal?: AbortSignal; stdin?: string } = {},
+): Promise<SshStreamHandle> {
+  return new Promise<SshStreamHandle>((resolve, reject) => {
+    client.exec(command, (err, stream) => {
+      if (err) return reject(err);
+
+      let closed = false;
+      let resolveDone!: (v: { exitCode: number | null; signal?: string }) => void;
+      const done = new Promise<{ exitCode: number | null; signal?: string }>((res) => {
+        resolveDone = res;
+      });
+      const onAbort = () => { try { stream.close(); } catch { /* already closing */ } };
+      const finish = (v: { exitCode: number | null; signal?: string }) => {
+        if (closed) return;
+        closed = true;
+        options.signal?.removeEventListener("abort", onAbort);
+        resolveDone(v);
+      };
+      options.signal?.addEventListener("abort", onAbort, { once: true });
+
+      stream.on("close", (code: number | null, signal?: string) => {
+        finish({ exitCode: code, ...(signal ? { signal } : {}) });
+      });
+      // A channel 'error' (link flap, window/protocol error) MUST be handled: with no
+      // listener Node throws an uncaught exception (can take down the whole agentbox), and
+      // `done` would otherwise never settle — leaving the job hung, the parent session's
+      // background-work count un-decremented, and the ssh chain never torn down (connection
+      // leak). Resolve `done` as a failure so the runner settles and the caller tears down.
+      stream.on("error", () => {
+        try { stream.destroy(); } catch { /* ignore */ }
+        finish({ exitCode: null, signal: "ERROR" });
+      });
+      // stderr shares the channel; swallow its 'error' so it can't throw unhandled (the
+      // failure is already surfaced via the main stream 'error' above).
+      stream.stderr?.on("error", () => { /* see main stream 'error' */ });
+
+      if (options.stdin !== undefined) {
+        // The remote may close stdin early (interpreter exits / channel drops) → EPIPE on
+        // this writable; with no listener that throws unhandled. Swallow it (close/error
+        // drives `done`). try/catch around .end() can't catch this async stream error.
+        stream.stdin.on("error", () => { /* EPIPE / broken pipe — ignore */ });
+        stream.stdin.end(options.stdin);
+      }
+
+      // The signal may already be aborted by the time exec's callback fires (a job_stop
+      // during a slow multi-hop dial). addEventListener won't fire for an already-fired
+      // signal, so close now — otherwise the stop is silently lost and the command runs on.
+      if (options.signal?.aborted) onAbort();
+
+      resolve({ stdout: stream, stderr: stream.stderr, done, abort: onAbort });
     });
   });
 }

--- a/src/tools/script-exec/host-script.ts
+++ b/src/tools/script-exec/host-script.ts
@@ -1,4 +1,4 @@
-import type { ToolEntry } from "../../core/tool-registry.js";
+import type { ToolEntry, BackgroundExecWiring } from "../../core/tool-registry.js";
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
@@ -6,9 +6,12 @@ import type { KubeconfigRef } from "../../core/types.js";
 import { resolveScript } from "../infra/script-resolver.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { postExecSecurity } from "../infra/security-pipeline.js";
+import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
+import { backgroundLaunchedResult } from "../cmd-exec/background-launch.js";
 import { parseArgs, shellEscape } from "../infra/command-sets.js";
 import { validateNodeName, stdinExecCmd } from "../infra/exec-utils.js";
-import { acquireSshTarget, sshExec } from "../infra/ssh-client.js";
+import { acquireSshTarget, sshExec, sshExecStream } from "../infra/ssh-client.js";
+import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "../infra/bg-session.js";
 
 interface HostScriptParams {
   host: string;
@@ -16,7 +19,13 @@ interface HostScriptParams {
   script: string;
   args?: string;
   timeout_seconds?: number;
+  run_in_background?: boolean;
 }
+
+// Background ssh leak-guard ttl (s): the script is `timeout`-wrapped so a dropped channel
+// can't orphan it. Generous vs the foreground cap; matches host_exec.
+const HOST_BG_DEFAULT_TTL = 600;
+const HOST_BG_MAX_TTL = 3600;
 
 /**
  * host_script — run a skill or user script on a non-K8s host via SSH.
@@ -30,7 +39,11 @@ interface HostScriptParams {
  * as node_script — scripts are trusted assets); but `args` are shell-escaped
  * to prevent injection.
  */
-export function createHostScriptTool(kubeconfigRef?: KubeconfigRef): ToolDefinition {
+export function createHostScriptTool(
+  kubeconfigRef?: KubeconfigRef,
+  bg?: BackgroundExecWiring,
+): ToolDefinition {
+  const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
   return {
     name: "host_script",
     label: "Host Script",
@@ -78,11 +91,25 @@ Examples (pass the id from host_list; names shown here for readability):
       ),
       timeout_seconds: Type.Optional(
         Type.Number({
-          description: "Timeout in seconds (default: 180, max: 300)",
+          description: "Timeout in seconds (default: 180, max: 300; in background: default 600, max 3600)",
         }),
       ),
+      ...(backgroundEnabled
+        ? {
+            run_in_background: Type.Optional(
+              Type.Boolean({
+                description:
+                  "Run the script on the host in the background instead of waiting. Returns immediately " +
+                  "with a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read " +
+                  "the file or call any tool, and do NOT sleep/wait. You are notified automatically when it " +
+                  "completes; ONLY THEN read the output_file. Use for long-running skill scripts over SSH " +
+                  "(orchestration, soak, perftest). The script is wrapped in `timeout` and capped (~3600s).",
+              }),
+            ),
+          }
+        : {}),
     }),
-    async execute(_toolCallId, rawParams, signal) {
+    async execute(toolCallId, rawParams, signal) {
       const params = rawParams as HostScriptParams;
 
       const hostErr = validateNodeName(params.host);
@@ -118,6 +145,40 @@ Examples (pass the id from host_list; names shown here for readability):
       const args = params.args?.trim() || "";
       const escapedArgs = args ? parseArgs(args).map(shellEscape).join(" ") : "";
       const remoteCmd = stdinExecCmd(resolved.interpreter, escapedArgs || undefined);
+
+      // ── Background mode ──────────────────────────────────────────────
+      // Pipe the script via stdin to a `setsid`-wrapped, `timeout <ttl>`-bounded remote shell,
+      // stream output to disk. setsid makes the remote command its own process-group leader and
+      // records its PGID so job_stop can kill the WHOLE remote tree over a fresh ssh channel
+      // (closing the streaming channel does NOT reliably SIGHUP a non-PTY remote process).
+      // Mirrors node_script. Script bodies aren't sanitized (trusted assets) → action null.
+      if (backgroundEnabled && params.run_in_background === true) {
+        const ttl = Math.min(params.timeout_seconds ?? HOST_BG_DEFAULT_TTL, HOST_BG_MAX_TTL);
+        // Run as a killable session so job_stop reaps the whole remote tree (incl. timeout's own
+        // process group); the script body on stdin flows through to `timeout … bash -s`/`python3 -`.
+        const pgidFile = backgroundPgidFile(toolCallId);
+        const wrapped = wrapBackgroundSession(`timeout ${ttl} ${remoteCmd}`, pgidFile);
+        const killScript = backgroundSessionKillScript(pgidFile);
+        const onAbort = () => { void sshExec(target, killScript, { timeoutMs: 20_000 }).catch(() => {}); };
+        try {
+          const { jobId, outputFile } = bg!.executor!({
+            streamFactory: () => sshExecStream(target, wrapped, { stdin: resolved.content }),
+            env: {},
+            action: null,
+            hasSensitiveKubectl: false,
+            description: `host ${params.host}: ${[params.skill, params.script].filter(Boolean).join("/")}`,
+            parentSessionId: bg!.sessionIdRef?.current ?? "",
+            jobId: toolCallId,
+            isProd: false,
+            jobType: "host",
+            onAbort,
+          });
+          return backgroundLaunchedResult(jobId, outputFile, "Running on the host in the background.");
+        } catch (err) {
+          console.warn(`[host-script] background launch declined, running foreground:`, err);
+        }
+      }
+
       const timeout = Math.min(params.timeout_seconds ?? 180, 300) * 1000;
 
       let result;
@@ -168,5 +229,9 @@ Examples (pass the id from host_list; names shown here for readability):
 
 export const registration: ToolEntry = {
   category: "script-exec",
-  create: (refs) => createHostScriptTool(refs.kubeconfigRef),
+  create: (refs) =>
+    createHostScriptTool(refs.kubeconfigRef, {
+      executor: refs.backgroundExecExecutor,
+      sessionIdRef: refs.sessionIdRef,
+    }),
 };

--- a/src/tools/script-exec/local-script.ts
+++ b/src/tools/script-exec/local-script.ts
@@ -1,4 +1,4 @@
-import type { ToolEntry } from "../../core/tool-registry.js";
+import type { ToolEntry, BackgroundExecWiring } from "../../core/tool-registry.js";
 import { Type } from "@sinclair/typebox";
 import { spawn } from "node:child_process";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
@@ -6,6 +6,8 @@ import { Text } from "@mariozechner/pi-tui";
 import type { KubeconfigRef } from "../../core/types.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { postExecSecurity } from "../infra/security-pipeline.js";
+import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
+import { backgroundLaunchedResult } from "../cmd-exec/background-launch.js";
 import { loadConfig } from "../../core/config.js";
 import { resolveRequiredKubeconfig } from "../infra/kubeconfig-resolver.js";
 import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
@@ -25,6 +27,7 @@ interface RunSkillParams {
   args?: string;
   cluster?: string;
   timeout_seconds?: number;
+  run_in_background?: boolean;
 }
 
 export function createLocalScriptTool(
@@ -32,7 +35,9 @@ export function createLocalScriptTool(
   sessionIdRef?: { current: string },
   userId?: string,
   agentId?: string | null,
+  bg?: BackgroundExecWiring,
 ): ToolDefinition {
+  const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
   return {
     name: "local_script",
     label: "Local Script",
@@ -87,8 +92,21 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
           description: "Timeout in seconds (default: 180, max: 300)",
         })
       ),
+      ...(backgroundEnabled
+        ? {
+            run_in_background: Type.Optional(
+              Type.Boolean({
+                description:
+                  "Run the script in the background instead of waiting. Returns immediately with a task_id " +
+                  "and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read the file or call " +
+                  "any tool, and do NOT sleep/wait. You are notified automatically when it completes; ONLY " +
+                  "THEN read the output_file. Use for long-running skill scripts (orchestration, soak, perftest).",
+              })
+            ),
+          }
+        : {}),
     }),
-    async execute(_toolCallId, rawParams, signal) {
+    async execute(toolCallId, rawParams, signal) {
       const params = rawParams as RunSkillParams;
       const skill = params.skill?.trim();
       const script = params.script?.trim();
@@ -151,6 +169,37 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
       // into a shell command string (prevents shell injection via args parameter)
       const cmdArgs = args ? parseArgs(args) : [];
 
+      const childEnv: Record<string, string> = {
+        ...sanitizeEnv(process.env as Record<string, string>),
+        SICLAW_DEBUG_IMAGE: loadConfig().debugImage,
+        ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
+        KUBECONFIG: kubeResult.path || "/dev/null",
+      };
+
+      // ── Background mode ──────────────────────────────────────────────
+      // Reuse the child-process runner in argv mode: interpreter + [scriptPath, ...args].
+      // Script output isn't sanitized (trusted asset), so action is null (line-safe).
+      // Note: background launches don't emit the skill_call diagnostic (no terminal outcome yet).
+      if (backgroundEnabled && params.run_in_background === true) {
+        try {
+          const { jobId, outputFile } = bg!.executor!({
+            file: resolved.interpreter,
+            args: [resolved.path, ...cmdArgs],
+            env: childEnv,
+            action: null,
+            hasSensitiveKubectl: false,
+            description: `${skill}/${script}${args ? " " + args : ""}`,
+            parentSessionId: sessionIdRef?.current ?? "",
+            jobId: toolCallId,
+            isProd: process.env.NODE_ENV === "production",
+            jobType: "local",
+          });
+          return backgroundLaunchedResult(jobId, outputFile, "Running the script in the background.");
+        } catch (err) {
+          console.warn(`[local-script] background launch declined, running foreground:`, err);
+        }
+      }
+
       const timeout = Math.min(params.timeout_seconds ?? 180, 300) * 1000;
       const startMs = Date.now();
 
@@ -158,12 +207,7 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
         const child = spawn(resolved.interpreter, [resolved.path, ...cmdArgs], {
           detached: true, // make child a process group leader for clean group kill
           stdio: ["ignore", "pipe", "pipe"],
-          env: {
-            ...sanitizeEnv(process.env as Record<string, string>),
-            SICLAW_DEBUG_IMAGE: loadConfig().debugImage,
-            ...(kubeconfigRef?.credentialsDir ? { SICLAW_CREDENTIALS_DIR: kubeconfigRef.credentialsDir } : {}),
-            KUBECONFIG: kubeResult.path || "/dev/null",
-          },
+          env: childEnv,
         });
 
         const onAbort = () => {
@@ -241,5 +285,9 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
 
 export const registration: ToolEntry = {
   category: "script-exec",
-  create: (refs) => createLocalScriptTool(refs.kubeconfigRef, refs.sessionIdRef, refs.userId, refs.agentId),
+  create: (refs) =>
+    createLocalScriptTool(refs.kubeconfigRef, refs.sessionIdRef, refs.userId, refs.agentId, {
+      executor: refs.backgroundExecExecutor,
+      sessionIdRef: refs.sessionIdRef,
+    }),
 };

--- a/src/tools/script-exec/node-script.ts
+++ b/src/tools/script-exec/node-script.ts
@@ -1,5 +1,7 @@
-import type { ToolEntry } from "../../core/tool-registry.js";
+import type { ToolEntry, BackgroundExecWiring } from "../../core/tool-registry.js";
 import { Type } from "@sinclair/typebox";
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import type { KubeconfigRef } from "../../core/types.js";
@@ -7,6 +9,8 @@ import { checkNodeReady } from "../infra/k8s-checks.js";
 import { resolveScript } from "../infra/script-resolver.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { loadConfig } from "../../core/config.js";
+import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
+import { backgroundLaunchedResult } from "../cmd-exec/background-launch.js";
 import { parseArgs, shellEscape } from "../infra/command-sets.js";
 import {
   validateNodeName,
@@ -15,7 +19,7 @@ import {
   stdinExecCmd,
 } from "../infra/exec-utils.js";
 import { postExecSecurity } from "../infra/security-pipeline.js";
-import { runInDebugPod } from "../infra/debug-pod.js";
+import { runInDebugPod, ensureDebugPodReady, acquireDebugPod, releaseDebugPod } from "../infra/debug-pod.js";
 import { resolveRequiredKubeconfig, resolveDebugImage } from "../infra/kubeconfig-resolver.js";
 import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
 
@@ -28,9 +32,15 @@ interface NodeScriptParams {
   cluster?: string;
   image?: string;
   timeout_seconds?: number;
+  run_in_background?: boolean;
 }
 
-export function createNodeScriptTool(kubeconfigRef?: KubeconfigRef, userId?: string): ToolDefinition {
+export function createNodeScriptTool(
+  kubeconfigRef?: KubeconfigRef,
+  userId?: string,
+  bg?: BackgroundExecWiring,
+): ToolDefinition {
+  const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
   return {
     name: "node_script",
     label: "Node Script",
@@ -100,8 +110,22 @@ Examples:
           description: "Timeout in seconds (default: 180, max: 300)",
         }),
       ),
+      ...(backgroundEnabled
+        ? {
+            run_in_background: Type.Optional(
+              Type.Boolean({
+                description:
+                  "Run the script on the node in the background instead of waiting. Returns immediately with " +
+                  "a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read the file " +
+                  "or call any tool, and do NOT sleep/wait. You are notified automatically when it completes; " +
+                  "ONLY THEN read the output_file. The script is wrapped in `timeout` and capped at the " +
+                  "debug-pod lifetime (~600s). Use for long-running node skill scripts (orchestration, soak).",
+              }),
+            ),
+          }
+        : {}),
     }),
-    async execute(_toolCallId, rawParams, signal) {
+    async execute(toolCallId, rawParams, signal) {
       const params = rawParams as NodeScriptParams;
 
       try {
@@ -177,10 +201,73 @@ Examples:
         ? `ip netns exec ${netns} ${baseCmd}`
         : baseCmd;
 
-      const nsenterCmd = [
-        "nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p",
-        "--", "sh", "-c", innerCmd,
-      ];
+      const NSENTER = ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--"];
+      const nsenterCmd = [...NSENTER, "sh", "-c", innerCmd];
+
+      // ── Background mode ──────────────────────────────────────────────
+      // Mirror node_exec's background path (ensure + pin a debug pod, record the remote PGID
+      // so job_stop can kill the host-namespace group, `timeout` as the leak backstop) but
+      // feed the SCRIPT via stdin: `sh -c launchScript` gets launchScript as its -c arg, so
+      // stdin stays free for the inner `sh -s`/`python3 -` reading the piped script body.
+      if (backgroundEnabled && params.run_in_background === true) {
+        const cfg = loadConfig();
+        const ttl = Math.min(params.timeout_seconds ?? cfg.debugPodTTL, cfg.debugPodTTL);
+        const safeJob = toolCallId.replace(/[^A-Za-z0-9_-]/g, "_");
+        const pgidFile = `/tmp/siclaw-bg-${safeJob}-${randomBytes(4).toString("hex")}.pgid`;
+        const launchScript = `echo $$ > ${pgidFile}; exec timeout ${ttl} ${innerCmd}`;
+        const bgNsenterCmd = [...NSENTER, "setsid", "-w", "sh", "-c", launchScript];
+        const spec = { userId: userId ?? "unknown", nodeName: params.node, command: bgNsenterCmd, image, clusterKey };
+        let cachedPod;
+        try {
+          cachedPod = await ensureDebugPodReady(spec, env, { signal });
+        } catch (err: any) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: true, message: `Debug pod failed to start: ${err?.message ?? String(err)}` }) }],
+            details: { error: true, reason: "debug_pod_failed" },
+          };
+        }
+        const pinnedPodName = acquireDebugPod(spec);
+        if (!pinnedPodName) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ error: true, message: "Debug pod went away before the background job could pin it; try again." }) }],
+            details: { error: true, reason: "debug_pod_gone" },
+          };
+        }
+        const killScript = `pgid=""; for i in 1 2 3; do pgid=$(cat ${pgidFile} 2>/dev/null); [ -n "$pgid" ] && break; sleep 1; done; if [ -n "$pgid" ]; then kill -TERM -"$pgid" 2>/dev/null; sleep 1; kill -KILL -"$pgid" 2>/dev/null; fi; rm -f ${pgidFile}`;
+        const onAbort = () => {
+          try {
+            const killer = spawn(
+              "kubectl",
+              [...env.kubeconfigArgs, "-n", cachedPod!.namespace, "exec", cachedPod!.podName, "--", ...NSENTER, "sh", "-c", killScript],
+              { env: env.childEnv as Record<string, string>, detached: true },
+            );
+            killer.on("error", () => {});
+            setTimeout(() => { try { killer.kill("SIGKILL"); } catch { /* gone */ } }, 15_000).unref();
+            killer.unref();
+          } catch { /* best-effort */ }
+        };
+        try {
+          const { jobId, outputFile } = bg!.executor!({
+            file: "kubectl",
+            args: [...env.kubeconfigArgs, "-n", cachedPod.namespace, "exec", "-i", cachedPod.podName, "--", ...bgNsenterCmd],
+            stdin: resolved.content,
+            env: env.childEnv as Record<string, string>,
+            action: null,
+            hasSensitiveKubectl: false,
+            description: `node ${params.node}: ${[params.skill, params.script].filter(Boolean).join("/")}`,
+            parentSessionId: bg!.sessionIdRef?.current ?? "",
+            jobId: toolCallId,
+            isProd: process.env.NODE_ENV === "production",
+            jobType: "node",
+            onComplete: () => releaseDebugPod(spec, pinnedPodName),
+            onAbort,
+          });
+          return backgroundLaunchedResult(jobId, outputFile, "Running the script on the node in the background.");
+        } catch (err) {
+          releaseDebugPod(spec, pinnedPodName);
+          console.warn(`[node-script] background launch declined, running foreground:`, err);
+        }
+      }
 
       const execResult = await runInDebugPod(
         { userId: userId ?? "unknown", nodeName: params.node, command: nsenterCmd, image, clusterKey, stdinData: resolved.content },
@@ -212,5 +299,9 @@ Examples:
 
 export const registration: ToolEntry = {
   category: "script-exec",
-  create: (refs) => createNodeScriptTool(refs.kubeconfigRef, refs.userId),
+  create: (refs) =>
+    createNodeScriptTool(refs.kubeconfigRef, refs.userId, {
+      executor: refs.backgroundExecExecutor,
+      sessionIdRef: refs.sessionIdRef,
+    }),
 };

--- a/src/tools/script-exec/pod-script.test.ts
+++ b/src/tools/script-exec/pod-script.test.ts
@@ -15,6 +15,10 @@ vi.mock("../infra/kubeconfig-resolver.js", () => ({
 vi.mock("../infra/ensure-kubeconfigs.js", () => ({
   ensureClusterForTool: vi.fn(),
 }));
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn(), kill: vi.fn() })),
+}));
+import { spawn } from "node:child_process";
 
 import { createPodScriptTool } from "./pod-script.js";
 import { resolveScript } from "../infra/script-resolver.js";
@@ -92,6 +96,67 @@ describe("pod_script tool", () => {
     expect(args).toContain("ns1");
     expect(args).toContain("-i");
     expect(stdin).toBe("echo hello");
+    // `-i` is an `exec` flag, NOT a global one — it MUST come after the `exec` subcommand,
+    // else kubectl stops at `-i` and errors ("flags cannot be placed before plugin name").
+    const execIdx = args.indexOf("exec");
+    expect(execIdx).toBeGreaterThan(-1);
+    expect(args.indexOf("-i")).toBeGreaterThan(execIdx);
+    expect(args.indexOf("my-pod")).toBeGreaterThan(execIdx);
+  });
+
+  it("background mode places -i AFTER exec in the kubectl argv", async () => {
+    vi.mocked(resolveScript).mockReturnValue({
+      interpreter: "bash", content: "echo hi", path: "/x", scope: "global",
+    } as any);
+    vi.mocked(checkPodRunning).mockResolvedValue(null);
+    let captured: any;
+    const bgTool = createPodScriptTool(undefined as any, {
+      executor: (req: any) => { captured = req; return { jobId: "j1", outputFile: "/o" }; },
+      sessionIdRef: { current: "s1" },
+    } as any);
+    const res = await bgTool.execute(
+      "tc1",
+      { pod: "my-pod", namespace: "ns1", script: "x.sh", run_in_background: true },
+      undefined, {} as any,
+    );
+    expect((res.details as any).backgroundTaskId).toBe("j1");
+    expect(captured.file).toBe("kubectl");
+    const execIdx = captured.args.indexOf("exec");
+    expect(execIdx).toBeGreaterThan(-1);
+    expect(captured.args.indexOf("-i")).toBeGreaterThan(execIdx); // exec before -i
+    expect(captured.args.indexOf("my-pod")).toBeGreaterThan(execIdx);
+    expect(captured.stdin).toBe("echo hi");
+    // The in-pod command runs under setsid (own session) so job_stop can reap it.
+    const inPodCmd = captured.args[captured.args.length - 1] as string;
+    expect(inPodCmd).toContain("setsid");
+    expect(inPodCmd).toContain(".pgid");
+  });
+
+  it("background onAbort kubectl-exec's a session-kill into the pod (reaps the in-pod tree)", async () => {
+    vi.mocked(resolveScript).mockReturnValue({
+      interpreter: "bash", content: "echo hi", path: "/x", scope: "global",
+    } as any);
+    vi.mocked(checkPodRunning).mockResolvedValue(null);
+    vi.mocked(spawn).mockClear();
+    let captured: any;
+    const bgTool = createPodScriptTool(undefined as any, {
+      executor: (req: any) => { captured = req; return { jobId: "j2", outputFile: "/o" }; },
+      sessionIdRef: { current: "s1" },
+    } as any);
+    await bgTool.execute(
+      "tc2",
+      { pod: "my-pod", namespace: "ns1", script: "x.sh", run_in_background: true },
+      undefined, {} as any,
+    );
+    expect(typeof captured.onAbort).toBe("function");
+    captured.onAbort();
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const [bin, killArgs] = vi.mocked(spawn).mock.calls[0] as any;
+    expect(bin).toBe("kubectl");
+    expect(killArgs).toContain("exec");
+    expect(killArgs).toContain("my-pod");
+    const killCmd = killArgs[killArgs.length - 1] as string;
+    expect(killCmd).toContain("pkill -TERM -s");
   });
 
   it("adds -c container flag when specified", async () => {

--- a/src/tools/script-exec/pod-script.ts
+++ b/src/tools/script-exec/pod-script.ts
@@ -1,4 +1,4 @@
-import type { ToolEntry } from "../../core/tool-registry.js";
+import type { ToolEntry, BackgroundExecWiring } from "../../core/tool-registry.js";
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
@@ -7,10 +7,15 @@ import { resolveScript } from "../infra/script-resolver.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { postExecSecurity } from "../infra/security-pipeline.js";
 import { checkPodRunning } from "../infra/k8s-checks.js";
+import { loadConfig } from "../../core/config.js";
+import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
+import { backgroundLaunchedResult } from "../cmd-exec/background-launch.js";
 import { parseArgs, shellEscape } from "../infra/command-sets.js";
 import { validatePodName, prepareExecEnv, spawnAsync, stdinExecCmd } from "../infra/exec-utils.js";
 import { resolveRequiredKubeconfig } from "../infra/kubeconfig-resolver.js";
 import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
+import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "../infra/bg-session.js";
+import { spawn } from "node:child_process";
 
 interface PodScriptParams {
   pod: string;
@@ -21,9 +26,14 @@ interface PodScriptParams {
   args?: string;
   cluster?: string;
   timeout_seconds?: number;
+  run_in_background?: boolean;
 }
 
-export function createPodScriptTool(kubeconfigRef?: KubeconfigRef): ToolDefinition {
+export function createPodScriptTool(
+  kubeconfigRef?: KubeconfigRef,
+  bg?: BackgroundExecWiring,
+): ToolDefinition {
+  const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
   return {
     name: "pod_script",
     label: "Pod Script",
@@ -90,8 +100,22 @@ Examples:
           description: "Timeout in seconds (default: 180, max: 300)",
         }),
       ),
+      ...(backgroundEnabled
+        ? {
+            run_in_background: Type.Optional(
+              Type.Boolean({
+                description:
+                  "Run the script in the pod in the background instead of waiting. Returns immediately with " +
+                  "a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read the file " +
+                  "or call any tool, and do NOT sleep/wait. You are notified automatically when it completes; " +
+                  "ONLY THEN read the output_file. The script is wrapped in `timeout` (requires coreutils/busybox " +
+                  "`timeout` in the pod). Use for long-running in-pod scripts (soak, load).",
+              }),
+            ),
+          }
+        : {}),
     }),
-    async execute(_toolCallId, rawParams, signal) {
+    async execute(toolCallId, rawParams, signal) {
       const params = rawParams as PodScriptParams;
 
       try {
@@ -154,13 +178,63 @@ Examples:
         };
       }
 
-      // Build kubectl exec args — pipe script via stdin, no temp files inside pod
-      const kubectlArgs = [...env.kubeconfigArgs, "-n", namespace, "-i", "exec", pod];
+      // Build kubectl exec args — pipe script via stdin, no temp files inside pod.
+      // `-i` is an `exec` flag (not a global one), so it MUST come AFTER the `exec`
+      // subcommand — placing it before makes kubectl stop at `-i`, fail to find a command,
+      // and fall into plugin resolution ("flags cannot be placed before plugin name").
+      const kubectlArgs = [...env.kubeconfigArgs, "-n", namespace, "exec", "-i", pod];
       if (params.container?.trim()) {
         kubectlArgs.push("-c", params.container.trim());
       }
       const execCmd = stdinExecCmd(resolved.interpreter, escapedArgs || undefined);
       kubectlArgs.push("--", "sh", "-c", execCmd);
+
+      // ── Background mode ──────────────────────────────────────────────
+      // Run the in-pod command under `setsid` (own session) wrapped in `timeout <ttl>`, with the
+      // script piped via stdin. job_stop only reaps the LOCAL kubectl, so on abort we kubectl-exec
+      // a session-kill in the pod (mirrors node_script) — closing the exec channel does not
+      // reliably reap the in-pod process tree. Scripts are trusted assets → action null (line-safe).
+      // Requires `timeout`/`setsid` in the pod.
+      if (backgroundEnabled && params.run_in_background === true) {
+        const cfg = loadConfig();
+        const ttl = Math.min(params.timeout_seconds ?? cfg.debugPodTTL, cfg.debugPodTTL);
+        const pgidFile = backgroundPgidFile(toolCallId);
+        const wrapped = wrapBackgroundSession(`timeout ${ttl} ${execCmd}`, pgidFile);
+        const bgArgs = [...env.kubeconfigArgs, "-n", namespace, "exec", "-i", pod];
+        if (params.container?.trim()) bgArgs.push("-c", params.container.trim());
+        bgArgs.push("--", "sh", "-c", wrapped);
+        const killScript = backgroundSessionKillScript(pgidFile);
+        const killArgs = [...env.kubeconfigArgs, "-n", namespace, "exec", pod];
+        if (params.container?.trim()) killArgs.push("-c", params.container.trim());
+        killArgs.push("--", "sh", "-c", killScript);
+        const onAbort = () => {
+          try {
+            const killer = spawn("kubectl", killArgs, { env: env.childEnv as Record<string, string>, detached: true });
+            killer.on("error", () => {});
+            setTimeout(() => { try { killer.kill("SIGKILL"); } catch { /* gone */ } }, 15_000).unref();
+            killer.unref();
+          } catch { /* best-effort */ }
+        };
+        try {
+          const { jobId, outputFile } = bg!.executor!({
+            file: "kubectl",
+            args: bgArgs,
+            stdin: resolved.content,
+            env: env.childEnv as Record<string, string>,
+            action: null,
+            hasSensitiveKubectl: false,
+            description: `pod ${namespace}/${pod}: ${[params.skill, params.script].filter(Boolean).join("/")}`,
+            parentSessionId: bg!.sessionIdRef?.current ?? "",
+            jobId: toolCallId,
+            isProd: process.env.NODE_ENV === "production",
+            jobType: "pod",
+            onAbort,
+          });
+          return backgroundLaunchedResult(jobId, outputFile, "Running the script in the pod in the background.");
+        } catch (err) {
+          console.warn(`[pod-script] background launch declined, running foreground:`, err);
+        }
+      }
 
       try {
         const result = await spawnAsync("kubectl", kubectlArgs, timeout, env.childEnv, signal, resolved.content);
@@ -182,5 +256,9 @@ Examples:
 
 export const registration: ToolEntry = {
   category: "script-exec",
-  create: (refs) => createPodScriptTool(refs.kubeconfigRef),
+  create: (refs) =>
+    createPodScriptTool(refs.kubeconfigRef, {
+      executor: refs.backgroundExecExecutor,
+      sessionIdRef: refs.sessionIdRef,
+    }),
 };

--- a/src/tools/script-exec/script-background.test.ts
+++ b/src/tools/script-exec/script-background.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { createHostScriptTool } from "./host-script.js";
+import { createLocalScriptTool } from "./local-script.js";
+import { createPodScriptTool } from "./pod-script.js";
+import { createNodeScriptTool } from "./node-script.js";
+import type { BackgroundExecExecutor } from "../../core/tool-registry.js";
+
+const fakeExecutor: BackgroundExecExecutor = vi.fn(() => ({ jobId: "j", outputFile: "/o" }));
+const wiring = { executor: fakeExecutor, sessionIdRef: { current: "s1" } };
+
+// Each script-exec tool exposes run_in_background ONLY when a background executor is wired,
+// and never loses its core params. Mirrors node-pod-background.test.ts for the exec family.
+describe("script-exec — run_in_background schema gating", () => {
+  it("host_script gates run_in_background on the executor", () => {
+    expect((createHostScriptTool(undefined, wiring).parameters as any).properties.run_in_background).toBeDefined();
+    expect((createHostScriptTool(undefined).parameters as any).properties.run_in_background).toBeUndefined();
+  });
+
+  it("local_script gates run_in_background on the executor", () => {
+    expect((createLocalScriptTool(undefined, { current: "s1" }, "u", null, wiring).parameters as any).properties.run_in_background).toBeDefined();
+    expect((createLocalScriptTool(undefined, { current: "s1" }, "u", null).parameters as any).properties.run_in_background).toBeUndefined();
+  });
+
+  it("pod_script gates run_in_background on the executor", () => {
+    expect((createPodScriptTool(undefined, wiring).parameters as any).properties.run_in_background).toBeDefined();
+    expect((createPodScriptTool(undefined).parameters as any).properties.run_in_background).toBeUndefined();
+  });
+
+  it("node_script gates run_in_background on the executor", () => {
+    expect((createNodeScriptTool(undefined, "u", wiring).parameters as any).properties.run_in_background).toBeDefined();
+    expect((createNodeScriptTool(undefined, "u").parameters as any).properties.run_in_background).toBeUndefined();
+  });
+
+  it("all keep their core params (skill/script) regardless of wiring", () => {
+    for (const tool of [
+      createHostScriptTool(undefined),
+      createLocalScriptTool(undefined, { current: "s1" }, "u", null),
+      createPodScriptTool(undefined),
+      createNodeScriptTool(undefined, "u"),
+    ]) {
+      expect((tool.parameters as any).properties.script).toBeDefined();
+    }
+  });
+});

--- a/src/tools/workflow/spawn-subagent.ts
+++ b/src/tools/workflow/spawn-subagent.ts
@@ -49,8 +49,11 @@ function buildDescription(): string {
     "concrete targets, paths, and what to check.\n\n" +
     "Sub-agents cannot spawn their own sub-agents (one level deep)." +
     (RUN_IN_BACKGROUND_ENABLED
-      ? " With run_in_background you are notified on completion — do NOT poll the job or fabricate its " +
-        "results; report status until the notification arrives."
+      ? " With run_in_background you get an automatic completion notification carrying the sub-agent's result — " +
+        "after launching, just END YOUR TURN (or do other independent work). Never poll it, never spawn another " +
+        "sub-agent to 'wait for' it, and never fabricate its result; report to the user only when the " +
+        "notification arrives. If you actually need the result before you can continue, use the FOREGROUND form " +
+        "(omit run_in_background) instead — that blocks and returns the result inline."
       : "") +
     "\n\nAvailable subagent_type values:\n" +
     lines.join("\n")
@@ -82,9 +85,10 @@ export function createSpawnSubagentTool(
         ? {
             run_in_background: Type.Optional(Type.Boolean({
               description:
-                "Run the sub-agent in the background instead of waiting. You are notified when it completes — " +
-                "do NOT poll. Use only for genuinely independent work you can proceed without. " +
-                "Returns a job_id you can pass to job_stop to cancel it.",
+                "Run the sub-agent in the background instead of waiting. A completion notification with its result " +
+                "arrives automatically — do NOT poll and do NOT spawn another sub-agent to wait for it. Use ONLY " +
+                "for genuinely independent work you can proceed without; if you need the result before continuing, " +
+                "omit this (foreground) so it returns inline. Returns a job_id you can pass to job_stop to cancel it.",
             })),
           }
         : {}),
@@ -143,8 +147,11 @@ function toToolOutput(result: SpawnSubagentResult) {
       status: "launched" as const,
       job_id: result.jobId,
       message:
-        "Sub-agent launched in the background. You will be notified when it completes — do NOT poll. " +
-        "Continue with other work or respond to the user. Use job_stop with this job_id to cancel it.",
+        "Sub-agent launched in the background. END YOUR TURN NOW unless you have OTHER independent work to do " +
+        "right now — do NOT poll it, do NOT sleep/wait, and do NOT spawn another sub-agent or call any tool whose " +
+        "purpose is to 'wait for', 'check on', or 'get the result of' this job. There is nothing to wait for: a " +
+        "completion notification carrying the result will arrive on its own, and you report to the user THEN. " +
+        "Tell the user in plain language what is running; do NOT show them this job_id (use it only with job_stop to cancel).",
     };
     return {
       content: [{ type: "text" as const, text: JSON.stringify(modelVisible) }],


### PR DESCRIPTION
## What

Adds `run_in_background` to **`host_exec` + all four script tools** (`local_script` / `host_script` / `pod_script` / `node_script`), completing background-execution coverage across the tool family (previously only `bash` / `node_exec` / `pod_exec` / `spawn_subagent` supported it). Also fixes several background-completion bugs surfaced by full-chain testing.

## Why

Long-running work (SSH host capture/perf, skill orchestration, soak/perftest) lives mostly on host/script tools — exactly the tools that lacked background support. The model had to block the whole turn on them.

## How

**New background backends** (`eef4ca2`)
- `host_exec` / `host_script` run via **ssh2 in-process**, so the existing subprocess-spawn background runner couldn't drive them — added a **streaming** ssh path (`runCommandStream` in `ssh-dial.ts`, `sshExecStream` in `ssh-client.ts`) and a `streamFactory` mode in `background-bash-runner.ts`.
- `node_script` / `pod_script` pipe the script via **stdin** to `kubectl exec` — added stdin support to the runner.
- `local_script` reuses the argv subprocess path.
- All background paths go through `preExecSecurity` (whitelist) first, reject non-line-safe (JSON) sanitizers, and don't widen the read-only/whitelist boundary. Gated by `BACKGROUND_BASH_ENABLED`.

**Sub-agent background completion fixes** (the UI was visibly wrong)
- `455d2fb` — the model spawned a bogus *"Wait for notification"* sub-agent to "wait"; launch guidance now forbids polling/sleeping/spawning a waiter — end the turn, report on notification (or use the foreground form if you need the result inline).
- `2776b46` — on a completion notification the model re-dispatched the same job; notification guidance now states the result is final and must not be re-run.
- `5718805` — **core**: the synthetic-turn persist guard kept a reaction only when it made a tool call (`turnHadTool`). A sub-agent's result is **inline in the notification summary**, so the model reports it as pure text (no tool call) and the answer was being dropped. A notification without `output_file` now allows a text-only report to persist (bash/exec, which carry `output_file`, keep the strict guard). `46f54ce`/`9b322b4` add the live background indicator + completion fold for the sub-agent card.

**Pre-existing bug found via testing** (`0c9c251`)
- `pod_script` built `kubectl … -i exec <pod>` — `-i` (an `exec` flag) **before** the `exec` subcommand → `Error: flags cannot be placed before plugin name`. Every `pod_script` call failed (exit 1), in both foreground and the new background path. Fixed to `… exec -i <pod> …` (matches `node_script`/`node_exec`). The background completion pipeline is what surfaced it — it correctly reported the failure.

**Test fixture** (`09aaf02`) — `exec-smoke` skill (side-effect-free `sleep N; echo MARKER`) to drive deterministic full-chain smokes across every backend.

## Verification (test env, siclaw-inner :test)

Full-chain background (launch → `exec_job_event` terminal status → model follow-up report), all **PASS**:

| Tool | Backend | Result |
|---|---|---|
| spawn_subagent | inline result | ✅ ×10 — no "wait" sub-agent, answer always reported |
| bash | subprocess | ✅ completed |
| host_exec | ssh2 in-process stream | ✅ completed |
| local_script | subprocess | ✅ completed |
| host_script | ssh2 stream | ✅ completed |
| pod_script | kubectl exec | ✅ completed (after the `-i`/`exec` fix) |
| node_script | debug-pod + nsenter | ✅ completed |

- `npm test`: 167 files / 3323 tests green (+ new regression tests for the persist guard and the `pod_script` argv order).
- Real-browser (CDP) smokes for the exec box fold + the sub-agent card indicator/fold.

## Known residual (model variance, not a correctness issue)

On the deliberately-artificial prompt "use a sub-agent to compute a trivial sum in the background", the model still **occasionally** spawns one extra *identical* compute sub-agent on the completion notification (~40% of runs). The answer is always correct and the bogus "wait" sub-agent is gone; guidance discourages it but can't fully eliminate the variance, and there's no clean non-hacky code-level guard for sequential post-completion re-dispatch.

## Notes for review
- `exec-smoke` is a smoke fixture baked into the core image; drop it if undesired.
- `src/core/prompt.ts` was **not** touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
