### PR TITLE
feat(security): deployment-configurable extra command whitelist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ mTLS is **K8s mode only**. Do not add mTLS dependencies to local mode code paths
 | If you change... | Must read | Must verify | Cross-cutting concerns |
 |---|---|---|---|
 | `src/tools/infra/command-sets.ts` | security.md §4, tools.md §6 | `npm test` | Skill scripts still work; sanitization rules still align |
+| `src/tools/infra/extra-commands.ts`, `docker/extra-commands.json` | 2026-06-10-extra-command-whitelist.md, security.md §4 | `npm test` (`extra-commands.test.ts`) | Additive-only merge via `setExtraCommands` (built-ins win; cache invalidated); `FORBIDDEN_EXTRA_COMMANDS` denylist must stay aligned with security.md exclusions; loaded once in `createSiclawSession` |
 | `src/tools/infra/output-sanitizer.ts` | sanitization.md, tools.md §6.2 | `npm test` | Pipeline fallback in restricted-bash; any tool that emits captured command output |
 | `src/tools/infra/command-validator.ts` | security.md §4, tools.md §6.2 | `npm test` | All tools calling `validateCommand()` |
 | `src/tools/cmd-exec/restricted-bash.ts` | security.md, tools.md §5, sanitization.md | `npm test` | kubectl validation; skill bypass (`isSkillScript`); 3-layer sanitization |

--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -71,6 +71,10 @@ COPY skills/core/ ./skills/core/
 COPY skills/extension/ ./skills/extension/
 COPY skills/platform/ ./skills/platform/
 COPY docker/agentbox-entrypoint.sh /usr/local/bin/agentbox-entrypoint.sh
+# Deployment-specific extra command whitelist (additive-only; loaded at agent
+# startup — docs/design/2026-06-10-extra-command-whitelist.md). Replace the
+# file content before building to whitelist site-specific diagnostic binaries.
+COPY docker/extra-commands.json /etc/siclaw/extra-commands.json
 
 # Build every stdio MCP listed in mcp/MCP_LIST.txt and symlink each into PATH.
 # To add a new MCP: drop a new mcp/<name>/ directory (standalone npm package

--- a/docker/extra-commands.json
+++ b/docker/extra-commands.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "commands": {}
+}

--- a/docs/design/2026-06-10-extra-command-whitelist.md
+++ b/docs/design/2026-06-10-extra-command-whitelist.md
@@ -1,0 +1,124 @@
+# Extra Command Whitelist (Deployment-Configurable)
+
+**Status**: Approved design, 2026-06-10
+**Related**: `docs/design/security.md` §4, `docs/design/command-whitelist.md`, `docs/design/tools.md` §6
+
+## Motivation
+
+The command whitelist (`COMMANDS` in `src/tools/infra/command-sets.ts`) is compiled into
+the binary. Deployments that need additional diagnostic binaries (site-specific vendor
+tools, extra perftest utilities, …) currently require a source change and a release.
+This design adds a **deployment-scoped, additive-only** extension mechanism: a JSON file
+loaded at agent startup and merged into the built-in registry.
+
+## Contract (what must hold)
+
+1. **Additive-only.** An extra entry can never replace or relax a built-in `COMMANDS`
+   entry. On name collision the built-in definition wins and the extra entry is skipped
+   with a warning. This preserves the second defense layer (per-command flag/subcommand
+   validation) — a config file must not be able to widen `curl`, `find`, etc.
+2. **Declarative constraints only.** The JSON schema supports `category` plus the five
+   declarative `CommandDef` constraint fields (`allowedFlags`, `blockedFlags`,
+   `allowedSubcommands`, `positionals`, `requiredFlags`). Custom `validate` functions are
+   not expressible in JSON — by design, configuration cannot inject code.
+3. **Forbidden names.** Binaries the built-in whitelist excludes *on purpose* cannot be
+   re-added via configuration: shells/interpreters (`bash`, `python3`, …), multi-call
+   wrappers that bundle a shell (`busybox`, `toybox`), Turing-complete text tools (`sed`,
+   `awk`, `bc`), exfiltration tools (`nc`, `wget`, `socat`), privilege escapes (`sudo`,
+   `nsenter`), argument-executing wrappers (`xargs`, `timeout`, `watch`, … — these would
+   bypass first-binary validation), remote exec (`ssh`, `scp`, `rsync`), and `kubectl` (it
+   has dedicated subcommand validation outside `COMMANDS`). Two guards enforce this: an
+   exact denylist (`FORBIDDEN_EXTRA_COMMANDS`) and a pattern that rejects version-suffixed
+   interpreter variants (`python3.11`, `node22`, `perl5.36`, … — common in real PATHs and
+   equally code-executing). Both are curated foot-gun guards, not exhaustive; violations
+   fail loud at load time. Keep them aligned with the exclusions in `security.md` §4 and
+   the `DANGER_PATTERNS` in `src/gateway/skills/script-evaluator.ts`.
+4. **Fail-loud on bad config.** A file that exists but fails schema validation aborts
+   agent creation with a descriptive error. If `SICLAW_EXTRA_COMMANDS_FILE` is set
+   explicitly, a missing file is also an error. Only the *default* path being absent is
+   a silent no-op.
+5. **Single merge point.** Extras are stored alongside (never inside) the frozen built-in
+   registry; every lookup consults built-in first, then extras. The per-context allowed-set
+   cache is invalidated when extras are (re)registered. All three exec tools
+   (restricted-bash, pod-exec, node-exec) automatically see the same merged view because
+   they all resolve through `validateCommand()` → command-sets.
+6. **All other defense layers unchanged.** Extra commands still run as the `sandbox` OS
+   user, still pass shell-operator validation, sensitive-path checks, and output
+   sanitization. `category` placement controls context availability via the existing
+   `CONTEXT_POLICIES` (e.g. a `file`-category extra is unavailable in `local` context).
+7. **Audit trail.** The loader logs the resolved file path and the full list of accepted
+   and skipped command names once at startup.
+
+## Config file schema
+
+```json
+{
+  "version": 1,
+  "commands": {
+    "iperf3": {
+      "category": "network",
+      "description": "optional free-text rationale (ignored by the engine)",
+      "allowedFlags": ["-c", "-s", "-p", "-t", "--json"]
+    }
+  }
+}
+```
+
+Validation rules (violations throw):
+
+- `version` must be `1`.
+- Command names must match `^[a-z0-9][a-z0-9._+-]*$` (lookup lowercases binary names).
+- `category` must be one of the existing `CommandCategory` values.
+- Only `category`, `description`, and the five declarative constraint fields are
+  accepted; unknown keys (including `validate`) are rejected.
+- Flags must be non-empty strings starting with `-`; `positionals` must be
+  `"allow" | "block" |` a non-negative integer; `allowedSubcommands` must be
+  `{ position: <non-negative int>, allowed: <non-empty string[]> }`.
+
+A bare entry (`{"category": "network"}`) means *no flag restrictions* for that binary —
+that responsibility lies with the config author; the startup audit log makes it visible.
+
+## Loading & precedence
+
+Resolution order at agent startup (`createSiclawSession` in `src/core/agent-factory.ts`,
+memoized — load happens once per process):
+
+1. `SICLAW_EXTRA_COMMANDS_FILE` env var, if set → file is mandatory.
+2. Default path `/etc/siclaw/extra-commands.json` → loaded if present, no-op if absent.
+
+This covers every runtime mode through one chokepoint: TUI and `siclaw local` set the
+env var if they want extras; the AgentBox image bakes a file at the default path.
+
+## Distribution
+
+- **Build-time bake (K8s mode)**: `docker/extra-commands.json` ships in the repo with an
+  empty `commands` object and is copied to `/etc/siclaw/extra-commands.json` in
+  `Dockerfile.agentbox`. Deployments replace the file content before `make docker push`.
+- **Runtime override (future, not in scope)**: mounting a ConfigMap over
+  `/etc/siclaw/extra-commands.json` in the AgentBox pod spec would avoid rebuilds; this
+  needs k8s-spawner pod-spec changes and is deliberately deferred.
+
+## Security analysis
+
+- Threat model: whoever can write the config file or set the env var already controls
+  the image / pod spec / local process — no new trust boundary is crossed.
+- The mechanism can only *add* binaries; it cannot remove or alter restrictions on
+  built-in commands, kubectl subcommand validation, shell-operator rules, or sensitive
+  path patterns.
+- Cross-reference `src/gateway/skills/script-evaluator.ts` (DANGER_PATTERNS) is
+  unaffected: it evaluates skill scripts, not the exec whitelist.
+
+## Testing
+
+- Schema validation unit tests (every rejection rule, plus a maximal valid config).
+- Merge semantics: built-in collision skipped + warned; cache invalidation observable
+  through `getContextAllowedSet`; category placement respects `CONTEXT_POLICIES`.
+- End-to-end through `validateCommand()`: an extra binary passes in the right context,
+  is rejected in a context whose policy excludes its category, and its declarative
+  constraints are enforced.
+- Loader: env-var-mandatory vs default-path-optional behavior; fail-loud on invalid file.
+
+## Documentation impact
+
+- `docs/design/command-whitelist.md`: new "Deployment extras" section.
+- `CLAUDE.md` Change Impact Matrix: row for `src/tools/infra/extra-commands.ts`.

--- a/docs/design/command-whitelist.md
+++ b/docs/design/command-whitelist.md
@@ -20,6 +20,26 @@ Additionally, `restricted-bash` validates **shell operators** (see [Shell Operat
 
 ---
 
+## Deployment Extras (Configurable Whitelist Additions)
+
+Deployments can whitelist **additional** binaries through a JSON config file loaded once
+at agent startup — see `docs/design/2026-06-10-extra-command-whitelist.md` for the full
+contract. Summary:
+
+- Resolution: `SICLAW_EXTRA_COMMANDS_FILE` env var (mandatory if set), else
+  `/etc/siclaw/extra-commands.json` (optional; baked into the AgentBox image from
+  `docker/extra-commands.json`).
+- **Additive-only**: entries colliding with built-in commands are skipped — a config
+  file can never relax built-in restrictions.
+- **Declarative constraints only**: `category` + `allowedFlags` / `blockedFlags` /
+  `allowedSubcommands` / `positionals` / `requiredFlags`. No custom validators.
+- **Forbidden names**: shells, interpreters, `sed`/`awk`, `nc`/`wget`/`socat`,
+  `sudo`/`nsenter`, argument-executing wrappers (`xargs`, `timeout`, `watch`, …),
+  `ssh`/`scp`/`rsync`, and `kubectl` are rejected at load time.
+- Invalid config fails agent startup loudly; accepted/skipped names are logged.
+
+---
+
 ## Excluded Commands
 
 The following are intentionally **NOT** in the whitelist:

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -40,6 +40,7 @@ import { PiAgentBrain } from "./brains/pi-agent-brain.js";
 import type { BrainSession } from "./brain-session.js";
 import { McpClientManager } from "./mcp-client.js";
 import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryEnabled } from "./config.js";
+import { initExtraCommands } from "../tools/infra/extra-commands.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
 
 import type { SessionMode, KubeconfigRef, MemoryRef, DpStateRef, MutableDpStateRef } from "./types.js";
@@ -287,6 +288,11 @@ export async function createSiclawSession(
   opts?: CreateSiclawSessionOpts,
 ): Promise<SiclawSessionResult> {
   const config = loadConfig();
+
+  // Register deployment-configured extra whitelist commands (idempotent,
+  // fail-loud on invalid config). Must run before any exec tool validates
+  // a command — all three exec tools share the merged registry.
+  initExtraCommands();
 
   const authStorage = AuthStorage.create();
 

--- a/src/tools/infra/command-sets.ts
+++ b/src/tools/infra/command-sets.ts
@@ -817,7 +817,7 @@ function applyContextPolicy(
   piped: boolean | undefined,
 ): string | null {
   if (!context) return null;
-  const def = COMMANDS[baseName];
+  const def = getCommandDef(baseName);
   if (!def) return null;
   const policy = CONTEXT_POLICIES[context];
   if (!policy) return null;
@@ -922,7 +922,7 @@ export function validateCommandRestrictions(
   if (args.length === 0) return null;
 
   const baseName = args[0].split("/").pop()?.toLowerCase() ?? "";
-  const def = COMMANDS[baseName];
+  const def = getCommandDef(baseName);
   if (!def) return null;
 
   // 1. Context policy constraints (pipeOnly, categoryBlockedFlags)
@@ -1329,12 +1329,54 @@ export const COMMANDS: Record<string, CommandDef> = {
   seq:    { category: "flow" },
 };
 
+// ── Extra commands (deployment-configured, additive-only) ───────
+//
+// Loaded from a JSON config at agent startup (see extra-commands.ts and
+// docs/design/2026-06-10-extra-command-whitelist.md). Stored SEPARATELY
+// from the built-in registry: lookups consult COMMANDS first, so an extra
+// entry can never replace or relax a built-in definition.
+
+let extraCommands: Record<string, CommandDef> = {};
+
+export interface SetExtraCommandsResult {
+  /** Extra command names now active. */
+  applied: string[];
+  /** Names dropped because they collide with built-in COMMANDS entries. */
+  skipped: string[];
+}
+
+/**
+ * Replace the active set of extra commands. Built-in collisions are skipped
+ * (additive-only contract). Invalidates the per-context allowed-set cache.
+ */
+export function setExtraCommands(extra: Record<string, CommandDef>): SetExtraCommandsResult {
+  const applied: string[] = [];
+  const skipped: string[] = [];
+  const accepted: Record<string, CommandDef> = {};
+  for (const [name, def] of Object.entries(extra)) {
+    if (name in COMMANDS) {
+      skipped.push(name);
+    } else {
+      accepted[name] = def;
+      applied.push(name);
+    }
+  }
+  extraCommands = accepted;
+  contextAllowedCache.clear();
+  return { applied, skipped };
+}
+
+/** Resolve a command definition: built-in registry first, then extras. */
+function getCommandDef(baseName: string): CommandDef | undefined {
+  return COMMANDS[baseName] ?? extraCommands[baseName];
+}
+
 // ── Context Policies (internal) ─────────────────────────────────
 //
 // Environment-level constraints. Not exported — only consumed by
 // validateCommandRestrictions() internally.
 
-const ALL_COMMAND_CATEGORIES: readonly CommandCategory[] = [
+export const ALL_COMMAND_CATEGORIES: readonly CommandCategory[] = [
   "text", "network", "rdma", "perftest", "gpu", "hardware", "kernel",
   "process", "file", "diagnostic", "services", "container", "firewall",
   "inspection", "compressed", "activity", "stream", "general", "general-env",
@@ -1377,14 +1419,14 @@ export function getContextAllowedSet(context: string): ReadonlySet<string> {
   const policy = CONTEXT_POLICIES[context];
   if (!policy) {
     // Unknown context → all commands
-    const all = new Set(Object.keys(COMMANDS));
+    const all = new Set([...Object.keys(COMMANDS), ...Object.keys(extraCommands)]);
     contextAllowedCache.set(context, all);
     return all;
   }
 
   const categorySet = new Set<string>(policy.available);
   const cmds = new Set<string>();
-  for (const [cmd, def] of Object.entries(COMMANDS)) {
+  for (const [cmd, def] of [...Object.entries(COMMANDS), ...Object.entries(extraCommands)]) {
     if (categorySet.has(def.category)) cmds.add(cmd);
   }
 

--- a/src/tools/infra/extra-commands.test.ts
+++ b/src/tools/infra/extra-commands.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  parseExtraCommandsConfig,
+  loadExtraCommands,
+} from "./extra-commands.js";
+import {
+  setExtraCommands,
+  getContextAllowedSet,
+  validateCommandRestrictions,
+} from "./command-sets.js";
+import { validateCommand } from "./command-validator.js";
+
+afterEach(() => {
+  setExtraCommands({});
+});
+
+// ── parseExtraCommandsConfig (schema validation) ────────────────────
+
+describe("parseExtraCommandsConfig", () => {
+  const wrap = (commands: unknown) =>
+    JSON.stringify({ version: 1, commands });
+
+  it("accepts a maximal valid config", () => {
+    const parsed = parseExtraCommandsConfig(wrap({
+      iperf3: {
+        category: "network",
+        description: "site-specific throughput tool",
+        allowedFlags: ["-c", "-p", "--json"],
+      },
+      mytool: {
+        category: "hardware",
+        blockedFlags: ["-w"],
+        positionals: 2,
+        requiredFlags: ["-b"],
+      },
+      vendorctl: {
+        category: "services",
+        allowedSubcommands: { position: 0, allowed: ["status", "show"] },
+        positionals: "block",
+      },
+    }), "test.json");
+
+    expect(Object.keys(parsed).sort()).toEqual(["iperf3", "mytool", "vendorctl"]);
+    expect(parsed.iperf3).toEqual({ category: "network", allowedFlags: ["-c", "-p", "--json"] });
+    expect(parsed.mytool.positionals).toBe(2);
+    expect(parsed.vendorctl.allowedSubcommands).toEqual({ position: 0, allowed: ["status", "show"] });
+  });
+
+  it("accepts a bare entry (category only)", () => {
+    const parsed = parseExtraCommandsConfig(wrap({ iperf3: { category: "network" } }), "t");
+    expect(parsed.iperf3).toEqual({ category: "network" });
+  });
+
+  it('accepts positionals "allow", "block", and 0', () => {
+    const parsed = parseExtraCommandsConfig(wrap({
+      a1: { category: "network", positionals: "allow" },
+      b2: { category: "network", positionals: "block" },
+      c3: { category: "network", positionals: 0 },
+    }), "t");
+    expect(parsed.c3.positionals).toBe(0);
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => parseExtraCommandsConfig("{nope", "bad.json")).toThrow(/bad\.json/);
+  });
+
+  it("rejects a non-object root", () => {
+    expect(() => parseExtraCommandsConfig("[]", "t")).toThrow(/object/i);
+  });
+
+  it("rejects a missing or wrong version", () => {
+    expect(() => parseExtraCommandsConfig(JSON.stringify({ commands: {} }), "t")).toThrow(/version/i);
+    expect(() => parseExtraCommandsConfig(JSON.stringify({ version: 2, commands: {} }), "t")).toThrow(/version/i);
+  });
+
+  it("rejects a missing commands object", () => {
+    expect(() => parseExtraCommandsConfig(JSON.stringify({ version: 1 }), "t")).toThrow(/commands/i);
+  });
+
+  it("rejects invalid command names", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ "Bad": { category: "network" } }), "t")).toThrow(/name/i);
+    expect(() => parseExtraCommandsConfig(wrap({ "a/b": { category: "network" } }), "t")).toThrow(/name/i);
+    expect(() => parseExtraCommandsConfig(wrap({ "": { category: "network" } }), "t")).toThrow(/name/i);
+  });
+
+  it("rejects an unknown category", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "shiny" } }), "t")).toThrow(/category/i);
+  });
+
+  it("rejects a missing category", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: {} }), "t")).toThrow(/category/i);
+  });
+
+  it("rejects unknown keys, including validate", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", nope: 1 } }), "t")).toThrow(/nope/);
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", validate: "x" } }), "t")).toThrow(/validate/);
+  });
+
+  it("rejects flags that do not start with a dash", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", allowedFlags: ["c"] } }), "t")).toThrow(/-/);
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", blockedFlags: [""] } }), "t")).toThrow(/-/);
+  });
+
+  it("rejects non-array flag fields", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", allowedFlags: "-c" } }), "t")).toThrow(/allowedFlags/);
+  });
+
+  it("rejects invalid positionals values", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", positionals: "maybe" } }), "t")).toThrow(/positionals/);
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", positionals: -1 } }), "t")).toThrow(/positionals/);
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", positionals: 1.5 } }), "t")).toThrow(/positionals/);
+  });
+
+  it("rejects malformed allowedSubcommands", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", allowedSubcommands: { position: -1, allowed: ["a"] } } }), "t")).toThrow(/allowedSubcommands/);
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", allowedSubcommands: { position: 0, allowed: [] } } }), "t")).toThrow(/allowedSubcommands/);
+    expect(() => parseExtraCommandsConfig(wrap({ x: { category: "network", allowedSubcommands: { allowed: ["a"] } } }), "t")).toThrow(/allowedSubcommands/);
+  });
+
+  it("rejects a non-object command entry", () => {
+    expect(() => parseExtraCommandsConfig(wrap({ x: "network" }), "t")).toThrow(/object/i);
+  });
+
+  it("rejects intentionally excluded binaries (shells, interpreters, wrappers, exfil tools)", () => {
+    for (const name of ["bash", "sh", "python3", "sed", "awk", "nc", "wget", "xargs", "timeout", "sudo", "nsenter", "ssh", "kubectl"]) {
+      expect(() => parseExtraCommandsConfig(wrap({ [name]: { category: "general" } }), "t"))
+        .toThrow(/cannot be whitelisted/i);
+    }
+  });
+
+  it("rejects multi-call wrappers (busybox/toybox) that provide a shell", () => {
+    for (const name of ["busybox", "toybox"]) {
+      expect(() => parseExtraCommandsConfig(wrap({ [name]: { category: "general" } }), "t"))
+        .toThrow(/cannot be whitelisted/i);
+    }
+  });
+
+  it("rejects version-suffixed interpreter variants", () => {
+    for (const name of ["python3.11", "python3.10", "python2.7", "node22", "node18", "perl5.36", "ruby3.2", "php8", "lua5.4", "bash5"]) {
+      expect(() => parseExtraCommandsConfig(wrap({ [name]: { category: "general" } }), "t"))
+        .toThrow(/cannot be whitelisted/i);
+    }
+  });
+
+  it("does not over-block legitimate names that merely resemble an interpreter stem", () => {
+    // iperf3 / sha256sum / show_gids / ib_write_bw end in or contain digits but are not
+    // <interpreter><version> forms — they must remain configurable.
+    for (const name of ["iperf3", "sha256sum", "show_gids", "ib_write_bw", "h5dump", "qperf"]) {
+      expect(() => parseExtraCommandsConfig(wrap({ [name]: { category: "network" } }), "t")).not.toThrow();
+    }
+  });
+});
+
+// ── setExtraCommands (merge semantics) ──────────────────────────────
+
+describe("setExtraCommands", () => {
+  it("makes an extra command visible in matching contexts and invalidates the cache", () => {
+    // Prime the cache first — registration must invalidate it.
+    expect(getContextAllowedSet("node").has("iperf3")).toBe(false);
+    expect(getContextAllowedSet("local").has("iperf3")).toBe(false);
+
+    const result = setExtraCommands({ iperf3: { category: "network" } });
+    expect(result.applied).toEqual(["iperf3"]);
+    expect(result.skipped).toEqual([]);
+
+    expect(getContextAllowedSet("node").has("iperf3")).toBe(true);
+    expect(getContextAllowedSet("local").has("iperf3")).toBe(true);
+  });
+
+  it("respects context policies for the extra command's category", () => {
+    setExtraCommands({ vendorcat: { category: "file" } });
+    // "file" category is excluded from the local context policy
+    expect(getContextAllowedSet("local").has("vendorcat")).toBe(false);
+    expect(getContextAllowedSet("node").has("vendorcat")).toBe(true);
+  });
+
+  it("skips collisions with built-in commands and keeps built-in restrictions", () => {
+    const result = setExtraCommands({
+      curl: { category: "network" }, // would lift curl's method restrictions
+      iperf3: { category: "network" },
+    });
+    expect(result.skipped).toEqual(["curl"]);
+    expect(result.applied).toEqual(["iperf3"]);
+
+    // Built-in curl validator still enforced
+    const err = validateCommandRestrictions("curl -X POST http://example.com");
+    expect(err).toContain("not allowed");
+  });
+
+  it("enforces declarative constraints on extra commands", () => {
+    setExtraCommands({ iperf3: { category: "network", allowedFlags: ["-c", "-p"] } });
+    expect(validateCommandRestrictions("iperf3 -c 10.0.0.1 -p 5201")).toBeNull();
+    expect(validateCommandRestrictions("iperf3 -F /tmp/x")).toContain("not allowed");
+  });
+
+  it("replaces previous extras on each call", () => {
+    setExtraCommands({ iperf3: { category: "network" } });
+    setExtraCommands({ qperf: { category: "network" } });
+    expect(getContextAllowedSet("node").has("iperf3")).toBe(false);
+    expect(getContextAllowedSet("node").has("qperf")).toBe(true);
+  });
+});
+
+// ── End-to-end through validateCommand ──────────────────────────────
+
+describe("validateCommand with extra commands", () => {
+  it("blocks an unregistered binary, allows it after registration", () => {
+    expect(validateCommand("iperf3 -c 10.0.0.1", { context: "node" })).toContain("iperf3");
+    setExtraCommands({ iperf3: { category: "network", allowedFlags: ["-c"] } });
+    expect(validateCommand("iperf3 -c 10.0.0.1", { context: "node" })).toBeNull();
+    expect(validateCommand("iperf3 -F /tmp/x", { context: "node" })).toContain("not allowed");
+  });
+
+  it("keeps category-based context exclusion for extras", () => {
+    setExtraCommands({ vendorcat: { category: "file" } });
+    expect(validateCommand("vendorcat /etc/hosts", { context: "local" })).toContain("vendorcat");
+    expect(validateCommand("vendorcat /etc/hosts", { context: "node" })).toBeNull();
+  });
+});
+
+// ── loadExtraCommands (file resolution) ─────────────────────────────
+
+describe("loadExtraCommands", () => {
+  let dir: string;
+  const make = (content: string): string => {
+    dir = mkdtempSync(join(tmpdir(), "siclaw-extra-"));
+    const p = join(dir, "extra-commands.json");
+    writeFileSync(p, content);
+    return p;
+  };
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("loads a valid file via explicit env path", () => {
+    const p = make(JSON.stringify({ version: 1, commands: { iperf3: { category: "network" } } }));
+    const loaded = loadExtraCommands({ envPath: p });
+    expect(loaded).toEqual({ iperf3: { category: "network" } });
+  });
+
+  it("throws when the env path is set but the file is missing", () => {
+    expect(() => loadExtraCommands({ envPath: "/nonexistent/extra.json" })).toThrow(/nonexistent/);
+  });
+
+  it("treats an empty env path as unset", () => {
+    expect(loadExtraCommands({ envPath: "", defaultPath: "/nonexistent/extra.json" })).toBeNull();
+  });
+
+  it("returns null when only the default path is configured and absent", () => {
+    expect(loadExtraCommands({ defaultPath: "/nonexistent/extra.json" })).toBeNull();
+  });
+
+  it("loads the default path when it exists", () => {
+    const p = make(JSON.stringify({ version: 1, commands: { qperf: { category: "network" } } }));
+    const loaded = loadExtraCommands({ defaultPath: p });
+    expect(loaded).toEqual({ qperf: { category: "network" } });
+  });
+
+  it("throws on an invalid file even at the default path", () => {
+    const p = make(JSON.stringify({ version: 1, commands: { curl2: { category: "bogus" } } }));
+    expect(() => loadExtraCommands({ defaultPath: p })).toThrow(/category/);
+  });
+});

--- a/src/tools/infra/extra-commands.ts
+++ b/src/tools/infra/extra-commands.ts
@@ -1,0 +1,215 @@
+/**
+ * Deployment-configurable extra command whitelist.
+ *
+ * Loads a JSON config file and registers additional commands into the
+ * whitelist via setExtraCommands(). Additive-only: built-in COMMANDS
+ * entries always win on collision; constraints are declarative-only
+ * (no validate functions — configuration cannot inject code).
+ *
+ * Contract: docs/design/2026-06-10-extra-command-whitelist.md
+ */
+import { existsSync, readFileSync } from "node:fs";
+import {
+  ALL_COMMAND_CATEGORIES,
+  setExtraCommands,
+  type CommandCategory,
+  type CommandDef,
+} from "./command-sets.js";
+
+/** Conventional path baked into the AgentBox image (Dockerfile.agentbox). */
+export const DEFAULT_EXTRA_COMMANDS_PATH = "/etc/siclaw/extra-commands.json";
+
+const NAME_PATTERN = /^[a-z0-9][a-z0-9._+-]*$/;
+
+// Binaries that must never enter the whitelist via configuration. The
+// built-in registry excludes these ON PURPOSE (security.md §4); a config
+// file re-adding one would silently void the whole second defense layer.
+// Not exhaustive — a curated foot-gun guard, fail-loud by design.
+const FORBIDDEN_EXTRA_COMMANDS = new Set([
+  // shell interpreters / script engines — arbitrary code execution
+  "sh", "bash", "dash", "zsh", "ksh", "csh", "tcsh", "fish",
+  "python", "python2", "python3", "perl", "ruby", "node", "deno", "bun", "lua",
+  // Turing-complete text tools intentionally excluded from the whitelist
+  "sed", "awk", "gawk", "mawk", "nawk", "bc",
+  // network exfiltration / arbitrary transfer intentionally excluded
+  "nc", "ncat", "netcat", "socat", "wget",
+  // privilege / namespace escape
+  "sudo", "su", "nsenter", "chroot", "setpriv", "runuser",
+  // wrappers that execute their arguments — would bypass first-binary validation
+  "xargs", "timeout", "nice", "ionice", "setsid", "stdbuf", "watch",
+  "strace", "ltrace", "gdb",
+  // multi-call binaries that bundle a shell (busybox sh / toybox sh)
+  "busybox", "toybox",
+  // remote execution / copy
+  "ssh", "scp", "sftp", "rsync", "telnet",
+  // kubectl has dedicated subcommand validation outside COMMANDS
+  "kubectl",
+]);
+
+// Version-suffixed interpreter variants (python3.11, node22, perl5.36, bash5, …)
+// are present in real PATHs and execute arbitrary code just like their unversioned
+// names, so an exact denylist alone leaves a hole. Reject any "<stem><version>" form
+// where the version starts with a digit. Anchored + digit-gated so legitimate names
+// that merely contain or end in digits (iperf3, sha256sum, show_gids) are unaffected.
+const INTERPRETER_VERSION_PATTERN =
+  /^(sh|bash|dash|ash|zsh|ksh|csh|tcsh|fish|python|perl|ruby|node|deno|bun|lua|php|tclsh|awk|gawk|sed)[0-9]/;
+
+const ALLOWED_ENTRY_KEYS = new Set([
+  "category", "description",
+  "allowedFlags", "blockedFlags", "allowedSubcommands", "positionals", "requiredFlags",
+]);
+
+function fail(source: string, message: string): never {
+  throw new Error(`Invalid extra-commands config (${source}): ${message}`);
+}
+
+function checkFlagArray(source: string, name: string, field: string, value: unknown): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    fail(source, `"${name}".${field} must be a non-empty string array`);
+  }
+  for (const flag of value) {
+    if (typeof flag !== "string" || !flag.startsWith("-")) {
+      fail(source, `"${name}".${field} entries must be strings starting with "-" (got ${JSON.stringify(flag)})`);
+    }
+  }
+  return value as string[];
+}
+
+function parseEntry(source: string, name: string, raw: unknown): CommandDef {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    fail(source, `"${name}" must be an object`);
+  }
+  const entry = raw as Record<string, unknown>;
+
+  for (const key of Object.keys(entry)) {
+    if (!ALLOWED_ENTRY_KEYS.has(key)) {
+      fail(source, `"${name}" has unsupported key "${key}" (only declarative constraints are configurable)`);
+    }
+  }
+
+  const category = entry.category;
+  if (typeof category !== "string" || !(ALL_COMMAND_CATEGORIES as readonly string[]).includes(category)) {
+    fail(source, `"${name}".category must be one of: ${ALL_COMMAND_CATEGORIES.join(", ")}`);
+  }
+
+  const def: CommandDef = { category: category as CommandCategory };
+
+  if (entry.allowedFlags !== undefined) def.allowedFlags = checkFlagArray(source, name, "allowedFlags", entry.allowedFlags);
+  if (entry.blockedFlags !== undefined) def.blockedFlags = checkFlagArray(source, name, "blockedFlags", entry.blockedFlags);
+  if (entry.requiredFlags !== undefined) def.requiredFlags = checkFlagArray(source, name, "requiredFlags", entry.requiredFlags);
+
+  if (entry.positionals !== undefined) {
+    const p = entry.positionals;
+    const isCount = typeof p === "number" && Number.isInteger(p) && p >= 0;
+    if (p !== "allow" && p !== "block" && !isCount) {
+      fail(source, `"${name}".positionals must be "allow", "block", or a non-negative integer`);
+    }
+    def.positionals = p as CommandDef["positionals"];
+  }
+
+  if (entry.allowedSubcommands !== undefined) {
+    const s = entry.allowedSubcommands as { position?: unknown; allowed?: unknown };
+    const positionOk = typeof s === "object" && s !== null &&
+      typeof s.position === "number" && Number.isInteger(s.position) && s.position >= 0;
+    const allowedOk = positionOk && Array.isArray(s.allowed) && s.allowed.length > 0 &&
+      s.allowed.every((a: unknown) => typeof a === "string" && a.length > 0);
+    if (!allowedOk) {
+      fail(source, `"${name}".allowedSubcommands must be { position: <non-negative int>, allowed: <non-empty string[]> }`);
+    }
+    def.allowedSubcommands = { position: s.position as number, allowed: s.allowed as string[] };
+  }
+
+  return def;
+}
+
+/**
+ * Parse and validate an extra-commands JSON document.
+ * Throws a descriptive error on any schema violation (fail-loud contract).
+ * The optional per-entry "description" field is documentation-only and stripped.
+ */
+export function parseExtraCommandsConfig(text: string, source: string): Record<string, CommandDef> {
+  let root: unknown;
+  try {
+    root = JSON.parse(text);
+  } catch (e) {
+    fail(source, `not valid JSON — ${(e as Error).message}`);
+  }
+  if (typeof root !== "object" || root === null || Array.isArray(root)) {
+    fail(source, "root must be a JSON object");
+  }
+  const doc = root as Record<string, unknown>;
+  if (doc.version !== 1) {
+    fail(source, `"version" must be 1`);
+  }
+  if (typeof doc.commands !== "object" || doc.commands === null || Array.isArray(doc.commands)) {
+    fail(source, `"commands" must be an object`);
+  }
+
+  const result: Record<string, CommandDef> = {};
+  for (const [name, raw] of Object.entries(doc.commands as Record<string, unknown>)) {
+    if (!NAME_PATTERN.test(name)) {
+      fail(source, `command name "${name}" is invalid (must match ${NAME_PATTERN})`);
+    }
+    if (FORBIDDEN_EXTRA_COMMANDS.has(name) || INTERPRETER_VERSION_PATTERN.test(name)) {
+      fail(source, `"${name}" cannot be whitelisted via configuration — it is intentionally excluded for security (shell/interpreter/wrapper/exfiltration risk)`);
+    }
+    result[name] = parseEntry(source, name, raw);
+  }
+  return result;
+}
+
+export interface LoadExtraCommandsOptions {
+  /** Explicit path (from SICLAW_EXTRA_COMMANDS_FILE). If set, the file MUST exist. */
+  envPath?: string;
+  /** Conventional path; silently skipped when absent. */
+  defaultPath?: string;
+}
+
+/**
+ * Resolve and load the extra-commands file.
+ * - envPath set (non-empty): mandatory — missing or invalid file throws.
+ * - otherwise defaultPath: loaded if present (invalid file still throws), null if absent.
+ * Returns the parsed command map, or null when no file is configured/present.
+ */
+export function loadExtraCommands(options?: LoadExtraCommandsOptions): Record<string, CommandDef> | null {
+  const envPath = options?.envPath;
+  if (envPath) {
+    if (!existsSync(envPath)) {
+      throw new Error(`SICLAW_EXTRA_COMMANDS_FILE points to a missing file: ${envPath}`);
+    }
+    return parseExtraCommandsConfig(readFileSync(envPath, "utf8"), envPath);
+  }
+
+  const defaultPath = options?.defaultPath;
+  if (defaultPath && existsSync(defaultPath)) {
+    return parseExtraCommandsConfig(readFileSync(defaultPath, "utf8"), defaultPath);
+  }
+  return null;
+}
+
+let initialized = false;
+
+/**
+ * Load extras from the environment once per process and register them.
+ * Called at agent startup (agent-factory). Throws on invalid config —
+ * fail-loud is deliberate so a typo cannot silently drop whitelist entries.
+ */
+export function initExtraCommands(): void {
+  if (initialized) return;
+  initialized = true;
+
+  const loaded = loadExtraCommands({
+    envPath: process.env.SICLAW_EXTRA_COMMANDS_FILE,
+    defaultPath: DEFAULT_EXTRA_COMMANDS_PATH,
+  });
+  if (!loaded || Object.keys(loaded).length === 0) return;
+
+  const { applied, skipped } = setExtraCommands(loaded);
+  // Audit trail: make deployment-widened whitelists visible in logs.
+  if (applied.length > 0) {
+    console.log(`[extra-commands] registered extra whitelist commands: ${applied.join(", ")}`);
+  }
+  if (skipped.length > 0) {
+    console.warn(`[extra-commands] skipped entries colliding with built-in commands (built-in restrictions win): ${skipped.join(", ")}`);
+  }
+}


### PR DESCRIPTION
## Summary

The exec command whitelist is compiled in, so adding a site-specific diagnostic binary needs a source change and a release. This adds an **additive-only** way to whitelist extra commands via a JSON config loaded once at agent startup — built-in restrictions can never be relaxed.

### Solution

- **`extra-commands.ts`** — strict schema parser accepting only declarative constraints (`category` + `allowedFlags`/`blockedFlags`/`allowedSubcommands`/`positionals`/`requiredFlags`); no `validate` functions, so configuration cannot inject code. Resolution: `SICLAW_EXTRA_COMMANDS_FILE` (mandatory if set) → `/etc/siclaw/extra-commands.json` (optional). Invalid config fails loud at startup.
- **Foot-gun denylist** — rejects code-executing binaries even if a config author lists them: shells/interpreters and their version-suffixed variants (`python3.11`, `node22`, …), `busybox`/`toybox`, `sed`/`awk`, `nc`/`wget`/`socat`, `sudo`/`nsenter`, argument-executing wrappers (`xargs`, `timeout`, …), `ssh`/`scp`/`rsync`, and `kubectl`.
- **`command-sets.ts`** — `setExtraCommands()` stores extras beside the frozen built-in registry (built-ins win on collision) and invalidates the per-context allowed-set cache. All three exec tools (restricted-bash, pod-exec, node-exec) share the merged view.
- **`Dockerfile.agentbox`** bakes an empty `docker/extra-commands.json`; deployments replace its content before build (a ConfigMap mount to avoid rebuilds is noted as future work).

Whoever can write the config or set the env var already controls the image/pod spec/local process — no new trust boundary is crossed. The mechanism can only *add* binaries; it cannot alter built-in restrictions, kubectl subcommand validation, shell-operator rules, or sensitive-path patterns.

Contract & rationale: `docs/design/2026-06-10-extra-command-whitelist.md`.

## Test Plan

- [x] `extra-commands.test.ts` — 33 tests: schema validation (every rejection rule + maximal valid config), denylist (shells/wrappers/busybox/versioned interpreters) with over-block guard for legit names (`iperf3`, `sha256sum`), merge semantics (collision skip, cache invalidation, context-policy placement), end-to-end through `validateCommand()`, loader file resolution (env-mandatory vs default-optional, fail-loud)
- [x] `npx tsc --noEmit` clean; `infra/` + `cmd-exec/` suites pass (1373 tests)
- [ ] Manual: build AgentBox image with a populated `extra-commands.json`, confirm the extra binary passes in the right context and its declarative constraints are enforced