### PR TITLE
Refine chat selection export controls

### DIFF
--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -34,9 +34,8 @@ import { downloadBlob } from "./svg-export"
 import { serializeMessagesToText, serializeMessagesToMarkdown, stripVisualizationFences, stripImageData } from "./transcript"
 import {
   EMPTY_SELECTION,
-  selectVisible,
+  toggleFollowing,
   toggleMessage,
-  selectAll as selectAllMessages,
   selectedIds as computeSelectedIds,
   type SelectionState,
 } from "./selection-model"
@@ -351,6 +350,7 @@ export function PilotArea({
 }: PilotAreaProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const selectBoundaryRef = useRef<HTMLDivElement>(null)
   const prevMsgCountRef = useRef(0)
   const userScrolledAwayRef = useRef(false)
   const needsScrollOnLoadRef = useRef(false)
@@ -444,7 +444,7 @@ export function PilotArea({
     [messages],
   )
   const hasVisibleMessages = renderMessages.length > 0
-  // The exact list rendered as rows, in order. Scroll-selection indexes into
+  // The exact list rendered as rows, in order. Range selection indexes into
   // this same list, so a row's data-msg-idx always maps back to the right message.
   const selectableMessages = renderMessages
   const latestEditableUserMessageId = useMemo(() => {
@@ -475,10 +475,9 @@ export function PilotArea({
     setEditingDraft("")
   }, [editingDraft, isLoading, wrappedSendMessage])
 
-  // --- Scroll-to-select copy ---
-  // Click a message to anchor, scroll to paint a contiguous band over the
-  // messages you pass, fine-tune with checkboxes, then copy the lot (images and
-  // all). See selection-model.ts for the pure state rules.
+  // --- Range selection copy ---
+  // Click the sticky "Select following" boundary to select a loaded message range,
+  // fine-tune with checkboxes, then copy/download the lot (images and all).
   const [selectMode, setSelectMode] = useState(false)
   const [selection, setSelection] = useState<SelectionState>(EMPTY_SELECTION)
   const selectModeRef = useRef(false)
@@ -504,32 +503,24 @@ export function PilotArea({
     setSelection((s) => toggleMessage(s, id))
   }, [])
 
-  // Scroll-to-select via IntersectionObserver: while in select mode, every
-  // message row that enters the viewport is auto-checked (accumulating, either
-  // scroll direction). The observer fires only on actual visibility changes —
-  // no per-scroll-event layout scans of the whole list — and its initial
-  // callback covers whatever is already on screen when select mode turns on.
-  useEffect(() => {
-    if (!selectMode) return
+  const getBoundaryStartIndex = useCallback(() => {
     const container = scrollContainerRef.current
-    if (!container) return
-    const visible = new Set<string>()
-    const io = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          const id = (entry.target as HTMLElement).getAttribute("data-msg-id")
-          if (!id) continue
-          if (entry.isIntersecting) visible.add(id)
-          else visible.delete(id)
-        }
-        setSelection((s) => selectVisible(s, [...visible]))
-      },
-      { root: container, threshold: 0 },
-    )
-    container.querySelectorAll<HTMLElement>("[data-msg-id]").forEach((row) => io.observe(row))
-    return () => io.disconnect()
-    // Re-observe when the rendered list changes so new rows are tracked too.
-  }, [selectMode, selectableMessages])
+    if (!container) return 0
+
+    const boundaryBottom = selectBoundaryRef.current?.getBoundingClientRect().bottom
+      ?? container.getBoundingClientRect().top
+    const rows = Array.from(container.querySelectorAll<HTMLElement>("[data-msg-id]"))
+    const firstBelowBoundary = rows.find((row) => row.getBoundingClientRect().bottom > boundaryBottom + 4)
+    const id = firstBelowBoundary?.getAttribute("data-msg-id")
+    const index = id ? selectableMessages.findIndex((m) => m.id === id) : selectableMessages.length
+    return index >= 0 ? index : 0
+  }, [selectableMessages])
+
+  const handleToggleFollowingBoundary = useCallback(() => {
+    const startIndex = getBoundaryStartIndex()
+    const ids = selectableMessages.map((m) => m.id)
+    setSelection((s) => toggleFollowing(ids, startIndex, s))
+  }, [getBoundaryStartIndex, selectableMessages])
 
   const selectedIdSet = useMemo(() => computeSelectedIds(selection), [selection])
   const selectedCount = selectedIdSet.size
@@ -556,24 +547,29 @@ export function PilotArea({
     const selected = selectableMessages.filter((m) => selectedIdSet.has(m.id))
     const base = `siclaw-chat-${selected.length}-messages`
 
-    // 1) Markdown — content verbatim, charts kept as ```chart spec blocks
-    //    (compact chart data; the HTML carries the rendered colour image).
-    const md = serializeMessagesToMarkdown(selected)
-    downloadBlob(new Blob([md], { type: "text/markdown;charset=utf-8" }), `${base}.md`)
-
-    // 2) Self-contained HTML — buildCopyHtml rasterizes charts/Mermaid to <img>,
-    //    which browsers always render, so double-clicking the .html shows them.
+    // Prefer one file per click: HTML when the rendered selection contains
+    // visuals, Markdown for plain text/tool transcripts.
     const container = scrollContainerRef.current
     if (container) {
-      const rowById = new Map(
-        Array.from(container.querySelectorAll<HTMLElement>("[data-msg-id]")).map(
-          (r) => [r.getAttribute("data-msg-id"), r] as const,
-        ),
-      )
-      const els = selected.map((m) => rowById.get(m.id)).filter((r): r is HTMLElement => !!r)
-      const { html } = await buildCopyHtml(els)
-      downloadBlob(new Blob([wrapChatHtml(html)], { type: "text/html;charset=utf-8" }), `${base}.html`)
+      try {
+        const rowById = new Map(
+          Array.from(container.querySelectorAll<HTMLElement>("[data-msg-id]")).map(
+            (r) => [r.getAttribute("data-msg-id"), r] as const,
+          ),
+        )
+        const els = selected.map((m) => rowById.get(m.id)).filter((r): r is HTMLElement => !!r)
+        const { html, hasVisual } = await buildCopyHtml(els)
+        if (hasVisual) {
+          downloadBlob(new Blob([wrapChatHtml(html)], { type: "text/html;charset=utf-8" }), `${base}.html`)
+          return
+        }
+      } catch (err) {
+        console.warn("[download] rich HTML export failed, falling back to Markdown:", err)
+      }
     }
+
+    const md = serializeMessagesToMarkdown(selected)
+    downloadBlob(new Blob([md], { type: "text/markdown;charset=utf-8" }), `${base}.md`)
   }, [selectedIdSet, selectableMessages])
 
   // Auto-scroll logic
@@ -604,8 +600,7 @@ export function PilotArea({
     prevMsgCountRef.current = messages.length
   }, [messages, scrollToBottom])
 
-  // Detect user scrolling away (scroll-to-select is handled by the
-  // IntersectionObserver above, not here).
+  // Detect user scrolling away.
   const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current
     if (!container) return
@@ -638,29 +633,14 @@ export function PilotArea({
       {selectMode && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 rounded-full border border-border bg-card/95 px-3 py-1.5 shadow-md shadow-black/10 backdrop-blur">
           <span className="text-xs font-medium text-foreground whitespace-nowrap">
-            {selectedCount > 0 ? `${selectedCount} selected` : "Scroll to select on-screen messages"}
+            {selectedCount > 0 ? `${selectedCount} selected` : "Use top boundary"}
           </span>
           <div className="h-3.5 w-px bg-border" />
           <button
             type="button"
-            onClick={() => setSelection(selectAllMessages(selectableMessages.map((m) => m.id)))}
-            className="px-2 py-0.5 rounded-md border border-border bg-secondary/40 text-xs font-medium text-foreground hover:bg-secondary transition-colors"
-          >
-            All
-          </button>
-          <button
-            type="button"
-            onClick={() => setSelection(EMPTY_SELECTION)}
-            disabled={selectedCount === 0}
-            className="px-2 py-0.5 rounded-md border border-border bg-secondary/40 text-xs font-medium text-foreground hover:bg-secondary transition-colors disabled:opacity-40 disabled:hover:bg-secondary/40"
-          >
-            Clear
-          </button>
-          <button
-            type="button"
             onClick={downloadSelection}
             disabled={selectedCount === 0}
-            title="Download selected as Markdown + HTML"
+            title="Download selected (HTML for visuals, Markdown otherwise)"
             className="flex items-center rounded-md border border-border bg-secondary/40 p-1 text-foreground hover:bg-secondary transition-colors disabled:opacity-40 disabled:hover:bg-secondary/40"
           >
             <Download className="h-4 w-4" />
@@ -719,6 +699,27 @@ export function PilotArea({
                 </div>
               )}
 
+              {selectMode && selectableMessages.length > 0 && (
+                <div
+                  ref={selectBoundaryRef}
+                  data-copy-ignore
+                  className="pointer-events-none sticky top-14 z-20 ml-8 flex items-center gap-2 bg-card/90 py-2 pr-2 backdrop-blur"
+                >
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleToggleFollowingBoundary()
+                    }}
+                    className="pointer-events-auto shrink-0 rounded-full border border-border bg-card/95 px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground shadow-sm transition-colors hover:bg-secondary hover:text-foreground"
+                    title="Toggle this boundary and following messages"
+                  >
+                    Select following
+                  </button>
+                  <div className="h-px flex-1 bg-border/70" />
+                </div>
+              )}
+
               {selectableMessages.map((msg) => {
                 const childSessionId = msg.metadata?.kind === "delegation_event"
                   ? (msg.metadata as Record<string, unknown>).child_session_id
@@ -726,80 +727,81 @@ export function PilotArea({
                 const subStatus = (msg.metadata as Record<string, unknown> | undefined)?.status
                 const selected = selectMode && selectedIdSet.has(msg.id)
                 return (
-                <div
-                  key={msg.id}
-                  data-msg-id={msg.id}
-                  data-msg-role={msg.role}
-                  onClick={selectMode ? () => handleToggleMessage(msg.id) : undefined}
-                  className={cn(
-                    "relative rounded-xl transition-colors",
-                    // No row-level highlight — the checkbox alone signals selection.
-                    selectMode && "cursor-pointer px-2 -mx-2 py-1 hover:bg-secondary/30",
-                  )}
-                >
-                  {selectMode && (
-                    <button
-                      type="button"
-                      data-copy-ignore
-                      title={selected ? "Deselect" : "Select"}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        handleToggleMessage(msg.id)
-                      }}
-                      className="absolute left-1.5 top-1.5 z-10 text-muted-foreground hover:text-foreground transition-colors"
-                    >
-                      {selected ? (
-                        <span className="flex h-3.5 w-3.5 items-center justify-center rounded-[4px] bg-blue-500 text-white">
-                          <Check className="h-2.5 w-2.5" strokeWidth={3} />
-                        </span>
-                      ) : (
-                        <Square className="h-3.5 w-3.5" />
+                  <div key={msg.id}>
+                    <div
+                      data-msg-id={msg.id}
+                      data-msg-role={msg.role}
+                      onClick={selectMode ? () => handleToggleMessage(msg.id) : undefined}
+                      className={cn(
+                        "relative rounded-xl transition-colors",
+                        // No row-level highlight — the checkbox alone signals selection.
+                        selectMode && "cursor-pointer px-2 -mx-2 py-1 hover:bg-secondary/30",
                       )}
-                    </button>
-                  )}
-                  <div className={cn(selectMode && "pl-8 pointer-events-none select-none")}>
-                    <MessageItem
-                      message={msg}
-                      sendMessage={wrappedSendMessage}
-                      showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
-                      dpActive={dpActive}
-                      canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
-                      editingContent={editingMessageId === msg.id ? editingDraft : null}
-                      onStartEditMessage={startEditingMessage}
-                      onEditMessageChange={setEditingDraft}
-                      onCancelEditMessage={cancelEditingMessage}
-                      onSubmitEditMessage={submitEditedMessage}
-                      onChipClick={(chip, meta) => {
-                        if (meta.isDpCheckpoint) {
-                          const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
-                          if (prefixChip) {
-                            setActivePrefix(prefixChip)
-                            setChipDraft(null)
-                            return
-                          }
-                        }
-                        setChipSeq((s) => s + 1)
-                        setChipDraft(chip.insertText + " ")
-                      }}
-                      onOpenSkillPanel={onOpenSkillPanel}
-                      onOpenSchedulePanel={onOpenSchedulePanel}
-                      agentId={agentId}
-                    />
-                    {typeof childSessionId === "string" && onOpenSubagent && (
-                      <div className="pl-12 -mt-1 mb-2">
+                    >
+                      {selectMode && (
                         <button
                           type="button"
-                          onClick={() => onOpenSubagent(childSessionId as string, typeof subStatus === "string" ? subStatus : undefined, "Sub-agent")}
-                          className="text-[11px] text-blue-400 hover:text-blue-300 hover:underline underline-offset-2"
+                          data-copy-ignore
+                          title={selected ? "Deselect" : "Select"}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleToggleMessage(msg.id)
+                          }}
+                          className="absolute left-1.5 top-1.5 z-10 text-muted-foreground hover:text-foreground transition-colors"
                         >
-                          View sub-agent transcript →
+                          {selected ? (
+                            <span className="flex h-3.5 w-3.5 items-center justify-center rounded-[4px] bg-blue-500 text-white">
+                              <Check className="h-2.5 w-2.5" strokeWidth={3} />
+                            </span>
+                          ) : (
+                            <Square className="h-3.5 w-3.5" />
+                          )}
                         </button>
+                      )}
+                      <div className={cn(selectMode && "pl-8 pointer-events-none select-none")}>
+                        <MessageItem
+                          message={msg}
+                          sendMessage={wrappedSendMessage}
+                          showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
+                          dpActive={dpActive}
+                          canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
+                          editingContent={editingMessageId === msg.id ? editingDraft : null}
+                          onStartEditMessage={startEditingMessage}
+                          onEditMessageChange={setEditingDraft}
+                          onCancelEditMessage={cancelEditingMessage}
+                          onSubmitEditMessage={submitEditedMessage}
+                          onChipClick={(chip, meta) => {
+                            if (meta.isDpCheckpoint) {
+                              const prefixChip = DP_CHECKPOINT_PREFIX_CHIPS[chip.insertText.toUpperCase()]
+                              if (prefixChip) {
+                                setActivePrefix(prefixChip)
+                                setChipDraft(null)
+                                return
+                              }
+                            }
+                            setChipSeq((s) => s + 1)
+                            setChipDraft(chip.insertText + " ")
+                          }}
+                          onOpenSkillPanel={onOpenSkillPanel}
+                          onOpenSchedulePanel={onOpenSchedulePanel}
+                          agentId={agentId}
+                        />
+                        {typeof childSessionId === "string" && onOpenSubagent && (
+                          <div className="pl-12 -mt-1 mb-2">
+                            <button
+                              type="button"
+                              onClick={() => onOpenSubagent(childSessionId as string, typeof subStatus === "string" ? subStatus : undefined, "Sub-agent")}
+                              className="text-[11px] text-blue-400 hover:text-blue-300 hover:underline underline-offset-2"
+                            >
+                              View sub-agent transcript →
+                            </button>
+                          </div>
+                        )}
                       </div>
-                    )}
+                    </div>
                   </div>
-                </div>
                 )
-                })}
+              })}
 
               {/* Dig deeper — shown when agent produced a conclusion and user may want
                   to trace the root cause upstream. Hidden while a prefix chip is active. */}

--- a/portal-web/src/components/chat/selection-model.test.ts
+++ b/portal-web/src/components/chat/selection-model.test.ts
@@ -2,52 +2,49 @@ import { describe, it, expect } from "vitest"
 import {
   EMPTY_SELECTION,
   isSelected,
-  selectVisible,
+  selectFollowing,
   toggleMessage,
-  selectAll,
+  toggleFollowing,
   selectedIds,
   selectedCount,
 } from "./selection-model"
 
 const ids = (s: Parameters<typeof selectedIds>[0]) => [...selectedIds(s)].sort()
 
-describe("selection-model (visibility accumulate)", () => {
+describe("selection-model (explicit following range)", () => {
   it("selects nothing by default", () => {
     expect(selectedCount(EMPTY_SELECTION)).toBe(0)
   })
 
-  it("auto-selects whatever is currently visible", () => {
-    const s = selectVisible(EMPTY_SELECTION, ["b", "c"])
+  it("selects all loaded messages from the chosen divider", () => {
+    const s = selectFollowing(["a", "b", "c", "d"], 2)
+    expect(ids(s)).toEqual(["c", "d"])
+  })
+
+  it("clamps out-of-range dividers", () => {
+    expect(ids(selectFollowing(["a", "b"], -1))).toEqual(["a", "b"])
+    expect(ids(selectFollowing(["a", "b"], 99))).toEqual([])
+  })
+
+  it("replacing the range clears previous manual exclusions", () => {
+    let s = selectFollowing(["a", "b", "c"], 0)
+    s = toggleMessage(s, "b")
+    expect(ids(s)).toEqual(["a", "c"])
+    s = selectFollowing(["a", "b", "c"], 1)
     expect(ids(s)).toEqual(["b", "c"])
   })
 
-  it("accumulates as new messages scroll into view (up or down)", () => {
-    let s = selectVisible(EMPTY_SELECTION, ["c", "d"]) // initial screenful
-    s = selectVisible(s, ["d", "e"]) // scroll down
-    s = selectVisible(s, ["a", "b"]) // scroll up past the start
-    expect(ids(s)).toEqual(["a", "b", "c", "d", "e"])
-  })
-
-  it("returns the same state object when nothing new becomes visible", () => {
-    const s = selectVisible(EMPTY_SELECTION, ["a", "b"])
-    expect(selectVisible(s, ["a", "b"])).toBe(s)
-  })
-
-  it("un-checking excludes a message and scrolling past it won't re-select it", () => {
-    let s = selectVisible(EMPTY_SELECTION, ["a", "b", "c"])
-    s = toggleMessage(s, "b") // user un-checks b
+  it("un-checking excludes a message from the current range", () => {
+    let s = selectFollowing(["a", "b", "c"], 0)
+    s = toggleMessage(s, "b")
     expect(ids(s)).toEqual(["a", "c"])
-    s = selectVisible(s, ["a", "b", "c"]) // scroll past b again
-    expect(ids(s)).toEqual(["a", "c"]) // stays excluded
   })
 
   it("re-checking clears the exclusion", () => {
-    let s = selectVisible(EMPTY_SELECTION, ["a"])
+    let s = selectFollowing(["a"], 0)
     s = toggleMessage(s, "a") // off
     expect(isSelected(s, "a")).toBe(false)
     s = toggleMessage(s, "a") // on again
-    expect(isSelected(s, "a")).toBe(true)
-    s = selectVisible(s, ["a"]) // and stays on while visible
     expect(isSelected(s, "a")).toBe(true)
   })
 
@@ -56,12 +53,16 @@ describe("selection-model (visibility accumulate)", () => {
     expect(ids(s)).toEqual(["z"])
   })
 
-  it("selectAll selects all and resets exclusions", () => {
-    let s = selectVisible(EMPTY_SELECTION, ["a"])
-    s = toggleMessage(s, "a") // exclude a
-    s = selectAll(["a", "b", "c"])
+  it("toggleFollowing clears when the same range is already selected", () => {
+    let s = toggleFollowing(["a", "b", "c"], 1, EMPTY_SELECTION)
+    expect(ids(s)).toEqual(["b", "c"])
+    s = toggleFollowing(["a", "b", "c"], 1, s)
+    expect(ids(s)).toEqual([])
+  })
+
+  it("toggleFollowing replaces a previous range", () => {
+    let s = toggleFollowing(["a", "b", "c"], 1, EMPTY_SELECTION)
+    s = toggleFollowing(["a", "b", "c"], 0, s)
     expect(ids(s)).toEqual(["a", "b", "c"])
-    // exclusion cleared: scrolling keeps everything
-    expect(selectVisible(s, ["a", "b", "c"])).toBe(s)
   })
 })

--- a/portal-web/src/components/chat/selection-model.ts
+++ b/portal-web/src/components/chat/selection-model.ts
@@ -1,18 +1,14 @@
 /**
- * Pure state model for scroll-to-select message copying.
+ * Pure state model for message-range copying.
  *
- * Auto-select by visibility: in select mode, every message that is (or scrolls)
- * into the viewport is selected automatically — no clicking. Selection
- * accumulates as you scroll up or down, so you "paint" a range just by scrolling
- * through it (mouse wheel or scrollbar, either direction). Checkboxes still let
- * you fine-tune: un-checking a message records it in `excluded` so a later scroll
- * past it won't re-select it.
+ * Selection starts from one sticky "Select following" boundary, then checkboxes
+ * let the user fine-tune individual messages.
  */
 
 export interface SelectionState {
   /** Currently selected message ids. */
   selected: ReadonlySet<string>
-  /** Ids the user explicitly un-checked — never auto-re-selected on scroll. */
+  /** Ids the user explicitly removed from the current selected range. */
   excluded: ReadonlySet<string>
 }
 
@@ -22,26 +18,26 @@ export function isSelected(state: SelectionState, id: string): boolean {
   return state.selected.has(id)
 }
 
-/**
- * Auto-select every currently-visible id, skipping ones the user un-checked.
- * Returns the SAME state object when nothing changed, so React skips the
- * re-render — cheap to call on every scroll tick.
- */
-export function selectVisible(state: SelectionState, visibleIds: readonly string[]): SelectionState {
-  let added = false
-  const selected = new Set(state.selected)
-  for (const id of visibleIds) {
-    if (state.excluded.has(id) || selected.has(id)) continue
-    selected.add(id)
-    added = true
-  }
-  return added ? { selected, excluded: state.excluded } : state
+/** Select a contiguous loaded range from `startIndex` through the end. */
+export function selectFollowing(ids: readonly string[], startIndex: number): SelectionState {
+  const safeStart = Math.max(0, Math.min(startIndex, ids.length))
+  return { selected: new Set(ids.slice(safeStart)), excluded: new Set() }
 }
 
 /**
- * Toggle one message via its checkbox (or a click on the bubble). Un-checking
- * records the id in `excluded` so scrolling past it again won't re-select it;
- * re-checking clears that.
+ * Toggle the current boundary range: selecting a new boundary replaces the
+ * range, while clicking the same fully-selected range clears it.
+ */
+export function toggleFollowing(ids: readonly string[], startIndex: number, state: SelectionState): SelectionState {
+  const next = selectFollowing(ids, startIndex)
+  if (sameSelectedIds(next.selected, state.selected)) return EMPTY_SELECTION
+  return next
+}
+
+/**
+ * Toggle one message via its checkbox (or a click on the bubble). Exclusions are
+ * kept so the state still records which selected range items were manually
+ * removed.
  */
 export function toggleMessage(state: SelectionState, id: string): SelectionState {
   const selected = new Set(state.selected)
@@ -56,15 +52,18 @@ export function toggleMessage(state: SelectionState, id: string): SelectionState
   return { selected, excluded }
 }
 
-/** Select every message (toolbar "All"); clears any manual exclusions. */
-export function selectAll(ids: readonly string[]): SelectionState {
-  return { selected: new Set(ids), excluded: new Set() }
-}
-
 export function selectedIds(state: SelectionState): Set<string> {
   return new Set(state.selected)
 }
 
 export function selectedCount(state: SelectionState): number {
   return state.selected.size
+}
+
+function sameSelectedIds(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false
+  for (const id of a) {
+    if (!b.has(id)) return false
+  }
+  return true
 }


### PR DESCRIPTION
## Summary
- replace scroll-to-select with a single sticky Select following boundary
- remove All/Clear from the selection toolbar and make the boundary toggle the current range
- export one file per download: HTML when the rendered selection contains visuals, Markdown otherwise

## Validation
- npx vitest run src/components/chat/selection-model.test.ts src/components/chat/transcript.test.ts
- npx tsc --noEmit --pretty false
- npm run build