### PR TITLE
fix(portal-web): correct tool timing label typo 'ran' -> 'run'

### DIFF
--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -2258,7 +2258,7 @@ function ToolItem({ message, nested }: { message: PilotMessage; nested?: boolean
               const t = message.timing
               const showThink = typeof t?.thinkingMs === "number"
               const showDur = typeof t?.durationMs === "number"
-              const durationLabel = message.toolStatus === "running" ? "running" : "ran"
+              const durationLabel = message.toolStatus === "running" ? "running" : "run"
               return (
                 <>
                   {(showThink || showDur) && (


### PR DESCRIPTION
## Summary

Fixes a typo in the tool-call timing label rendered in the chat pilot area. A completed tool call displayed `ran <duration>` (e.g. `thinking 4.6s, ran 162ms`), where the verb should read `run`.

## Change

- `portal-web/src/components/chat/PilotArea.tsx`: change the completed-state duration label from `"ran"` to `"run"`. The in-progress label (`"running"`) is unchanged.

```diff
-const durationLabel = message.toolStatus === "running" ? "running" : "ran"
+const durationLabel = message.toolStatus === "running" ? "running" : "run"
```

## Test plan

- Frontend-only string change; the label now reads e.g. `thinking 4.6s, run 162ms`.
