### PR TITLE
build: add docker-ocr/push-ocr targets so make docker covers the OCR image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ TAG       ?= $(if $(GIT_TAG),$(GIT_TAG),$(VERSION)-$(GIT_COMMIT)$(GIT_DIRTY))
 RUNTIME_IMAGE  = $(REGISTRY)/siclaw-runtime:$(TAG)
 AGENTBOX_IMAGE = $(REGISTRY)/siclaw-agentbox:$(TAG)
 PORTAL_IMAGE   = $(REGISTRY)/siclaw-portal:$(TAG)
+OCR_IMAGE      = $(REGISTRY)/siclaw-ocr:$(TAG)
 
 # ── OCI labels injected into every image ──
 DOCKER_LABELS = \
@@ -71,7 +72,7 @@ build-portal-web: ## Compile Portal frontend (Vite)
 # ==================== Docker ====================
 ##@ Docker
 
-docker: docker-runtime docker-agentbox docker-portal ## Build all Docker images
+docker: docker-runtime docker-agentbox docker-portal docker-ocr ## Build all Docker images
 
 docker-runtime: ## Build runtime image
 	docker build -f Dockerfile.runtime $(DOCKER_LABELS) -t $(RUNTIME_IMAGE) .
@@ -82,7 +83,10 @@ docker-agentbox: ## Build agentbox image
 docker-portal: ## Build portal image
 	docker build -f Dockerfile.portal $(DOCKER_LABELS) -t $(PORTAL_IMAGE) .
 
-push: push-runtime push-agentbox push-portal ## Push all images to registry
+docker-ocr: ## Build OCR backend image
+	docker build -f Dockerfile.ocr $(DOCKER_LABELS) -t $(OCR_IMAGE) .
+
+push: push-runtime push-agentbox push-portal push-ocr ## Push all images to registry
 
 push-runtime: ## Push runtime image
 	docker push $(RUNTIME_IMAGE)
@@ -92,6 +96,9 @@ push-agentbox: ## Push agentbox image
 
 push-portal: ## Push portal image
 	docker push $(PORTAL_IMAGE)
+
+push-ocr: ## Push OCR backend image
+	docker push $(OCR_IMAGE)
 
 # ==================== Test ====================
 ##@ Test
@@ -116,6 +123,7 @@ info: ## Print build variables
 	@echo "RUNTIME:     $(RUNTIME_IMAGE)"
 	@echo "AGENTBOX:    $(AGENTBOX_IMAGE)"
 	@echo "PORTAL:      $(PORTAL_IMAGE)"
+	@echo "OCR:         $(OCR_IMAGE)"
 
 logs: ## View recent logs (all components)
 	@echo "=== Runtime ===" && \


### PR DESCRIPTION
## Problem

`Dockerfile.ocr` exists (added in 2eab058, portal attachment parsing) and the helm chart defaults to `ocr.enabled: true`, deriving the image as `<registry>/siclaw-ocr:<image.tag>` when `ocr.image.repository` is empty — i.e. the chart assumes every release tag has a matching `siclaw-ocr` image.

But the Makefile never builds it: `make docker` covers runtime/agentbox/portal only, and nothing references `Dockerfile.ocr`. Result: deploying a release with default chart values hits `ImagePullBackOff` on the OCR backend unless someone manually retags a previous siclaw-ocr image to the new tag (which is what operators have been doing, e.g. v0.1.7 → v0.1.8).

## Change

- `OCR_IMAGE = $(REGISTRY)/siclaw-ocr:$(TAG)`
- `docker-ocr` / `push-ocr` targets, wired into the `docker` / `push` aggregates
- `make info` prints the OCR image

## Verification

Real build from this branch (v0.1.9 + this fix): `make docker-ocr REGISTRY=… TAG=v0.1.9` built and tagged `siclaw-ocr:v0.1.9` successfully; `make -n` / `make info` output as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)