### PR TITLE
feat(mcp): surface admin-provided MCP server description to the agent

### DIFF
--- a/src/core/mcp-client.test.ts
+++ b/src/core/mcp-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { jsonSchemaToTypebox, buildMcpToolName, isMcpTool, MCP_TOOL_PREFIX, mcpContentToAgentContent } from "./mcp-client.js";
+import { jsonSchemaToTypebox, buildMcpToolName, isMcpTool, MCP_TOOL_PREFIX, mcpContentToAgentContent, McpClientManager } from "./mcp-client.js";
 
 describe("jsonSchemaToTypebox", () => {
   it("converts string type", () => {
@@ -140,5 +140,31 @@ describe("mcpContentToAgentContent", () => {
     expect(result.content).toEqual([
       { type: "image", data: "aW1n", mimeType: "image/jpeg" },
     ]);
+  });
+});
+
+describe("createToolDefinition server description", () => {
+  const manager = new McpClientManager({ mcpServers: {} });
+  const makeDef = (serverDescription: string | undefined, toolDescription?: string) =>
+    (manager as any).createToolDefinition(
+      "grafana",
+      serverDescription,
+      { name: "query", description: toolDescription },
+      {},
+    );
+
+  it("prepends the admin-provided server description to the tool description", () => {
+    const def = makeDef("Monitoring tenant ID: t-123", "Run a PromQL query");
+    expect(def.description).toBe('[Server "grafana" context: Monitoring tenant ID: t-123]\nRun a PromQL query');
+  });
+
+  it("keeps the plain tool description when no server description is set", () => {
+    expect(makeDef(undefined, "Run a PromQL query").description).toBe("Run a PromQL query");
+    expect(makeDef("   ", "Run a PromQL query").description).toBe("Run a PromQL query");
+  });
+
+  it("applies the server context to the fallback description too", () => {
+    const def = makeDef("Monitoring tenant ID: t-123");
+    expect(def.description).toBe('[Server "grafana" context: Monitoring tenant ID: t-123]\nMCP tool query from grafana');
   });
 });

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -19,18 +19,24 @@ export interface McpStdioServerConfig {
   command: string;
   args?: string[];
   env?: Record<string, string>;
+  /** Admin-provided server context (e.g. tenant IDs) — surfaced to the model via tool descriptions. */
+  description?: string;
 }
 
 export interface McpSseServerConfig {
   transport: "sse";
   url: string;
   headers?: Record<string, string>;
+  /** Admin-provided server context (e.g. tenant IDs) — surfaced to the model via tool descriptions. */
+  description?: string;
 }
 
 export interface McpStreamableHttpServerConfig {
   transport: "streamable-http";
   url: string;
   headers?: Record<string, string>;
+  /** Admin-provided server context (e.g. tenant IDs) — surfaced to the model via tool descriptions. */
+  description?: string;
 }
 
 export type McpServerConfig =
@@ -225,7 +231,7 @@ export class McpClientManager {
         console.log(`[mcp-client] "${serverName}" provides ${mcpTools.length} tools: ${mcpTools.map((t: any) => t.name).join(", ")}`);
 
         for (const mcpTool of mcpTools) {
-          const toolDef = this.createToolDefinition(serverName, mcpTool, client);
+          const toolDef = this.createToolDefinition(serverName, cfg.description, mcpTool, client);
           this.tools.push(toolDef);
         }
 
@@ -273,6 +279,7 @@ export class McpClientManager {
    */
   private createToolDefinition(
     serverName: string,
+    serverDescription: string | undefined,
     mcpTool: { name: string; description?: string; inputSchema?: any },
     client: any,
   ): ToolDefinition {
@@ -280,10 +287,17 @@ export class McpClientManager {
     const inputSchema = mcpTool.inputSchema ?? { type: "object", properties: {} };
     const parameters = jsonSchemaToTypebox(inputSchema);
 
+    // Prepend the admin-provided server description so the model sees server-level
+    // context (e.g. monitoring tenant IDs) on every tool from that server.
+    const serverContext = serverDescription?.trim()
+      ? `[Server "${serverName}" context: ${serverDescription.trim()}]\n`
+      : "";
+    const toolDescription = mcpTool.description ?? `MCP tool ${mcpTool.name} from ${serverName}`;
+
     return {
       name: fullName,
       label: `${serverName}/${mcpTool.name}`,
-      description: mcpTool.description ?? `MCP tool ${mcpTool.name} from ${serverName}`,
+      description: serverContext + toolDescription,
       parameters,
       execute: async (_toolCallId, args) => {
         try {

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -315,6 +315,24 @@ describe("config.getMcpServers", () => {
     expect(result.mcpServers["stdio-server"].args).toEqual(["arg1", "arg2"]);
     expect(result.mcpServers["stdio-server"].env).toEqual({ KEY: "val" });
   });
+
+  it("includes the admin-provided description when present", async () => {
+    mockQuery([
+      { name: "grafana", transport: "sse", url: "https://mcp.example.com", command: null, args: null, env: null, headers: null, description: "Monitoring tenant ID: t-123" },
+    ]);
+
+    const result = await getHandler("config.getMcpServers")({ ids: ["id1"] }, "a1");
+    expect(result.mcpServers.grafana.description).toBe("Monitoring tenant ID: t-123");
+  });
+
+  it("omits description when null", async () => {
+    mockQuery([
+      { name: "plain", transport: "sse", url: "https://mcp.example.com", command: null, args: null, env: null, headers: null, description: null },
+    ]);
+
+    const result = await getHandler("config.getMcpServers")({ ids: ["id1"] }, "a1");
+    expect("description" in result.mcpServers.plain).toBe(false);
+  });
 });
 
 describe("config.getSkillBundle", () => {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1907,7 +1907,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     const db = getDb();
     const placeholders = params.ids.map(() => "?").join(",");
     const [rows] = await db.query(
-      `SELECT name, transport, url, command, args, env, headers, enabled
+      `SELECT name, transport, url, command, args, env, headers, description, enabled
        FROM mcp_servers WHERE id IN (${placeholders}) AND enabled = 1`,
       params.ids,
     ) as any;
@@ -1920,6 +1920,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
         ...(row.args ? { args: safeParseJson(row.args, []) } : {}),
         ...(row.env ? { env: safeParseJson(row.env, {}) } : {}),
         ...(row.headers ? { headers: safeParseJson(row.headers, {}) } : {}),
+        ...(row.description ? { description: row.description } : {}),
       };
     }
     return { mcpServers };

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1091,7 +1091,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     const db = getDb();
     const placeholders = body.ids.map(() => "?").join(",");
     const [rows] = await db.query(
-      `SELECT name, transport, url, command, args, env, headers, enabled
+      `SELECT name, transport, url, command, args, env, headers, description, enabled
        FROM mcp_servers WHERE id IN (${placeholders}) AND enabled = 1`,
       body.ids,
     ) as any;
@@ -1104,6 +1104,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
         ...(row.args ? { args: safeParseJson(row.args, []) } : {}),
         ...(row.env ? { env: safeParseJson(row.env, {}) } : {}),
         ...(row.headers ? { headers: safeParseJson(row.headers, {}) } : {}),
+        ...(row.description ? { description: row.description } : {}),
       };
     }
     sendJson(res, 200, { mcpServers });

--- a/src/portal/cli-snapshot-api.test.ts
+++ b/src/portal/cli-snapshot-api.test.ts
@@ -278,6 +278,20 @@ describe("GET /api/v1/cli-snapshot", () => {
     expect(Object.keys(body.mcpServers)).toEqual(["enabled-one"]);
   });
 
+  it("includes the admin-provided MCP server description", async () => {
+    const db = getDb();
+    await db.query(
+      "INSERT INTO mcp_servers (id, org_id, name, transport, url, command, args, env, headers, enabled, description, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      ["x1", "default", "grafana", "http", "https://a.example", null, null, null, null, 1, "Monitoring tenant ID: t-123", "system"],
+    );
+
+    const { body } = await runRoute(
+      router,
+      fakeReq({ url: "/api/v1/cli-snapshot", headers: authedHeaders() }),
+    );
+    expect(body.mcpServers.grafana.description).toBe("Monitoring tenant ID: t-123");
+  });
+
   it("surfaces custom skills with their specs + scripts", async () => {
     const db = getDb();
     const specs = "---\nname: my-custom-skill\ndescription: test\n---\n# Body\n";

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -111,6 +111,7 @@ interface McpRow {
   args: string | null;
   env: string | null;
   headers: string | null;
+  description: string | null;
   enabled: number;
 }
 
@@ -295,7 +296,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
     // MCP: scoped to agent via agent_mcp_servers when active, else all enabled.
     const [mcps] = activeAgentId
       ? await db.query<McpRow[]>(
-          `SELECT m.id, m.name, m.transport, m.url, m.command, m.args, m.env, m.headers, m.enabled
+          `SELECT m.id, m.name, m.transport, m.url, m.command, m.args, m.env, m.headers, m.description, m.enabled
            FROM mcp_servers m
            JOIN agent_mcp_servers ams ON ams.mcp_server_id = m.id
            WHERE m.enabled = 1 AND ams.agent_id = ?
@@ -303,7 +304,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
           [activeAgentId],
         )
       : await db.query<McpRow[]>(
-          "SELECT id, name, transport, url, command, args, env, headers, enabled FROM mcp_servers WHERE enabled = 1 ORDER BY name",
+          "SELECT id, name, transport, url, command, args, env, headers, description, enabled FROM mcp_servers WHERE enabled = 1 ORDER BY name",
         );
     // Skills: with agent scope we filter via agent_skills; otherwise all
     // non-overlay skills in the default org. Overlay suppression applies in
@@ -438,6 +439,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
         ...(m.args ? { args: safeJson(m.args, []) } : {}),
         ...(m.env ? { env: safeJson(m.env, {}) } : {}),
         ...(m.headers ? { headers: safeJson(m.headers, {}) } : {}),
+        ...(m.description ? { description: m.description } : {}),
       };
     }
 


### PR DESCRIPTION
The description field on mcp_servers is stored in the Portal DB but was dropped on every delivery path, so the model never saw admin context such as monitoring tenant IDs. Cluster descriptions already reach the agent via the cluster_info tool; MCP descriptions had no equivalent.

Pipe description through config.getMcpServers (Gateway mode) and the CLI snapshot (TUI + local Portal mode), then prepend it to every tool description from that server so the model sees the context at tool-selection time without an extra lookup call.

Rejected: dedicated mcp_info tool | needs the same wire plumbing plus a new tool registration, and relies on the model remembering to call it Tested: full vitest suite (177 files / 3533 tests) and tsc --noEmit

## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **DB parity**: Schema changes keep `src/portal/migrate.ts` compatible with both MySQL and SQLite (see [`docs/design/invariants.md §5`](../docs/design/invariants.md)).
- [ ] **Tool protocol**: New tools register through `src/core/tool-registry.ts` and use the TypeBox `ToolDefinition` protocol.

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
