### PR TITLE
fix(chat): make Stop reliably halt all work across every scenario

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -156,6 +156,9 @@ function makeFakeSessionManager() {
     list: () => Array.from(sessions.values()),
     get: (id: string) => sessions.get(id),
     stopSessionJobs: vi.fn(() => 0),
+    markPendingAbort: vi.fn(),
+    consumePendingAbort: vi.fn(() => false),
+    discardPendingNotifications: vi.fn(),
     getOrCreate: async (id?: string, _mode?: unknown, _systemPromptTemplate?: unknown, activeMode?: unknown) => {
       getOrCreateCalls.push({ id, activeMode });
       const key = id ?? "default";
@@ -842,6 +845,35 @@ describe("http-server — steer / abort / clear-queue", () => {
     expect(r.status).toBe(200);
     expect(r.data).toEqual({ ok: true, stoppedJobs: 0, pending: true });
     expect(s._aborted).toBe(true);
+  });
+
+  it("Stop clears the steer queue, discards pending notifications, and re-sweeps jobs after brain.abort", async () => {
+    await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "ab2" });
+    const s = sm.sessions.get("ab2")!;
+    const r = await getJson(port, "/api/sessions/ab2/abort", "POST");
+    expect(r.status).toBe(200);
+    expect(s.brain.clearQueue).toHaveBeenCalled();          // #2 steer queue dropped
+    expect(sm.discardPendingNotifications).toHaveBeenCalledWith("ab2"); // #7 resurrection guard
+    // #1: stopSessionJobs swept once before brain.abort AND once after the run drains.
+    expect(sm.stopSessionJobs).toHaveBeenCalledTimes(2);
+  });
+
+  it("Stop before the session exists records a pending abort (200, not 404)", async () => {
+    const r = await getJson(port, "/api/sessions/ghost-bg/abort", "POST");
+    expect(r.status).toBe(200);
+    expect(r.data).toMatchObject({ ok: true, pending: true });
+    expect(sm.markPendingAbort).toHaveBeenCalledWith("ghost-bg"); // #6 pre-spawn
+  });
+
+  it("a consumed pending abort short-circuits the next prompt (pre-prompt latch)", async () => {
+    sm.consumePendingAbort.mockReturnValueOnce(true);          // #6 consume → #5 latch
+    const r = await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "ab-pre" });
+    expect(r.status).toBe(200);
+    expect(r.data).toMatchObject({ aborted: true });
+    const s = sm.sessions.get("ab-pre")!;
+    expect(s.brain.prompt).not.toHaveBeenCalled();             // never started the run
+    expect(s._promptDone).toBe(true);                          // session unlocked
+    expect(s._promptInflight).toBe(null);
   });
 
   it("POST /api/prompt returns 409 when _promptInflight is held even if _promptDone flipped back", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -383,6 +383,13 @@ export function createHttpServer(
     // fast double-submit cannot start a second prompt on the same brain.
     managed._promptDone = false;
     managed._aborted = false;
+    // Pre-spawn Stop: a /abort that arrived before this session existed recorded a pending abort.
+    // Consume it HERE — AFTER the unconditional `_aborted = false` reset above (placing it before
+    // would be wiped by that reset) — so the pre-prompt latch below short-circuits this turn.
+    if (sessionManager.consumePendingAbort(managed.id)) {
+      managed._aborted = true;
+      console.log(`[agentbox-http] Consumed pre-spawn pending abort for session ${managed.id}`);
+    }
     managed._routeBrainEventsThroughExtra = routeEnabled;
     // Acquire the brain.prompt mutex synchronously before any await so the
     // synth notify path (which polls _promptDone via waitForParentIdle)
@@ -604,6 +611,21 @@ export function createHttpServer(
     const emitRouteEvent = (event: ModelRouteEvent): void => {
       emitSessionExtraEvent({ ...event, sessionId: managed.id });
     };
+
+    // Pre-prompt latch: a Stop that landed during model setup (or a consumed pre-spawn pending
+    // abort) set `_aborted` true. Do NOT start the run — finish cleanly so the session unlocks
+    // and the SSE stream closes. Reset `_aborted` so the NEXT prompt isn't wrongly skipped.
+    if (managed._aborted) {
+      console.log(`[agentbox-http] Prompt for ${managed.id} aborted before start (pre-prompt latch)`);
+      managed._aborted = false;
+      // Use actuallyFinish (NOT onPromptFinish): no brain run started, so there is no
+      // agent_end/auto_*_end event coming. onPromptFinish would take its deferred branch and
+      // wait forever if isAgentActive/isCompacting/isRetrying were left stale-true by a prior
+      // abnormal turn — permanently locking the session at 409. actuallyFinish unlocks now.
+      actuallyFinish();
+      sendJson(res, 200, { ok: true, sessionId: managed.id, aborted: true });
+      return;
+    }
 
     const promptPromise = routeEnabled
       ? runPromptWithModelRouting(
@@ -876,13 +898,35 @@ export function createHttpServer(
     const managed = sessionManager.get(sessionId);
 
     if (!managed) {
-      sendJson(res, 404, { error: "Session not found" });
+      // Pre-spawn Stop: the session doesn't exist yet (Stop clicked before the prompt's
+      // getOrCreate ran). Record the intent so the imminent /api/prompt short-circuits instead
+      // of running the turn the user already cancelled. Return 200 (not 404) so the UI/gateway
+      // treats Stop as accepted. Consumed one-shot by the next /api/prompt (TTL backstop guards
+      // a Stop that never gets a following prompt).
+      sessionManager.markPendingAbort(sessionId);
+      console.log(`[agentbox-http] Abort for not-yet-created session ${sessionId}; recorded pending abort`);
+      sendJson(res, 200, { ok: true, pending: true, stoppedJobs: 0 });
       return;
     }
 
     console.log(`[agentbox-http] Aborting session ${sessionId} (abort endpoint called)`);
-    console.trace(`[agentbox-http] Abort stack trace for session ${sessionId}`);
     managed._aborted = true;
+
+    // Stop is terminal: drop any queued steer/followUp so it does NOT replay on the next prompt.
+    try {
+      const cleared = managed.brain.clearQueue();
+      if (cleared.steering.length || cleared.followUp.length) {
+        console.log(`[agentbox-http] Stop cleared queue for ${sessionId}: ${cleared.steering.length} steer, ${cleared.followUp.length} followUp`);
+      }
+    } catch (err) {
+      console.warn(`[agentbox-http] clearQueue on abort failed for ${sessionId}:`, err);
+    }
+
+    // Discard buffered background-job completion notifications + cancel the coalesce timer:
+    // a job that completed moments BEFORE Stop is already past the stopSessionJobs "running"
+    // filter, and its armed coalesce timer would otherwise fire flushPendingNotifications →
+    // runSyntheticPrompt → brain.prompt() AFTER the Stop = the model "comes back to life".
+    sessionManager.discardPendingNotifications(sessionId);
 
     // Foreground sub-agents are cancelled via the parent brain's abort signal
     // (threaded into runSpawnedSubagent). The user's Stop should also halt the session's
@@ -893,11 +937,22 @@ export function createHttpServer(
       console.log(`[agentbox-http] Stop also halted ${stoppedJobs} background job(s) for session ${sessionId}`);
     }
     const outcome = await abortBrainForHttp(managed.brain, sessionId);
+    // Re-sweep AFTER brain.abort() resolves: it resolves only once the run loop fully drains
+    // (every in-flight tool call returned), so a tool call that launched a background job DURING
+    // the drain registered it AFTER the first sweep. Catch it now — this is the fix for the
+    // "background job launched mid-abort escapes Stop" bug. (On a 2s-timeout outcome the run may
+    // not have drained; the per-launch _aborted latch in createBackgroundExecExecutor is the
+    // backstop there.)
+    const reSwept = sessionManager.stopSessionJobs(sessionId);
+    if (reSwept > 0) {
+      console.log(`[agentbox-http] Re-sweep after brain.abort halted ${reSwept} background job(s) for session ${sessionId}`);
+    }
+    const totalStopped = stoppedJobs + reSwept;
     if (outcome === "failed") {
-      sendJson(res, 500, { error: "Abort failed", stoppedJobs });
+      sendJson(res, 500, { error: "Abort failed", stoppedJobs: totalStopped });
       return;
     }
-    sendJson(res, 200, { ok: true, stoppedJobs, ...(outcome === "timeout" ? { pending: true } : {}) });
+    sendJson(res, 200, { ok: true, stoppedJobs: totalStopped, ...(outcome === "timeout" ? { pending: true } : {}) });
   });
 
   /**

--- a/src/agentbox/notify-parent.test.ts
+++ b/src/agentbox/notify-parent.test.ts
@@ -107,6 +107,31 @@ describe("notifyParent", () => {
     expect((brain.prompt.mock.calls[0][0] as string).match(/<task_notification>/g)?.length).toBe(1);
   });
 
+  // #7: a job that completed just BEFORE Stop has already buffered its notification + armed the
+  // coalesce timer. The Stop must not let that timer wake the model ("comes back to life").
+  it("#7 Stop: a buffered completion is NOT flushed as a synthetic turn while _aborted", async () => {
+    const { mgr, brain, managed } = setup(true); // idle, job completed
+    await mgr.notifyParent("s1", "j1", { taskId: "j1", status: "completed", summary: "done" });
+    expect(managed._pendingNotifications.length).toBe(1); // buffered, timer armed
+    managed._aborted = true; // user presses Stop before the coalesce flush
+    await flushCoalesce();
+    expect(brain.prompt).not.toHaveBeenCalled();           // no resurrection
+    expect(brain.followUp).not.toHaveBeenCalled();
+    expect(managed._pendingNotifications.length).toBe(0);  // drained, not delivered
+  });
+
+  it("#7 discardPendingNotifications clears the buffer + cancels the coalesce timer", async () => {
+    const { mgr, brain, managed } = setup(true);
+    await mgr.notifyParent("s1", "j1", { taskId: "j1", status: "completed", summary: "done" });
+    expect(managed._pendingNotifications.length).toBe(1);
+    expect(managed._coalesceTimer).not.toBeNull();
+    mgr.discardPendingNotifications("s1");
+    expect(managed._pendingNotifications.length).toBe(0);
+    expect(managed._coalesceTimer).toBeNull();
+    await flushCoalesce();
+    expect(brain.prompt).not.toHaveBeenCalled();
+  });
+
   it("restores _promptDone after a synthetic turn", async () => {
     const { mgr, managed } = setup(true);
     await mgr.notifyParent("s1", "j1", { taskId: "j1", status: "completed", summary: "x" });

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -579,3 +579,88 @@ describe("AgentBoxSessionManager — credentialsDir override (Local mode multi-A
     expect(call.kubeconfigRef.credentialsDir).toBe(path.resolve(process.cwd(), _cfgCredentialsDir));
   });
 });
+
+describe("AgentBoxSessionManager — Stop / abort latches", () => {
+  it("#3 background-exec executor latches on parent _aborted (registers stopped, no spawn)", () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    mgr.sessions.set("p1", { id: "p1", _aborted: true, _backgroundWorkCount: 0, _releaseTimer: null });
+    const exec = mgr.createBackgroundExecExecutor();
+    const res = exec({ jobId: "bg1", parentSessionId: "p1", description: "ping -c 100", jobType: "host", command: "ping" });
+    // Returns a normal launched handle (must NOT throw — a throw makes the tool fall back to foreground).
+    expect(res.jobId).toBe("bg1");
+    expect(typeof res.outputFile).toBe("string");
+    // Job is registered terminal "stopped" (a real spawn would be "running") and suppresses the wake turn.
+    const job = mgr.jobs.get("bg1");
+    expect(job.status).toBe("stopped");
+    expect(job.suppressNotifyTurn).toBe(true);
+  });
+
+  it("#4 startBackgroundSubagent latches on parent _aborted (registers stopped, never runs the child)", () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    mgr.sessions.set("p1", { id: "p1", _aborted: true });
+    const runSpy = vi.spyOn(mgr, "runSpawnedSubagent");
+    const res = mgr.startBackgroundSubagent({ spawnId: "sub1", parentSessionId: "p1", description: "d", prompt: "x", userId: "u" });
+    expect(res.status).toBe("launched");
+    expect(runSpy).not.toHaveBeenCalled();
+    const job = mgr.jobs.get("sub1");
+    expect(job.status).toBe("stopped");
+    expect(job.suppressNotifyTurn).toBe(true);
+  });
+
+  it("#1/#4 background sub-agent latch PERSISTS a terminal delegation event (card folds on reload)", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    const sent: any[] = [];
+    mgr.gatewayClient = { sendDelegationPersistenceEvent: async (e: any) => { sent.push(e); return { ok: true }; } };
+    mgr.agentId = "agent-1";
+    mgr.sessions.set("p1", { id: "p1", _aborted: true });
+    const res = mgr.startBackgroundSubagent({ spawnId: "sub1", parentSessionId: "p1", description: "d", prompt: "x", userId: "u" });
+    expect(res.status).toBe("launched");
+    expect(mgr.jobs.get("sub1").status).toBe("stopped");
+    await new Promise((r) => setTimeout(r, 5)); // let the fire-and-forget persist run
+    // The PERSISTED terminal delegation_event is what annotateSubagentCompletions reads on reload
+    // to fold the launch card — without it the card would re-paint "Running…" forever.
+    const terminal = sent.find((e) => e.type === "delegation.append_event");
+    expect(terminal).toBeDefined();
+    expect(terminal.event.status).toBe("partial");
+    expect(terminal.event.delegationId).toBe("sub1");
+  });
+
+  it("#9 background sub-agent bails when parent _aborted during setup (no child prompt)", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    // Parent already aborted by the time the child's setup (createSiclawSession) completes.
+    mgr.sessions.set("p1", { id: "p1", _aborted: true });
+    mgr.jobs.register({ jobId: "sub1", type: "subagent", parentSessionId: "p1", childSessionId: "c1", status: "running", description: "d", startedAt: 0, notified: false });
+    const promptSpy = vi.fn(async () => {});
+    (globalThis as any).__fakeBrainFactories.push(() => ({ prompt: promptSpy, abort: vi.fn(async () => {}) }));
+    // Call runSpawnedSubagent directly (bypassing #4's pre-launch latch) to exercise the
+    // post-setup parent-_aborted check — the window where job.abort isn't wired and the job
+    // status is still "running" (so a job-status check would never fire).
+    const res = await mgr.runSpawnedSubagent(
+      { spawnId: "sub1", parentSessionId: "p1", description: "d", prompt: "do x", userId: "u" },
+      { childSessionId: "c1", jobId: "sub1" },
+    );
+    expect(promptSpy).not.toHaveBeenCalled(); // child run never started
+    expect(res.status).toBe("partial");
+  });
+
+  it("#1 stopSessionJobs re-sweep catches a job registered after the first sweep", () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    mgr.jobs.register({ jobId: "j1", type: "bash", parentSessionId: "p1", status: "running", description: "d", startedAt: 0, notified: false, abort: () => {} });
+    expect(mgr.stopSessionJobs("p1")).toBe(1); // first sweep
+    // A tool call launched a new background job DURING the abort drain.
+    mgr.jobs.register({ jobId: "j2", type: "bash", parentSessionId: "p1", status: "running", description: "d2", startedAt: 0, notified: false, abort: () => {} });
+    expect(mgr.stopSessionJobs("p1")).toBe(1); // re-sweep catches it
+  });
+
+  it("markPendingAbort arms only for a never-created (pre-spawn) session, not a released one", () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    // Truly pre-spawn: no on-disk history dir → arms → consumable by the imminent first prompt.
+    mgr.markPendingAbort("never-created");
+    expect(mgr.consumePendingAbort("never-created")).toBe(true);
+    // Ran-before / released: a history dir exists → markPendingAbort is a NO-OP, so a Stop on a
+    // released-but-idle session can't poison the user's next prompt for that reused sessionId.
+    fs.mkdirSync(path.join(mgr.getBaseSessionDir(), "ran-before"), { recursive: true });
+    mgr.markPendingAbort("ran-before");
+    expect(mgr.consumePendingAbort("ran-before")).toBe(false);
+  });
+});

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -33,6 +33,7 @@ import { getSubagentType, DEFAULT_SUBAGENT_TYPE, getSubagentConcurrency, getSuba
 import { JobRegistry, type JobStatus } from "../core/job-registry.js";
 import { buildNotificationBatch, type TaskNotification } from "../core/task-notification.js";
 import { spawnBackgroundBash } from "../core/background-bash-runner.js";
+import { DiskTaskOutput, getTaskOutputPath } from "../tools/cmd-exec/disk-output.js";
 import { ConcurrencyLimiter } from "../core/concurrency-limiter.js";
 import { buildDelegateSummaryBundle } from "./delegation-summary.js";
 import type { KubeconfigRef, SessionMode, DpStateRef } from "../core/types.js";
@@ -333,6 +334,64 @@ export class AgentBoxSessionManager {
    */
   private jobs = new JobRegistry();
 
+  /**
+   * Sessions for which a Stop arrived BEFORE the session existed (pre-spawn). Consumed one-shot
+   * by the next getOrCreate-driven /api/prompt for that id (the prompt being cancelled — which is
+   * already in flight and cold-starting, so it consumes within the cold-start window). The TTL
+   * is only a leak backstop for an ORPHAN (a Stop whose paired prompt never arrives). Keep it
+   * tight: it must outlast a cold start (image pull / container start, "routinely exceeds 30s"
+   * per the runtime's async-ack comment) but no longer — a too-long TTL widens the window in
+   * which a stale orphan could wrongly short-circuit a brand-new, deliberate prompt for the same
+   * reused sessionId. 3 min covers cold start with margin while bounding that risk.
+   */
+  private _pendingAborts = new Map<string, ReturnType<typeof setTimeout>>();
+  private static readonly PENDING_ABORT_TTL_MS = 180_000;
+
+  /** Record a pre-spawn Stop so the imminent /api/prompt short-circuits (see _pendingAborts). */
+  markPendingAbort(sessionId: string): void {
+    // Only a TRUE pre-spawn Stop should arm a pending abort: one where the session was NEVER
+    // created, so no in-flight turn exists yet and the imminent first /api/prompt is the one to
+    // cancel. A genuine pre-spawn session has no on-disk history dir yet; a session that ran
+    // before and was merely RELEASED from memory (30s TTL) always does. Without this guard, a
+    // Stop on a released-but-idle session (e.g. the Stop button still live after a missed
+    // prompt_done) would arm a pending abort that silently cancels the user's NEXT prompt for
+    // the same reused sessionId. If the existence check throws, fall through and arm (best-effort).
+    try {
+      if (fs.existsSync(path.join(this.getBaseSessionDir(), sessionId))) return;
+    } catch { /* fall through — arm */ }
+    const existing = this._pendingAborts.get(sessionId);
+    if (existing) clearTimeout(existing);
+    const t = setTimeout(() => this._pendingAborts.delete(sessionId), AgentBoxSessionManager.PENDING_ABORT_TTL_MS);
+    t.unref?.();
+    this._pendingAborts.set(sessionId, t);
+  }
+
+  /** Consume (one-shot) a pre-spawn Stop recorded by markPendingAbort. */
+  consumePendingAbort(sessionId: string): boolean {
+    const t = this._pendingAborts.get(sessionId);
+    if (!t) return false;
+    clearTimeout(t);
+    this._pendingAborts.delete(sessionId);
+    return true;
+  }
+
+  /**
+   * Discard buffered background-job completion notifications + cancel the coalesce timer for a
+   * session. Called from /abort: a job that completed moments before Stop already armed the
+   * coalesce timer, which would otherwise flush → runSyntheticPrompt → brain.prompt() AFTER Stop
+   * ("comes back to life"). The per-entry suppressNotifyTurn check still guards the flush path,
+   * but clearing here makes the resurrection impossible regardless.
+   */
+  discardPendingNotifications(sessionId: string): void {
+    const managed = this.sessions.get(sessionId);
+    if (!managed) return;
+    managed._pendingNotifications.length = 0;
+    if (managed._coalesceTimer) {
+      clearTimeout(managed._coalesceTimer);
+      managed._coalesceTimer = null;
+    }
+  }
+
   private createSpawnSubagentExecutor(): SpawnSubagentExecutor {
     return async (request, onProgress, signal) => {
       if (request.runInBackground) return this.startBackgroundSubagent(request);
@@ -403,6 +462,38 @@ export class AgentBoxSessionManager {
    */
   private createBackgroundExecExecutor(): BackgroundExecExecutor {
     return (req) => {
+      // Stop latch: the user pressed Stop on this session; do NOT spawn a new background job.
+      // Register a terminal "stopped" job and return a normal launched handle — NEVER throw,
+      // because every background-capable tool treats an executor throw as "fall back to a
+      // FOREGROUND run", which would re-introduce the escape this latch closes. The launching
+      // tool's card folds to stopped via the exec_job_done event from notifyParent below;
+      // suppressNotifyTurn keeps the model from waking on its own cancellation.
+      const aborting = this.sessions.get(req.parentSessionId);
+      if (aborting?._aborted) {
+        const outputFile = getTaskOutputPath(req.jobId);
+        const disk = new DiskTaskOutput(req.jobId);
+        void disk.ensureCreated().then(() => disk.markFinal()).catch(() => {});
+        this.jobs.register({
+          jobId: req.jobId,
+          type: req.jobType ?? "bash",
+          parentSessionId: req.parentSessionId,
+          description: req.description,
+          status: "stopped",
+          startedAt: Date.now(),
+          notified: false,
+          suppressNotifyTurn: true,
+          outputFile,
+        });
+        try { req.onComplete?.(); } catch { /* best-effort (e.g. node_exec debug-pod unpin) */ }
+        void this.notifyParent(req.parentSessionId, req.jobId, {
+          taskId: req.jobId,
+          outputFile,
+          status: "stopped",
+          summary: `Background command "${req.description}" was stopped`,
+        });
+        return { jobId: req.jobId, outputFile };
+      }
+
       const cap = getBackgroundBashConcurrency();
       // Cap counts ALL background exec jobs (bash/node/pod), not sub-agents.
       const running = this.jobs
@@ -459,6 +550,66 @@ export class AgentBoxSessionManager {
   private startBackgroundSubagent(request: SpawnSubagentRequest): SpawnSubagentResult {
     const childSessionId = randomUUID();
     const jobId = request.spawnId;
+    // Stop latch: the user pressed Stop before this sub-agent launched; register it terminal
+    // ("stopped") and skip runSpawnedSubagent so no child run/LLM work starts. suppressNotifyTurn
+    // keeps the model from waking on the cancellation.
+    if (this.sessions.get(request.parentSessionId)?._aborted) {
+      this.jobs.register({
+        jobId,
+        type: "subagent",
+        parentSessionId: request.parentSessionId,
+        childSessionId,
+        status: "stopped",
+        description: request.description,
+        startedAt: Date.now(),
+        notified: false,
+        suppressNotifyTurn: true,
+      });
+      // notifyParent gives the LIVE card fold (subagent_done). It is NOT persisted, so we ALSO
+      // write the terminal delegation_event + child session row that runSpawnedSubagent would
+      // have written — without these the launch card re-paints as "Running…" forever on reload
+      // (annotateSubagentCompletions reads the persisted delegation_event), and the
+      // "open transcript" deep-link 404s. Mirrors runSpawnedSubagent's terminal persistence.
+      const stoppedAgentId = request.parentAgentId ?? this.agentId ?? null;
+      if (this.gatewayClient && stoppedAgentId && request.userId) {
+        void (async () => {
+          try {
+            await this.persistEnsureChatSession(
+              childSessionId, stoppedAgentId, request.userId,
+              `Sub-agent: ${request.description}`,
+              "", "subagent",
+              { parentSessionId: request.parentSessionId, parentAgentId: stoppedAgentId, delegationId: jobId, targetAgentId: stoppedAgentId },
+            );
+          } catch { /* best-effort */ }
+          try {
+            await this.persistAppendDelegationEvent({
+              parentSessionId: request.parentSessionId,
+              parentAgentId: stoppedAgentId,
+              userId: request.userId,
+              delegationId: jobId,
+              childSessionId,
+              targetAgentId: stoppedAgentId,
+              // "partial" is the terminal status runSpawnedSubagent persists for a stopped
+              // sub-agent (the delegation status enum has no "stopped"); keep it consistent so
+              // the card folds the same way on reload.
+              status: "partial",
+              capsule: `Sub-agent "${request.description}" was stopped`,
+              fullSummary: `Sub-agent "${request.description}" was stopped before it started.`,
+              summaryTruncated: false,
+              scope: request.prompt,
+              toolCalls: 0,
+              durationMs: 0,
+            });
+          } catch { /* best-effort */ }
+        })();
+      }
+      void this.notifyParent(request.parentSessionId, jobId, {
+        taskId: jobId,
+        status: "stopped",
+        summary: `Sub-agent "${request.description}" was stopped`,
+      });
+      return { status: "launched", childSessionId, jobId };
+    }
     this.jobs.register({
       jobId,
       type: "subagent",
@@ -591,6 +742,13 @@ export class AgentBoxSessionManager {
       clearTimeout(managed._coalesceTimer);
       managed._coalesceTimer = null;
     }
+    // Stop is terminal: a Stop sets _aborted and stays true until the next REAL user prompt
+    // resets it. Do NOT flush a synthetic turn during the Stop window — that would wake the
+    // model on a completion it cancelled ("comes back to life after Stop").
+    if (managed._aborted) {
+      managed._pendingNotifications.length = 0;
+      return;
+    }
     if (!managed._promptDone) {
       // A turn is running — wait for it to finish, then deliver as a synthetic turn (where a
       // pure-ack reaction is suppressed). Re-arm rather than followUp: a followUp's ack rides
@@ -628,6 +786,10 @@ export class AgentBoxSessionManager {
     const run = (managed._syntheticPromptQueue ?? Promise.resolve())
       .catch(() => {})
       .then(async () => {
+        // Stop is terminal: if the user pressed Stop while this synthetic turn was queued, do
+        // NOT start it (and do NOT followUp — that would ride a turn too). _aborted stays true
+        // until the next real user prompt resets it. Checked under the queue, before the reset.
+        if (managed._aborted) return;
         // Re-check under the queue: an HTTP /prompt may have started since notifyParent
         // decided "idle". If so, degrade to followUp (delivered to that running turn).
         if (!managed._promptDone || managed._promptInflight) {
@@ -1114,6 +1276,15 @@ export class AgentBoxSessionManager {
       }
     }
 
+    // Setup-window Stop: if the user pressed Stop while we were awaiting createSiclawSession
+    // above (job.abort was not wired yet, so a /abort sweep's stopJob no-op'd with "starting up"
+    // and left the job "running"), honour it now before the child's run starts. The reliable
+    // signal is the PARENT session's _aborted (set at /abort, true for the whole Stop window) —
+    // NOT the job status, which stopJob never set to "stopped" in this window.
+    if (this.sessions.get(request.parentSessionId)?._aborted) {
+      requestStop(`parent stopped during sub-agent setup ${childSessionId}`);
+    }
+
     // ── Transcript persistence (design §13). Serialized via a promise queue so
     //    writes land in order; a write failure disables the trace but never the run. ──
     const delegationId = request.spawnId;
@@ -1235,6 +1406,10 @@ export class AgentBoxSessionManager {
 
     let interruptedTool: string | undefined;
     try {
+      // Stop landed before/during setup: requestStop already fired, but child.brain.abort() is a
+      // no-op with no active run — so DON'T start the prompt at all, or it would run a fresh,
+      // un-aborted turn. Throw straight into the stopRequested branch below.
+      if (stopRequested) throw new Error("stopped before sub-agent prompt started");
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("spawn_subagent_timeout")), DELEGATED_AGENT_MAX_RUNTIME_MS),
       );

--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -145,32 +145,45 @@ describe("PiAgentBrain", () => {
     expect(starts[1].attempt).toBe(2);
   });
 
-  it("abort cancels retry sleep and calls session.abort", async () => {
+  it("#10 abort cancels the retry sleep AND does not fire a fresh re-prompt after Stop", async () => {
     const session = makeFakeSession();
     let callCount = 0;
     session.prompt = vi.fn(async () => {
       callCount++;
       session.__emit({ type: "message_start", message: { role: "assistant" } });
-      // First call: empty → triggers retry
-      // Second call (after abort): emit aborted stopReason so while-loop exits
-      if (callCount === 1) {
-        session.__emit({ type: "message_end", message: { role: "assistant", content: [], stopReason: "end_turn" } });
-      } else {
-        session.__emit({ type: "message_end", message: { role: "assistant", content: [], stopReason: "aborted" } });
-      }
+      // Empty response → enters the retry backoff.
+      session.__emit({ type: "message_end", message: { role: "assistant", content: [], stopReason: "end_turn" } });
     });
     // Large delay so abort() resolves the sleep early.
     (PiAgentBrain as any).RETRY_DELAY_MS = 60000;
     const brain = new PiAgentBrain(session);
     const p = brain.prompt("q");
-    // Wait briefly for first prompt to complete, retry to begin sleeping
+    // Wait briefly for the first prompt to complete and the retry to begin sleeping.
     await new Promise((r) => setTimeout(r, 10));
     await brain.abort();
     expect(session.abort).toHaveBeenCalled();
     await p;
-    // Two prompts: initial + one retry cancelled by abort
-    expect(callCount).toBe(2);
+    // ONLY the initial prompt ran — the retry must NOT re-prompt after Stop (pre-fix this was 2,
+    // an un-aborted re-prompt firing after the user clicked Stop).
+    expect(callCount).toBe(1);
   }, 3000);
+
+  it("#8 abort also cancels in-flight compaction via session.abortCompaction", async () => {
+    const abortCompaction = vi.fn();
+    const session = makeFakeSession({ abortCompaction });
+    const brain = new PiAgentBrain(session);
+    await brain.abort();
+    expect(abortCompaction).toHaveBeenCalled();
+    expect(session.abort).toHaveBeenCalled();
+  });
+
+  it("#8 abort is safe when the session has no abortCompaction (optional)", async () => {
+    const session = makeFakeSession();
+    delete (session as any).abortCompaction;
+    const brain = new PiAgentBrain(session);
+    await expect(brain.abort()).resolves.toBeUndefined();
+    expect(session.abort).toHaveBeenCalled();
+  });
 
   it("reload delegates", async () => {
     const session = makeFakeSession();

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -26,6 +26,10 @@ export class PiAgentBrain implements BrainSession {
   /** Set during prompt(); abort() resolves this to cancel backoff sleep. */
   private abortRetry: (() => void) | null = null;
 
+  /** True from abort() until the next prompt() starts. Stops the empty-response retry loop from
+   *  firing a fresh (un-aborted) re-prompt when Stop lands during the backoff sleep. */
+  private aborted = false;
+
   constructor(readonly session: AgentSession) {}
 
   private static readonly MAX_EMPTY_RETRIES = 2;
@@ -47,6 +51,7 @@ export class PiAgentBrain implements BrainSession {
   }
 
   async prompt(text: string): Promise<void> {
+    this.aborted = false;
     let lastAssistantHadContent = false;
     let lastAssistantMessage: any = null;
 
@@ -85,6 +90,7 @@ export class PiAgentBrain implements BrainSession {
       let retries = 0;
       while (
         !lastAssistantHadContent &&
+        !this.aborted &&
         lastAssistantMessage?.stopReason !== "aborted" &&
         lastAssistantMessage?.stopReason !== "error" &&
         retries < PiAgentBrain.MAX_EMPTY_RETRIES
@@ -109,18 +115,22 @@ export class PiAgentBrain implements BrainSession {
         });
         try {
           await this.abortableSleep(delayMs);
+          // Stop landed during the backoff: do NOT fire a fresh, un-aborted re-prompt.
+          if (this.aborted) break;
           await this.session.prompt(text);
         } finally {
+          // A user Stop landing in the backoff is not an empty-response failure — don't label it
+          // one (telemetry/alerting could otherwise count Stops as model defects).
           this.emit({
             type: "auto_retry_end",
             attempt: retries,
             success: lastAssistantHadContent,
-            finalError: lastAssistantHadContent ? undefined : "Model returned empty response",
+            finalError: lastAssistantHadContent || this.aborted ? undefined : "Model returned empty response",
           });
         }
       }
 
-      if (!lastAssistantHadContent) {
+      if (!lastAssistantHadContent && !this.aborted) {
         const msg = lastAssistantMessage;
         console.error(
           `[pi-agent-brain] Empty response persisted after ${PiAgentBrain.MAX_EMPTY_RETRIES} retries, ` +
@@ -135,7 +145,15 @@ export class PiAgentBrain implements BrainSession {
   }
 
   async abort(): Promise<void> {
+    this.aborted = true;
     this.abortRetry?.();
+    // session.abort() (agent.abort + waitForIdle) aborts the RUN's controller — but auto-compaction
+    // and routing-preflight compaction use SEPARATE controllers it does not touch. Abort those too,
+    // so a Stop during compaction cancels the compaction LLM call AND lets waitForIdle() resolve
+    // promptly instead of blocking until compaction finishes. Defensive optional — older cores or
+    // a non-pi brain may not expose it.
+    try { (this.session as { abortCompaction?: () => void }).abortCompaction?.(); }
+    catch { /* best-effort */ }
     return this.session.abort();
   }
 


### PR DESCRIPTION
## Problem
After PR #324 (foreground tool rows no longer resume on refresh), Stop was still unreliable for **background work** and several edge windows. The reported case: send a message, the agent launches `host_exec(run_in_background)` (ping -c 100), click Stop immediately — the foreground turn stops but the background ping **runs to completion**.

## Root cause
Abort was a one-shot sweep + `brain.abort()`, with no persistent latch. A tool call mid-flight at Stop registers its background job **after** the single `stopSessionJobs()` sweep, so nothing ever stops it. Plus several pre/post-prompt and notification windows leaked. `_aborted` existed but was only read by the model-routing `shouldAbort` callback — never by the background-exec executor or sub-agent launcher.

## Changes (10)
- **#1 (primary) Re-sweep** `stopSessionJobs` in `/abort` AFTER `brain.abort()` resolves (the run loop is fully drained, so the job the in-flight tool launched during the drain is now registered → caught).
- **#2** Clear the steer queue (`brain.clearQueue()`) on Stop so a queued steer doesn't replay on the next prompt.
- **#3** Latch `createBackgroundExecExecutor` on parent `_aborted`: register a terminal "stopped" job and return a launched handle (never throw — throwing makes the tool fall back to a foreground run); no process spawned.
- **#4** Latch `startBackgroundSubagent` on parent `_aborted`: register stopped, skip `runSpawnedSubagent`.
- **#5** Pre-prompt latch in `/api/prompt`: if `_aborted` before the run starts, finish cleanly without prompting.
- **#6** Pre-spawn pending-abort (`markPendingAbort`/`consumePendingAbort`, 10-min TTL): `/abort` on a not-yet-created session returns `200 {pending:true}` instead of `404`; `/api/prompt` consumes it AFTER the unconditional `_aborted=false` reset (placing it before would be wiped).
- **#7** Discard buffered completion notifications + cancel the coalesce timer on Stop, and guard `flushPendingNotifications`/`runSyntheticPrompt` on `_aborted` — kills the "a job that finished just before Stop wakes the model via a synthetic turn" resurrection path (independent of #1–#6).
- **#8** `PiAgentBrain.abort()` also calls `session.abortCompaction()` — the run AbortController doesn't cover the separate compaction controllers, so a Stop during compaction otherwise leaks the LLM call and hangs `waitForIdle()`.
- **#9** `runSpawnedSubagent` bails on parent `_aborted` after `createSiclawSession` — the setup window where `job.abort` isn't wired and `stopJob` no-ops (job stays "running", so a job-status check would never fire; parent `_aborted` is the reliable signal).
- **#10** `PiAgentBrain` tracks an `aborted` flag so the empty-response retry loop can't fire a fresh, un-aborted re-prompt when Stop lands in the backoff sleep.

## Scenario coverage
pre-spawn (#6+#5), post-spawn pre-LLM (#5), LLM streaming / foreground tool (already worked via the run AbortSignal), foreground sub-agent (already worked), background sub-agent (#4+#9+#1), background job — the reported bug (#1+#3), compaction (#8), empty-response retry (#10), just-completed-job resurrection (#7), steer queue (#2).

Out of scope (documented): sub-tree job sweep is unnecessary (child sessions get no background executors, so no job registers under a child sessionId); a foreground `host_exec` that itself `nohup &`-backgrounds a remote process is unreachable by Stop.

## Testing
Targeted tests added/updated across `http-server.test.ts`, `session.test.ts`, `notify-parent.test.ts`, `pi-agent-brain.test.ts` (the prior pi-agent-brain abort test is flipped from the buggy `callCount===2` to the fixed `===1` — direct proof of no re-prompt after Stop). `npx tsc --noEmit` clean; full suite **3554 passed / 2 skipped**.

Built as `siclaw-runtime:v0.1.9-fixstop2` and deployed to `siclaw-inner` + `sicore-test` for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)