### PR TITLE
Authorize Mermaid xychart visual guidance

### DIFF
--- a/docs/design/chart-rendering.md
+++ b/docs/design/chart-rendering.md
@@ -58,12 +58,14 @@ ChartRenderer  (portal-web/src/components/chat/ChartRenderer.tsx)
 
 Mermaid is a separate baseline Markdown capability, not a `ChartSpec` type and
 not an MCP requirement. The chat frontend recognises fenced Markdown blocks with
-the language tag `mermaid` and renders the initial supported diagram families:
+the language tag `mermaid` and renders these supported diagram families:
 
 - `flowchart` / `graph` for process, dependency, cause/effect, and remediation
   flows.
 - `sequenceDiagram` for cross-component request or event ordering.
 - `timeline` for task lifecycles, incidents, and investigation progress.
+- `xychart-beta` for lightweight x/y bars or trends when a full `chart` fence is
+  unnecessary.
 
 Mermaid blocks are rendered client-side with Mermaid's strict security mode and
 bounded text/edge limits. Init/config directives in chat-authored diagrams are
@@ -77,6 +79,10 @@ Mermaid diagrams share the frontend SVG export helpers used by charts:
   PNG download controls;
 - message/session rich-copy treats rendered Mermaid SVGs as images, matching the
   chart copy path.
+
+Use `chart` fences for finalized pie/bar/line data that should use Siclaw's
+native chart interactivity and validation. Use Mermaid `xychart-beta` for compact
+inline comparisons that are naturally authored as a diagram.
 
 ### Why the spinner, not a partial chart?
 

--- a/mcp/create-chart/src/handler.test.ts
+++ b/mcp/create-chart/src/handler.test.ts
@@ -29,8 +29,17 @@ describe("RENDER_CHART_INPUT_SCHEMA", () => {
     expect(RENDER_CHART_DESCRIPTION).toMatch(/exactly/i);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/Do not rewrite, escape, quote/);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/mermaid/i);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/xychart-beta/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/画图/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/画饼图/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/柱状图/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/趋势图/);
+    expect(RENDER_CHART_DESCRIPTION).not.toMatch(/visual-card/);
+    expect(RENDER_CHART_DESCRIPTION).not.toMatch(/final_report/);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/data must be an object/i);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/never a JSON string/i);
+    expect(RENDER_CHART_INPUT_SCHEMA.properties.data.description).toMatch(/Every numeric value must be finite/);
+    expect(RENDER_CHART_INPUT_SCHEMA.properties.data.description).toContain("x/category labels may be strings");
   });
 });
 

--- a/mcp/create-chart/src/handler.ts
+++ b/mcp/create-chart/src/handler.ts
@@ -17,7 +17,7 @@ export const RENDER_CHART_INPUT_SCHEMA = {
     data: {
       type: "object",
       description:
-        "Chart data as a real JSON object, never as a JSON string. Pie: {slices:[{label,value}]}. Bar: {categories:[string], series:[{name,values:[number]}]}. Line: {series:[{name, points:[{x:number|string, y:number}]}]}. Every value must be a finite number; do not use placeholders, variables, or references to earlier messages.",
+        "Chart data as a real JSON object, never as a JSON string. Pie: {slices:[{label,value}]}. Bar: {categories:[string], series:[{name,values:[number]}]}. Line: {series:[{name, points:[{x:number|string, y:number}]}]}. Every numeric value must be finite; x/category labels may be strings. Do not use placeholders, variables, or references to earlier messages.",
     },
     title: { type: "string" },
     width: { type: "integer", minimum: 200, maximum: 2400 },
@@ -30,8 +30,8 @@ export const RENDER_CHART_INPUT_SCHEMA = {
 
 export const RENDER_CHART_DESCRIPTION =
   [
-    "Render a pie/bar/line chart only when finalized structured numeric data is already in context and can be passed as valid tool arguments.",
-    "For qualitative diagrams, workflows, topology, decision trees, rough summaries, or small category/count visuals where tool arguments might be uncertain, use a ```mermaid fenced block instead; xychart-beta is suitable for simple bar charts.",
+    "Render a pie/bar/line chart only when finalized structured numeric data is already in context and can be passed as valid tool arguments. This includes requests such as 画图, 画饼图, 柱状图, 趋势图 when the required numeric data is available.",
+    "For qualitative diagrams, workflows, topology, or decision trees, use a ```mermaid fenced block instead; xychart-beta is suitable for simple bar charts.",
     "Arguments must be one JSON object. data must be an object, never a JSON string. Use only literal finite numbers; never use placeholders, expressions, previous-message references, or bare tokens.",
     "The tool returns a READY_TO_PASTE chart block as plain markdown plus metadata. In your final reply, paste the READY_TO_PASTE block exactly as returned. Do not rewrite, escape, quote, or wrap the chart JSON; the frontend renders ```chart fenced JSON blocks as SVG.",
   ].join(" ");

--- a/src/core/prompt.test.ts
+++ b/src/core/prompt.test.ts
@@ -47,3 +47,30 @@ describe("buildSreSystemPrompt memory flag", () => {
     expect(prompt).not.toContain("remember context from previous sessions");
   });
 });
+
+describe("buildSreSystemPrompt visual output guidance", () => {
+  it("authorizes every Mermaid family supported by Sicore Web", () => {
+    const prompt = buildSreSystemPrompt("web");
+
+    expect(prompt).toContain("flowchart");
+    expect(prompt).toContain("sequenceDiagram");
+    expect(prompt).toContain("timeline");
+    expect(prompt).toContain("xychart-beta");
+  });
+
+  it("does not steer shared Siclaw surfaces to unsupported visual-card output", () => {
+    const prompt = buildSreSystemPrompt("web");
+
+    expect(prompt).not.toContain("```visual-card");
+    expect(prompt).not.toContain('type: "report"');
+    expect(prompt).not.toContain("final_report");
+    expect(prompt).not.toContain("health_check");
+    expect(prompt).not.toContain("incident_timeline");
+    expect(prompt).not.toContain("root_cause_chain");
+    expect(prompt).not.toContain("metric_snapshot");
+    expect(prompt).not.toContain("status_distribution");
+    expect(prompt).not.toContain("action_plan");
+    expect(prompt).toContain("Mermaid for diagrams");
+    expect(prompt).toContain("chart");
+  });
+});

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -134,11 +134,11 @@ const DEFAULT_TEMPLATE = `You are Siclaw, a personal SRE AI assistant. You help 
 
 # Visual Output
 
-- You may use Mermaid diagrams as a native response format when the user asks to draw/diagram a flow, sequence, lifecycle, timeline, topology, or dependency chain, or when a compact diagram clearly makes an SRE explanation easier to verify.
-- Supported Mermaid forms are \`flowchart\` / \`graph\`, \`sequenceDiagram\`, and \`timeline\`. Keep diagrams small and readable; prefer roughly 5-12 nodes/events and avoid decorative detail.
-- Use \`flowchart\` for cause/effect, decision, dependency, or remediation flows; \`sequenceDiagram\` for request paths and cross-component call order; \`timeline\` for incidents, task lifecycles, and investigation progress.
-- Inside Mermaid fences, output only Mermaid syntax. Do not add line numbers, event labels, or stream prefixes such as \`123-content:\`.
-- Do not force a diagram into simple answers. If exact times or relationships are unknown, label them as unknown/approx instead of inventing precision.
+- Choose the rendered visual output path by intent: Mermaid for diagrams and \`\`\`chart\` / \`render_chart\` for finalized numeric pie/bar/line charts.
+- Use Mermaid diagrams when you are actually drawing structure, relationships, flow, sequence, lifecycle, topology, or dependency chains. Supported Mermaid forms are \`flowchart\` / \`graph\`, \`sequenceDiagram\`, \`timeline\`, and \`xychart-beta\`. Keep diagrams small and readable; prefer roughly 5-12 nodes/events and avoid decorative detail.
+- Use \`flowchart\` for cause/effect, decision, dependency, or remediation flows; \`sequenceDiagram\` for request paths and cross-component call order; \`timeline\` for pure event ordering; \`xychart-beta\` for compact x/y bars or trends when a full chart tool call is unnecessary.
+- Inside Mermaid fences, output only Mermaid syntax. Do not add line numbers, event labels, or stream prefixes such as \`123-content:\`. If exact times or relationships are unknown, label them as unknown/approx instead of inventing precision.
+- Do not force a diagram into simple answers. If the response is a prose report rather than a diagram or finalized numeric chart, write normal Markdown so every Siclaw surface can render it.
 
 {{memorySection}}
 # Environment & Configuration


### PR DESCRIPTION
## Summary
- authorize `xychart-beta` in the shared Siclaw visual-output prompt to match portal-web Mermaid support
- keep unsupported `visual-card` / report-card guidance out of Siclaw's shared prompt and chart tool description
- clarify `render_chart` guidance: Chinese chart intents are preserved, and only numeric values must be finite while x/category labels may be strings

## Review response
- addresses the latest review blocker by choosing option (b): no `visual-card` steering in shared `DEFAULT_TEMPLATE` until Siclaw surfaces have a renderer
- removes the earlier report-card docs/tool guidance from this PR; Sicore-specific report cards remain in the Sicore MR

## Validation
- `node_modules/.bin/vitest run src/core/prompt.test.ts mcp/create-chart/src/handler.test.ts`
- `npm run build`
- `git diff --check`