### PR TITLE
fix(stop): make the Stop button truly stop everything a session runs (bg jobs + fg exec + UI)

### DIFF
--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -275,26 +275,17 @@ export function PilotArea({
     setEditingDraft("")
   }, [sessionKey])
 
-  const lastSentRef = useRef<string | null>(null)
   const wrappedSendMessage = useCallback(
     (text: string, attachments?: ChatAttachment[]) => {
-      if (!isLoading) lastSentRef.current = text
       sendMessage(text, attachments)
     },
-    [sendMessage, isLoading],
+    [sendMessage],
   )
+  // Stop just stops: abort the running turn and leave the input alone. We intentionally do NOT
+  // restore the sent message back into the input box — the turn has usually already been
+  // partly processed (tools ran), so re-filling the input reads as the message "bouncing back".
   const wrappedAbort = useCallback(() => {
     abortResponse?.()
-    if (lastSentRef.current) {
-      // Strip the injected markers + fullPrompt so only what the user actually
-      // typed returns to the input. Same parsers used to render past user
-      // bubbles cleanly, so round-trip is consistent.
-      const { text: afterDp } = parseDeepInvestigation(lastSentRef.current)
-      const { text: userTyped } = parseActionChipMarker(afterDp)
-      setChipSeq((s) => s + 1)
-      setChipDraft(userTyped)
-      lastSentRef.current = null
-    }
   }, [abortResponse])
 
   const scrollToBottom = useCallback((smooth = true) => {
@@ -359,11 +350,6 @@ export function PilotArea({
     const text = editingDraft.trim()
     if (!text || isLoading) return
     wrappedSendMessage(text)
-    // wrappedSendMessage records lastSentRef so wrappedAbort can restore the
-    // draft if the user aborts a normal send. For edit-resends the message is
-    // already visible in the conversation, so we don't want abort to re-fill
-    // the input with it.
-    lastSentRef.current = null
     setEditingMessageId(null)
     setEditingDraft("")
   }, [editingDraft, isLoading, wrappedSendMessage])

--- a/portal-web/src/hooks/format-host-tool.test.ts
+++ b/portal-web/src/hooks/format-host-tool.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest"
+import { formatToolInput } from "./usePilotChat"
+
+// host_exec/host_script: the model passes an opaque host id; the backend resolves the friendly
+// name into metadata.host_label. The card must read `<name> $ <command>` like node_exec.
+describe("formatToolInput — host_exec / host_script", () => {
+  const ID = "d456a827-8dca-4e0c-954c-0bfdf9e78450"
+
+  it("host_exec shows '<resolved name> $ <command>' when metadata.host_label is present", () => {
+    const s = formatToolInput("host_exec", { host: ID, command: "ping -c 100 10.155.55.254" }, { host_label: "061" })
+    expect(s).toBe("061 $ ping -c 100 10.155.55.254")
+    expect(s).not.toContain(ID)
+  })
+
+  it("host_exec falls back to the raw host id when no label yet (pre-resolution frame), but still shows the command", () => {
+    const s = formatToolInput("host_exec", { host: ID, command: "uptime" })
+    expect(s).toBe(`${ID} $ uptime`) // command no longer hidden behind the id
+  })
+
+  it("host_script shows '<name> $ skill/script args'", () => {
+    const s = formatToolInput(
+      "host_script",
+      { host: ID, skill: "rdma-diag", script: "check.sh", args: "--all" },
+      { host_label: "061" },
+    )
+    expect(s).toBe("061 $ rdma-diag/check.sh --all")
+  })
+})

--- a/portal-web/src/hooks/pilot-message-status.test.ts
+++ b/portal-web/src/hooks/pilot-message-status.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest"
+import { toPilotMessage } from "./usePilotChat"
+
+// A tool the user Stopped is persisted with metadata.status="stopped" (outcome stays null) by the
+// gateway's abort finalization. toPilotMessage must map that to toolStatus "aborted" so the card
+// shows the terminal ⊘ state even after a history refetch — not fall through to a forever-spinner.
+function toolMsg(over: Record<string, unknown> = {}) {
+  return { id: "m1", role: "tool", content: "", tool_name: "node_exec", ...over } as never
+}
+
+describe("toPilotMessage — stopped tool rows render as aborted", () => {
+  it("maps metadata.status=\"stopped\" (outcome null) to toolStatus \"aborted\"", () => {
+    const pm = toPilotMessage(toolMsg({ outcome: null, metadata: { status: "stopped" } }))
+    expect(pm.toolStatus).toBe("aborted")
+  })
+
+  it("also treats \"aborted\"/\"killed\" status as aborted", () => {
+    expect(toPilotMessage(toolMsg({ metadata: { status: "aborted" } })).toolStatus).toBe("aborted")
+    expect(toPilotMessage(toolMsg({ metadata: { status: "killed" } })).toolStatus).toBe("aborted")
+  })
+
+  it("still maps a genuinely running row (no terminal status) to \"running\"", () => {
+    const pm = toPilotMessage(toolMsg({ outcome: null, metadata: { status: "running", started_at: new Date().toISOString() } }))
+    expect(pm.toolStatus).toBe("running")
+  })
+
+  it("does not disturb success/error mapping", () => {
+    expect(toPilotMessage(toolMsg({ outcome: "success" })).toolStatus).toBe("success")
+    expect(toPilotMessage(toolMsg({ outcome: "error" })).toolStatus).toBe("error")
+  })
+})

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -1139,6 +1139,12 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
                 ...(toolDetails ? { toolDetails, metadata: toolDetails } : {}),
                 ...(durationMs != null ? { timing: { ...(current.timing ?? {}), durationMs } } : {}),
                 ...(dbMessageId ? { id: dbMessageId } : {}),
+                // Recompute the header now that result metadata is in hand — e.g. host_exec/host_script
+                // resolve metadata.host_label here so the LIVE card flips from the raw host id to the
+                // friendly name without waiting for a refetch. No-op for tools that ignore metadata.
+                ...(current.toolName && current.toolArgs
+                  ? { toolInput: formatToolInput(current.toolName, current.toolArgs, (toolDetails ?? current.metadata) as Record<string, unknown> | undefined) }
+                  : {}),
               }
               return [
                 ...prev.slice(0, fallbackIndex),

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -267,6 +267,11 @@ function isTaskTool(toolName?: string | null): boolean {
 
 function toolStatusFromMessage(m: ChatMessage): PilotMessage["toolStatus"] | undefined {
   if (m.role !== "tool") return undefined;
+  // A tool the user Stopped is finalized with metadata.status="stopped" (outcome stays null —
+  // see sse-consumer abort finalization). Map it to "aborted" so it shows the terminal ⊘ state
+  // even after a history refetch, instead of falling through to "running" (spinner forever).
+  const status = m.metadata?.status;
+  if (status === "stopped" || status === "aborted" || status === "killed") return "aborted";
   if (isStaleRunningTool(m)) return "error";
   if (m.outcome === "error" || m.outcome === "blocked") return "error";
   if (m.outcome === "success") return "success";
@@ -322,7 +327,7 @@ async function fetchSessionPage1(
   return { items, pilotMsgs: annotateSubagentCompletions(annotateExecJobCompletions(annotateDelegationSynthesis(items.map(toPilotMessage)))) }
 }
 
-function toPilotMessage(m: ChatMessage): PilotMessage {
+export function toPilotMessage(m: ChatMessage): PilotMessage {
   const toolArgs = m.tool_input ? tryParseJson(m.tool_input) : undefined
   const metadata = normalizeMetadata(m.metadata)
   const isDelegationEvent = metadata?.kind === "delegation_event"
@@ -599,6 +604,11 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const streamingRef = useRef(false)
   const recoveredStreamingRef = useRef(false)
   const isAbortingRef = useRef(false)
+  // Timestamp until which history refetches stay suppressed AFTER chatAbort resolves. The gateway
+  // finalizes the stopped tool rows asynchronously (decoupled from the abort RPC), so a refetch in
+  // that gap could re-paint them "running" over the optimistic "aborted". Bounded (a few hundred ms)
+  // so a stuck/failed abort can never freeze the message list.
+  const abortGuardUntilRef = useRef(0)
   const activeSessionIdRef = useRef<string | undefined>(sessionId ?? undefined)
   const [isCompacting, setIsCompacting] = useState(false)
   const hasActiveAsyncDelegation = hasActiveAsyncDelegationSurface(messages)
@@ -619,6 +629,14 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const resetDpState = useCallback(() => {
     setDpActive(false)
   }, [])
+
+  // True while a Stop is in flight or within the brief grace window after it — the single gate the
+  // history-refetch pollers consult before wholesale-replacing messages, so none of them re-paints
+  // an optimistically-aborted tool row as "running" before the gateway has persisted "stopped".
+  const refetchSuppressedByAbort = useCallback(
+    () => isAbortingRef.current || Date.now() < abortGuardUntilRef.current,
+    [],
+  )
 
   // Load message history when session changes
   useEffect(() => {
@@ -738,7 +756,9 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         const hasRunning = hasRunningPersistedMessages(pilotMsgs)
         const latest = pilotMsgs[pilotMsgs.length - 1]
 
-        setMessages(pilotMsgs)
+        // While an abort is in flight the gateway is still finalizing the stopped tool rows;
+        // don't let this poll re-paint them as "running" over the optimistic "aborted" state.
+        if (!refetchSuppressedByAbort()) setMessages(pilotMsgs)
         setHasMore(items.length >= PAGE_SIZE)
 
         if (hasRunning) {
@@ -785,7 +805,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
         if (cancelled) return
         const pendingSynthesis = hasPendingDelegationSynthesis(pilotMsgs)
-        setMessages(pilotMsgs)
+        if (!refetchSuppressedByAbort()) setMessages(pilotMsgs)
         setHasMore(items.length >= PAGE_SIZE)
         if (pendingSynthesis) {
           setStreaming(true)
@@ -824,7 +844,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
       try {
         const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
         if (cancelled) return
-        if (pageRef.current === 1 && !streamingRef.current) {
+        if (pageRef.current === 1 && !streamingRef.current && !refetchSuppressedByAbort()) {
           setMessages(pilotMsgs)
           setHasMore(items.length >= PAGE_SIZE)
         }
@@ -860,7 +880,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
       if (pageRef.current !== 1) return
       try {
         const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
-        if (closed) return
+        if (closed || refetchSuppressedByAbort()) return
         setMessages(pilotMsgs)
         setHasMore(items.length >= PAGE_SIZE)
       } catch (err) {
@@ -1538,9 +1558,14 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
       await chatAbort(agentId, sessionId)
     } catch (err) {
       console.error("[usePilotChat] abort error:", err)
+    } finally {
+      // chatAbort only signals the abort; the gateway persists the "stopped" rows a beat later.
+      // Keep refetches suppressed for a brief bounded window past here so a poll landing in that
+      // gap can't re-paint the optimistic "aborted" tool cards as "running". finally (not the
+      // straight-line path) guarantees the flag clears even if chatAbort throws.
+      isAbortingRef.current = false
+      abortGuardUntilRef.current = Date.now() + 1500
     }
-    // Only allow new input after backend confirms abort
-    isAbortingRef.current = false
     setStreaming(false)
     streamingRef.current = false
     recoveredStreamingRef.current = false

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -123,9 +123,26 @@ const DELEGATED_TOOL_NAMES = new Set(["delegate_to_agent", "delegate_to_agents"]
 const ASYNC_DELEGATED_TOOL_NAMES = new Set(["delegate_to_agents"])
 
 /** Format tool args into a readable one-liner for display */
-export function formatToolInput(toolName: string, args?: Record<string, unknown>): string {
+export function formatToolInput(toolName: string, args?: Record<string, unknown>, metadata?: Record<string, unknown>): string {
   if (!args) return ""
   const name = toolName.toLowerCase()
+  // host_exec/host_script: the model passes an opaque host id; the backend resolves the friendly
+  // name into metadata.host_label so the card reads `<name> $ <command>` like node_exec (falls
+  // back to the raw id if the label isn't present, e.g. a pre-resolution live frame).
+  if (name === "host_exec") {
+    const host = (metadata?.host_label as string) || (args.host as string) || ""
+    const cmd = (args.command as string) || ""
+    return host && cmd ? `${host} $ ${cmd}` : host || cmd
+  }
+  if (name === "host_script") {
+    const host = (metadata?.host_label as string) || (args.host as string) || ""
+    const skill = (args.skill as string) || ""
+    const script = (args.script as string) || ""
+    const sArgs = (args.args as string) || ""
+    const scriptPart = [skill, script].filter(Boolean).join("/")
+    const cmdPart = sArgs ? `${scriptPart} ${sArgs}` : scriptPart
+    return host && cmdPart ? `${host} $ ${cmdPart}` : host || cmdPart
+  }
   if (name === "bash" || name === "shell" || name === "command") {
     return (args.command as string) || (args.cmd as string) || ""
   }
@@ -361,7 +378,7 @@ export function toPilotMessage(m: ChatMessage): PilotMessage {
       : m.role === "user" ? stripAttachmentOcrEvidence(m.content) : m.content,
     toolName: m.tool_name,
     toolArgs,
-    toolInput: toolArgs ? formatToolInput(m.tool_name ?? "", toolArgs) : undefined,
+    toolInput: toolArgs ? formatToolInput(m.tool_name ?? "", toolArgs, metadata ?? undefined) : undefined,
     toolStatus,
     // Persisted tool result details (e.g. sub-agent steps, child_session_id) live in
     // metadata; surface them as toolDetails so cards recover their content on refresh.

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -142,6 +142,7 @@ function makeFakeSessionManager() {
     activeCount: () => sessions.size,
     list: () => Array.from(sessions.values()),
     get: (id: string) => sessions.get(id),
+    stopSessionJobs: vi.fn(() => 0),
     getOrCreate: async (id?: string, _mode?: unknown, _systemPromptTemplate?: unknown, activeMode?: unknown) => {
       getOrCreateCalls.push({ id, activeMode });
       const key = id ?? "default";
@@ -339,13 +340,15 @@ describe("http-server — steer / abort / clear-queue", () => {
     expect(s.brain.steer).toHaveBeenCalledWith("stop");
   });
 
-  it("POST /api/sessions/:id/abort calls brain.abort", async () => {
+  it("POST /api/sessions/:id/abort calls brain.abort AND stops the session's background jobs", async () => {
     await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "ab1" });
     const s = sm.sessions.get("ab1")!;
     const r = await getJson(port, "/api/sessions/ab1/abort", "POST");
     expect(r.status).toBe(200);
     expect(s.brain.abort).toHaveBeenCalled();
     expect(s._aborted).toBe(true);
+    // Stop also halts the session's detached background jobs (not just the live turn).
+    expect(sm.stopSessionJobs).toHaveBeenCalledWith("ab1");
   });
 
   it("POST /api/sessions/:id/abort returns pending when brain abort hangs", async () => {
@@ -356,7 +359,7 @@ describe("http-server — steer / abort / clear-queue", () => {
     const r = await getJson(port, "/api/sessions/ab-hangs/abort", "POST");
 
     expect(r.status).toBe(200);
-    expect(r.data).toEqual({ ok: true, pending: true });
+    expect(r.data).toEqual({ ok: true, stoppedJobs: 0, pending: true });
     expect(s._aborted).toBe(true);
   });
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -782,14 +782,19 @@ export function createHttpServer(
     managed._aborted = true;
 
     // Foreground sub-agents are cancelled via the parent brain's abort signal
-    // (threaded into runSpawnedSubagent); background sub-agent jobs are cancelled
-    // explicitly via the job_stop tool and block session release until they settle.
+    // (threaded into runSpawnedSubagent). The user's Stop should also halt the session's
+    // DETACHED background jobs (background exec + background sub-agents), which are decoupled
+    // from the turn — stop them all here so one Stop click halts everything the session runs.
+    const stoppedJobs = sessionManager.stopSessionJobs(sessionId);
+    if (stoppedJobs > 0) {
+      console.log(`[agentbox-http] Stop also halted ${stoppedJobs} background job(s) for session ${sessionId}`);
+    }
     const outcome = await abortBrainForHttp(managed.brain, sessionId);
     if (outcome === "failed") {
-      sendJson(res, 500, { error: "Abort failed" });
+      sendJson(res, 500, { error: "Abort failed", stoppedJobs });
       return;
     }
-    sendJson(res, 200, { ok: true, ...(outcome === "timeout" ? { pending: true } : {}) });
+    sendJson(res, 200, { ok: true, stoppedJobs, ...(outcome === "timeout" ? { pending: true } : {}) });
   });
 
   /**

--- a/src/agentbox/notify-parent.test.ts
+++ b/src/agentbox/notify-parent.test.ts
@@ -286,4 +286,89 @@ describe("notifyParent", () => {
     expect(brain.prompt).toHaveBeenCalledTimes(1); // synthetic turn still runs
     // (nothing to assert on a send mock — there is no gatewayClient; the guard prevents the call)
   });
+
+  it("persists a COMPLETED tool call in a synthetic turn with outcome 'success' (not null → no stuck 'running' card on refresh)", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    let cb: ((e: any) => void) | undefined;
+    const brain = {
+      followUp: vi.fn(async () => {}),
+      subscribe: vi.fn((fn: (e: any) => void) => { cb = fn; return () => {}; }),
+      prompt: vi.fn(async () => {
+        cb?.({ type: "tool_execution_start", name: "read" }); // turnHadTool → the turn persists
+        cb?.({ type: "message_end", message: { role: "toolResult", toolName: "read", content: [{ type: "text", text: "PING … 0.264 ms" }] } });
+        cb?.({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "gateway ok" }] } });
+      }),
+    };
+    const managed = fakeManaged("s1", brain as any, true);
+    mgr.sessions.set("s1", managed);
+    mgr.jobs.register({ jobId: "j1", type: "bash", parentSessionId: "s1", description: "ping", status: "completed", startedAt: 0, notified: false, outputFile: "/o" });
+    const send = vi.fn(async () => ({ ok: true, id: "x" }));
+    mgr.gatewayClient = { sendDelegationPersistenceEvent: send };
+    mgr.agentId = "agent-1";
+    await mgr.notifyParent("s1", "j1", { taskId: "j1", outputFile: "/o", status: "completed", summary: "done" });
+    await flushCoalesce();
+    const toolRow = send.mock.calls
+      .map((c) => c[0])
+      .filter((e: any) => e?.type === "delegation.append_message")
+      .find((e: any) => e.message?.role === "tool");
+    expect(toolRow).toBeTruthy();
+    expect(toolRow.message.outcome).toBe("success"); // terminal → card renders done, NOT a forever-spinner
+  });
+});
+
+describe("stopSessionJobs (the Stop button halts all of a session's background jobs)", () => {
+  it("stops only THIS session's RUNNING jobs (bg exec + bg sub-agents), leaving others alone", () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    const reg = (jobId: string, parentSessionId: string, status: string, type = "bash") => {
+      const abort = vi.fn();
+      mgr.jobs.register({ jobId, type, parentSessionId, description: jobId, status, startedAt: 0, notified: false, abort });
+      return abort;
+    };
+    const aRun = reg("a", "s1", "running");             // bg exec, this session, running → stop
+    const aSub = reg("sub", "s1", "running", "subagent"); // bg sub-agent, this session, running → stop
+    const aDone = reg("done", "s1", "completed");        // already finished → untouched
+    const other = reg("b", "s2", "running");             // other session → untouched
+
+    const n = mgr.stopSessionJobs("s1");
+
+    expect(n).toBe(2);
+    expect(aRun).toHaveBeenCalledTimes(1);
+    expect(aSub).toHaveBeenCalledTimes(1);
+    expect(aDone).not.toHaveBeenCalled();
+    expect(other).not.toHaveBeenCalled();
+    expect(mgr.jobs.get("a").status).toBe("stopped");
+    expect(mgr.jobs.get("sub").status).toBe("stopped");
+    expect(mgr.jobs.get("b").status).toBe("running"); // other session's job keeps running
+  });
+
+  it("returns 0 when the session has no running jobs", () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    expect(mgr.stopSessionJobs("nope")).toBe(0);
+  });
+
+  it("marks user-stopped jobs suppressNotifyTurn so their completion folds the card but does NOT wake the model", async () => {
+    const { mgr, brain } = setup(true); // idle parent
+    // j1 is registered as running with an abort hook; stopSessionJobs stops it with suppression.
+    mgr.jobs.setStatus("j1", "running");
+    mgr.jobs.setAbort("j1", vi.fn());
+    expect(mgr.stopSessionJobs("s1")).toBe(1);
+    expect(mgr.jobs.get("j1").suppressNotifyTurn).toBe(true);
+
+    // The settle path still calls notifyParent (dedup/card-fold), but the synthetic turn is suppressed.
+    await mgr.notifyParent("s1", "j1", { taskId: "j1", outputFile: "/o", status: "stopped", summary: "stopped" });
+    await flushCoalesce();
+    expect(brain.prompt).not.toHaveBeenCalled();   // model is NOT woken to react to its own cancellation
+    expect(brain.followUp).not.toHaveBeenCalled();
+  });
+
+  it("a NORMAL job_stop (model tool, no suppression) still notifies the parent", async () => {
+    const { mgr, brain } = setup(true);
+    mgr.jobs.setStatus("j1", "running");
+    mgr.jobs.setAbort("j1", vi.fn());
+    mgr.jobs.stopJob("j1"); // model's job_stop — no suppressNotifyTurn
+    expect(mgr.jobs.get("j1").suppressNotifyTurn).toBeFalsy();
+    await mgr.notifyParent("s1", "j1", { taskId: "j1", status: "stopped", summary: "stopped by model" });
+    await flushCoalesce();
+    expect(brain.prompt).toHaveBeenCalledTimes(1); // model-initiated stop still reacts (unchanged)
+  });
 });

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -356,6 +356,24 @@ export class AgentBoxSessionManager {
   }
 
   /**
+   * Stop ALL running background jobs (background exec + background sub-agents) of a session.
+   * Called from the /abort handler so the user's "Stop" button halts everything the session is
+   * running — not just the live turn (foreground tools/sub-agents die with the turn's abort
+   * signal), but also the detached background jobs, which are otherwise decoupled from the turn.
+   * Returns how many were stopped.
+   */
+  stopSessionJobs(sessionId: string): number {
+    let stopped = 0;
+    for (const job of this.jobs.list(sessionId)) {
+      // suppressNotifyTurn: the user's Stop is terminal. The completion still folds each job's card
+      // to "stopped", but we must NOT wake the model with a synthetic turn reacting to the
+      // cancellation — that "comes back to life after Stop" is exactly what the button must avoid.
+      if (job.status === "running" && this.jobs.stopJob(job.jobId, { suppressNotifyTurn: true }).stopped) stopped++;
+    }
+    return stopped;
+  }
+
+  /**
    * Background exec executor (run_in_background on bash / node_exec / pod_exec). Injected
    * into ToolRefs; the calling tool hands over the already-assembled command. Throws when
    * the per-session concurrency cap is reached so the tool falls back to foreground.
@@ -518,6 +536,11 @@ export class AgentBoxSessionManager {
         event: { type: "subagent_done", sessionId, job_id: jobId, status: n.status },
       }).catch(() => {});
     }
+
+    // User Stop is terminal: the card already folded to "stopped" above, but do NOT wake the model
+    // with a synthetic turn reacting to its own cancellation (the "won't stop" behavior). Card
+    // folds, model stays silent.
+    if (job?.suppressNotifyTurn) return;
 
     // Buffer the model-facing notification and arm the coalescing window. We deliver it ONLY
     // via the synthetic-turn path (never followUp): the completion itself already shows in the
@@ -751,7 +774,11 @@ export class AgentBoxSessionManager {
       content,
       toolName: message.toolName ?? null,
       metadata: isNotification ? { kind: "task_notification" } : null,
-      outcome: message.isError ? "error" : null,
+      // A COMPLETED tool row must persist a terminal outcome. Without this a successful tool call
+      // in a synthetic (background-completion) turn was written with outcome=null, which the
+      // frontend maps to "running" → a spinner that never resolves and a recovered-run poller stuck
+      // on "Thinking…" after refresh. Only tool rows carry an outcome; user/assistant rows stay null.
+      outcome: role === "tool" ? (message.isError ? "error" : "success") : null,
     });
   }
 

--- a/src/core/job-registry.ts
+++ b/src/core/job-registry.ts
@@ -53,6 +53,13 @@ export interface JobRecord {
    */
   notified: boolean;
   /**
+   * Set when the job was stopped by the USER's Stop button (not the model's job_stop tool, and
+   * not natural completion). The completion still folds the launching card to "stopped", but the
+   * parent is NOT woken with a synthetic turn — a user Stop is terminal; the model reacting to its
+   * own cancellation is exactly the "it won't stop" behavior the Stop button must avoid.
+   */
+  suppressNotifyTurn?: boolean;
+  /**
    * Kill hook. subagent → requestStop(); bash → process.kill(-pid, SIGKILL).
    * Undefined while the job is still starting up (no PID/controller yet).
    */
@@ -121,11 +128,13 @@ export class JobRegistry {
    * (agentbox + TUI) so the guard sequence and the stopped-status transition can't drift.
    * The message wording adapts to the job type ("sub-agent" vs "command").
    */
-  stopJob(jobId: string): JobStopResult {
+  stopJob(jobId: string, opts?: { suppressNotifyTurn?: boolean }): JobStopResult {
     const job = this.jobs.get(jobId);
     if (!job) return { stopped: false, message: `No background job "${jobId}".` };
     if (job.status !== "running") return { stopped: false, message: `Job "${jobId}" is not running (${job.status}).` };
     if (!job.abort) return { stopped: false, message: `Job "${jobId}" is starting up; try again shortly.` };
+    // Set BEFORE abort() so the (later, async) settle → notifyParent already sees the flag.
+    if (opts?.suppressNotifyTurn) job.suppressNotifyTurn = true;
     job.abort();
     this.setStatus(jobId, "stopped");
     return { stopped: true, message: `Stopping background ${job.type === "subagent" ? "sub-agent" : "command"} "${jobId}".` };

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -295,6 +295,47 @@ describe("consumeAgentSse — tool execution", () => {
   });
 });
 
+describe("consumeAgentSse — abort finalization", () => {
+  it("finalizes an in-flight tool row as stopped and persists partial assistant text on abort", async () => {
+    const controller = new AbortController();
+    const client = {
+      async *streamEvents() {
+        yield { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Let me run that" } };
+        yield { type: "tool_execution_start", toolName: "node_exec", args: { command: "ib_write_bw -D 60" } };
+        controller.abort(); // user clicks Stop while the tool is in flight
+        yield { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "(never processed — loop breaks)" } };
+      },
+    } as unknown as AgentBoxClient;
+
+    await consumeAgentSse({ client, sessionId: "s", userId: "u", persistMessages: true, signal: controller.signal });
+
+    // The running tool row (msg-1) is finalized as stopped — outcome stays null, metadata.status="stopped"
+    // (mirrors a background job's stopped representation) so the UI shows ⊘ instead of a forever-spinner.
+    const stopped = updateCalls.find((u) => u.metadata?.status === "stopped");
+    expect(stopped).toBeDefined();
+    expect(stopped.messageId).toBe("msg-1");
+    expect(stopped.outcome).toBeNull();
+    // updateMessage REPLACES columns, so finalize must re-send toolName/toolInput or the stopped
+    // card would render blank (no tool identity / no command) after a refetch.
+    expect(stopped.toolName).toBe("node_exec");
+    expect(stopped.toolInput).toContain("ib_write_bw -D 60");
+    // The partial assistant text the model already streamed is persisted so it doesn't vanish on refetch.
+    const partial = appendCalls.find((a) => a.role === "assistant");
+    expect(partial).toBeDefined();
+    expect(partial.content).toContain("Let me run that");
+    expect(partial.metadata?.incomplete).toBe(true);
+  });
+
+  it("does NOT finalize tool rows on a normal (non-abort) stream end", async () => {
+    const events = [
+      { type: "tool_execution_start", toolName: "node_exec", args: { command: "x" } },
+      // stream ends without a tool_execution_end, but the turn was NOT aborted
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    expect(updateCalls.find((u) => u.metadata?.status === "stopped")).toBeUndefined();
+  });
+});
+
 // ── Timing (TTFT / 💭 / ⚙️ / turn total) ──────────────
 
 describe("consumeAgentSse — timing", () => {

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -518,6 +518,59 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
     // when the agentbox closes the SSE stream after prompt() fully resolves.
   }
 
+  // ── Abort finalization ───────────────────────────────────────────────
+  // The loop above breaks on `signal.aborted` (L205) the moment the user hits Stop. At that
+  // point any tool whose tool_execution_start row was persisted but never got a matching
+  // tool_execution_end is left with outcome=null / metadata.status="running" — so it would
+  // spin forever in the UI and a history refetch would re-paint it as running. Finalize those
+  // rows here as "stopped" (mirroring a background job's stopped representation: outcome stays
+  // null, metadata.status="stopped"), and persist any partial assistant text so the words the
+  // model already streamed don't vanish on the next refetch.
+  if (persist && signal?.aborted) {
+    for (const [toolName, ids] of pendingToolMessageIds) {
+      // startTimes/inputs are pushed in lockstep with the message ids on tool_execution_start
+      // and shifted together on tool_execution_end, so the surviving entries stay index-aligned.
+      const startTimes = pendingToolStartTimes.get(toolName) ?? [];
+      const inputs = pendingToolInputs.get(toolName) ?? [];
+      for (let i = 0; i < ids.length; i++) {
+        const stoppedMeta: Record<string, unknown> = { status: "stopped" };
+        if (startTimes[i] != null) stoppedMeta.started_at = new Date(startTimes[i]).toISOString();
+        try {
+          // updateMessage REPLACES columns (it is not a partial patch), so we must re-send
+          // toolName + toolInput or they'd be NULLed — leaving the stopped card with no identity.
+          await updateMessage({
+            messageId: ids[i],
+            sessionId,
+            content: "",
+            toolName,
+            toolInput: inputs[i] ? redactText(inputs[i], redactionConfig) : null,
+            outcome: null,
+            metadata: stoppedMeta,
+          });
+        } catch (err) {
+          console.warn(`[sse-consumer] ${userId}: failed to finalize aborted tool row ${ids[i]}:`, err);
+        }
+      }
+    }
+    if (assistantContent) {
+      const cleaned = stripEmptyResponseMarkers(assistantContent);
+      if (cleaned.length > 0) {
+        try {
+          await appendMessage({
+            sessionId,
+            role: "assistant",
+            content: redactText(cleaned, redactionConfig),
+            metadata: { incomplete: true },
+          });
+          await incrementMessageCount(sessionId);
+        } catch (err) {
+          console.warn(`[sse-consumer] ${userId}: failed to persist partial assistant message on abort:`, err);
+        }
+      }
+      assistantContent = "";
+    }
+  }
+
   // Fallback: if no message_end arrived but we have accumulated text
   if (!resultText && currentMsgText) {
     resultText = currentMsgText;

--- a/src/tools/cmd-exec/background-launch.ts
+++ b/src/tools/cmd-exec/background-launch.ts
@@ -36,6 +36,7 @@ export function backgroundLaunchedResult(
   jobId: string,
   outputFile: string,
   runningWhere: string,
+  extraDetails?: Record<string, unknown>,
 ): BackgroundToolResult {
   return {
     content: [{ type: "text", text: JSON.stringify({
@@ -54,6 +55,8 @@ export function backgroundLaunchedResult(
         "NOTE: task_id and output_file are internal handles for YOUR use only — do NOT show them to the user; just " +
         "tell the user in plain language what is running and that you'll report back when it finishes.",
     }, null, 2) }],
-    details: { backgroundTaskId: jobId, outputFile },
+    // extraDetails (e.g. a resolved host_label) is persisted to the tool row metadata so the
+    // card can render a friendly label even when the model passed an opaque id.
+    details: { backgroundTaskId: jobId, outputFile, ...extraDetails },
   };
 }

--- a/src/tools/cmd-exec/host-exec-background.test.ts
+++ b/src/tools/cmd-exec/host-exec-background.test.ts
@@ -84,9 +84,13 @@ describe("host_exec — one-step pod netns", () => {
     await tool.execute("c1", { host: "node-1", pod: "rdma-a", namespace: "rdma-test", command: "show_gids" }, undefined, {} as any);
     expect(resolvePodNetnsViaSsh).toHaveBeenCalledTimes(1);
     expect(vi.mocked(resolvePodNetnsViaSsh).mock.calls[0][0]).toMatchObject({ pod: "rdma-a", namespace: "rdma-test" });
-    // The actual remote command wraps the whole thing in `ip netns exec <netns> sh -c '<cmd>'`.
+    // Foreground now runs as a killable, timeout-bounded setsid session (so Stop can reap the
+    // remote process group), with the user command still inside `ip netns exec <netns> sh -c`.
     const fgCmd = vi.mocked(sshExec).mock.calls.find((c) => String(c[1]).includes("show_gids"))![1] as string;
-    expect(fgCmd).toBe("ip netns exec cni-x sh -c 'show_gids'");
+    expect(fgCmd).toContain("setsid -w sh -c");
+    expect(fgCmd).toContain("timeout 30 ");
+    expect(fgCmd).toContain(".pgid");
+    expect(fgCmd).toContain("ip netns exec cni-x sh -c '\\''show_gids'\\''");
   });
 
   it("background: the launched command runs under ip netns exec + timeout + setsid", async () => {

--- a/src/tools/cmd-exec/host-exec.test.ts
+++ b/src/tools/cmd-exec/host-exec.test.ts
@@ -70,6 +70,36 @@ describe("host_exec", () => {
     expect((result.details as any).error).toBe(true);
   });
 
+  it("foreground: wraps the command as a killable timeout-bounded session and reaps it on abort", async () => {
+    const controller = new AbortController();
+    vi.mocked(acquireSshTarget).mockResolvedValueOnce({
+      host: "10.0.0.1", port: 22, username: "root",
+      auth: { type: "key", privateKeyPath: "/tmp/h1.key" },
+    });
+    // First sshExec = the wrapped foreground command; abort mid-flight to trip the reap.
+    vi.mocked(sshExec).mockImplementation(async (_t: any, cmd: any) => {
+      if (typeof cmd === "string" && cmd.includes("setsid")) controller.abort();
+      return { stdout: "", stderr: "", exitCode: null, signal: "SIGKILL" } as any;
+    });
+
+    const result = await tool.execute(
+      "tc1", { host: "h1", command: "ib_write_bw -D 60 -F", timeout_seconds: 90 }, controller.signal, {} as any,
+    );
+
+    // (1) The foreground command ran as a setsid session, `timeout`-bounded at the cap, recording a .pgid.
+    const fgCmd = vi.mocked(sshExec).mock.calls[0][1] as string;
+    expect(fgCmd).toContain("setsid -w sh -c");
+    expect(fgCmd).toContain("timeout 90 ");
+    expect(fgCmd).toMatch(/\.pgid/);
+    expect(fgCmd).toContain("ib_write_bw -D 60 -F");
+    // (2) Abort fired a SECOND sshExec carrying the reap script over a fresh, time-boxed connection.
+    expect(vi.mocked(sshExec).mock.calls.length).toBeGreaterThanOrEqual(2);
+    const killCmd = vi.mocked(sshExec).mock.calls[1][1] as string;
+    expect(killCmd).toContain("pkill -TERM -s");
+    expect(vi.mocked(sshExec).mock.calls[1][2]).toEqual({ timeoutMs: 20_000 });
+    expect((result.details as any).error).toBe(true); // "Aborted."
+  });
+
   it("signal-killed with stdout is NOT treated as error (mirrors node_exec)", async () => {
     vi.mocked(acquireSshTarget).mockResolvedValueOnce({
       host: "10.0.0.1", port: 22, username: "root",

--- a/src/tools/cmd-exec/host-exec.test.ts
+++ b/src/tools/cmd-exec/host-exec.test.ts
@@ -100,6 +100,26 @@ describe("host_exec", () => {
     expect((result.details as any).error).toBe(true); // "Aborted."
   });
 
+  it("foreground: an SSH reject AFTER abort returns a clean 'Aborted.' (not ssh_exec_failed)", async () => {
+    const controller = new AbortController();
+    vi.mocked(acquireSshTarget).mockResolvedValueOnce({
+      host: "10.0.0.1", port: 22, username: "root",
+      auth: { type: "key", privateKeyPath: "/tmp/h1.key" },
+    });
+    // Real SSH path: rejects with Error("Aborted") once the signal fires (the reject path the
+    // earlier resolve-mock missed). The catch must recognize signal.aborted, not report a
+    // connection failure.
+    vi.mocked(sshExec).mockImplementation(async (_t: any, cmd: any) => {
+      if (typeof cmd === "string" && cmd.includes("setsid")) { controller.abort(); throw new Error("Aborted"); }
+      return { stdout: "", stderr: "", exitCode: 0 } as any;
+    });
+    const result = await tool.execute(
+      "tc2", { host: "h1", command: "ping -c 100 10.0.0.254" }, controller.signal, {} as any,
+    );
+    expect(result.content[0].text).toBe("Aborted.");
+    expect((result.details as any).reason).not.toBe("ssh_exec_failed");
+  });
+
   it("signal-killed with stdout is NOT treated as error (mirrors node_exec)", async () => {
     vi.mocked(acquireSshTarget).mockResolvedValueOnce({
       host: "10.0.0.1", port: 22, username: "root",

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -257,6 +257,12 @@ Examples (pass the id from host_list; names shown here for readability):
       try {
         result = await sshExec(target, fgWrapped, { timeoutMs: timeout, signal });
       } catch (err) {
+        // The SSH path REJECTS with Error("Aborted") when the signal fires — surface a clean stop
+        // here (the post-try abort check below is unreachable on the reject path), not a spurious
+        // "ssh_exec_failed" connection error.
+        if (signal?.aborted) {
+          return { content: [{ type: "text", text: "Aborted." }], details: { error: true } };
+        }
         const msg = err instanceof Error ? err.message : String(err);
         return {
           content: [{ type: "text", text: `Error: ${msg}\n\nSSH connection to "${params.host}" failed (a connection failure, not a command error). If "${params.host}" is a Kubernetes node, retry this command with node_exec (debug pod, no SSH).` }],

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -170,6 +170,10 @@ Examples (pass the id from host_list; names shown here for readability):
           details: { error: true, reason: "host_acquire_failed" },
         };
       }
+      // The model often passes an opaque host id; surface the resolved friendly name so the tool
+      // card can render `<name> $ <command>` like node_exec instead of a bare UUID. Persisted via
+      // the result details → tool row metadata (foreground details + background extraDetails).
+      const hostLabel = target.name || params.host;
 
       // One-step pod netns: resolve the pod's netns over SSH (crictl on this node; needs root),
       // then run the command inside it via `ip netns exec`. The prefix is tool-built — only the
@@ -226,7 +230,7 @@ Examples (pass the id from host_list; names shown here for readability):
             jobType: "host",
             onAbort,
           });
-          return backgroundLaunchedResult(jobId, outputFile, "Running on the host in the background.");
+          return backgroundLaunchedResult(jobId, outputFile, "Running on the host in the background.", { host_label: hostLabel });
         } catch (err) {
           // Concurrency cap (or executor failure): fall through to a foreground run.
           console.warn(`[host-exec] background launch declined, running foreground:`, err);
@@ -287,6 +291,7 @@ Examples (pass the id from host_list; names shown here for readability):
         details: {
           exitCode: result.exitCode,
           host: params.host,
+          host_label: hostLabel,
           ...(isError && { error: true }),
           ...(result.signal ? { signal: result.signal } : {}),
         },

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -5,7 +5,7 @@ import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { KubeconfigRef } from "../../core/types.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { CONTAINER_SENSITIVE_PATHS } from "../infra/command-sets.js";
-import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "../infra/bg-session.js";
+import { backgroundPgidFile, wrapBackgroundSession, killRemoteSessionViaSsh } from "../infra/bg-session.js";
 import { preExecSecurity, postExecSecurity } from "../infra/security-pipeline.js";
 import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
 import { backgroundNotLineSafeError, backgroundLaunchedResult } from "./background-launch.js";
@@ -208,10 +208,9 @@ Examples (pass the id from host_list; names shown here for readability):
         // remote tree incl. timeout's own process group. See bg-session.ts for the rationale.
         const pgidFile = backgroundPgidFile(toolCallId);
         const wrapped = wrapBackgroundSession(userCmd, pgidFile);
-        const killScript = backgroundSessionKillScript(pgidFile);
         // job_stop: kill the remote process group over a FRESH ssh connection (the streaming
         // channel is being torn down). Best-effort, time-boxed; the runner closes the channel after.
-        const onAbort = () => { void sshExec(target, killScript, { timeoutMs: 20_000 }).catch(() => {}); };
+        const onAbort = () => killRemoteSessionViaSsh({ target, pgidFile });
         try {
           const { jobId, outputFile } = bg!.executor!({
             // The job outlives this turn, so it is NOT tied to the turn's AbortSignal —
@@ -234,18 +233,33 @@ Examples (pass the id from host_list; names shown here for readability):
         }
       }
 
-      const timeout = Math.min(params.timeout_seconds ?? 30, 120) * 1000;
+      // ── Foreground mode ──────────────────────────────────────────────
+      // Run as a killable session (setsid + recorded session id) wrapped in `timeout <cap>`, just
+      // like the background path. On abort the local ssh channel is torn down, but closing it does
+      // NOT reliably SIGHUP a non-PTY remote process — so we ALSO reap the remote process group
+      // over a FRESH ssh connection, and the remote `timeout` is the backstop. Previously a
+      // foreground command had no remote bound and could keep running on the host past the local wait.
+      // This requires `setsid` + `timeout` on the host — the SAME dependency the background path
+      // already takes for every host command (util-linux + coreutils, present on any normal SSH
+      // target incl. BusyBox); a host missing them errors visibly rather than orphaning silently.
+      const cap = Math.min(params.timeout_seconds ?? 30, 120);
+      const timeout = cap * 1000;
+      const fgPgidFile = backgroundPgidFile(toolCallId);
+      const fgWrapped = wrapBackgroundSession(`timeout ${cap} ${netnsExec}sh -c '${esc}'`, fgPgidFile);
+      const onAbort = () => killRemoteSessionViaSsh({ target, pgidFile: fgPgidFile });
+      signal?.addEventListener("abort", onAbort, { once: true });
 
       let result;
       try {
-        const fgCmd = netnsExec ? `${netnsExec}sh -c '${esc}'` : params.command;
-        result = await sshExec(target, fgCmd, { timeoutMs: timeout, signal });
+        result = await sshExec(target, fgWrapped, { timeoutMs: timeout, signal });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         return {
           content: [{ type: "text", text: `Error: ${msg}\n\nSSH connection to "${params.host}" failed (a connection failure, not a command error). If "${params.host}" is a Kubernetes node, retry this command with node_exec (debug pod, no SSH).` }],
           details: { error: true, reason: "ssh_exec_failed", host: params.host },
         };
+      } finally {
+        signal?.removeEventListener("abort", onAbort);
       }
 
       if (signal?.aborted) {

--- a/src/tools/cmd-exec/node-exec-foreground.test.ts
+++ b/src/tools/cmd-exec/node-exec-foreground.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock the transport layer so we can inspect the command shape + the abort reap without a cluster.
+const spawnMock = vi.fn(() => ({ on: vi.fn(), unref: vi.fn(), kill: vi.fn() }));
+vi.mock("node:child_process", () => ({ spawn: (...a: unknown[]) => spawnMock(...a) }));
+vi.mock("../infra/k8s-checks.js", () => ({ checkNodeReady: vi.fn(async () => null) }));
+
+const ensureDebugPodReady = vi.fn(async () => ({ podName: "node-debug-x", namespace: "siclaw-debug" }));
+const runInDebugPod = vi.fn();
+const acquireDebugPod = vi.fn(() => "node-debug-x");
+const releaseDebugPod = vi.fn();
+vi.mock("../infra/debug-pod.js", () => ({
+  ensureDebugPodReady: (...a: unknown[]) => ensureDebugPodReady(...a),
+  runInDebugPod: (...a: unknown[]) => runInDebugPod(...a),
+  acquireDebugPod: (...a: unknown[]) => acquireDebugPod(...a),
+  releaseDebugPod: (...a: unknown[]) => releaseDebugPod(...a),
+}));
+
+const { createNodeExecTool } = await import("./node-exec.js");
+
+describe("node_exec foreground: killable session + abort reap", () => {
+  it("runs the host command as a setsid+timeout session and reaps the remote group on abort", async () => {
+    const tool = createNodeExecTool();
+    const controller = new AbortController();
+    // Abort mid-exec (the user clicks Stop) so the abort listener fires the reap.
+    runInDebugPod.mockImplementation(async () => {
+      controller.abort();
+      return { stdout: "", stderr: "", exitCode: null };
+    });
+
+    const result = await tool.execute(
+      "tc1", { node: "node-1", command: "ib_write_bw -D 60 -F", timeout_seconds: 90 }, controller.signal, {} as never,
+    );
+
+    // (1) The command handed to runInDebugPod is a host-namespace setsid session, `timeout`-bounded
+    //     at the cap, recording a .pgid — i.e. the same killable shape the background path uses.
+    const cmd = (runInDebugPod.mock.calls[0][0] as { command: string[] }).command;
+    expect(cmd.slice(0, 3)).toEqual(["nsenter", "-t", "1"]); // host namespace
+    const joined = cmd.join(" ");
+    expect(joined).toContain("setsid -w sh -c");
+    expect(joined).toContain("timeout 90 ");
+    expect(joined).toMatch(/\.pgid/);
+    expect(joined).toContain("ib_write_bw -D 60 -F");
+
+    // (2) Abort spawned a FRESH `kubectl exec … nsenter … sh -c <pkill -s …>` into the same pod.
+    expect(spawnMock).toHaveBeenCalled();
+    const [bin, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(bin).toBe("kubectl");
+    expect(args).toContain("node-debug-x");
+    expect(args.join(" ")).toContain("pkill -TERM -s");
+
+    // (3) The pod is PINNED for the exec (so it can't be idle-evicted mid-run) and released after.
+    expect(acquireDebugPod).toHaveBeenCalledTimes(1);
+    expect(releaseDebugPod).toHaveBeenCalledTimes(1);
+
+    expect((result.details as Record<string, unknown>).error).toBe(true); // "Aborted."
+  });
+});

--- a/src/tools/cmd-exec/node-exec.ts
+++ b/src/tools/cmd-exec/node-exec.ts
@@ -1,6 +1,4 @@
 import type { ToolEntry, BackgroundExecWiring } from "../../core/tool-registry.js";
-import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import { Text } from "@mariozechner/pi-tui";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
@@ -9,8 +7,7 @@ import { renderTextResult } from "../infra/tool-render.js";
 import { checkNodeReady } from "../infra/k8s-checks.js";
 import { loadConfig } from "../../core/config.js";
 import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
-import { parseArgs, CONTAINER_SENSITIVE_PATHS } from "../infra/command-sets.js";
-import { extractCommands } from "../infra/command-validator.js";
+import { CONTAINER_SENSITIVE_PATHS } from "../infra/command-sets.js";
 import { preExecSecurity, postExecSecurity } from "../infra/security-pipeline.js";
 import { backgroundNotLineSafeError, backgroundLaunchedResult } from "./background-launch.js";
 import {
@@ -21,6 +18,7 @@ import {
 } from "../infra/exec-utils.js";
 import { resolvePodNetnsViaKubectl, validateNetnsName } from "../infra/pod-netns-resolve.js";
 import { runInDebugPod, ensureDebugPodReady, acquireDebugPod, releaseDebugPod } from "../infra/debug-pod.js";
+import { backgroundPgidFile, wrapBackgroundSession, killRemoteSessionViaKubectl } from "../infra/bg-session.js";
 import { resolveRequiredKubeconfig, resolveDebugImage } from "../infra/kubeconfig-resolver.js";
 import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
 
@@ -260,53 +258,32 @@ To run in a POD's network namespace (host tools + the pod's network view — e.g
         }
       }
       const timeout = Math.min(params.timeout_seconds ?? 30, 120) * 1000;
-      const commands = extractCommands(params.command);
-      const needsShell = commands.length > 1;
-      const cmdArgs = parseArgs(params.command);
-
-      // Build nsenter command (use rewritten args for single-command case)
-      // When netns is specified, wrap with "ip netns exec <name>" to run
-      // in the pod's network namespace using host tools.
+      // Build the nsenter prefix for host-namespace execution. When netns is specified, wrap
+      // with "ip netns exec <name>" to run in the pod's network namespace using host tools.
+      // Both the foreground and background forms run the user command via `sh -c` so they can be
+      // wrapped in setsid + `timeout` (a killable, time-bounded session — see bg-session.ts).
       const netnsPrefix = netns ? `ip netns exec ${netns} ` : "";
       const NSENTER = ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--"];
-      // tail = the part after `nsenter -- ` (the host-namespace command); reused for the
-      // foreground and (timeout-wrapped) background forms.
-      const tail: string[] =
-        needsShell || netnsPrefix
-          ? ["sh", "-c", netnsPrefix + params.command]
-          : [...cmdArgs];
-      const nsenterCmd: string[] = [...NSENTER, ...tail];
 
       // ── Background mode ──────────────────────────────────────────────
       // Ensure+pin the debug pod, then hand a detached `kubectl exec … -- nsenter …` to
-      // the runtime executor. The remote command runs in its OWN process group via
-      // `setsid` and records its PGID to a node-side file, so job_stop can promptly kill
-      // the whole group (kubectl exec does NOT propagate kill to a host-namespace
-      // process). `timeout <ttl>` is the backstop if the job is never stopped. The user
-      // command is interpolated single-quote-escaped into `sh -c` (kubectl exec does NOT
-      // forward local env), already whitelisted by preExecSecurity; see the launchScript below.
+      // the runtime executor. The remote command runs as its own session leader via `setsid`
+      // and records its session id to a node-side file, so job_stop can promptly reap the whole
+      // session (kubectl exec does NOT propagate kill to a host-namespace process). `timeout <ttl>`
+      // is the backstop if the job is never stopped. This uses the SAME killable-session helpers
+      // (bg-session.ts) as the foreground path so there is one reap mechanism per transport.
       if (backgroundEnabled && params.run_in_background === true) {
         if (pre.action && !pre.action.lineSafe) {
           return backgroundNotLineSafeError();
         }
         const cfg = loadConfig();
         const ttl = Math.min(params.timeout_seconds ?? cfg.debugPodTTL, cfg.debugPodTTL);
-        const userShell = netnsPrefix + params.command;
-        const safeJob = toolCallId.replace(/[^A-Za-z0-9_-]/g, "_");
-        // Random suffix: two background jobs whose tool-call ids sanitize to the same
-        // string (cross-session reuse → same node, host PID ns), or a stale .pgid left by
-        // a crashed prior run, must NOT share this file — otherwise job_stop could read the
-        // wrong PGID and kill an unrelated process group.
-        const pgidFile = `/tmp/siclaw-bg-${safeJob}-${randomBytes(4).toString("hex")}.pgid`;
         // The user command is interpolated single-quote-escaped (NOT via env — kubectl exec
         // does not forward the local process env to the remote command). preExecSecurity
         // already whitelisted it; the '\'' escaping makes it injection-safe regardless.
-        const userShellEsc = userShell.replace(/'/g, "'\\''");
-        // `setsid -w` (wait): run the command as a NEW session/group leader (its PID == PGID,
-        // recorded to pgidFile) but KEEP the exec attached & streaming until it exits — plain
-        // setsid forks+detaches and returns immediately. `timeout <ttl>` is the leak backstop.
-        const launchScript = `echo $$ > ${pgidFile}; exec timeout ${ttl} sh -c '${userShellEsc}'`;
-        const bgNsenterCmd = [...NSENTER, "setsid", "-w", "sh", "-c", launchScript];
+        const userShellEsc = (netnsPrefix + params.command).replace(/'/g, "'\\''");
+        const pgidFile = backgroundPgidFile(toolCallId);
+        const bgNsenterCmd = [...NSENTER, "sh", "-c", wrapBackgroundSession(`timeout ${ttl} sh -c '${userShellEsc}'`, pgidFile)];
         const spec = { userId: userId ?? "unknown", nodeName, command: bgNsenterCmd, image, clusterKey };
         let cachedPod;
         try {
@@ -328,24 +305,16 @@ To run in a POD's network namespace (host tools + the pod's network view — e.g
             details: { error: true, reason: "debug_pod_gone" },
           };
         }
-        // job_stop → kill the remote process GROUP (TERM, then KILL) by the recorded PGID.
-        // Poll briefly for the pgid file: job_stop can race the remote launch (the file is
-        // written by `echo $$` at the very start of launchScript), and reading an empty
-        // pgid would make the kill a silent no-op, leaking the host process until `timeout`.
-        const killScript = `pgid=""; for i in 1 2 3; do pgid=$(cat ${pgidFile} 2>/dev/null); [ -n "$pgid" ] && break; sleep 1; done; if [ -n "$pgid" ]; then kill -TERM -"$pgid" 2>/dev/null; sleep 1; kill -KILL -"$pgid" 2>/dev/null; fi; rm -f ${pgidFile}`;
-        const onAbort = () => {
-          try {
-            const killer = spawn(
-              "kubectl",
-              [...env.kubeconfigArgs, "-n", cachedPod!.namespace, "exec", cachedPod!.podName, "--", ...NSENTER, "sh", "-c", killScript],
-              { env: env.childEnv as Record<string, string>, detached: true },
-            );
-            killer.on("error", () => {});
-            // Don't let the kill-exec linger forever.
-            setTimeout(() => { try { killer.kill("SIGKILL"); } catch { /* gone */ } }, 15_000).unref();
-            killer.unref();
-          } catch { /* best-effort */ }
-        };
+        // job_stop → reap the remote session (pkill -s, catching timeout's own child group) over
+        // a FRESH kubectl exec; the kill script retries reading the .pgid to cover the launch race.
+        const onAbort = () => killRemoteSessionViaKubectl({
+          kubeconfigArgs: env.kubeconfigArgs,
+          childEnv: env.childEnv as Record<string, string>,
+          namespace: cachedPod!.namespace,
+          podName: cachedPod!.podName,
+          nsenterPrefix: NSENTER,
+          pgidFile,
+        });
         try {
           const { jobId, outputFile } = bg!.executor!({
             file: "kubectl",
@@ -369,11 +338,51 @@ To run in a POD's network namespace (host tools + the pod's network view — e.g
         }
       }
 
-      const execResult = await runInDebugPod(
-        { userId: userId ?? "unknown", nodeName, command: nsenterCmd, image, clusterKey },
-        env,
-        { timeoutMs: timeout, signal },
-      );
+      // ── Foreground mode ──────────────────────────────────────────────
+      // Run the host-namespace command as a killable session (setsid + recorded session id)
+      // wrapped in `timeout <cap>`, exactly like the background path. On abort the LOCAL kubectl
+      // is killed by runInDebugPod's signal, but that does NOT propagate to the host-namespace
+      // process — so we ALSO reap the remote process group over a FRESH kubectl exec. The remote
+      // `timeout` is the backstop if the reap is somehow missed (previously a foreground command
+      // had no remote bound and orphaned on the node past the local wait).
+      const cap = Math.min(params.timeout_seconds ?? 30, 120);
+      const fgUserShellEsc = (netnsPrefix + params.command).replace(/'/g, "'\\''");
+      const fgPgidFile = backgroundPgidFile(toolCallId);
+      const fgNsenterCmd = [...NSENTER, "sh", "-c", wrapBackgroundSession(`timeout ${cap} sh -c '${fgUserShellEsc}'`, fgPgidFile)];
+      const fgSpec = { userId: userId ?? "unknown", nodeName, command: fgNsenterCmd, image, clusterKey };
+
+      // Ensure the (idempotent, cache-hit) pod up front, then PIN it for the duration of the exec.
+      // runInDebugPod only resets the idle timer AFTER a successful exec, so without a pin a long
+      // foreground command (cap up to 120s; idle timeout can be shorter) could be idle-evicted
+      // mid-exec — killing the command AND leaving the abort reap to target a deleted pod. The pin
+      // also guarantees fgPod stays the live pod the reap kubectl-execs into.
+      let fgPod;
+      try {
+        fgPod = await ensureDebugPodReady(fgSpec, env, { signal });
+      } catch (err: any) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ error: true, message: `Debug pod failed to start: ${err?.message ?? String(err)}` }) }],
+          details: { error: true, reason: "debug_pod_failed" },
+        };
+      }
+      const fgPinnedPodName = acquireDebugPod(fgSpec); // null if the pod vanished; proceed best-effort
+      const onAbort = () => killRemoteSessionViaKubectl({
+        kubeconfigArgs: env.kubeconfigArgs,
+        childEnv: env.childEnv as Record<string, string>,
+        namespace: fgPod!.namespace,
+        podName: fgPod!.podName,
+        nsenterPrefix: NSENTER,
+        pgidFile: fgPgidFile,
+      });
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      let execResult;
+      try {
+        execResult = await runInDebugPod(fgSpec, env, { timeoutMs: timeout, signal });
+      } finally {
+        signal?.removeEventListener("abort", onAbort);
+        if (fgPinnedPodName) releaseDebugPod(fgSpec, fgPinnedPodName);
+      }
 
       if (signal?.aborted) {
         return {

--- a/src/tools/cmd-exec/pod-exec-signal.test.ts
+++ b/src/tools/cmd-exec/pod-exec-signal.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Capture the options handed to the local kubectl so we can assert the AbortSignal is threaded.
+// promisify(execFile) calls our mock callback-style: (file, args, options, cb).
+let capturedOptions: Record<string, unknown> | undefined;
+let rejectWith: { code?: string; message?: string } | undefined; // set to make the mock reject (abort path)
+vi.mock("node:child_process", () => ({
+  execFile: (_file: string, _args: string[], options: Record<string, unknown>, cb: (e: unknown, r: unknown) => void) => {
+    capturedOptions = options;
+    if (rejectWith) cb(rejectWith, null);
+    else cb(null, { stdout: "ok\n", stderr: "" });
+  },
+}));
+// Pretend the target pod is Running so execute() reaches the kubectl exec.
+vi.mock("../infra/k8s-checks.js", () => ({ checkPodRunning: vi.fn(async () => null) }));
+
+const { createPodExecTool } = await import("./pod-exec.js");
+
+describe("pod_exec foreground threads the AbortSignal to the local kubectl", () => {
+  it("passes `signal` in the execFile options so Stop kills the local kubectl promptly", async () => {
+    const tool = createPodExecTool();
+    const controller = new AbortController();
+    const result = await tool.execute(
+      "tc1", { pod: "my-pod", command: "ip addr show", timeout_seconds: 5 }, controller.signal, {} as never,
+    );
+    expect((result.details as Record<string, unknown>).blocked).toBeUndefined();
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions!.signal).toBe(controller.signal);
+  });
+
+  it("returns a clean 'Aborted.' (not an ABORT_ERR command error) when Stopped", async () => {
+    const tool = createPodExecTool();
+    const controller = new AbortController();
+    controller.abort();
+    rejectWith = { code: "ABORT_ERR", message: "The operation was aborted" }; // how Node rejects an aborted execFile
+    const result = await tool.execute(
+      "tc2", { pod: "my-pod", command: "ip addr show", timeout_seconds: 5 }, controller.signal, {} as never,
+    );
+    rejectWith = undefined;
+    expect(result.content[0].text).toBe("Aborted.");
+    expect(result.content[0].text).not.toContain("ABORT_ERR");
+  });
+});

--- a/src/tools/cmd-exec/pod-exec.ts
+++ b/src/tools/cmd-exec/pod-exec.ts
@@ -122,7 +122,7 @@ Examples:
       );
     },
     renderResult: renderTextResult,
-    async execute(toolCallId, rawParams) {
+    async execute(toolCallId, rawParams, signal) {
       const params = rawParams as PodExecParams;
 
       try {
@@ -224,10 +224,14 @@ Examples:
       }
 
       try {
+        // Thread the turn's AbortSignal so a Stop promptly kills the LOCAL kubectl. The in-pod
+        // process runs in the pod's own PID namespace and is bounded by the pod lifecycle (we do
+        // not setsid/timeout-wrap it here — minimal target images may lack sh/setsid/timeout), so
+        // unlike node_exec/host_exec there is no host-namespace orphan to reap over a new connection.
         const { stdout, stderr } = await execFileAsync(
           "kubectl",
           kubectlArgs,
-          { timeout, env: env.childEnv },
+          { timeout, env: env.childEnv, signal },
         );
 
         return {
@@ -235,6 +239,11 @@ Examples:
           details: { exitCode: 0 },
         };
       } catch (err: any) {
+        // User Stop → execFile rejects with an AbortError; surface a clean "Aborted." rather than
+        // a spurious command error like "[exit code: ABORT_ERR]" (mirrors node_exec/host_exec).
+        if (signal?.aborted) {
+          return { content: [{ type: "text", text: "Aborted." }], details: { error: true } };
+        }
         const stdout = (err.stdout?.trim() ?? "") as string;
         const stderr = (err.stderr?.trim() ?? err.message) as string;
         const exitCode = err.code ?? "unknown";

--- a/src/tools/infra/bg-session.test.ts
+++ b/src/tools/infra/bg-session.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from "vitest";
-import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "./bg-session.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({ spawn: (...a: unknown[]) => spawnMock(...a) }));
+
+const sshExecMock = vi.fn(async () => ({ stdout: "", stderr: "", exitCode: 0 }));
+vi.mock("./ssh-client.js", () => ({ sshExec: (...a: unknown[]) => sshExecMock(...a) }));
+
+const {
+  backgroundPgidFile,
+  wrapBackgroundSession,
+  backgroundSessionKillScript,
+  killRemoteSessionViaKubectl,
+  killRemoteSessionViaSsh,
+} = await import("./bg-session.js");
 
 describe("bg-session", () => {
   it("builds a unique, sanitized pidfile path", () => {
@@ -26,5 +39,77 @@ describe("bg-session", () => {
     expect(kill).toContain("pkill -KILL -s");
     expect(kill).toContain("kill -TERM -");  // group-kill fallback when pkill is absent
     expect(kill).toContain("rm -f /tmp/x.pgid");
+  });
+});
+
+describe("killRemoteSessionViaKubectl", () => {
+  beforeEach(() => { spawnMock.mockReset(); vi.useFakeTimers(); });
+  afterEach(() => vi.useRealTimers());
+
+  function fakeChild() {
+    return { on: vi.fn(), unref: vi.fn(), kill: vi.fn() };
+  }
+
+  it("spawns a detached `kubectl exec … nsenter … sh -c <killScript>` over a fresh connection", () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    killRemoteSessionViaKubectl({
+      kubeconfigArgs: ["--kubeconfig", "/k"],
+      childEnv: { KUBECONFIG: "/k" },
+      namespace: "siclaw-debug",
+      podName: "node-debug-abcd",
+      nsenterPrefix: ["nsenter", "-t", "1", "--"],
+      pgidFile: "/tmp/x.pgid",
+    });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = spawnMock.mock.calls[0];
+    expect(cmd).toBe("kubectl");
+    expect(args).toEqual([
+      "--kubeconfig", "/k", "-n", "siclaw-debug", "exec", "node-debug-abcd", "--",
+      "nsenter", "-t", "1", "--", "sh", "-c", backgroundSessionKillScript("/tmp/x.pgid"),
+    ]);
+    expect((opts as { detached?: boolean }).detached).toBe(true);
+    expect(child.on).toHaveBeenCalledWith("error", expect.any(Function)); // swallow spawn errors
+    expect(child.unref).toHaveBeenCalled();
+  });
+
+  it("self-kills the reap exec if it lingers past the timeout, then is unreffed", () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    killRemoteSessionViaKubectl({
+      kubeconfigArgs: [], childEnv: {}, namespace: "ns", podName: "p",
+      nsenterPrefix: [], pgidFile: "/tmp/x.pgid", timeoutMs: 5000,
+    });
+    // pod_exec passes an empty nsenter prefix → kill runs directly in the pod.
+    expect(spawnMock.mock.calls[0][1]).toEqual(["-n", "ns", "exec", "p", "--", "sh", "-c", backgroundSessionKillScript("/tmp/x.pgid")]);
+    expect(child.kill).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(5000);
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("never throws when spawn itself throws (best-effort)", () => {
+    spawnMock.mockImplementation(() => { throw new Error("ENOENT kubectl"); });
+    expect(() => killRemoteSessionViaKubectl({
+      kubeconfigArgs: [], childEnv: {}, namespace: "ns", podName: "p", nsenterPrefix: [], pgidFile: "/tmp/x.pgid",
+    })).not.toThrow();
+  });
+});
+
+describe("killRemoteSessionViaSsh", () => {
+  beforeEach(() => sshExecMock.mockClear());
+
+  it("reaps the remote session over a fresh ssh connection with a bounded timeout", () => {
+    const target = { host: "h" } as never;
+    killRemoteSessionViaSsh({ target, pgidFile: "/tmp/x.pgid" });
+    expect(sshExecMock).toHaveBeenCalledTimes(1);
+    expect(sshExecMock.mock.calls[0][0]).toBe(target);
+    expect(sshExecMock.mock.calls[0][1]).toBe(backgroundSessionKillScript("/tmp/x.pgid"));
+    expect(sshExecMock.mock.calls[0][2]).toEqual({ timeoutMs: 20_000 });
+  });
+
+  it("swallows a rejected sshExec (best-effort)", async () => {
+    sshExecMock.mockRejectedValueOnce(new Error("connect failed"));
+    expect(() => killRemoteSessionViaSsh({ target: {} as never, pgidFile: "/tmp/x.pgid" })).not.toThrow();
+    await Promise.resolve(); // let the .catch settle without an unhandled rejection
   });
 });

--- a/src/tools/infra/bg-session.ts
+++ b/src/tools/infra/bg-session.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from "node:crypto";
+import { spawn } from "node:child_process";
 import { shellEscape } from "./command-sets.js";
+import { sshExec, type SshTarget } from "./ssh-client.js";
 
 /**
  * Shared shell-string builders for background jobs that run a command on a REMOTE shell
@@ -37,4 +39,53 @@ export function wrapBackgroundSession(innerCmd: string, pgidFile: string): strin
  */
 export function backgroundSessionKillScript(pgidFile: string): string {
   return `sid=""; for i in 1 2 3; do sid=$(cat ${pgidFile} 2>/dev/null); [ -n "$sid" ] && break; sleep 1; done; if [ -n "$sid" ]; then pkill -TERM -s "$sid" 2>/dev/null || kill -TERM -"$sid" 2>/dev/null; sleep 1; pkill -KILL -s "$sid" 2>/dev/null || kill -KILL -"$sid" 2>/dev/null; fi; rm -f ${pgidFile}`;
+}
+
+/**
+ * Fire {@link backgroundSessionKillScript} on a node's debug pod over a FRESH `kubectl exec`
+ * connection — used to reap a remote session started with {@link wrapBackgroundSession} when the
+ * caller can no longer use the streaming channel (it is being torn down on abort). Detached and
+ * self-killed after `timeoutMs` so a hung reap can never keep the process alive or leak a client.
+ *
+ * `nsenterPrefix` is the host-namespace prefix the command was launched under (e.g.
+ * `["nsenter","-t","1",...,"--"]` for node_exec) so the kill lands in the SAME PID namespace as
+ * the target; pass `[]` to run the kill directly inside the pod. Best-effort: errors are swallowed
+ * (the local-client kill and the remote `timeout` backstop are complementary safety nets).
+ */
+export function killRemoteSessionViaKubectl(opts: {
+  kubeconfigArgs: string[];
+  childEnv: Record<string, string>;
+  namespace: string;
+  podName: string;
+  nsenterPrefix: string[];
+  pgidFile: string;
+  timeoutMs?: number;
+}): void {
+  const { kubeconfigArgs, childEnv, namespace, podName, nsenterPrefix, pgidFile } = opts;
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  try {
+    const killer = spawn(
+      "kubectl",
+      [...kubeconfigArgs, "-n", namespace, "exec", podName, "--", ...nsenterPrefix, "sh", "-c", backgroundSessionKillScript(pgidFile)],
+      { env: childEnv, detached: true },
+    );
+    killer.on("error", () => {});
+    setTimeout(() => { try { killer.kill("SIGKILL"); } catch { /* gone */ } }, timeoutMs).unref();
+    killer.unref();
+  } catch { /* best-effort */ }
+}
+
+/**
+ * Fire {@link backgroundSessionKillScript} on a host over a FRESH ssh connection — the foreground
+ * (and background) counterpart of {@link killRemoteSessionViaKubectl} for the SSH transport. The
+ * streaming channel is being torn down on abort and closing it does NOT reliably SIGHUP a non-PTY
+ * remote process, so the reap runs over a new, time-boxed connection. Best-effort; errors swallowed.
+ */
+export function killRemoteSessionViaSsh(opts: {
+  target: SshTarget;
+  pgidFile: string;
+  timeoutMs?: number;
+}): void {
+  const { target, pgidFile } = opts;
+  void sshExec(target, backgroundSessionKillScript(pgidFile), { timeoutMs: opts.timeoutMs ?? 20_000 }).catch(() => {});
 }

--- a/src/tools/infra/ssh-client.test.ts
+++ b/src/tools/infra/ssh-client.test.ts
@@ -236,6 +236,7 @@ describe("acquireSshTarget", () => {
       host: "10.0.0.1",
       port: 2222,
       username: "ops",
+      name: "host-1", // friendly name surfaced for display labeling
       auth: { type: "key", privateKeyPath: "/tmp/host-1.host-1.key" },
     });
   });
@@ -250,6 +251,7 @@ describe("acquireSshTarget", () => {
       host: "10.0.0.2",
       port: 22,
       username: "root",
+      name: "host-2", // friendly name surfaced for display labeling
       auth: { type: "password", passwordPath: "/tmp/host-2.host-2.password" },
     });
   });

--- a/src/tools/infra/ssh-client.ts
+++ b/src/tools/infra/ssh-client.ts
@@ -51,6 +51,9 @@ export interface SshTarget {
   host: string;
   port: number;
   username: string;
+  /** Friendly host name from the registry (HostMeta.name), for display/labeling. The model may
+   *  pass an opaque host id, so callers use this to show a human name instead of the id. */
+  name?: string;
   auth:
     | { type: "key"; privateKeyPath: string; passphrasePath?: string }
     | { type: "password"; passwordPath: string }
@@ -143,7 +146,7 @@ async function acquireSshTargetInner(
     }
   }
 
-  const target: SshTarget = { host: meta.ip, port: meta.port, username: meta.username, auth };
+  const target: SshTarget = { host: meta.ip, port: meta.port, username: meta.username, auth, name: meta.name };
 
   if (chain && chain.length > 0) {
     // Server pre-resolved the chain [outermost … nearest]. Nest it onto the

--- a/src/tools/script-exec/host-script.test.ts
+++ b/src/tools/script-exec/host-script.test.ts
@@ -109,8 +109,29 @@ describe("host_script — one-step pod netns", () => {
     expect((res.details as any).error).toBeFalsy();
     expect(resolvePodNetnsViaSsh).toHaveBeenCalledTimes(1);
     expect(vi.mocked(resolvePodNetnsViaSsh).mock.calls[0][0]).toMatchObject({ pod: "rdma-a", namespace: "rdma-test" });
+    // Foreground now runs as a killable, timeout-bounded setsid session; the netns'd interpreter
+    // command lives inside that wrapper (so the abort reap can kill the whole remote group).
     const remoteCmd = vi.mocked(sshExec).mock.calls[0][1] as string;
-    expect(remoteCmd.startsWith("ip netns exec cni-x ")).toBe(true);
+    expect(remoteCmd).toContain("setsid -w sh -c");
+    expect(remoteCmd).toContain("timeout ");
+    expect(remoteCmd).toContain("ip netns exec cni-x ");
     expect(remoteCmd).toContain("bash -s");
+  });
+
+  it("foreground: reaps the remote session on abort instead of returning ssh_exec_failed", async () => {
+    const controller = new AbortController();
+    vi.mocked(acquireSshTarget).mockResolvedValue(okTarget as any);
+    vi.mocked(resolveScript).mockReturnValue({ interpreter: "bash", content: "echo hi", path: "/x", scope: "global" } as any);
+    // The real SSH path rejects with Error("Aborted") on abort; emulate that after the signal fires.
+    vi.mocked(sshExec).mockImplementation(async (_t: any, cmd: any) => {
+      if (typeof cmd === "string" && cmd.includes("setsid")) { controller.abort(); throw new Error("Aborted"); }
+      return { stdout: "", stderr: "", exitCode: 0 } as any;
+    });
+    const res = await tool.execute("tc1", { host: "node-1", script: "x.sh" }, controller.signal, {} as any);
+    expect(res.content[0].text).toBe("Aborted.");
+    expect((res.details as any).reason).not.toBe("ssh_exec_failed");
+    // A SECOND sshExec carried the reap script over a fresh connection.
+    const kill = vi.mocked(sshExec).mock.calls.find((c) => String(c[1]).includes("pkill -TERM -s"));
+    expect(kill).toBeTruthy();
   });
 });

--- a/src/tools/script-exec/host-script.ts
+++ b/src/tools/script-exec/host-script.ts
@@ -158,6 +158,8 @@ Examples (pass the id from host_list; names shown here for readability):
           details: { error: true, reason: "host_acquire_failed" },
         };
       }
+      // Resolved friendly name for the card label (model may pass an opaque host id). See host-exec.
+      const hostLabel = target.name || params.host;
 
       const args = params.args?.trim() || "";
       const escapedArgs = args ? parseArgs(args).map(shellEscape).join(" ") : "";
@@ -207,7 +209,7 @@ Examples (pass the id from host_list; names shown here for readability):
             jobType: "host",
             onAbort,
           });
-          return backgroundLaunchedResult(jobId, outputFile, "Running on the host in the background.");
+          return backgroundLaunchedResult(jobId, outputFile, "Running on the host in the background.", { host_label: hostLabel });
         } catch (err) {
           console.warn(`[host-script] background launch declined, running foreground:`, err);
         }
@@ -253,6 +255,7 @@ Examples (pass the id from host_list; names shown here for readability):
         details: {
           exitCode: result.exitCode,
           host: params.host,
+          host_label: hostLabel,
           ...(isError && { error: true }),
           ...(result.signal ? { signal: result.signal } : {}),
         },

--- a/src/tools/script-exec/host-script.ts
+++ b/src/tools/script-exec/host-script.ts
@@ -12,7 +12,7 @@ import { parseArgs, shellEscape } from "../infra/command-sets.js";
 import { validateNodeName, validatePodName, stdinExecCmd } from "../infra/exec-utils.js";
 import { resolvePodNetnsViaSsh } from "../infra/pod-netns-resolve.js";
 import { acquireSshTarget, sshExec, sshExecStream } from "../infra/ssh-client.js";
-import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "../infra/bg-session.js";
+import { backgroundPgidFile, wrapBackgroundSession, killRemoteSessionViaSsh } from "../infra/bg-session.js";
 
 interface HostScriptParams {
   host: string;
@@ -194,8 +194,7 @@ Examples (pass the id from host_list; names shown here for readability):
         // process group); the script body on stdin flows through to `timeout … bash -s`/`python3 -`.
         const pgidFile = backgroundPgidFile(toolCallId);
         const wrapped = wrapBackgroundSession(`timeout ${ttl} ${remoteCmd}`, pgidFile);
-        const killScript = backgroundSessionKillScript(pgidFile);
-        const onAbort = () => { void sshExec(target, killScript, { timeoutMs: 20_000 }).catch(() => {}); };
+        const onAbort = () => killRemoteSessionViaSsh({ target, pgidFile });
         try {
           const { jobId, outputFile } = bg!.executor!({
             streamFactory: () => sshExecStream(target, wrapped, { stdin: resolved.content }),
@@ -215,21 +214,38 @@ Examples (pass the id from host_list; names shown here for readability):
         }
       }
 
-      const timeout = Math.min(params.timeout_seconds ?? 180, 300) * 1000;
+      // ── Foreground mode ──────────────────────────────────────────────
+      // Run as a killable, `timeout`-bounded setsid session like the background path, and reap the
+      // remote group over a FRESH ssh connection on abort (closing the streaming channel does not
+      // reliably SIGHUP a non-PTY remote process). The script body still flows through stdin to the
+      // inner interpreter (`echo $$` consumes no stdin). Mirrors host_exec foreground.
+      const cap = Math.min(params.timeout_seconds ?? 180, 300);
+      const timeout = cap * 1000;
+      const fgPgidFile = backgroundPgidFile(toolCallId);
+      const fgWrapped = wrapBackgroundSession(`timeout ${cap} ${remoteCmd}`, fgPgidFile);
+      const onFgAbort = () => killRemoteSessionViaSsh({ target, pgidFile: fgPgidFile });
+      signal?.addEventListener("abort", onFgAbort, { once: true });
 
       let result;
       try {
-        result = await sshExec(target, remoteCmd, {
+        result = await sshExec(target, fgWrapped, {
           timeoutMs: timeout,
           signal,
           stdin: resolved.content,
         });
       } catch (err) {
+        // The SSH path rejects with Error("Aborted") on abort — return a clean stop, not a
+        // spurious connection error (the post-try abort check is unreachable on the reject path).
+        if (signal?.aborted) {
+          return { content: [{ type: "text", text: "Aborted." }], details: { error: true } };
+        }
         const msg = err instanceof Error ? err.message : String(err);
         return {
           content: [{ type: "text", text: `Error: ${msg}\n\nSSH connection to "${params.host}" failed (a connection failure, not a script error). If "${params.host}" is a Kubernetes node, retry this script with node_script (debug pod, no SSH).` }],
           details: { error: true, reason: "ssh_exec_failed", host: params.host },
         };
+      } finally {
+        signal?.removeEventListener("abort", onFgAbort);
       }
 
       if (signal?.aborted) {

--- a/src/tools/script-exec/node-script.test.ts
+++ b/src/tools/script-exec/node-script.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("../infra/script-resolver.js", () => ({ resolveScript: vi.fn() }));
 vi.mock("../infra/k8s-checks.js", () => ({ checkNodeReady: vi.fn() }));
-vi.mock("../infra/debug-pod.js", () => ({ runInDebugPod: vi.fn() }));
+vi.mock("../infra/debug-pod.js", () => ({
+  runInDebugPod: vi.fn(),
+  ensureDebugPodReady: vi.fn(async () => ({ podName: "node-debug-x", namespace: "siclaw-debug" })),
+  acquireDebugPod: vi.fn(() => "node-debug-x"),
+  releaseDebugPod: vi.fn(),
+}));
 vi.mock("../infra/kubeconfig-resolver.js", () => ({
   resolveRequiredKubeconfig: vi.fn(() => ({ path: "/tmp/kc" })),
   resolveDebugImage: vi.fn(() => "debug:latest"),

--- a/src/tools/script-exec/node-script.ts
+++ b/src/tools/script-exec/node-script.ts
@@ -1,7 +1,5 @@
 import type { ToolEntry, BackgroundExecWiring } from "../../core/tool-registry.js";
 import { Type } from "@sinclair/typebox";
-import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import type { KubeconfigRef } from "../../core/types.js";
@@ -22,6 +20,7 @@ import {
 import { resolvePodNetnsViaKubectl, validateNetnsName } from "../infra/pod-netns-resolve.js";
 import { postExecSecurity } from "../infra/security-pipeline.js";
 import { runInDebugPod, ensureDebugPodReady, acquireDebugPod, releaseDebugPod } from "../infra/debug-pod.js";
+import { backgroundPgidFile, wrapBackgroundSession, killRemoteSessionViaKubectl } from "../infra/bg-session.js";
 import { resolveRequiredKubeconfig, resolveDebugImage } from "../infra/kubeconfig-resolver.js";
 import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
 
@@ -224,7 +223,6 @@ Examples:
         : baseCmd;
 
       const NSENTER = ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--"];
-      const nsenterCmd = [...NSENTER, "sh", "-c", innerCmd];
 
       // ── Background mode ──────────────────────────────────────────────
       // Mirror node_exec's background path (ensure + pin a debug pod, record the remote PGID
@@ -234,10 +232,11 @@ Examples:
       if (backgroundEnabled && params.run_in_background === true) {
         const cfg = loadConfig();
         const ttl = Math.min(params.timeout_seconds ?? cfg.debugPodTTL, cfg.debugPodTTL);
-        const safeJob = toolCallId.replace(/[^A-Za-z0-9_-]/g, "_");
-        const pgidFile = `/tmp/siclaw-bg-${safeJob}-${randomBytes(4).toString("hex")}.pgid`;
-        const launchScript = `echo $$ > ${pgidFile}; exec timeout ${ttl} ${innerCmd}`;
-        const bgNsenterCmd = [...NSENTER, "setsid", "-w", "sh", "-c", launchScript];
+        // Killable setsid session + remote `timeout` backstop, reaped by SESSION id over a fresh
+        // kubectl exec on job_stop — the SAME helpers node_exec uses (one reap mechanism). The
+        // script body flows through stdin (`echo $$` consumes none).
+        const pgidFile = backgroundPgidFile(toolCallId);
+        const bgNsenterCmd = [...NSENTER, "sh", "-c", wrapBackgroundSession(`timeout ${ttl} ${innerCmd}`, pgidFile)];
         const spec = { userId: userId ?? "unknown", nodeName, command: bgNsenterCmd, image, clusterKey };
         let cachedPod;
         try {
@@ -255,19 +254,14 @@ Examples:
             details: { error: true, reason: "debug_pod_gone" },
           };
         }
-        const killScript = `pgid=""; for i in 1 2 3; do pgid=$(cat ${pgidFile} 2>/dev/null); [ -n "$pgid" ] && break; sleep 1; done; if [ -n "$pgid" ]; then kill -TERM -"$pgid" 2>/dev/null; sleep 1; kill -KILL -"$pgid" 2>/dev/null; fi; rm -f ${pgidFile}`;
-        const onAbort = () => {
-          try {
-            const killer = spawn(
-              "kubectl",
-              [...env.kubeconfigArgs, "-n", cachedPod!.namespace, "exec", cachedPod!.podName, "--", ...NSENTER, "sh", "-c", killScript],
-              { env: env.childEnv as Record<string, string>, detached: true },
-            );
-            killer.on("error", () => {});
-            setTimeout(() => { try { killer.kill("SIGKILL"); } catch { /* gone */ } }, 15_000).unref();
-            killer.unref();
-          } catch { /* best-effort */ }
-        };
+        const onAbort = () => killRemoteSessionViaKubectl({
+          kubeconfigArgs: env.kubeconfigArgs,
+          childEnv: env.childEnv as Record<string, string>,
+          namespace: cachedPod!.namespace,
+          podName: cachedPod!.podName,
+          nsenterPrefix: NSENTER,
+          pgidFile,
+        });
         try {
           const { jobId, outputFile } = bg!.executor!({
             file: "kubectl",
@@ -291,11 +285,42 @@ Examples:
         }
       }
 
-      const execResult = await runInDebugPod(
-        { userId: userId ?? "unknown", nodeName, command: nsenterCmd, image, clusterKey, stdinData: resolved.content },
-        env,
-        { timeoutMs: timeout, signal },
-      );
+      // ── Foreground mode ──────────────────────────────────────────────
+      // Run the host-namespace script as a killable setsid session wrapped in `timeout <cap>` and
+      // PIN the debug pod for the duration, then reap the remote group over a fresh kubectl exec on
+      // abort — mirrors node_exec foreground (kubectl exec does not propagate kill to a
+      // host-namespace process). The script body still streams via stdin.
+      const cap = Math.round(timeout / 1000);
+      const fgPgidFile = backgroundPgidFile(toolCallId);
+      const fgNsenterCmd = [...NSENTER, "sh", "-c", wrapBackgroundSession(`timeout ${cap} ${innerCmd}`, fgPgidFile)];
+      const fgSpec = { userId: userId ?? "unknown", nodeName, command: fgNsenterCmd, image, clusterKey, stdinData: resolved.content };
+      let fgPod;
+      try {
+        fgPod = await ensureDebugPodReady(fgSpec, env, { signal });
+      } catch (err: any) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ error: true, message: `Debug pod failed to start: ${err?.message ?? String(err)}` }) }],
+          details: { error: true, reason: "debug_pod_failed" },
+        };
+      }
+      const fgPinnedPodName = acquireDebugPod(fgSpec); // null if the pod vanished; proceed best-effort
+      const onFgAbort = () => killRemoteSessionViaKubectl({
+        kubeconfigArgs: env.kubeconfigArgs,
+        childEnv: env.childEnv as Record<string, string>,
+        namespace: fgPod!.namespace,
+        podName: fgPod!.podName,
+        nsenterPrefix: NSENTER,
+        pgidFile: fgPgidFile,
+      });
+      signal?.addEventListener("abort", onFgAbort, { once: true });
+
+      let execResult;
+      try {
+        execResult = await runInDebugPod(fgSpec, env, { timeoutMs: timeout, signal });
+      } finally {
+        signal?.removeEventListener("abort", onFgAbort);
+        if (fgPinnedPodName) releaseDebugPod(fgSpec, fgPinnedPodName);
+      }
 
       if (signal?.aborted) {
         return {


### PR DESCRIPTION
Two commits.

## 1) fix(stop): make the Stop button truly stop everything a session runs

Clicking the dialog Stop should halt the live turn, its background jobs, and any foreground exec — and reflect that in the UI.

- **Background jobs**: `/abort` only called `brain.abort()` (live turn + foreground tools/sub-agents); `run_in_background` jobs are decoupled. Added `stopSessionJobs()` (called from `/abort`) which calls `JobRegistry.stopJob` on every running job.
- **Terminal stop**: user-stopped jobs are marked `suppressNotifyTurn` — the card folds to "stopped" but the model is NOT woken by a synthetic turn to react to its own cancellation (the "comes back to life after Stop"). The model's own `job_stop` is unchanged.
- **Foreground orphan**: `node_exec`/`host_exec` foreground only killed the local kubectl/ssh client, which does not propagate to a host-namespace (`nsenter -t 1`) or non-PTY ssh process. They now run as a `setsid` + `timeout` killable session and reap the remote group over a FRESH connection on abort (`killRemoteSessionViaKubectl`/`ViaSsh`); node_exec foreground PINS the debug pod so it cannot be idle-evicted mid-exec; node_exec background is unified onto the same `pkill -s` helpers. `pod_exec` threads `signal` and returns a clean `Aborted.`.
- **Stuck UI**: `sse-consumer` finalizes un-ended tool rows as stopped (preserving toolName/toolInput) and persists partial assistant text on abort; `persistSyntheticMessage` now writes a terminal `outcome` — a successful tool in a background-completion turn was stored with `outcome=null`, which the frontend rendered as a forever "running"/Thinking… card on refresh. The frontend maps `metadata.status` stopped to `"aborted"`, guards the wholesale-replace refetch pollers, and no longer bounces the sent message back into the input.

## 2) fix(ui): show resolved host name in host_exec/host_script cards (not the id)

The model passes an opaque host id, and `formatToolInput` had no `host_exec` case, so the card showed a bare UUID and hid the command. `acquireSshTarget` now carries `HostMeta.name` on `SshTarget.name`; the tools put it in result details as `host_label` (persisted to tool metadata); `formatToolInput` reads it and renders `<name> $ <command>` like node_exec, falling back to the id. Model behavior is unchanged (still uses the unambiguous id).

## Tests
tsc (root + portal-web) clean; `npm test` green (171 files / 3365 tests) plus portal-web vitest green. Deployed to siclaw-inner and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
