### PR TITLE
fix: harden model fallback routing edge cases (#308 follow-up)

### DIFF
--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -124,14 +124,6 @@ function ModelTimeLabel({ timing }: { timing: MessageTiming | undefined }) {
   )
 }
 
-function stringMeta(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined
-}
-
-function numberMeta(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined
-}
-
 function modelRouteMetadata(message: PilotMessage): ModelRouteMetadata | null {
   const route = message.metadata?.model_route
   if (!route || typeof route !== "object" || Array.isArray(route)) return null
@@ -146,22 +138,10 @@ function isVisibleChatMessage(message: PilotMessage): boolean {
   return !message.hidden && !isModelRouteNoticeMessage(message)
 }
 
-function routeModelLabel(provider?: string, modelId?: string): string {
-  return provider && modelId ? `${provider}/${modelId}` : provider || modelId || "unknown"
-}
-
 function routeModelDisplayName(modelId?: string, provider?: string): string {
   if (!modelId) return provider || "unknown"
   const parts = modelId.split("/").filter(Boolean)
   return parts[parts.length - 1] || modelId
-}
-
-function formatCooldown(until: unknown): string | undefined {
-  const value = numberMeta(until)
-  if (value == null) return undefined
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return undefined
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
 }
 
 function ModelRouteIndicator({ route }: { route: ModelRouteMetadata | null }) {
@@ -1502,10 +1482,6 @@ function MessageItem({
     return <DelegationStatusNotice content={message.content} />
   }
 
-  if (message.metadata?.kind === "model_route_notice") {
-    return <ModelRouteNotice message={message} />
-  }
-
   if (isTool) {
     if (message.toolName === "delegate_to_agents") {
       return <AgentWorkBatchCard message={message} />
@@ -1681,39 +1657,6 @@ function DelegationStatusNotice({ content }: { content: string }) {
         <span className="font-medium">{headline}</span>
         {detail && <span className="text-blue-300/70">·</span>}
         {detail && <span className="truncate">{detail}</span>}
-      </div>
-    </div>
-  )
-}
-
-function ModelRouteNotice({ message }: { message: PilotMessage }) {
-  const metadata = message.metadata ?? {}
-  const eventType = stringMeta(metadata.event_type)
-  const from = routeModelLabel(stringMeta(metadata.from_provider), stringMeta(metadata.from_model_id))
-  const to = routeModelLabel(stringMeta(metadata.to_provider), stringMeta(metadata.to_model_id))
-  const failureKind = stringMeta(metadata.failure_kind)
-  const cooldown = formatCooldown(metadata.cooldown_until)
-  const isRecovery = eventType === "model_route.recovered"
-  const title = [
-    isRecovery ? `Recovered to ${to}` : `Switched from ${from} to ${to}`,
-    failureKind ? `Reason: ${failureKind}` : undefined,
-    stringMeta(metadata.error_message),
-    cooldown ? `Primary cooldown until ${cooldown}` : undefined,
-  ].filter(Boolean).join("\n")
-
-  return (
-    <div className="pl-12 min-w-0" data-copy-ignore>
-      <div
-        title={title}
-        className={cn(
-          "inline-flex max-w-3xl items-center gap-2 rounded-full border px-3 py-1.5 text-xs shadow-sm shadow-black/10",
-          isRecovery
-            ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-700"
-            : "border-amber-500/30 bg-amber-500/10 text-amber-700",
-        )}
-      >
-        <ArrowRight className="h-3.5 w-3.5 shrink-0" />
-        <span className="font-medium truncate">{message.content}</span>
       </div>
     </div>
   )

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -1035,7 +1035,12 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           break
 
         case "model_route_success": {
-          currentModelRouteRef.current = modelRouteFromEvent(evt)
+          // Match the gateway's persistence predicate (sse-consumer): route
+          // metadata is kept only for fallback/recovery replies. Tagging every
+          // routed reply live would make the model label vanish on reload.
+          const route = modelRouteFromEvent(evt)
+          currentModelRouteRef.current =
+            route && (route.is_fallback || route.recovered_from_candidate_key) ? route : null
           break
         }
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -619,6 +619,7 @@ export function createHttpServer(
             // routed sessions still get token/cost stats.
             emitBrainEvent: (event) => emitSessionExtraEvent(enrichAgentEndEvent(managed.brain, event)),
             onStateChange: () => sessionManager.persistModelRouteState(managed.id, managed.modelRouteState),
+            shouldAbort: () => managed._aborted,
           },
         )
       : managed.brain.prompt(promptText);

--- a/src/agentbox/notify-parent.test.ts
+++ b/src/agentbox/notify-parent.test.ts
@@ -34,6 +34,8 @@ function fakeManaged(id: string, brain: ReturnType<typeof fakeBrain>, promptDone
     _syntheticPromptQueue: null as Promise<void> | null,
     _promptDoneCallbacks: new Set<() => void>(),
     _backgroundWorkCount: 1, // >0 so runSyntheticPrompt's finally skips scheduleRelease (no timers)
+    _aborted: false,
+    _routeBrainEventsThroughExtra: false,
     _eventBuffer: [] as unknown[],
     _bufferUnsub: null as null | (() => void),
     _extraEventBuffer: [] as unknown[],
@@ -216,6 +218,7 @@ describe("notifyParent", () => {
     ];
     let currentModel = models[0];
     const seenModels: string[] = [];
+    const routeFlagDuringPrompt: boolean[] = [];
     const brain = {
       followUp: vi.fn(async () => {}),
       subscribe: vi.fn((fn: (e: any) => void) => {
@@ -224,6 +227,10 @@ describe("notifyParent", () => {
       }),
       prompt: vi.fn(async () => {
         seenModels.push(`${currentModel.provider}/${currentModel.id}`);
+        // The routed runner buffers brain events; the SSE route's live brain
+        // subscription must be suppressed for the whole turn or a connected
+        // client streams every failed attempt raw.
+        routeFlagDuringPrompt.push(managed._routeBrainEventsThroughExtra);
         if (currentModel.provider === "openai") {
           emit({
             type: "message_end",
@@ -273,6 +280,8 @@ describe("notifyParent", () => {
     await flushCoalesce();
 
     expect(seenModels).toEqual(["openai/gpt-4", "anthropic/claude"]);
+    expect(routeFlagDuringPrompt).toEqual([true, true]);
+    expect(managed._routeBrainEventsThroughExtra).toBe(false);
     expect(managed.modelRouteState.activeCandidateKey).toBe("anthropic/claude");
     const events = send.mock.calls.map((c) => c[0]);
     const report = events

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -196,6 +196,8 @@ async function abortBrainBestEffort(
 
 export class AgentBoxSessionManager {
   private sessions = new Map<string, ManagedSession>();
+  /** Per-session write chain so route-state persists land in call order. */
+  private _modelRouteStatePersists = new Map<string, Promise<void>>();
   private defaultSessionId = "default";
 
   /** Optional userId — set by LocalSpawner for per-user skill directory isolation */
@@ -677,6 +679,11 @@ export class AgentBoxSessionManager {
         let turnHadTool = false;
         const routePolicy = managed.modelRoutePolicy;
         const routeEnabled = shouldUseModelRouteRunner(routePolicy, managed.modelRouteState);
+        // Mirror the HTTP /prompt path: while the routing runner buffers brain
+        // events, suppress the SSE route's live brain subscription too —
+        // otherwise a client connected during a routed synthetic turn streams
+        // every failed attempt raw, the exact leak routing exists to prevent.
+        managed._routeBrainEventsThroughExtra = routeEnabled;
         let latestModelRouteSwitch: Extract<ModelRouteEvent, { type: "model_route_switch" }> | null = null;
         let currentModelRouteMetadata: Record<string, unknown> | null = null;
         const handleRouteEvent = (event: ModelRouteEvent): void => {
@@ -733,6 +740,7 @@ export class AgentBoxSessionManager {
                 emitEvent: handleRouteEvent,
                 emitBrainEvent: handleBrainEvent,
                 onStateChange: () => this.persistModelRouteState(managed.id, managed.modelRouteState),
+                shouldAbort: () => managed._aborted,
               },
             );
           } else {
@@ -742,6 +750,7 @@ export class AgentBoxSessionManager {
           console.warn(`[agentbox-session] synthetic prompt failed for ${managed.id}:`, err);
         } finally {
           managed._promptDone = true;
+          managed._routeBrainEventsThroughExtra = false;
           if (managed._bufferUnsub) { managed._bufferUnsub(); managed._bufferUnsub = null; }
           for (const cb of managed._promptDoneCallbacks) { try { cb(); } catch { /* ignore */ } }
           managed._promptDoneCallbacks.clear();
@@ -914,7 +923,12 @@ export class AgentBoxSessionManager {
     try {
       const raw = JSON.parse(fs.readFileSync(this.modelRouteStateFile(sessionId), "utf8"));
       return normalizeModelRouteState(raw);
-    } catch {
+    } catch (err) {
+      // Missing file is the normal first-run case; anything else (corrupt
+      // JSON, permissions) silently resetting cooldowns deserves a trace.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        console.warn(`[agentbox-session] model-route state for ${sessionId} unreadable, starting fresh:`, err);
+      }
       return createModelRouteState();
     }
   }
@@ -927,15 +941,27 @@ export class AgentBoxSessionManager {
    */
   persistModelRouteState(sessionId: string, state: ModelRouteState): void {
     const file = this.modelRouteStateFile(sessionId);
-    const tmp = `${file}.${randomUUID()}.tmp`;
+    // Snapshot synchronously, then serialize writes per session: each write is
+    // atomic (tmp + rename), but without ordering a slow older write could
+    // rename over a newer one, leaving stale state on disk.
     const payload = `${JSON.stringify(normalizeModelRouteState(state), null, 2)}\n`;
-    void fs.promises
-      .writeFile(tmp, payload, "utf8")
-      .then(() => fs.promises.rename(tmp, file))
-      .catch((err) => {
+    const prev = this._modelRouteStatePersists.get(sessionId) ?? Promise.resolve();
+    const next = prev.then(async () => {
+      const tmp = `${file}.${randomUUID()}.tmp`;
+      try {
+        await fs.promises.writeFile(tmp, payload, "utf8");
+        await fs.promises.rename(tmp, file);
+      } catch (err) {
         console.warn(`[agentbox-session] model-route state persist failed for ${sessionId}:`, err);
         void fs.promises.unlink(tmp).catch(() => {});
-      });
+      }
+    });
+    this._modelRouteStatePersists.set(sessionId, next);
+    void next.finally(() => {
+      if (this._modelRouteStatePersists.get(sessionId) === next) {
+        this._modelRouteStatePersists.delete(sessionId);
+      }
+    });
   }
 
   /**

--- a/src/core/model-routing.test.ts
+++ b/src/core/model-routing.test.ts
@@ -1014,8 +1014,10 @@ describe("runPromptWithModelRouting", () => {
     expect(result.success).toBe(false);
     expect(result.exhausted).toBe(false);
     expect(result.finalFailureKind).toBe("user_abort");
-    const exhaustedEvent = events.find((event) => event.type === "model_route_exhausted");
-    expect(exhaustedEvent).toMatchObject({ failureKind: "user_abort" });
+    // A user stop is reported as its own event, never as exhaustion.
+    const abortedEvent = events.find((event) => event.type === "model_route_aborted");
+    expect(abortedEvent).toMatchObject({ errorMessage: "Prompt aborted between fallback attempts." });
+    expect(events.some((event) => event.type === "model_route_exhausted")).toBe(false);
   });
 
   it("falls back on a transport-level abort but not on a genuine user stop", async () => {

--- a/src/core/model-routing.test.ts
+++ b/src/core/model-routing.test.ts
@@ -232,6 +232,12 @@ describe("model-routing classifier", () => {
     expect(classifyModelRouteFailure("context_length_exceeded: max context")).toBe("context_overflow");
     expect(classifyModelRouteFailure("cancelled by user", "aborted")).toBe("user_abort");
     expect(classifyModelRouteFailure("content filter blocked")).toBe("content_policy");
+    expect(classifyModelRouteFailure("response blocked due to safety")).toBe("content_policy");
+    expect(classifyModelRouteFailure("prompt triggering content management policy")).toBe("content_policy");
+    // Bare "blocked" / "policy" must not be mistaken for a content block —
+    // these were previously mislabeled content_policy (a no-fallback kind).
+    expect(classifyModelRouteFailure("request blocked by upstream proxy")).toBe("network");
+    expect(classifyModelRouteFailure("retry policy exceeded for request")).toBe("unknown");
     expect(classifyModelRouteFailure("401 invalid api key")).toBe("auth");
     expect(classifyModelRouteFailure("403 permission denied")).toBe("auth");
     expect(classifyModelRouteFailure("400 invalid parameter")).toBe("format_error");
@@ -928,6 +934,108 @@ describe("runPromptWithModelRouting", () => {
     await runPromptWithModelRouting(recoveredBrain, "hello", policy, state, { now: () => 6000 });
     expect(recoveredBrain.promptModels).toEqual(["openai/gpt-4"]);
     expect(state.activeCandidateKey).toBe("openai/gpt-4");
+  });
+
+  it("tries cooling candidates as a last resort when every fresh candidate fails", async () => {
+    const policy = makePolicy();
+    const state = createModelRouteState();
+    state.cooldowns[candidateKey(policy.candidates![1])] = 5000;
+    state.cooldowns[candidateKey(policy.candidates![2])] = 5000;
+
+    const brain = makeBrain(["rate_limit", "ok"]);
+    const result = await runPromptWithModelRouting(brain, "hello", policy, state, { now: () => 1000 });
+
+    expect(result.success).toBe(true);
+    expect(brain.promptModels).toEqual(["openai/gpt-4", "anthropic/claude"]);
+  });
+
+  it("records a cooldown when the final candidate fails too", async () => {
+    const policy = makePolicy();
+    const state = createModelRouteState();
+
+    const brain = makeBrain(["rate_limit", "rate_limit", "rate_limit"]);
+    const result = await runPromptWithModelRouting(brain, "hello", policy, state, { now: () => 10_000 });
+
+    expect(result.exhausted).toBe(true);
+    expect(state.cooldowns[candidateKey(policy.candidates![0])]).toBe(11_000);
+    expect(state.cooldowns[candidateKey(policy.candidates![1])]).toBe(11_000);
+    expect(state.cooldowns[candidateKey(policy.candidates![2])]).toBe(11_000);
+  });
+
+  it("clears a candidate's cooldown when it succeeds while still cooling", async () => {
+    const policy = makePolicy();
+    const state = createModelRouteState();
+    for (const candidate of policy.candidates!) {
+      state.cooldowns[candidateKey(candidate)] = 5000;
+    }
+
+    const brain = makeBrain(["ok"]);
+    await runPromptWithModelRouting(brain, "hello", policy, state, { now: () => 1000 });
+
+    expect(brain.promptModels).toEqual(["openai/gpt-4"]);
+    expect(state.cooldowns[candidateKey(policy.candidates![0])]).toBeUndefined();
+    expect(state.cooldowns[candidateKey(policy.candidates![1])]).toBe(5000);
+  });
+
+  it("preserves a manual pin that lands while the runner is in flight", async () => {
+    const policy = makePolicy();
+    const state = createModelRouteState();
+    let pinned = false;
+
+    const brain = makeBrain(["rate_limit", "ok"]);
+    const result = await runPromptWithModelRouting(brain, "hello", policy, state, {
+      now: () => 10_000,
+      onStateChange: () => {
+        if (!pinned) {
+          pinned = true;
+          markModelRouteUserSelection(state, { provider: "deepseek", modelId: "deepseek-chat" });
+        }
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.activeCandidateSource).toBe("user");
+    expect(state.activeCandidateKey).toBe("deepseek/deepseek-chat");
+  });
+
+  it("halts between attempts when shouldAbort reports a user stop", async () => {
+    const policy = makePolicy();
+    const state = createModelRouteState();
+    const events: ModelRouteEvent[] = [];
+
+    const brain = makeBrain(["rate_limit", "ok"]);
+    const result = await runPromptWithModelRouting(brain, "hello", policy, state, {
+      now: () => 10_000,
+      emitEvent: (event) => events.push(event),
+      shouldAbort: () => brain.promptModels.length >= 1,
+    });
+
+    expect(brain.prompt).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.exhausted).toBe(false);
+    expect(result.finalFailureKind).toBe("user_abort");
+    const exhaustedEvent = events.find((event) => event.type === "model_route_exhausted");
+    expect(exhaustedEvent).toMatchObject({ failureKind: "user_abort" });
+  });
+
+  it("falls back on a transport-level abort but not on a genuine user stop", async () => {
+    const transportBrain = makeBrain([
+      { stopReason: "aborted", errorMessage: "connection aborted by remote host" },
+      "ok",
+    ]);
+    const transportResult = await runPromptWithModelRouting(
+      transportBrain, "hello", makePolicy(), createModelRouteState(), { now: () => 10_000 },
+    );
+    expect(transportResult.success).toBe(true);
+    expect(transportBrain.promptModels).toEqual(["openai/gpt-4", "anthropic/claude"]);
+
+    const userStopBrain = makeBrain([{ stopReason: "aborted" }]);
+    const userStopResult = await runPromptWithModelRouting(
+      userStopBrain, "hello", makePolicy(), createModelRouteState(), { now: () => 10_000 },
+    );
+    expect(userStopResult.success).toBe(false);
+    expect(userStopResult.finalFailureKind).toBe("user_abort");
+    expect(userStopBrain.prompt).toHaveBeenCalledTimes(1);
   });
 
   it("emits fallback and recovery telemetry on the success event", async () => {

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -113,6 +113,12 @@ export type ModelRouteEvent =
       failureKind?: ModelRouteFailureKind;
       fallbackBlockedReason?: ModelRouteFallbackBlockedReason;
       errorMessage?: string;
+    }
+  | {
+      type: "model_route_aborted";
+      attempt: number;
+      candidateKey?: string;
+      errorMessage?: string;
     };
 
 export interface ModelRouteRunResult {
@@ -490,12 +496,15 @@ export async function runPromptWithModelRouting(
   const now = options.now ?? (() => Date.now());
   const attempted: ModelRouteAttempt[] = [];
 
-  pruneExpiredCooldowns(state, now());
   // Cooling candidates are deprioritized, not excluded: when every fresh
   // candidate fails, trying a cooling one as a last resort still beats
-  // failing the whole turn with an untried candidate on the bench.
-  const freshCandidates = candidates.filter((candidate) => !isCandidateCooling(state, candidate, now()));
-  const coolingCandidates = candidates.filter((candidate) => isCandidateCooling(state, candidate, now()));
+  // failing the whole turn with an untried candidate on the bench. Partition
+  // against a single timestamp so a cooldown expiring mid-evaluation cannot
+  // drop a candidate from both halves.
+  const orderingNow = now();
+  pruneExpiredCooldowns(state, orderingNow);
+  const freshCandidates = candidates.filter((candidate) => !isCandidateCooling(state, candidate, orderingNow));
+  const coolingCandidates = candidates.filter((candidate) => isCandidateCooling(state, candidate, orderingNow));
   const ordered = [...freshCandidates, ...coolingCandidates];
 
   emitEvent({
@@ -519,11 +528,12 @@ export async function runPromptWithModelRouting(
       const abortMessage = "Prompt aborted between fallback attempts.";
       state.lastSwitchReason = "user_abort";
       options.onStateChange?.(state);
+      // A user stop is not exhaustion — emit a dedicated event so a future
+      // consumer cannot render "all candidates failed" for a manual Stop.
       emitEvent({
-        type: "model_route_exhausted",
+        type: "model_route_aborted",
         attempt: i,
         candidateKey: attempted[attempted.length - 1]?.candidateKey,
-        failureKind: "user_abort",
         errorMessage: abortMessage,
       });
       return {

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -128,6 +128,8 @@ export interface RunPromptWithModelRoutingOptions {
   emitEvent?: (event: ModelRouteEvent) => void;
   emitBrainEvent?: (event: unknown) => void;
   onStateChange?: (state: ModelRouteState) => void;
+  /** Polled between attempts so a user Stop landing in the switch window halts the chain. */
+  shouldAbort?: () => boolean;
   now?: () => number;
 }
 
@@ -350,7 +352,13 @@ export function classifyModelRouteFailure(
   if (/\b401\b|unauthorized|invalid api key|no api key|missing api key|authentication failed|authentication/i.test(combined)) {
     return "auth";
   }
-  if (/content[_ -]?filter|finish_reason:\s*content_filter|safety|policy|blocked/.test(combined)) {
+  // Anchor on phrases real providers emit (OpenAI/Azure content filter,
+  // Anthropic usage policy, Gemini SAFETY blocks). Bare "policy" / "blocked" /
+  // "safety" intercepted unrelated errors here ("blocked by upstream proxy")
+  // and mislabeled them as content_policy, which is a no-fallback kind.
+  if (
+    /content[_ -]?(?:filter|policy|moderation)|finish_reason:\s*content_filter|content management policy|usage policy|policy violation|moderation|blocked (?:due to|by) (?:safety|content|policy)|safety (?:filter|system|setting|rating|violation)/.test(combined)
+  ) {
     return "content_policy";
   }
 
@@ -483,8 +491,12 @@ export async function runPromptWithModelRouting(
   const attempted: ModelRouteAttempt[] = [];
 
   pruneExpiredCooldowns(state, now());
-  let ordered = candidates.filter((candidate) => !isCandidateCooling(state, candidate, now()));
-  if (ordered.length === 0) ordered = candidates;
+  // Cooling candidates are deprioritized, not excluded: when every fresh
+  // candidate fails, trying a cooling one as a last resort still beats
+  // failing the whole turn with an untried candidate on the bench.
+  const freshCandidates = candidates.filter((candidate) => !isCandidateCooling(state, candidate, now()));
+  const coolingCandidates = candidates.filter((candidate) => isCandidateCooling(state, candidate, now()));
+  const ordered = [...freshCandidates, ...coolingCandidates];
 
   emitEvent({
     type: "model_route_start",
@@ -499,6 +511,30 @@ export async function runPromptWithModelRouting(
   let finalFailure: AttemptFailure | undefined;
   for (let i = 0; i < ordered.length; i++) {
     const candidate = ordered[i];
+    // A user Stop can land in the switch window (cooldown persist, checkpoint
+    // restore, setModel are all awaited) where no brain.prompt is in flight to
+    // absorb it — poll the abort signal so the cancelled prompt is not re-run
+    // on the next candidate.
+    if (i > 0 && options.shouldAbort?.()) {
+      const abortMessage = "Prompt aborted between fallback attempts.";
+      state.lastSwitchReason = "user_abort";
+      options.onStateChange?.(state);
+      emitEvent({
+        type: "model_route_exhausted",
+        attempt: i,
+        candidateKey: attempted[attempted.length - 1]?.candidateKey,
+        failureKind: "user_abort",
+        errorMessage: abortMessage,
+      });
+      return {
+        success: false,
+        exhausted: false,
+        attempted,
+        activeCandidateKey: state.activeCandidateKey,
+        finalFailureKind: "user_abort",
+        finalErrorMessage: abortMessage,
+      };
+    }
     const key = candidateKey(candidate);
     const startedAt = now();
     const attempt: ModelRouteAttempt = {
@@ -528,8 +564,15 @@ export async function runPromptWithModelRouting(
       const recoveredFrom = previousActiveCandidateKey && previousActiveCandidateKey !== key && key === primaryCandidateKey
         ? findCandidateByKey(candidates, previousActiveCandidateKey)
         : undefined;
-      state.activeCandidateKey = key;
-      state.activeCandidateSource = "auto";
+      // A success proves the candidate healthy again — drop any cooldown left
+      // over from a run that used it as a last resort while still cooling.
+      delete state.cooldowns[key];
+      // A manual pin (PUT /model) can land while this runner is in flight;
+      // the run's outcome must not clobber that explicit user choice.
+      if (state.activeCandidateSource !== "user") {
+        state.activeCandidateKey = key;
+        state.activeCandidateSource = "auto";
+      }
       state.lastSuccessAt = attempt.finishedAt;
       recordAttempt(state, attempt);
       options.onStateChange?.(state);
@@ -576,12 +619,18 @@ export async function runPromptWithModelRouting(
     });
 
     const nextCandidate = ordered[i + 1];
-    if (attempt.fallbackBlockedReason && nextCandidate) {
-      const cooldownUntil = cooldownUntilForFailure(failure, policy, now());
-      if (cooldownUntil) state.cooldowns[key] = cooldownUntil;
-      else delete state.cooldowns[key];
-    }
-    if (!nextCandidate || attempt.fallbackBlockedReason || !shouldTryNextCandidateForFailure(failure, policy)) {
+    const willSwitch = Boolean(nextCandidate)
+      && !attempt.fallbackBlockedReason
+      && shouldTryNextCandidateForFailure(failure, policy);
+    // Record the cooldown for every failure that carries one, not only when
+    // switching: a terminal failure (last candidate, tool-blocked, or
+    // no-fallback kind) still marks the candidate unhealthy for the NEXT
+    // turn's ordering. Only the switch path clears a stale cooldown — a
+    // terminal zero-cooldown failure (e.g. user_abort) keeps what it had.
+    const cooldownUntil = cooldownUntilForFailure(failure, policy, now());
+    if (cooldownUntil) state.cooldowns[key] = cooldownUntil;
+    else if (willSwitch) delete state.cooldowns[key];
+    if (!willSwitch) {
       flushBrainEvents(attemptResult.events, emitBrainEvent);
       state.lastSwitchReason = failure.kind;
       options.onStateChange?.(state);
@@ -608,9 +657,6 @@ export async function runPromptWithModelRouting(
       };
     }
 
-    const cooldownUntil = cooldownUntilForFailure(failure, policy, now());
-    if (cooldownUntil) state.cooldowns[key] = cooldownUntil;
-    else delete state.cooldowns[key];
     state.lastSwitchReason = failure.kind;
     options.onStateChange?.(state);
     try {
@@ -821,8 +867,19 @@ function failureFromAssistantMessage(
     };
   }
   if (stopReason === "aborted") {
+    // Route through the classifier instead of hardcoding user_abort: it
+    // distinguishes a transport-level abort ("connection aborted") — which
+    // should fall back — from a genuine user stop.
     return {
-      kind: "user_abort",
+      kind: classifyModelRouteFailure({
+        errorMessage: messageError,
+        stopReason,
+        provider: typeof message.provider === "string" ? message.provider : candidate.provider,
+        modelId: typeof message.model === "string" ? message.model : candidate.modelId,
+        status: providerResponse?.status,
+        headers: providerResponse?.headers,
+        diagnostics: message.diagnostics,
+      }),
       source: "message_end",
       message: messageError,
       providerResponse,
@@ -1004,10 +1061,6 @@ function normalizeFailureKinds(kinds: unknown): ModelRouteFailureKind[] {
     normalized.push(kind);
   }
   return normalized;
-}
-
-function isModelRouteFailureKind(value: unknown): value is ModelRouteFailureKind {
-  return normalizeFailureKind(value) !== undefined;
 }
 
 function normalizeFailureKind(value: unknown): ModelRouteFailureKind | undefined {


### PR DESCRIPTION
## Summary

Follow-up hardening for the model fallback routing layer introduced in #308 (and patched in #312). A post-merge review of the feature surfaced a set of confirmed edge-case defects in the runner, the AgentBox plumbing, and the chat UI metadata path. This PR fixes the ones that are small, low-risk, and behavior-correct without product decisions.

Larger known gaps are intentionally **out of scope** (see below).

## Fixes

### Core runner (`src/core/model-routing.ts`)

- **Cooling candidates are deprioritized, not excluded.** Previously a candidate in cooldown was dropped from the run entirely: with `[A, B]` where B was cooling, an A failure exhausted the turn without ever trying B. Cooling candidates now sort to the end and are tried as a last resort.
- **Cooldowns now reflect terminal failures and successes.** A failure on the last candidate (or a tool-blocked / no-fallback failure) records its cooldown so the next turn's ordering sees it; a success clears that candidate's cooldown (it could previously stay "cooling" after serving a reply in the all-cooling path).
- **A user Stop between attempts halts the chain.** The abort flag was only consulted while `brain.prompt` was in flight; a Stop landing in the switch window (cooldown persist / checkpoint restore / setModel are all awaited) was swallowed and the cancelled prompt re-ran on the next candidate. The runner now polls a `shouldAbort` hook between attempts; both AgentBox prompt paths wire it to the session abort flag.
- **Message-end `aborted` results go through the classifier.** The `message_end` path hardcoded `user_abort`, bypassing the transport-vs-user abort distinction the classifier already implements — a transport-level abort surfacing as `stopReason: "aborted"` could not fall back. Genuine user stops still never fall back.
- **A manual model pin landing mid-run is preserved.** `PUT /api/sessions/:id/model` during an in-flight routed turn was silently clobbered by the runner's success handler (`activeCandidateSource` reset to `auto`). The success path now respects a user pin.
- **`content_policy` classification anchors on real provider phrasing.** Bare `policy` / `blocked` / `safety` matched unrelated errors ("blocked by upstream proxy", "retry policy exceeded") and mislabeled them as a no-fallback kind, intercepting kinds that would otherwise classify as fallback-worthy further down the chain.
- Drop dead `isModelRouteFailureKind`.

### AgentBox plumbing (`src/agentbox/session.ts`, `http-server.ts`)

- **Routed synthetic turns no longer leak raw brain events.** The synthetic prompt path computed `routeEnabled` but never set `_routeBrainEventsThroughExtra`, so an SSE client connected during a routed synthetic turn streamed every failed attempt's raw events live — the exact leak the runner's buffering exists to prevent. The flag is now set/reset exactly like the HTTP `/prompt` path (regression-tested).
- **Route-state persists are serialized per session.** Each write was atomic (tmp + rename) but writes were unordered, so a slow older write could rename over a newer one, leaving stale state on disk.
- **Unreadable state files warn instead of silently resetting.** Corrupt JSON / permission errors on `.model-route-state.json` now leave a trace; `ENOENT` (normal first run) stays quiet.

### Portal-web (`usePilotChat.ts`, `PilotArea.tsx`)

- **Model route indicator is now deterministic across reload.** The live path set route metadata on every routed reply while the gateway only persists it for fallback/recovery replies (`sse-consumer.ts`), so the model label vanished from normal routed replies after a refresh. The live predicate now matches the persistence predicate.
- **Remove the unreachable `ModelRouteNotice` renderer** and its now-unused helpers. `isVisibleChatMessage` has filtered `model_route_notice` rows out of the render list since `1a8f6f5`, so the component could never mount (~60 lines of dead UI).

## Known gaps left out of scope

These are real but need product/design decisions rather than spot fixes:

- Routed turns deliver the winning attempt as one burst (no live token streaming), which also skews persisted per-tool timing metadata.
- Persisted `model_route_notice` audit rows are never surfaced in any UI.
- Spawned sub-agents and the first post-restart synthetic turn bypass routing.
- `model_route_exhausted` is not consumed end-to-end.

## Validation

- `npm test` — 176 files, 3489 passed / 2 skipped
- `npm run build`, `npx tsc -p tsconfig.agentbox.json`
- `npm run build:web`, portal-web `vitest run` — 12 files, 113 passed
- New coverage: 7 runner unit tests (cooling last-resort, terminal cooldown, success clears cooldown, mid-run pin, inter-attempt abort, transport-vs-user abort, classifier narrowing) + synthetic-turn SSE suppression assertions in `notify-parent.test.ts`