### PR TITLE
Guide chart tool toward valid structured data

### DIFF
--- a/mcp/create-chart/src/handler.test.ts
+++ b/mcp/create-chart/src/handler.test.ts
@@ -28,6 +28,9 @@ describe("RENDER_CHART_INPUT_SCHEMA", () => {
     expect(RENDER_CHART_DESCRIPTION).toMatch(/READY_TO_PASTE/);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/exactly/i);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/Do not rewrite, escape, quote/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/mermaid/i);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/data must be an object/i);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/never a JSON string/i);
   });
 });
 

--- a/mcp/create-chart/src/handler.ts
+++ b/mcp/create-chart/src/handler.ts
@@ -17,7 +17,7 @@ export const RENDER_CHART_INPUT_SCHEMA = {
     data: {
       type: "object",
       description:
-        "Chart data. Pie: {slices:[{label,value}]}. Bar: {categories:[string], series:[{name,values:[number]}]}. Line: {series:[{name, points:[{x:number|string, y:number}]}]}. For time series pass x as epoch seconds (number) and y as the metric value.",
+        "Chart data as a real JSON object, never as a JSON string. Pie: {slices:[{label,value}]}. Bar: {categories:[string], series:[{name,values:[number]}]}. Line: {series:[{name, points:[{x:number|string, y:number}]}]}. Every value must be a finite number; do not use placeholders, variables, or references to earlier messages.",
     },
     title: { type: "string" },
     width: { type: "integer", minimum: 200, maximum: 2400 },
@@ -29,7 +29,12 @@ export const RENDER_CHART_INPUT_SCHEMA = {
 } as const;
 
 export const RENDER_CHART_DESCRIPTION =
-  "Render a pie/bar/line chart from structured data. The tool returns a READY_TO_PASTE chart block as plain markdown plus metadata. Use proactively when the user asks to visualize, plot, or 画图/出图/画饼图/柱状图/曲线/折线/趋势图, AND chartable data is already in context. Typical sources: status_counts (pie), category_summary anomaly/no_anomaly counts (bar), time-series samples (line, x=epoch seconds or display string, y=value). In your final reply, paste the READY_TO_PASTE block exactly as returned. Do not rewrite, escape, quote, or wrap the chart JSON; the frontend renders ```chart fenced JSON blocks as SVG.";
+  [
+    "Render a pie/bar/line chart only when finalized structured numeric data is already in context and can be passed as valid tool arguments.",
+    "For qualitative diagrams, workflows, topology, decision trees, rough summaries, or small category/count visuals where tool arguments might be uncertain, use a ```mermaid fenced block instead; xychart-beta is suitable for simple bar charts.",
+    "Arguments must be one JSON object. data must be an object, never a JSON string. Use only literal finite numbers; never use placeholders, expressions, previous-message references, or bare tokens.",
+    "The tool returns a READY_TO_PASTE chart block as plain markdown plus metadata. In your final reply, paste the READY_TO_PASTE block exactly as returned. Do not rewrite, escape, quote, or wrap the chart JSON; the frontend renders ```chart fenced JSON blocks as SVG.",
+  ].join(" ");
 
 function chartBaseDir(): string {
   const root =

--- a/portal-web/src/components/chat/Markdown.test.tsx
+++ b/portal-web/src/components/chat/Markdown.test.tsx
@@ -58,6 +58,20 @@ describe("Markdown Mermaid fences", () => {
       ok: true,
       kind: "timeline",
     })
+    expect(
+      validateMermaidSource(
+        [
+          "xychart-beta",
+          '  title "事故单AI可解决性分析"',
+          '  x-axis ["AI可解决", "AI不可解决", "有条件可解决"]',
+          '  y-axis "数量" 0 --> 2',
+          "  bar [1, 0, 2]",
+        ].join("\n"),
+      ),
+    ).toMatchObject({
+      ok: true,
+      kind: "xychart",
+    })
   })
 
   it("repairs leaked stream content prefixes inside Mermaid blocks", () => {

--- a/portal-web/src/components/chat/MermaidRenderer.tsx
+++ b/portal-web/src/components/chat/MermaidRenderer.tsx
@@ -13,7 +13,7 @@ const MAX_MERMAID_LINES = 160
 const MAX_MERMAID_EDGES = 80
 
 type MermaidValidation =
-  | { ok: true; source: string; kind: "flowchart" | "sequence" | "timeline" }
+  | { ok: true; source: string; kind: "flowchart" | "sequence" | "timeline" | "xychart" }
   | { ok: false; reason: string }
 
 type RenderState =
@@ -88,9 +88,12 @@ export function validateMermaidSource(raw: string): MermaidValidation {
   if (/^timeline\b/i.test(head)) {
     return { ok: true, source, kind: "timeline" }
   }
+  if (/^xychart-beta\b/i.test(head)) {
+    return { ok: true, source, kind: "xychart" }
+  }
   return {
     ok: false,
-    reason: "Only flowchart/graph, sequenceDiagram, and timeline diagrams are supported.",
+    reason: "Only flowchart/graph, sequenceDiagram, timeline, and xychart-beta diagrams are supported.",
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten render_chart guidance so models only call it with finalized structured numeric data
- steer uncertain/simple category charts toward Mermaid xychart-beta
- document that chart data must be an object, not a JSON string or placeholder expression

## Validation
- npx vitest run mcp/create-chart/src/handler.test.ts
- npm run build