### PR TITLE
feat(bg-jobs): status-aware background output (task_output tool + eager file + GC)

### DIFF
--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -26,6 +26,7 @@ import type {
   SpawnSubagentStatus,
   JobStopExecutor,
   BackgroundExecExecutor,
+  TaskOutputReader,
   AgentMode,
 } from "../core/tool-registry.js";
 import { getSubagentType, DEFAULT_SUBAGENT_TYPE, getSubagentConcurrency, getSubagentMaxRuntimeMs, getBackgroundBashConcurrency } from "../core/subagent-registry.js";
@@ -368,6 +369,11 @@ export class AgentBoxSessionManager {
   private createJobStopExecutor(): JobStopExecutor {
     // Shared stop logic lives on JobRegistry (same as the TUI path).
     return async (jobId) => this.jobs.stopJob(jobId);
+  }
+
+  private createTaskOutputReader(): TaskOutputReader {
+    // Snapshot the job's live status so task_output can report running/terminal (same as TUI).
+    return (jobId) => this.jobs.snapshot(jobId);
   }
 
   /**
@@ -1427,6 +1433,7 @@ export class AgentBoxSessionManager {
       spawnSubagentExecutor: this.createSpawnSubagentExecutor(),
       jobStopExecutor: this.createJobStopExecutor(),
       backgroundExecExecutor: this.createBackgroundExecExecutor(),
+      taskOutputReader: this.createTaskOutputReader(),
     });
 
     // Populate sessionIdRef so skill_call events can associate with this session

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -221,6 +221,7 @@ const buildSiclawOpts = (sm: SessionManager) => ({
   // stay TUI-unavailable; that needs the agentbox child-session machinery.)
   backgroundExecExecutor: tuiBackgroundHost.createBackgroundExecExecutor(),
   jobStopExecutor: tuiBackgroundHost.createJobStopExecutor(),
+  taskOutputReader: tuiBackgroundHost.createTaskOutputReader(),
 });
 
 const { brain, session, services, extensionsResult, modelFallbackMessage, customTools, skillsDirs, memoryIndexer, mcpManager } =

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -115,6 +115,8 @@ export interface CreateSiclawSessionOpts {
   jobStopExecutor?: import("./tool-registry.js").JobStopExecutor;
   /** Runtime bridge that launches a background bash command. Injected by agentbox / TUI host. */
   backgroundExecExecutor?: import("./tool-registry.js").BackgroundExecExecutor;
+  /** Runtime bridge that reads a background job's live status. Injected by agentbox / TUI host. */
+  taskOutputReader?: import("./tool-registry.js").TaskOutputReader;
 }
 
 export interface SiclawSessionResult {
@@ -393,6 +395,7 @@ export async function createSiclawSession(
       spawnSubagentExecutor: opts?.spawnSubagentExecutor,
       jobStopExecutor: opts?.jobStopExecutor,
       backgroundExecExecutor: opts?.backgroundExecExecutor,
+      taskOutputReader: opts?.taskOutputReader,
     },
     allowedTools,
     activeMode: opts?.activeMode ?? "normal",

--- a/src/core/background-bash-runner.test.ts
+++ b/src/core/background-bash-runner.test.ts
@@ -6,7 +6,7 @@ import { PassThrough } from "node:stream";
 import { reloadConfig } from "./config.js";
 import { JobRegistry } from "./job-registry.js";
 import { spawnBackgroundBash } from "./background-bash-runner.js";
-import { DiskTaskOutput, getTaskOutputDir, getTaskOutputPath, SanitizingLineBuffer } from "../tools/cmd-exec/disk-output.js";
+import { DiskTaskOutput, getTaskOutputDir, getTaskOutputPath, SanitizingLineBuffer, sweepStaleTaskOutputs } from "../tools/cmd-exec/disk-output.js";
 import type { BackgroundExecRequest } from "./tool-registry.js";
 import type { OutputAction } from "../tools/infra/output-sanitizer.js";
 
@@ -103,6 +103,25 @@ describe("spawnBackgroundBash", () => {
     // close handler must NOT overwrite "stopped" with "killed" — same terminal state as a
     // stopped sub-agent, so the notification the model sees is consistent across paths.
     expect(await done).toBe("stopped");
+  });
+
+  it("releases the live-writer guard when setup throws before settle is wired (no liveTaskOutputs leak)", async () => {
+    const jobs = new JobRegistry();
+    const jobId = `jthrow-${Math.random().toString(36).slice(2)}`;
+    // A non-line-safe action makes the SanitizingLineBuffer ctor throw inside spawnBackgroundBash,
+    // before settle() (the only caller of disk.markFinal()) is wired.
+    const nonLineSafe: OutputAction = { type: "sanitize", sanitize: (s) => s, lineSafe: false };
+    expect(() => spawnBackgroundBash(req({ jobId, action: nonLineSafe }), jobs, () => {})).toThrow();
+    // Let the eager-create settle, then prove the basename is NOT protected: a file at that path
+    // with an old mtime must be swept. If markFinal hadn't run in the catch, the guard would leak
+    // and the file would survive forever.
+    await new Promise((r) => setTimeout(r, 20));
+    const p = getTaskOutputPath(jobId);
+    fs.writeFileSync(p, "leftover");
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    fs.utimesSync(p, old, old);
+    await sweepStaleTaskOutputs(30 * 60 * 1000);
+    expect(fs.existsSync(p)).toBe(false);
   });
 });
 

--- a/src/core/background-bash-runner.ts
+++ b/src/core/background-bash-runner.ts
@@ -21,9 +21,15 @@ import {
   DiskTaskOutput,
   getTaskOutputPath,
   SanitizingLineBuffer,
+  sweepStaleTaskOutputs,
 } from "../tools/cmd-exec/disk-output.js";
 
 export type NotifyFn = (jobId: string, n: TaskNotification) => void;
+
+// Throttle the opportunistic stale-output GC: it's a 24h-granularity sweep, so running it on
+// EVERY launch (full readdir + stat per file) is pure waste. At most once per hour per process.
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+let lastSweepAt = 0;
 
 /**
  * Launch `req.command` detached, streaming sanitized output to disk. Registers the
@@ -42,8 +48,31 @@ export function spawnBackgroundBash(
   // One disk file, but a separate line buffer per stream so a partial (newline-less)
   // stdout line is never glued to the next stderr line.
   const disk = new DiskTaskOutput(req.jobId);
-  const outSink = new SanitizingLineBuffer(disk, req.action, req.hasSensitiveKubectl);
-  const errSink = new SanitizingLineBuffer(disk, req.action, req.hasSensitiveKubectl);
+  // Create the file NOW so reading `output_file` before any output exists yields an empty
+  // file (= "running, no output yet"), not ENOENT.
+  void disk.ensureCreated();
+  // Opportunistic GC of stale leftovers (throttled to once/hour). sweepStaleTaskOutputs
+  // self-protects every file with a live writer (process-wide, registry-independent), so a
+  // silent long-running job — including one owned by another session/agent sharing this dir —
+  // is never swept.
+  const now = Date.now();
+  if (now - lastSweepAt > SWEEP_INTERVAL_MS) {
+    lastSweepAt = now;
+    void sweepStaleTaskOutputs();
+  }
+  // SanitizingLineBuffer throws on a non-line-safe action (defense-in-depth) and spawn() below
+  // can throw synchronously. Either way settle() — the one place disk.markFinal() runs — was
+  // never wired, so release the live-writer guard here or the basename leaks in liveTaskOutputs
+  // forever (its file would also never become GC-eligible).
+  let outSink: SanitizingLineBuffer;
+  let errSink: SanitizingLineBuffer;
+  try {
+    outSink = new SanitizingLineBuffer(disk, req.action, req.hasSensitiveKubectl);
+    errSink = new SanitizingLineBuffer(disk, req.action, req.hasSensitiveKubectl);
+  } catch (err) {
+    disk.markFinal();
+    throw err;
+  }
   const flushAll = async () => {
     try {
       await Promise.all([outSink.flush(), errSink.flush()]);
@@ -60,6 +89,7 @@ export function spawnBackgroundBash(
     if (settled) return;
     settled = true;
     await flushAll();
+    disk.markFinal(); // writer done — release it from the stale-output sweep's live-writer guard
     jobs.setStatus(req.jobId, status, code != null ? { exitCode: code } : undefined);
     // Per-job cleanup (node_exec unpins its debug pod) — before notify so the pod is
     // released even if notify throws. Independent of onSettled (parent work-count).
@@ -140,10 +170,16 @@ export function spawnBackgroundBash(
   //  - argv (node/pod): spawn the kubectl-exec binary + args WITHOUT a shell, so the
   //    nested `nsenter … <cmd>` is passed verbatim (no re-tokenizing/quoting).
   //  - shell (bash): run the already-wrapped string (incl. sudo -E -u sandbox in prod).
-  const child =
-    req.file != null
-      ? spawn(req.file, req.args ?? [], { cwd: req.cwd, env: req.env, detached: true })
-      : spawn(req.command!, { cwd: req.cwd, env: req.env, shell: "/bin/bash", detached: true });
+  let child: ReturnType<typeof spawn>;
+  try {
+    child =
+      req.file != null
+        ? spawn(req.file, req.args ?? [], { cwd: req.cwd, env: req.env, detached: true })
+        : spawn(req.command!, { cwd: req.cwd, env: req.env, shell: "/bin/bash", detached: true });
+  } catch (err) {
+    disk.markFinal(); // spawn threw before the exit handlers wired settle() — release the guard
+    throw err;
+  }
   // Decode as UTF-8 via StringDecoder so a multibyte char split across two data chunks
   // is not corrupted into U+FFFD (raw Buffer.toString() per chunk would garble it).
   child.stdout?.setEncoding("utf8");

--- a/src/core/job-registry.ts
+++ b/src/core/job-registry.ts
@@ -14,7 +14,7 @@
  * (replacing the old inline `subagentJobs` map); the TUI host owns its own.
  */
 
-import type { JobStopResult } from "./tool-registry.js";
+import type { JobStopResult, TaskOutputSnapshot } from "./tool-registry.js";
 
 export type JobType = "subagent" | "bash" | "node" | "pod" | "host" | "local";
 
@@ -109,6 +109,17 @@ export class JobRegistry {
   setAbort(jobId: string, abort: () => void): void {
     const job = this.jobs.get(jobId);
     if (job) job.abort = abort;
+  }
+
+  /**
+   * Project a job to the status shape the task_output tool consumes. One owner of the
+   * registry→snapshot mapping so the agentbox and TUI readers can't drift.
+   */
+  snapshot(jobId: string): TaskOutputSnapshot {
+    const job = this.jobs.get(jobId);
+    return job
+      ? { found: true, status: job.status, exitCode: job.exitCode, outputFile: job.outputFile }
+      : { found: false };
   }
 
   /** All jobs, optionally filtered to one parent session. */

--- a/src/core/task-notification.ts
+++ b/src/core/task-notification.ts
@@ -46,10 +46,10 @@ export function escapeXml(s: string): string {
  */
 const NOTIFICATION_INSTRUCTIONS =
   "This is an automatic background-job result, NOT a new user request. The job has ALREADY FINISHED and its " +
-  "result is FINAL — the <summary> below (and the output_file, for shell jobs) IS that result. Do NOT re-launch, " +
+  "result is FINAL — the <summary> below IS that result. Do NOT re-launch, " +
   "re-run, or re-dispatch this work, and do NOT spawn another sub-agent or call another tool to redo, verify, " +
   "wait for, or 'get' a result you have just been handed — simply relay it. " +
-  "Read the output_file only if you still need this result. " +
+  "For a shell job, if you still need the full output, call task_output(task_id) (it returns the final output and exit code) — do not read the raw output_file. " +
   "If it adds nothing the user doesn't already know — e.g. it matches a result or issue you already reported — " +
   "END YOUR TURN WITH NO MESSAGE AT ALL. Do NOT post 'no new info', 'same as above', or a restated summary; silence is the correct response and avoids a noise bubble. " +
   "Produce text ONLY when there is genuinely NEW, actionable information (e.g. the answer the user was waiting for), and then keep it to a brief update — never a re-run of a full report. " +

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -119,6 +119,23 @@ export interface JobStopResult {
 /** Cancels a running background job — sub-agent OR bash (design §7: job_stop). */
 export type JobStopExecutor = (jobId: string) => Promise<JobStopResult>;
 
+/** Live status of a background job, from the runtime's JobRegistry (for the task_output tool). */
+export interface TaskOutputSnapshot {
+  /** False when the job id is unknown to this runtime's registry. */
+  found: boolean;
+  status?: import("./job-registry.js").JobStatus;
+  exitCode?: number;
+  outputFile?: string;
+}
+
+/**
+ * Reads a background job's CURRENT status from the runtime's JobRegistry. Injected by the
+ * agentbox session manager and the TUI host (they own the registry). Enables the task_output
+ * tool to return "running / completed / failed / stopped" instead of the model blindly
+ * file-reading the output path (which 404s while the job has produced no output).
+ */
+export type TaskOutputReader = (jobId: string) => TaskOutputSnapshot;
+
 // ── background exec (run_in_background on bash / node_exec / pod_exec) ──────
 
 /**
@@ -244,6 +261,8 @@ export interface ToolRefs {
    * the agentbox session manager and the TUI background host.
    */
   backgroundExecExecutor?: BackgroundExecExecutor;
+  /** Reads a background job's live status from the runtime's JobRegistry. Enables task_output. */
+  taskOutputReader?: TaskOutputReader;
 }
 
 /** Declarative registration for a single tool. */

--- a/src/core/tui-background-host.ts
+++ b/src/core/tui-background-host.ts
@@ -31,7 +31,9 @@ import { buildTaskNotificationText, type TaskNotification } from "./task-notific
 import type {
   BackgroundExecExecutor,
   JobStopExecutor,
+  TaskOutputReader,
 } from "./tool-registry.js";
+import { cleanupTaskOutput } from "../tools/cmd-exec/disk-output.js";
 
 export class TuiBackgroundHost {
   private jobs = new JobRegistry();
@@ -58,6 +60,9 @@ export class TuiBackgroundHost {
           /* already gone */
         }
       }
+      // The session is ending — the model won't read these again, so reclaim the output
+      // files now (in TUI/local mode the process is long-lived and nothing else GCs them).
+      if (job.outputFile) void cleanupTaskOutput(job.jobId);
     }
   }
 
@@ -82,6 +87,10 @@ export class TuiBackgroundHost {
   createJobStopExecutor(): JobStopExecutor {
     // Shared stop logic lives on JobRegistry (same as the agentbox path).
     return async (jobId) => this.jobs.stopJob(jobId);
+  }
+
+  createTaskOutputReader(): TaskOutputReader {
+    return (jobId) => this.jobs.snapshot(jobId);
   }
 
   private notify(jobId: string, n: TaskNotification): void {

--- a/src/tools/all-entries.ts
+++ b/src/tools/all-entries.ts
@@ -39,6 +39,7 @@ import {
 } from "./workflow/task-tools.js";
 import { registration as spawnSubagent } from "./workflow/spawn-subagent.js";
 import { registration as jobStop } from "./workflow/job-stop.js";
+import { registration as taskOutput } from "./workflow/task-output.js";
 
 export const allToolEntries: ToolEntry[] = [
   // ── cmd-exec ──
@@ -51,5 +52,5 @@ export const allToolEntries: ToolEntry[] = [
   // ── workflow ──
   saveFeedback, manageSchedule, taskReport, skillPreview,
   taskCreateRegistration, taskUpdateRegistration, taskListRegistration, taskGetRegistration,
-  spawnSubagent, jobStop,
+  spawnSubagent, jobStop, taskOutput,
 ];

--- a/src/tools/cmd-exec/background-launch.test.ts
+++ b/src/tools/cmd-exec/background-launch.test.ts
@@ -10,7 +10,11 @@ describe("backgroundLaunchedResult message", () => {
   it("keeps the default: end the turn, don't poll/sleep/spawn-a-waiter", () => {
     const m = msg();
     expect(m).toMatch(/END YOUR TURN/);
-    expect(m).toMatch(/do NOT read this file, poll, sleep, or spawn a sub-agent/i);
+    expect(m).toMatch(/do NOT read anything, poll, sleep, or spawn a sub-agent/i);
+  });
+
+  it("directs the model to task_output(task_id) rather than reading the raw output_file", () => {
+    expect(msg()).toMatch(/task_output\(task_id\)/);
   });
 
   it("carries the paired server/client EXCEPTION (so a perftest server isn't waited on → no deadlock)", () => {

--- a/src/tools/cmd-exec/background-launch.ts
+++ b/src/tools/cmd-exec/background-launch.ts
@@ -45,13 +45,14 @@ export function backgroundLaunchedResult(
       output_file: outputFile,
       message:
         `${runningWhere} It runs detached and you are notified automatically when it COMPLETES. ` +
-        "Default: END YOUR TURN NOW — do NOT read this file, poll, sleep, or spawn a sub-agent to wait on it. " +
+        "Default: END YOUR TURN NOW — do NOT read anything, poll, sleep, or spawn a sub-agent to wait on it. " +
         "EXCEPTION — paired/orchestrated tests: if this is ONE SIDE of a protocol that only makes progress once " +
         "its counterpart runs (a server/listener blocking until its client connects; a packet capture needing " +
         "traffic generated), do NOT wait for completion — immediately run the counterpart (e.g. the client on the peer " +
-        "node) and read this output_file once the test finishes. Waiting for such a server's completion FIRST " +
+        "node), then call task_output(task_id) once the test finishes. Waiting for such a server's completion FIRST " +
         "deadlocks: it blocks until a client connects, then times out. " +
-        "Otherwise read the output_file ONLY after the completion notification. Stop it early with job_stop. " +
+        "Otherwise call task_output(task_id) ONLY after the completion notification — it reports " +
+        "running/completed/failed/stopped, so use it instead of reading output_file directly. Stop it early with job_stop. " +
         "NOTE: task_id and output_file are internal handles for YOUR use only — do NOT show them to the user; just " +
         "tell the user in plain language what is running and that you'll report back when it finishes.",
     }, null, 2) }],

--- a/src/tools/cmd-exec/background-output-guidance.test.ts
+++ b/src/tools/cmd-exec/background-output-guidance.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression guard for the model-visible text of every background-capable tool.
+//
+// A backgrounded job's output must be consumed via the status-aware task_output(task_id) tool —
+// NOT by reading the raw output_file path, which returns a hard ENOENT while a silent job has
+// produced nothing yet (the bug this feature fixes) and bypasses status/exit-code/bounded-read.
+// Two examples (node_exec / host_exec tcpdump flows) regressed to "read the/its output_file";
+// this test fails if any background tool's source reintroduces that guidance.
+
+const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const TOOL_FILES = [
+  "tools/cmd-exec/node-exec.ts",
+  "tools/cmd-exec/host-exec.ts",
+  "tools/cmd-exec/pod-exec.ts",
+  "tools/cmd-exec/restricted-bash.ts",
+  "tools/script-exec/node-script.ts",
+  "tools/script-exec/host-script.ts",
+  "tools/script-exec/pod-script.ts",
+  "tools/script-exec/local-script.ts",
+];
+
+// "read the/its/your [raw] output_file" = telling the model to consume the raw path. The legit
+// references — "a task_id and output_file", "not the raw output_file" — never put "read" before
+// "output_file", so this pattern catches only the bad guidance.
+const FORBIDDEN = /read\s+(the|its|your)(\s+raw)?\s+output_file/i;
+
+describe("background tools steer the model to task_output, not the raw output_file", () => {
+  for (const rel of TOOL_FILES) {
+    it(`${rel}: no "read the output_file" guidance`, () => {
+      const src = fs.readFileSync(path.join(srcRoot, rel), "utf8");
+      expect(src).not.toMatch(FORBIDDEN);
+    });
+
+    it(`${rel}: references task_output`, () => {
+      const src = fs.readFileSync(path.join(srcRoot, rel), "utf8");
+      expect(src).toMatch(/task_output/);
+    });
+  }
+});

--- a/src/tools/cmd-exec/disk-output.test.ts
+++ b/src/tools/cmd-exec/disk-output.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { reloadConfig } from "../../core/config.js";
+import {
+  DiskTaskOutput,
+  getTaskOutputPath,
+  readTaskOutput,
+  sweepStaleTaskOutputs,
+} from "./disk-output.js";
+
+let tmp: string;
+let prevEnv: string | undefined;
+
+beforeAll(() => {
+  prevEnv = process.env.SICLAW_USER_DATA_DIR;
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "siclaw-diskout-"));
+  process.env.SICLAW_USER_DATA_DIR = tmp;
+  reloadConfig();
+});
+
+afterAll(() => {
+  if (prevEnv === undefined) delete process.env.SICLAW_USER_DATA_DIR;
+  else process.env.SICLAW_USER_DATA_DIR = prevEnv;
+  reloadConfig();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("DiskTaskOutput.ensureCreated", () => {
+  it("creates an empty file at launch so a pre-output read returns '' not ENOENT", async () => {
+    const disk = new DiskTaskOutput("job-eager");
+    await disk.ensureCreated();
+    expect(fs.existsSync(getTaskOutputPath("job-eager"))).toBe(true);
+    const r = await readTaskOutput("job-eager");
+    expect(r).toEqual({ output: "", bytes: 0, truncated: false, exists: true });
+  });
+
+  it("is idempotent and never truncates already-written content", async () => {
+    const disk = new DiskTaskOutput("job-idem");
+    await disk.ensureCreated();
+    disk.append("hello\n");
+    await disk.flush();
+    await disk.ensureCreated(); // second call must not clobber
+    const r = await readTaskOutput("job-idem");
+    expect(r.output).toContain("hello");
+  });
+});
+
+describe("readTaskOutput", () => {
+  it("returns empty (not a throw) for a job whose file was never created", async () => {
+    const r = await readTaskOutput("job-never-created");
+    expect(r).toEqual({ output: "", bytes: 0, truncated: false, exists: false });
+  });
+
+  it("returns the last N lines with truncated=true when tail_lines is smaller", async () => {
+    const disk = new DiskTaskOutput("job-tail");
+    await disk.ensureCreated();
+    disk.append("l1\nl2\nl3\nl4\nl5\n");
+    await disk.flush();
+    const r = await readTaskOutput("job-tail", 2);
+    expect(r.truncated).toBe(true);
+    // trailing-newline aware: a tail of 2 returns the 2 REAL last lines (l4, l5), not l5 + a phantom empty.
+    expect(r.output).toBe("l4\nl5");
+  });
+
+  it("returns all real lines (no phantom empty, not truncated) when tail_lines >= line count", async () => {
+    const disk = new DiskTaskOutput("job-exact");
+    await disk.ensureCreated();
+    disk.append("a\nb\nc\n");
+    await disk.flush();
+    const r = await readTaskOutput("job-exact", 3);
+    expect(r.output).toBe("a\nb\nc");
+    expect(r.truncated).toBe(false);
+  });
+
+  it("does not throw or return empty for a large output (reads a bounded tail from the end)", async () => {
+    const disk = new DiskTaskOutput("job-big");
+    await disk.ensureCreated();
+    // ~3MB of lines — exceeds the 2MB tail read cap.
+    disk.append(Array.from({ length: 60_000 }, (_, i) => `line-${i}`).join("\n") + "\n");
+    await disk.flush();
+    const r = await readTaskOutput("job-big", 5);
+    expect(r.exists).toBe(true);
+    expect(r.truncated).toBe(true);
+    expect(r.output.split("\n").length).toBe(5);
+    expect(r.output).toContain("line-59999"); // last line is present
+  });
+
+  it("keeps the raw tail (not empty) for a large NEWLINE-LESS blob beyond the cap", async () => {
+    const disk = new DiskTaskOutput("job-no-nl");
+    await disk.ensureCreated();
+    // ~3MB single line, no newlines at all — exceeds the 2MB tail cap. The byte-offset read
+    // would drop a "first line" that never ends, so without the fallback this collapses to "".
+    disk.append("x".repeat(3 * 1024 * 1024));
+    await disk.flush();
+    const r = await readTaskOutput("job-no-nl", 5);
+    expect(r.exists).toBe(true);
+    expect(r.truncated).toBe(true);
+    expect(r.output.length).toBeGreaterThan(0); // raw last-cap bytes, not empty
+    expect(r.output).toMatch(/^x+$/);
+  });
+});
+
+describe("sweepStaleTaskOutputs", () => {
+  it("deletes files older than maxAge and keeps fresh ones", async () => {
+    // Both represent FINISHED jobs (markFinal) — only mtime should decide their fate.
+    const fresh = new DiskTaskOutput("job-fresh");
+    await fresh.ensureCreated();
+    const stale = new DiskTaskOutput("job-stale");
+    await stale.ensureCreated();
+    fresh.markFinal();
+    stale.markFinal();
+    const stalePath = getTaskOutputPath("job-stale");
+    const old = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    fs.utimesSync(stalePath, old, old);
+
+    await sweepStaleTaskOutputs(30 * 60 * 1000); // 30-min threshold
+
+    expect(fs.existsSync(stalePath)).toBe(false);
+    expect(fs.existsSync(getTaskOutputPath("job-fresh"))).toBe(true);
+  });
+
+  it("never deletes a protected (still-running) job's file even when its mtime is old", async () => {
+    const disk = new DiskTaskOutput("job-silent-running");
+    await disk.ensureCreated();
+    const p = getTaskOutputPath("job-silent-running");
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    fs.utimesSync(p, old, old);
+
+    await sweepStaleTaskOutputs(30 * 60 * 1000, new Set([path.basename(p)]));
+
+    expect(fs.existsSync(p)).toBe(true); // protected — a long-running silent job keeps its file
+    disk.markFinal();
+  });
+
+  it("protects a live writer process-wide WITHOUT an explicit protect set (cross-registry safety)", async () => {
+    // A job owned by another session/agent (whose registry this sweep can't see) must still be
+    // protected purely because it has a live DiskTaskOutput writer — this is the cross-registry fix.
+    const disk = new DiskTaskOutput("job-live-elsewhere");
+    await disk.ensureCreated();
+    const p = getTaskOutputPath("job-live-elsewhere");
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    fs.utimesSync(p, old, old);
+
+    await sweepStaleTaskOutputs(30 * 60 * 1000); // no protect arg — relies on the live-writer set
+    expect(fs.existsSync(p)).toBe(true);
+
+    disk.markFinal(); // writer done → now eligible
+    fs.utimesSync(p, old, old); // ensureCreated/sweep may have touched nothing, but be explicit
+    await sweepStaleTaskOutputs(30 * 60 * 1000);
+    expect(fs.existsSync(p)).toBe(false);
+  });
+
+  it("is a no-op when the tasks dir does not exist", async () => {
+    await expect(sweepStaleTaskOutputs(0)).resolves.toBeUndefined();
+  });
+});

--- a/src/tools/cmd-exec/disk-output.ts
+++ b/src/tools/cmd-exec/disk-output.ts
@@ -20,7 +20,7 @@
  */
 
 import { constants as fsConstants } from "node:fs";
-import { type FileHandle, mkdir, open, stat, unlink } from "node:fs/promises";
+import { type FileHandle, mkdir, open, readdir, stat, unlink } from "node:fs/promises";
 import * as path from "node:path";
 import { loadConfig } from "../../core/config.js";
 import {
@@ -62,11 +62,37 @@ export function getTaskOutputPath(jobId: string): string {
 }
 
 /**
+ * Open a task-output file for appending. Centralizes the security-relevant flags
+ * (O_NOFOLLOW anti-symlink, O_APPEND, O_CREAT — never O_TRUNC) so the writer (drain) and
+ * the eager create path can't drift. Caller owns close().
+ */
+function openAppendHandle(filePath: string): Promise<FileHandle> {
+  return open(
+    filePath,
+    process.platform === "win32"
+      ? "a"
+      : fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | O_NOFOLLOW,
+  );
+}
+
+/**
+ * Basenames of output files that currently have a LIVE writer (a DiskTaskOutput constructed
+ * but not yet markFinal()'d). Process-wide on purpose: the opportunistic stale-output sweep
+ * scans the SHARED task dir but is triggered by a single session's JobRegistry, so a
+ * registry-local protect set can't see another session/agent's running jobs (local mode runs
+ * one manager+registry per agent in one process). A silent long-running job has an old mtime
+ * yet must never be swept — its writer would reopen an empty file on the next chunk and lose
+ * output. Tracking liveness here, independent of any registry, closes that cross-registry gap.
+ */
+const liveTaskOutputs = new Set<string>();
+
+/**
  * Async disk writer for one job's output. Flat-array write queue + single drain loop:
  * each chunk is released as soon as its write completes (no retained .then() closures).
  */
 export class DiskTaskOutput {
   #path: string;
+  #base: string;
   #fileHandle: FileHandle | null = null;
   #queue: string[] = [];
   #bytesWritten = 0;
@@ -76,6 +102,35 @@ export class DiskTaskOutput {
 
   constructor(jobId: string) {
     this.#path = getTaskOutputPath(jobId);
+    this.#base = path.basename(this.#path);
+    liveTaskOutputs.add(this.#base); // protected from the stale-output sweep until markFinal()
+  }
+
+  /**
+   * Mark this writer permanently done (call once the job settles). Drops it from the
+   * live-writer protection set so the stale-output GC may reclaim its file once it ages
+   * past the cutoff. Idempotent; the file itself is left in place for the read window.
+   */
+  markFinal(): void {
+    liveTaskOutputs.delete(this.#base);
+  }
+
+  /**
+   * Eagerly create the (empty) output file at job launch. Without this the file is created
+   * only on the first non-empty append(), so a background job that has not produced output
+   * yet (e.g. an `ib_write_bw` server blocked waiting for a client) has NO file, and reading
+   * the `output_file` handed back at launch returns ENOENT — read as "task failed/missing"
+   * rather than "running, no output yet". Idempotent (O_APPEND|O_CREAT, never truncates);
+   * best-effort (the first append() would create it anyway).
+   */
+  async ensureCreated(): Promise<void> {
+    try {
+      await mkdir(getTaskOutputDir(), { recursive: true });
+      const fh = await openAppendHandle(this.#path);
+      await fh.close();
+    } catch {
+      /* best-effort — drain's open() will create it on the first chunk */
+    }
   }
 
   append(content: string): void {
@@ -106,12 +161,7 @@ export class DiskTaskOutput {
       try {
         if (!this.#fileHandle) {
           await mkdir(getTaskOutputDir(), { recursive: true });
-          this.#fileHandle = await open(
-            this.#path,
-            process.platform === "win32"
-              ? "a"
-              : fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | O_NOFOLLOW,
-          );
+          this.#fileHandle = await openAppendHandle(this.#path);
         }
         while (this.#queue.length > 0) {
           const queue = this.#queue.splice(0, this.#queue.length);
@@ -167,6 +217,105 @@ export async function cleanupTaskOutput(jobId: string): Promise<void> {
   } catch {
     /* ENOENT or already gone */
   }
+}
+
+/** Max bytes read back for a tail request / a whole-file request — bounds memory well below
+ * the 5GB disk cap so a huge output can never OOM (or exceed V8's max string) on the read. */
+const READ_TAIL_BYTE_CAP = 2 * 1024 * 1024; // 2MB
+const READ_FULL_BYTE_CAP = 8 * 1024 * 1024; // 8MB
+
+/**
+ * Read a job's output file, tolerant of "not created yet" (returns empty + exists:false
+ * rather than throwing ENOENT). Content is already sanitized on the write side. Reads only
+ * the LAST `cap` bytes (never the whole multi-GB file), so a large output can't OOM; when
+ * `tailLines` > 0 only the last N lines are returned. `bytes` is the full file size;
+ * `truncated` is set when the byte cap and/or the line tail dropped content.
+ */
+export async function readTaskOutput(
+  jobId: string,
+  tailLines?: number,
+): Promise<{ output: string; bytes: number; truncated: boolean; exists: boolean }> {
+  let fh: FileHandle;
+  try {
+    // Read with O_NOFOLLOW (symmetric with the append side) so a symlink planted at the
+    // output path can't redirect the read off-target. Plain "r" on win32 (no O_NOFOLLOW).
+    fh = await open(
+      getTaskOutputPath(jobId),
+      process.platform === "win32" ? "r" : fsConstants.O_RDONLY | O_NOFOLLOW,
+    );
+  } catch {
+    return { output: "", bytes: 0, truncated: false, exists: false }; // not created yet / cleaned
+  }
+  try {
+    const size = (await fh.stat()).size;
+    const wantTail = tailLines != null && tailLines > 0;
+    const cap = wantTail ? READ_TAIL_BYTE_CAP : READ_FULL_BYTE_CAP;
+    const readLen = Math.min(size, cap);
+    const buf = Buffer.alloc(readLen);
+    if (readLen > 0) await fh.read(buf, 0, readLen, size - readLen);
+    let content = buf.toString("utf8");
+    let truncated = size > readLen;
+    // We read from an arbitrary byte offset — drop the (possibly partial / split-multibyte)
+    // first line so we never surface a corrupted leading fragment. But if the whole window
+    // has NO newline (a pathological newline-less blob, e.g. a base64 stream), keep the raw
+    // bytes rather than collapse to "" — better a blob clipped at the front than empty output.
+    if (truncated) {
+      const nl = content.indexOf("\n");
+      if (nl >= 0) content = content.slice(nl + 1);
+    }
+    if (!wantTail) return { output: content, bytes: size, truncated, exists: true };
+    const lines = content.split("\n");
+    // Output ends in "\n" → split yields a trailing "" — drop it so a tail of N returns N real lines.
+    if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+    if (lines.length > tailLines) {
+      return { output: lines.slice(-tailLines).join("\n"), bytes: size, truncated: true, exists: true };
+    }
+    return { output: lines.join("\n"), bytes: size, truncated, exists: true };
+  } finally {
+    await fh.close();
+  }
+}
+
+/** Default age past which a finished job's output file is swept (24h). */
+const STALE_TASK_OUTPUT_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Best-effort GC of stale task-output files. The app otherwise never deletes them, so in a
+ * long-lived process (local / TUI mode) they accumulate forever. Called opportunistically at
+ * each background launch — no scheduler needed, runtime-agnostic — and deletes `*.output`
+ * files whose mtime is older than `maxAgeMs` (well past any read window). A K8s agentbox pod
+ * is ephemeral and reclaims them on teardown anyway; this covers local/TUI and crash leftovers.
+ *
+ * Files with a live writer are ALWAYS skipped (via the process-wide liveTaskOutputs set), so a
+ * silent long-running job — even one owned by another session/agent sharing this dir — is never
+ * swept. `protect` is an optional extra set of basenames for explicit callers/tests.
+ */
+export async function sweepStaleTaskOutputs(
+  maxAgeMs = STALE_TASK_OUTPUT_MS,
+  protect?: Set<string>,
+): Promise<void> {
+  const dir = getTaskOutputDir();
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return; // dir not created yet — nothing to sweep
+  }
+  const cutoff = Date.now() - maxAgeMs;
+  await Promise.all(
+    entries.map(async (name) => {
+      if (!name.endsWith(".output")) return;
+      // Never delete a still-running job's file: it may be silent (old mtime) yet alive — its
+      // writer would otherwise reopen an empty file on the next chunk and lose prior output.
+      if (liveTaskOutputs.has(name) || protect?.has(name)) return;
+      const full = path.join(dir, name);
+      try {
+        if ((await stat(full)).mtimeMs < cutoff) await unlink(full);
+      } catch {
+        /* raced with another sweep / already gone */
+      }
+    }),
+  );
 }
 
 /**

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -80,7 +80,7 @@ Examples (pass the id from host_list; names shown here for readability):
 - host: "<bare-metal-3 id>", command: "nvidia-smi"
 - host: "<storage-1 id>", command: "df -h"
 - host: "<node-a id>", command: "journalctl -u kubelet -n 100 | grep error"
-- host: "<node-a id>", command: "tcpdump -i eth0 -nn", run_in_background: true   (open-ended capture; returns immediately — stop it later with job_stop, then read the output_file)`,
+- host: "<node-a id>", command: "tcpdump -i eth0 -nn", run_in_background: true   (open-ended capture; returns immediately — stop it later with job_stop, then task_output(task_id))`,
     parameters: Type.Object({
       host: Type.String({
         description: "Host id from host_list (preferred — names can be duplicated, so the id is the unambiguous handle; a unique name also works). Must be bound to this agent.",
@@ -111,9 +111,10 @@ Examples (pass the id from host_list; names shown here for readability):
                 description:
                   "Run the command on the host in the background instead of waiting. Returns immediately " +
                   "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, " +
-                  "sleep, or read the output_file until the completion notification). EXCEPTION: when this is the " +
+                  "sleep, or read its output until the completion notification — then call task_output(task_id), " +
+                  "not the raw output_file). EXCEPTION: when this is the " +
                   "server/listener side of a paired test, do NOT wait — IMMEDIATELY run the client on the peer " +
-                  "host, then read the output_file when the test finishes (waiting for the server's completion " +
+                  "host, then call task_output(task_id) when the test finishes (waiting for the server's completion " +
                   "first deadlocks: it blocks until the client connects, then times out). Use for long-running " +
                   "host commands over SSH. The command is wrapped in `timeout` and capped (~3600s). Output needing " +
                   "structural (JSON) redaction cannot run in background.",

--- a/src/tools/cmd-exec/node-exec.ts
+++ b/src/tools/cmd-exec/node-exec.ts
@@ -99,11 +99,11 @@ Examples:
 - node: "node-1", command: "ibstat"
 - node: "node-1", command: "ib_write_bw --help"
 - node: "node-1", command: "tcpdump -i eth0 -nn -c 50 port 53"   (bounded capture: 50 DNS packets)
-- node: "node-1", command: "tcpdump -i eth0 -nn", run_in_background: true   (open-ended capture; returns immediately — stop it later with job_stop, then read the output_file)
+- node: "node-1", command: "tcpdump -i eth0 -nn", run_in_background: true   (open-ended capture; returns immediately — stop it later with job_stop, then task_output(task_id))
 - paired capture/traffic — start the capture in the background, then IMMEDIATELY generate the traffic it should observe (do NOT wait for the capture first: it blocks until packets arrive, so waiting deadlocks):
     1. node: "node-1", command: "tcpdump -i eth0 -nn -c 5 port 80", run_in_background: true   (capture; returns immediately — go straight to step 2, same turn)
     2. node: "node-1", command: "curl -s http://10.0.0.1/healthz"                             (client; one request easily produces the few packets the capture is waiting for)
-    3. once the capture hits its packet count it exits and you're notified — then read its output_file.
+    3. once the capture hits its packet count it exits and you're notified — then call task_output(task_id).
 - node: "node-1", command: "dmesg --level=err"
 - node: "node-1", command: "sysctl net.ipv4.ip_forward"
 - node: "node-1", command: "cat /etc/os-release"
@@ -161,9 +161,10 @@ To run in a POD's network namespace (host tools + the pod's network view — e.g
                 description:
                   "Run the command on the node in the background instead of waiting. Returns immediately " +
                   "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, " +
-                  "sleep, or read the output_file until the completion notification). EXCEPTION: when this is the " +
+                  "sleep, or read its output until the completion notification — then call task_output(task_id), " +
+                  "not the raw output_file). EXCEPTION: when this is the " +
                   "server/listener side of a paired test, do NOT wait — IMMEDIATELY run the client on the peer " +
-                  "node, then read the output_file when the test finishes (waiting for the server's completion " +
+                  "node, then call task_output(task_id) when the test finishes (waiting for the server's completion " +
                   "first deadlocks: it blocks until the client connects, then times out). Use for long-running " +
                   "node commands. The command is wrapped in `timeout` and capped at the debug-pod lifetime (~600s) — " +
                   "for longer runs lower the command's own duration. Output needing structural (JSON) redaction cannot run in background.",

--- a/src/tools/cmd-exec/pod-exec.ts
+++ b/src/tools/cmd-exec/pod-exec.ts
@@ -99,9 +99,10 @@ Examples:
                 description:
                   "Run the command inside the pod in the background instead of waiting. Returns immediately " +
                   "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, " +
-                  "sleep, or read the output_file until the completion notification). EXCEPTION: when this is the " +
-                  "server/listener side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read " +
-                  "the output_file when the test finishes (waiting for the server's completion first deadlocks: it " +
+                  "sleep, or read its output until the completion notification — then call task_output(task_id), " +
+                  "not the raw output_file). EXCEPTION: when this is the " +
+                  "server/listener side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then call " +
+                  "task_output(task_id) when the test finishes (waiting for the server's completion first deadlocks: it " +
                   "blocks until the client connects, then times out). Note: if stopped early, the in-pod process may " +
                   "keep running until the pod ends. Output needing structural (JSON) redaction cannot run in background.",
               })

--- a/src/tools/cmd-exec/restricted-bash.ts
+++ b/src/tools/cmd-exec/restricted-bash.ts
@@ -309,7 +309,7 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
                   "Run the command in the background instead of waiting. Returns immediately with a " +
                   "task_id and output_file. IMPORTANT: after launching, END YOUR TURN — do NOT call " +
                   "read (or any other tool) to check on it, and do NOT sleep or wait. You will be " +
-                  "automatically notified when it completes; ONLY THEN read the output_file. Polling " +
+                  "automatically notified when it completes; ONLY THEN call task_output(task_id). Polling " +
                   "the file before the notification just wastes turns (it will not be there yet). Use " +
                   "for long-running work (perftest, follow logs, big collections). Output that needs " +
                   "structural (JSON) redaction cannot run in the background — use -o wide/name or run foreground.",
@@ -406,7 +406,7 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
 
       // ── Background mode ──────────────────────────────────────────────
       // Hand the fully-wrapped command to the runtime executor and return immediately.
-      // The model reads progress via `read` on output_file and is notified on completion.
+      // The model reads progress via task_output(task_id) and is notified on completion.
       if (backgroundEnabled && params.run_in_background === true) {
         // Structural (JSON) sanitizers are not line-safe and cannot be streamed
         // per line without risking a leak — reject background mode for them.

--- a/src/tools/script-exec/host-script.ts
+++ b/src/tools/script-exec/host-script.ts
@@ -116,8 +116,9 @@ Examples (pass the id from host_list; names shown here for readability):
                 description:
                   "Run the script on the host in the background instead of waiting. Returns immediately " +
                   "with a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, " +
-                  "or read the output_file until the completion notification). EXCEPTION: when this is the server/listener " +
-                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when " +
+                  "or read its output until the completion notification — then call task_output(task_id), not the raw " +
+                  "output_file). EXCEPTION: when this is the server/listener " +
+                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then call task_output(task_id) when " +
                   "the test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
                   "connects, then times out). Use for long-running skill scripts over SSH " +
                   "(orchestration, soak, perftest). The script is wrapped in `timeout` and capped (~3600s).",

--- a/src/tools/script-exec/local-script.ts
+++ b/src/tools/script-exec/local-script.ts
@@ -98,9 +98,10 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
               Type.Boolean({
                 description:
                   "Run the script in the background instead of waiting. Returns immediately with a task_id " +
-                  "and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, or read the " +
-                  "output_file until the completion notification). EXCEPTION: when this is the server/listener side " +
-                  "of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when the " +
+                  "and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, or read its " +
+                  "output until the completion notification — then call task_output(task_id), not the raw output_file). " +
+                  "EXCEPTION: when this is the server/listener side " +
+                  "of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then call task_output(task_id) when the " +
                   "test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
                   "connects, then times out). Use for long-running skill scripts (orchestration, soak, perftest).",
               })

--- a/src/tools/script-exec/node-script.ts
+++ b/src/tools/script-exec/node-script.ts
@@ -136,8 +136,9 @@ Examples:
                 description:
                   "Run the script on the node in the background instead of waiting. Returns immediately with " +
                   "a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, or " +
-                  "read the output_file until the completion notification). EXCEPTION: when this is the server/listener " +
-                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when " +
+                  "read its output until the completion notification — then call task_output(task_id), not the raw " +
+                  "output_file). EXCEPTION: when this is the server/listener " +
+                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then call task_output(task_id) when " +
                   "the test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
                   "connects, then times out). The script is wrapped in `timeout` and capped at the " +
                   "debug-pod lifetime (~600s). Use for long-running node skill scripts (orchestration, soak).",

--- a/src/tools/script-exec/pod-script.ts
+++ b/src/tools/script-exec/pod-script.ts
@@ -107,8 +107,9 @@ Examples:
                 description:
                   "Run the script in the pod in the background instead of waiting. Returns immediately with " +
                   "a task_id and output_file. After launching, END YOUR TURN by default (do NOT poll, sleep, or " +
-                  "read the output_file until the completion notification). EXCEPTION: when this is the server/listener " +
-                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then read the output_file when " +
+                  "read its output until the completion notification — then call task_output(task_id), not the raw " +
+                  "output_file). EXCEPTION: when this is the server/listener " +
+                  "side of a paired test, do NOT wait — IMMEDIATELY run the counterpart, then call task_output(task_id) when " +
                   "the test finishes (waiting for the server's completion first deadlocks: it blocks until the client " +
                   "connects, then times out). The script is wrapped in `timeout` (requires coreutils/busybox " +
                   "`timeout` in the pod). Use for long-running in-pod scripts (soak, load).",

--- a/src/tools/workflow/task-output.test.ts
+++ b/src/tools/workflow/task-output.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { reloadConfig } from "../../core/config.js";
+import { DiskTaskOutput } from "../cmd-exec/disk-output.js";
+import { createTaskOutputTool } from "./task-output.js";
+import type { ToolRefs, TaskOutputReader, TaskOutputSnapshot } from "../../core/tool-registry.js";
+
+let tmp: string;
+let prevEnv: string | undefined;
+
+beforeAll(() => {
+  prevEnv = process.env.SICLAW_USER_DATA_DIR;
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "siclaw-taskout-"));
+  process.env.SICLAW_USER_DATA_DIR = tmp;
+  reloadConfig();
+});
+
+afterAll(() => {
+  if (prevEnv === undefined) delete process.env.SICLAW_USER_DATA_DIR;
+  else process.env.SICLAW_USER_DATA_DIR = prevEnv;
+  reloadConfig();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+async function seedOutput(jobId: string, content: string): Promise<void> {
+  const disk = new DiskTaskOutput(jobId);
+  await disk.ensureCreated();
+  if (content) {
+    disk.append(content);
+    await disk.flush();
+  }
+}
+
+async function run(reader: TaskOutputReader, params: Record<string, unknown>) {
+  const tool = createTaskOutputTool({} as ToolRefs, reader);
+  const r = await tool.execute("tc-1", params);
+  return JSON.parse((r.content[0] as { text: string }).text);
+}
+
+const snap = (s: Partial<TaskOutputSnapshot>): TaskOutputReader => () => ({ found: true, ...s });
+
+describe("task_output tool", () => {
+  it("reports running + partial output + a 'still running' note, never an error", async () => {
+    await seedOutput("job-run", "partial line 1\n");
+    const out = await run(snap({ status: "running" }), { task_id: "job-run" });
+    expect(out.status).toBe("running");
+    expect(out.running).toBe(true);
+    expect(out.output).toContain("partial line 1");
+    expect(out.note).toMatch(/still running/i);
+    expect(out.error).toBeUndefined();
+  });
+
+  it("returns empty (not 404/error) for a running job that has produced no output yet", async () => {
+    await seedOutput("job-silent", ""); // ensureCreated only — the ib_write_bw-server case
+    const out = await run(snap({ status: "running", outputFile: "x" }), { task_id: "job-silent" });
+    expect(out.running).toBe(true);
+    expect(out.output).toBe("");
+    expect(out.error).toBeUndefined();
+  });
+
+  it("returns final output + exit_code when completed", async () => {
+    await seedOutput("job-done", "BW result table\n");
+    const out = await run(snap({ status: "completed", exitCode: 0 }), { task_id: "job-done" });
+    expect(out.status).toBe("completed");
+    expect(out.running).toBe(false);
+    expect(out.exit_code).toBe(0);
+    expect(out.output).toContain("BW result table");
+    expect(out.note).toBeUndefined();
+  });
+
+  it("reflects failed / stopped terminal states", async () => {
+    await seedOutput("job-fail", "boom\n");
+    const failed = await run(snap({ status: "failed", exitCode: 1 }), { task_id: "job-fail" });
+    expect(failed.status).toBe("failed");
+    expect(failed.running).toBe(false);
+
+    await seedOutput("job-stop", "");
+    const stopped = await run(snap({ status: "stopped" }), { task_id: "job-stop" });
+    expect(stopped.status).toBe("stopped");
+    expect(stopped.running).toBe(false);
+  });
+
+  it("errors for an unknown task_id", async () => {
+    const out = await run(() => ({ found: false }), { task_id: "nope" });
+    expect(out.error).toBe(true);
+    expect(out.message).toMatch(/no background job/i);
+  });
+
+  it("errors when no reader is wired", async () => {
+    const tool = createTaskOutputTool({} as ToolRefs, undefined);
+    const r = await tool.execute("tc", { task_id: "x" });
+    expect(JSON.parse((r.content[0] as { text: string }).text).error).toBe(true);
+  });
+});

--- a/src/tools/workflow/task-output.ts
+++ b/src/tools/workflow/task-output.ts
@@ -1,0 +1,110 @@
+/**
+ * task_output — read a background job's output in a STATUS-AWARE way.
+ *
+ * Replaces the model blindly `read`ing the raw `output_file` path, which returns a hard
+ * ENOENT while a backgrounded job has produced no output yet (e.g. an `ib_write_bw` server
+ * blocked waiting for a client). This tool consults the runtime's JobRegistry (via the
+ * injected taskOutputReader) and the on-disk file, so it can report:
+ *   - running   → partial output so far + "still running, wait for the completion notice"
+ *   - completed/failed/stopped → final output + exit code
+ * Output is already sanitized on the write side (SanitizingLineBuffer). Hidden until the
+ * runtime injects the reader (so a task_id can actually exist).
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { renderTextResult } from "../infra/tool-render.js";
+import type { ToolEntry, ToolRefs } from "../../core/tool-registry.js";
+import { BACKGROUND_BASH_ENABLED, RUN_IN_BACKGROUND_ENABLED } from "../../core/subagent-registry.js";
+import { readTaskOutput } from "../cmd-exec/disk-output.js";
+
+const DEFAULT_TAIL_LINES = 400;
+
+export function createTaskOutputTool(
+  refs: ToolRefs,
+  reader = refs.taskOutputReader,
+): ToolDefinition {
+  return {
+    name: "task_output",
+    label: "Task Output",
+    renderCall: (_a, theme) => new Text(theme.fg("toolTitle", theme.bold("task_output")), 0, 0),
+    renderResult: renderTextResult,
+    description:
+      "Read the output of a background job (started with run_in_background) by its task_id. " +
+      "Reports the job's status (running / completed / failed / stopped) plus its output — use " +
+      "this instead of reading the raw output_file path. If status is \"running\", the output is " +
+      "partial: END YOUR TURN and call task_output again only after the completion notification. " +
+      "By default returns the last ~400 lines; pass tail_lines to change (0 = as much as fits, up to the last ~8MB).",
+    parameters: Type.Object({
+      task_id: Type.String({ description: "The task_id returned by a background launch (run_in_background)." }),
+      tail_lines: Type.Optional(
+        Type.Number({ description: "Return only the last N lines of output. Omit for the default (~400); 0 for as much as fits (up to the last ~8MB)." }),
+      ),
+    }),
+    async execute(_toolCallId, rawParams) {
+      if (!reader) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: true, message: "task_output is not available." }) }], details: { error: true } };
+      }
+      const params = rawParams as { task_id?: string; tail_lines?: number };
+      const jobId = params.task_id?.trim();
+      if (!jobId) {
+        return { content: [{ type: "text" as const, text: JSON.stringify({ error: true, message: "task_output requires a task_id." }) }], details: { error: true } };
+      }
+
+      const before = reader(jobId);
+      if (!before.found) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: true, message: `No background job "${jobId}" (unknown task_id, or it predates this session).` }) }],
+          details: { error: true, task_id: jobId },
+        };
+      }
+
+      const tail = params.tail_lines ?? DEFAULT_TAIL_LINES;
+      const { output, bytes, truncated, exists } = await readTaskOutput(jobId, tail);
+      // Re-snapshot AFTER the read: a job that finished during the read is now reported terminal
+      // with its (already-flushed) final output, not stale "running".
+      const after = reader(jobId);
+      const status = after.found ? after.status : before.status;
+      const exitCode = after.found ? after.exitCode : before.exitCode;
+      const running = status === "running";
+
+      const notes: string[] = [];
+      if (running) {
+        notes.push("Job is still running — this output is PARTIAL. Do not treat it as final; end your turn and read again after the completion notification.");
+      }
+      if (truncated) {
+        notes.push("Output was truncated to the most recent lines — call task_output with tail_lines:0 for more (up to the last ~8MB).");
+      }
+      if (!running && !exists) {
+        notes.push("The output file is no longer available (it may have been cleaned up after the job finished).");
+      }
+
+      const result = {
+        task_id: jobId,
+        status,
+        running,
+        ...(exitCode != null ? { exit_code: exitCode } : {}),
+        bytes,
+        truncated,
+        output,
+        ...(notes.length ? { note: notes.join(" ") } : {}),
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        details: { task_id: jobId, status, running, bytes, truncated },
+      };
+    },
+  };
+}
+
+export const registration: ToolEntry = {
+  category: "workflow",
+  create: (refs) => createTaskOutputTool(refs),
+  modes: ["web", "channel", "cli"],
+  platform: true,
+  // Available once a background mode is on AND the runtime injected the reader (so a task_id
+  // can exist and be looked up). Hidden otherwise.
+  available: (refs) =>
+    (RUN_IN_BACKGROUND_ENABLED || BACKGROUND_BASH_ENABLED) && Boolean(refs.taskOutputReader),
+};


### PR DESCRIPTION
## Problem
Reading a background job's `output_file` blindly returned a hard ENOENT while the job had produced nothing yet (e.g. an `ib_write_bw` server backgrounded and blocked waiting for a client). The model mis-read "no output file" as the job having failed or vanished.

## Changes
- **Eager-create** the output file at launch (`DiskTaskOutput.ensureCreated`) → a read before any output yields an empty file, not ENOENT.
- **New `task_output(task_id[, tail_lines])` tool**: consults the JobRegistry (new `JobRegistry.snapshot()` + `taskOutputReader` bridge injected by the agentbox session manager and the TUI host) plus the on-disk file, reporting running/completed/failed/stopped with the output. Running → PARTIAL output + "wait for the completion notice"; re-snapshots after the read so a job that finishes mid-read reports terminal. Gated to when a background mode is on AND the reader is injected.
- **Bounded read**: `readTaskOutput` reads only the last ~2MB (tail) / ~8MB (full) from the file END (no OOM / V8 max-string), trailing-newline aware, `exists:false` for a missing file, and opens with `O_NOFOLLOW` (symmetric with the append side).
- Point the launch result, the completion notification, and the eight exec/script tool descriptions at `task_output(task_id)` instead of reading `output_file`.
- **GC**: `sweepStaleTaskOutputs` reclaims `*.output` >24h, throttled once/hour, protecting every file with a LIVE writer via a process-wide guard (registry-independent → a silent long-running job, even one owned by another session/agent sharing the dir in local mode, is never swept); guard released on settle, with a fallback release if setup throws before settle() is wired. TUI shutdown reclaims its jobs' files.

## Tests
disk-output (ensureCreated / bounded+tail read / large output / sweep + live-writer protection incl. cross-registry), task_output (running/silent/completed/failed/stopped/unknown/no-reader), setup-throw guard-release. `tsc` clean; `npm test` green (174 files, 3389).

🤖 Generated with [Claude Code](https://claude.com/claude-code)