### PR TITLE
feat(vision): forward image attachments to vision-capable models

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -304,6 +304,14 @@ describe("http-server — prompt + session lifecycle", () => {
     expect(r.data.error).toMatch(/Missing.*text/);
   });
 
+  it("POST /api/prompt drops images whose data is not valid base64", async () => {
+    const r = await getJson(port, "/api/prompt", "POST", {
+      images: [{ mimeType: "image/png", data: "not base64!!!" }], // bad base64 → dropped
+    });
+    expect(r.status).toBe(400);
+    expect(r.data.error).toMatch(/Missing.*text/);
+  });
+
   it("resolves the active operating mode from DP markers and passes it to getOrCreate", async () => {
     const lastMode = () => sm.getOrCreateCalls[sm.getOrCreateCalls.length - 1].activeMode;
 

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -269,6 +269,41 @@ describe("http-server — prompt + session lifecycle", () => {
     expect(r.data.error).toMatch(/Missing.*text/);
   });
 
+  it("POST /api/prompt forwards images to brain.prompt as vision input", async () => {
+    const session = await sm.getOrCreate("img-1");
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "what is in this image?",
+      sessionId: "img-1",
+      images: [{ mimeType: "image/png", data: "aW1n" }],
+    });
+    expect(r.status).toBe(200);
+    expect(session.brain.prompt).toHaveBeenCalledWith(
+      "what is in this image?",
+      [{ mimeType: "image/png", data: "aW1n" }],
+    );
+  });
+
+  it("POST /api/prompt accepts an image-only message and defaults the text", async () => {
+    const session = await sm.getOrCreate("img-only");
+    const r = await getJson(port, "/api/prompt", "POST", {
+      sessionId: "img-only",
+      images: [{ mimeType: "image/png", data: "aW1n" }],
+    });
+    expect(r.status).toBe(200);
+    expect(session.brain.prompt).toHaveBeenCalledWith(
+      "Please analyze the attached image.",
+      [{ mimeType: "image/png", data: "aW1n" }],
+    );
+  });
+
+  it("POST /api/prompt drops malformed images and rejects when nothing usable remains", async () => {
+    const r = await getJson(port, "/api/prompt", "POST", {
+      images: [{ mimeType: "image/gif", data: "aW1n" }], // unsupported mime → dropped
+    });
+    expect(r.status).toBe(400);
+    expect(r.data.error).toMatch(/Missing.*text/);
+  });
+
   it("resolves the active operating mode from DP markers and passes it to getOrCreate", async () => {
     const lastMode = () => sm.getOrCreateCalls[sm.getOrCreateCalls.length - 1].activeMode;
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -60,9 +60,19 @@ interface PromptRequestBody {
 
 // Defense-in-depth bound; the sicore proxy already caps attachments, but the
 // agentbox /prompt is also reachable directly so re-validate here.
+// MUST stay consistent with MAX_BODY_SIZE (parseJsonBody, below): the whole JSON
+// body is rejected at MAX_BODY_SIZE *before* this runs, so MAX_PROMPT_IMAGES ×
+// MAX_PROMPT_IMAGE_BASE64_CHARS must fit under it with headroom for the JSON
+// envelope + text. 4 × 2MB = 8MB < 10MB MAX_BODY_SIZE → all advertised images
+// are actually deliverable (raising one without the other reintroduces the
+// "limit unreachable" mismatch).
 const MAX_PROMPT_IMAGES = 4;
-const MAX_PROMPT_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
+const MAX_PROMPT_IMAGE_BASE64_CHARS = 2 * 1024 * 1024;
 const SUPPORTED_PROMPT_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+// Standard base64 (optionally padded). PromptImage.data is raw base64 with no
+// `data:` URL prefix; a non-base64 string would only fail later at the provider.
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 
 /** Keep only well-formed, supported image parts; drop anything malformed. */
 function sanitizePromptImages(raw: unknown): PromptImage[] | undefined {
@@ -76,6 +86,7 @@ function sanitizePromptImages(raw: unknown): PromptImage[] | undefined {
     if (typeof mimeType !== "string" || typeof data !== "string") continue;
     if (!SUPPORTED_PROMPT_IMAGE_MIMES.has(mimeType.toLowerCase())) continue;
     if (data.length === 0 || data.length > MAX_PROMPT_IMAGE_BASE64_CHARS) continue;
+    if (data.length % 4 !== 0 || !BASE64_RE.test(data)) continue; // reject non-base64
     out.push({ mimeType: mimeType.toLowerCase(), data });
   }
   return out.length > 0 ? out : undefined;

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -30,7 +30,7 @@ import {
   type ModelRouteEvent,
   type ModelRoutePolicy,
 } from "../core/model-routing.js";
-import type { BrainSession } from "../core/brain-session.js";
+import type { BrainSession, PromptImage } from "../core/brain-session.js";
 
 type RequestHandler = (
   req: http.IncomingMessage,
@@ -54,6 +54,31 @@ interface PromptRequestBody {
   systemPromptTemplate?: string;
   modelConfig?: Record<string, unknown>;
   modelRouting?: ModelRoutePolicy;
+  /** Image attachments forwarded as vision input (vision-capable models only). */
+  images?: PromptImage[];
+}
+
+// Defense-in-depth bound; the sicore proxy already caps attachments, but the
+// agentbox /prompt is also reachable directly so re-validate here.
+const MAX_PROMPT_IMAGES = 4;
+const MAX_PROMPT_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
+const SUPPORTED_PROMPT_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+/** Keep only well-formed, supported image parts; drop anything malformed. */
+function sanitizePromptImages(raw: unknown): PromptImage[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: PromptImage[] = [];
+  for (const item of raw) {
+    if (out.length >= MAX_PROMPT_IMAGES) break;
+    if (!item || typeof item !== "object") continue;
+    const mimeType = (item as { mimeType?: unknown }).mimeType;
+    const data = (item as { data?: unknown }).data;
+    if (typeof mimeType !== "string" || typeof data !== "string") continue;
+    if (!SUPPORTED_PROMPT_IMAGE_MIMES.has(mimeType.toLowerCase())) continue;
+    if (data.length === 0 || data.length > MAX_PROMPT_IMAGE_BASE64_CHARS) continue;
+    out.push({ mimeType: mimeType.toLowerCase(), data });
+  }
+  return out.length > 0 ? out : undefined;
 }
 
 /**
@@ -339,12 +364,16 @@ export function createHttpServer(
   addRoute("POST", "/api/prompt", async (req, res) => {
     const body = (await parseJsonBody(req)) as PromptRequestBody;
 
-    if (!body.text) {
+    const promptImages = sanitizePromptImages(body.images);
+
+    // An image-only message is valid (vision models read the picture directly);
+    // only reject when there is neither text nor a usable image.
+    if (!body.text && !promptImages) {
       sendJson(res, 400, { error: "Missing 'text' field" });
       return;
     }
 
-    const activeMode = resolveActiveMode(body.text, body.sessionId, sessionManager);
+    const activeMode = resolveActiveMode(body.text ?? "", body.sessionId, sessionManager);
     const managed = await sessionManager.getOrCreate(body.sessionId, body.mode, body.systemPromptTemplate, activeMode);
     if (!managed._promptDone || managed._promptInflight) {
       // _promptInflight covers the synthetic-parent-prompt path that may
@@ -477,7 +506,11 @@ export function createHttpServer(
         }
       }
 
-      promptText = body.text;
+      // Image-only messages arrive with empty text; give the model a minimal
+      // default instruction so the turn isn't a bare image with no ask.
+      promptText = body.text && body.text.length > 0
+        ? body.text
+        : (promptImages ? "Please analyze the attached image." : "");
     } catch (err) {
       releasePromptLockOnSetupFailure(err);
       return;
@@ -487,7 +520,7 @@ export function createHttpServer(
     // IMPORTANT: append after DP markers, not prepend before them.
     // Prepending would break marker detection in pi-agent extension input handlers
     // (e.g., [System: respond in Chinese]\n[Deep Investigation]\n... fails startsWith check).
-    const detectedLang = detectLanguage(body.text);
+    const detectedLang = detectLanguage(promptText);
     if (detectedLang !== "English" && isMemoryEnabled()) {
       // Only two DP markers remain after the refactor: activation and exit.
       const dpMarkers = [DP_ACTIVATION_MARKER, `${DP_EXIT_MARKER}\n`];
@@ -643,8 +676,9 @@ export function createHttpServer(
             onStateChange: () => sessionManager.persistModelRouteState(managed.id, managed.modelRouteState),
             shouldAbort: () => managed._aborted,
           },
+          promptImages,
         )
-      : managed.brain.prompt(promptText);
+      : managed.brain.prompt(promptText, promptImages);
 
     promptPromise.then((result) => {
       // The routing runner reports exhaustion (and user aborts) as a result,

--- a/src/core/brain-session.ts
+++ b/src/core/brain-session.ts
@@ -14,6 +14,17 @@
 
 export type BrainType = "pi-agent";
 
+/**
+ * An image attachment to send alongside a prompt. `data` is raw base64 (no
+ * `data:` URL prefix); the provider layer builds the data URL. Only carried
+ * through to vision-capable models — pi-ai downgrades images to a text
+ * placeholder when the model's `input` does not include "image".
+ */
+export interface PromptImage {
+  mimeType: string;
+  data: string;
+}
+
 export interface BrainModelInfo {
   id: string;
   name: string;
@@ -58,8 +69,9 @@ export interface BrainContextPreflightResult {
 export interface BrainSession {
   readonly brainType: BrainType;
 
-  /** Send a prompt to the agent. Resolves when the agent finishes responding. */
-  prompt(text: string): Promise<void>;
+  /** Send a prompt to the agent. Resolves when the agent finishes responding.
+   *  `images` are passed to the model as vision input (vision-capable models only). */
+  prompt(text: string, images?: PromptImage[]): Promise<void>;
 
   /** Abort the current agent run. */
   abort(): Promise<void>;

--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -72,6 +72,30 @@ describe("PiAgentBrain", () => {
     expect(session.prompt).toHaveBeenCalledTimes(1);
   });
 
+  it("prompt maps images to ImageContent and passes them to session.prompt", async () => {
+    const session = makeFakeSession();
+    session.prompt = vi.fn(async (_text: string, _opts?: any) => {
+      session.__emit({ type: "message_start", message: { role: "assistant" } });
+      session.__emit({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } });
+    });
+    const brain = new PiAgentBrain(session);
+    await brain.prompt("describe", [{ mimeType: "image/png", data: "aW1n" }]);
+    expect(session.prompt).toHaveBeenCalledWith("describe", {
+      images: [{ type: "image", data: "aW1n", mimeType: "image/png" }],
+    });
+  });
+
+  it("prompt passes no options when there are no images", async () => {
+    const session = makeFakeSession();
+    session.prompt = vi.fn(async (_text: string, _opts?: any) => {
+      session.__emit({ type: "message_start", message: { role: "assistant" } });
+      session.__emit({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } });
+    });
+    const brain = new PiAgentBrain(session);
+    await brain.prompt("hi");
+    expect(session.prompt).toHaveBeenCalledWith("hi", undefined);
+  });
+
   it("prompt skips retry when stopReason is aborted", async () => {
     const session = makeFakeSession();
     session.prompt = vi.fn(async (_text: string) => {

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -13,6 +13,7 @@ import type {
   BrainSessionStats,
   BrainProviderResponse,
   BrainContextPreflightResult,
+  PromptImage,
 } from "../brain-session.js";
 import { estimateMessagesTokens } from "../compaction.js";
 
@@ -50,10 +51,18 @@ export class PiAgentBrain implements BrainSession {
     });
   }
 
-  async prompt(text: string): Promise<void> {
+  async prompt(text: string, images?: PromptImage[]): Promise<void> {
     this.aborted = false;
     let lastAssistantHadContent = false;
     let lastAssistantMessage: any = null;
+
+    // pi-coding-agent appends these to the user message content; the
+    // openai-codex-responses provider serializes them to `input_image` data
+    // URLs. Dropped (replaced with a placeholder) by pi-ai when the active
+    // model's `input` lacks "image", so non-vision models degrade gracefully.
+    const promptOptions = images && images.length > 0
+      ? { images: images.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType })) }
+      : undefined;
 
     const unsub = this.session.subscribe((event: any) => {
       if (event.type === "message_start" && event.message?.role === "assistant") {
@@ -70,7 +79,7 @@ export class PiAgentBrain implements BrainSession {
     });
 
     try {
-      await this.session.prompt(text);
+      await this.session.prompt(text, promptOptions);
 
       // Empty response guard: some models (e.g. Kimi-K2.5) occasionally return
       // a completely empty response (0 content blocks) on the final turn after
@@ -117,7 +126,7 @@ export class PiAgentBrain implements BrainSession {
           await this.abortableSleep(delayMs);
           // Stop landed during the backoff: do NOT fire a fresh, un-aborted re-prompt.
           if (this.aborted) break;
-          await this.session.prompt(text);
+          await this.session.prompt(text, promptOptions);
         } finally {
           // A user Stop landing in the backoff is not an empty-response failure — don't label it
           // one (telemetry/alerting could otherwise count Stops as model defects).

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -1,4 +1,4 @@
-import type { BrainModelInfo, BrainProviderResponse, BrainSession } from "./brain-session.js";
+import type { BrainModelInfo, BrainProviderResponse, BrainSession, PromptImage } from "./brain-session.js";
 
 export type ModelRouteFailureKind =
   | "billing"
@@ -506,9 +506,10 @@ export async function runPromptWithModelRouting(
   policy: ModelRoutePolicy | undefined,
   state: ModelRouteState,
   options: RunPromptWithModelRoutingOptions = {},
+  images?: PromptImage[],
 ): Promise<ModelRouteRunResult> {
   if (!isModelRoutePolicyEnabled(policy)) {
-    await brain.prompt(text);
+    await brain.prompt(text, images);
     return { success: true, exhausted: false, attempted: [] };
   }
 
@@ -597,7 +598,7 @@ export async function runPromptWithModelRouting(
     // buffer every attempt, since a live failed attempt would leak into the
     // turn they persist from collected events.
     const streamFromStart = optimisticPrimaryStream && i === 0;
-    const attemptResult = await runAttempt(brain, text, candidate, emitBrainEvent, streamFromStart);
+    const attemptResult = await runAttempt(brain, text, candidate, emitBrainEvent, streamFromStart, images);
     const failure = attemptResult.failure;
     attempt.finishedAt = now();
 
@@ -779,6 +780,7 @@ async function runAttempt(
   candidate: ModelRouteCandidate,
   emitBrainEvent: (event: unknown) => void,
   streamFromStart: boolean,
+  images?: PromptImage[],
 ): Promise<AttemptResult> {
   const checkpoint = brain.createPromptCheckpoint?.();
   let lastProviderResponse: BrainProviderResponse | undefined;
@@ -888,7 +890,7 @@ async function runAttempt(
         },
       };
     }
-    await brain.prompt(text);
+    await brain.prompt(text, images);
   } catch (err) {
     const message = errorMessage(err);
     return {

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -50,6 +50,8 @@ export interface PromptOptions {
   };
   /** Optional ordered model fallback policy. Omitted means legacy single-model behavior. */
   modelRouting?: ModelRoutePolicy;
+  /** Image attachments (raw base64, no data: prefix) forwarded as vision input. */
+  images?: Array<{ mimeType: string; data: string }>;
 }
 
 export interface PromptResponse {

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -171,6 +171,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
 
     const modelConfig = params.modelConfig as PromptOptions["modelConfig"];
     const modelRouting = params.modelRouting as PromptOptions["modelRouting"];
+    const images = params.images as PromptOptions["images"];
     const promptOpts: PromptOptions = {
       sessionId,
       text,
@@ -181,6 +182,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       mode: params.mode as string | undefined,
       modelConfig,
       modelRouting,
+      images,
     };
 
     // Async-ack protocol: return { ok, sessionId } within milliseconds; do


### PR DESCRIPTION
## What
Thread image attachments from the chat path down to pi-agent so vision-capable models (e.g. the ChatGPT/Codex gpt-5.x subscription) read pasted/attached images as **native vision input**, instead of relying on OCR-to-text.

## Why
The chat transport was text-only at every hop (`chat.send` RPC → agentbox `/prompt` → `brain.prompt` → pi-agent), so image bytes were dropped before reaching the model. pi-ai + pi-coding-agent already support image input end-to-end (they serialize `{type:"image"}` to `input_image` data URLs and gate on `model.input` including `"image"`); the only missing piece was plumbing the bytes through siclaw's layers.

## Changes
- `BrainSession.prompt(text, images?)` carries `PromptImage[]` (raw base64).
- `PiAgentBrain` maps them to pi-ai `ImageContent` and passes via `session.prompt(text, { images })`; re-passed on empty-response retries.
- `runPromptWithModelRouting` / `runAttempt` thread images to each attempt.
- agentbox `/prompt` accepts + validates an `images` field (≤4, png/jpeg/webp, ≤8MB b64); image-only messages allowed with a minimal default instruction.
- gateway `chat.send` + `AgentBoxClient` `PromptOptions` carry images.

Sicore advertises `input:["text","image"]` for codex/vision models and forwards the raw image (separate sicore MR).

## Test
- New unit tests: image passthrough / image-only / malformed-drop (http-server), `{mimeType,data}`→`ImageContent` mapping (pi-agent-brain), routing threads images to each attempt.
- `npm test` green for model-routing / http-server / pi-agent-brain / brain-session (131 tests); `tsc --noEmit` clean.
- Verified end-to-end in a live cluster: gpt-5.5 read a pasted screenshot and extracted ticket IDs from it (OCR confirmed not involved).
