### PR TITLE
fix(bg): don't wait for a paired server's completion — carve a generic server/client exception

### DIFF
--- a/src/tools/cmd-exec/background-launch.test.ts
+++ b/src/tools/cmd-exec/background-launch.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { backgroundLaunchedResult, backgroundNotLineSafeError } from "./background-launch.js";
+
+describe("backgroundLaunchedResult message", () => {
+  const msg = () => {
+    const r = backgroundLaunchedResult("functions.node_exec:0", "/o/file.output", "Running on the node in the background.");
+    return JSON.parse(r.content[0].text).message as string;
+  };
+
+  it("keeps the default: end the turn, don't poll/sleep/spawn-a-waiter", () => {
+    const m = msg();
+    expect(m).toMatch(/END YOUR TURN/);
+    expect(m).toMatch(/do NOT read this file, poll, sleep, or spawn a sub-agent/i);
+  });
+
+  it("carries the paired server/client EXCEPTION (so a perftest server isn't waited on → no deadlock)", () => {
+    const m = msg();
+    expect(m).toMatch(/EXCEPTION/);
+    expect(m).toMatch(/immediately run the counterpart/i);
+    expect(m).toMatch(/deadlock/i);
+    expect(m.toLowerCase()).toContain("client"); // the counterpart to run now
+  });
+
+  it("still hides the internal handles from the user", () => {
+    expect(msg()).toMatch(/do NOT show them to the user/);
+  });
+
+  it("backgroundNotLineSafeError stays a blocked structural-redaction rejection", () => {
+    const r = backgroundNotLineSafeError();
+    expect((r.details as any).blocked).toBe(true);
+    expect((r.details as any).reason).toBe("background_not_line_safe");
+  });
+});

--- a/src/tools/cmd-exec/background-launch.ts
+++ b/src/tools/cmd-exec/background-launch.ts
@@ -43,11 +43,16 @@ export function backgroundLaunchedResult(
       task_id: jobId,
       output_file: outputFile,
       message:
-        `${runningWhere} END YOUR TURN NOW — do NOT read this file or call any other tool yet, and do NOT ` +
-        "wait/sleep. You will be notified automatically when it completes; read the output_file ONLY after " +
-        "that notification arrives. To stop it early, use job_stop. NOTE: task_id and output_file are internal " +
-        "handles for YOUR use only (job_stop / reading the file later) — do NOT show them to the user; just tell " +
-        "the user in plain language what is running and that you'll report back when it finishes.",
+        `${runningWhere} It runs detached and you are notified automatically when it COMPLETES. ` +
+        "Default: END YOUR TURN NOW — do NOT read this file, poll, sleep, or spawn a sub-agent to wait on it. " +
+        "EXCEPTION — paired/orchestrated tests: if this is ONE SIDE of a protocol that only makes progress once " +
+        "its counterpart runs (a server/listener blocking until its client connects; a packet capture needing " +
+        "traffic generated), do NOT wait for completion — immediately run the counterpart (e.g. the client on the peer " +
+        "node) and read this output_file once the test finishes. Waiting for such a server's completion FIRST " +
+        "deadlocks: it blocks until a client connects, then times out. " +
+        "Otherwise read the output_file ONLY after the completion notification. Stop it early with job_stop. " +
+        "NOTE: task_id and output_file are internal handles for YOUR use only — do NOT show them to the user; just " +
+        "tell the user in plain language what is running and that you'll report back when it finishes.",
     }, null, 2) }],
     details: { backgroundTaskId: jobId, outputFile },
   };

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -79,7 +79,8 @@ Examples (pass the id from host_list; names shown here for readability):
 - host: "<jump-1 id>", command: "uptime"
 - host: "<bare-metal-3 id>", command: "nvidia-smi"
 - host: "<storage-1 id>", command: "df -h"
-- host: "<node-a id>", command: "journalctl -u kubelet -n 100 | grep error"`,
+- host: "<node-a id>", command: "journalctl -u kubelet -n 100 | grep error"
+- host: "<node-a id>", command: "tcpdump -i eth0 -nn", run_in_background: true   (open-ended capture; returns immediately — stop it later with job_stop, then read the output_file)`,
     parameters: Type.Object({
       host: Type.String({
         description: "Host id from host_list (preferred — names can be duplicated, so the id is the unambiguous handle; a unique name also works). Must be bound to this agent.",
@@ -109,12 +110,13 @@ Examples (pass the id from host_list; names shown here for readability):
               Type.Boolean({
                 description:
                   "Run the command on the host in the background instead of waiting. Returns immediately " +
-                  "with a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read " +
-                  "the file or call any tool, and do NOT sleep/wait. You are notified automatically when it " +
-                  "completes; ONLY THEN read the output_file. Use for long host work like RDMA perftest over " +
-                  "SSH (start the server on host A in the background, then the client on host B). The command " +
-                  "is wrapped in `timeout` and capped (~3600s). Output needing structural (JSON) redaction " +
-                  "cannot run in background.",
+                  "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, " +
+                  "sleep, or read the output_file until the completion notification). EXCEPTION: when this is the " +
+                  "server/listener side of a paired test, do NOT wait — IMMEDIATELY run the client on the peer " +
+                  "host, then read the output_file when the test finishes (waiting for the server's completion " +
+                  "first deadlocks: it blocks until the client connects, then times out). Use for long-running " +
+                  "host commands over SSH. The command is wrapped in `timeout` and capped (~3600s). Output needing " +
+                  "structural (JSON) redaction cannot run in background.",
               })
             ),
           }

--- a/src/tools/cmd-exec/node-exec.ts
+++ b/src/tools/cmd-exec/node-exec.ts
@@ -100,10 +100,12 @@ Examples:
 - node: "node-1", command: "nvidia-smi"
 - node: "node-1", command: "ibstat"
 - node: "node-1", command: "ib_write_bw --help"
-- RDMA perftest across two nodes (server on A in the background, then client on B):
-    1. node: "node-A", command: "ib_write_bw -d mlx5_1 -x 3 -D 20 -F", run_in_background: true   (server; returns immediately)
-    2. node: "node-B", command: "ib_write_bw -d mlx5_1 -x 3 -D 20 -F <node-A-ip>"               (client; blocks ~20s, prints the bandwidth table)
 - node: "node-1", command: "tcpdump -i eth0 -nn -c 50 port 53"   (bounded capture: 50 DNS packets)
+- node: "node-1", command: "tcpdump -i eth0 -nn", run_in_background: true   (open-ended capture; returns immediately — stop it later with job_stop, then read the output_file)
+- paired capture/traffic — start the capture in the background, then IMMEDIATELY generate the traffic it should observe (do NOT wait for the capture first: it blocks until packets arrive, so waiting deadlocks):
+    1. node: "node-1", command: "tcpdump -i eth0 -nn -c 5 port 80", run_in_background: true   (capture; returns immediately — go straight to step 2, same turn)
+    2. node: "node-1", command: "curl -s http://10.0.0.1/healthz"                             (client; one request easily produces the few packets the capture is waiting for)
+    3. once the capture hits its packet count it exits and you're notified — then read its output_file.
 - node: "node-1", command: "dmesg --level=err"
 - node: "node-1", command: "sysctl net.ipv4.ip_forward"
 - node: "node-1", command: "cat /etc/os-release"
@@ -160,12 +162,13 @@ To run in a POD's network namespace (host tools + the pod's network view — e.g
               Type.Boolean({
                 description:
                   "Run the command on the node in the background instead of waiting. Returns immediately " +
-                  "with a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read " +
-                  "the file or call any tool, and do NOT sleep/wait. You are notified automatically when it " +
-                  "completes; ONLY THEN read the output_file. Use for long node work like RDMA perftest " +
-                  "(start the server on node A in the background, then the client on node B). The command is " +
-                  "wrapped in `timeout` and capped at the debug-pod lifetime (~600s) — for longer runs lower " +
-                  "the perftest duration. Output needing structural (JSON) redaction cannot run in background.",
+                  "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, " +
+                  "sleep, or read the output_file until the completion notification). EXCEPTION: when this is the " +
+                  "server/listener side of a paired test, do NOT wait — IMMEDIATELY run the client on the peer " +
+                  "node, then read the output_file when the test finishes (waiting for the server's completion " +
+                  "first deadlocks: it blocks until the client connects, then times out). Use for long-running " +
+                  "node commands. The command is wrapped in `timeout` and capped at the debug-pod lifetime (~600s) — " +
+                  "for longer runs lower the command's own duration. Output needing structural (JSON) redaction cannot run in background.",
               })
             ),
           }

--- a/src/tools/cmd-exec/pod-exec.ts
+++ b/src/tools/cmd-exec/pod-exec.ts
@@ -98,10 +98,12 @@ Examples:
               Type.Boolean({
                 description:
                   "Run the command inside the pod in the background instead of waiting. Returns immediately " +
-                  "with a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read the " +
-                  "file or call any tool, and do NOT sleep/wait. You are notified when it completes; ONLY THEN " +
-                  "read the output_file. Note: if stopped early, the in-pod process may keep running until the " +
-                  "pod ends. Output needing structural (JSON) redaction cannot run in background.",
+                  "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, " +
+                  "sleep, or read the output_file until the completion notification). EXCEPTION: when this is the " +
+                  "server/listener side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read " +
+                  "the output_file when the test finishes (waiting for the server's completion first deadlocks: it " +
+                  "blocks until the client connects, then times out). Note: if stopped early, the in-pod process may " +
+                  "keep running until the pod ends. Output needing structural (JSON) redaction cannot run in background.",
               })
             ),
           }

--- a/src/tools/script-exec/host-script.ts
+++ b/src/tools/script-exec/host-script.ts
@@ -115,9 +115,11 @@ Examples (pass the id from host_list; names shown here for readability):
               Type.Boolean({
                 description:
                   "Run the script on the host in the background instead of waiting. Returns immediately " +
-                  "with a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read " +
-                  "the file or call any tool, and do NOT sleep/wait. You are notified automatically when it " +
-                  "completes; ONLY THEN read the output_file. Use for long-running skill scripts over SSH " +
+                  "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, " +
+                  "or read the output_file until the completion notification). EXCEPTION: when this is the server/listener " +
+                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when " +
+                  "the test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
+                  "connects, then times out). Use for long-running skill scripts over SSH " +
                   "(orchestration, soak, perftest). The script is wrapped in `timeout` and capped (~3600s).",
               }),
             ),

--- a/src/tools/script-exec/local-script.ts
+++ b/src/tools/script-exec/local-script.ts
@@ -98,9 +98,11 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
               Type.Boolean({
                 description:
                   "Run the script in the background instead of waiting. Returns immediately with a task_id " +
-                  "and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read the file or call " +
-                  "any tool, and do NOT sleep/wait. You are notified automatically when it completes; ONLY " +
-                  "THEN read the output_file. Use for long-running skill scripts (orchestration, soak, perftest).",
+                  "and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, or read the " +
+                  "output_file until the completion notification). EXCEPTION: when this is the server/listener side " +
+                  "of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when the " +
+                  "test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
+                  "connects, then times out). Use for long-running skill scripts (orchestration, soak, perftest).",
               })
             ),
           }

--- a/src/tools/script-exec/node-script.ts
+++ b/src/tools/script-exec/node-script.ts
@@ -134,9 +134,11 @@ Examples:
               Type.Boolean({
                 description:
                   "Run the script on the node in the background instead of waiting. Returns immediately with " +
-                  "a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read the file " +
-                  "or call any tool, and do NOT sleep/wait. You are notified automatically when it completes; " +
-                  "ONLY THEN read the output_file. The script is wrapped in `timeout` and capped at the " +
+                  "a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, or " +
+                  "read the output_file until the completion notification). EXCEPTION: when this is the server/listener " +
+                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when " +
+                  "the test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
+                  "connects, then times out). The script is wrapped in `timeout` and capped at the " +
                   "debug-pod lifetime (~600s). Use for long-running node skill scripts (orchestration, soak).",
               }),
             ),

--- a/src/tools/script-exec/pod-script.ts
+++ b/src/tools/script-exec/pod-script.ts
@@ -106,9 +106,11 @@ Examples:
               Type.Boolean({
                 description:
                   "Run the script in the pod in the background instead of waiting. Returns immediately with " +
-                  "a task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT read the file " +
-                  "or call any tool, and do NOT sleep/wait. You are notified automatically when it completes; " +
-                  "ONLY THEN read the output_file. The script is wrapped in `timeout` (requires coreutils/busybox " +
+                  "a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, or " +
+                  "read the output_file until the completion notification). EXCEPTION: when this is the server/listener " +
+                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when " +
+                  "the test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
+                  "connects, then times out). The script is wrapped in `timeout` (requires coreutils/busybox " +
                   "`timeout` in the pod). Use for long-running in-pod scripts (soak, load).",
               }),
             ),


### PR DESCRIPTION
## What

Carves a **generic paired server/client exception** into the `run_in_background` guidance so the model stops waiting for a blocking background *server's* completion before launching its *client*. Stated generically — these are general diagnostic tools, not RDMA tools.

## Why

The shared launch guidance said, absolutely: *"END YOUR TURN NOW — do NOT call any other tool yet, and do NOT wait/sleep"* (added to stop the model spawning "wait" sub-agents / polling). For a **paired** test that rule deadlocks: a server/listener with no peer arg blocks until a client connects, but its completion notification only fires when it **exits** — so a model that "ends the turn and waits" never launches the client, and the server times out (`exit 124`). First hit in two-node RDMA perftest runs, but the failure mode is general (any server/listener→client, or capture→traffic flow).

## How

Keep the default (end turn; don't poll/sleep/spawn-a-waiter), but add an **EXCEPTION**: when the background command is one **side** of a protocol that only makes progress once its counterpart runs, do NOT wait — run the counterpart now, then read the `output_file` once the test finishes. Stated generically, with no RDMA-specific wording:

- `background-launch.ts` — the shared launched-result message (read on every background launch; the primary lever).
- `node_exec` / `host_exec` / `pod_exec` and `node_script` / `host_script` / `pod_script` / `local_script` — replaced the contradictory absolute *"do NOT call any tool"* with the default + server/listener exception, so **every** background-capable tool's param description now agrees with the shared launch result.
- Re-illustrated `run_in_background` with **whitelist-only, non-RDMA** examples: an open-ended `tcpdump` capture (start in background, stop with `job_stop`) on `node_exec`/`host_exec`, and a paired capture/traffic example on `node_exec` (`tcpdump -c 5` in the background, then `curl` to generate the packets it's waiting for). `nc`/`netcat`/`socat`/`iperf` are intentionally excluded from the command whitelist, so they can't appear in a runnable example; the packet count is kept low enough that one request trips it.

The command whitelist (incl. the RDMA/perftest groups) and the perftest tuning-flag note are left intact — those are capability/security facts, not "how to run RDMA". `prompt.ts` is **untouched** (it carries no background guidance). Added `background-launch.test.ts` asserting both the default and the (generic) exception wording.

## Verification

- `npx tsc --noEmit` clean.
- Background suites green: `background-launch`, `node-pod-background`, `host-exec-background`, `script-background`.
- Wording-only change to tool/param descriptions — no runtime, `job_stop`, or sanitization behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
