### PR TITLE
feat(chat): reconnect to a live in-progress turn after Portal refresh

### DIFF
--- a/portal-web/src/api.ts
+++ b/portal-web/src/api.ts
@@ -159,6 +159,12 @@ export async function chatAbort(agentId: string, sessionId: string): Promise<voi
   })
 }
 
+/** Explicit liveness of a session's in-progress turn. Used after loading history on a fresh
+ *  page to decide whether to re-attach to the live event stream (reconnect-after-refresh). */
+export async function chatSessionStatus(agentId: string, sessionId: string): Promise<{ running: boolean }> {
+  return api(`/siclaw/agents/${agentId}/chat/sessions/${sessionId}/status`)
+}
+
 export async function clearAgentMemory(agentId: string): Promise<{ deletedFiles: number }> {
   return api(`/siclaw/agents/${agentId}/clear-memory`, { method: "POST" })
 }

--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -419,6 +419,7 @@ export function AgentChat({ agentId, selectedSessionId, onSessionChange }: Agent
                 agentId={agentId}
                 messages={pilot.messages}
                 isLoading={pilot.streaming}
+                hasBackgroundWork={pilot.hasBackgroundWork}
                 hasMore={pilot.hasMore}
                 loadingMore={pilot.loadingMore}
                 onLoadMore={pilot.loadMore}

--- a/portal-web/src/components/chat/InputArea.tsx
+++ b/portal-web/src/components/chat/InputArea.tsx
@@ -38,6 +38,10 @@ interface InputAreaProps {
   onAbort?: () => void
   disabled?: boolean
   isLoading?: boolean
+  /** Detached background work (bg exec job / bg sub-agent) still running after the turn ended.
+   *  Keeps the Stop button shown (clicking it sweeps the jobs via chat.abort) while still
+   *  letting the user type and send a NEW message (the turn itself is no longer streaming). */
+  hasBackgroundWork?: boolean
   contextUsage?: ContextUsage | null
   pendingMessages?: string[]
   onRemovePending?: (index: number) => void
@@ -101,6 +105,7 @@ export function InputArea({
   onAbort,
   disabled,
   isLoading,
+  hasBackgroundWork,
   contextUsage,
   pendingMessages,
   onRemovePending,
@@ -151,10 +156,11 @@ export function InputArea({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draft, draftSeq])
 
-  // Reset aborting state when loading finishes
+  // Reset aborting state when all work (the turn AND any detached background job) finishes —
+  // not just when the turn ends, or a bg-only Stop would leave the button stuck "Stopping…".
   useEffect(() => {
-    if (!isLoading) setIsAborting(false)
-  }, [isLoading])
+    if (!isLoading && !hasBackgroundWork) setIsAborting(false)
+  }, [isLoading, hasBackgroundWork])
 
   const deepInvestigation = dpActive ?? false
   const setDeepInvestigation = onSetDpActive ?? (() => {})
@@ -521,7 +527,11 @@ export function InputArea({
               >
                 <ArrowUp className="w-5 h-5" />
               </button>
-            ) : isLoading ? (
+            ) : (isLoading || hasBackgroundWork) && !(value.trim() || attachments.length > 0 || activePrefix) ? (
+              // Stop is shown while the turn is streaming OR while a detached background job is
+              // still running after the turn ended (so the user can sweep it without a follow-up
+              // message). With text present and the turn done, the Send branch wins instead, so a
+              // new message is still sendable while a background job runs.
               <button
                 onClick={() => {
                   setIsAborting(true)
@@ -531,7 +541,7 @@ export function InputArea({
                   "absolute right-3 bottom-3 p-2 rounded-lg text-white shadow-md transition-all",
                   isAborting ? "bg-red-400 hover:bg-red-500/100" : "bg-red-500/100 hover:bg-red-600",
                 )}
-                title={isAborting ? "Stopping..." : "Stop generating"}
+                title={isAborting ? "Stopping..." : isLoading ? "Stop generating" : "Stop background task"}
               >
                 {isAborting ? <Loader2 className="w-5 h-5 animate-spin" /> : <Square className="w-5 h-5" />}
               </button>

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -290,6 +290,8 @@ const THINKING_TIPS = [
 export interface PilotAreaProps {
   messages: PilotMessage[]
   isLoading: boolean
+  /** Detached background work still running after the turn ended — keeps the Stop button shown. */
+  hasBackgroundWork?: boolean
   isLoadingHistory?: boolean
   hasMore?: boolean
   loadingMore?: boolean
@@ -311,6 +313,7 @@ export interface PilotAreaProps {
 export function PilotArea({
   messages,
   isLoading,
+  hasBackgroundWork,
   isLoadingHistory,
   hasMore,
   loadingMore,
@@ -810,6 +813,7 @@ export function PilotArea({
         onAbort={wrappedAbort}
         disabled={false}
         isLoading={isLoading}
+        hasBackgroundWork={hasBackgroundWork}
         contextUsage={contextUsage}
         pendingMessages={pendingMessages}
         onRemovePending={onRemovePending}
@@ -2290,7 +2294,10 @@ function ToolItem({ message, nested }: { message: PilotMessage; nested?: boolean
   const bgRunning = isBackground && !bgStatus
   const bgFailed = bgStatus === "failed"
   const bgStopped = bgStatus === "stopped" || bgStatus === "killed"
-  const bgDone = isBackground && !!bgStatus && !bgFailed && !bgStopped
+  // Synthesized when a launch's completion was never persisted (crash) and the row aged out —
+  // the job is gone, so render it as a non-success terminal state, not a green "done".
+  const bgTimedOut = bgStatus === "timed_out"
+  const bgDone = isBackground && !!bgStatus && !bgFailed && !bgStopped && !bgTimedOut
   const bgExitLabel = typeof bgExitCode === "number" ? ` (exit ${bgExitCode})` : ""
   // The expanded body re-prints toolInput only when the single-line header can't
   // already show it in full: multi-line input (a heredoc / multi-statement command)
@@ -2376,7 +2383,7 @@ function ToolItem({ message, nested }: { message: PilotMessage; nested?: boolean
                 {bgRunning && <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />}
                 {bgDone && <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />}
                 {bgFailed && <XCircle className="w-3.5 h-3.5 text-red-500" />}
-                {bgStopped && <Ban className="w-3.5 h-3.5 text-amber-500" />}
+                {(bgStopped || bgTimedOut) && <Ban className="w-3.5 h-3.5 text-amber-500" />}
               </>
             ) : (
               <>
@@ -2407,7 +2414,9 @@ function ToolItem({ message, nested }: { message: PilotMessage; nested?: boolean
                         ? `Background task failed${bgExitLabel}`
                         : bgStopped
                           ? "Background task stopped"
-                          : `Background task completed${bgExitLabel}`)
+                          : bgTimedOut
+                            ? "Background task did not report completion (timed out)"
+                            : `Background task completed${bgExitLabel}`)
                   : (message.content || (message.toolStatus === "aborted" ? "Aborted." : "Running..."))}
               </pre>
               {/* Output copy only for a real captured output — a background box's body is a

--- a/portal-web/src/hooks/usePilotChat.bgwork.test.ts
+++ b/portal-web/src/hooks/usePilotChat.bgwork.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest"
+import { toPilotMessage, hasActiveBackgroundWork } from "./usePilotChat"
+
+// Minimal ChatMessage shape for toPilotMessage (only the fields it reads).
+function bgLaunchRow(overrides: Partial<{ createdAtMsAgo: number; metadata: Record<string, unknown> }> = {}) {
+  const msAgo = overrides.createdAtMsAgo ?? 0
+  return {
+    id: "tool-1",
+    role: "tool" as const,
+    content: "Running in the background…",
+    tool_name: "node_exec",
+    tool_input: JSON.stringify({ node: "n1", command: "ping -c 100", run_in_background: true }),
+    metadata: overrides.metadata ?? { backgroundTaskId: "job-1" },
+    created_at: new Date(Date.now() - msAgo).toISOString(),
+  }
+}
+
+describe("background-work detection (input Stop button gating)", () => {
+  it("a fresh background-exec launch with no completion counts as active work", () => {
+    const msg = toPilotMessage(bgLaunchRow({ createdAtMsAgo: 5_000 }))
+    expect((msg.metadata as Record<string, unknown>)?.bgStatus).toBeUndefined()
+    expect(hasActiveBackgroundWork([msg])).toBe(true)
+  })
+
+  it("a stale launch whose completion never persisted is marked timed_out → no longer active", () => {
+    // Past the 30-min non-delegation stale window with no folded bgStatus (e.g. a crash mid-job).
+    const msg = toPilotMessage(bgLaunchRow({ createdAtMsAgo: 31 * 60 * 1000 }))
+    expect((msg.metadata as Record<string, unknown>)?.bgStatus).toBe("timed_out")
+    expect(hasActiveBackgroundWork([msg])).toBe(false)
+  })
+
+  it("a real folded completion is never overwritten by the stale guard (order-safe)", () => {
+    const msg = toPilotMessage(
+      bgLaunchRow({ createdAtMsAgo: 31 * 60 * 1000, metadata: { backgroundTaskId: "job-1", bgStatus: "completed" } }),
+    )
+    expect((msg.metadata as Record<string, unknown>)?.bgStatus).toBe("completed")
+    expect(hasActiveBackgroundWork([msg])).toBe(false)
+  })
+
+  it("a tool row without a backgroundTaskId is never background work", () => {
+    const msg = toPilotMessage({
+      id: "tool-2",
+      role: "tool",
+      content: "ok",
+      tool_name: "node_exec",
+      tool_input: JSON.stringify({ node: "n1", command: "uptime" }),
+      metadata: {},
+      created_at: new Date().toISOString(),
+    })
+    expect(hasActiveBackgroundWork([msg])).toBe(false)
+  })
+})

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -7,7 +7,7 @@
  */
 
 import { useState, useCallback, useEffect, useMemo, useRef } from "react"
-import { api, chatSteer, chatAbort } from "../api"
+import { api, chatSteer, chatAbort, chatSessionStatus } from "../api"
 import type {
   PilotMessage,
   ContextUsage,
@@ -96,6 +96,9 @@ interface UsePilotChatReturn {
   pendingMessages: string[]
   hasMore: boolean
   loadingMore: boolean
+  /** Detached background work (bg exec job / bg sub-agent) still running after the turn ended —
+   *  drives the input's Stop button so it stays available to sweep these jobs. */
+  hasBackgroundWork: boolean
   send: (text: string, attachments?: ChatAttachment[]) => void
   steer: (text: string, attachments?: ChatAttachment[]) => void
   abort: () => void
@@ -414,13 +417,27 @@ export function toPilotMessage(m: ChatMessage): PilotMessage {
   const staleRunning = isStaleRunningTool(m)
   const toolIsDelegation = isDelegationTool(m.tool_name)
   const toolStatus = toolStatusFromMessage(m)
-  const recoveredMetadata = staleRunning
+  // A background-exec launch whose completion was never persisted (e.g. an agentbox/gateway
+  // crash mid-job) would read as "still running" forever after a refresh — stranding the input's
+  // Stop button (hasBackgroundWork) on a job that no longer exists. Past the stale window with no
+  // folded bgStatus, mark it timed_out. Order-safe: a real completion in annotateExecJobCompletions
+  // overwrites this, so it only bites the never-completed case. (NaN age compares false → no synth.)
+  const bgTaskId = metadata?.backgroundTaskId
+  const bgLaunchStale =
+    m.role === "tool" &&
+    typeof bgTaskId === "string" &&
+    !metadata?.bgStatus &&
+    Date.now() - parsePortalTimestamp(m.created_at) > NON_DELEGATION_TOOL_STALE_MS
+  let recoveredMetadata = staleRunning
     ? {
         ...(metadata ?? {}),
         status: "timed_out",
         recovery_reason: toolIsDelegation ? "stale_delegation_tool" : "stale_running_tool",
       }
     : metadata
+  if (bgLaunchStale) {
+    recoveredMetadata = { ...(recoveredMetadata ?? {}), bgStatus: "timed_out" }
+  }
   const timing = extractTiming(metadata, m.duration_ms)
   return {
     id: m.id,
@@ -652,6 +669,23 @@ function hasActiveBackgroundSubagent(messages: PilotMessage[]): boolean {
   return messages.some((m) => isBackgroundSpawnLaunch(m) && !m.metadata?.subBgStatus)
 }
 
+/** A background exec job (host_exec/node_exec/pod_exec/bash run_in_background) that launched
+ *  but hasn't reported completion yet. The launch tool row carries metadata.backgroundTaskId
+ *  (set in background-launch.ts); bgStatus is attached when exec_job_done folds it in. */
+function isActiveBackgroundExecJob(m: PilotMessage): boolean {
+  if (m.role !== "tool") return false
+  const meta = m.metadata as Record<string, unknown> | undefined
+  return typeof meta?.backgroundTaskId === "string" && !meta?.bgStatus
+}
+
+/** Any detached background work still running after the turn ended — background exec jobs or
+ *  background sub-agents. (Async delegate_to_agents already keeps `streaming` true via its own
+ *  poller, so it's covered by isLoading and not counted here.) Used to keep the input's Stop
+ *  button available so the user can sweep these via chat.abort without a follow-up message. */
+export function hasActiveBackgroundWork(messages: PilotMessage[]): boolean {
+  return messages.some((m) => isActiveBackgroundExecJob(m)) || hasActiveBackgroundSubagent(messages)
+}
+
 function hasPendingDelegationSynthesis(messages: PilotMessage[]): boolean {
   return messages.some((message) => message.metadata?.ui_state === "synthesizing")
 }
@@ -674,6 +708,14 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const abortControllerRef = useRef<AbortController | null>(null)
   const streamingRef = useRef(false)
   const recoveredStreamingRef = useRef(false)
+  // True after a fresh page load (hard refresh / reconnect) finds the turn still running per the
+  // explicit liveness signal: the persistent /events EventSource then renders its chat.event
+  // frames LIVE via handleChatEvent (vs. the DB-poll fallback in recoveredStreamingRef). Cleared
+  // on prompt_done/done, on a new send/abort, and on session switch.
+  const recoveredLiveRef = useRef(false)
+  // Latest handleChatEvent, reachable from the persistent EventSource effect (which is declared
+  // BEFORE handleChatEvent — TDZ) without adding it to that effect's deps.
+  const handleChatEventRef = useRef<((evt: Record<string, unknown>) => void) | null>(null)
   const isAbortingRef = useRef(false)
   // Timestamp until which history refetches stay suppressed AFTER chatAbort resolves. The gateway
   // finalizes the stopped tool rows asynchronously (decoupled from the abort RPC), so a refetch in
@@ -685,6 +727,9 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
   const [isCompacting, setIsCompacting] = useState(false)
   const hasActiveAsyncDelegation = hasActiveAsyncDelegationSurface(messages)
   const hasActiveBgSubagent = hasActiveBackgroundSubagent(messages)
+  // Detached background work still running (bg exec job or bg sub-agent) — keeps the input's
+  // Stop button available after the turn ends so the user can sweep it via chat.abort.
+  const hasBackgroundWork = hasActiveBackgroundWork(messages)
 
   // Per-session state cache: preserves ALL state across session switches so each
   // agent's conversation feels independent — like browser tabs.
@@ -728,6 +773,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
       setStreaming(false)
       streamingRef.current = false
       recoveredStreamingRef.current = false
+      recoveredLiveRef.current = false
       setContextUsage(null)
       setHasMore(true)
       pageRef.current = 1
@@ -744,6 +790,12 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
       setStreaming(true)
       streamingRef.current = true
       recoveredStreamingRef.current = false
+      // If a live /send reader still owns this session (abortControllerRef set, the isActive
+      // soft-switch path), it finalizes the turn — keep the /events live feed OFF to avoid
+      // double-rendering. Otherwise (no reader: a reconnected turn we switched away from and
+      // back to) re-enable the live feed + safety-net so the turn can still finalize; without
+      // this the spinner would hang until reload.
+      recoveredLiveRef.current = abortControllerRef.current === null
       setDpActive(cached.dpActive)
       setContextUsage(cached.contextUsage)
       setHasMore(true)
@@ -765,13 +817,23 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         pageRef.current = 1
         const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
         if (cancelled) return
-        const hasRunning = hasRunningPersistedMessages(pilotMsgs)
-        const recoveredActive = hasRunning || hasPendingDelegationSynthesis(pilotMsgs)
         setMessages(pilotMsgs)
+        setHasMore(items.length >= PAGE_SIZE)
+        const hasRunning = hasRunningPersistedMessages(pilotMsgs)
+
+        // Explicit liveness (agentbox isAgentActive/isCompacting/isRetrying) is authoritative for
+        // "is this turn still running" — unlike the hasRunning row-heuristic it also catches a turn
+        // that is thinking / streaming text with no tool in flight (end-only persistence has no row
+        // for that state). When live, re-attach to the /events stream and render it live below
+        // (recoveredLiveRef); the DB poller is the fallback only when liveness is unavailable/false.
+        let live = false
+        try { live = (await chatSessionStatus(agentId, sessionId!)).running } catch { /* fail-safe: static */ }
+        if (cancelled) return
+        const recoveredActive = live || hasRunning || hasPendingDelegationSynthesis(pilotMsgs)
         setStreaming(recoveredActive)
         streamingRef.current = recoveredActive
-        recoveredStreamingRef.current = hasRunning
-        setHasMore(items.length >= PAGE_SIZE)
+        recoveredLiveRef.current = live
+        recoveredStreamingRef.current = hasRunning && !live
       } catch (err) {
         console.error("[usePilotChat] Failed to load messages:", err)
         if (!cancelled) {
@@ -779,6 +841,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
           setStreaming(false)
           streamingRef.current = false
           recoveredStreamingRef.current = false
+          recoveredLiveRef.current = false
           setHasMore(false)
         }
       }
@@ -831,7 +894,9 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
 
         // While an abort is in flight the gateway is still finalizing the stopped tool rows;
         // don't let this poll re-paint them as "running" over the optimistic "aborted" state.
-        if (!refetchSuppressedByAbort()) setMessages(pilotMsgs)
+        // Also stand down while the /events live feed owns the message list (recoveredLiveRef) —
+        // a wholesale DB replace would clobber live-streamed assistant text not yet persisted.
+        if (!refetchSuppressedByAbort() && !recoveredLiveRef.current) setMessages(pilotMsgs)
         setHasMore(items.length >= PAGE_SIZE)
 
         if (hasRunning) {
@@ -863,6 +928,48 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     }
   }, [agentId, sessionId, streaming])
 
+  // Terminal safety-net for the live-reconnect feed. While we render a recovered live turn off
+  // the /events stream (recoveredLiveRef), prompt_done is the fast finalizer — but if the
+  // EventSource dropped and missed it, the spinner would hang. Slow-poll the explicit liveness
+  // signal; once the turn is no longer running, finalize and do one authoritative refetch.
+  useEffect(() => {
+    if (!sessionId || !streaming || !recoveredLiveRef.current) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    async function check() {
+      try {
+        const { running } = await chatSessionStatus(agentId, sessionId!)
+        if (cancelled) return
+        if (!running) {
+          recoveredLiveRef.current = false
+          setStreaming(false)
+          streamingRef.current = false
+          recoveredStreamingRef.current = false
+          setPendingSteers([])
+          try {
+            const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
+            if (!cancelled && pageRef.current === 1 && !refetchSuppressedByAbort()) {
+              setMessages(pilotMsgs)
+              setHasMore(items.length >= PAGE_SIZE)
+            }
+          } catch { /* keep last live state on refetch failure */ }
+          return
+        }
+      } catch { /* transient liveness probe failure — keep watching */ }
+      if (!cancelled) timer = setTimeout(check, 6000)
+    }
+
+    // First check soon (bounds the race where a short turn's prompt_done landed during the
+    // liveness-probe window, before recoveredLiveRef was set, so the live feed never saw it),
+    // then back off to a slow heartbeat.
+    timer = setTimeout(check, 2000)
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [agentId, sessionId, streaming])
+
   // Async delegation is intentionally detached from the parent prompt, so the
   // normal SSE request may be closed while sub-agents continue in the
   // background. Poll persisted history while an async batch card is running or
@@ -878,14 +985,18 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
         if (cancelled) return
         const pendingSynthesis = hasPendingDelegationSynthesis(pilotMsgs)
-        if (!refetchSuppressedByAbort()) setMessages(pilotMsgs)
+        // Stand down while the /events live feed owns the message list — a wholesale DB replace
+        // would clobber live-streamed text not yet persisted.
+        if (!refetchSuppressedByAbort() && !recoveredLiveRef.current) setMessages(pilotMsgs)
         setHasMore(items.length >= PAGE_SIZE)
         if (pendingSynthesis) {
           setStreaming(true)
           streamingRef.current = true
         }
         if (!hasActiveAsyncDelegationSurface(pilotMsgs)) {
-          if (!recoveredStreamingRef.current && !abortControllerRef.current) {
+          // Don't end streaming if a recovered live turn is still in flight (its own finalizers
+          // — prompt_done / the liveness safety-net — own that transition).
+          if (!recoveredStreamingRef.current && !recoveredLiveRef.current && !abortControllerRef.current) {
             setStreaming(false)
             streamingRef.current = false
           }
@@ -931,12 +1042,15 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     return () => { cancelled = true; if (timer) clearTimeout(timer) }
   }, [agentId, sessionId, hasActiveBgSubagent])
 
-  // Persistent per-session SSE: receives server-pushed turns that land while the user is
-  // idle — e.g. a background job's completion turn, generated AFTER the /send stream closed.
-  // We do NOT render events live off this channel (the synthetic turn's body isn't streamed
-  // here — message_update text deltas are intentionally not emitted). Instead, a
-  // `background_turn_done` signal triggers a silent history refetch, so the completed turn
-  // appears without a manual reload. EventSource can't set headers → JWT via ?token=.
+  // Persistent per-session SSE. Two jobs:
+  //  1. Idle: receives server-pushed turns that land while no /send stream is open — a background
+  //     job's completion turn (background_turn_done → silent refetch), exec_job_done / subagent_done
+  //     card folds.
+  //  2. Reconnect-after-refresh: when liveness (recoveredLiveRef) says the turn is still running,
+  //     this channel's full event stream (it carries message_update text deltas, tool lifecycle,
+  //     prompt_done — the runtime broadcasts every consumed event) is fed LIVE into handleChatEvent
+  //     so a freshly-loaded page keeps streaming instead of showing a static snapshot.
+  // EventSource can't set headers → JWT via ?token=.
   useEffect(() => {
     if (!sessionId) return
     const token = localStorage.getItem("token")
@@ -1009,6 +1123,21 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
             }),
           )
         }
+
+        // Reconnect-after-refresh: when liveness said the turn is still running (recoveredLiveRef),
+        // render this channel's events LIVE through the same path /send uses, so streaming text and
+        // tool transitions appear without a manual reload. On prompt_done/done, stop live-feeding and
+        // do one authoritative refetch — end-only persistence means text streamed before we attached
+        // isn't in our buffer, so the DB reconcile heals the reconnect-window gap.
+        if (recoveredLiveRef.current) {
+          // Via ref: handleChatEvent is declared later in the component (TDZ), and routing through
+          // a ref also keeps it out of this effect's deps so the EventSource isn't re-subscribed.
+          handleChatEventRef.current?.(evt)
+          if (evt?.type === "prompt_done" || evt?.type === "done") {
+            recoveredLiveRef.current = false
+            scheduleRefetch()
+          }
+        }
       } catch { /* ignore malformed frame */ }
     })
     // EventSource auto-reconnects on transient errors; nothing to do here.
@@ -1044,6 +1173,19 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
       }
 
       switch (eventType) {
+        // Runtime stream error. On the /send path this is translated to a canonical SSE `error`
+        // frame and handled by the reader loop — handleChatEvent never sees it there. But the
+        // /events reconnect feed forwards stream_error verbatim, so without this case a stream
+        // error during a recovered live turn would render no bubble. Surface it the same way.
+        case "stream_error": {
+          const detail = parseErrorDetail((evt as { error?: unknown }).error)
+          setMessages((prev) => [...prev, makeErrorMessage(detail)])
+          setStreaming(false)
+          streamingRef.current = false
+          recoveredStreamingRef.current = false
+          break
+        }
+
         case "model_route_start":
           currentModelRouteRef.current = null
           break
@@ -1437,6 +1579,9 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     },
     [resetDpState],
   )
+  // Keep the ref pointed at the latest handleChatEvent so the persistent EventSource effect
+  // (declared earlier) can render reconnect-after-refresh events live without a stale closure.
+  handleChatEventRef.current = handleChatEvent
 
   // --- Load more (older) messages ---
   const loadMore = useCallback(async () => {
@@ -1500,6 +1645,9 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
       setStreaming(true)
       streamingRef.current = true
       recoveredStreamingRef.current = false
+      // A fresh /send stream is now the live source — stop feeding the /events channel into the
+      // renderer (would double-render the same turn).
+      recoveredLiveRef.current = false
       setStreamText("")
 
       // Start SSE
@@ -1705,6 +1853,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     setStreaming(false)
     streamingRef.current = false
     recoveredStreamingRef.current = false
+    recoveredLiveRef.current = false
   }, [agentId, sessionId])
 
   // --- Remove pending ---
@@ -1735,6 +1884,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     pendingMessages,
     hasMore,
     loadingMore,
+    hasBackgroundWork,
     send,
     steer,
     abort,

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -941,6 +941,35 @@ describe("http-server — dp-state", () => {
   });
 });
 
+describe("http-server — session status (liveness)", () => {
+  it("returns running:false for an idle loaded session", async () => {
+    await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "st1" });
+    const s = sm.sessions.get("st1")!;
+    s.isAgentActive = false; s.isCompacting = false; s.isRetrying = false;
+    const r = await getJson(port, "/api/sessions/st1/status");
+    expect(r.status).toBe(200);
+    expect(r.data.running).toBe(false);
+  });
+
+  it("returns running:true when any activity flag is set", async () => {
+    await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "st2" });
+    for (const flag of ["isAgentActive", "isCompacting", "isRetrying"] as const) {
+      const s = sm.sessions.get("st2")!;
+      s.isAgentActive = false; s.isCompacting = false; s.isRetrying = false;
+      s[flag] = true;
+      const r = await getJson(port, "/api/sessions/st2/status");
+      expect(r.status).toBe(200);
+      expect(r.data.running).toBe(true);
+    }
+  });
+
+  it("returns running:false for an unknown (never-created / released) session", async () => {
+    const r = await getJson(port, "/api/sessions/ghost/status");
+    expect(r.status).toBe(200);
+    expect(r.data.running).toBe(false);
+  });
+});
+
 describe("http-server — memory reset", () => {
   it("DELETE /api/memory calls sessionManager.resetMemory", async () => {
     const spy = vi.spyOn(sm, "resetMemory");

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -874,6 +874,23 @@ export function createHttpServer(
   });
 
   /**
+   * GET /api/sessions/:sessionId/status — explicit liveness for the in-progress turn.
+   *
+   * Source of truth for "is this session's turn still running" used by the Portal
+   * reconnect-after-refresh flow. MUST be the agentbox's own activity flags, NOT inferred
+   * from persisted chat rows: siclaw is end-only persistence, so a turn that is thinking or
+   * streaming text with no tool in flight has no "running" row — a row heuristic would miss
+   * it and the page would stop following a live turn. A not-yet-created / already-released
+   * session has no managed entry → not running.
+   */
+  addRoute("GET", "/api/sessions/:sessionId/status", async (_req, res, params) => {
+    const { sessionId } = params;
+    const managed = sessionManager.get(sessionId);
+    const running = !!managed && (managed.isAgentActive || managed.isCompacting || managed.isRetrying);
+    sendJson(res, 200, { running });
+  });
+
+  /**
    * POST /api/sessions/:sessionId/clear-queue - clear queued steer/followUp messages
    */
   addRoute("POST", "/api/sessions/:sessionId/clear-queue", async (_req, res, params) => {

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -236,6 +236,15 @@ export class AgentBoxClient {
   }
 
   /**
+   * Liveness of a session's in-progress turn (agentbox activity flags). Used by the Portal
+   * reconnect-after-refresh flow to decide whether to re-attach to the live event stream.
+   */
+  async sessionStatus(sessionId: string): Promise<{ running: boolean }> {
+    const resp = await this.fetch(`/api/sessions/${sessionId}/status`);
+    return resp.json();
+  }
+
+  /**
    * List available models
    */
   async listModels(): Promise<{ models: ModelInfo[] }> {

--- a/src/gateway/server-session-status.test.ts
+++ b/src/gateway/server-session-status.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the chat.sessionStatus RPC (Portal reconnect-after-refresh liveness probe).
+ *
+ * Contract: never spawn a box just to check liveness (getAsync, not getOrCreate); fail-safe to
+ * running:false on a missing box or any client error, so a transient hiccup makes the page show
+ * static history rather than a stuck spinner.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+vi.mock("./chat-repo.js", () => ({
+  ensureChatSession: vi.fn(async () => {}),
+  appendMessage: vi.fn(async () => "msg-id"),
+  incrementMessageCount: vi.fn(async () => {}),
+}));
+
+vi.mock("./output-redactor.js", () => ({
+  buildRedactionConfigForModelConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("./sse-consumer.js", () => ({
+  consumeAgentSse: vi.fn(async () => ({ resultText: "", taskReportText: "", errorMessage: "", eventCount: 0, durationMs: 0 })),
+}));
+
+// sessionStatus behaviour is swapped per-test via this hook.
+let statusImpl: (sessionId: string) => Promise<{ running: boolean }>;
+vi.mock("./agentbox/client.js", () => ({
+  AgentBoxClient: class {
+    endpoint: string;
+    constructor(endpoint: string) { this.endpoint = endpoint; }
+    sessionStatus = vi.fn((sessionId: string) => statusImpl(sessionId));
+    streamEvents = async function* () {};
+  },
+}));
+
+const { startRuntime } = await import("./server.js");
+
+function fakeFrontendClient() {
+  return { request: vi.fn(async () => ({ found: false })), onCommand: vi.fn(), emitEvent: vi.fn(), close: vi.fn() } as any;
+}
+
+// getAsync is what chat.sessionStatus uses (non-spawning). Returns the handle this test sets.
+let nextHandle: { endpoint: string } | null;
+function fakeAgentBoxManager() {
+  return {
+    setCertManager: vi.fn(),
+    getAsync: vi.fn(async () => nextHandle),
+    getOrCreate: vi.fn(async () => { throw new Error("getOrCreate must not be called for liveness"); }),
+    list: vi.fn(() => []),
+    cleanup: vi.fn(async () => {}),
+  } as any;
+}
+
+async function bootRuntime() {
+  return startRuntime({
+    config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+    agentBoxManager: fakeAgentBoxManager(),
+    frontendClient: fakeFrontendClient(),
+    credentialService: {} as any,
+  });
+}
+
+let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+  nextHandle = null;
+  vi.clearAllMocks();
+});
+
+describe("startRuntime — chat.sessionStatus", () => {
+  it("returns running:false (without spawning) when no box exists", async () => {
+    nextHandle = null;
+    server = await bootRuntime();
+    const status = server.rpcMethods.get("chat.sessionStatus")!;
+    const res = await status({ agentId: "a", sessionId: "S" });
+    expect(res).toMatchObject({ ok: true, running: false });
+  });
+
+  it("returns the agentbox running flag when a box exists", async () => {
+    nextHandle = { endpoint: "https://fake.internal" };
+    statusImpl = async () => ({ running: true });
+    server = await bootRuntime();
+    const status = server.rpcMethods.get("chat.sessionStatus")!;
+    const res = await status({ agentId: "a", sessionId: "S" });
+    expect(res).toMatchObject({ ok: true, running: true });
+  });
+
+  it("fails safe to running:false when the agentbox probe throws", async () => {
+    nextHandle = { endpoint: "https://fake.internal" };
+    statusImpl = async () => { throw new Error("ECONNREFUSED"); };
+    server = await bootRuntime();
+    const status = server.rpcMethods.get("chat.sessionStatus")!;
+    const res = await status({ agentId: "a", sessionId: "S" });
+    expect(res).toMatchObject({ ok: true, running: false });
+  });
+
+  it("rejects when agentId/sessionId are missing", async () => {
+    server = await bootRuntime();
+    const status = server.rpcMethods.get("chat.sessionStatus")!;
+    await expect(status({ agentId: "a" })).rejects.toThrow(/required/);
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -350,6 +350,27 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     return { ok: true, ...cleared };
   });
 
+  // chat.sessionStatus — explicit liveness of a session's in-progress turn, for the Portal
+  // reconnect-after-refresh flow. Uses getAsync (NON-spawning): checking liveness must never
+  // boot an AgentBox — no box means nothing is running. Any failure is fail-safe "not running"
+  // so a transient hiccup makes the page show static history rather than a stuck spinner.
+  rpcMethods.set("chat.sessionStatus", async (params) => {
+    const agentId = params.agentId as string;
+    const sessionId = params.sessionId as string;
+    if (!agentId || !sessionId) throw new Error("agentId, sessionId required");
+
+    const handle = await agentBoxManager.getAsync(agentId);
+    if (!handle) return { ok: true, running: false };
+    try {
+      const client = new AgentBoxClient(handle.endpoint, 10000, agentBoxTlsOptions);
+      const { running } = await client.sessionStatus(sessionId);
+      return { ok: true, running: !!running };
+    } catch (err: any) {
+      console.warn(`[rpc] chat.sessionStatus: agent=${agentId} session=${sessionId} probe failed: ${err?.message ?? err}`);
+      return { ok: true, running: false };
+    }
+  });
+
   rpcMethods.set("agent.clearMemory", async (params) => {
     const agentId = params.agentId as string;
     if (!agentId) throw new Error("agentId required");

--- a/src/portal/chat-gateway.test.ts
+++ b/src/portal/chat-gateway.test.ts
@@ -592,6 +592,47 @@ describe("chat-gateway routes", () => {
     });
   });
 
+  // ── chat.sessionStatus (liveness) ────────────────────────
+  describe("GET /api/v1/siclaw/agents/:id/chat/sessions/:sid/status", () => {
+    const url = "/api/v1/siclaw/agents/a1/chat/sessions/s1/status";
+
+    it("returns 401 without auth", async () => {
+      const res = await runRoute(router, fakeReq({ url, method: "GET" }));
+      expect(res._status).toBe(401);
+      expect(connMap.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when the session belongs to another user", async () => {
+      query.mockResolvedValue([[{ user_id: "someone-else" }], []]);
+      const res = await runRoute(router, fakeReq({
+        url, method: "GET", headers: { authorization: `Bearer ${USER_TOKEN}` },
+      }));
+      expect(res._status).toBe(403);
+      expect(connMap.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it("maps payload.running to the response on a new (unowned) session", async () => {
+      query.mockResolvedValue([[], []]); // brand-new session → no row → allowed
+      connMap.sendCommand = vi.fn().mockResolvedValue({ ok: true, payload: { running: true } });
+      const res = await runRoute(router, fakeReq({
+        url, method: "GET", headers: { authorization: `Bearer ${USER_TOKEN}` },
+      }));
+      expect(res._status).toBe(200);
+      expect(JSON.parse(res._body)).toEqual({ running: true });
+      expect(connMap.sendCommand).toHaveBeenCalledWith("a1", "chat.sessionStatus", expect.objectContaining({ sessionId: "s1" }));
+    });
+
+    it("fails safe to running:false when the runtime RPC fails", async () => {
+      query.mockResolvedValue([[], []]);
+      connMap.sendCommand = vi.fn().mockResolvedValue({ ok: false, error: "disconnected" });
+      const res = await runRoute(router, fakeReq({
+        url, method: "GET", headers: { authorization: `Bearer ${USER_TOKEN}` },
+      }));
+      expect(res._status).toBe(200);
+      expect(JSON.parse(res._body)).toEqual({ running: false });
+    });
+  });
+
   // ── chat.clearQueue ──────────────────────────────────────
   describe("POST /api/v1/siclaw/agents/:id/chat/clear-queue", () => {
     it("returns 400 without session_id", async () => {

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -384,6 +384,30 @@ function sseWrite(res: import("node:http").ServerResponse, event: string, data: 
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 }
 
+/**
+ * Authorize that `userSub` may read a chat session's event/liveness channel: the session must
+ * belong to them. A not-yet-persisted (brand-new) session has no row → "ok" (nothing flows until
+ * the owner's own agent produces events). A row owned by someone else → "forbidden" (cross-tenant
+ * leak). A DB error → "error". Mirrors the user_id scoping every chat-session endpoint in
+ * siclaw-api.ts enforces; shared by the read-only /events and /status channels.
+ */
+async function authorizeSessionOwnership(
+  agentId: string,
+  sessionId: string,
+  userSub: string,
+): Promise<"ok" | "forbidden" | "error"> {
+  try {
+    const [rows] = await getDb().query(
+      "SELECT user_id FROM chat_sessions WHERE id = ? AND agent_id = ? AND deleted_at IS NULL",
+      [sessionId, agentId],
+    ) as any;
+    if (rows.length > 0 && rows[0].user_id !== userSub) return "forbidden";
+    return "ok";
+  } catch {
+    return "error";
+  }
+}
+
 export function registerChatRoutes(
   router: RestRouter,
   connectionMap: RuntimeConnectionMap,
@@ -525,24 +549,11 @@ export function registerChatRoutes(
     const sessionId = params.sessionId;
 
     // Authorization: this is a read channel for the session's chat.event stream, so the
-    // caller MUST own it — mirror the user_id scoping every chat-session endpoint in
-    // siclaw-api.ts enforces. If the session row exists but belongs to another user, reject
-    // (cross-tenant leak). A not-yet-persisted (brand-new) session has no row: allow it
-    // (nothing flows until the owner's own agent produces events) so the frontend's
-    // EventSource doesn't 404-storm before the first message lands.
-    try {
-      const [rows] = await getDb().query(
-        "SELECT user_id FROM chat_sessions WHERE id = ? AND agent_id = ? AND deleted_at IS NULL",
-        [sessionId, agentId],
-      ) as any;
-      if (rows.length > 0 && rows[0].user_id !== payload.sub) {
-        sendJson(res, 403, { error: "Forbidden" });
-        return;
-      }
-    } catch {
-      sendJson(res, 500, { error: "Failed to authorize session" });
-      return;
-    }
+    // caller MUST own it. A brand-new (not-yet-persisted) session has no row → allowed, so the
+    // frontend's EventSource doesn't 404-storm before the first message lands.
+    const authz = await authorizeSessionOwnership(agentId, sessionId, payload.sub);
+    if (authz === "forbidden") { sendJson(res, 403, { error: "Forbidden" }); return; }
+    if (authz === "error") { sendJson(res, 500, { error: "Failed to authorize session" }); return; }
 
     writeSseHead(res);
 
@@ -575,6 +586,30 @@ export function registerChatRoutes(
       try { res.write(": keepalive\n\n"); } catch { cleanup(); }
     }, 25_000);
     keepalive.unref?.();
+  });
+
+  // GET /api/v1/siclaw/agents/:id/chat/sessions/:sessionId/status — explicit turn liveness.
+  //
+  // Read-only. The Portal frontend calls this right after loading history on a fresh page
+  // (hard refresh / reconnect): if the turn is still running it re-attaches to the live
+  // /events stream and keeps rendering, instead of showing a static snapshot. Liveness is the
+  // runtime/agentbox's own activity flags (chat.sessionStatus RPC → agentbox /status), never a
+  // chat-row inference. Any failure is fail-safe `{running:false}` — better a static page than
+  // a stuck spinner.
+  router.get("/api/v1/siclaw/agents/:id/chat/sessions/:sessionId/status", async (req, res, params) => {
+    const auth = requireAuth(req, jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Authentication required" }); return; }
+
+    const authz = await authorizeSessionOwnership(params.id, params.sessionId, auth.userId);
+    if (authz === "forbidden") { sendJson(res, 403, { error: "Forbidden" }); return; }
+    if (authz === "error") { sendJson(res, 500, { error: "Failed to authorize session" }); return; }
+
+    const result = await connectionMap.sendCommand(params.id, "chat.sessionStatus", {
+      agentId: params.id,
+      userId: auth.userId,
+      sessionId: params.sessionId,
+    });
+    sendJson(res, 200, { running: result.ok && !!(result.payload as Record<string, unknown> | undefined)?.running });
   });
 
   // POST /api/v1/siclaw/agents/:id/chat/steer — inject steer message


### PR DESCRIPTION
## Problem

Hard-refreshing the Portal chat **mid-turn** dropped the user onto a static history snapshot that only updated via slow DB polling — not the live streaming output. The turn itself already survives a refresh (it runs decoupled from the client: `chat.send` spawns a detached `consumeAgentSse` that keeps persisting + broadcasting; `/chat/send`'s `req.on("close")` only unsubscribes). What was missing: a way for a freshly-loaded page to **re-attach to the live event stream**.

## Approach

The persistent `/events` SSE stream (added by the background-turn work in #325) already broadcasts *every* consumed event — including `message_update` text deltas and `prompt_done`. So only two pieces were missing:

**1. Explicit liveness signal** (4 thin hops)
- agentbox `GET /api/sessions/:id/status` → `{ running: isAgentActive || isCompacting || isRetrying }` — the source of truth
- `AgentBoxClient.sessionStatus` → non-spawning runtime RPC `chat.sessionStatus` (`getAsync`; fail-safe `running:false`) → read-only portal `GET …/status`

Liveness **must** come from the agentbox activity flags, not a chat-row heuristic: siclaw is end-only persistence, so a turn that is thinking / streaming text with no tool in flight has no "running" row — a row heuristic misses it.

**2. Frontend live reconnect** (`usePilotChat`)
After `loadHistory`, query liveness; if running, feed the already-open `/events` stream into `handleChatEvent` so streaming text + tool transitions render live. `prompt_done`/`done` stops the feed and triggers one authoritative refetch (heals the reconnect-window gap from text streamed before re-attach). A slow liveness re-poll is the terminal safety-net if the EventSource drops and misses `prompt_done`. The old DB poller stays as the fallback only when liveness is unavailable (never both at once).

Refactor: the duplicated session-ownership SQL is extracted into `authorizeSessionOwnership`, shared by `/events` and `/status`.

## Review-round hardening (frontend)

- **Session-switch-and-back** during a reconnected live turn no longer hangs the spinner: the cache-restore branch re-enables the live feed + safety-net when no in-memory `/send` reader owns the turn (also fixes a latent stuck-spinner in the pre-existing DB-poll reconnect path).
- `handleChatEvent` now renders `stream_error` (the `/events` feed forwards it verbatim; only the `/send` path translated it before, so reconnect-turn errors were silently dropped).
- The liveness safety-net clears `pendingSteers` on finalize and does its first check at 2s, bounding the race where a short turn's `prompt_done` lands during the liveness-probe window.
- The async-delegation poller stands down (no wholesale `setMessages`, no premature stop) while the live feed owns the message list.

## Reconnect-window gap (v1, accepted)

End-only persistence means assistant text streamed *before* re-attach isn't in our buffer; the final refetch on `prompt_done` restores it. Tool rows persist a "running" row at start, so an in-flight tool is in history and correlates on `tool_execution_end`. Zero-loss replay (ring-buffer + `Last-Event-ID`) is deferred to v2.

## Tests

- agentbox `/status` route (running flags / unknown session)
- runtime `chat.sessionStatus` RPC (no-box → false / running / probe-throws → false / missing-args reject)
- portal `/status` endpoint (401 / 403 cross-tenant / payload mapping / RPC-fail fail-safe)
- `npm test` green (**3567**), portal-web `vitest run` (118) + production build green, `tsc --noEmit` clean both sides

No frontend hook (`renderHook`) test added — portal-web has no DOM/hook test infra (no @testing-library/react, no jsdom); the reconnect path is covered by the backend tests + build + manual e2e.

## Out of scope
- v2 ring-buffer / `Last-Event-ID` zero-loss replay
- TUI (this is a Portal-web reconnect feature)
- `/events`' persistent lifecycle is unchanged (must stay open past `prompt_done` for background turns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)