### PR TITLE
feat(tools): keep plan panel visible until a new plan starts

### DIFF
--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -177,25 +177,14 @@ export function AgentChat({ agentId, selectedSessionId, onSessionChange }: Agent
   // Pilot-style chat hook
   const pilot = usePilotChat({ agentId, sessionId: activeSessionId })
 
-  // Plan panel visibility. The backend auto-clears a fully-completed plan ~5s
-  // after completion and emits a `reset` task_event — but that reset fires after
-  // the turn's SSE stream has already closed, so the live client only picks it up
-  // on reload (hence "only disappears on refresh"). Mirror the 5s auto-hide on the
-  // client so the panel goes away live; the persisted reset keeps it hidden after
-  // a refresh, and a new (incomplete) plan reveals it again.
+  // Plan panel visibility. A completed plan stays visible until a NEW plan begins:
+  // the backend emits a `reset` task_event when task_create starts a fresh plan after
+  // the previous one fully completed (src/tools/workflow/task-tools.ts). That reset
+  // fires inside a live turn, so foldPlan drops the old plan live and swaps in the new
+  // one; the persisted reset keeps it cleared after a refresh too. No client-side timer.
   const plan = useMemo(() => foldPlan(pilot.messages), [pilot.messages])
   const planExists = plan.length > 0
-  const planDone = planExists && plan.every((t) => t.group === "completed")
-  const [planAutoHidden, setPlanAutoHidden] = useState(false)
-  useEffect(() => {
-    if (!planDone) {
-      setPlanAutoHidden(false) // no plan, or a fresh/incomplete one → keep it visible
-      return
-    }
-    const timer = window.setTimeout(() => setPlanAutoHidden(true), 5000)
-    return () => window.clearTimeout(timer)
-  }, [planDone])
-  const planActive = planExists && !planAutoHidden
+  const planActive = planExists
 
   // Fetch sessions
   useEffect(() => {

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -168,8 +168,6 @@ const SESSION_RELEASE_TTL_MS = 30_000;
 const NOTIFICATION_COALESCE_MS = 600;
 /** One-time guard for the "synthetic turn can't persist" diagnostic (see runSyntheticPrompt). */
 let warnedNoPersist = false;
-/** Delay before auto-clearing a fully-completed plan (CC V2 parity: HIDE_DELAY_MS). */
-const LEDGER_AUTOCLEAR_MS = 5_000;
 const DELEGATED_AGENT_MAX_RUNTIME_MS = getSubagentMaxRuntimeMs();
 const DELEGATED_AGENT_ABORT_TIMEOUT_MS = 2_000;
 function delay(ms: number): Promise<void> {
@@ -317,9 +315,6 @@ export class AgentBoxSessionManager {
     }
     // MCP is initialized per-session inside createSiclawSession via loadConfig().mcpServers.
   }
-
-  /** Pending plan auto-clear timers, keyed by taskListId (all tasks completed → clear after delay). */
-  private ledgerHideTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   /**
    * Bounds concurrent foreground sub-agent child sessions across this AgentBox
@@ -1160,32 +1155,6 @@ export class AgentBoxSessionManager {
     } catch { /* no snapshot (new session) — fine */ }
   }
 
-  /** CC V2 resetTaskList parity: when every task is completed, clear the plan after a
-   *  short delay; a new pending task before the timer fires cancels the clear. The
-   *  reset is emitted as a task_event so the UI/foldPlan + persistence reset too. The
-   *  ledger's id sequence is preserved so the next plan's ids never reuse cleared ones. */
-  private scheduleLedgerAutoClear(taskListId: string, emit: (event: Record<string, unknown>) => void): void {
-    const existing = this.ledgerHideTimers.get(taskListId);
-    if (getOrCreateLedger(taskListId).allCompleted()) {
-      if (existing) return; // already scheduled
-      const timer = setTimeout(() => {
-        this.ledgerHideTimers.delete(taskListId);
-        const ledger = getOrCreateLedger(taskListId);
-        if (!ledger.allCompleted()) return; // a new task arrived; abort the clear
-        // Only the parent touches the ledger (sub-agents have no task tools — see
-        // isSubagent gating), so allCompleted() reflects the whole plan and clearing
-        // here can't wipe anything out from under a child. No in-flight-child guard.
-        ledger.clear();
-        emit({ kind: "task_event", taskListId, action: "reset" });
-      }, LEDGER_AUTOCLEAR_MS);
-      timer.unref?.();
-      this.ledgerHideTimers.set(taskListId, timer);
-    } else if (existing) {
-      clearTimeout(existing);
-      this.ledgerHideTimers.delete(taskListId);
-    }
-  }
-
   private async persistUpdateMessage(message: DelegationUpdateMessagePayload): Promise<void> {
     await this.persistDelegationEvent({ type: "delegation.update_message", message });
   }
@@ -1599,9 +1568,6 @@ export class AgentBoxSessionManager {
         // survives a pod/process restart — keyed by the event's taskListId (the
         // parent's id, even when a sub-agent mutated a task it owns).
         this.persistLedgerSnapshot(event.taskListId ?? id);
-        // CC V2 parity: once the whole plan is completed, auto-clear it after a
-        // short delay (a new pending task before then cancels the clear).
-        if (event.action !== "reset") this.scheduleLedgerAutoClear(event.taskListId ?? id, emitExtraEvent);
       }
       if (extraEventSubs.size === 0) {
         extraEventBuffer.push(event);
@@ -2033,11 +1999,6 @@ export class AgentBoxSessionManager {
       this.sessions.delete(sessionId);
       // Permanent closure — drop the in-memory ledger so it doesn't accumulate
       // (the durable snapshot + Portal task_events remain for history/recovery).
-      const hideTimer = this.ledgerHideTimers.get(sessionId);
-      if (hideTimer) {
-        clearTimeout(hideTimer);
-        this.ledgerHideTimers.delete(sessionId);
-      }
       deleteLedger(sessionId);
       emitDiagnostic({ type: "session_released", sessionId });
     }

--- a/src/shared/task-events.ts
+++ b/src/shared/task-events.ts
@@ -14,8 +14,8 @@ import type { LedgerTask } from "../core/task-ledger.js";
 /**
  * Discriminated by `action` so illegal states are unrepresentable: only an upsert
  * carries `task`, only a delete carries `taskId`, a reset carries neither. "reset"
- * clears the whole plan (emitted ~5s after every task completes — CC V2 parity,
- * see resetTaskList).
+ * clears the whole plan (emitted when a new plan starts via task_create after the
+ * previous one fully completed — CC V2 parity, see resetTaskList).
  */
 export type TaskEvent =
   | { kind: "task_event"; taskListId: string; action: "upsert"; task: LedgerTask }

--- a/src/tools/workflow/task-tools.test.ts
+++ b/src/tools/workflow/task-tools.test.ts
@@ -73,6 +73,28 @@ describe("task tools", () => {
     expect(events[2]).toMatchObject({ action: "delete", taskId: "1" });
   });
 
+  it("starting a new plan after the previous one fully completed emits a reset before the new task", async () => {
+    const events: any[] = [];
+    const emit = (e: any) => events.push(e);
+    const create = createTaskCreateTool(TLID, emit);
+    await create.execute("c1", { subject: "step one", description: "" });        // upsert #1
+    await createTaskUpdateTool(TLID, emit).execute("u1", { id: "1", status: "completed" }); // upsert #1 completed
+    // Plan is now fully completed → the next create starts a NEW plan.
+    const r = await create.execute("c2", { subject: "step two", description: "" });
+    expect(events.map((e) => e.action)).toEqual(["upsert", "upsert", "reset", "upsert"]);
+    // clear() keeps the id high-water-mark, so the new task continues the sequence.
+    expect(events[3]).toMatchObject({ action: "upsert", task: { id: "2", subject: "step two" } });
+    expect(text(r)).toContain("#2");
+  });
+
+  it("creating a second task while the first is still incomplete does NOT emit a reset", async () => {
+    const events: any[] = [];
+    const create = createTaskCreateTool(TLID, (e) => events.push(e));
+    await create.execute("c1", { subject: "a", description: "" }); // pending
+    await create.execute("c2", { subject: "b", description: "" }); // plan not all-completed → no reset
+    expect(events.map((e) => e.action)).toEqual(["upsert", "upsert"]);
+  });
+
   it("task_list shows ready vs blocked with waiting-on ids (deps set via task_update)", async () => {
     const c = createTaskCreateTool(TLID);
     await c.execute("c1", { subject: "n", description: "" });               // #1

--- a/src/tools/workflow/task-tools.ts
+++ b/src/tools/workflow/task-tools.ts
@@ -74,7 +74,18 @@ export function createTaskCreateTool(taskListId: string, emit?: SessionEventEmit
     async execute(_id, raw) {
       const p = raw as { subject: string; description: string; activeForm?: string; owner?: string };
       if (!p.subject?.trim()) return err("task_create requires a non-empty subject.");
-      const t = getOrCreateLedger(taskListId).create(p);
+      const ledger = getOrCreateLedger(taskListId);
+      // CC V2 resetTaskList parity: creating a task while the previous plan was fully
+      // completed starts a NEW plan — clear the old one first (and emit a reset task_event so
+      // the UI/foldPlan + persistence drop it) so the panel shows only current work. clear()
+      // keeps the id high-water-mark, so the new task's id never collides with a cleared one.
+      // This replaces the former time-based auto-clear (a completed plan now stays visible
+      // until the next plan begins, not 5s after completion).
+      if (ledger.allCompleted()) {
+        ledger.clear();
+        emit?.({ kind: "task_event", taskListId, action: "reset" } satisfies TaskEvent);
+      }
+      const t = ledger.create(p);
       emitUpsert(emit, taskListId, t);
       return ok(`Created task #${t.id}: ${t.subject}`);
     },
@@ -104,7 +115,8 @@ export function createTaskUpdateTool(taskListId: string, emit?: SessionEventEmit
       "Set ordering with addBlockedBy using the real ids from task_create / task_list, " +
       "e.g. {\"id\":\"2\",\"addBlockedBy\":[\"1\"]}. If unsure of a task's current state, task_get it first.\n" +
       "Remove a task that is no longer relevant or was created in error with status=deleted. " +
-      "(A fully-completed plan is auto-cleared after a short delay, so the list stays scoped to current work.)",
+      "(A fully-completed plan stays visible until you start a new plan with task_create, which clears " +
+      "it so the list stays scoped to current work.)",
     parameters: Type.Object({
       id: Type.String(),
       status: Type.Optional(Type.Union([


### PR DESCRIPTION
## Summary

The plan panel auto-hid ~5 seconds after the last task completed. This changes the behavior so a completed plan **stays visible until a new plan is created**, removing all time-based hiding.

### Problem

A fully-completed plan disappeared on a 5s timer, driven by two coupled timers that had to stay in sync:
- Backend `LEDGER_AUTOCLEAR_MS = 5_000` (`src/agentbox/session.ts`) — emitted a `reset` task_event + cleared the ledger 5s after completion.
- Frontend `setTimeout(…, 5000)` (`portal-web/src/components/AgentChat.tsx`) — mirrored the hide live, because the backend reset fired *after* the turn's SSE stream had closed.

Users wanted the plan to persist rather than vanish on a timer. (A "keep 60s" variant was rejected because 60s exceeds the 30s `SESSION_RELEASE_TTL_MS` — the idle session releases and clears the timer before it fires, so the reset would never persist.)

### Solution

Move the clear trigger from *"5s after completion"* to *"a new plan begins"*:

- `task_create` now detects that the previous plan was fully completed (`ledger.allCompleted()`), and if so clears the ledger (keeping the id high-water-mark so ids never collide) and emits a `reset` task_event **before** creating the new task.
- Because this `reset` fires inside a live turn, it streams to the client and `foldPlan` swaps the old plan for the new one immediately — and it persists for reload recovery exactly as before (same `emitExtraEvent` channel → `persistTaskEvent` + `persistLedgerSnapshot`).
- Removes the entire time-based auto-clear path (`scheduleLedgerAutoClear`, `LEDGER_AUTOCLEAR_MS`, `ledgerHideTimers`) and the client-side timer. Nothing is timer-driven anymore, so there is no collision with the 30s session-release TTL.

**Behavior notes:**
- A completed plan stays visible (live and after reload) until the next `task_create` starts a fresh one.
- Continuation still works: if the agent creates the new task *before* marking the last one completed, `allCompleted()` is false → no reset → the new task joins the existing plan.
- Reopening a completed task via `task_update` does not reset (only `task_create` after `allCompleted()` does).

## Test Plan

- `src/tools/workflow/task-tools.test.ts`: added tests that (a) create → complete → create emits a `reset` between the upserts and the new id continues the sequence, and (b) creating a second task while the first is still incomplete emits **no** reset.
- `npm test` — 179 files / 3569 passed.
- `npx tsc --noEmit` (backend + portal-web) — clean.
- portal-web `vitest run` — 14 files / 122 passed (`foldPlan` reset semantics unchanged).
- Manual: complete a multi-step plan → panel stays (no 5s vanish); reload → still visible; ask a new multi-step question → panel swaps to the new plan live; reload → only the new plan persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)