### PR TITLE
Guard model fallback replay and compact preflight

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -431,6 +431,63 @@ describe("http-server — model routing", () => {
     expect(sm.persistModelRouteState).toHaveBeenCalledWith("route-fallback", s.modelRouteState);
   });
 
+  it("does not fallback by replaying the prompt after a tool has executed", async () => {
+    const s = await sm.getOrCreate("route-tool-side-effect");
+    const seenModels: string[] = [];
+    s.brain.prompt.mockImplementation(async () => {
+      const model = s.brain.getModel();
+      seenModels.push(`${model.provider}/${model.id}`);
+      s.brain.emitter.emit("event", {
+        type: "tool_execution_start",
+        toolCallId: "call_1",
+        toolName: "read",
+        args: { path: "README.md" },
+      });
+      s.brain.emitter.emit("event", {
+        type: "tool_execution_end",
+        toolCallId: "call_1",
+        toolName: "read",
+        result: { content: [{ type: "text", text: "ok" }] },
+        isError: false,
+      });
+      s.brain.emitter.emit("event", {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "429 rate limit exceeded",
+        },
+      });
+    });
+
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "route me after tool",
+      sessionId: "route-tool-side-effect",
+      modelRouting: routePolicy,
+    });
+    await flushAsync();
+
+    expect(r.status).toBe(200);
+    expect(seenModels).toEqual(["openai/gpt-4"]);
+    expect(s.modelRouteState.activeCandidateKey).toBeUndefined();
+    expect(s.modelRouteState.cooldowns["openai/gpt-4"]).toBeGreaterThan(0);
+    expect(s.modelRouteState.attempts[0]).toMatchObject({
+      failureKind: "rate_limit",
+      fallbackBlockedReason: "tool_execution",
+    });
+    expect(s._extraEventBuffer.some((event) => event.type === "model_route_switch")).toBe(false);
+    expect(s._extraEventBuffer.find((event) => event.type === "model_route_exhausted")).toMatchObject({
+      failureKind: "rate_limit",
+      fallbackBlockedReason: "tool_execution",
+    });
+    expect(s._extraEventBuffer.some((event) => event.type === "tool_execution_end")).toBe(true);
+    expect(s._extraEventBuffer.some((event) =>
+      event.type === "message_end" && (event.message as any)?.stopReason === "error",
+    )).toBe(true);
+    expect(sm.persistModelRouteState).toHaveBeenCalledWith("route-tool-side-effect", s.modelRouteState);
+  });
+
   it("does not fallback on context overflow", async () => {
     const s = await sm.getOrCreate("route-context");
     const seenModels: string[] = [];

--- a/src/core/brain-session.ts
+++ b/src/core/brain-session.ts
@@ -47,6 +47,14 @@ export interface BrainProviderResponse {
   headers: Record<string, string>;
 }
 
+export interface BrainContextPreflightResult {
+  ok: boolean;
+  compacted: boolean;
+  tokens?: number;
+  contextWindow?: number;
+  errorMessage?: string;
+}
+
 export interface BrainSession {
   readonly brainType: BrainType;
 
@@ -89,6 +97,13 @@ export interface BrainSession {
 
   /** Find a model by provider + id. Returns undefined if not found. */
   findModel(provider: string, modelId: string): BrainModelInfo | undefined;
+
+  /**
+   * Optional preflight before prompting on the current model. Implementations
+   * can compact when a fallback candidate has a smaller context window than the
+   * active session history.
+   */
+  ensureContextForModelPrompt?(model: BrainModelInfo, text: string): Promise<BrainContextPreflightResult>;
 
   /** Register a provider dynamically (from gateway DB config). */
   registerProvider?(name: string, config: Record<string, unknown>): void;

--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -19,7 +19,11 @@ function makeFakeSession(overrides: Partial<Record<string, any>> = {}) {
     getContextUsage: vi.fn(() => ({ tokens: 10, contextWindow: 100, percent: 10 })),
     getSessionStats: vi.fn(() => ({ tokens: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, total: 3 }, cost: 0.001 })),
     model: { id: "m", name: "M", provider: "p", contextWindow: 100, maxTokens: 10, reasoning: false },
-    agent: { onResponse: vi.fn(async () => {}) },
+    agent: { onResponse: vi.fn(async () => {}), state: { messages: [] } },
+    compact: vi.fn(async () => ({ summary: "ok", firstKeptEntryId: "entry-1", tokensBefore: 100 })),
+    settingsManager: {
+      getCompactionSettings: vi.fn(() => ({ enabled: true, reserveTokens: 16, keepRecentTokens: 20 })),
+    },
     modelRegistry: {
       find: vi.fn((provider: string, id: string) => ({
         id, name: id, provider, contextWindow: 1000, maxTokens: 100, reasoning: false,
@@ -198,6 +202,88 @@ describe("PiAgentBrain", () => {
     const session = makeFakeSession({ getContextUsage: () => ({ tokens: 50, contextWindow: 100 }) });
     const brain = new PiAgentBrain(session);
     expect(brain.getContextUsage()).toEqual({ tokens: 50, contextWindow: 100, percent: 0 });
+  });
+
+  it("context preflight skips compaction when the target model window fits", async () => {
+    const session = makeFakeSession({
+      getContextUsage: vi.fn(() => ({ tokens: 10, contextWindow: 1000, percent: 1 })),
+    });
+    const brain = new PiAgentBrain(session);
+
+    const result = await brain.ensureContextForModelPrompt(
+      { id: "kimi", name: "Kimi", provider: "moonshot", contextWindow: 1000, maxTokens: 100, reasoning: false },
+      "short prompt",
+    );
+
+    expect(result).toMatchObject({ ok: true, compacted: false });
+    expect(session.compact).not.toHaveBeenCalled();
+  });
+
+  it("context preflight does not compact when fallback target has a larger window", async () => {
+    const session = makeFakeSession({
+      getContextUsage: vi.fn(() => ({ tokens: 1_000_000, contextWindow: 1_000_000, percent: 100 })),
+    });
+    const brain = new PiAgentBrain(session);
+
+    const result = await brain.ensureContextForModelPrompt(
+      { id: "bigger", name: "Bigger", provider: "p", contextWindow: 1_250_000, maxTokens: 100, reasoning: false },
+      "continue",
+    );
+
+    expect(result).toMatchObject({ ok: true, compacted: false });
+    expect(session.compact).not.toHaveBeenCalled();
+  });
+
+  it("context preflight compacts before prompting on a smaller target window", async () => {
+    const session = makeFakeSession({
+      getContextUsage: vi.fn()
+        .mockReturnValueOnce({ tokens: 990, contextWindow: 1000, percent: 99 })
+        .mockReturnValueOnce({ tokens: 100, contextWindow: 1000, percent: 10 }),
+    });
+    const brain = new PiAgentBrain(session);
+
+    const result = await brain.ensureContextForModelPrompt(
+      { id: "kimi", name: "Kimi", provider: "moonshot", contextWindow: 1000, maxTokens: 100, reasoning: false },
+      "continue",
+    );
+
+    expect(result).toMatchObject({ ok: true, compacted: true });
+    expect(session.compact).toHaveBeenCalledWith(expect.stringContaining("moonshot/kimi"));
+  });
+
+  it("context preflight fails closed when compaction cannot fit the target window", async () => {
+    const session = makeFakeSession({
+      getContextUsage: vi.fn(() => ({ tokens: 990, contextWindow: 1000, percent: 99 })),
+    });
+    const brain = new PiAgentBrain(session);
+
+    const result = await brain.ensureContextForModelPrompt(
+      { id: "kimi", name: "Kimi", provider: "moonshot", contextWindow: 1000, maxTokens: 100, reasoning: false },
+      "continue",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.compacted).toBe(true);
+    expect(result.errorMessage).toContain("still exceeds");
+  });
+
+  it("context preflight uses message estimation when provider usage is unavailable", async () => {
+    const session = makeFakeSession({
+      getContextUsage: vi.fn(() => undefined),
+      agent: {
+        onResponse: vi.fn(async () => {}),
+        state: { messages: [{ role: "user", content: [{ type: "text", text: "x".repeat(4000) }] }] },
+      },
+    });
+    const brain = new PiAgentBrain(session);
+
+    const result = await brain.ensureContextForModelPrompt(
+      { id: "tiny", name: "Tiny", provider: "p", contextWindow: 1000, maxTokens: 100, reasoning: false },
+      "continue",
+    );
+
+    expect(result.compacted).toBe(true);
+    expect(session.compact).toHaveBeenCalled();
   });
 
   it("getSessionStats returns token + cost values", () => {

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -12,7 +12,9 @@ import type {
   BrainContextUsage,
   BrainSessionStats,
   BrainProviderResponse,
+  BrainContextPreflightResult,
 } from "../brain-session.js";
+import { estimateMessagesTokens } from "../compaction.js";
 
 export class PiAgentBrain implements BrainSession {
   readonly brainType = "pi-agent" as const;
@@ -28,6 +30,7 @@ export class PiAgentBrain implements BrainSession {
 
   private static readonly MAX_EMPTY_RETRIES = 2;
   private static readonly RETRY_DELAY_MS = 2000;
+  private static readonly PROMPT_PREFLIGHT_SAFETY_TOKENS = 2048;
 
   private emit(event: any): void {
     for (const listener of this.extraListeners) {
@@ -217,6 +220,69 @@ export class PiAgentBrain implements BrainSession {
     this.session.modelRegistry.registerProvider(name, config as any);
   }
 
+  async ensureContextForModelPrompt(
+    model: BrainModelInfo,
+    text: string,
+  ): Promise<BrainContextPreflightResult> {
+    const settings = this.session.settingsManager.getCompactionSettings();
+    const contextWindow = Math.max(0, Math.floor(model.contextWindow || 0));
+    const reserveTokens = Math.max(0, Math.floor(settings.reserveTokens || 0));
+    const promptTokens = estimatePromptTokens(text) + Math.min(
+      PiAgentBrain.PROMPT_PREFLIGHT_SAFETY_TOKENS,
+      Math.max(0, Math.floor(contextWindow * 0.02)),
+    );
+    const budget = contextWindow - reserveTokens;
+    if (contextWindow <= 0 || budget <= 0) {
+      return {
+        ok: false,
+        compacted: false,
+        contextWindow,
+        errorMessage: `Context preflight failed: invalid context window for ${model.provider}/${model.id}`,
+      };
+    }
+
+    const beforeTokens = estimateCurrentContextTokens(this.session) + promptTokens;
+    if (beforeTokens <= budget) {
+      return { ok: true, compacted: false, tokens: beforeTokens, contextWindow };
+    }
+    if (!settings.enabled) {
+      return {
+        ok: false,
+        compacted: false,
+        tokens: beforeTokens,
+        contextWindow,
+        errorMessage: `Context preflight failed: estimated ${beforeTokens} tokens exceeds ${model.provider}/${model.id} window ${contextWindow} and compaction is disabled.`,
+      };
+    }
+
+    try {
+      await this.session.compact(
+        `Prepare this session to continue on ${model.provider}/${model.id} with a ${contextWindow} token context window. Preserve the user's latest request, current task state, decisions, constraints, tool findings, and exact identifiers needed to continue.`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false,
+        compacted: false,
+        tokens: beforeTokens,
+        contextWindow,
+        errorMessage: `Context preflight compaction failed before using ${model.provider}/${model.id}: ${message}`,
+      };
+    }
+
+    const afterTokens = estimateCurrentContextTokens(this.session) + promptTokens;
+    if (afterTokens > budget) {
+      return {
+        ok: false,
+        compacted: true,
+        tokens: afterTokens,
+        contextWindow,
+        errorMessage: `Context preflight failed after compaction: estimated ${afterTokens} tokens still exceeds ${model.provider}/${model.id} budget ${budget}.`,
+      };
+    }
+    return { ok: true, compacted: true, tokens: afterTokens, contextWindow };
+  }
+
   captureProviderResponse(listener: (response: BrainProviderResponse) => void): () => void {
     const agent = (this.session as unknown as { agent?: { onResponse?: unknown } }).agent;
     if (!agent || typeof agent !== "object") return () => {};
@@ -263,6 +329,25 @@ export class PiAgentBrain implements BrainSession {
     }
     this.session.agent.state.messages = sessionManager.buildSessionContext().messages;
   }
+}
+
+function estimatePromptTokens(text: string): number {
+  return estimateMessagesTokens([
+    {
+      role: "user",
+      content: [{ type: "text", text }],
+      timestamp: Date.now(),
+    } as any,
+  ]);
+}
+
+function estimateCurrentContextTokens(session: AgentSession): number {
+  const usage = session.getContextUsage();
+  if (usage && typeof usage.tokens === "number" && Number.isFinite(usage.tokens)) {
+    return Math.max(0, Math.ceil(usage.tokens));
+  }
+  const messages = Array.isArray(session.agent.state.messages) ? session.agent.state.messages : [];
+  return estimateMessagesTokens(messages as any[]);
 }
 
 function normalizeHeaders(value: unknown): Record<string, string> {

--- a/src/core/model-routing.test.ts
+++ b/src/core/model-routing.test.ts
@@ -49,6 +49,7 @@ function makePolicy(): ModelRoutePolicy {
 type BrainOutcome =
   | "ok"
   | "rate_limit"
+  | "tool_then_rate_limit"
   | "model_not_found"
   | "context"
   | "empty"
@@ -102,6 +103,31 @@ function makeBrain(outcomes: BrainOutcome[]): BrainSession & {
         return;
       }
       if (outcome === "rate_limit") {
+        emitter.emit("event", {
+          type: "message_end",
+          message: {
+            role: "assistant",
+            content: [],
+            stopReason: "error",
+            errorMessage: "429 rate limit exceeded",
+          },
+        });
+        return;
+      }
+      if (outcome === "tool_then_rate_limit") {
+        emitter.emit("event", {
+          type: "tool_execution_start",
+          toolCallId: "call_1",
+          toolName: "read",
+          args: { path: "README.md" },
+        });
+        emitter.emit("event", {
+          type: "tool_execution_end",
+          toolCallId: "call_1",
+          toolName: "read",
+          result: { content: [{ type: "text", text: "ok" }] },
+          isError: false,
+        });
         emitter.emit("event", {
           type: "message_end",
           message: {
@@ -169,6 +195,7 @@ function makeBrain(outcomes: BrainOutcome[]): BrainSession & {
       setModelCalls.push(model);
     }),
     findModel: vi.fn((provider: string, id: string) => MODELS.find((model) => model.provider === provider && model.id === id)),
+    ensureContextForModelPrompt: vi.fn(async () => ({ ok: true, compacted: false })),
     registerProvider: vi.fn(),
     captureProviderResponse: vi.fn((listener) => {
       providerResponseListener = listener;
@@ -356,6 +383,130 @@ describe("runPromptWithModelRouting", () => {
     expect(state.activeCandidateKey).toBe("anthropic/claude");
     expect(state.cooldowns["openai/gpt-4"]).toBe(11_000);
     expect(events.some((event) => event.type === "model_route_switch")).toBe(true);
+  });
+
+  it("does not replay a prompt on fallback after a tool has executed", async () => {
+    const brain = makeBrain(["tool_then_rate_limit", "ok"]);
+    const state = createModelRouteState();
+    const routeEvents: ModelRouteEvent[] = [];
+    const brainEvents: unknown[] = [];
+
+    const result = await runPromptWithModelRouting(brain, "inspect then fail", makePolicy(), state, {
+      emitEvent: (event) => routeEvents.push(event),
+      emitBrainEvent: (event) => brainEvents.push(event),
+      now: () => 10_000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.exhausted).toBe(true);
+    expect(result.finalFailureKind).toBe("rate_limit");
+    expect(brain.prompt).toHaveBeenCalledTimes(1);
+    expect(brain.promptModels).toEqual(["openai/gpt-4"]);
+    expect(result.attempted[0]).toMatchObject({
+      failureKind: "rate_limit",
+      fallbackBlockedReason: "tool_execution",
+    });
+    expect(state.cooldowns["openai/gpt-4"]).toBe(11_000);
+    expect(routeEvents.some((event) => event.type === "model_route_switch")).toBe(false);
+    expect(routeEvents.find((event) => event.type === "model_route_exhausted")).toMatchObject({
+      failureKind: "rate_limit",
+      fallbackBlockedReason: "tool_execution",
+    });
+    expect(brainEvents.some((event) => isEventType(event, "tool_execution_end"))).toBe(true);
+    expect(brainEvents.some((event) => isEventType(event, "message_end"))).toBe(true);
+  });
+
+  it("runs context preflight before prompting each candidate", async () => {
+    const brain = makeBrain(["ok"]);
+    const state = createModelRouteState();
+
+    const result = await runPromptWithModelRouting(brain, "hello", makePolicy(), state, {
+      now: () => 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(brain.ensureContextForModelPrompt).toHaveBeenCalledWith(MODELS[0], "hello");
+    expect(brain.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not prompt a candidate when context preflight cannot fit its window", async () => {
+    const brain = makeBrain(["ok"]);
+    brain.ensureContextForModelPrompt = vi.fn(async () => ({
+      ok: false,
+      compacted: true,
+      tokens: 300_000,
+      contextWindow: 128_000,
+      errorMessage: "Context preflight failed after compaction",
+    }));
+    const state = createModelRouteState();
+    const events: ModelRouteEvent[] = [];
+    const policy: ModelRoutePolicy = {
+      ...makePolicy(),
+      candidates: [{ provider: "openai", modelId: "gpt-4" }],
+    };
+
+    const result = await runPromptWithModelRouting(brain, "huge history", policy, state, {
+      emitEvent: (event) => events.push(event),
+      now: () => 10_000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.exhausted).toBe(true);
+    expect(result.finalFailureKind).toBe("context_overflow");
+    expect(brain.prompt).not.toHaveBeenCalled();
+    expect(result.attempted[0]).toMatchObject({
+      failureKind: "context_overflow",
+      failureSource: "setup",
+      errorMessage: "Context preflight failed after compaction",
+    });
+    expect(events.some((event) => event.type === "model_route_switch")).toBe(false);
+    expect(events.find((event) => event.type === "model_route_exhausted")).toMatchObject({
+      failureKind: "context_overflow",
+    });
+  });
+
+  it("skips a preflight-overflow candidate and tries the next route candidate", async () => {
+    const brain = makeBrain(["rate_limit", "ok"]);
+    brain.ensureContextForModelPrompt = vi.fn(async (model: BrainModelInfo) => {
+      if (model.provider === "anthropic") {
+        return {
+          ok: false,
+          compacted: true,
+          tokens: 300_000,
+          contextWindow: 128_000,
+          errorMessage: "Context preflight failed after compaction",
+        };
+      }
+      return { ok: true, compacted: false };
+    });
+    const state = createModelRouteState();
+    const events: ModelRouteEvent[] = [];
+
+    const result = await runPromptWithModelRouting(brain, "huge history", makePolicy(), state, {
+      emitEvent: (event) => events.push(event),
+      now: () => 10_000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.attempted.map((attempt) => attempt.candidateKey)).toEqual([
+      "openai/gpt-4",
+      "anthropic/claude",
+      "deepseek/deepseek-chat",
+    ]);
+    expect(result.attempted[1]).toMatchObject({
+      failureKind: "context_overflow",
+      failureSource: "setup",
+    });
+    expect(brain.promptModels).toEqual(["openai/gpt-4", "deepseek/deepseek-chat"]);
+    expect(state.cooldowns["openai/gpt-4"]).toBe(11_000);
+    expect(state.cooldowns["anthropic/claude"]).toBeUndefined();
+    expect(events.filter((event) => event.type === "model_route_switch")).toHaveLength(2);
+    expect(events.find((event): event is ModelRouteEvent & { type: "model_route_success" } =>
+      event.type === "model_route_success",
+    )).toMatchObject({
+      candidateKey: "deepseek/deepseek-chat",
+      isFallback: true,
+    });
   });
 
   it("classifies routed attempts using captured provider response status", async () => {
@@ -867,3 +1018,7 @@ describe("runPromptWithModelRouting", () => {
     });
   });
 });
+
+function isEventType(event: unknown, type: string): boolean {
+  return typeof event === "object" && event !== null && (event as { type?: unknown }).type === type;
+}

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -18,6 +18,7 @@ export type ModelRouteFailureKind =
   | "unknown";
 
 export type ModelRouteCooldownMsByKind = Partial<Record<ModelRouteFailureKind, number>>;
+export type ModelRouteFallbackBlockedReason = "tool_execution";
 
 export interface ModelRouteCandidate {
   provider: string;
@@ -45,6 +46,7 @@ export interface ModelRouteAttempt {
   success?: boolean;
   failureKind?: ModelRouteFailureKind;
   failureSource?: "prompt_error" | "message_end" | "setup";
+  fallbackBlockedReason?: ModelRouteFallbackBlockedReason;
   errorMessage?: string;
 }
 
@@ -76,6 +78,7 @@ export type ModelRouteEvent =
       modelId: string;
       status: "started" | "failed";
       failureKind?: ModelRouteFailureKind;
+      fallbackBlockedReason?: ModelRouteFallbackBlockedReason;
       errorMessage?: string;
     }
   | {
@@ -108,6 +111,7 @@ export type ModelRouteEvent =
       attempt: number;
       candidateKey?: string;
       failureKind?: ModelRouteFailureKind;
+      fallbackBlockedReason?: ModelRouteFallbackBlockedReason;
       errorMessage?: string;
     };
 
@@ -159,6 +163,7 @@ interface AttemptResult {
   failure: AttemptFailure | null;
   checkpoint: unknown;
   events: unknown[];
+  hadToolExecution: boolean;
 }
 
 const ATTEMPT_HISTORY_LIMIT = 20;
@@ -450,6 +455,13 @@ export function shouldFallbackForKind(kind: ModelRouteFailureKind, policy: Model
   return DEFAULT_FALLBACK_ON.has(kind);
 }
 
+function shouldTryNextCandidateForFailure(failure: AttemptFailure, policy: ModelRoutePolicy): boolean {
+  if (failure.kind === "context_overflow" && failure.source === "setup") {
+    return !normalizeFailureKindSet(policy.noFallbackOn).has("context_overflow");
+  }
+  return shouldFallbackForKind(failure.kind, policy);
+}
+
 export async function runPromptWithModelRouting(
   brain: BrainSession,
   text: string,
@@ -547,6 +559,7 @@ export async function runPromptWithModelRouting(
     attempt.failureKind = failure.kind;
     attempt.failureSource = failure.source;
     attempt.errorMessage = failure.message;
+    if (attemptResult.hadToolExecution) attempt.fallbackBlockedReason = "tool_execution";
     state.lastFailureAt = attempt.finishedAt;
     recordAttempt(state, attempt);
 
@@ -558,11 +571,17 @@ export async function runPromptWithModelRouting(
       modelId: candidate.modelId,
       status: "failed",
       failureKind: failure.kind,
+      fallbackBlockedReason: attempt.fallbackBlockedReason,
       errorMessage: failure.message,
     });
 
     const nextCandidate = ordered[i + 1];
-    if (!nextCandidate || !shouldFallbackForKind(failure.kind, policy)) {
+    if (attempt.fallbackBlockedReason && nextCandidate) {
+      const cooldownUntil = cooldownUntilForFailure(failure, policy, now());
+      if (cooldownUntil) state.cooldowns[key] = cooldownUntil;
+      else delete state.cooldowns[key];
+    }
+    if (!nextCandidate || attempt.fallbackBlockedReason || !shouldTryNextCandidateForFailure(failure, policy)) {
       flushBrainEvents(attemptResult.events, emitBrainEvent);
       state.lastSwitchReason = failure.kind;
       options.onStateChange?.(state);
@@ -571,6 +590,7 @@ export async function runPromptWithModelRouting(
         attempt: attempt.attempt,
         candidateKey: key,
         failureKind: failure.kind,
+        fallbackBlockedReason: attempt.fallbackBlockedReason,
         errorMessage: failure.message,
       });
 
@@ -643,16 +663,18 @@ async function runAttempt(
     if (response.modelId && response.modelId !== candidate.modelId) return;
     lastProviderResponse = response;
   });
+  let model: BrainModelInfo | undefined;
   try {
     if (candidate.modelConfig && brain.registerProvider) {
       brain.registerProvider(candidate.provider, candidate.modelConfig);
     }
-    const model = brain.findModel(candidate.provider, candidate.modelId);
+    model = brain.findModel(candidate.provider, candidate.modelId);
     if (!model) {
       unsubscribeProviderResponse?.();
       return {
         checkpoint,
         events: [],
+        hadToolExecution: false,
         failure: {
           kind: "model_not_found",
           source: "setup",
@@ -670,6 +692,7 @@ async function runAttempt(
     return {
       checkpoint,
       events: [],
+      hadToolExecution: false,
       failure: {
         kind: classifyModelRouteFailure({
           errorMessage: message,
@@ -688,8 +711,10 @@ async function runAttempt(
 
   let lastAssistantMessage: AssistantMessageLike | null = null;
   const events: unknown[] = [];
+  let hadToolExecution = false;
   const unsubscribe = brain.subscribe((event: unknown) => {
     events.push(event);
+    if (isToolExecutionEvent(event)) hadToolExecution = true;
     if (!isRecord(event) || event.type !== "message_end") return;
     const message = event.message;
     if (isRecord(message) && message.role === "assistant") {
@@ -698,12 +723,29 @@ async function runAttempt(
   });
 
   try {
+    const preflight = model
+      ? await brain.ensureContextForModelPrompt?.(model, text)
+      : undefined;
+    if (preflight && !preflight.ok) {
+      return {
+        checkpoint,
+        events,
+        hadToolExecution,
+        failure: {
+          kind: "context_overflow",
+          source: "setup",
+          message: preflight.errorMessage ?? `Context preflight failed for ${candidate.provider}/${candidate.modelId}`,
+          providerResponse: lastProviderResponse,
+        },
+      };
+    }
     await brain.prompt(text);
   } catch (err) {
     const message = errorMessage(err);
     return {
       checkpoint,
       events,
+      hadToolExecution,
       failure: {
         kind: classifyModelRouteFailure({
           errorMessage: message,
@@ -726,6 +768,7 @@ async function runAttempt(
   return {
     checkpoint,
     events,
+    hadToolExecution,
     failure: failureFromAssistantMessage(lastAssistantMessage, candidate, lastProviderResponse),
   };
 }
@@ -736,6 +779,13 @@ async function restorePromptCheckpoint(brain: BrainSession, checkpoint: unknown)
 
 function flushBrainEvents(events: unknown[], emitBrainEvent: (event: unknown) => void): void {
   for (const event of events) emitBrainEvent(event);
+}
+
+function isToolExecutionEvent(event: unknown): boolean {
+  if (!isRecord(event)) return false;
+  if (event.type === "tool_execution_start" || event.type === "tool_execution_end") return true;
+  if (event.type !== "message_end" || !isRecord(event.message)) return false;
+  return event.message.role === "toolResult";
 }
 
 function failureFromAssistantMessage(


### PR DESCRIPTION
## Summary
- prevent automatic model-route prompt replay after a failed attempt has already executed tools
- add fallback context preflight so smaller-context candidates compact before prompting and fail closed when they still cannot fit
- cover the routing, PiAgentBrain, and AgentBox HTTP paths with focused tests

## Why
When a fallback attempt fails after tool execution, replaying the same user prompt on another model can duplicate external side effects. Also, if 1M-context models are unavailable and the route falls back to a 256K/128K model, the runtime should compact proactively instead of blindly hitting context overflow.

## Validation
- `npx vitest run src/core/brains/pi-agent-brain.test.ts src/core/model-routing.test.ts src/agentbox/http-server.test.ts`
- `npx vitest run src/core/compaction.test.ts src/core/extensions/compaction-safeguard.test.ts`
- `npx tsc -p tsconfig.agentbox.json`
- `npx tsc --noEmit --pretty false`
- `git diff --check`
