### PR TITLE
feat(channels): add DingTalk (Stream mode) channel handler

### DIFF
--- a/portal-web/src/pages/Channels.tsx
+++ b/portal-web/src/pages/Channels.tsx
@@ -10,6 +10,7 @@ interface Channel {
 
 const CHANNEL_TYPES = [
   { value: "lark", label: "Lark / Feishu" },
+  { value: "dingtalk", label: "DingTalk 钉钉" },
   { value: "slack", label: "Slack" },
   { value: "discord", label: "Discord" },
   { value: "telegram", label: "Telegram" },
@@ -31,6 +32,10 @@ const CONFIG_FIELDS: Record<string, ConfigField[]> = {
     { key: "app_secret", label: "App Secret", type: "password", placeholder: "App secret from console", required: true },
     { key: "verification_token", label: "Verification Token", type: "text", placeholder: "Optional" },
     { key: "encrypt_key", label: "Encrypt Key", type: "text", placeholder: "Optional" },
+  ],
+  dingtalk: [
+    { key: "client_id", label: "Client ID (AppKey)", type: "text", placeholder: "dingxxxxxxxxxx", required: true },
+    { key: "client_secret", label: "Client Secret (AppSecret)", type: "password", placeholder: "App secret from console", required: true },
   ],
   slack: [
     { key: "bot_token", label: "Bot Token", type: "password", placeholder: "xoxb-...", required: true },

--- a/src/gateway/channel-manager.test.ts
+++ b/src/gateway/channel-manager.test.ts
@@ -18,8 +18,8 @@ interface FakeHandlerRecord {
 
 const fakeHandlerRegistry: FakeHandlerRecord[] = [];
 
-vi.mock("./channels/lark.js", () => ({
-  createLarkHandler: (channel: Record<string, any>) => {
+function makeFakeFactory() {
+  return (channel: Record<string, any>) => {
     const record: FakeHandlerRecord = { started: false, stopped: false, receivedChannel: channel };
     fakeHandlerRegistry.push(record);
     const handler: ChannelHandler = {
@@ -27,7 +27,15 @@ vi.mock("./channels/lark.js", () => ({
       async stop() { record.stopped = true; },
     };
     return handler;
-  },
+  };
+}
+
+vi.mock("./channels/lark.js", () => ({
+  createLarkHandler: makeFakeFactory(),
+}));
+
+vi.mock("./channels/dingtalk.js", () => ({
+  createDingTalkHandler: makeFakeFactory(),
 }));
 
 class FakeFrontendClient {
@@ -164,6 +172,13 @@ describe("ChannelManager.startChannel / stopChannel", () => {
   it("starts a channel and stores its handler", async () => {
     const mgr = new ChannelManager(fakeManager, undefined, frontend as unknown as FrontendWsClient);
     await mgr.startChannel({ id: "c1", type: "lark", config: { app_id: "a", app_secret: "s" } });
+    expect(mgr.size).toBe(1);
+    expect(fakeHandlerRegistry[0].started).toBe(true);
+  });
+
+  it("starts a dingtalk channel via its factory", async () => {
+    const mgr = new ChannelManager(fakeManager, undefined, frontend as unknown as FrontendWsClient);
+    await mgr.startChannel({ id: "d1", type: "dingtalk", config: { client_id: "k", client_secret: "s" } });
     expect(mgr.size).toBe(1);
     expect(fakeHandlerRegistry[0].started).toBe(true);
   });

--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -11,6 +11,7 @@
 import type { AgentBoxManager } from "./agentbox/manager.js";
 import type { FrontendWsClient } from "./frontend-ws-client.js";
 import { createLarkHandler } from "./channels/lark.js";
+import { createDingTalkHandler } from "./channels/dingtalk.js";
 
 export interface ChannelHandler {
   start(): Promise<void>;
@@ -133,6 +134,14 @@ export class ChannelManager {
     switch (channel.type) {
       case "lark":
         handler = createLarkHandler(
+          channel,
+          this.agentBoxManager,
+          this.agentBoxTlsOptions,
+          this.frontendClient,
+        );
+        break;
+      case "dingtalk":
+        handler = createDingTalkHandler(
           channel,
           this.agentBoxManager,
           this.agentBoxTlsOptions,

--- a/src/gateway/channels/dingtalk-card.ts
+++ b/src/gateway/channels/dingtalk-card.ts
@@ -32,19 +32,35 @@ export const EMPTY_RESULT_NOTICE_BY_LOCALE: Record<DingTalkLocale, string> = {
   "zh-CN": "⚠️ Agent 未返回结果。",
 };
 
+/**
+ * Shown when the agent run fails. Intentionally generic: the raw error often
+ * carries internal endpoints / infra details, and the chat (group or 1:1) is
+ * not a trusted audience — the real error is written to the Runtime log only.
+ */
+export const AGENT_ERROR_NOTICE_BY_LOCALE: Record<DingTalkLocale, string> = {
+  "zh-CN": "❌ 处理失败，请稍后重试。如持续失败，请联系管理员查看服务日志。",
+};
+
 export const DEFAULT_PLACEHOLDER = PLACEHOLDER_BY_LOCALE["zh-CN"];
 export const EMPTY_RESULT_NOTICE = EMPTY_RESULT_NOTICE_BY_LOCALE["zh-CN"];
+export const AGENT_ERROR_NOTICE = AGENT_ERROR_NOTICE_BY_LOCALE["zh-CN"];
 
 /**
  * Normalise markdown for DingTalk's `markdown` message renderer.
  *
  * DingTalk supports a broad subset of standard markdown (headings, bold,
- * italic, lists, links, images, inline code, fenced code, blockquote), so
- * unlike Feishu we pass almost everything through unchanged. The one fix-up:
- * collapse 4-6 `#` headings down to `###`, the deepest level DingTalk renders
- * distinctly — deeper levels otherwise show as plain text with stray hashes.
+ * italic, lists, links, inline code, fenced code, blockquote), so unlike
+ * Feishu we pass almost everything through unchanged. Two fix-ups:
+ *  1. Collapse 4-6 `#` headings down to `###`, the deepest level DingTalk
+ *     renders distinctly — deeper levels otherwise show as plain text with
+ *     stray hashes.
+ *  2. Strip image syntax (`![alt](url)` → its alt text). Agent output is
+ *     untrusted; an inline image makes DingTalk clients auto-fetch an external
+ *     URL, which a prompt-injected agent could abuse to exfiltrate data. We
+ *     keep the alt text so a legitimate caption survives but no fetch fires.
  *
- * Code fences are carved out first so heading syntax inside code is preserved.
+ * Code fences are carved out first so heading/image syntax inside code is
+ * preserved.
  */
 export function sanitizeMarkdownForDingTalk(input: string): string {
   if (!input) return input;
@@ -55,6 +71,9 @@ export function sanitizeMarkdownForDingTalk(input: string): string {
     return `\u0000CODEBLOCK${codeBlocks.length - 1}\u0000`;
   });
 
+  // Neutralise images: keep the alt text, drop the URL so no auto-fetch fires.
+  text = text.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+
   // Clamp #### / ##### / ###### → ### (DingTalk only styles h1-h3).
   text = text.replace(/^(\s*)#{4,6}(\s+)/gm, "$1###$2");
 
@@ -64,16 +83,40 @@ export function sanitizeMarkdownForDingTalk(input: string): string {
 }
 
 /**
+ * Derive a notification-preview title from the reply body. DingTalk requires
+ * `markdown.title` and uses it ONLY for push notifications and the
+ * conversation-list preview (it is never rendered in the chat bubble) — a
+ * static title means every preview reads "Siclaw" with no hint of content.
+ *
+ * Takes the first non-empty line, strips markdown decoration, and truncates.
+ */
+export function deriveTitleFromText(text: string, maxChars = 60): string {
+  const firstLine = (text ?? "")
+    .split("\n")
+    .map((l) => l
+      // headings / blockquotes / list bullets
+      .replace(/^\s*(?:#{1,6}|>|[-*+]|\d+\.)\s+/, "")
+      // emphasis and inline code markers
+      .replace(/(\*\*|__|\*|_|`|~~)/g, "")
+      .trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return DINGTALK_TITLE;
+  return firstLine.length > maxChars ? `${firstLine.slice(0, maxChars)}…` : firstLine;
+}
+
+/**
  * Build the markdown message body POSTed to a DingTalk `sessionWebhook`.
  * `title` shows in notification previews; `text` is the rendered body.
+ * When no explicit title is given, it is derived from the body so the
+ * conversation-list preview shows actual content instead of a static name.
  */
 export function buildMarkdownMessage(
   text: string,
-  title: string = DINGTALK_TITLE,
+  title?: string,
 ): Record<string, unknown> {
   return {
     msgtype: "markdown",
-    markdown: { title, text: sanitizeMarkdownForDingTalk(text) },
+    markdown: { title: title ?? deriveTitleFromText(text), text: sanitizeMarkdownForDingTalk(text) },
   };
 }
 

--- a/src/gateway/channels/dingtalk-card.ts
+++ b/src/gateway/channels/dingtalk-card.ts
@@ -1,0 +1,106 @@
+/**
+ * DingTalk (钉钉) reply-formatting helpers.
+ *
+ * Phase 1 (current): the DingTalk handler replies via the temporary
+ * `sessionWebhook` URL with a `markdown` message once the agent finishes.
+ * This module owns the locale strings and the light markdown normalisation
+ * applied before sending. It mirrors `lark-card.ts` in spirit but is much
+ * smaller because DingTalk's markdown renderer is close to standard GFM.
+ *
+ * Phase 2 (future, not implemented): DingTalk AI streaming cards give a
+ * Feishu-CardKit-like "typing" experience but require a card template
+ * (`cardTemplateId`) registered in the DingTalk developer console plus the
+ * AI-card update OpenAPI. The `DingTalkStreamingCard` interface below is the
+ * reserved seam for that work — see the TODO at the bottom.
+ */
+
+/**
+ * DingTalk is a China-domestic platform; there is no global/EN variant, so we
+ * keep a single zh-CN locale. The type is kept open for symmetry with
+ * `lark-card.ts` in case an English deployment is ever needed.
+ */
+export type DingTalkLocale = "zh-CN";
+
+/** Shown as the card/message title and as the "thinking" placeholder. */
+export const DINGTALK_TITLE = "Siclaw";
+
+export const PLACEHOLDER_BY_LOCALE: Record<DingTalkLocale, string> = {
+  "zh-CN": "🤔 正在思考...",
+};
+
+export const EMPTY_RESULT_NOTICE_BY_LOCALE: Record<DingTalkLocale, string> = {
+  "zh-CN": "⚠️ Agent 未返回结果。",
+};
+
+export const DEFAULT_PLACEHOLDER = PLACEHOLDER_BY_LOCALE["zh-CN"];
+export const EMPTY_RESULT_NOTICE = EMPTY_RESULT_NOTICE_BY_LOCALE["zh-CN"];
+
+/**
+ * Normalise markdown for DingTalk's `markdown` message renderer.
+ *
+ * DingTalk supports a broad subset of standard markdown (headings, bold,
+ * italic, lists, links, images, inline code, fenced code, blockquote), so
+ * unlike Feishu we pass almost everything through unchanged. The one fix-up:
+ * collapse 4-6 `#` headings down to `###`, the deepest level DingTalk renders
+ * distinctly — deeper levels otherwise show as plain text with stray hashes.
+ *
+ * Code fences are carved out first so heading syntax inside code is preserved.
+ */
+export function sanitizeMarkdownForDingTalk(input: string): string {
+  if (!input) return input;
+
+  const codeBlocks: string[] = [];
+  let text = input.replace(/```[\s\S]*?```/g, (block) => {
+    codeBlocks.push(block);
+    return `\u0000CODEBLOCK${codeBlocks.length - 1}\u0000`;
+  });
+
+  // Clamp #### / ##### / ###### → ### (DingTalk only styles h1-h3).
+  text = text.replace(/^(\s*)#{4,6}(\s+)/gm, "$1###$2");
+
+  text = text.replace(/\u0000CODEBLOCK(\d+)\u0000/g, (_m, i: string) => codeBlocks[Number(i)] ?? "");
+
+  return text;
+}
+
+/**
+ * Build the markdown message body POSTed to a DingTalk `sessionWebhook`.
+ * `title` shows in notification previews; `text` is the rendered body.
+ */
+export function buildMarkdownMessage(
+  text: string,
+  title: string = DINGTALK_TITLE,
+): Record<string, unknown> {
+  return {
+    msgtype: "markdown",
+    markdown: { title, text: sanitizeMarkdownForDingTalk(text) },
+  };
+}
+
+/**
+ * Build a plain-text message body for the `sessionWebhook`. Used for short
+ * control replies (e.g. PAIR confirmations) where markdown adds no value.
+ */
+export function buildTextMessage(content: string): Record<string, unknown> {
+  return { msgtype: "text", text: { content } };
+}
+
+// ── Phase 2 reserved seam (NOT implemented) ───────────────────────────
+//
+// DingTalk AI streaming cards would replace the single markdown reply with a
+// live "typing" card, matching the Feishu CardKit UX. Implementing it requires:
+//   1. A card template registered in the DingTalk developer console; the
+//      resulting `cardTemplateId` would become a per-channel config field.
+//   2. Creating a card instance and delivering it to the conversation
+//      (`/v1.0/card/instances` + `.../deliver`).
+//   3. Streaming updates via the AI-card update OpenAPI as agent output
+//      arrives, then a terminal "finished" update.
+//
+// When implemented, `openTypingCard`/`finalizeCard` here would mirror the
+// lark-card contract: return `null`/`false` on failure so the handler can
+// fall back to `buildMarkdownMessage` over `sessionWebhook` (the Phase 1 path).
+export interface DingTalkStreamingCard {
+  cardInstanceId: string;
+  /** Monotonic counter for ordering streamed updates, as the API requires. */
+  sequence: number;
+}

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -7,6 +7,7 @@ import {
   resetConversationSessionsForTest,
 } from "./dingtalk.js";
 import { sessionRegistry } from "../session-registry.js";
+import { buildMarkdownMessage, DINGTALK_TITLE, sanitizeMarkdownForDingTalk } from "./dingtalk-card.js";
 
 // ── Mocks ──────────────────────────────────────────────────────────
 
@@ -247,14 +248,17 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
     expect(promptArg).not.toHaveProperty("userId");
   });
 
-  it("replies with a plain-text error when the agent throws", async () => {
+  it("replies with a generic notice (not raw error detail) when the agent throws", async () => {
     resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
-    promptMock.mockRejectedValue(new Error("AgentBox unreachable"));
+    promptMock.mockRejectedValue(new Error("AgentBox unreachable at https://internal-host:8443"));
     await handleDingTalkMessage(makeDownstream("hello"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
     const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
     expect(body.msgtype).toBe("text");
     expect(body.text.content).toContain("\u274C");
-    expect(body.text.content).toContain("AgentBox unreachable");
+    expect(body.text.content).toContain("处理失败");
+    // The raw error (internal host) must NOT leak to the chat.
+    expect(body.text.content).not.toContain("internal-host");
+    expect(body.text.content).not.toContain("AgentBox unreachable");
   });
 
   it("replies with the empty-result notice when the agent returns no text", async () => {
@@ -293,6 +297,23 @@ describe("handleDingTalkMessage — conversation model", () => {
   it("group chat uses a fresh sessionId per message (ephemeral)", async () => {
     await handleDingTalkMessage(makeDownstream("first"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
     await handleDingTalkMessage(makeDownstream("second"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const s1 = (promptMock.mock.calls[0][0] as any).sessionId;
+    const s2 = (promptMock.mock.calls[1][0] as any).sessionId;
+    expect(s1).not.toBe(s2);
+    sessionRegistry.forget(s1);
+    sessionRegistry.forget(s2);
+  });
+
+  it("an unknown/missing conversationType defaults to ephemeral (group) routing", async () => {
+    // No conversationType field at all → must NOT accumulate multi-turn context.
+    await handleDingTalkMessage(
+      makeDownstream("first", { conversationType: undefined, conversationId: "cidUNK" }),
+      "ch", makeAgentBoxManager("a1") as any, undefined, {} as any,
+    );
+    await handleDingTalkMessage(
+      makeDownstream("second", { conversationType: undefined, conversationId: "cidUNK" }),
+      "ch", makeAgentBoxManager("a1") as any, undefined, {} as any,
+    );
     const s1 = (promptMock.mock.calls[0][0] as any).sessionId;
     const s2 = (promptMock.mock.calls[1][0] as any).sessionId;
     expect(s1).not.toBe(s2);
@@ -392,5 +413,89 @@ describe("replyToDingTalk", () => {
   it("never throws when fetch rejects", async () => {
     fetchMock.mockRejectedValueOnce(new Error("network down"));
     await expect(replyToDingTalk(WEBHOOK, { msgtype: "text" })).resolves.toBeUndefined();
+  });
+
+  it("refuses to POST to a non-dingtalk host (SSRF guard) and does not fetch", async () => {
+    await replyToDingTalk("https://evil.example.com/exfil", { msgtype: "text" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a host that merely contains 'dingtalk.com' but is not a subdomain", async () => {
+    await replyToDingTalk("https://oapi.dingtalk.com.evil.com/x", { msgtype: "text" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-https webhook", async () => {
+    await replyToDingTalk("http://oapi.dingtalk.com/robot/send", { msgtype: "text" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a malformed webhook URL", async () => {
+    await replyToDingTalk("not a url", { msgtype: "text" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows api.dingtalk.com and *.dingtalk.com subdomains", async () => {
+    await replyToDingTalk("https://api.dingtalk.com/v1.0/robot/send", { msgtype: "text" });
+    await replyToDingTalk("https://anything.dingtalk.com/robot/send", { msgtype: "text" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── markdown title derivation (notification preview) ───────────────
+
+describe("buildMarkdownMessage — title derived from body", () => {
+  it("uses the first non-empty line, stripped of markdown decoration", () => {
+    const body = buildMarkdownMessage("# 巡检报告 — hke-prod-a-sh01\n\n全部正常。") as any;
+    expect(body.markdown.title).toBe("巡检报告 — hke-prod-a-sh01");
+  });
+
+  it("strips bold/inline-code markers and list bullets", () => {
+    const body = buildMarkdownMessage("- **节点**：`273` 个全部 Ready") as any;
+    expect(body.markdown.title).toBe("节点：273 个全部 Ready");
+  });
+
+  it("truncates long first lines with an ellipsis", () => {
+    const long = "A".repeat(80);
+    const body = buildMarkdownMessage(long) as any;
+    expect(body.markdown.title.length).toBeLessThanOrEqual(61);
+    expect(body.markdown.title.endsWith("…")).toBe(true);
+  });
+
+  it("falls back to the static title for empty/whitespace bodies", () => {
+    const body = buildMarkdownMessage("   \n  ") as any;
+    expect(body.markdown.title).toBe(DINGTALK_TITLE);
+  });
+
+  it("an explicit title overrides derivation", () => {
+    const body = buildMarkdownMessage("内容", "自定义标题") as any;
+    expect(body.markdown.title).toBe("自定义标题");
+  });
+});
+
+// ── sanitizeMarkdownForDingTalk — image neutralisation (exfil guard) ─
+
+describe("sanitizeMarkdownForDingTalk — strips images", () => {
+  it("replaces an image with its alt text so no auto-fetch fires", () => {
+    const out = sanitizeMarkdownForDingTalk("before ![diagram](https://evil.example/x.png) after");
+    expect(out).toBe("before diagram after");
+    expect(out).not.toContain("evil.example");
+    expect(out).not.toContain("![");
+  });
+
+  it("removes an image with empty alt text entirely", () => {
+    const out = sanitizeMarkdownForDingTalk("a ![](http://tracker/p.gif) b");
+    expect(out).toBe("a  b");
+    expect(out).not.toContain("tracker");
+  });
+
+  it("leaves image-like syntax inside fenced code blocks untouched", () => {
+    const src = "```md\n![x](http://example/y.png)\n```";
+    expect(sanitizeMarkdownForDingTalk(src)).toBe(src);
+  });
+
+  it("keeps ordinary links clickable (only images are neutralised)", () => {
+    const out = sanitizeMarkdownForDingTalk("[docs](https://oapi.dingtalk.com/help)");
+    expect(out).toBe("[docs](https://oapi.dingtalk.com/help)");
   });
 });

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createDingTalkHandler,
+  handleDingTalkMessage,
+  replyToDingTalk,
+  ackDingTalkCallback,
+  resetConversationSessionsForTest,
+} from "./dingtalk.js";
+import { sessionRegistry } from "../session-registry.js";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+// Stub AgentBoxClient so tests don't open real HTTPS sockets.
+const promptMock = vi.fn();
+const streamEventsMock = vi.fn();
+const closeSessionMock = vi.fn();
+
+vi.mock("../agentbox/client.js", () => ({
+  AgentBoxClient: class {
+    prompt = promptMock;
+    streamEvents = streamEventsMock;
+    closeSession = closeSessionMock;
+  },
+}));
+
+// Stub channel-manager RPCs so we don't hit frontend-ws in unit tests.
+const resolveBindingMock = vi.fn();
+const handlePairingCodeMock = vi.fn();
+
+vi.mock("../channel-manager.js", () => ({
+  resolveBinding: (...args: unknown[]) => resolveBindingMock(...args),
+  handlePairingCode: (...args: unknown[]) => handlePairingCodeMock(...args),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const WEBHOOK = "https://oapi.dingtalk.com/robot/sendBySession?session=tok";
+
+function makeAgentBoxManager(agentId = "agent-7") {
+  return {
+    getOrCreate: vi.fn().mockResolvedValue({
+      boxId: `agentbox-${agentId}`,
+      endpoint: "https://stub",
+      agentId,
+    }),
+  };
+}
+
+/** Build a raw DWClientDownStream whose `data` carries a robot message. */
+function makeDownstream(text: string, overrides: Record<string, unknown> = {}) {
+  const message = {
+    msgtype: "text",
+    text: { content: text },
+    conversationId: "cidGROUP",
+    conversationType: "2",
+    sessionWebhook: WEBHOOK,
+    msgId: "mid-1",
+    ...overrides,
+  };
+  return { data: JSON.stringify(message) };
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  promptMock.mockReset();
+  streamEventsMock.mockReset();
+  closeSessionMock.mockReset();
+  closeSessionMock.mockResolvedValue(undefined);
+  resolveBindingMock.mockReset();
+  handlePairingCodeMock.mockReset();
+  resetConversationSessionsForTest();
+  fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+  vi.stubGlobal("fetch", fetchMock);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  // The DingTalk SDK is an installed optionalDependency, so the "SDK missing"
+  // fallback tests actually reach DWClient.connect(), which logs via
+  // console.info/warn and attempts a (failing) network call. Silence the noise.
+  vi.spyOn(console, "info").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ── Fallback when SDK missing / config parsing ──────────────────────
+
+describe("createDingTalkHandler — fallback when SDK is missing", () => {
+  it("start() resolves and does not throw when SDK import fails", async () => {
+    const handler = createDingTalkHandler(
+      { id: "c1", config: { client_id: "x", client_secret: "y" } },
+      {} as any,
+    );
+    await expect(handler.start()).resolves.toBeUndefined();
+    await expect(handler.stop()).resolves.toBeUndefined();
+  });
+
+  it("accepts channel.config as a JSON string", async () => {
+    const handler = createDingTalkHandler(
+      { id: "c2", config: JSON.stringify({ client_id: "a", client_secret: "b" }) },
+      {} as any,
+    );
+    await expect(handler.start()).resolves.toBeUndefined();
+    await expect(handler.stop()).resolves.toBeUndefined();
+  });
+});
+
+// ── handleDingTalkMessage — payload shape guards ────────────────────
+
+describe("handleDingTalkMessage — payload shape guards", () => {
+  it("bails when downstream.data is undefined", async () => {
+    await handleDingTalkMessage({}, "ch", makeAgentBoxManager() as any);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("bails when data is not valid JSON", async () => {
+    await handleDingTalkMessage({ data: "not-json" }, "ch", makeAgentBoxManager() as any);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("bails on non-text msgtype", async () => {
+    const ds = makeDownstream("ignored", { msgtype: "image" });
+    await handleDingTalkMessage(ds, "ch", makeAgentBoxManager() as any);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("bails when text content is empty/whitespace", async () => {
+    const ds = makeDownstream("   ");
+    await handleDingTalkMessage(ds, "ch", makeAgentBoxManager() as any);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("bails when sessionWebhook is missing", async () => {
+    const ds = makeDownstream("hello", { sessionWebhook: "" });
+    await handleDingTalkMessage(ds, "ch", makeAgentBoxManager() as any);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── handleDingTalkMessage — PAIR command ────────────────────────────
+
+describe("handleDingTalkMessage — PAIR command", () => {
+  it("routes a group PAIR to handlePairingCode with route_type=group and replies success", async () => {
+    handlePairingCodeMock.mockResolvedValue({ success: true, agentName: "SRE Bot" });
+    const ds = makeDownstream("PAIR ABC123");
+
+    await handleDingTalkMessage(ds, "ch", makeAgentBoxManager() as any, undefined, {} as any);
+
+    expect(handlePairingCodeMock).toHaveBeenCalledWith("ABC123", "ch", "cidGROUP", "group", expect.anything());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(WEBHOOK);
+    const body = JSON.parse((init as any).body);
+    expect(body.msgtype).toBe("text");
+    expect(body.text.content).toContain("SRE Bot");
+    expect(body.text.content).toContain("绑定成功");
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("uses route_type=user for a 1:1 conversation", async () => {
+    handlePairingCodeMock.mockResolvedValue({ success: true, agentName: "n" });
+    const ds = makeDownstream("PAIR ABC123", { conversationType: "1" });
+    await handleDingTalkMessage(ds, "ch", makeAgentBoxManager() as any, undefined, {} as any);
+    expect(handlePairingCodeMock.mock.calls[0][3]).toBe("user");
+  });
+
+  it("upper-cases the pair code (case-insensitive regex)", async () => {
+    handlePairingCodeMock.mockResolvedValue({ success: true, agentName: "n" });
+    const ds = makeDownstream("pair abc123");
+    await handleDingTalkMessage(ds, "ch", makeAgentBoxManager() as any, undefined, {} as any);
+    expect(handlePairingCodeMock.mock.calls[0][0]).toBe("ABC123");
+  });
+
+  it("replies with the error message when pairing fails", async () => {
+    handlePairingCodeMock.mockResolvedValue({ success: false, error: "Invalid or expired code" });
+    const ds = makeDownstream("PAIR DEADBE");
+    await handleDingTalkMessage(ds, "ch", makeAgentBoxManager() as any, undefined, {} as any);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.text.content).toContain("Invalid or expired code");
+  });
+
+  it("codes shorter or longer than 6 chars are not matched", async () => {
+    await handleDingTalkMessage(makeDownstream("PAIR AB12E"), "ch", makeAgentBoxManager() as any, undefined, {} as any);
+    await handleDingTalkMessage(makeDownstream("PAIR AB12EF3"), "ch", makeAgentBoxManager() as any, undefined, {} as any);
+    expect(handlePairingCodeMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── handleDingTalkMessage — routing to AgentBox ─────────────────────
+
+describe("handleDingTalkMessage — routing to AgentBox", () => {
+  it("no binding → logs and returns without touching AgentBox", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const mgr = makeAgentBoxManager();
+    await handleDingTalkMessage(makeDownstream("hello"), "ch", mgr as any, undefined, {} as any);
+    expect(resolveBindingMock).toHaveBeenCalledWith("ch", "cidGROUP", expect.anything());
+    expect(mgr.getOrCreate).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("with binding → getOrCreate(agentId), registers session, prompts, replies markdown", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-7", bindingId: "b1" });
+    promptMock.mockResolvedValue({ sessionId: "remote-session-42" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "最终答复 **加粗**" }] } };
+    });
+    const mgr = makeAgentBoxManager("agent-7");
+    const rememberSpy = vi.spyOn(sessionRegistry, "remember");
+
+    await handleDingTalkMessage(makeDownstream("hi there"), "ch", mgr as any, undefined, {} as any);
+
+    expect(mgr.getOrCreate).toHaveBeenCalledWith("agent-7");
+    expect(mgr.getOrCreate.mock.calls[0]).toHaveLength(1);
+
+    expect(rememberSpy).toHaveBeenCalledTimes(1);
+    const [sessionId, conversationKey, agentId] = rememberSpy.mock.calls[0];
+    expect(typeof sessionId).toBe("string");
+    expect(conversationKey).toBe("dingtalk:cidGROUP");
+    expect(agentId).toBe("agent-7");
+
+    expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+      text: "hi there",
+      agentId: "agent-7",
+      mode: "channel",
+      sessionId,
+    }));
+
+    // Final markdown reply via sessionWebhook
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.msgtype).toBe("markdown");
+    expect(body.markdown.text).toContain("最终答复");
+
+    rememberSpy.mockRestore();
+    sessionRegistry.forget(sessionId as string);
+  });
+
+  it("does not pass userId into the AgentBox prompt payload", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    await handleDingTalkMessage(makeDownstream("ping"), "ch", makeAgentBoxManager("a") as any, undefined, {} as any);
+    const promptArg = promptMock.mock.calls[0][0];
+    expect(promptArg).not.toHaveProperty("userId");
+  });
+
+  it("replies with a plain-text error when the agent throws", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockRejectedValue(new Error("AgentBox unreachable"));
+    await handleDingTalkMessage(makeDownstream("hello"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.msgtype).toBe("text");
+    expect(body.text.content).toContain("\u274C");
+    expect(body.text.content).toContain("AgentBox unreachable");
+  });
+
+  it("replies with the empty-result notice when the agent returns no text", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-empty" });
+    streamEventsMock.mockImplementation(async function* () { /* no assistant text */ });
+    await handleDingTalkMessage(makeDownstream("hello"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.msgtype).toBe("text");
+    expect(body.text.content).toContain("\u26A0");
+  });
+});
+
+// ── Conversation model: group ephemeral vs 1:1 multi-turn ──────────
+
+describe("handleDingTalkMessage — conversation model", () => {
+  beforeEach(() => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "x" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+  });
+
+  function userMsg(text: string) {
+    return makeDownstream(text, { conversationType: "1", conversationId: "cidUSER" });
+  }
+
+  it("1:1 chat reuses a stable sessionId across messages (multi-turn)", async () => {
+    await handleDingTalkMessage(userMsg("first"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    await handleDingTalkMessage(userMsg("second"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const s1 = (promptMock.mock.calls[0][0] as any).sessionId;
+    const s2 = (promptMock.mock.calls[1][0] as any).sessionId;
+    expect(s1).toBe(s2);
+    sessionRegistry.forget(s1);
+  });
+
+  it("group chat uses a fresh sessionId per message (ephemeral)", async () => {
+    await handleDingTalkMessage(makeDownstream("first"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    await handleDingTalkMessage(makeDownstream("second"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const s1 = (promptMock.mock.calls[0][0] as any).sessionId;
+    const s2 = (promptMock.mock.calls[1][0] as any).sessionId;
+    expect(s1).not.toBe(s2);
+    sessionRegistry.forget(s1);
+    sessionRegistry.forget(s2);
+  });
+
+  it("replies a friendly busy notice when the session is already running (409)", async () => {
+    promptMock.mockRejectedValue(new Error("AgentBox request failed: 409 Session is already running."));
+    await handleDingTalkMessage(userMsg("hi"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const reply = JSON.parse((fetchMock.mock.calls.at(-1)![1] as any).body);
+    expect(reply.msgtype).toBe("text");
+    expect(reply.text.content).toContain("处理中");
+  });
+});
+
+// ── /new command ────────────────────────────────────────────────────
+
+describe("handleDingTalkMessage — /new command", () => {
+  function userMsg(text: string) {
+    return makeDownstream(text, { conversationType: "1", conversationId: "cidUSER" });
+  }
+
+  it("resets a 1:1 session, closes the old AgentBox session, and replies confirmation", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "x" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    // Establish a stable session.
+    await handleDingTalkMessage(userMsg("hello"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const firstSession = (promptMock.mock.calls[0][0] as any).sessionId;
+
+    // /new resets it.
+    await handleDingTalkMessage(userMsg("/new"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    expect(closeSessionMock).toHaveBeenCalledWith(firstSession);
+    const resetReply = JSON.parse((fetchMock.mock.calls.at(-1)![1] as any).body);
+    expect(resetReply.text.content).toContain("已开启新会话");
+
+    // The next message starts a brand-new session.
+    await handleDingTalkMessage(userMsg("again"), "ch", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    const newSession = (promptMock.mock.calls.at(-1)![0] as any).sessionId;
+    expect(newSession).not.toBe(firstSession);
+    sessionRegistry.forget(newSession);
+  });
+
+  it("is a no-op hint in a group chat and closes nothing", async () => {
+    await handleDingTalkMessage(makeDownstream("/new"), "ch", makeAgentBoxManager() as any, undefined, {} as any);
+    const reply = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(reply.text.content).toContain("群聊");
+    expect(closeSessionMock).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("matches /new case-insensitively", async () => {
+    await handleDingTalkMessage(makeDownstream("/NEW"), "ch", makeAgentBoxManager() as any, undefined, {} as any);
+    const reply = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(reply.text.content).toContain("群聊");
+  });
+});
+
+// ── ackDingTalkCallback ─────────────────────────────────────────────
+
+describe("ackDingTalkCallback", () => {
+  it("ACKs with the messageId and a SUCCESS status (prevents redelivery)", () => {
+    const send = vi.fn();
+    ackDingTalkCallback({ send }, { headers: { messageId: "mid-42" } });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith("mid-42", { status: "SUCCESS" });
+  });
+
+  it("is a no-op when there is no messageId", () => {
+    const send = vi.fn();
+    ackDingTalkCallback({ send }, { headers: {} });
+    ackDingTalkCallback({ send }, {});
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("never throws when send() fails", () => {
+    const send = vi.fn(() => { throw new Error("socket closed"); });
+    expect(() => ackDingTalkCallback({ send }, { headers: { messageId: "m" } })).not.toThrow();
+  });
+});
+
+// ── replyToDingTalk ─────────────────────────────────────────────────
+
+describe("replyToDingTalk", () => {
+  it("POSTs JSON to the webhook and swallows non-ok responses", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    await expect(replyToDingTalk(WEBHOOK, { msgtype: "text", text: { content: "hi" } })).resolves.toBeUndefined();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(WEBHOOK);
+    expect((init as any).method).toBe("POST");
+    expect((init as any).headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("never throws when fetch rejects", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    await expect(replyToDingTalk(WEBHOOK, { msgtype: "text" })).resolves.toBeUndefined();
+  });
+});

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
-  createDingTalkHandler,
   handleDingTalkMessage,
   replyToDingTalk,
   ackDingTalkCallback,
@@ -75,9 +74,6 @@ beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
-  // The DingTalk SDK is an installed optionalDependency, so the "SDK missing"
-  // fallback tests actually reach DWClient.connect(), which logs via
-  // console.info/warn and attempts a (failing) network call. Silence the noise.
   vi.spyOn(console, "info").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
 });
@@ -86,23 +82,72 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-// ── Fallback when SDK missing / config parsing ──────────────────────
+// ── start()/stop() lifecycle + SDK-missing fallback ─────────────────
+//
+// These tests must stay HERMETIC: `dingtalk-stream-sdk-nodejs` is an installed
+// optionalDependency, so without mocking, `start()` reaches `DWClient.connect()`
+// — a real WSS call to the DingTalk gateway that hangs to the test timeout on a
+// network-restricted runner (CI/offline). We mock the SDK per-test via
+// `vi.doMock` + `vi.resetModules()` and a fresh dynamic import of the handler so
+// no socket is ever opened.
 
-describe("createDingTalkHandler — fallback when SDK is missing", () => {
-  it("start() resolves and does not throw when SDK import fails", async () => {
-    const handler = createDingTalkHandler(
+describe("createDingTalkHandler — start/stop lifecycle (hermetic, no network)", () => {
+  afterEach(() => {
+    vi.doUnmock("dingtalk-stream-sdk-nodejs");
+    vi.resetModules();
+  });
+
+  /** Load the handler module with the SDK mocked so connect() never networks. */
+  async function loadWithSdkMock() {
+    vi.resetModules();
+    const disconnect = vi.fn();
+    const connect = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("dingtalk-stream-sdk-nodejs", () => ({
+      DWClient: class {
+        registerCallbackListener() { return this; }
+        connect = connect;
+        disconnect = disconnect;
+        send() {}
+      },
+    }));
+    const mod = await import("./dingtalk.js");
+    return { createDingTalkHandler: mod.createDingTalkHandler, connect, disconnect };
+  }
+
+  it("start() connects and stop() disconnects without opening a socket", async () => {
+    const { createDingTalkHandler: create, connect, disconnect } = await loadWithSdkMock();
+    const handler = create(
       { id: "c1", config: { client_id: "x", client_secret: "y" } },
       {} as any,
     );
     await expect(handler.start()).resolves.toBeUndefined();
+    expect(connect).toHaveBeenCalledTimes(1);
     await expect(handler.stop()).resolves.toBeUndefined();
+    expect(disconnect).toHaveBeenCalledTimes(1);
   });
 
   it("accepts channel.config as a JSON string", async () => {
-    const handler = createDingTalkHandler(
+    const { createDingTalkHandler: create, connect } = await loadWithSdkMock();
+    const handler = create(
       { id: "c2", config: JSON.stringify({ client_id: "a", client_secret: "b" }) },
       {} as any,
     );
+    await expect(handler.start()).resolves.toBeUndefined();
+    expect(connect).toHaveBeenCalledTimes(1);
+    await expect(handler.stop()).resolves.toBeUndefined();
+  });
+
+  it("start() falls back gracefully when the SDK is not installed", async () => {
+    vi.resetModules();
+    vi.doMock("dingtalk-stream-sdk-nodejs", () => {
+      throw new Error("Cannot find package 'dingtalk-stream-sdk-nodejs'");
+    });
+    const mod = await import("./dingtalk.js");
+    const handler = mod.createDingTalkHandler(
+      { id: "c3", config: { client_id: "x", client_secret: "y" } },
+      {} as any,
+    );
+    // The import throws → start() swallows it and returns; stop() is a no-op.
     await expect(handler.start()).resolves.toBeUndefined();
     await expect(handler.stop()).resolves.toBeUndefined();
   });

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -1,0 +1,375 @@
+/**
+ * DingTalk (钉钉) channel handler.
+ *
+ * Connects to DingTalk via its Stream Mode WebSocket (`dingtalk-stream-sdk-nodejs`).
+ * Routes messages dynamically via channel_bindings (not a hardcoded agent).
+ * Supports the PAIR command for binding chat groups to agents.
+ *
+ * Reply path (Phase 1): once the agent finishes, we POST a markdown message
+ * to the message's temporary `sessionWebhook` URL. The streaming "typing card"
+ * UX is a reserved Phase 2 seam (see `dingtalk-card.ts`).
+ *
+ * Delivery ACK: DingTalk's Stream gateway redelivers any callback it does not
+ * get a response for within a short window, and the SDK's `onCallback` does
+ * NOT auto-ACK (unlike `onEvent`). We therefore ACK each robot message
+ * immediately (`DWClient.send(messageId, {status:"SUCCESS"})`) in the listener,
+ * BEFORE kicking off the agent work — otherwise every message is reprocessed,
+ * which duplicates agent runs and makes a redelivered PAIR fail with "Invalid
+ * or expired pairing code" (its code was consumed on the first delivery).
+ *
+ * Conversation model:
+ *  - Group chats (route_type=group) are EPHEMERAL: every message spins up a
+ *    fresh random sessionId, so the agent has no cross-message memory. This
+ *    keeps shared group threads stateless and avoids one user's context
+ *    leaking into another's question.
+ *  - 1:1 chats (route_type=user) are MULTI-TURN: the conversation reuses a
+ *    stable sessionId so AgentBox restores prior history (JSONL) and the agent
+ *    remembers earlier turns. The conversationId→sessionId mapping is an
+ *    in-process Map (see `conversationSessions`) — intentionally NOT persisted,
+ *    so a Runtime restart starts the 1:1 conversation fresh.
+ *  - `/new` resets a 1:1 conversation (drops the mapping, closes the old
+ *    AgentBox session). In a group it is a no-op (already ephemeral).
+ */
+
+import crypto from "node:crypto";
+import type { AgentBoxManager } from "../agentbox/manager.js";
+import { AgentBoxClient, type PromptOptions } from "../agentbox/client.js";
+import type { ChannelHandler } from "../channel-manager.js";
+import { resolveBinding, handlePairingCode } from "../channel-manager.js";
+import type { FrontendWsClient } from "../frontend-ws-client.js";
+import { sessionRegistry } from "../session-registry.js";
+import { collectResponse } from "./lark.js";
+import {
+  buildMarkdownMessage,
+  buildTextMessage,
+  EMPTY_RESULT_NOTICE,
+} from "./dingtalk-card.js";
+
+/** Robot-message callback topic (see SDK `constants`). */
+const TOPIC_ROBOT = "/v1.0/im/bot/messages/get";
+
+export interface DingTalkChannelConfig {
+  /** ClientID — AppKey from the DingTalk developer console. */
+  client_id: string;
+  /** ClientSecret — AppSecret from the DingTalk developer console. */
+  client_secret: string;
+}
+
+/**
+ * Shape of the robot message payload carried in `DWClientDownStream.data`
+ * (a JSON string). We read only the fields the handler needs.
+ */
+interface DingTalkRobotMessage {
+  msgtype: string;
+  text?: { content?: string };
+  conversationId: string;
+  conversationType?: string;  // "1" = 1:1, "2" = group
+  sessionWebhook: string;
+  msgId?: string;
+}
+
+/**
+ * In-process map of a 1:1 conversation → its current AgentBox sessionId.
+ * Reused so single chats accumulate multi-turn context. Group chats never
+ * touch this map (they always use a throwaway random sessionId).
+ *
+ * Intentionally in-memory only: a Runtime restart forgets the pointer and the
+ * next 1:1 message starts a fresh session (the old JSONL history is orphaned
+ * but harmless). Keyed by `${channelId}:${conversationId}`.
+ */
+const conversationSessions = new Map<string, string>();
+
+function conversationSessionKey(channelId: string, conversationId: string): string {
+  return `${channelId}:${conversationId}`;
+}
+
+/** Test-only helper to reset the in-memory session map between cases. */
+export function resetConversationSessionsForTest(): void {
+  conversationSessions.clear();
+}
+
+/**
+ * Create a DingTalk channel handler for one global channel record.
+ */
+export function createDingTalkHandler(
+  channel: Record<string, any>,
+  agentBoxManager: AgentBoxManager,
+  tlsOptions?: { cert: string; key: string; ca: string },
+  frontendClient?: FrontendWsClient,
+): ChannelHandler {
+  const channelId: string = channel.id;
+  const config: DingTalkChannelConfig =
+    typeof channel.config === "string"
+      ? JSON.parse(channel.config)
+      : channel.config;
+
+  let client: { disconnect(): void } | null = null;
+
+  return {
+    async start() {
+      let sdk: typeof import("dingtalk-stream-sdk-nodejs");
+      try {
+        sdk = await import("dingtalk-stream-sdk-nodejs");
+      } catch {
+        console.error(`[dingtalk] dingtalk-stream-sdk-nodejs not installed — skipping channel ${channelId}`);
+        return;
+      }
+
+      try {
+        const dwClient = new sdk.DWClient({
+          clientId: config.client_id,
+          clientSecret: config.client_secret,
+        });
+
+        dwClient.registerCallbackListener(TOPIC_ROBOT, (downstream) => {
+          // ACK the callback IMMEDIATELY. DingTalk's Stream gateway redelivers
+          // any callback it does not receive a response for within a short
+          // window — and the SDK's onCallback does NOT auto-ACK (unlike
+          // onEvent). Without this, every message is re-sent, causing duplicate
+          // agent runs and, for PAIR, a spurious "Invalid or expired pairing
+          // code" on the redelivered copy (the code was consumed on first run).
+          // The ACK is independent of the reply, which still goes out over the
+          // sessionWebhook once the agent finishes.
+          ackDingTalkCallback(dwClient, downstream);
+          // Run the actual work detached so the WS read loop is never blocked.
+          setImmediate(() => {
+            handleDingTalkMessage(downstream, channelId, agentBoxManager, tlsOptions, frontendClient)
+              .catch((err) => {
+                console.error(`[dingtalk] Error handling message for channel=${channelId}:`, err);
+              });
+          });
+        });
+
+        await dwClient.connect();
+        client = dwClient;
+        console.log(`[dingtalk] Channel started id=${channelId} client_id=${config.client_id}`);
+      } catch (err) {
+        console.error(`[dingtalk] Failed to start channel ${channelId}:`, err);
+      }
+    },
+
+    async stop() {
+      if (client) {
+        try { client.disconnect(); } catch (err) {
+          console.error(`[dingtalk] Error disconnecting channel ${channelId}:`, err);
+        }
+      }
+      client = null;
+      console.log(`[dingtalk] Channel stopped id=${channelId}`);
+    },
+  };
+}
+
+/**
+ * ACK a DingTalk Stream callback so the gateway marks it delivered and does
+ * not redeliver. Exported for unit testing. Best-effort: a missing messageId
+ * or a send failure is logged, never thrown into the WS read loop.
+ */
+export function ackDingTalkCallback(
+  client: { send(messageId: string, value: unknown): void },
+  downstream: { headers?: { messageId?: string } },
+): void {
+  try {
+    const messageId = downstream?.headers?.messageId;
+    if (messageId) client.send(messageId, { status: "SUCCESS" });
+  } catch (err) {
+    console.error("[dingtalk] Failed to ACK callback:", err);
+  }
+}
+
+// ── Message handler ────────────────────────────────────────────
+
+/**
+ * Exported for unit tests. Consumes a raw `DWClientDownStream` whose `data`
+ * field is a JSON string carrying the robot message.
+ */
+export async function handleDingTalkMessage(
+  downstream: { data?: string },
+  channelId: string,
+  agentBoxManager: AgentBoxManager,
+  tlsOptions?: { cert: string; key: string; ca: string },
+  frontendClient?: FrontendWsClient,
+): Promise<void> {
+  let message: DingTalkRobotMessage;
+  try {
+    if (!downstream?.data) return;
+    message = JSON.parse(downstream.data);
+  } catch {
+    return;
+  }
+
+  if (!message || message.msgtype !== "text") return;
+
+  const conversationId = message.conversationId;
+  const sessionWebhook = message.sessionWebhook;
+  if (!conversationId || !sessionWebhook) return;
+
+  // conversationType "2" = group chat; anything else (incl. "1") is 1:1.
+  const routeType: "group" | "user" = message.conversationType === "2" ? "group" : "user";
+
+  let text = message.text?.content;
+  if (!text || text.trim().length === 0) return;
+  text = text.trim();
+
+  // Check for PAIR command.
+  const pairMatch = text.match(/^PAIR\s+([A-Z0-9]{6})$/i);
+  if (pairMatch) {
+    const code = pairMatch[1].toUpperCase();
+    const result = await handlePairingCode(code, channelId, conversationId, routeType, frontendClient!);
+    await replyToDingTalk(sessionWebhook, buildTextMessage(formatPairReply(result)));
+    return;
+  }
+
+  // Check for /new command — resets a 1:1 conversation's multi-turn session.
+  if (/^\/new$/i.test(text)) {
+    await handleNewCommand(channelId, conversationId, routeType, sessionWebhook, agentBoxManager, tlsOptions, frontendClient);
+    return;
+  }
+
+  // Look up binding for this conversation.
+  const binding = await resolveBinding(channelId, conversationId, frontendClient!);
+  if (!binding) {
+    console.log(`[dingtalk] No binding for channel=${channelId} conversation=${conversationId} — ignoring`);
+    return;
+  }
+
+  const agentId = binding.agentId;
+  // Tenant key for the conversation's context — used as the "user" in
+  // chat_sessions and session registry. Mirrors lark's `lark:<chat_id>`.
+  const conversationKey = `dingtalk:${conversationId}`;
+
+  // Group chats are ephemeral (fresh context per message); 1:1 chats reuse a
+  // stable session so the agent remembers earlier turns.
+  let sessionId: string;
+  if (routeType === "user") {
+    const key = conversationSessionKey(channelId, conversationId);
+    sessionId = conversationSessions.get(key) ?? crypto.randomUUID();
+    conversationSessions.set(key, sessionId);
+  } else {
+    sessionId = crypto.randomUUID();
+  }
+  sessionRegistry.remember(sessionId, conversationKey, agentId);
+
+  console.log(`[dingtalk] Message channel=${channelId} conversation=${conversationId} type=${routeType} \u2192 agent=${agentId} session=${sessionId}: "${text.slice(0, 80)}"`);
+
+  const handle = await agentBoxManager.getOrCreate(agentId);
+  const client = new AgentBoxClient(handle.endpoint, 120_000, tlsOptions);
+
+  const promptOpts: PromptOptions = { text, agentId, mode: "channel", sessionId };
+  let resultText = "";
+  let agentError: Error | null = null;
+  try {
+    const promptResult = await client.prompt(promptOpts);
+    resultText = await collectResponse(client, promptResult.sessionId);
+  } catch (err) {
+    agentError = err instanceof Error ? err : new Error(String(err));
+    console.error(`[dingtalk] Agent execution failed for session=${sessionId}:`, agentError);
+  }
+
+  // Concurrency: a 1:1 session is single-threaded in AgentBox. A second
+  // message that lands while the prior turn is still running gets a 409
+  // ("Session is already running") — surface a friendly "still working" notice
+  // rather than a scary error, and DON'T clobber the in-flight session.
+  if (agentError && isSessionBusyError(agentError)) {
+    await replyToDingTalk(sessionWebhook, buildTextMessage("\u23F3 上一条消息还在处理中，请稍候再发。"));
+    return;
+  }
+
+  const finalBody = agentError
+    ? `\u274C ${agentError.message.slice(0, 500)}`
+    : (resultText || EMPTY_RESULT_NOTICE);
+
+  // Errors and the empty-result notice go out as plain text; real answers as
+  // markdown so formatting (code blocks, lists, bold) renders.
+  const body = agentError
+    ? buildTextMessage(finalBody)
+    : (resultText ? buildMarkdownMessage(finalBody) : buildTextMessage(finalBody));
+  await replyToDingTalk(sessionWebhook, body);
+}
+
+/**
+ * Handle the `/new` command. In a 1:1 chat it drops the stored session (so the
+ * next message starts fresh) and best-effort closes the old AgentBox session
+ * to free resources. In a group it is a no-op — group chats are already
+ * ephemeral, so there is no accumulated context to clear.
+ */
+async function handleNewCommand(
+  channelId: string,
+  conversationId: string,
+  routeType: "group" | "user",
+  sessionWebhook: string,
+  agentBoxManager: AgentBoxManager,
+  tlsOptions?: { cert: string; key: string; ca: string },
+  frontendClient?: FrontendWsClient,
+): Promise<void> {
+  if (routeType !== "user") {
+    await replyToDingTalk(sessionWebhook, buildTextMessage("\u2139\uFE0F 群聊为临时会话，每条消息相互独立，无需 /new。"));
+    return;
+  }
+
+  const key = conversationSessionKey(channelId, conversationId);
+  const oldSessionId = conversationSessions.get(key);
+  conversationSessions.delete(key);
+
+  if (oldSessionId) {
+    sessionRegistry.forget(oldSessionId);
+    // Best-effort: tear down the old AgentBox session so its context/resources
+    // are released. Needs the bound agent to locate the right AgentBox.
+    try {
+      const binding = await resolveBinding(channelId, conversationId, frontendClient!);
+      if (binding) {
+        const handle = await agentBoxManager.getOrCreate(binding.agentId);
+        const client = new AgentBoxClient(handle.endpoint, 120_000, tlsOptions);
+        await client.closeSession(oldSessionId);
+      }
+    } catch (err) {
+      console.error(`[dingtalk] Failed to close old session=${oldSessionId} on /new:`, err);
+    }
+  }
+
+  await replyToDingTalk(sessionWebhook, buildTextMessage("\u2705 已开启新会话，之前的上下文已清空。"));
+}
+
+/**
+ * True when an AgentBox prompt failed because the session is already running
+ * (HTTP 409). The client wraps non-2xx responses as `AgentBox request failed:
+ * <status> <body>`, so we match on the status and the server's message text.
+ */
+function isSessionBusyError(err: Error): boolean {
+  return /\b409\b/.test(err.message) || /already running/i.test(err.message);
+}
+
+/**
+ * Build the PAIR-command reply. DingTalk is zh-CN only, so no locale branch.
+ */
+function formatPairReply(
+  result: { success: boolean; agentName?: string; error?: string },
+): string {
+  if (result.success) {
+    return `\u2705 绑定成功！此会话已连接到 Agent "${result.agentName}"。`;
+  }
+  return `\u274C 绑定失败: ${result.error}`;
+}
+
+/**
+ * POST a message body to a DingTalk `sessionWebhook` URL. The webhook is a
+ * temporary, signed URL the platform hands us per incoming message, so no
+ * auth header is needed. Failures are logged, never thrown into the WS loop.
+ */
+export async function replyToDingTalk(
+  sessionWebhook: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const res = await fetch(sessionWebhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.error(`[dingtalk] sessionWebhook reply failed: HTTP ${res.status}`);
+    }
+  } catch (err) {
+    console.error("[dingtalk] Failed to reply via sessionWebhook:", err);
+  }
+}

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -43,10 +43,36 @@ import {
   buildMarkdownMessage,
   buildTextMessage,
   EMPTY_RESULT_NOTICE,
+  AGENT_ERROR_NOTICE,
 } from "./dingtalk-card.js";
 
 /** Robot-message callback topic (see SDK `constants`). */
 const TOPIC_ROBOT = "/v1.0/im/bot/messages/get";
+
+/**
+ * Hosts we are willing to POST agent output to. DingTalk hands us a temporary
+ * `sessionWebhook` per inbound frame; the frame is authenticated, but this
+ * fetch is issued by the trusted Runtime process (inside the cluster), NOT the
+ * agent sandbox — so an unexpected host would be a ready-made internal SSRF /
+ * data-exfiltration channel. Pin replies to the DingTalk OpenAPI domains.
+ */
+const ALLOWED_WEBHOOK_HOSTS = new Set(["oapi.dingtalk.com", "api.dingtalk.com"]);
+
+function isAllowedWebhookHost(host: string): boolean {
+  return ALLOWED_WEBHOOK_HOSTS.has(host) || host.endsWith(".dingtalk.com");
+}
+
+/**
+ * Build a log-safe error string. The DingTalk SDK fetches its access token
+ * with the AppSecret in the URL query string (`gettoken?appkey=…&appsecret=…`),
+ * and an axios error object carries `config.url`, so dumping a whole error can
+ * leak the secret into log collectors. We log the message only, with any
+ * `appsecret`/`accessKey` query value redacted as a belt-and-braces measure.
+ */
+function safeErrorMessage(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.replace(/(appsecret|appkey|accessKey|access_token)=[^&\s]+/gi, "$1=***");
+}
 
 export interface DingTalkChannelConfig {
   /** ClientID — AppKey from the DingTalk developer console. */
@@ -144,17 +170,27 @@ export function createDingTalkHandler(
         client = dwClient;
         console.log(`[dingtalk] Channel started id=${channelId} client_id=${config.client_id}`);
       } catch (err) {
-        console.error(`[dingtalk] Failed to start channel ${channelId}:`, err);
+        // Log message only — never the whole error object: the SDK's token
+        // fetch puts the AppSecret in the request URL, which axios attaches to
+        // the error as `config.url`.
+        console.error(`[dingtalk] Failed to start channel ${channelId}: ${safeErrorMessage(err)}`);
       }
     },
 
     async stop() {
       if (client) {
         try { client.disconnect(); } catch (err) {
-          console.error(`[dingtalk] Error disconnecting channel ${channelId}:`, err);
+          console.error(`[dingtalk] Error disconnecting channel ${channelId}: ${safeErrorMessage(err)}`);
         }
       }
       client = null;
+      // Drop this channel's 1:1 session pointers so a stop/start cycle does not
+      // leak Map entries (one per active conversation). Entries are prefixed
+      // with `${channelId}:`.
+      const prefix = `${channelId}:`;
+      for (const key of conversationSessions.keys()) {
+        if (key.startsWith(prefix)) conversationSessions.delete(key);
+      }
       console.log(`[dingtalk] Channel stopped id=${channelId}`);
     },
   };
@@ -204,8 +240,11 @@ export async function handleDingTalkMessage(
   const sessionWebhook = message.sessionWebhook;
   if (!conversationId || !sessionWebhook) return;
 
-  // conversationType "2" = group chat; anything else (incl. "1") is 1:1.
-  const routeType: "group" | "user" = message.conversationType === "2" ? "group" : "user";
+  // conversationType "1" = 1:1 chat; "2" = group. Only an explicit "1" gets the
+  // persistent multi-turn (1:1) treatment — anything else, including a missing
+  // or future value, defaults to ephemeral group routing so an unknown type can
+  // never accumulate cross-message context.
+  const routeType: "group" | "user" = message.conversationType === "1" ? "user" : "group";
 
   let text = message.text?.content;
   if (!text || text.trim().length === 0) return;
@@ -260,7 +299,7 @@ export async function handleDingTalkMessage(
   let agentError: Error | null = null;
   try {
     const promptResult = await client.prompt(promptOpts);
-    resultText = await collectResponse(client, promptResult.sessionId);
+    resultText = await collectResponse(client, promptResult.sessionId, "dingtalk");
   } catch (err) {
     agentError = err instanceof Error ? err : new Error(String(err));
     console.error(`[dingtalk] Agent execution failed for session=${sessionId}:`, agentError);
@@ -275,8 +314,11 @@ export async function handleDingTalkMessage(
     return;
   }
 
+  // On failure, reply with a generic notice only — the raw error message can
+  // leak internal endpoints / infra details to everyone in the chat. The full
+  // error was already logged above for operators.
   const finalBody = agentError
-    ? `\u274C ${agentError.message.slice(0, 500)}`
+    ? AGENT_ERROR_NOTICE
     : (resultText || EMPTY_RESULT_NOTICE);
 
   // Errors and the empty-result notice go out as plain text; real answers as
@@ -336,7 +378,9 @@ async function handleNewCommand(
  * <status> <body>`, so we match on the status and the server's message text.
  */
 function isSessionBusyError(err: Error): boolean {
-  return /\b409\b/.test(err.message) || /already running/i.test(err.message);
+  // Anchor to the client's fixed "request failed: <status>" prefix so a bare
+  // "409" appearing elsewhere in an error body can't be misreported as busy.
+  return /request failed: 409\b/i.test(err.message) || /already running/i.test(err.message);
 }
 
 /**
@@ -360,6 +404,26 @@ export async function replyToDingTalk(
   sessionWebhook: string,
   body: Record<string, unknown>,
 ): Promise<void> {
+  // SSRF / exfil guard: this fetch runs in the trusted Runtime process (inside
+  // the cluster), so we only ever POST agent output to the DingTalk OpenAPI
+  // domains — never to an arbitrary host smuggled in via the downstream frame.
+  let host: string;
+  try {
+    const parsed = new URL(sessionWebhook);
+    if (parsed.protocol !== "https:") {
+      console.error(`[dingtalk] Refusing non-https sessionWebhook (protocol=${parsed.protocol})`);
+      return;
+    }
+    host = parsed.hostname;
+  } catch {
+    console.error("[dingtalk] Refusing to reply to a malformed sessionWebhook URL");
+    return;
+  }
+  if (!isAllowedWebhookHost(host)) {
+    console.error(`[dingtalk] Refusing to reply to an unexpected sessionWebhook host=${host}`);
+    return;
+  }
+
   try {
     const res = await fetch(sessionWebhook, {
       method: "POST",
@@ -370,6 +434,6 @@ export async function replyToDingTalk(
       console.error(`[dingtalk] sessionWebhook reply failed: HTTP ${res.status}`);
     }
   } catch (err) {
-    console.error("[dingtalk] Failed to reply via sessionWebhook:", err);
+    console.error(`[dingtalk] Failed to reply via sessionWebhook: ${safeErrorMessage(err)}`);
   }
 }

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -250,7 +250,11 @@ async function replyToLark(larkClient: any, messageId: string, text: string): Pr
 
 // ── SSE response collector ─────────────────────────────────────
 
-export async function collectResponse(client: AgentBoxClient, sessionId: string): Promise<string> {
+export async function collectResponse(
+  client: AgentBoxClient,
+  sessionId: string,
+  logPrefix = "lark",
+): Promise<string> {
   const parts: string[] = [];
   // Track the latest assistant turn so we only reply with the *final* text
   // (tool-use turns emit intermediate message_end events that aren't meant
@@ -273,7 +277,7 @@ export async function collectResponse(client: AgentBoxClient, sessionId: string)
       }
     }
   } catch (err) {
-    console.error(`[lark] SSE collect error for session=${sessionId}:`, err);
+    console.error(`[${logPrefix}] SSE collect error for session=${sessionId}:`, err);
   }
   // Prefer the last full assistant turn; fall back to streamed deltas if the
   // brain only emits content_block_delta events.


### PR DESCRIPTION
## Summary

Add a DingTalk (钉钉) channel handler so agents can be paired with DingTalk group and 1:1 chats, mirroring the existing Lark channel pattern.

### Problem

Siclaw lists lark/slack/discord/telegram as channel types in the Portal UI, but only Lark is actually implemented. DingTalk — widely used by China-based teams — had no handler, so agents could not be reached from DingTalk at all.

### Solution

- New `src/gateway/channels/dingtalk.ts` built on `dingtalk-stream-sdk-nodejs` (already an optionalDependency): Stream-mode WebSocket intake (no public callback URL needed), `PAIR` pairing, binding-routed prompts, markdown reply via the per-message `sessionWebhook`.
- Callbacks are ACKed immediately in the listener — DingTalk's Stream gateway redelivers un-ACKed callbacks, which double-ran `PAIR` and consumed the pairing code on the redelivered copy.
- Conversation model: group chats stay ephemeral (fresh session per message, no cross-user context bleed); 1:1 chats reuse a stable in-memory sessionId for multi-turn context; `/new` resets it; a 409-busy prompt surfaces a friendly “still working” notice instead of clobbering the running turn.
- `dingtalk-card.ts` holds zh-CN strings + markdown normalisation, with a reserved seam for Phase-2 AI streaming cards (requires a `cardTemplateId` registered in the DingTalk console).
- Portal web: DingTalk channel type + AppKey/AppSecret config fields.

## Known Issues (shared with the existing lark handler, observed during live testing)

Both issues predate this PR — they affect the lark channel equally — but DingTalk 1:1 multi-turn sessions running real inspections (task ledger + background sub-agents) surface them much more visibly. Calling them out here with root-cause analysis; happy to fix in follow-up PRs.

### 1. Channel sessions have no `chat_sessions` row → best-effort persists 500

Channel handlers generate a sessionId and prompt directly, without the `ensureChatSession()` step that the web-chat `chat.send` RPC performs. When the agent uses task tools or sub-agents, agentbox tries to persist task/delegation events into `chat_messages`, which fails the FK constraint:

```
[internal-api] delegation-events error: Cannot add or update a child row: a foreign key
constraint fails (chat_messages, CONSTRAINT fk_chat_messages_session ...)
```

Impact: agent execution is unaffected (persists are best-effort), but channel conversations have no chat history / audit trail in Portal, and logs are noisy. Proposed fix: extend `channel.resolveBinding` to return the binding's `created_by`, then call `chat.ensureSession` (user_id = pairing user, origin = “channel”) before prompting.

### 2. Background synthetic turns are never delivered to the channel

When the agent spawns background sub-agents and ends its turn early (“I'll report back when they finish”), the final report is produced in a later synthetic turn triggered by `task_notification` — after the channel handler's SSE collection has already closed and the interim reply was sent. Web UI (persistent SSE + `background_turn_done` refetch) and TUI (`tui-background-host`) both have delivery hosts for this; channels have none, so the final report never reaches DingTalk/Lark.

Proposed fix: keep `sessionId → sessionWebhook` registered (with expiry) after the first reply, and forward the synthetic turn's assistant message through the webhook when `background_turn_done` passes through Runtime's delegation-events path.

## Test Plan

- [x] `npx tsc --noEmit` — no errors in changed files
- [x] `npm test` — 28 new tests in `dingtalk.test.ts` + new `channel-manager.test.ts` cases all pass
- [x] Manual verification: live DingTalk group + 1:1 chat against a K8s deployment (PAIR, multi-turn 1:1 context, `/new` reset, busy notice, markdown replies)

## Architecture Checklist

- [x] **Deployment mode**: handler runs inside Runtime's ChannelManager with the same lifecycle as lark; no filesystem writes
- [x] **Security model**: no new shell execution paths
- [x] **DB parity**: no schema changes
- [x] **Tool protocol**: no new tools

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unrelated changes included
