### PR TITLE
feat(agentbox): DB-backed session checkpoints to remove the shared RWX PVC

### DIFF
--- a/docs/design/2026-06-10-session-checkpoint-db.md
+++ b/docs/design/2026-06-10-session-checkpoint-db.md
@@ -1,0 +1,118 @@
+# AgentBox Session Checkpoint — DB-backed, NFS Removal
+
+> Status: accepted (supersedes `2026-06-10-agentbox-session-checkpoint-oss.md` — the
+> OSS variant was rejected for v1; blob storage moved to the Portal DB. The `storage`
+> dimension of the contract below keeps the OSS door open without changing callers.)
+> Date: 2026-06-10
+> Scope: Siclaw only.
+
+## 1. Problem
+
+AgentBox `user-data` (pi-agent session JSONL, plan ledger, model-route state) currently
+requires a shared RWX PVC (NFS on the manager clusters). The NFS is being decommissioned.
+
+Two facts make a checkpoint design sufficient:
+
+1. **Restart is routine, not exceptional.** AgentBox self-destructs after 5 idle minutes
+   (`http-server.ts` idle timer); session continuity across that boundary is what the
+   PVC provides today. At idle-exit time every session has already been released, so a
+   release-time checkpoint fully covers the self-destruct path.
+2. **User-visible chat history is already DB-backed** (every message/tool row is written
+   through `chat.appendMessage`). What the checkpoint protects is the *framework's
+   resumable execution state* only. Worst-case loss (hard crash between checkpoints) is
+   the in-flight burst of agent context — never rendered chat history.
+
+## 2. Shape
+
+```
+AgentBox (emptyDir, unchanged POSIX writes)
+  release(30s idle) / SIGTERM(preStop)        getOrCreate() with empty dir
+        │ pack tar.gz (deterministic)               │ fetch + sha256 verify + extract
+        ▼                                           ▼
+Gateway internal mTLS API  (identity = client cert; same path in K8s and local mode)
+        │ FrontendWsClient RPC: checkpoint.save / checkpoint.load
+        ▼
+RPC server (standalone: Portal adapter → MySQL/SQLite; production: Sicore → PostgreSQL)
+```
+
+The Gateway never branches on deployment mode: persistence is always delegated over the
+phone-home WS RPC, exactly like `chat.appendMessage` and `config.getKnowledgeBundle`.
+
+## 3. RPC contract (the only cross-repo coupling point)
+
+Two methods. Sicore implements the same two against `siclaw_session_checkpoints`.
+
+### `checkpoint.save`
+
+Request:
+
+```jsonc
+{
+  "agent_id":   "…",        // injected by Gateway from mTLS identity — never client-supplied
+  "session_id": "…",
+  "revision":   3,           // strictly monotonic per (agent_id, session_id)
+  "sha256":     "<hex of compressed bytes>",
+  "size_bytes": 123456,      // compressed size
+  "data_base64": "…"
+}
+```
+
+Response: `{ "ok": true, "revision": 3 }`
+Conflict: `{ "ok": false, "error": "revision_conflict", "latest": 5 }` — returned (not
+thrown) when `revision <= MAX(existing revision)`. The single-writer assumption makes
+this an anomaly signal (stale counter after takeover, or split-brain); the client may
+re-sync once from `latest` and retry, then must give up loudly.
+
+Retention: after a successful insert the server deletes revisions `<= revision - 3`
+(keep last 3). GC ships with v1, not as a follow-up.
+
+### `checkpoint.load`
+
+Request: `{ "agent_id", "session_id", "before_revision"?: number, "meta_only"?: bool }`
+
+Response (found): `{ "found": true, "revision", "sha256", "size_bytes", "data_base64"? }`
+— latest revision, or latest `< before_revision` (integrity-failure fallback walk).
+`meta_only: true` omits `data_base64` (used to re-sync the revision counter cheaply).
+Response (none): `{ "found": false }`.
+
+## 4. Payload contract
+
+- Archive: `tar.gz` of the session directory **contents** (`agent/sessions/<id>/`),
+  relative paths only. Created with `portable + noMtime` so identical content yields
+  identical bytes — the client dedups by sha256 and skips no-op uploads.
+- Excluded by construction: `agent/tasks/*.output` live outside the session dir.
+  Task outputs are 24h-GC'd runtime traces; they are deliberately not durable.
+- Hard cap: 64 MiB compressed. An over-cap session logs an error and skips checkpointing
+  (bounded failure: that session degrades to fresh-on-restart; nothing else is affected).
+- Extraction validates: gzip integrity, no absolute paths, no `..` traversal, per-file
+  and total size caps, then writes into the (empty) session dir.
+
+## 5. Client semantics (AgentBox)
+
+- **Checkpoint triggers**: session `release()` (fires 30s after each prompt completes —
+  this is the workhorse), and process `SIGTERM` (preStop) for sessions still live.
+  Per-turn checkpointing was considered and deferred: release-cadence bounds crash loss
+  to the active burst, which matches what any architecture loses mid-generation.
+- **Hydrate trigger**: `getOrCreate()` finding no `*.jsonl` in the session dir. Verify
+  sha256; on mismatch walk back via `before_revision` (≤2 steps); if nothing verifies,
+  log and start fresh — never block the user's prompt on hydration failure.
+- **Eligibility**: only sessions created through `getOrCreate()` (top-level chat).
+  Delegated child sessions are one-shot and are not checkpointed.
+- **Feature flag**: `SICLAW_SESSION_CHECKPOINT_ENABLED` (default off), same pattern as
+  `SICLAW_MEMORY_ENABLED`. Requires `SICLAW_GATEWAY_URL` (the GatewayClient transport).
+
+## 6. Why DB blob, not OSS / RWX / rebuild-from-chat
+
+- **DB (chosen)**: release-cadence writes are ~MBs per conversation burst — trivial at
+  current scale (~200 users). `knowledge_versions.data LONGBLOB` is the in-repo
+  precedent. Zero new infrastructure or credentials.
+- **OSS**: right long-term home for blobs; rejected for v1 because Siclaw has no object
+  storage client today and the scale doesn't demand one. The RPC contract carries
+  `sha256/size/revision` metadata separately from bytes, so moving blobs later changes
+  only the two RPC server implementations.
+- **Another RWX filesystem**: keeps the architectural false requirement (RWX is only
+  needed because agents share one PVC; every session dir is single-writer).
+- **Rebuild from `chat_messages`**: lossy — plan ledger, DP mode, model-route state and
+  compaction state cannot be reconstructed, and the rebuild couples to pi-agent's JSONL
+  format. The checkpoint preserves the directory verbatim; correctness stays the
+  framework's own concern.

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -64,6 +64,13 @@ spec:
             - name: SICLAW_PERSISTENCE_CLAIM_NAME
               value: {{ include "siclaw.dataPvcName" . | quote }}
             {{- end }}
+            {{- if .Values.agentbox.sessionCheckpoint.enabled }}
+            # Forwarded by the runtime spawner into each AgentBox pod: session
+            # dirs are checkpointed to the DB via the Gateway on release/preStop
+            # and hydrated after pod restarts (replaces the shared RWX PVC).
+            - name: SICLAW_SESSION_CHECKPOINT_ENABLED
+              value: "true"
+            {{- end }}
             {{- if .Values.agentbox.debugImage }}
             - name: SICLAW_DEBUG_IMAGE
               value: {{ .Values.agentbox.debugImage | quote }}

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -161,6 +161,13 @@ agentbox:
     # Leaving this empty while enabled keeps the PVC in Pending state.
     storageClassName: ""
     size: "10Gi"
+  # DB-backed session checkpoints — the PVC-free successor to `persistence`
+  # (docs/design/2026-06-10-session-checkpoint-db.md). Session dirs are
+  # uploaded through the Gateway on release/preStop and restored after pod
+  # restarts. Safe to run alongside persistence during migration (double-
+  # write); once verified, disable persistence and drop the PVC.
+  sessionCheckpoint:
+    enabled: false
 
 # -- Metrics & Observability
 metrics:

--- a/src/agentbox-main.ts
+++ b/src/agentbox-main.ts
@@ -136,6 +136,11 @@ async function main() {
   // the final state before the pod terminates.
   const shutdown = async () => {
     console.log("[agentbox] Shutting down...");
+    // Checkpoint live sessions FIRST (preStop / rolling update): closeAll()
+    // tears down session state, and the K8s grace period is ticking.
+    await sessionManager.checkpointAllSessions("sigterm").catch((err) => {
+      console.error("[agentbox] Shutdown checkpoint pass failed:", err);
+    });
     await debugPodCache.evictAll();
     await sessionManager.closeAll();
     server.close();

--- a/src/agentbox/gateway-client.ts
+++ b/src/agentbox/gateway-client.ts
@@ -37,6 +37,10 @@ export interface AgentTask {
   agentId?: string | null;
 }
 
+const DEFAULT_TIMEOUT_MS = 5_000;
+/** Checkpoint blobs are MBs and may cross a cross-region link — see saveSessionCheckpoint. */
+const CHECKPOINT_TIMEOUT_MS = 120_000;
+
 export class GatewayClient {
   private gatewayUrl: string;
   private tlsOptions: https.RequestOptions | null = null;
@@ -134,6 +138,39 @@ export class GatewayClient {
   }
 
   /**
+   * Upload a session checkpoint. MB-scale base64 bodies can cross a
+   * cross-region link (Gateway → central RPC server), so this call gets a
+   * much longer timeout than the metadata default.
+   * Contract: docs/design/2026-06-10-session-checkpoint-db.md §3.
+   */
+  async saveSessionCheckpoint(payload: {
+    session_id: string;
+    revision: number;
+    sha256: string;
+    size_bytes: number;
+    data_base64: string;
+  }): Promise<{ ok: boolean; revision?: number; error?: string; latest?: number }> {
+    return this.request("/api/internal/session-checkpoints", "POST", payload, CHECKPOINT_TIMEOUT_MS);
+  }
+
+  /** Fetch the latest (or pre-`beforeRevision`) checkpoint for a session. */
+  async loadSessionCheckpoint(
+    sessionId: string,
+    opts?: { beforeRevision?: number; metaOnly?: boolean },
+  ): Promise<{ found: boolean; revision?: number; sha256?: string; size_bytes?: number; data_base64?: string }> {
+    const qs = new URLSearchParams();
+    if (opts?.beforeRevision != null) qs.set("before_revision", String(opts.beforeRevision));
+    if (opts?.metaOnly) qs.set("meta_only", "true");
+    const suffix = qs.size > 0 ? `?${qs.toString()}` : "";
+    return this.request(
+      `/api/internal/session-checkpoints/${encodeURIComponent(sessionId)}${suffix}`,
+      "GET",
+      undefined,
+      CHECKPOINT_TIMEOUT_MS,
+    );
+  }
+
+  /**
    * Return a GatewaySyncClientLike adapter for use with sync handlers.
    * Keeps `request()` private while exposing a minimal interface.
    */
@@ -146,7 +183,7 @@ export class GatewayClient {
   /**
    * Make HTTP(S) request to Gateway with mTLS authentication
    */
-  private request(path: string, method: "GET" | "POST" | "PUT" | "DELETE" = "GET", body?: any): Promise<any> {
+  private request(path: string, method: "GET" | "POST" | "PUT" | "DELETE" = "GET", body?: any, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<any> {
     return new Promise((resolve, reject) => {
       const url = new URL(path, this.gatewayUrl);
       const isHttps = url.protocol === "https:";
@@ -192,7 +229,7 @@ export class GatewayClient {
         reject(new Error(`Gateway request failed: ${err.message}`));
       });
 
-      req.setTimeout(5000, () => {
+      req.setTimeout(timeoutMs, () => {
         req.destroy();
         reject(new Error("Gateway request timeout"));
       });

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -54,6 +54,7 @@ vi.mock("../core/config.js", () => ({
     modelRouting: mockConfigState.modelRouting,
   }),
   isMemoryEnabled: () => true,
+  isSessionCheckpointEnabled: () => false,
 }));
 
 // Make sync-handlers a no-op registry.

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -12,10 +12,11 @@ import type { TLSSocket } from "node:tls";
 import type { AgentBoxSessionManager } from "./session.js";
 import type { SessionMode } from "../core/types.js";
 import type { AgentMode } from "../core/tool-registry.js";
-import { isMemoryEnabled, loadConfig } from "../core/config.js";
+import { isMemoryEnabled, isSessionCheckpointEnabled, loadConfig } from "../core/config.js";
 import { emitDiagnostic } from "../shared/diagnostic-events.js";
 import { checkMetricsAuth } from "../shared/metrics.js"; // also registers metrics subscriber (side-effect)
 import { GatewayClient } from "./gateway-client.js";
+import { SessionCheckpointer } from "./session-checkpointer.js";
 import { CredentialBroker } from "./credential-broker.js";
 import { HttpTransport } from "./credential-transport.js";
 import { getSyncHandler, createClusterHandler, createHostHandler } from "./sync-handlers.js";
@@ -219,6 +220,10 @@ export function createHttpServer(
       const client = sessionManager.gatewayClient;
       sessionManager.credentialBroker = new CredentialBroker(new HttpTransport(client), credentialsDir);
       console.log(`[agentbox-http] Credential broker initialized (${gatewayUrl})`);
+    }
+    if (isSessionCheckpointEnabled() && sessionManager.gatewayClient && !sessionManager.checkpointer) {
+      sessionManager.checkpointer = new SessionCheckpointer(sessionManager.gatewayClient);
+      console.log(`[agentbox-http] Session checkpointing enabled (${gatewayUrl})`);
     }
   }
 

--- a/src/agentbox/session-checkpointer.test.ts
+++ b/src/agentbox/session-checkpointer.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { SessionCheckpointer, type CheckpointTransport } from "./session-checkpointer.js";
+import { packSessionDir } from "../shared/session-checkpoint.js";
+
+const SESSION = "sess-1";
+
+/** In-memory transport with the same semantics as the checkpoint.* RPC handlers. */
+class FakeTransport implements CheckpointTransport {
+  rows = new Map<number, { sha256: string; size_bytes: number; data_base64: string }>();
+  saveCalls: number[] = [];
+  loadCalls = 0;
+  failNextSave = false;
+
+  async saveSessionCheckpoint(p: { session_id: string; revision: number; sha256: string; size_bytes: number; data_base64: string }) {
+    this.saveCalls.push(p.revision);
+    if (this.failNextSave) {
+      this.failNextSave = false;
+      throw new Error("transport down");
+    }
+    const latest = this.latest();
+    if (latest !== null && p.revision <= latest) {
+      return { ok: false, error: "revision_conflict", latest };
+    }
+    this.rows.set(p.revision, { sha256: p.sha256, size_bytes: p.size_bytes, data_base64: p.data_base64 });
+    return { ok: true, revision: p.revision };
+  }
+
+  async loadSessionCheckpoint(_sessionId: string, opts?: { beforeRevision?: number; metaOnly?: boolean }) {
+    this.loadCalls++;
+    const candidates = [...this.rows.keys()]
+      .filter((r) => (opts?.beforeRevision != null ? r < opts.beforeRevision : true))
+      .sort((a, b) => b - a);
+    if (candidates.length === 0) return { found: false };
+    const revision = candidates[0];
+    const row = this.rows.get(revision)!;
+    return {
+      found: true,
+      revision,
+      sha256: row.sha256,
+      size_bytes: row.size_bytes,
+      ...(opts?.metaOnly ? {} : { data_base64: row.data_base64 }),
+    };
+  }
+
+  latest(): number | null {
+    return this.rows.size === 0 ? null : Math.max(...this.rows.keys());
+  }
+}
+
+let tmpRoot: string;
+let transport: FakeTransport;
+let checkpointer: SessionCheckpointer;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "checkpointer-test-"));
+  transport = new FakeTransport();
+  checkpointer = new SessionCheckpointer(transport);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function sessionDir(name = "dir"): string {
+  const dir = path.join(tmpRoot, name);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeJsonl(dir: string, content: string): void {
+  fs.writeFileSync(path.join(dir, "session.jsonl"), content);
+}
+
+/** Seed the fake server with a checkpoint packed from real fixture content. */
+async function seedServer(revision: number, content: string): Promise<void> {
+  const src = sessionDir(`seed-${revision}`);
+  writeJsonl(src, content);
+  const packed = (await packSessionDir(src))!;
+  transport.rows.set(revision, {
+    sha256: packed.sha256,
+    size_bytes: packed.sizeBytes,
+    data_base64: packed.data.toString("base64"),
+  });
+}
+
+describe("hydrate", () => {
+  it("skips when the dir already has a jsonl", async () => {
+    const dir = sessionDir();
+    writeJsonl(dir, "live");
+    expect(await checkpointer.hydrate(SESSION, dir)).toBe("skipped");
+    expect(transport.loadCalls).toBe(0);
+  });
+
+  it("returns fresh when nothing is stored", async () => {
+    expect(await checkpointer.hydrate(SESSION, sessionDir())).toBe("fresh");
+  });
+
+  it("restores the latest checkpoint and dedups the next no-op upload", async () => {
+    await seedServer(4, `{"m":1}\n`);
+    const dir = sessionDir();
+    expect(await checkpointer.hydrate(SESSION, dir)).toBe("restored");
+    expect(fs.readFileSync(path.join(dir, "session.jsonl"), "utf8")).toBe(`{"m":1}\n`);
+
+    // Unchanged content → no upload at release time
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.saveCalls).toEqual([]);
+  });
+
+  it("walks back past a corrupt head and saves above the head afterwards", async () => {
+    await seedServer(4, `{"m":"good"}\n`);
+    await seedServer(5, `{"m":"head"}\n`);
+    transport.rows.get(5)!.data_base64 = Buffer.from("corrupted").toString("base64");
+
+    const dir = sessionDir();
+    expect(await checkpointer.hydrate(SESSION, dir)).toBe("restored");
+    expect(fs.readFileSync(path.join(dir, "session.jsonl"), "utf8")).toBe(`{"m":"good"}\n`);
+
+    // New content must save as rev 6 (above the corrupt head 5, not 4+1)
+    writeJsonl(dir, `{"m":"new"}\n`);
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.saveCalls).toEqual([6]);
+    expect(transport.latest()).toBe(6);
+  });
+
+  it("degrades to fresh when no revision verifies, still saving above the head", async () => {
+    await seedServer(2, "x");
+    await seedServer(3, "y");
+    transport.rows.get(2)!.sha256 = "0".repeat(64);
+    transport.rows.get(3)!.sha256 = "0".repeat(64);
+
+    const dir = sessionDir();
+    expect(await checkpointer.hydrate(SESSION, dir)).toBe("fresh");
+
+    writeJsonl(dir, "new");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.saveCalls).toEqual([4]);
+  });
+
+  it("degrades to fresh when the transport throws", async () => {
+    transport.loadSessionCheckpoint = async () => { throw new Error("gateway down"); };
+    expect(await checkpointer.hydrate(SESSION, sessionDir())).toBe("fresh");
+  });
+});
+
+describe("checkpoint", () => {
+  it("does nothing for an empty session dir", async () => {
+    await checkpointer.checkpoint(SESSION, sessionDir(), "release");
+    expect(transport.saveCalls).toEqual([]);
+  });
+
+  it("saves monotonically as content changes and dedups unchanged content", async () => {
+    const dir = sessionDir();
+    await checkpointer.hydrate(SESSION, dir); // fresh → counter 0
+
+    writeJsonl(dir, "v1");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    writeJsonl(dir, "v2");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    await checkpointer.checkpoint(SESSION, dir, "release"); // unchanged
+
+    expect(transport.saveCalls).toEqual([1, 2]);
+    expect(transport.latest()).toBe(2);
+  });
+
+  it("re-syncs the revision counter via meta load when it has none", async () => {
+    await seedServer(7, "old");
+    const dir = sessionDir();
+    writeJsonl(dir, "live-content"); // dir already live → hydrate never ran
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.saveCalls).toEqual([8]);
+  });
+
+  it("recovers from a single revision conflict by re-syncing once", async () => {
+    const dir = sessionDir();
+    await checkpointer.hydrate(SESSION, dir); // counter 0
+    await seedServer(3, "someone-else"); // server moved ahead behind our back
+
+    writeJsonl(dir, "mine");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.saveCalls).toEqual([1, 4]); // conflict at 1, retry at latest+1
+    expect(transport.latest()).toBe(4);
+  });
+
+  it("stops writing a session after repeated conflicts (split-brain)", async () => {
+    const dir = sessionDir();
+    await checkpointer.hydrate(SESSION, dir);
+
+    // A competing writer that always stays ahead: force conflicts on every save.
+    transport.saveSessionCheckpoint = async (p) => {
+      transport.saveCalls.push(p.revision);
+      return { ok: false, error: "revision_conflict", latest: p.revision + 10 };
+    };
+
+    writeJsonl(dir, "mine");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.saveCalls.length).toBe(2); // initial + one re-sync, then stop
+
+    writeJsonl(dir, "more");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.saveCalls.length).toBe(2); // poisoned — no further writes
+  });
+
+  it("propagates transport errors so callers can log and retry next trigger", async () => {
+    const dir = sessionDir();
+    await checkpointer.hydrate(SESSION, dir);
+    writeJsonl(dir, "v1");
+    transport.failNextSave = true;
+    await expect(checkpointer.checkpoint(SESSION, dir, "release")).rejects.toThrow(/transport down/);
+
+    // Next trigger succeeds and still uses revision 1
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.latest()).toBe(1);
+  });
+
+  it("forget() drops tracking so a closed session re-syncs from the server", async () => {
+    const dir = sessionDir();
+    await checkpointer.hydrate(SESSION, dir);
+    writeJsonl(dir, "v1");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    checkpointer.forget(SESSION);
+
+    writeJsonl(dir, "v2");
+    await checkpointer.checkpoint(SESSION, dir, "release");
+    expect(transport.latest()).toBe(2);
+  });
+});
+
+describe("hydrate + checkpoint roundtrip", () => {
+  it("simulates pod restart: checkpoint, wipe dir, hydrate, continue", async () => {
+    const dir = sessionDir();
+    await checkpointer.hydrate(SESSION, dir);
+    writeJsonl(dir, `{"turn":1}\n`);
+    fs.writeFileSync(path.join(dir, ".plan-ledger.json"), `{"tasks":["a"]}`);
+    await checkpointer.checkpoint(SESSION, dir, "release");
+
+    // Pod restart: emptyDir wiped, new process
+    fs.rmSync(dir, { recursive: true, force: true });
+    const fresh = new SessionCheckpointer(transport);
+    const newDir = sessionDir("after-restart");
+    expect(await fresh.hydrate(SESSION, newDir)).toBe("restored");
+    expect(fs.readFileSync(path.join(newDir, "session.jsonl"), "utf8")).toBe(`{"turn":1}\n`);
+    expect(fs.readFileSync(path.join(newDir, ".plan-ledger.json"), "utf8")).toBe(`{"tasks":["a"]}`);
+
+    // Conversation continues; next checkpoint builds on the restored revision
+    fs.appendFileSync(path.join(newDir, "session.jsonl"), `{"turn":2}\n`);
+    await fresh.checkpoint(SESSION, newDir, "release");
+    expect(transport.latest()).toBe(2);
+    const head = await transport.loadSessionCheckpoint(SESSION);
+    expect(crypto.createHash("sha256").update(Buffer.from(head.data_base64!, "base64")).digest("hex"))
+      .toBe(head.sha256);
+  });
+});

--- a/src/agentbox/session-checkpointer.ts
+++ b/src/agentbox/session-checkpointer.ts
@@ -1,0 +1,186 @@
+/**
+ * SessionCheckpointer — durable session-dir snapshots via the Gateway.
+ *
+ * Replaces the shared RWX PVC for AgentBox `user-data` session state:
+ * the session directory lives on local/emptyDir storage and is packed to a
+ * tar.gz checkpoint on session release / SIGTERM, then restored (hydrated)
+ * by getOrCreate() after a pod restart.
+ * Contract: docs/design/2026-06-10-session-checkpoint-db.md.
+ *
+ * Failure philosophy: checkpointing is a background durability path — it
+ * must never block or fail a user's prompt. Hydration degrades to a fresh
+ * session (chat history stays DB-backed); upload failures are logged loudly
+ * and retried on the next trigger. The one hard stop is a repeated revision
+ * conflict, which signals a competing writer (split-brain) — we stop writing
+ * for that session instead of fighting over the row.
+ */
+
+import {
+  packSessionDir,
+  extractSessionCheckpoint,
+  sessionDirNeedsHydration,
+  sha256Hex,
+} from "../shared/session-checkpoint.js";
+
+/** Subset of GatewayClient used here — narrow so tests can fake it. */
+export interface CheckpointTransport {
+  saveSessionCheckpoint(payload: {
+    session_id: string;
+    revision: number;
+    sha256: string;
+    size_bytes: number;
+    data_base64: string;
+  }): Promise<{ ok: boolean; revision?: number; error?: string; latest?: number }>;
+  loadSessionCheckpoint(
+    sessionId: string,
+    opts?: { beforeRevision?: number; metaOnly?: boolean },
+  ): Promise<{ found: boolean; revision?: number; sha256?: string; size_bytes?: number; data_base64?: string }>;
+}
+
+export type HydrateOutcome = "restored" | "fresh" | "skipped";
+
+/** Integrity-fallback walk depth: latest plus up to 2 older revisions (keep-3 retention). */
+const MAX_HYDRATE_ATTEMPTS = 3;
+
+export class SessionCheckpointer {
+  private transport: CheckpointTransport;
+  /** Last revision known to exist server-side, per session (re-synced lazily). */
+  private revisions = new Map<string, number>();
+  /** sha256 of the last successful upload — dedups no-op checkpoints. */
+  private lastUploadedSha = new Map<string, string>();
+  /**
+   * Sessions we stopped writing: repeated revision conflict (split-brain
+   * signal) or over-cap archives. Cleared only by process restart — both
+   * conditions need operator attention, not silent retries.
+   */
+  private stopped = new Map<string, string>();
+
+  constructor(transport: CheckpointTransport) {
+    this.transport = transport;
+  }
+
+  /**
+   * Restore a session directory from its latest verifiable checkpoint.
+   * Never throws: any failure degrades to "fresh" with a loud log — the
+   * user's prompt proceeds either way.
+   */
+  async hydrate(sessionId: string, sessionDir: string): Promise<HydrateOutcome> {
+    if (!sessionDirNeedsHydration(sessionDir)) return "skipped";
+    try {
+      let beforeRevision: number | undefined;
+      let latestSeen: number | undefined;
+      for (let attempt = 0; attempt < MAX_HYDRATE_ATTEMPTS; attempt++) {
+        const result = await this.transport.loadSessionCheckpoint(sessionId, { beforeRevision });
+        if (!result.found) break;
+        // The first revision we see is the server-side head — later saves
+        // must build on it even when we restore an older (intact) revision,
+        // otherwise the next save would collide with the corrupt head row.
+        latestSeen ??= result.revision;
+        const data = Buffer.from(result.data_base64 ?? "", "base64");
+        if (!result.sha256 || sha256Hex(data) !== result.sha256) {
+          console.warn(
+            `[session-checkpoint] sha256 mismatch for ${sessionId} rev ${result.revision}; walking back`,
+          );
+          beforeRevision = result.revision;
+          continue;
+        }
+        await extractSessionCheckpoint(data, sessionDir);
+        this.revisions.set(sessionId, latestSeen ?? result.revision ?? 0);
+        this.lastUploadedSha.set(sessionId, result.sha256);
+        console.log(
+          `[session-checkpoint] restored ${sessionId} from rev ${result.revision} (${result.size_bytes} bytes)`,
+        );
+        return "restored";
+      }
+      if (latestSeen !== undefined) {
+        // Checkpoints exist but none verified — start fresh above the head.
+        this.revisions.set(sessionId, latestSeen);
+        console.error(
+          `[session-checkpoint] no verifiable checkpoint for ${sessionId} (head rev ${latestSeen}); starting fresh`,
+        );
+      } else {
+        this.revisions.set(sessionId, 0);
+      }
+      return "fresh";
+    } catch (err) {
+      console.error(`[session-checkpoint] hydrate failed for ${sessionId}; starting fresh:`, err);
+      return "fresh";
+    }
+  }
+
+  /**
+   * Pack and upload the session directory. No-op when content is unchanged
+   * since the last upload. Throws transport errors to the caller (which logs
+   * and relies on the next trigger); permanently stops on split-brain or
+   * over-cap (see `stopped`).
+   */
+  async checkpoint(sessionId: string, sessionDir: string, reason: string): Promise<void> {
+    const stopReason = this.stopped.get(sessionId);
+    if (stopReason !== undefined) return;
+
+    let packed;
+    try {
+      packed = await packSessionDir(sessionDir);
+    } catch (err) {
+      // Over-cap archives don't shrink on retry — stop re-tarring a huge dir
+      // on every release and surface once per process.
+      this.stopped.set(sessionId, "over-cap");
+      console.error(`[session-checkpoint] stopping checkpoints for ${sessionId}:`, err);
+      return;
+    }
+    if (!packed) return;
+    if (this.lastUploadedSha.get(sessionId) === packed.sha256) return;
+
+    let revision = this.revisions.get(sessionId);
+    if (revision === undefined) {
+      // Long-lived dir without a prior hydrate in this process (local mode,
+      // or PVC double-write transition) — re-sync the counter cheaply.
+      const head = await this.transport.loadSessionCheckpoint(sessionId, { metaOnly: true });
+      revision = head.found ? (head.revision ?? 0) : 0;
+    }
+
+    const save = (rev: number) =>
+      this.transport.saveSessionCheckpoint({
+        session_id: sessionId,
+        revision: rev,
+        sha256: packed.sha256,
+        size_bytes: packed.sizeBytes,
+        data_base64: packed.data.toString("base64"),
+      });
+
+    let next = revision + 1;
+    let result = await save(next);
+    if (!result.ok && result.error === "revision_conflict" && typeof result.latest === "number") {
+      // A stale counter (e.g. recovered pod) re-syncs once; a real competing
+      // writer will conflict again immediately.
+      console.warn(
+        `[session-checkpoint] revision conflict for ${sessionId} (ours ${next}, server ${result.latest}); re-syncing once`,
+      );
+      next = result.latest + 1;
+      result = await save(next);
+    }
+
+    if (result.ok) {
+      this.revisions.set(sessionId, next);
+      this.lastUploadedSha.set(sessionId, packed.sha256);
+      console.log(
+        `[session-checkpoint] saved ${sessionId} rev ${next} (${packed.sizeBytes} bytes, ${packed.fileCount} files, trigger=${reason})`,
+      );
+    } else if (result.error === "revision_conflict") {
+      this.stopped.set(sessionId, "revision-conflict");
+      console.error(
+        `[session-checkpoint] stopping checkpoints for ${sessionId}: repeated revision conflict — ` +
+        `a second AgentBox appears to be writing this session (split-brain)`,
+      );
+    } else {
+      throw new Error(`checkpoint.save rejected for ${sessionId}: ${JSON.stringify(result)}`);
+    }
+  }
+
+  /** Drop in-memory tracking for an explicitly closed session. */
+  forget(sessionId: string): void {
+    this.revisions.delete(sessionId);
+    this.lastUploadedSha.delete(sessionId);
+    this.stopped.delete(sessionId);
+  }
+}

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -35,6 +35,7 @@ import { buildNotificationBatch, type TaskNotification } from "../core/task-noti
 import { spawnBackgroundBash } from "../core/background-bash-runner.js";
 import { ConcurrencyLimiter } from "../core/concurrency-limiter.js";
 import { buildDelegateSummaryBundle } from "./delegation-summary.js";
+import type { SessionCheckpointer } from "./session-checkpointer.js";
 import type { KubeconfigRef, SessionMode, DpStateRef } from "../core/types.js";
 import type { BrainSession } from "../core/brain-session.js";
 import type { McpClientManager } from "../core/mcp-client.js";
@@ -212,6 +213,21 @@ export class AgentBoxSessionManager {
    * and must persist delegation/audit rows through Runtime's internal API.
    */
   gatewayClient?: GatewayClient;
+
+  /**
+   * Optional durable session snapshots (set by http-server when
+   * SICLAW_SESSION_CHECKPOINT_ENABLED and a gatewayClient exist).
+   * Hydrates session dirs in getOrCreate() and uploads them on release/SIGTERM
+   * — see docs/design/2026-06-10-session-checkpoint-db.md.
+   */
+  checkpointer?: SessionCheckpointer;
+
+  /**
+   * Sessions eligible for checkpointing: only top-level sessions created via
+   * getOrCreate(). Delegated child sessions are one-shot and never restored,
+   * so checkpointing them would only accumulate dead rows.
+   */
+  private checkpointEligible = new Set<string>();
 
   /**
    * Optional override for the directory where the broker materializes credential
@@ -1343,6 +1359,15 @@ export class AgentBoxSessionManager {
 
     const sessionDir = this.getSessionDir(id);
     console.log(`[agentbox-session] Creating session: ${id} in ${sessionDir}`);
+
+    // Restore the session dir from its durable checkpoint before pi-agent
+    // reads it (pod restarts wipe emptyDir). Never throws — hydration
+    // failure degrades to a fresh framework session; chat history is DB-backed.
+    this.checkpointEligible.add(id);
+    if (this.checkpointer) {
+      await this.checkpointer.hydrate(id, sessionDir);
+    }
+
     const modelRouteState = this.loadModelRouteState(id);
 
     if (isMemoryEnabled()) {
@@ -1727,7 +1752,19 @@ export class AgentBoxSessionManager {
       console.log(`[agentbox-session] Skipping memory auto-save for ${sessionId} (memory disabled)`);
     }
 
-    // 2. Shutdown per-session MCP connections
+    // 2. Durable checkpoint — the workhorse trigger (fires 30s after each
+    // prompt completes, so it also covers the 5-min idle self-destruct, by
+    // which time every session has been released). Failures are logged and
+    // retried on the next trigger; they never block the release.
+    if (this.checkpointer && this.checkpointEligible.has(sessionId)) {
+      try {
+        await this.checkpointer.checkpoint(sessionId, this.getSessionDir(sessionId), "release");
+      } catch (err) {
+        console.error(`[agentbox-session] Session checkpoint failed for ${sessionId}:`, err);
+      }
+    }
+
+    // 3. Shutdown per-session MCP connections
     if (managed.mcpManager) {
       try {
         await managed.mcpManager.shutdown();
@@ -1736,14 +1773,14 @@ export class AgentBoxSessionManager {
       }
     }
 
-    // 3. Sync shared memory index to pick up the new summary file
+    // 4. Sync shared memory index to pick up the new summary file
     if (isMemoryEnabled() && this._sharedMemoryIndexer) {
       await this._sharedMemoryIndexer.sync().catch((err) => {
         console.warn(`[agentbox-session] Memory sync on release failed:`, err);
       });
     }
 
-    // 3. Remove session from map (shared components remain alive).
+    // 5. Remove session from map (shared components remain alive).
     // Guard: only delete if the map still holds the same instance — a new
     // getOrCreate() may have replaced it while release() was running async.
     if (this.sessions.get(sessionId) === managed) {
@@ -1826,6 +1863,10 @@ export class AgentBoxSessionManager {
         }
       }
       this.sessions.delete(sessionId);
+      // Permanent closure — stop tracking for checkpointing (the stored
+      // revisions remain server-side until their session is GC'd).
+      this.checkpointEligible.delete(sessionId);
+      this.checkpointer?.forget(sessionId);
       // Permanent closure — drop the in-memory ledger so it doesn't accumulate
       // (the durable snapshot + Portal task_events remain for history/recovery).
       const hideTimer = this.ledgerHideTimers.get(sessionId);
@@ -1836,6 +1877,29 @@ export class AgentBoxSessionManager {
       deleteLedger(sessionId);
       emitDiagnostic({ type: "session_released", sessionId });
     }
+  }
+
+  /**
+   * Checkpoint every eligible live session — the SIGTERM/preStop path.
+   * Sessions already released have already checkpointed; this covers the
+   * ones still active when the pod is told to terminate (rolling update).
+   * Best-effort with a loud log per failure: the pod is going down either
+   * way, and a failed upload only widens the loss window to the last
+   * release-time checkpoint.
+   */
+  async checkpointAllSessions(reason = "shutdown"): Promise<void> {
+    if (!this.checkpointer) return;
+    const ids = [...this.sessions.keys()].filter((id) => this.checkpointEligible.has(id));
+    if (ids.length === 0) return;
+    console.log(`[agentbox-session] Checkpointing ${ids.length} live session(s) (${reason})`);
+    const results = await Promise.allSettled(
+      ids.map((id) => this.checkpointer!.checkpoint(id, this.getSessionDir(id), reason)),
+    );
+    results.forEach((r, i) => {
+      if (r.status === "rejected") {
+        console.error(`[agentbox-session] Shutdown checkpoint failed for ${ids[i]}:`, r.reason);
+      }
+    });
   }
 
   /**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -89,6 +89,13 @@ export function isMemoryEnabled(): boolean {
   return parseBooleanEnv(process.env.SICLAW_MEMORY_ENABLED, false);
 }
 
+export function isSessionCheckpointEnabled(): boolean {
+  // Off by default — session checkpointing (durable session-dir snapshots via
+  // Gateway → DB; docs/design/2026-06-10-session-checkpoint-db.md) replaces the
+  // shared RWX PVC. Also requires SICLAW_GATEWAY_URL for the upload transport.
+  return parseBooleanEnv(process.env.SICLAW_SESSION_CHECKPOINT_ENABLED, false);
+}
+
 // ---------------------------------------------------------------------------
 // Defaults
 // ---------------------------------------------------------------------------

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -177,11 +177,12 @@ export class K8sSpawner implements BoxSpawner {
     }
 
     // Forward agentbox-relevant runtime knobs into the agentbox pod. The agentbox
-    // runs in its own pod and does NOT inherit the runtime process env, yet this
-    // flag is read inside the agentbox (sub-agent fan-out limiter, design §3).
+    // runs in its own pod and does NOT inherit the runtime process env, yet these
+    // flags are read inside the agentbox (sub-agent fan-out limiter, design §3;
+    // session checkpointing, 2026-06-10-session-checkpoint-db.md §5).
     // Curated allowlist only — never forward arbitrary env. Set the value on the
     // runtime deployment to control every agentbox it spawns.
-    const AGENTBOX_FORWARDED_ENV = ["SICLAW_SUBAGENT_CONCURRENCY"];
+    const AGENTBOX_FORWARDED_ENV = ["SICLAW_SUBAGENT_CONCURRENCY", "SICLAW_SESSION_CHECKPOINT_ENABLED"];
     for (const name of AGENTBOX_FORWARDED_ENV) {
       const value = process.env[name];
       if (value !== undefined && value !== "") {

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -423,6 +423,88 @@ export async function handleAgentTasksDelete(
   }
 }
 
+/**
+ * POST /api/internal/session-checkpoints
+ *
+ * AgentBox uploads a session-dir checkpoint (tar.gz, base64). agent_id is
+ * taken from the mTLS identity — the body cannot attribute to another agent.
+ * Contract: docs/design/2026-06-10-session-checkpoint-db.md §3.
+ */
+export async function handleSessionCheckpointSave(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  identity: CertificateIdentity,
+  frontendClient: FrontendWsClient,
+): Promise<void> {
+  try {
+    const body = await readJsonBody(req) as {
+      session_id?: string;
+      revision?: number;
+      sha256?: string;
+      size_bytes?: number;
+      data_base64?: string;
+    };
+    if (!body.session_id || !body.revision || !body.sha256 || !body.data_base64) {
+      sendJson(res, 400, { error: "session_id, revision, sha256, data_base64 are required" });
+      return;
+    }
+    if (!(await sessionBelongsToIdentity(body.session_id, identity))) {
+      sendJson(res, 403, { error: "session ownership mismatch" });
+      return;
+    }
+    const data = await frontendClient.request("checkpoint.save", {
+      agent_id: identity.agentId,
+      session_id: body.session_id,
+      revision: body.revision,
+      sha256: body.sha256,
+      size_bytes: body.size_bytes ?? null,
+      data_base64: body.data_base64,
+    });
+    if (data.ok === false && data.error === "revision_conflict") {
+      sendJson(res, 409, data);
+      return;
+    }
+    sendJson(res, 200, data);
+  } catch (err) {
+    console.error("[internal-api] session-checkpoint save error:", err);
+    sendJson(res, 500, { error: "Internal server error" });
+  }
+}
+
+/**
+ * GET /api/internal/session-checkpoints/:sessionId
+ *
+ * Query params: before_revision (integrity-fallback walk), meta_only
+ * (revision-counter re-sync without the blob). Always 200; absence is
+ * `{found:false}` so the client never treats "no checkpoint yet" as an error.
+ */
+export async function handleSessionCheckpointLoad(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  identity: CertificateIdentity,
+  sessionId: string,
+  frontendClient: FrontendWsClient,
+): Promise<void> {
+  try {
+    if (!(await sessionBelongsToIdentity(sessionId, identity))) {
+      sendJson(res, 403, { error: "session ownership mismatch" });
+      return;
+    }
+    const query = new URL(req.url || "/", "http://_").searchParams;
+    const beforeRevision = query.get("before_revision");
+    const data = await frontendClient.request("checkpoint.load", {
+      agent_id: identity.agentId,
+      session_id: sessionId,
+      before_revision: beforeRevision != null ? Number(beforeRevision) : undefined,
+      meta_only: query.get("meta_only") === "true",
+    });
+    sendJson(res, 200, data);
+  } catch (err) {
+    console.error("[internal-api] session-checkpoint load error:", err);
+    sendJson(res, 500, { error: "Internal server error" });
+  }
+}
+
 function maybeJson(metadata: Record<string, unknown> | null | undefined): string | null {
   return metadata != null ? JSON.stringify(metadata) : null;
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -47,6 +47,8 @@ import {
   handleAgentTasksUpdate,
   handleAgentTasksDelete,
   handleDelegationEvents,
+  handleSessionCheckpointSave,
+  handleSessionCheckpointLoad,
 } from "./internal-api.js";
 // siclaw-api.ts routes moved to Portal — Runtime no longer registers CRUD routes.
 import { appendMessage, incrementMessageCount, ensureChatSession } from "./chat-repo.js";
@@ -635,6 +637,24 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           if (url === "/api/internal/delegation-events" && method === "POST") {
             if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
             handleDelegationEvents(req, res, identity, frontendClient);
+            return;
+          }
+
+          // Session checkpoints — durable session-dir snapshots (via RPC).
+          if (url.startsWith("/api/internal/session-checkpoints")) {
+            if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
+            const pathOnly = url.split("?")[0];
+            if (pathOnly === "/api/internal/session-checkpoints" && method === "POST") {
+              void handleSessionCheckpointSave(req, res, identity, frontendClient);
+              return;
+            }
+            const idMatch = pathOnly.match(/^\/api\/internal\/session-checkpoints\/([^/]+)$/);
+            if (idMatch && method === "GET") {
+              void handleSessionCheckpointLoad(req, res, identity, decodeURIComponent(idMatch[1]), frontendClient);
+              return;
+            }
+            res.writeHead(405, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "Method not allowed" }));
             return;
           }
 

--- a/src/portal/adapter-checkpoint.test.ts
+++ b/src/portal/adapter-checkpoint.test.ts
@@ -1,0 +1,116 @@
+/**
+ * checkpoint.save / checkpoint.load RPC handlers against a real SQLite DB —
+ * exercises BLOB round-tripping, monotonic revision enforcement and keep-3 GC
+ * (contract: docs/design/2026-06-10-session-checkpoint-db.md §3).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import crypto from "node:crypto";
+import { initDb, closeDb, getDb } from "../gateway/db.js";
+import { runPortalMigrations } from "./migrate.js";
+import { buildAdapterRpcHandlers } from "./adapter.js";
+
+const AGENT = "11111111-1111-1111-1111-111111111111";
+const SESSION = "22222222-2222-2222-2222-222222222222";
+
+function payload(revision: number, content: string) {
+  const data = Buffer.from(content, "utf8");
+  return {
+    agent_id: AGENT,
+    session_id: SESSION,
+    revision,
+    sha256: crypto.createHash("sha256").update(data).digest("hex"),
+    size_bytes: data.length,
+    data_base64: data.toString("base64"),
+  };
+}
+
+let save: (params: any, agentId: string) => Promise<any>;
+let load: (params: any, agentId: string) => Promise<any>;
+
+beforeEach(async () => {
+  initDb("sqlite::memory:");
+  await runPortalMigrations();
+  const handlers = buildAdapterRpcHandlers();
+  save = handlers.get("checkpoint.save")!;
+  load = handlers.get("checkpoint.load")!;
+});
+
+afterEach(async () => {
+  await closeDb();
+});
+
+describe("checkpoint.save / checkpoint.load", () => {
+  it("round-trips blob bytes and metadata", async () => {
+    const p = payload(1, "jsonl-bytes-\x00\x01\x02-binary-safe");
+    expect(await save(p, AGENT)).toEqual({ ok: true, revision: 1 });
+
+    const result = await load({ agent_id: AGENT, session_id: SESSION }, AGENT);
+    expect(result.found).toBe(true);
+    expect(result.revision).toBe(1);
+    expect(result.sha256).toBe(p.sha256);
+    expect(result.size_bytes).toBe(p.size_bytes);
+    expect(Buffer.from(result.data_base64, "base64").toString("utf8"))
+      .toBe("jsonl-bytes-\x00\x01\x02-binary-safe");
+  });
+
+  it("returns found:false when nothing is stored", async () => {
+    expect(await load({ agent_id: AGENT, session_id: SESSION }, AGENT)).toEqual({ found: false });
+  });
+
+  it("rejects non-monotonic revisions with a structured conflict", async () => {
+    await save(payload(3, "v3"), AGENT);
+    expect(await save(payload(3, "v3-again"), AGENT))
+      .toEqual({ ok: false, error: "revision_conflict", latest: 3 });
+    expect(await save(payload(2, "v2-stale"), AGENT))
+      .toEqual({ ok: false, error: "revision_conflict", latest: 3 });
+    // The stored blob is untouched by conflicting writes
+    const result = await load({ agent_id: AGENT, session_id: SESSION }, AGENT);
+    expect(Buffer.from(result.data_base64, "base64").toString("utf8")).toBe("v3");
+  });
+
+  it("keeps only the last 3 revisions", async () => {
+    for (let r = 1; r <= 5; r++) await save(payload(r, `v${r}`), AGENT);
+    const db = getDb();
+    const [rows] = await db.query<Array<{ revision: number }>>(
+      "SELECT revision FROM session_checkpoints WHERE agent_id = ? AND session_id = ? ORDER BY revision",
+      [AGENT, SESSION],
+    );
+    expect(rows.map((r) => Number(r.revision))).toEqual([3, 4, 5]);
+  });
+
+  it("load with before_revision walks back to an older revision", async () => {
+    for (let r = 1; r <= 3; r++) await save(payload(r, `v${r}`), AGENT);
+    const result = await load(
+      { agent_id: AGENT, session_id: SESSION, before_revision: 3 }, AGENT,
+    );
+    expect(result.revision).toBe(2);
+    expect(Buffer.from(result.data_base64, "base64").toString("utf8")).toBe("v2");
+  });
+
+  it("load with meta_only omits the blob", async () => {
+    await save(payload(1, "v1"), AGENT);
+    const result = await load(
+      { agent_id: AGENT, session_id: SESSION, meta_only: true }, AGENT,
+    );
+    expect(result.found).toBe(true);
+    expect(result.revision).toBe(1);
+    expect(result.data_base64).toBeUndefined();
+  });
+
+  it("rejects a save whose sha256 does not match the bytes", async () => {
+    const p = payload(1, "v1");
+    p.sha256 = "0".repeat(64);
+    await expect(save(p, AGENT)).rejects.toThrow(/sha256 mismatch/);
+  });
+
+  it("rejects malformed saves", async () => {
+    await expect(save({ agent_id: AGENT, session_id: SESSION, revision: 0, sha256: "x", data_base64: "" }, AGENT))
+      .rejects.toThrow(/requires/);
+  });
+
+  it("scopes checkpoints by agent and session", async () => {
+    await save(payload(1, "mine"), AGENT);
+    expect(await load({ agent_id: AGENT, session_id: "other-session" }, AGENT)).toEqual({ found: false });
+    expect(await load({ agent_id: "other-agent", session_id: SESSION }, AGENT)).toEqual({ found: false });
+  });
+});

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1539,9 +1539,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 44 handlers", () => {
+  it("registers exactly 46 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(44);
+    expect(handlers.size).toBe(46);
   });
 
   it("all expected handler names are registered", () => {
@@ -1559,6 +1559,7 @@ describe("buildAdapterRpcHandlers", () => {
       "channel.list", "channel.resolveBinding", "channel.pair",
       "agent.listForSkill", "agent.listForMcp", "agent.listForCluster", "agent.listForHost",
       "metrics.summary", "metrics.audit", "metrics.auditDetail",
+      "checkpoint.save", "checkpoint.load",
     ];
     for (const name of expected) {
       expect(handlers.has(name), `Missing handler: ${name}`).toBe(true);

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -2552,5 +2552,86 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     };
   });
 
+  // --- checkpoint.* ---
+  // AgentBox session checkpoints (NFS removal). Contract:
+  // docs/design/2026-06-10-session-checkpoint-db.md §3. agent_id is injected
+  // by the Gateway from the caller's mTLS identity — never client-supplied.
+
+  handlers.set("checkpoint.save", async (params) => {
+    const agentId = typeof params.agent_id === "string" ? params.agent_id : "";
+    const sessionId = typeof params.session_id === "string" ? params.session_id : "";
+    const revision = Number(params.revision);
+    const sha256 = typeof params.sha256 === "string" ? params.sha256.toLowerCase() : "";
+    const dataBase64 = typeof params.data_base64 === "string" ? params.data_base64 : "";
+    if (!agentId || !sessionId || !Number.isInteger(revision) || revision < 1
+      || !/^[0-9a-f]{64}$/.test(sha256) || !dataBase64) {
+      throw new Error("checkpoint.save requires agent_id, session_id, revision >= 1, sha256, data_base64");
+    }
+    const data = Buffer.from(dataBase64, "base64");
+    // Recompute over the wire bytes — catches base64 truncation/corruption
+    // before a broken blob becomes the session's only durable copy.
+    const actualSha = crypto.createHash("sha256").update(data).digest("hex");
+    if (actualSha !== sha256) {
+      throw new Error(`checkpoint.save sha256 mismatch for session ${sessionId}`);
+    }
+
+    const db = getDb();
+    const [rows] = await db.query(
+      `SELECT MAX(revision) AS latest FROM session_checkpoints WHERE agent_id = ? AND session_id = ?`,
+      [agentId, sessionId],
+    ) as any;
+    const latest = rows?.[0]?.latest ?? null;
+    if (latest !== null && revision <= Number(latest)) {
+      // Structured conflict (not a throw): the client re-syncs once and
+      // retries; a second conflict means a competing writer — give up loudly.
+      return { ok: false, error: "revision_conflict", latest: Number(latest) };
+    }
+    await db.query(
+      `INSERT INTO session_checkpoints (agent_id, session_id, revision, sha256, size_bytes, data)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [agentId, sessionId, revision, sha256, data.length, data],
+    );
+    // Retention: keep the last 3 revisions (design §3) — GC ships with v1.
+    await db.query(
+      `DELETE FROM session_checkpoints WHERE agent_id = ? AND session_id = ? AND revision <= ?`,
+      [agentId, sessionId, revision - 3],
+    );
+    return { ok: true, revision };
+  });
+
+  handlers.set("checkpoint.load", async (params) => {
+    const agentId = typeof params.agent_id === "string" ? params.agent_id : "";
+    const sessionId = typeof params.session_id === "string" ? params.session_id : "";
+    if (!agentId || !sessionId) {
+      throw new Error("checkpoint.load requires agent_id and session_id");
+    }
+    const metaOnly = params.meta_only === true;
+    const beforeRevision = Number.isInteger(Number(params.before_revision))
+      ? Number(params.before_revision) : null;
+
+    const conds = ["agent_id = ?", "session_id = ?"];
+    const sqlParams: unknown[] = [agentId, sessionId];
+    if (beforeRevision !== null) {
+      conds.push("revision < ?");
+      sqlParams.push(beforeRevision);
+    }
+    const db = getDb();
+    const [rows] = await db.query(
+      `SELECT revision, sha256, size_bytes${metaOnly ? "" : ", data"}
+       FROM session_checkpoints WHERE ${conds.join(" AND ")}
+       ORDER BY revision DESC LIMIT 1`,
+      sqlParams,
+    ) as any;
+    if (!rows || rows.length === 0) return { found: false };
+    const r = rows[0];
+    return {
+      found: true,
+      revision: Number(r.revision),
+      sha256: r.sha256,
+      size_bytes: Number(r.size_bytes),
+      ...(metaOnly ? {} : { data_base64: Buffer.from(r.data).toString("base64") }),
+    };
+  });
+
   return handlers;
 }

--- a/src/portal/migrate-sqlite.test.ts
+++ b/src/portal/migrate-sqlite.test.ts
@@ -46,6 +46,7 @@ describe("runPortalMigrations on SQLite :memory:", () => {
       "model_entries",
       "model_providers",
       "notifications",
+      "session_checkpoints",
       "siclaw_users",
       "skill_import_history",
       "skill_reviews",

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -453,6 +453,22 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_kpe_repo FOREIGN KEY (repo_id) REFERENCES knowledge_repos(id) ON DELETE CASCADE
   )`,
+
+  // AgentBox session checkpoints (tar.gz of the session dir; replaces the
+  // shared RWX PVC — docs/design/2026-06-10-session-checkpoint-db.md).
+  // Keep-3 retention is enforced by the checkpoint.save handler. No FK:
+  // session ids include framework-internal sessions that have no
+  // chat_sessions row, and checkpoints must survive agent rebinds.
+  `CREATE TABLE IF NOT EXISTS session_checkpoints (
+    agent_id CHAR(36) NOT NULL,
+    session_id CHAR(36) NOT NULL,
+    revision INT NOT NULL,
+    sha256 CHAR(64) NOT NULL,
+    size_bytes INT NOT NULL,
+    data LONGBLOB NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (agent_id, session_id, revision)
+  )`,
 ];
 
 /** Secondary indexes — kept separate so both drivers can handle them idempotently. */

--- a/src/shared/session-checkpoint.test.ts
+++ b/src/shared/session-checkpoint.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import {
+  packSessionDir,
+  extractSessionCheckpoint,
+  sessionDirNeedsHydration,
+  MAX_CHECKPOINT_COMPRESSED_BYTES,
+} from "./session-checkpoint.js";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "checkpoint-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeSessionFixture(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "2026-06-10-abc.jsonl"), `{"type":"message"}\n{"type":"message"}\n`);
+  fs.writeFileSync(path.join(dir, ".plan-ledger.json"), `{"tasks":[]}`);
+  fs.mkdirSync(path.join(dir, "nested"));
+  fs.writeFileSync(path.join(dir, "nested", "state.json"), `{"k":1}`);
+}
+
+/** Minimal ustar header for a single entry — used to forge traversal names. */
+function forgeTarGz(entryName: string, content: string): Buffer {
+  const body = Buffer.from(content, "utf8");
+  const header = Buffer.alloc(512);
+  header.write(entryName, 0, "utf8");
+  header.write("0000644\0", 100, "utf8"); // mode
+  header.write("0000000\0", 108, "utf8"); // uid
+  header.write("0000000\0", 116, "utf8"); // gid
+  header.write(body.length.toString(8).padStart(11, "0") + "\0", 124, "utf8"); // size
+  header.write("00000000000\0", 136, "utf8"); // mtime
+  header.write("        ", 148, "utf8"); // checksum placeholder = spaces
+  header.write("0", 156, "utf8"); // typeflag: regular file
+  header.write("ustar\0", 257, "utf8");
+  header.write("00", 263, "utf8");
+  let sum = 0;
+  for (const b of header) sum += b;
+  header.write(sum.toString(8).padStart(6, "0") + "\0 ", 148, "utf8");
+
+  const padded = Buffer.alloc(Math.ceil(body.length / 512) * 512);
+  body.copy(padded);
+  const end = Buffer.alloc(1024);
+  return gzipSync(Buffer.concat([header, padded, end]));
+}
+
+describe("packSessionDir", () => {
+  it("returns null for a missing directory", async () => {
+    expect(await packSessionDir(path.join(tmpRoot, "nope"))).toBeNull();
+  });
+
+  it("returns null for an empty directory", async () => {
+    const dir = path.join(tmpRoot, "empty");
+    fs.mkdirSync(dir);
+    expect(await packSessionDir(dir)).toBeNull();
+  });
+
+  it("packs and reports file count, size and sha256", async () => {
+    const dir = path.join(tmpRoot, "session");
+    writeSessionFixture(dir);
+    const packed = await packSessionDir(dir);
+    expect(packed).not.toBeNull();
+    expect(packed!.fileCount).toBe(3);
+    expect(packed!.sizeBytes).toBe(packed!.data.length);
+    expect(packed!.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic: identical content yields identical sha256", async () => {
+    const dir = path.join(tmpRoot, "session");
+    writeSessionFixture(dir);
+    const first = await packSessionDir(dir);
+    await new Promise((r) => setTimeout(r, 30));
+    // Touch mtimes — content unchanged must still dedup (noMtime).
+    const f = path.join(dir, "2026-06-10-abc.jsonl");
+    fs.utimesSync(f, new Date(), new Date());
+    const second = await packSessionDir(dir);
+    expect(second!.sha256).toBe(first!.sha256);
+  });
+});
+
+describe("extractSessionCheckpoint", () => {
+  it("round-trips a packed session directory", async () => {
+    const src = path.join(tmpRoot, "src");
+    writeSessionFixture(src);
+    const packed = await packSessionDir(src);
+
+    const dst = path.join(tmpRoot, "dst");
+    await extractSessionCheckpoint(packed!.data, dst);
+
+    expect(fs.readFileSync(path.join(dst, "2026-06-10-abc.jsonl"), "utf8"))
+      .toBe(fs.readFileSync(path.join(src, "2026-06-10-abc.jsonl"), "utf8"));
+    expect(fs.readFileSync(path.join(dst, ".plan-ledger.json"), "utf8")).toBe(`{"tasks":[]}`);
+    expect(fs.readFileSync(path.join(dst, "nested", "state.json"), "utf8")).toBe(`{"k":1}`);
+  });
+
+  it("rejects empty buffers", async () => {
+    await expect(extractSessionCheckpoint(Buffer.alloc(0), path.join(tmpRoot, "x")))
+      .rejects.toThrow(/empty/);
+  });
+
+  it("rejects non-gzip buffers", async () => {
+    await expect(extractSessionCheckpoint(Buffer.from("plain text"), path.join(tmpRoot, "x")))
+      .rejects.toThrow(/gzip/);
+  });
+
+  it("rejects buffers over the compressed cap", async () => {
+    const big = Buffer.alloc(MAX_CHECKPOINT_COMPRESSED_BYTES + 1, 0x1f);
+    big[1] = 0x8b;
+    await expect(extractSessionCheckpoint(big, path.join(tmpRoot, "x")))
+      .rejects.toThrow(/too large/);
+  });
+
+  it("rejects parent-directory traversal entries", async () => {
+    const evil = forgeTarGz("../evil.txt", "pwned");
+    const dst = path.join(tmpRoot, "dst");
+    await expect(extractSessionCheckpoint(evil, dst)).rejects.toThrow(/Unsafe entry/);
+    expect(fs.existsSync(path.join(tmpRoot, "evil.txt"))).toBe(false);
+  });
+});
+
+describe("sessionDirNeedsHydration", () => {
+  it("true for missing dir", () => {
+    expect(sessionDirNeedsHydration(path.join(tmpRoot, "nope"))).toBe(true);
+  });
+
+  it("true for dir without jsonl", () => {
+    const dir = path.join(tmpRoot, "d");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, ".plan-ledger.json"), "{}");
+    expect(sessionDirNeedsHydration(dir)).toBe(true);
+  });
+
+  it("false once a jsonl exists", () => {
+    const dir = path.join(tmpRoot, "d");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "a.jsonl"), "{}");
+    expect(sessionDirNeedsHydration(dir)).toBe(false);
+  });
+});

--- a/src/shared/session-checkpoint.ts
+++ b/src/shared/session-checkpoint.ts
@@ -1,0 +1,134 @@
+/**
+ * Session checkpoint pack/extract — tar.gz of an AgentBox session directory.
+ *
+ * Contract: docs/design/2026-06-10-session-checkpoint-db.md §4.
+ *
+ * Packing is deterministic (`portable` + `noMtime`): identical directory
+ * content yields identical bytes, so callers can dedup uploads by sha256.
+ * Extraction follows the same tar-slip defense as `portal/skill-import.ts`:
+ * node-tar already strips absolute paths and refuses `..`, and the explicit
+ * filter is defense-in-depth against a future dep swap or option drift.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+
+/**
+ * Hard cap on the compressed archive. An over-cap session is not an error the
+ * user can act on mid-turn — callers log and skip checkpointing (that one
+ * session degrades to fresh-on-restart; see design §4).
+ */
+export const MAX_CHECKPOINT_COMPRESSED_BYTES = 64 * 1024 * 1024;
+/** Decompression bomb guard for extraction. */
+const MAX_TOTAL_UNPACKED_BYTES = 512 * 1024 * 1024;
+
+export interface PackedCheckpoint {
+  /** Compressed tar.gz bytes. */
+  data: Buffer;
+  /** sha256 hex of `data` (the compressed bytes — what the server stores/verifies). */
+  sha256: string;
+  sizeBytes: number;
+  fileCount: number;
+}
+
+export function sha256Hex(buf: Buffer): string {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Pack a session directory into a deterministic tar.gz.
+ * Returns null when there is nothing to checkpoint (missing or empty dir).
+ * Throws when the archive exceeds MAX_CHECKPOINT_COMPRESSED_BYTES.
+ */
+export async function packSessionDir(sessionDir: string): Promise<PackedCheckpoint | null> {
+  if (!fs.existsSync(sessionDir)) return null;
+  const topEntries = await fsp.readdir(sessionDir);
+  if (topEntries.length === 0) return null;
+
+  const allEntries = await fsp.readdir(sessionDir, { recursive: true, withFileTypes: true });
+  const fileCount = allEntries.filter((e) => e.isFile()).length;
+  if (fileCount === 0) return null;
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "siclaw-checkpoint-"));
+  const archivePath = path.join(tmpDir, "session.tar.gz");
+  try {
+    await tar.create(
+      // portable omits uid/gid/system metadata and zeroes the gzip mtime;
+      // noMtime drops per-entry mtimes — together: same content, same bytes.
+      { gzip: true, cwd: sessionDir, portable: true, noMtime: true, file: archivePath },
+      topEntries.sort(),
+    );
+    const data = await fsp.readFile(archivePath);
+    if (data.length > MAX_CHECKPOINT_COMPRESSED_BYTES) {
+      throw new Error(
+        `Session checkpoint exceeds ${MAX_CHECKPOINT_COMPRESSED_BYTES} bytes: ${data.length} (${sessionDir})`,
+      );
+    }
+    return { data, sha256: sha256Hex(data), sizeBytes: data.length, fileCount };
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Extract a checkpoint archive into the session directory.
+ * Validates gzip magic, size caps, and entry paths before/while unpacking.
+ */
+export async function extractSessionCheckpoint(buf: Buffer, targetDir: string): Promise<void> {
+  if (buf.length === 0) throw new Error("Session checkpoint is empty");
+  if (buf.length > MAX_CHECKPOINT_COMPRESSED_BYTES) {
+    throw new Error(`Session checkpoint is too large: ${buf.length} bytes`);
+  }
+  if (!(buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b)) {
+    throw new Error("Session checkpoint must be a gzip archive");
+  }
+
+  await fsp.mkdir(targetDir, { recursive: true });
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "siclaw-checkpoint-"));
+  const archivePath = path.join(tmpDir, "session.tar.gz");
+  try {
+    await fsp.writeFile(archivePath, buf, { mode: 0o600 });
+
+    // Throwing inside `filter` gets swallowed by node-tar's internal callback
+    // chain (see skill-import.ts) — mark, skip, and reject after completion.
+    let unsafeEntry: string | null = null;
+    let totalUnpacked = 0;
+    await tar.extract({
+      file: archivePath,
+      cwd: targetDir,
+      filter: (entryPath, entry) => {
+        const normalized = entryPath.replace(/\\/g, "/");
+        if (normalized.startsWith("/") || normalized.split("/").includes("..")) {
+          unsafeEntry ??= entryPath;
+          return false;
+        }
+        totalUnpacked += entry.size ?? 0;
+        if (totalUnpacked > MAX_TOTAL_UNPACKED_BYTES) {
+          unsafeEntry ??= `${entryPath} (unpacked size cap exceeded)`;
+          return false;
+        }
+        return true;
+      },
+    });
+    if (unsafeEntry !== null) {
+      throw new Error(`Unsafe entry in session checkpoint: ${unsafeEntry}`);
+    }
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+/** True when the directory contains no pi-agent JSONL — i.e. hydration is worth attempting. */
+export function sessionDirNeedsHydration(sessionDir: string): boolean {
+  if (!fs.existsSync(sessionDir)) return true;
+  try {
+    return !fs.readdirSync(sessionDir).some((f) => f.endsWith(".jsonl"));
+  } catch {
+    return true;
+  }
+}


### PR DESCRIPTION
## Why

AgentBox keeps its pi-agent session state (conversation JSONL, plan ledger, model-route state) on a shared **ReadWriteMany** PVC so it survives the 5-minute idle self-destruct and pod restarts. RWX storage (e.g. an NFS-backed PVC) is operationally heavy and a single point of failure, and the architecture doesn't actually need a *shared* filesystem — every session directory is single-writer.

This replaces the RWX dependency with **DB-backed checkpoints**: the session directory lives on local `emptyDir`, gets packed to a `tar.gz` and uploaded through the Gateway on release / `preStop`, and is hydrated back after a pod restart.

User-visible chat history is unaffected — it is already DB-backed via `chat.appendMessage`. The checkpoint only protects the framework's resumable execution state; worst-case loss (a hard crash between checkpoints) is the in-flight conversation burst, never rendered history.

## What

- **Pack/extract** (`src/shared/session-checkpoint.ts`): deterministic `tar.gz` (`portable` + `noMtime`, so identical content → identical bytes → sha256 dedup) with tar-slip-safe extraction and size caps.
- **Checkpointer** (`src/agentbox/session-checkpointer.ts`): hydrate (sha256 verify, walk back over retained revisions, degrade-to-fresh on failure — never blocks the user's prompt) and checkpoint (sha256 dedup, monotonic revision with a structured conflict that re-syncs once then stops on split-brain).
- **Triggers** (`src/agentbox/session.ts`, `agentbox-main.ts`): session `release()` (the workhorse — fires 30s after each prompt, which also covers the idle self-destruct) and `SIGTERM`/`preStop` for still-live sessions. Hydrate runs in `getOrCreate()` before the framework reads the dir. Only top-level sessions are eligible; delegated child sessions are not.
- **Transport** (`src/gateway/internal-api.ts`, `src/agentbox/gateway-client.ts`): AgentBox uploads via the Gateway internal mTLS API (`/api/internal/session-checkpoints`), which forwards `checkpoint.save` / `checkpoint.load` over the existing RPC. AgentBox holds no storage credentials.
- **Storage** (`src/portal/adapter.ts`, `src/portal/migrate.ts`): standalone Portal backend — `session_checkpoints` table (LONGBLOB), server-side sha256 re-verification, strict monotonic revisions, keep-3 retention GC on write. The production RPC backend implements the same two methods separately.
- **Wiring** (`helm/`, `k8s-spawner`): opt-in via `SICLAW_SESSION_CHECKPOINT_ENABLED` (default off), surfaced as `agentbox.sessionCheckpoint.enabled`. Safe to run alongside the existing PVC during migration (double-write), then drop the PVC.

Contract & rationale: `docs/design/2026-06-10-session-checkpoint-db.md`.

## Testing

- Unit + integration: pack/extract roundtrip & tar-slip rejection, checkpointer state machine (hydrate / dedup / revision conflict / split-brain stop / pod-restart roundtrip), Portal RPC handlers against real SQLite (BLOB roundtrip, monotonic, keep-3 GC). Full suite green (3556 passed), `tsc` clean, `helm template` verified in both flag states.
- End-to-end on a test deployment: drove multiple turns, confirmed checkpoint rows land in the DB with monotonic growth, deleted the AgentBox pod and confirmed the respawned pod **hydrated** the session before continuing, and confirmed keep-3 GC prunes old revisions.

## Rollout

Opt-in and reversible. Enable the flag with the PVC still mounted (checkpoints write to the DB while restore still falls back to the PVC); once verified, switch `user-data` to `emptyDir` and drop the PVC.