### PR TITLE
Remember chat agent and session selection

### DIFF
--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -136,9 +136,11 @@ function SessionSidebar({
 
 interface AgentChatProps {
   agentId: string
+  selectedSessionId?: string | null
+  onSessionChange?: (sessionId: string | null) => void
 }
 
-export function AgentChat({ agentId }: AgentChatProps) {
+export function AgentChat({ agentId, selectedSessionId, onSessionChange }: AgentChatProps) {
   const toast = useToast()
   const confirmDialog = useConfirm()
   const [showSessions, setShowSessions] = useState(false)
@@ -146,6 +148,8 @@ export function AgentChat({ agentId }: AgentChatProps) {
   const [sessions, setSessions] = useState<ChatSession[]>([])
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const activeSessionIdRef = useRef<string | null>(null)
+  const selectedSessionIdRef = useRef<string | null | undefined>(selectedSessionId)
 
   // Panel state
   const [skillPanelMsg, setSkillPanelMsg] = useState<PilotMessage | null>(null)
@@ -155,6 +159,20 @@ export function AgentChat({ agentId }: AgentChatProps) {
 
   // Auto-title: track whether we already titled this session
   const titledSessionRef = useRef<string | null>(null)
+
+  const selectSession = useCallback((sessionId: string | null) => {
+    activeSessionIdRef.current = sessionId
+    setActiveSessionId(sessionId)
+    onSessionChange?.(sessionId)
+  }, [onSessionChange])
+
+  useEffect(() => {
+    activeSessionIdRef.current = activeSessionId
+  }, [activeSessionId])
+
+  useEffect(() => {
+    selectedSessionIdRef.current = selectedSessionId
+  }, [selectedSessionId])
 
   // Pilot-style chat hook
   const pilot = usePilotChat({ agentId, sessionId: activeSessionId })
@@ -186,12 +204,24 @@ export function AgentChat({ agentId }: AgentChatProps) {
       try {
         setLoading(true)
         const res = await api<{ data: ChatSession[] }>(`/siclaw/agents/${agentId}/chat/sessions`)
-        const items = Array.isArray(res.data) ? res.data : Array.isArray(res) ? (res as any) : []
+        const items: ChatSession[] = Array.isArray(res.data)
+          ? res.data
+          : Array.isArray(res)
+            ? (res as ChatSession[])
+            : []
         if (!cancelled) {
           setSessions(items)
-          if (items.length > 0 && !activeSessionId) {
-            setActiveSessionId(items[0].id)
-          }
+          const hasSession = (sessionId: string | null | undefined) => (
+            Boolean(sessionId) && items.some((item) => item.id === sessionId)
+          )
+          const requestedSessionId = selectedSessionIdRef.current
+          const currentSessionId = activeSessionIdRef.current
+          const nextSessionId = hasSession(requestedSessionId)
+            ? requestedSessionId!
+            : hasSession(currentSessionId)
+              ? currentSessionId!
+              : items[0]?.id || null
+          selectSession(nextSessionId)
         }
       } catch (err: any) {
         if (!cancelled) toast.error(err.message || "Failed to load sessions")
@@ -203,7 +233,34 @@ export function AgentChat({ agentId }: AgentChatProps) {
     return () => {
       cancelled = true
     }
-  }, [agentId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [agentId, selectSession, toast])
+
+  useEffect(() => {
+    if (selectedSessionId === undefined) return
+
+    const hasSession = (sessionId: string | null | undefined) => (
+      Boolean(sessionId) && sessions.some((item) => item.id === sessionId)
+    )
+
+    if (selectedSessionId && hasSession(selectedSessionId)) {
+      if (activeSessionId !== selectedSessionId) {
+        selectSession(selectedSessionId)
+      }
+      return
+    }
+
+    if (selectedSessionId && sessions.length > 0) {
+      const fallbackSessionId = hasSession(activeSessionId)
+        ? activeSessionId
+        : sessions[0].id
+      selectSession(fallbackSessionId)
+      return
+    }
+
+    if (!selectedSessionId && sessions.length === 0 && activeSessionId) {
+      selectSession(null)
+    }
+  }, [activeSessionId, selectedSessionId, selectSession, sessions])
 
   // Auto-generate title from first user message (only if still default name)
   useEffect(() => {
@@ -238,11 +295,11 @@ export function AgentChat({ agentId }: AgentChatProps) {
     try {
       const session = await api<ChatSession>(`/siclaw/agents/${agentId}/chat/sessions`, { method: "POST" })
       setSessions((prev) => [session, ...prev])
-      setActiveSessionId(session.id)
+      selectSession(session.id)
     } catch (err: any) {
       toast.error(err.message || "Failed to create session")
     }
-  }, [agentId, toast])
+  }, [agentId, selectSession, toast])
 
   const handleDeleteSession = useCallback(
     async (sid: string) => {
@@ -255,16 +312,17 @@ export function AgentChat({ agentId }: AgentChatProps) {
       if (!ok) return
       try {
         await api(`/siclaw/agents/${agentId}/chat/sessions/${sid}`, { method: "DELETE" })
-        setSessions((prev) => prev.filter((s) => s.id !== sid))
+        const nextSessions = sessions.filter((s) => s.id !== sid)
+        setSessions(nextSessions)
         if (activeSessionId === sid) {
-          setActiveSessionId(null)
+          selectSession(nextSessions[0]?.id || null)
         }
         toast.success("Session deleted")
       } catch (err: any) {
         toast.error(err.message || "Failed to delete session")
       }
     },
-    [agentId, activeSessionId, toast, confirmDialog],
+    [agentId, activeSessionId, confirmDialog, selectSession, sessions, toast],
   )
 
   // Wrap send to also handle first-message session creation
@@ -275,7 +333,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
         api<ChatSession>(`/siclaw/agents/${agentId}/chat/sessions`, { method: "POST" })
           .then((session) => {
             setSessions((prev) => [session, ...prev])
-            setActiveSessionId(session.id)
+            selectSession(session.id)
             // Short delay to let state propagate
             setTimeout(() => pilot.send(text, attachments), 50)
           })
@@ -286,7 +344,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
       }
       pilot.send(text, attachments)
     },
-    [activeSessionId, agentId, pilot, toast],
+    [activeSessionId, agentId, pilot, selectSession, toast],
   )
 
   if (loading) {
@@ -314,7 +372,7 @@ export function AgentChat({ agentId }: AgentChatProps) {
               sessions={sessions}
               activeSessionId={activeSessionId}
               agentId={agentId}
-              onSelect={(id) => { setActiveSessionId(id); setShowSessions(false) }}
+              onSelect={(id) => { selectSession(id); setShowSessions(false) }}
               onNew={() => { handleNewSession(); setShowSessions(false) }}
               onDelete={handleDeleteSession}
               onRenamed={(sid, title) => setSessions(prev => prev.map(s => s.id === sid ? { ...s, title } : s))}

--- a/portal-web/src/components/toast.tsx
+++ b/portal-web/src/components/toast.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, createContext, useContext } from "react"
+import { useState, useEffect, useCallback, useMemo, createContext, useContext } from "react"
 import { X } from "lucide-react"
 
 interface Toast {
@@ -26,11 +26,11 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 4000)
   }, [])
 
-  const value: ToastContextValue = {
+  const value = useMemo<ToastContextValue>(() => ({
     success: (m) => add(m, "success"),
     error: (m) => add(m, "error"),
     info: (m) => add(m, "info"),
-  }
+  }), [add])
 
   return (
     <ToastContext.Provider value={value}>

--- a/portal-web/src/lib/chatSelection.test.ts
+++ b/portal-web/src/lib/chatSelection.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  buildChatPath,
+  chatPathFromStoredSelection,
+  chatSessionForAgent,
+  readChatSelection,
+  rememberChatAgent,
+  rememberChatSession,
+} from "./chatSelection"
+
+function installMockWindow() {
+  const storage = new Map<string, string>()
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    },
+    dispatchEvent: vi.fn(),
+  })
+}
+
+describe("chatSelection", () => {
+  beforeEach(() => {
+    installMockWindow()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("builds chat paths with agent and session params", () => {
+    expect(buildChatPath({ agentId: "agent-a", sessionId: "session-1" })).toBe(
+      "/chat?agent=agent-a&session=session-1",
+    )
+    expect(buildChatPath({ agentId: "agent-a" })).toBe("/chat?agent=agent-a")
+    expect(buildChatPath()).toBe("/chat")
+  })
+
+  it("remembers the last agent and each agent's last session", () => {
+    rememberChatSession("agent-a", "session-a1")
+    rememberChatSession("agent-b", "session-b1")
+    rememberChatAgent("agent-a")
+
+    const selection = readChatSelection()
+    expect(selection.lastAgentId).toBe("agent-a")
+    expect(selection.lastSessionId).toBe("session-a1")
+    expect(chatSessionForAgent("agent-b", selection)).toBe("session-b1")
+    expect(chatPathFromStoredSelection()).toBe("/chat?agent=agent-a&session=session-a1")
+  })
+
+  it("clears only the deleted agent session", () => {
+    rememberChatSession("agent-a", "session-a1")
+    rememberChatSession("agent-b", "session-b1")
+    rememberChatSession("agent-a", null)
+
+    const selection = readChatSelection()
+    expect(selection.lastAgentId).toBe("agent-a")
+    expect(selection.lastSessionId).toBeNull()
+    expect(chatSessionForAgent("agent-a", selection)).toBeNull()
+    expect(chatSessionForAgent("agent-b", selection)).toBe("session-b1")
+    expect(chatPathFromStoredSelection()).toBe("/chat?agent=agent-a")
+  })
+})

--- a/portal-web/src/lib/chatSelection.ts
+++ b/portal-web/src/lib/chatSelection.ts
@@ -1,0 +1,168 @@
+const STORAGE_KEY = "siclaw.chatSelection.v1"
+
+export const CHAT_SELECTION_CHANGE_EVENT = "siclaw:chat-selection-change"
+
+export interface ChatSelectionState {
+  lastAgentId: string | null
+  lastSessionId: string | null
+  sessionsByAgent: Record<string, string>
+}
+
+interface ChatPathSelection {
+  agentId?: string | null
+  sessionId?: string | null
+}
+
+const emptySelection = (): ChatSelectionState => ({
+  lastAgentId: null,
+  lastSessionId: null,
+  sessionsByAgent: {},
+})
+
+const normalizeId = (value: unknown): string | null => {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const normalizeSelection = (value: unknown): ChatSelectionState => {
+  if (!value || typeof value !== "object") {
+    return emptySelection()
+  }
+
+  const raw = value as Partial<ChatSelectionState>
+  const sessionsByAgent: Record<string, string> = {}
+
+  if (raw.sessionsByAgent && typeof raw.sessionsByAgent === "object") {
+    Object.entries(raw.sessionsByAgent).forEach(([agentId, sessionId]) => {
+      const normalizedAgentId = normalizeId(agentId)
+      const normalizedSessionId = normalizeId(sessionId)
+      if (normalizedAgentId && normalizedSessionId) {
+        sessionsByAgent[normalizedAgentId] = normalizedSessionId
+      }
+    })
+  }
+
+  const lastAgentId = normalizeId(raw.lastAgentId)
+  const lastSessionId = lastAgentId
+    ? normalizeId(raw.lastSessionId) || sessionsByAgent[lastAgentId] || null
+    : null
+
+  if (lastAgentId && lastSessionId) {
+    sessionsByAgent[lastAgentId] = lastSessionId
+  }
+
+  return {
+    lastAgentId,
+    lastSessionId,
+    sessionsByAgent,
+  }
+}
+
+const emitSelectionChange = () => {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new Event(CHAT_SELECTION_CHANGE_EVENT))
+}
+
+const writeChatSelection = (selection: ChatSelectionState): ChatSelectionState => {
+  if (typeof window === "undefined") {
+    return selection
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(selection))
+    emitSelectionChange()
+  } catch {
+    // Keep chat usable when localStorage is unavailable.
+  }
+
+  return selection
+}
+
+export const readChatSelection = (): ChatSelectionState => {
+  if (typeof window === "undefined") {
+    return emptySelection()
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? normalizeSelection(JSON.parse(raw)) : emptySelection()
+  } catch {
+    return emptySelection()
+  }
+}
+
+export const chatSessionForAgent = (
+  agentId: string | null | undefined,
+  selection: ChatSelectionState = readChatSelection(),
+): string | null => {
+  const normalizedAgentId = normalizeId(agentId)
+  if (!normalizedAgentId) return null
+  return selection.sessionsByAgent[normalizedAgentId] || null
+}
+
+export const rememberChatAgent = (agentId: string): ChatSelectionState => {
+  const normalizedAgentId = normalizeId(agentId)
+  if (!normalizedAgentId) {
+    return readChatSelection()
+  }
+
+  const previous = readChatSelection()
+  return writeChatSelection({
+    lastAgentId: normalizedAgentId,
+    lastSessionId: previous.sessionsByAgent[normalizedAgentId] || null,
+    sessionsByAgent: previous.sessionsByAgent,
+  })
+}
+
+export const rememberChatSession = (
+  agentId: string,
+  sessionId: string | null,
+): ChatSelectionState => {
+  const normalizedAgentId = normalizeId(agentId)
+  if (!normalizedAgentId) {
+    return readChatSelection()
+  }
+
+  const normalizedSessionId = normalizeId(sessionId)
+  const previous = readChatSelection()
+  const sessionsByAgent = { ...previous.sessionsByAgent }
+
+  if (normalizedSessionId) {
+    sessionsByAgent[normalizedAgentId] = normalizedSessionId
+  } else {
+    delete sessionsByAgent[normalizedAgentId]
+  }
+
+  return writeChatSelection({
+    lastAgentId: normalizedAgentId,
+    lastSessionId: normalizedSessionId,
+    sessionsByAgent,
+  })
+}
+
+export const buildChatPath = (
+  selection: ChatPathSelection = {},
+  basePath = "/chat",
+): string => {
+  const params = new URLSearchParams()
+  const agentId = normalizeId(selection.agentId)
+  const sessionId = normalizeId(selection.sessionId)
+
+  if (agentId) params.set("agent", agentId)
+  if (sessionId) params.set("session", sessionId)
+
+  const query = params.toString()
+  return query ? `${basePath}?${query}` : basePath
+}
+
+export const chatPathFromStoredSelection = (basePath = "/chat"): string => {
+  const selection = readChatSelection()
+  return buildChatPath(
+    {
+      agentId: selection.lastAgentId,
+      sessionId: chatSessionForAgent(selection.lastAgentId, selection),
+    },
+    basePath,
+  )
+}

--- a/portal-web/src/pages/Agents.tsx
+++ b/portal-web/src/pages/Agents.tsx
@@ -5,6 +5,7 @@ import { api, clearAgentMemory } from "../api"
 import { useToast } from "../components/toast"
 import { Tooltip } from "../components/tooltip"
 import { useConfirm } from "../components/confirm-dialog"
+import { buildChatPath, chatSessionForAgent } from "../lib/chatSelection"
 
 interface Agent {
   id: string; name: string; description: string; status: string
@@ -81,6 +82,10 @@ export function Agents() {
     const m = p?.models?.find((mo) => mo.model_id === agent.model_id)
     return m?.name || agent.model_id
   }
+
+  const chatPathForAgent = (agentId: string) => (
+    buildChatPath({ agentId, sessionId: chatSessionForAgent(agentId) })
+  )
 
   if (loading) return <div className="flex items-center justify-center h-full"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>
 
@@ -163,7 +168,7 @@ export function Agents() {
         ) : (
           <div className="px-6 py-4 space-y-2">
             {agents.map((a) => (
-              <div key={a.id} className="flex items-center gap-4 p-4 rounded-lg border border-border/50 hover:bg-secondary/20 cursor-pointer transition-colors" onClick={() => navigate(`/chat?agent=${a.id}`)}>
+              <div key={a.id} className="flex items-center gap-4 p-4 rounded-lg border border-border/50 hover:bg-secondary/20 cursor-pointer transition-colors" onClick={() => navigate(chatPathForAgent(a.id))}>
                 {/* Icon */}
                 <div className="h-10 w-10 rounded-lg flex items-center justify-center shrink-0 bg-secondary text-muted-foreground">
                   <Bot className="h-5 w-5" />
@@ -205,7 +210,7 @@ export function Agents() {
 
                 {/* Actions */}
                 <div className="flex items-center gap-0.5 shrink-0">
-                  <Tooltip content="Chat"><button onClick={(e) => { e.stopPropagation(); navigate(`/chat?agent=${a.id}`) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><MessageSquare className="h-4 w-4" /></button></Tooltip>
+                  <Tooltip content="Chat"><button onClick={(e) => { e.stopPropagation(); navigate(chatPathForAgent(a.id)) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><MessageSquare className="h-4 w-4" /></button></Tooltip>
                   <Tooltip content="Fork"><button onClick={(e) => { e.stopPropagation(); handleFork(a) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><Copy className="h-4 w-4" /></button></Tooltip>
                   <Tooltip content="Clear Memory"><button onClick={(e) => { e.stopPropagation(); handleClearMemory(a.id) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><Eraser className="h-4 w-4" /></button></Tooltip>
                   <Tooltip content="Settings"><button onClick={(e) => { e.stopPropagation(); navigate(`/agents/${a.id}?tab=basic`) }} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground"><Settings className="h-4 w-4" /></button></Tooltip>

--- a/portal-web/src/pages/Chat.tsx
+++ b/portal-web/src/pages/Chat.tsx
@@ -168,11 +168,7 @@ export function Chat() {
     if (!selectedAgentId) return
 
     setSelectedSessionId(sessionId)
-    if (sessionId) {
-      rememberChatSession(selectedAgentId, sessionId)
-    } else {
-      rememberChatSession(selectedAgentId, null)
-    }
+    rememberChatSession(selectedAgentId, sessionId)
     updateChatSearchParams(selectedAgentId, sessionId, true)
   }, [selectedAgentId, updateChatSearchParams])
 

--- a/portal-web/src/pages/Chat.tsx
+++ b/portal-web/src/pages/Chat.tsx
@@ -1,8 +1,14 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { useSearchParams, useLocation } from "react-router-dom"
 import { Bot, Loader2, MessageSquare, PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { api } from "../api"
 import { AgentChat } from "../components/AgentChat"
+import {
+  chatSessionForAgent,
+  readChatSelection,
+  rememberChatAgent,
+  rememberChatSession,
+} from "../lib/chatSelection"
 
 const AGENT_SELECTOR_COLLAPSED_KEY = "siclaw.agentSelector.collapsed"
 const AGENT_SELECTOR_OVERLAY_WIDTH = 220
@@ -16,7 +22,15 @@ export function Chat() {
   const location = useLocation()
   const [agents, setAgents] = useState<Agent[]>([])
   const [loading, setLoading] = useState(true)
-  const [selectedAgentId, setSelectedAgentId] = useState<string>(searchParams.get("agent") || "")
+  const [selectedAgentId, setSelectedAgentId] = useState<string>(() => {
+    const selection = readChatSelection()
+    return searchParams.get("agent") || selection.lastAgentId || ""
+  })
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(() => {
+    const selection = readChatSelection()
+    const initialAgentId = searchParams.get("agent") || selection.lastAgentId || ""
+    return searchParams.get("session") || chatSessionForAgent(initialAgentId, selection)
+  })
   const [agentPreview, setAgentPreview] = useState<{ agentId: string; left: number; top: number } | null>(null)
   const [agentSelectorCollapsed, setAgentSelectorCollapsed] = useState<boolean>(() => {
     try {
@@ -26,28 +40,75 @@ export function Chat() {
     }
   })
 
-  // Sync agent selection when the URL's ?agent= param changes (e.g. deep link
-  // navigation while the component is always mounted in Layout).
+  const updateChatSearchParams = useCallback(
+    (agentId: string, sessionId: string | null, replace = false) => {
+      const pathname = typeof window === "undefined" ? location.pathname : window.location.pathname
+      if (!pathname.startsWith("/chat")) return
+
+      const next = new URLSearchParams()
+      next.set("agent", agentId)
+      if (sessionId) next.set("session", sessionId)
+      setSearchParams(next, { replace })
+    },
+    [location.pathname, setSearchParams],
+  )
+
+  // Sync selection when URL params change while Chat is kept mounted by Layout.
   const agentFromUrl = searchParams.get("agent")
+  const sessionFromUrl = searchParams.get("session")
   useEffect(() => {
-    if (agentFromUrl && agentFromUrl !== selectedAgentId) {
-      setSelectedAgentId(agentFromUrl)
+    if (!location.pathname.startsWith("/chat") || !agentFromUrl) {
+      return
+    }
+
+    const restoredSessionId = sessionFromUrl || chatSessionForAgent(agentFromUrl)
+    setSelectedAgentId((current) => (current === agentFromUrl ? current : agentFromUrl))
+    setSelectedSessionId((current) => (current === restoredSessionId ? current : restoredSessionId))
+
+    if (sessionFromUrl) {
+      rememberChatSession(agentFromUrl, sessionFromUrl)
+    } else {
+      rememberChatAgent(agentFromUrl)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentFromUrl])
+  }, [agentFromUrl, sessionFromUrl, location.pathname])
 
   useEffect(() => {
+    const initialAgentFromUrl = searchParams.get("agent")
+    const initialSessionFromUrl = searchParams.get("session")
+
     api<{ data: Agent[] }>("/agents")
       .then((r) => {
         const list = Array.isArray(r.data) ? r.data : []
         setAgents(list)
-        // Auto-select first agent if none specified
-        if (!selectedAgentId && list.length > 0) {
-          setSelectedAgentId(list[0].id)
+        if (list.length === 0) return
+
+        const selection = readChatSelection()
+        const candidateAgentId = [
+          initialAgentFromUrl,
+          selectedAgentId,
+          selection.lastAgentId,
+        ].find((agentId): agentId is string => (
+          Boolean(agentId) && list.some((agent) => agent.id === agentId)
+        ))
+
+        const nextAgentId = candidateAgentId || list[0].id
+        const nextSessionId = nextAgentId === initialAgentFromUrl && initialSessionFromUrl
+          ? initialSessionFromUrl
+          : chatSessionForAgent(nextAgentId, selection)
+
+        setSelectedAgentId(nextAgentId)
+        setSelectedSessionId(nextSessionId)
+        if (nextSessionId) {
+          rememberChatSession(nextAgentId, nextSessionId)
+        } else {
+          rememberChatAgent(nextAgentId)
         }
+        updateChatSearchParams(nextAgentId, nextSessionId, true)
       })
       .catch(() => setAgents([]))
       .finally(() => setLoading(false))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
@@ -91,12 +152,29 @@ export function Chat() {
   }
 
   const handleSelectAgent = (agentId: string) => {
+    const nextSessionId = chatSessionForAgent(agentId)
     setSelectedAgentId(agentId)
-    collapseAgentSelector()
-    if (location.pathname.startsWith("/chat")) {
-      setSearchParams({ agent: agentId })
+    setSelectedSessionId(nextSessionId)
+    if (nextSessionId) {
+      rememberChatSession(agentId, nextSessionId)
+    } else {
+      rememberChatAgent(agentId)
     }
+    collapseAgentSelector()
+    updateChatSearchParams(agentId, nextSessionId)
   }
+
+  const handleSessionChange = useCallback((sessionId: string | null) => {
+    if (!selectedAgentId) return
+
+    setSelectedSessionId(sessionId)
+    if (sessionId) {
+      rememberChatSession(selectedAgentId, sessionId)
+    } else {
+      rememberChatSession(selectedAgentId, null)
+    }
+    updateChatSearchParams(selectedAgentId, sessionId, true)
+  }, [selectedAgentId, updateChatSearchParams])
 
   const handleShowAgentPreview = (agentId: string, element: HTMLElement) => {
     if (!agentSelectorCollapsed) return
@@ -252,7 +330,12 @@ export function Chat() {
       {/* Chat area */}
       <div className="flex-1 min-w-0 overflow-hidden">
         {selectedAgentId ? (
-          <AgentChat key={selectedAgentId} agentId={selectedAgentId} />
+          <AgentChat
+            key={selectedAgentId}
+            agentId={selectedAgentId}
+            selectedSessionId={selectedSessionId}
+            onSessionChange={handleSessionChange}
+          />
         ) : (
           <div className="flex flex-col items-center justify-center h-full">
             <MessageSquare className="h-12 w-12 text-muted-foreground/30 mb-3" />

--- a/portal-web/src/pages/Layout.tsx
+++ b/portal-web/src/pages/Layout.tsx
@@ -5,6 +5,7 @@ import { api, clearToken } from "../api"
 import { NotificationBell } from "../components/NotificationBell"
 import { useTheme } from "../hooks/useTheme"
 import { Chat } from "./Chat"
+import { CHAT_SELECTION_CHANGE_EVENT, chatPathFromStoredSelection } from "../lib/chatSelection"
 
 const siclawItems = [
   { path: "/chat", label: "Chat", icon: MessageSquare },
@@ -40,6 +41,7 @@ export function Layout() {
     location.pathname.startsWith("/settings")
   )
   const [isAdmin, setIsAdmin] = useState(false)
+  const [chatPath, setChatPath] = useState(() => chatPathFromStoredSelection())
 
   useEffect(() => {
     api<{ role: string }>("/auth/me")
@@ -50,6 +52,17 @@ export function Layout() {
   useEffect(() => {
     try { localStorage.setItem(COLLAPSED_KEY, collapsed ? "1" : "0") } catch { /* ignore */ }
   }, [collapsed])
+
+  useEffect(() => {
+    const updateChatPath = () => setChatPath(chatPathFromStoredSelection())
+    updateChatPath()
+    window.addEventListener(CHAT_SELECTION_CHANGE_EVENT, updateChatPath)
+    window.addEventListener("storage", updateChatPath)
+    return () => {
+      window.removeEventListener(CHAT_SELECTION_CHANGE_EVENT, updateChatPath)
+      window.removeEventListener("storage", updateChatPath)
+    }
+  }, [location.pathname, location.search])
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -117,7 +130,7 @@ export function Layout() {
           {siclawItems.map(({ path, label, icon: Icon }) => (
             <Link
               key={path}
-              to={path}
+              to={path === "/chat" ? chatPath : path}
               title={collapsed ? label : undefined}
               className={`${rowBase} ${rowLayout} ${isActive(path) ? rowActive : rowIdle}`}
             >


### PR DESCRIPTION
## Summary

- remember the last selected chat agent and each agent's last selected session in localStorage
- restore agent/session from URL params or stored selection when Chat mounts or receives a kept-alive route update
- point sidebar Chat and Agents-page Chat navigation at the remembered chat path

## Why

Returning to Chat from agent or skill configuration currently falls back to a default agent/session because only the current component state and the agent URL param are considered. This preserves the user's last Chat context across navigation and refreshes.

## Validation

- npm test -- src/lib/chatSelection.test.ts
- npm run build

## Test Deployment

- Built and pushed portal-only image: registry-cn-shanghai.siflow.cn/k8s/siclaw-portal:chat-selection-binding-20260609162343-1427357
- Image digest: sha256:29990267bf4a8ea35f05b1be2560658ff2b3f9ab90887313368b9b6fb274bfa7
- Deployed to sdliu-siclaw deploy/siclaw-portal
- Verified rollout and /api/health