### PR TITLE
feat(tools): whitelist sichek gpu/infiniband/gpfs/transceiver/lldp checks

### DIFF
--- a/docs/design/command-whitelist.md
+++ b/docs/design/command-whitelist.md
@@ -267,6 +267,27 @@ Allowed subcommands: `topo`, `nvlink`
 
 ---
 
+### Node Health-Check Agent
+
+| Command | Validator | Restrictions |
+|---------|-----------|-------------|
+| `sichek` | declarative `allowedSubcommands` | Only the GPU/IB/GPFS/transceiver/LLDP check subcommands; everything else (incl. `daemon`/`config`/`exporter`) rejected |
+
+`sichek` runs hardware/software health checks and prints results. Its internal tool calls
+run inside the `sichek` process (they do not re-enter `validateCommand()`). Only the specific
+read-only check subcommands needed are allowed; every other subcommand — including the
+state-changing `daemon` (systemd unit / Node annotations / config overwrite), `config`
+(`config sync` writes files), and `exporter` (long-running server) — is absent from the
+allow-list and therefore auto-rejected.
+
+#### sichek — allowed subcommands (position 0)
+
+```
+gpu (g)  infiniband (i)  gpfs (f)  transceiver (tr)  lldp (l)
+```
+
+---
+
 ### Hardware Info
 
 | Command | Validator | Restrictions |

--- a/src/tools/infra/command-sets.test.ts
+++ b/src/tools/infra/command-sets.test.ts
@@ -50,6 +50,8 @@ describe("COMMANDS registry", () => {
     "mst", "mlxlink", "perfquery", "ibqueryerrors", "saquery", "ibping",
     "dcgmi", "smartctl", "nvme", "sensors", "getconf",
     "pidstat", "pstree", "numastat", "ipcs", "nstat", "tree", "hexdump", "od", "tac", "nl",
+    // node health-check agent
+    "sichek",
   ];
   for (const cmd of newCommands) {
     it(`contains "${cmd}"`, () => {
@@ -1586,5 +1588,31 @@ describe("read-only enforcement for added diagnostic commands", () => {
     expect(validateCommandRestrictions("resolvectl flush-caches")).not.toBeNull();
     expect(validateCommandRestrictions("resolvectl dns eth0 1.1.1.1")).not.toBeNull();
     expect(validateCommandRestrictions("resolvectl revert eth0")).not.toBeNull();
+  });
+
+  // sichek node health-check agent — only the gpu/infiniband/gpfs/transceiver/lldp checks
+  it("allows the specific sichek check subcommands (full names + aliases)", () => {
+    expect(validateCommandRestrictions("sichek gpu")).toBeNull();
+    expect(validateCommandRestrictions("sichek g -v")).toBeNull();
+    expect(validateCommandRestrictions("sichek infiniband")).toBeNull();
+    expect(validateCommandRestrictions("sichek i")).toBeNull();
+    expect(validateCommandRestrictions("sichek gpfs")).toBeNull();
+    expect(validateCommandRestrictions("sichek f")).toBeNull();
+    expect(validateCommandRestrictions("sichek transceiver")).toBeNull();
+    expect(validateCommandRestrictions("sichek tr")).toBeNull();
+    expect(validateCommandRestrictions("sichek lldp")).toBeNull();
+    expect(validateCommandRestrictions("sichek l")).toBeNull();
+    // flag values (e.g. -v) must not be mistaken for the subcommand
+    expect(validateCommandRestrictions("sichek gpu -v")).toBeNull();
+  });
+  it("rejects sichek subcommands outside the allow-list", () => {
+    // other read checks not requested
+    expect(validateCommandRestrictions("sichek all")).not.toBeNull();
+    expect(validateCommandRestrictions("sichek cpu")).not.toBeNull();
+    expect(validateCommandRestrictions("sichek nccltest")).not.toBeNull();
+    // state-changing subcommands
+    expect(validateCommandRestrictions("sichek daemon start")).not.toBeNull();
+    expect(validateCommandRestrictions("sichek config sync")).not.toBeNull();
+    expect(validateCommandRestrictions("sichek exporter")).not.toBeNull();
   });
 });

--- a/src/tools/infra/command-sets.ts
+++ b/src/tools/infra/command-sets.ts
@@ -1180,6 +1180,20 @@ export const COMMANDS: Record<string, CommandDef> = {
   // toggle DCGM watches. "config"/"policy"/"set"/"profile"/"group"/"diag" are not allowed.
   dcgmi:        { category: "gpu", validate: validateDcgmi },
 
+  // ── node health-check agent (read-only diagnostics) ──
+  // sichek runs hardware/software health checks as a child process and prints results.
+  // Only the specific read-only check subcommands we need are allowed (full name + alias);
+  // every other subcommand — including the state-changing daemon/config/exporter — is NOT
+  // listed → auto-rejected. sichek's own internal tool calls run inside its process and
+  // never re-enter validateCommand().
+  sichek: { category: "diagnostic", allowedSubcommands: { position: 0, allowed: [
+    "gpu", "g",            // Nvidia GPU
+    "infiniband", "i",     // InfiniBand
+    "gpfs", "f",           // GPFS
+    "transceiver", "tr",   // optical modules
+    "lldp", "l",           // LLDP neighbors
+  ] } },
+
   // ── hardware info ──
   lspci:     { category: "hardware" },
   lsusb:     { category: "hardware" },


### PR DESCRIPTION
## Summary

The agent needs to run the `sichek` node-health agent for GPU/IB/GPFS/transceiver/LLDP triage, but `sichek` was absent from the command whitelist, so `validateCommand()` default-denied it in every context. This adds a single `COMMANDS` entry scoped to exactly the five read-only check subcommands we need.

## What changed

- `src/tools/infra/command-sets.ts` — add `sichek` (category `diagnostic`) with `allowedSubcommands` (position 0) allowing only: `gpu`/`g`, `infiniband`/`i`, `gpfs`/`f`, `transceiver`/`tr`, `lldp`/`l`.
- Everything else is absent from the allow-list and therefore auto-rejected — notably the state-changing subcommands: `daemon` (writes a systemd unit, enable/restart `sichek.service`, writes Node annotations, `daemon run -c` can overwrite `default_user_config.yaml`), `config` (`config sync` writes files), and `exporter` (long-running server).
- `sichek`'s own internal tool calls run inside its process and never re-enter `validateCommand()`, so no underlying binaries need whitelisting.
- Tests + `command-whitelist.md` updated per the Change Impact Matrix for `command-sets.ts`.

## Validation

- `npx vitest run src/tools/infra/command-sets.test.ts` — 336 pass (incl. new allow/reject cases)
- exec-context suites (`command-validator`, `node-exec`, `pod-exec`, `restricted-bash`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)