### PR TITLE
feat(agent): apply agent system_prompt across Web UI, API, channels, …

### DIFF
--- a/src/gateway/agent-model-binding.ts
+++ b/src/gateway/agent-model-binding.ts
@@ -29,6 +29,8 @@ export interface ResolvedModelBinding {
     }>;
   };
   modelRouting?: ModelRoutePolicy;
+  /** Agent's custom system prompt template (agents.system_prompt). Null/absent = built-in default. */
+  systemPrompt?: string | null;
 }
 
 export async function resolveAgentModelBinding(
@@ -41,5 +43,27 @@ export async function resolveAgentModelBinding(
   } catch (err) {
     console.error(`[agent-model-binding] RPC error:`, err);
     return null;
+  }
+}
+
+/**
+ * Resolve an agent's custom system prompt via Portal RPC (config.getAgent).
+ *
+ * Best-effort: callers (channel handlers) must never fail a user message just
+ * because the prompt lookup failed — on any error this returns undefined and
+ * the AgentBox session falls back to the built-in default template.
+ */
+export async function resolveAgentSystemPrompt(
+  agentId: string,
+  frontendClient?: FrontendWsClient,
+): Promise<string | undefined> {
+  if (typeof frontendClient?.request !== "function") return undefined;
+  try {
+    const agent = await frontendClient.request("config.getAgent", { agentId }) as { system_prompt?: string | null } | undefined;
+    const prompt = agent?.system_prompt?.trim();
+    return prompt || undefined;
+  } catch (err) {
+    console.error(`[agent-model-binding] config.getAgent RPC error:`, err);
+    return undefined;
   }
 }

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -284,6 +284,45 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
     sessionRegistry.forget(sessionId as string);
   });
 
+  it("passes the agent's custom system prompt (config.getAgent) into the prompt payload", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-sp", bindingId: "b1" });
+    promptMock.mockResolvedValue({ sessionId: "s-sp" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    const frontend = { request: vi.fn().mockResolvedValue({ system_prompt: "你是一个 SRE 专家。" }) };
+
+    await handleDingTalkMessage(makeDownstream("hi"), "ch", makeAgentBoxManager("agent-sp") as any, undefined, frontend as any);
+
+    expect(frontend.request).toHaveBeenCalledWith("config.getAgent", { agentId: "agent-sp" });
+    const promptArg = promptMock.mock.calls[0][0] as any;
+    expect(promptArg.systemPromptTemplate).toBe("你是一个 SRE 专家。");
+    sessionRegistry.forget(promptArg.sessionId);
+  });
+
+  it("omits the system prompt when the config.getAgent RPC fails (best-effort)", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-sp", bindingId: "b1" });
+    promptMock.mockResolvedValue({ sessionId: "s-sp" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    const frontend = { request: vi.fn().mockRejectedValue(new Error("portal down")) };
+
+    await handleDingTalkMessage(makeDownstream("hi"), "ch", makeAgentBoxManager("agent-sp") as any, undefined, frontend as any);
+
+    const promptArg = promptMock.mock.calls[0][0] as any;
+    expect(promptArg.systemPromptTemplate).toBeUndefined();
+    sessionRegistry.forget(promptArg.sessionId);
+  });
+
+  it("omits the system prompt when frontendClient has no request method", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-sp", bindingId: "b1" });
+    promptMock.mockResolvedValue({ sessionId: "s-sp" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleDingTalkMessage(makeDownstream("hi"), "ch", makeAgentBoxManager("agent-sp") as any, undefined, {} as any);
+
+    const promptArg = promptMock.mock.calls[0][0] as any;
+    expect(promptArg.systemPromptTemplate).toBeUndefined();
+    sessionRegistry.forget(promptArg.sessionId);
+  });
+
   it("does not pass userId into the AgentBox prompt payload", async () => {
     resolveBindingMock.mockResolvedValue({ agentId: "a", bindingId: "b" });
     promptMock.mockResolvedValue({ sessionId: "s" });

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -36,6 +36,7 @@ import type { AgentBoxManager } from "../agentbox/manager.js";
 import { AgentBoxClient, type PromptOptions } from "../agentbox/client.js";
 import type { ChannelHandler } from "../channel-manager.js";
 import { resolveBinding, handlePairingCode } from "../channel-manager.js";
+import { resolveAgentSystemPrompt } from "../agent-model-binding.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
 import { collectResponse } from "./lark.js";
@@ -294,7 +295,13 @@ export async function handleDingTalkMessage(
   const handle = await agentBoxManager.getOrCreate(agentId);
   const client = new AgentBoxClient(handle.endpoint, 120_000, tlsOptions);
 
-  const promptOpts: PromptOptions = { text, agentId, mode: "channel", sessionId };
+  // Apply the agent's custom system prompt (best-effort — undefined falls back
+  // to the built-in default template). Note: AgentBox only applies the template
+  // at session creation, so an existing 1:1 multi-turn session keeps the prompt
+  // it was created with until /new.
+  const systemPromptTemplate = await resolveAgentSystemPrompt(agentId, frontendClient);
+
+  const promptOpts: PromptOptions = { text, agentId, mode: "channel", sessionId, systemPromptTemplate };
   let resultText = "";
   let agentError: Error | null = null;
   try {

--- a/src/gateway/task-coordinator.test.ts
+++ b/src/gateway/task-coordinator.test.ts
@@ -358,6 +358,32 @@ describe("TaskCoordinator execution", () => {
     expect(lastFakeClient?.promptCalls[0].modelRouting).toEqual(bindingResponder.result.modelRouting);
   });
 
+  it("passes the agent's custom system prompt from the binding to AgentBox prompt", async () => {
+    const { coord, frontend } = makeCoord();
+    bindingResponder.result = {
+      modelProvider: "p", modelId: "m",
+      modelConfig: { name: "n", baseUrl: "u", apiKey: "k", api: "x", authHeader: false, models: [] },
+      systemPrompt: "You are a scheduled ops bot.",
+    };
+    sseResponder.result = { resultText: "done", taskReportText: "", errorMessage: "", eventCount: 1, durationMs: 5 };
+    frontend.responses.set("task.fireNow", {
+      outcome: "ok",
+      task: {
+        id: "t1", agent_id: "a", name: "Prompt Task", description: null,
+        schedule: "*/5 * * * *", prompt: "p", status: "active",
+        created_by: "u1", last_run_at: null, last_result: null, last_manual_run_at: null,
+      },
+    });
+    frontend.responses.set("task.runStart", { ok: true });
+    frontend.responses.set("task.runFinalize", { ok: true });
+    frontend.responses.set("task.updateMeta", { ok: true });
+
+    await coord.fireNow("t1");
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(lastFakeClient?.promptCalls[0].systemPromptTemplate).toBe("You are a scheduled ops bot.");
+  });
+
   it("propagates SSE-layer errorMessage as failure", async () => {
     const { coord, frontend } = makeCoord();
     bindingResponder.result = {

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -283,6 +283,7 @@ export class TaskCoordinator {
         modelId: binding.modelId,
         modelConfig: binding.modelConfig,
         modelRouting: binding.modelRouting,
+        systemPromptTemplate: binding.systemPrompt ?? undefined,
       };
       await client.prompt(promptOpts);
 

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -197,7 +197,7 @@ describe("config.getSettings", () => {
 describe("config.getModelBinding", () => {
   it("returns binding when agent has valid provider", async () => {
     mockQuery(
-      [{ model_provider: "openai", model_id: "gpt-4" }],
+      [{ model_provider: "openai", model_id: "gpt-4", system_prompt: "You are an ops bot." }],
       [{ id: "p1", name: "openai", base_url: "https://api.openai.com", api_key: "sk-key", api_type: "openai" }],
       [{ model_id: "gpt-4", name: "GPT-4", reasoning: 1, context_window: 128000, max_tokens: 4096 }],
     );
@@ -206,6 +206,7 @@ describe("config.getModelBinding", () => {
     expect(result.binding).toBeDefined();
     expect(result.binding.modelProvider).toBe("openai");
     expect(result.binding.modelId).toBe("gpt-4");
+    expect(result.binding.systemPrompt).toBe("You are an ops bot.");
     expect(result.binding.modelConfig.name).toBe("openai");
     expect(result.binding.modelConfig.authHeader).toBe(true);
     expect(result.binding.modelConfig.models[0].reasoning).toBe(true);

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1600,10 +1600,10 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
   handlers.set("config.getModelBinding", async (params) => {
     const db = getDb();
     const [agentRows] = await db.query(
-      "SELECT model_provider, model_id, model_routing FROM agents WHERE id = ?",
+      "SELECT model_provider, model_id, model_routing, system_prompt FROM agents WHERE id = ?",
       [params.agentId],
     ) as any;
-    const agent = agentRows[0] as { model_provider?: string; model_id?: string; model_routing?: unknown } | undefined;
+    const agent = agentRows[0] as { model_provider?: string; model_id?: string; model_routing?: unknown; system_prompt?: string | null } | undefined;
     if (!agent?.model_provider || !agent?.model_id) {
       return { binding: null };
     }
@@ -1646,6 +1646,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
           models,
         },
         ...(modelRouting ? { modelRouting } : {}),
+        systemPrompt: agent.system_prompt ?? null,
       },
     };
   });

--- a/src/portal/chat-gateway.test.ts
+++ b/src/portal/chat-gateway.test.ts
@@ -151,7 +151,7 @@ describe("chat-gateway routes", () => {
 
     it("opens SSE stream and sends chat.send command when model is configured", async () => {
       query
-        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4" }], []])
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4", system_prompt: "You are an ops bot." }], []])
         .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
         .mockResolvedValueOnce([[{ model_id: "gpt-4", name: "GPT-4", reasoning: 0, context_window: 128000, max_tokens: 4096 }], []]);
 
@@ -178,6 +178,7 @@ describe("chat-gateway routes", () => {
         userId: "u1",
         text: "hi",
         sessionId: "s1",
+        systemPrompt: "You are an ops bot.",
       }));
     });
 

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -280,10 +280,10 @@ async function parseChatRequestBody(
 async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelBinding | null> {
   const db = getDb();
   const [agentRows] = await db.query(
-    "SELECT model_provider, model_id, model_routing FROM agents WHERE id = ?",
+    "SELECT model_provider, model_id, model_routing, system_prompt FROM agents WHERE id = ?",
     [agentId],
   ) as any;
-  const agent = agentRows[0] as { model_provider?: string; model_id?: string; model_routing?: unknown } | undefined;
+  const agent = agentRows[0] as { model_provider?: string; model_id?: string; model_routing?: unknown; system_prompt?: string | null } | undefined;
   if (!agent?.model_provider || !agent?.model_id) return null;
 
   const [providerRows] = await db.query(
@@ -327,6 +327,7 @@ async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelB
       models,
     },
     ...(modelRouting ? { modelRouting } : {}),
+    systemPrompt: agent.system_prompt ?? null,
   };
 }
 
@@ -510,6 +511,7 @@ export function registerChatRoutes(
       modelId: modelBinding.modelId,
       modelConfig: modelBinding.modelConfig,
       modelRouting: modelBinding.modelRouting,
+      systemPrompt: modelBinding.systemPrompt ?? undefined,
       turnStartMs,
     });
 
@@ -764,6 +766,7 @@ export function registerChatRoutes(
       modelId: modelBinding.modelId,
       modelConfig: modelBinding.modelConfig,
       modelRouting: modelBinding.modelRouting,
+      systemPrompt: modelBinding.systemPrompt ?? undefined,
     });
 
     if (!result.ok && !resolved) {


### PR DESCRIPTION
## Summary

The agent-configured **System Prompt** (`agents.system_prompt`, editable in the Portal Web UI under *Agent → Basic*) was only honored on the **TUI / Portal-snapshot** path. Web UI, the external API, DingTalk, and scheduled tasks all silently fell back to the built-in default SRE template — even though the `Runtime → AgentBox → createSiclawSession` pipeline already accepted a `systemPromptTemplate`. The prompt was simply never threaded into the `chat.send` / prompt payloads.

| Entry point | Before | After |
|---|---|---|
| TUI (Portal snapshot) | ✅ | ✅ (unchanged) |
| Web UI (`/chat/send`) | ❌ default | ✅ |
| External API (`/api/v1/run`) | ❌ default | ✅ |
| DingTalk channel | ❌ default | ✅ |
| Scheduled tasks (cron) | ❌ default | ✅ |

## Changes

- **`config.getModelBinding`** (`adapter.ts` + chat-gateway's own resolver) now selects and returns `systemPrompt`.
- **Web UI / External API** (`src/portal/chat-gateway.ts`): both `chat.send` call sites (`/chat/send`, `/api/v1/run`) forward `systemPrompt`.
- **Cron** (`src/gateway/task-coordinator.ts`): forwards `binding.systemPrompt` as `systemPromptTemplate`.
- **DingTalk** (`src/gateway/channels/dingtalk.ts`): resolves it best-effort via a new `resolveAgentSystemPrompt()` helper (`config.getAgent` RPC). On any RPC failure / missing client it returns `undefined`, so a prompt-lookup error never fails a user message — the session just uses the default template.

## Notes

- **Cron mode** still appends the hardcoded *Automated Task* + *Safety* sections on top of the custom template (intentionally not overridable).
- AgentBox applies the template **only at session creation**, so existing multi-turn sessions (Web sessions, DingTalk 1:1 conversations) keep their original prompt until a fresh session starts (DingTalk `/new`, new Web conversation).
- **Lark/Feishu** is intentionally out of scope; it can adopt the same `resolveAgentSystemPrompt()` helper in a follow-up.

## Test plan

- [x] `vitest run` for the four affected suites — 215 tests pass:
  - `src/gateway/channels/dingtalk.test.ts` (3 new cases: prompt threaded, RPC-failure fallback, no-`request`-method fallback)
  - `src/gateway/task-coordinator.test.ts` (new case asserting `systemPromptTemplate` is forwarded)
  - `src/portal/chat-gateway.test.ts` (asserts `systemPrompt` on `chat.send`)
  - `src/portal/adapter-rpc.test.ts` (asserts `getModelBinding` returns `systemPrompt`)
- [x] Manual: set a custom System Prompt on an agent, send a message via Web UI / DingTalk / a scheduled task, confirm the agent follows it.

## Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unrelated changes included
- [x] No new shell execution paths; no schema changes (read-only `SELECT system_prompt` addition only)