### PR TITLE
feat(metrics): Grafana-style time range picker on a unified from/to contract

### DIFF
--- a/docs/design/2026-06-15-metrics-time-range-picker.md
+++ b/docs/design/2026-06-15-metrics-time-range-picker.md
@@ -1,0 +1,205 @@
+# Metrics Time Range Picker (Grafana-style) — Design
+
+> Status: draft · 2026-06-15
+> Scope: `portal-web` Metrics dashboard + `src/portal/siclaw-api.ts` `/api/v1/siclaw/metrics/*`
+> Ports the Grafana-style time picker already shipped in the downstream sicore web dashboard.
+
+## Background & goal
+
+The Metrics dashboard (`portal-web/src/pages/Metrics.tsx`) filters time with a 3-option
+`<select>` — Today / Last 7 days / Last 30 days — driving `summary` and `timing`. The Audit
+tab carries its **own, independent** range `<select>` (Last 1h/6h/24h/7d/30d), so the header
+period and the audit window can silently disagree. Neither path can express an **absolute**
+window ("2026-06-10 09:00 → 12:00").
+
+Goal: replace the period enum with a **Grafana-style time picker** — quick relative ranges
+plus an absolute From/To — and unify the backend `live`/`summary`/`timing`/`audit` endpoints
+on a single `from`/`to` timestamp contract, matching what audit already half-did with
+`startDate`/`endDate`. Clean break, no compatibility shim.
+
+## What stays untouched (contract boundary)
+
+`src/portal/adapter.ts` `/api/internal/siclaw/metrics/*` is a **separate, parallel**
+implementation (independent SQL, `period` enum) consumed by the downstream sicore Portal over
+the internal-auth channel. It is a cross-system wire contract and is **out of scope** — exactly
+mirroring how the sicore port left its own `adapter/rpc.go` alone. Only `/api/v1/*` (siclaw's
+own portal-web) migrates.
+
+```
+┌─────────────────┐   /api/v1/siclaw/metrics/*    ┌──────────────────────┐
+│  portal-web SPA │ ────────────────────────────▶ │  siclaw-api.ts       │  ◀── MIGRATE
+│  (this change)  │      from / to (ms|ISO)        │  /api/v1 handlers    │
+└─────────────────┘                                └──────────────────────┘
+┌─────────────────┐   /api/internal/.../metrics    ┌──────────────────────┐
+│  sicore Portal  │ ────────────────────────────▶ │  adapter.ts          │  ◀── DO NOT TOUCH
+│  (downstream)   │      period / startDate        │  /api/internal       │
+└─────────────────┘                                └──────────────────────┘
+```
+
+## Overall approach
+
+Same shape as the sicore port, adapted to siclaw's stack (Vite SPA, no i18n, no UI lib,
+TypeScript backend):
+
+1. **Time model in `useMetrics.ts`** — a `TimeRange { from, to }` where each side is either a
+   relative expression (`now`, `now-30m`) or an absolute ISO string. `resolveRange()` converts
+   to absolute `{ fromMs, toMs }` **at fetch time**, so the backend only ever sees absolute ms.
+2. **`TimeRangePicker` component** — hand-rolled (no shadcn/radix/day-picker in this repo):
+   a button showing the current label, opening a popover with quick ranges (right) and an
+   absolute From/To editor (left).
+3. **Backend `from`/`to`** — `resolveWindow()` reads `from`/`to` (unix-ms or ISO), defaults to a
+   trailing 7d window, 400 on invalid / `from>=to`. `summary` and `timing` gain a `created_at <= to`
+   upper bound; `audit` renames `startDate`/`endDate` → `from`/`to` (keeps its `BETWEEN`).
+
+### Refresh semantics — relative slides / absolute fixed
+
+Precise behavior (corrected per peer review — only `useLive` owns a timer):
+
+- **`useLive`** owns the single 30s `setInterval`. Each tick re-runs `resolveRange`, so a
+  **relative** live window re-bases on `now` (slides); an **absolute** one is constant (fixed).
+  The KPI live fields (active sessions, WS connections, tool-calls total) and Top Tools/Skills
+  ride this tick.
+- **`useSummary` / `useTimingStats`** have **no timer**. They refetch only when their deps
+  change — `[range.from, range.to, userId]` — or on the manual Refresh button. Because a
+  relative range's strings (`"now-7d"`) are constant across renders, the cards do **not** silently
+  slide every 30s; they re-resolve to the current `now` the next time the user changes the range
+  or hits Refresh. This preserves the existing summary/timing refresh behavior — we are only
+  swapping the window contract, not adding a ticking slide.
+- The **Audit** list resolves the window **once per filter change and freezes it**, reusing the
+  snapshot while paginating — a relative window must not slide mid-pagination or the cursor
+  drifts (rows duplicate / skip). Audit therefore does **not** auto-refresh with the header tick.
+
+## Detailed design
+
+### Module 1 — backend `/api/v1` contract (`src/portal/siclaw-api.ts`)
+
+- Add a local `resolveWindow(query)` helper:
+  - reads `query.from` / `query.to`. **Parse rule (pinned to kill the ms-vs-ISO ambiguity):**
+    a value matching `/^\d+$/` → `new Date(Number(v))` (unix **ms**, what the frontend always
+    sends); otherwise → `new Date(v)` (ISO, for manual curl/debug only); a `NaN` `getTime()` is
+    rejected. Note: this differs from audit's current `new Date(query.startDate)`, which would
+    mis-handle a bare ms string — the helper fixes that. Bare years (`"2026"`) are intentionally
+    read as ms, not a calendar year; the frontend never sends those.
+  - both missing → default `{ from: now-7d, to: now }`.
+  - present but unparseable, or `from >= to` → returns `null`; caller responds `400 Invalid time range`.
+- `summary`: drop `PERIODS`/`period`/`cutoff`; use `from` as the `created_at >= ?` lower bound
+  and add `AND ... created_at <= ?` upper bound to **all three** windowed queries (totalSessions,
+  totalPrompts, byUser).
+- `timing`: same swap; add the upper bound to both the assistant-rows and tool-rows SELECTs.
+- `audit`: rename `startDate`/`endDate` → `from`/`to` (the `BETWEEN ? AND ?` already bounds both
+  ends). Default window unchanged (trailing 24h when both absent — but the frontend will always
+  send an explicit window).
+- `live`: unchanged — it has no period (live snapshot, `userId` only).
+- Dialect: `from`/`to` are passed as `Date` objects into parameterized queries exactly like the
+  current `cutoff`/`startDate`, so MySQL + SQLite behavior is unchanged (invariants.md §5).
+
+### Module 2 — time model (`portal-web/src/hooks/useMetrics.ts`)
+
+```ts
+export interface TimeRange { from: string; to: string }   // "now" | "now-30m" | ISO
+export const QUICK_RANGES: Array<{ label: string; from: string }>   // to: "now"
+export const DEFAULT_RANGE: TimeRange = { from: "now-7d", to: "now" }
+export function isRelativeExpr(v: string): boolean
+export function resolveRange(r: TimeRange): { fromMs: number; toMs: number }
+export function rangeLabel(r: TimeRange): string
+```
+
+- `resolveRange` parses `now`, the **exact** regex `^now-(\d+)([smhdw])$` (`m`=minutes, **not**
+  months; units s/m/h/d/w), else `Date.parse` of an absolute string interpreted in the browser's
+  **local timezone** (`YYYY-MM-DD HH:mm` or ISO). The picker's Apply button is gated on
+  `resolveRange` yielding a valid `from < to`, so unknown units (`now-3M`) are rejected at the UI
+  rather than silently becoming `NaN` → backend 400.
+- `useSummary` / `useTimingStats`: signature `period: string` → `range: TimeRange`; `fetchOnce`
+  reads `rangeRef.current`, `resolveRange` → `from`/`to` ms query params; effect deps become
+  `[range.from, range.to, userId]` (primitives, not the object).
+- `useLive`: still `userId`-only + 30s interval — unchanged.
+- `useAudit`: `AuditParams.startDate/endDate` → `from/to`.
+
+### Module 3 — `TimeRangePicker` (`portal-web/src/components/metrics/TimeRangePicker.tsx`, new)
+
+Hand-rolled to match siclaw's dependency-free style (raw Tailwind + lucide, popover via an
+absolute-positioned panel + a `mousedown` outside-click listener):
+
+```
+┌─ Trigger: [🕐  Last 7 days  ▾] ─────────────────────────────────┐
+│                                                                  │
+│  ┌─ Absolute time range ─────┐  ┌─ Quick ranges ──────────────┐ │
+│  │ From [ now-7d        ]    │  │ [search…]                   │ │
+│  │ To   [ now           ]    │  │  Last 30 minutes            │ │
+│  │ <calendar — see decision> │  │  Last 1 hour                │ │
+│  │ [ Apply time range ]      │  │  Last 6 hours   … (10)      │ │
+│  └───────────────────────────┘  └─────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- Quick range click → `onChange({ from, to: "now" })`, closes.
+- Absolute From/To text inputs accept a relative expr (`now-30m`) or an absolute time; Apply
+  validates via `resolveRange` and emits the literal strings (relative stays relative → slides;
+  absolute stays absolute → fixed).
+- Popover open/close via an absolute panel + a `mousedown` outside-click listener attached
+  **only while open**; the handler must ignore clicks inside **both** the panel and the trigger
+  button (two-ref containment check) to avoid a close-then-reopen race.
+- Mini-calendar is **date-only** (no date-fns): a `◀ month ▶` header + 7-col day grid built from
+  `Date` math; clicking a day fills the date portion of whichever field (From/To) is "active",
+  leaving time-of-day to the text input. The pure grid-generation function (first-of-month
+  weekday offset, 28/29/30/31, Dec→Jan rollover) gets a unit test.
+
+### Module 4 — wiring
+
+- `Metrics.tsx`: `period` state → `timeRange: TimeRange`; header `<select>` → `<TimeRangePicker>`;
+  pass `timeRange` to `useSummary`/`useTimingStats`/`AuditTable` and `rangeLabel(timeRange)` to the
+  cards.
+- `AuditTable.tsx`: accept `timeRange` from the page header and **drop its own `rangeMs`
+  `<select>`** + `RANGE_OPTIONS` (decision #2 — unify). Resolve to `{fromMs,toMs}` in a `useMemo`
+  keyed on `[timeRange.from, timeRange.to, tool, status, userFilterId]` (primitives only, **never
+  `Date.now()`**), and feed the **resolved ms** into `useAudit`'s `from`/`to` params — this is the
+  freeze that keeps pagination cursors stable.
+- `KpiCards.tsx` / `TimingStatsCard.tsx`: `period` prop → `rangeLabel: string`; drop local period maps.
+- `Metrics.tsx`: also update the **"By User" subtitle** at line ~149 (`(period: ${period})`) which
+  references the deleted `period` state — becomes `rangeLabel(timeRange)`; this is a hard compile
+  dependency, not cosmetic.
+
+## Out of scope / deliberately skipped
+
+- **i18n** — portal-web has none; strings stay inline English (consistent with the page).
+- **OpenAPI** — no spec exists in this repo; nothing to update.
+- **Product docs** — metrics is an admin-only internal surface with no existing `docs/features`
+  page; no user-facing doc to sync.
+- **`adapter.ts` `/api/internal`** — cross-system contract, untouched.
+
+## Risks & edge cases
+
+- **Audit pagination drift** — mitigated by freezing the resolved window per filter change.
+- **Clock/timezone** — all relative resolution happens client-side; backend sees absolute ms only.
+- **Invalid absolute input** — Apply is gated on `resolveRange` producing a valid `from < to`;
+  backend independently 400s on bad params (fail-fast, no silent fallback).
+- **byUser session-vs-message timestamp asymmetry** — `byUser` filters `s.created_at` while
+  `totalPrompts`/timing filter `m.created_at`. With an upper bound, a session created before `to`
+  whose messages land after `to` counts its session but not those messages (can read sessions=1,
+  messages=0 in a tight absolute window). Pre-existing semantics the upper bound merely surfaces;
+  not changed here.
+- **Test migration** — `siclaw-api.misc.test.ts` `summary?period=bogus → 400` becomes
+  `summary?from=2000&to=1000 → 400`. Verify `timing` had no separate invalid-period test to migrate,
+  and that the summary happy-path assertion on `query.mock.calls[1][0]` still holds (the added
+  `created_at <= ?` keeps the `delegation_event` LIKE clause and adds no extra query call).
+
+## Estimate
+
+- Files: ~7 (`useMetrics.ts`, `TimeRangePicker.tsx` [new], `Metrics.tsx`, `AuditTable.tsx`,
+  `KpiCards.tsx`, `TimingStatsCard.tsx`, `siclaw-api.ts`) + 1 test.
+- Lines: ~450–650 (main-agent execution; under the 1000-line threshold).
+
+## Decision Record
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | Absolute From/To entry widget | **Hand-rolled mini calendar + text inputs** | Zero new deps, fits siclaw's dependency-free Tailwind style, closest parity to sicore/Grafana. From/To text accept `now-30m`/ISO; an inline month grid sets the date; `Apply` commits. Native `<input type="datetime-local">` was rejected — it can't express relative expressions (`now-30m`), the core of the Grafana model, so it'd force running text + native pickers in parallel. Both peer reviewers flagged the calendar as the highest-effort/bug-density piece and suggested text-only; honored the user's explicit choice for the calendar, mitigated by keeping it date-only, self-contained, and unit-tested. |
+| 2 | Audit tab time source | **Unify under the header picker** (drop Audit's own `rangeMs` select) | Matches sicore's end state; removes the duplicate, drift-prone path. Audit freezes the resolved window per filter change for pagination stability. |
+| 3 | Quick-range set | **Match sicore's 10** (30m / 1h / 3h / 6h / 12h / 24h / 2d / 7d / 30d / 90d) | Cross-product consistency with the downstream sicore dashboard. |
+
+### Mini-calendar scope (decision #1)
+
+A compact, dependency-free month grid (`Date` math only, no date-fns): header with ◀ month ▶,
+a 7-column day grid, click a day to fill whichever of From/To is "active". Time-of-day stays in
+the text input (minute precision via `now-30m` or `YYYY-MM-DD HH:mm`); the calendar only sets the
+date portion. ~100 lines, lives inside `TimeRangePicker.tsx`.

--- a/portal-web/src/components/metrics/AuditTable.tsx
+++ b/portal-web/src/components/metrics/AuditTable.tsx
@@ -1,17 +1,10 @@
 import { useMemo, useState } from "react"
 import { ChevronDown, ChevronRight, CheckCircle, XCircle, Ban, Loader2 } from "lucide-react"
-import { useAudit, useUsers, type AuditLog } from "../../hooks/useMetrics"
+import { useAudit, useUsers, resolveRange, type AuditLog, type TimeRange } from "../../hooks/useMetrics"
 import { AuditDetailPanel } from "./AuditDetailPanel"
 
 const TOOL_OPTIONS = ["All", "restricted_bash", "local_script", "pod_exec", "kubectl", "cluster_probe", "cluster_list"]
 const STATUS_OPTIONS = ["All", "success", "error", "blocked"]
-const RANGE_OPTIONS = [
-  { label: "Last 1h", value: 3_600_000 },
-  { label: "Last 6h", value: 21_600_000 },
-  { label: "Last 24h", value: 86_400_000 },
-  { label: "Last 7d", value: 7 * 86_400_000 },
-  { label: "Last 30d", value: 30 * 86_400_000 },
-]
 
 function formatDuration(ms: number | null): string {
   if (ms == null) return "—"
@@ -54,10 +47,9 @@ function OutcomeIcon({ outcome }: { outcome: string | null }) {
   }
 }
 
-export function AuditTable({ userFilterId, usernameHint }: { userFilterId: string | null; usernameHint: string | null }) {
+export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilterId: string | null; usernameHint: string | null; timeRange: TimeRange }) {
   const [tool, setTool] = useState("All")
   const [status, setStatus] = useState("All")
-  const [rangeMs, setRangeMs] = useState(86_400_000)
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const { users } = useUsers()
   const userMap = useMemo(() => {
@@ -66,16 +58,19 @@ export function AuditTable({ userFilterId, usernameHint }: { userFilterId: strin
     return m
   }, [users])
 
+  // Resolve the header window ONCE per filter change and freeze it. The deps are
+  // primitives (the relative expressions, not Date.now()), so paginating a
+  // sliding relative range can't move the window mid-scroll and drift the cursor.
   const params = useMemo(() => {
-    const now = Date.now()
+    const { fromMs, toMs } = resolveRange(timeRange)
     return {
       userId: userFilterId ?? undefined,
       toolName: tool === "All" ? undefined : tool,
       outcome: status === "All" ? undefined : status,
-      startDate: new Date(now - rangeMs).toISOString(),
-      endDate: new Date(now).toISOString(),
+      from: String(fromMs),
+      to: String(toMs),
     }
-  }, [tool, status, rangeMs, userFilterId])
+  }, [tool, status, timeRange.from, timeRange.to, userFilterId])
 
   const { logs, hasMore, loading, loadMore } = useAudit(params)
 
@@ -102,13 +97,6 @@ export function AuditTable({ userFilterId, usernameHint }: { userFilterId: strin
           className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
         >
           {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s === "All" ? "All Status" : s}</option>)}
-        </select>
-        <select
-          value={rangeMs}
-          onChange={(e) => setRangeMs(parseInt(e.target.value, 10))}
-          className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
-        >
-          {RANGE_OPTIONS.map((r) => <option key={r.value} value={r.value}>{r.label}</option>)}
         </select>
         <div className="flex-1"></div>
         <div className="text-[11px] text-muted-foreground font-mono">{logs.length} entries{hasMore ? "+" : ""}</div>

--- a/portal-web/src/components/metrics/KpiCards.tsx
+++ b/portal-web/src/components/metrics/KpiCards.tsx
@@ -6,7 +6,7 @@ interface Props {
   activeSessions: number
   wsConnections: number
   toolCallsTotal: number
-  period: "today" | "7d" | "30d"
+  rangeLabel: string
 }
 
 function fmt(n: number): string {
@@ -15,14 +15,8 @@ function fmt(n: number): string {
   return String(n)
 }
 
-const periodLabel: Record<Props["period"], string> = {
-  today: "today",
-  "7d": "7d",
-  "30d": "30d",
-}
-
 export function KpiCards(p: Props) {
-  const plabel = periodLabel[p.period]
+  const plabel = p.rangeLabel
   return (
     <div className="grid grid-cols-4 gap-4">
       <KpiCard

--- a/portal-web/src/components/metrics/TimeRangePicker.test.ts
+++ b/portal-web/src/components/metrics/TimeRangePicker.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest"
+import { buildMonthGrid } from "./TimeRangePicker"
+
+const daysInMonth = (y: number, m: number) => new Date(y, m + 1, 0).getDate()
+
+describe("buildMonthGrid", () => {
+  it("always returns a 42-cell (6×7) grid", () => {
+    expect(buildMonthGrid(2026, 5)).toHaveLength(42)
+    expect(buildMonthGrid(2026, 0)).toHaveLength(42)
+  })
+
+  it("first column is always Sunday-aligned", () => {
+    // The first cell's date must fall on a Sunday for every month.
+    // Anchor at local noon so a DST transition can't shift the weekday.
+    for (let m = 0; m < 12; m++) {
+      const first = buildMonthGrid(2026, m)[0]
+      expect(new Date(first.iso + "T12:00").getDay()).toBe(0)
+    }
+  })
+
+  it("marks exactly the in-month days, starting at 1", () => {
+    const grid = buildMonthGrid(2026, 5) // June 2026
+    const inMonth = grid.filter((c) => c.inMonth)
+    expect(inMonth).toHaveLength(daysInMonth(2026, 5)) // 30
+    expect(inMonth[0].day).toBe(1)
+    expect(inMonth[0].iso).toBe("2026-06-01")
+    expect(inMonth[inMonth.length - 1].day).toBe(30)
+    expect(inMonth[inMonth.length - 1].iso).toBe("2026-06-30")
+  })
+
+  it("handles leap vs non-leap February", () => {
+    expect(buildMonthGrid(2024, 1).filter((c) => c.inMonth)).toHaveLength(29)
+    expect(buildMonthGrid(2025, 1).filter((c) => c.inMonth)).toHaveLength(28)
+  })
+
+  it("rolls over December into the next January", () => {
+    const grid = buildMonthGrid(2026, 11) // Dec 2026
+    expect(grid.some((c) => !c.inMonth && c.iso.startsWith("2027-01"))).toBe(true)
+    expect(grid.filter((c) => c.inMonth)).toHaveLength(31)
+  })
+
+  it("rolls leading days back into the previous December for January", () => {
+    const grid = buildMonthGrid(2026, 0) // Jan 2026
+    expect(grid.some((c) => !c.inMonth && c.iso.startsWith("2025-12"))).toBe(true)
+  })
+
+  it("produces strictly contiguous calendar days", () => {
+    // Anchor at local noon + round so a DST 23h/25h day still reads as +1 day.
+    const grid = buildMonthGrid(2026, 1)
+    for (let i = 1; i < grid.length; i++) {
+      const prev = new Date(grid[i - 1].iso + "T12:00").getTime()
+      const cur = new Date(grid[i].iso + "T12:00").getTime()
+      expect(Math.round((cur - prev) / 86_400_000)).toBe(1)
+    }
+  })
+})

--- a/portal-web/src/components/metrics/TimeRangePicker.test.ts
+++ b/portal-web/src/components/metrics/TimeRangePicker.test.ts
@@ -1,7 +1,34 @@
 import { describe, it, expect } from "vitest"
-import { buildMonthGrid } from "./TimeRangePicker"
+import { buildMonthGrid, extractTime } from "./TimeRangePicker"
 
 const daysInMonth = (y: number, m: number) => new Date(y, m + 1, 0).getDate()
+
+describe("extractTime", () => {
+  it("pulls HH:mm from a `date HH:mm` draft", () => {
+    expect(extractTime("2026-06-15 10:30")).toBe("10:30")
+  })
+
+  it("drops the seconds field instead of matching it", () => {
+    // Regression: a trailing-anchored regex matched "30:45" out of "10:30:45".
+    expect(extractTime("2026-06-15 10:30:45")).toBe("10:30")
+  })
+
+  it("handles an ISO `T`-separated draft, dropping seconds/timezone", () => {
+    expect(extractTime("2026-06-15T10:30:45Z")).toBe("10:30")
+    expect(extractTime("2026-06-15T08:05")).toBe("08:05")
+  })
+
+  it("keeps single-digit hours intact", () => {
+    expect(extractTime("2026-06-15 9:30:45")).toBe("9:30")
+  })
+
+  it("returns '' when there is no time-of-day", () => {
+    expect(extractTime("now-7d")).toBe("")
+    expect(extractTime("now")).toBe("")
+    expect(extractTime("2026-06-15")).toBe("")
+    expect(extractTime("")).toBe("")
+  })
+})
 
 describe("buildMonthGrid", () => {
   it("always returns a 42-cell (6×7) grid", () => {

--- a/portal-web/src/components/metrics/TimeRangePicker.tsx
+++ b/portal-web/src/components/metrics/TimeRangePicker.tsx
@@ -1,0 +1,221 @@
+/**
+ * Grafana-style time range picker for the Metrics dashboard.
+ *
+ * A trigger button shows the current range label; clicking opens a popover with
+ *   • left  — absolute From/To text inputs (accept `now-30m` or `2026-06-15 10:30`)
+ *             plus a dependency-free mini month calendar that sets the date part
+ *   • right — quick relative ranges (searchable list)
+ *
+ * The picker only ever emits a `TimeRange` of literal expressions/ISO strings —
+ * resolution to absolute ms happens in the data hooks (`resolveRange`), so a
+ * relative range stays relative (slides) and an absolute one stays fixed.
+ *
+ * Hand-rolled (no shadcn/radix/date-fns in this repo): popover is an absolute
+ * panel closed on outside `mousedown`; the calendar is plain `Date` math.
+ */
+import { useEffect, useMemo, useRef, useState } from "react"
+import { Clock, ChevronDown, ChevronLeft, ChevronRight, Search } from "lucide-react"
+import { QUICK_RANGES, isValidRange, rangeLabel, type TimeRange } from "../../hooks/useMetrics"
+
+interface Props {
+  value: TimeRange
+  onChange: (r: TimeRange) => void
+}
+
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+export interface MonthCell { day: number; inMonth: boolean; iso: string }
+
+/** Build a 6×7 (42-cell) grid for `month` (0-based) of `year`, padded with the
+ *  surrounding days so the first column is always Sunday. Pure — unit-tested. */
+export function buildMonthGrid(year: number, month: number): MonthCell[] {
+  const startOffset = new Date(year, month, 1).getDay() // Sunday = 0
+  const cells: MonthCell[] = []
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(year, month, 1 - startOffset + i)
+    const p = (n: number) => String(n).padStart(2, "0")
+    cells.push({
+      day: d.getDate(),
+      inMonth: d.getMonth() === month,
+      iso: `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`,
+    })
+  }
+  return cells
+}
+
+/** Pull a trailing `HH:mm` out of a draft like "2026-06-15 10:30", else "". */
+function extractTime(v: string): string {
+  const m = /(\d{1,2}:\d{2})\s*$/.exec(v.trim())
+  return m ? m[1] : ""
+}
+
+export function TimeRangePicker({ value, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  const [fromDraft, setFromDraft] = useState(value.from)
+  const [toDraft, setToDraft] = useState(value.to)
+  const [activeField, setActiveField] = useState<"from" | "to">("from")
+  const [search, setSearch] = useState("")
+
+  const today = useMemo(() => new Date(), [])
+  const [calYear, setCalYear] = useState(today.getFullYear())
+  const [calMonth, setCalMonth] = useState(today.getMonth())
+
+  // Re-seed drafts each time the popover opens or the committed value changes.
+  useEffect(() => {
+    if (open) { setFromDraft(value.from); setToDraft(value.to) }
+  }, [open, value.from, value.to])
+
+  // Outside-click close (mousedown, only while open). The trigger lives inside
+  // rootRef too, so one containment check covers trigger + panel.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("mousedown", onDown)
+    return () => document.removeEventListener("mousedown", onDown)
+  }, [open])
+
+  const draft: TimeRange = { from: fromDraft.trim(), to: toDraft.trim() }
+  const draftValid = isValidRange(draft)
+
+  const filteredRanges = QUICK_RANGES.filter((r) =>
+    r.label.toLowerCase().includes(search.trim().toLowerCase()),
+  )
+
+  const pickQuick = (from: string) => {
+    onChange({ from, to: "now" })
+    setSearch("")
+    setOpen(false)
+  }
+
+  const applyAbsolute = () => {
+    if (!draftValid) return
+    onChange(draft)
+    setOpen(false)
+  }
+
+  const pickDay = (iso: string) => {
+    const cur = activeField === "from" ? fromDraft : toDraft
+    const time = extractTime(cur)
+    const next = `${iso} ${time || "00:00"}`
+    if (activeField === "from") { setFromDraft(next); setActiveField("to") }
+    else setToDraft(next)
+  }
+
+  const grid = buildMonthGrid(calYear, calMonth)
+  const prevMonth = () => {
+    if (calMonth === 0) { setCalMonth(11); setCalYear(calYear - 1) } else setCalMonth(calMonth - 1)
+  }
+  const nextMonth = () => {
+    if (calMonth === 11) { setCalMonth(0); setCalYear(calYear + 1) } else setCalMonth(calMonth + 1)
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="h-8 px-2.5 inline-flex items-center gap-1.5 text-[12px] rounded-md bg-secondary border border-border text-foreground hover:border-blue-500/60 focus:outline-none focus:border-blue-500"
+      >
+        <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+        <span>{rangeLabel(value)}</span>
+        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-1 z-20 w-[480px] rounded-lg border border-border bg-card shadow-xl">
+          <div className="grid grid-cols-[1fr_200px]">
+            {/* ── Absolute editor ─────────────────────── */}
+            <div className="p-3 border-r border-border">
+              <h4 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">Absolute time range</h4>
+
+              <label className="block text-[11px] text-muted-foreground mb-1">From</label>
+              <input
+                value={fromDraft}
+                onChange={(e) => setFromDraft(e.target.value)}
+                onFocus={() => setActiveField("from")}
+                placeholder="now-7d or 2026-06-15 10:30"
+                className={`w-full h-8 px-2 mb-2 text-[12px] rounded-md bg-secondary border text-foreground focus:outline-none ${activeField === "from" ? "border-blue-500" : "border-border"}`}
+              />
+
+              <label className="block text-[11px] text-muted-foreground mb-1">To</label>
+              <input
+                value={toDraft}
+                onChange={(e) => setToDraft(e.target.value)}
+                onFocus={() => setActiveField("to")}
+                placeholder="now"
+                className={`w-full h-8 px-2 mb-2 text-[12px] rounded-md bg-secondary border text-foreground focus:outline-none ${activeField === "to" ? "border-blue-500" : "border-border"}`}
+              />
+
+              {/* Mini calendar — sets the date portion of the active field. */}
+              <div className="mt-1 mb-2">
+                <div className="flex items-center justify-between mb-1">
+                  <button onClick={prevMonth} className="p-1 rounded hover:bg-secondary text-muted-foreground" aria-label="Previous month"><ChevronLeft className="h-3.5 w-3.5" /></button>
+                  <span className="text-[12px] font-medium">{MONTHS[calMonth]} {calYear}</span>
+                  <button onClick={nextMonth} className="p-1 rounded hover:bg-secondary text-muted-foreground" aria-label="Next month"><ChevronRight className="h-3.5 w-3.5" /></button>
+                </div>
+                <div className="grid grid-cols-7 gap-0.5 text-center">
+                  {WEEKDAYS.map((w) => (
+                    <div key={w} className="text-[10px] text-muted-foreground py-0.5">{w}</div>
+                  ))}
+                  {grid.map((c, i) => (
+                    <button
+                      key={i}
+                      onClick={() => pickDay(c.iso)}
+                      className={`text-[11px] py-1 rounded hover:bg-blue-500/20 ${c.inMonth ? "text-foreground" : "text-muted-foreground/40"}`}
+                    >
+                      {c.day}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <button
+                onClick={applyAbsolute}
+                disabled={!draftValid}
+                className="w-full h-8 text-[12px] rounded-md bg-blue-500 text-white font-medium hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Apply time range
+              </button>
+              {!draftValid && (
+                <p className="mt-1 text-[10px] text-red-400">Enter a valid range (from must be before to).</p>
+              )}
+            </div>
+
+            {/* ── Quick ranges ────────────────────────── */}
+            <div className="p-3 flex flex-col">
+              <div className="relative mb-2">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-muted-foreground" />
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search…"
+                  className="w-full h-7 pl-7 pr-2 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
+                />
+              </div>
+              <div className="flex flex-col overflow-y-auto max-h-[260px] -mr-1 pr-1">
+                {filteredRanges.length === 0 ? (
+                  <div className="text-[11px] text-muted-foreground py-2 text-center">No matches</div>
+                ) : filteredRanges.map((r) => {
+                  const active = value.to === "now" && value.from === r.from
+                  return (
+                    <button
+                      key={r.key}
+                      onClick={() => pickQuick(r.from)}
+                      className={`text-left text-[12px] px-2 py-1.5 rounded-md hover:bg-secondary ${active ? "bg-secondary text-blue-400 font-medium" : "text-foreground"}`}
+                    >
+                      {r.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/portal-web/src/components/metrics/TimeRangePicker.tsx
+++ b/portal-web/src/components/metrics/TimeRangePicker.tsx
@@ -44,9 +44,15 @@ export function buildMonthGrid(year: number, month: number): MonthCell[] {
   return cells
 }
 
-/** Pull a trailing `HH:mm` out of a draft like "2026-06-15 10:30", else "". */
-function extractTime(v: string): string {
-  const m = /(\d{1,2}:\d{2})\s*$/.exec(v.trim())
+/** Pull the time-of-day `HH:mm` out of a draft like "2026-06-15 10:30",
+ *  "2026-06-15 10:30:45", or an ISO "2026-06-15T10:30:45Z" (seconds and timezone
+ *  are dropped), else "". Split on the date/time separator first so the segment
+ *  match never picks up the seconds field — a trailing-anchored regex on
+ *  "10:30:45" would otherwise yield "30:45" and corrupt the field. Exported for
+ *  unit tests. */
+export function extractTime(v: string): string {
+  const seg = v.trim().split(/[ T]+/)[1] ?? ""
+  const m = /^(\d{1,2}:\d{2})/.exec(seg)
   return m ? m[1] : ""
 }
 

--- a/portal-web/src/components/metrics/TimingStatsCard.tsx
+++ b/portal-web/src/components/metrics/TimingStatsCard.tsx
@@ -16,13 +16,7 @@ import type { LatencyStats, TimingStats, ToolLatencyStats } from "../../hooks/us
 
 interface Props {
   data: TimingStats | null
-  period: "today" | "7d" | "30d"
-}
-
-const PERIOD_LABEL: Record<Props["period"], string> = {
-  today: "today",
-  "7d": "last 7 days",
-  "30d": "last 30 days",
+  rangeLabel: string
 }
 
 const TOP_OPTIONS = [3, 5, 10] as const
@@ -43,7 +37,7 @@ const MODEL_ROWS: Array<{ key: "ttft" | "thinking"; emoji: string; label: string
   { key: "thinking", emoji: "💭", label: "Thinking", hint: "boundary → first token" },
 ]
 
-export function TimingStatsCard({ data, period }: Props) {
+export function TimingStatsCard({ data, rangeLabel }: Props) {
   const [topN, setTopN] = useState<TopN>(3)
   const tools = data?.tools ?? []
   const visibleTools = tools.slice(0, topN)
@@ -54,7 +48,7 @@ export function TimingStatsCard({ data, period }: Props) {
         <div>
           <h3 className="text-sm font-semibold tracking-tight">Latency Breakdown</h3>
           <p className="text-[11px] text-muted-foreground mt-0.5">
-            avg · min · max · p90 · {PERIOD_LABEL[period]}
+            avg · min · max · p90 · {rangeLabel}
           </p>
         </div>
         {data?.truncated && (

--- a/portal-web/src/hooks/useMetrics.test.ts
+++ b/portal-web/src/hooks/useMetrics.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest"
+import { isRelativeExpr, resolveRange, isValidRange, rangeLabel } from "./useMetrics"
+
+describe("isRelativeExpr", () => {
+  it("accepts `now` and `now-<n><unit>`", () => {
+    expect(isRelativeExpr("now")).toBe(true)
+    expect(isRelativeExpr("now-30m")).toBe(true)
+    expect(isRelativeExpr("now-7d")).toBe(true)
+    expect(isRelativeExpr("  now-12h  ")).toBe(true)
+  })
+
+  it("rejects absolute strings and garbage", () => {
+    expect(isRelativeExpr("2026-06-15")).toBe(false)
+    expect(isRelativeExpr("now+1h")).toBe(false)
+    expect(isRelativeExpr("now-5x")).toBe(false) // unsupported unit
+    expect(isRelativeExpr("")).toBe(false)
+  })
+})
+
+describe("resolveRange", () => {
+  it("resolves a relative window to an exact span (single `now` for both bounds)", () => {
+    const { fromMs, toMs } = resolveRange({ from: "now-1h", to: "now" })
+    expect(toMs - fromMs).toBe(3_600_000)
+  })
+
+  it("resolves absolute ISO bounds to their parsed ms", () => {
+    const from = "2026-06-01T00:00:00Z"
+    const to = "2026-06-02T00:00:00Z"
+    const { fromMs, toMs } = resolveRange({ from, to })
+    expect(fromMs).toBe(Date.parse(from))
+    expect(toMs).toBe(Date.parse(to))
+  })
+
+  it("falls back to a trailing 7d window on unparseable input", () => {
+    const { fromMs, toMs } = resolveRange({ from: "garbage", to: "now" })
+    expect(toMs - fromMs).toBe(7 * 86_400_000)
+  })
+})
+
+describe("isValidRange", () => {
+  it("is true when both parse and from < to", () => {
+    expect(isValidRange({ from: "2026-06-01", to: "2026-06-02" })).toBe(true)
+    expect(isValidRange({ from: "now-1h", to: "now" })).toBe(true)
+  })
+
+  it("is false when from >= to", () => {
+    expect(isValidRange({ from: "2026-06-02", to: "2026-06-01" })).toBe(false)
+    expect(isValidRange({ from: "2026-06-01", to: "2026-06-01" })).toBe(false)
+  })
+
+  it("is false when a bound is unparseable", () => {
+    expect(isValidRange({ from: "garbage", to: "2026-06-02" })).toBe(false)
+    expect(isValidRange({ from: "2026-06-01", to: "garbage" })).toBe(false)
+  })
+})
+
+describe("rangeLabel", () => {
+  it("shows a quick range's canned label", () => {
+    expect(rangeLabel({ from: "now-30m", to: "now" })).toBe("Last 30 minutes")
+    expect(rangeLabel({ from: "now-7d", to: "now" })).toBe("Last 7 days")
+  })
+
+  it("passes a non-canned relative range through verbatim", () => {
+    expect(rangeLabel({ from: "now-99h", to: "now" })).toBe("now-99h → now")
+  })
+})

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -84,6 +84,98 @@ export interface AuditResponse {
   hasMore: boolean
 }
 
+// ── Time range model ─────────────────────────────────────
+//
+// A TimeRange's `from`/`to` are each either a relative expression ("now",
+// "now-30m") or an absolute ISO/local string. resolveRange() converts to
+// absolute ms at fetch time, so the backend only ever sees absolute windows.
+// Relative ranges therefore "slide" (re-resolve to the current now on each
+// fetch); absolute ranges are fixed. This mirrors Grafana's model and the
+// downstream sicore dashboard.
+
+export interface TimeRange {
+  from: string
+  to: string
+}
+
+export const QUICK_RANGES: Array<{ key: string; label: string; from: string }> = [
+  { key: "30m", label: "Last 30 minutes", from: "now-30m" },
+  { key: "1h", label: "Last 1 hour", from: "now-1h" },
+  { key: "3h", label: "Last 3 hours", from: "now-3h" },
+  { key: "6h", label: "Last 6 hours", from: "now-6h" },
+  { key: "12h", label: "Last 12 hours", from: "now-12h" },
+  { key: "24h", label: "Last 24 hours", from: "now-24h" },
+  { key: "2d", label: "Last 2 days", from: "now-2d" },
+  { key: "7d", label: "Last 7 days", from: "now-7d" },
+  { key: "30d", label: "Last 30 days", from: "now-30d" },
+  { key: "90d", label: "Last 90 days", from: "now-90d" },
+]
+
+export const DEFAULT_RANGE: TimeRange = { from: "now-7d", to: "now" }
+
+const UNIT_MS: Record<string, number> = {
+  s: 1000,
+  m: 60_000,       // minutes (Grafana 'm'); months are intentionally unsupported
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+}
+
+const RELATIVE_RE = /^now-(\d+)([smhdw])$/
+
+export function isRelativeExpr(v: string): boolean {
+  const s = v.trim()
+  return s === "now" || RELATIVE_RE.test(s)
+}
+
+/** Resolve one side of a range to absolute ms, or null if unparseable.
+ *  Absolute strings are parsed in the browser's local timezone. */
+function resolveExpr(v: string, now: number): number | null {
+  const s = v.trim()
+  if (s === "now") return now
+  const m = RELATIVE_RE.exec(s)
+  if (m) return now - Number(m[1]) * UNIT_MS[m[2]]
+  const t = Date.parse(s)
+  return Number.isNaN(t) ? null : t
+}
+
+/** Convert a TimeRange to absolute ms. Unparseable input falls back to a
+ *  trailing 7d window rather than emitting NaN params; the picker independently
+ *  gates Apply on isValidRange, and the backend 400s on a bad window. */
+export function resolveRange(r: TimeRange): { fromMs: number; toMs: number } {
+  const now = Date.now()
+  const fromMs = resolveExpr(r.from, now)
+  const toMs = resolveExpr(r.to, now)
+  if (fromMs == null || toMs == null) return { fromMs: now - 7 * UNIT_MS.d, toMs: now }
+  return { fromMs, toMs }
+}
+
+/** True when both sides parse and from < to. Gates the picker's Apply button. */
+export function isValidRange(r: TimeRange): boolean {
+  const now = Date.now()
+  const fromMs = resolveExpr(r.from, now)
+  const toMs = resolveExpr(r.to, now)
+  return fromMs != null && toMs != null && fromMs < toMs
+}
+
+/** Human label for the trigger button: a quick range shows its canned label,
+ *  an absolute range a compact "from → to". */
+export function rangeLabel(r: TimeRange): string {
+  if (r.to === "now") {
+    const q = QUICK_RANGES.find((x) => x.from === r.from)
+    if (q) return q.label
+  }
+  const fmt = (v: string): string => {
+    if (isRelativeExpr(v)) return v
+    const t = Date.parse(v)
+    if (Number.isNaN(t)) return v
+    const d = new Date(t)
+    const p = (n: number) => String(n).padStart(2, "0")
+    return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`
+  }
+  return `${fmt(r.from)} → ${fmt(r.to)}`
+}
+
 // ── Hooks ────────────────────────────────────────────────
 
 export function useLive(userId: string | null): { data: LiveData | null; loading: boolean; error: Error | null; refresh: () => void } {
@@ -110,44 +202,46 @@ export function useLive(userId: string | null): { data: LiveData | null; loading
   return { data, loading, error, refresh: fetchOnce }
 }
 
-export function useTimingStats(period: string, userId: string | null): { data: TimingStats | null; loading: boolean; refresh: () => void } {
+export function useTimingStats(range: TimeRange, userId: string | null): { data: TimingStats | null; loading: boolean; refresh: () => void } {
   const [data, setData] = useState<TimingStats | null>(null)
   const [loading, setLoading] = useState(true)
-  const paramsRef = useRef({ period, userId })
-  paramsRef.current = { period, userId }
+  const paramsRef = useRef({ range, userId })
+  paramsRef.current = { range, userId }
 
   const fetchOnce = useCallback(() => {
     setLoading(true)
-    const { period: p, userId: uid } = paramsRef.current
-    const q = new URLSearchParams({ period: p })
+    const { range: r, userId: uid } = paramsRef.current
+    const { fromMs, toMs } = resolveRange(r)
+    const q = new URLSearchParams({ from: String(fromMs), to: String(toMs) })
     if (uid) q.set("userId", uid)
     return api<TimingStats>(`/siclaw/metrics/timing?${q.toString()}`)
       .then((d) => { setData(d); setLoading(false) })
       .catch(() => setLoading(false))
   }, [])
 
-  useEffect(() => { fetchOnce() }, [period, userId, fetchOnce])
+  useEffect(() => { fetchOnce() }, [range.from, range.to, userId, fetchOnce])
 
   return { data, loading, refresh: fetchOnce }
 }
 
-export function useSummary(period: string, userId: string | null): { data: SummaryData | null; loading: boolean; refresh: () => void } {
+export function useSummary(range: TimeRange, userId: string | null): { data: SummaryData | null; loading: boolean; refresh: () => void } {
   const [data, setData] = useState<SummaryData | null>(null)
   const [loading, setLoading] = useState(true)
-  const paramsRef = useRef({ period, userId })
-  paramsRef.current = { period, userId }
+  const paramsRef = useRef({ range, userId })
+  paramsRef.current = { range, userId }
 
   const fetchOnce = useCallback(() => {
     setLoading(true)
-    const { period: p, userId: uid } = paramsRef.current
-    const q = new URLSearchParams({ period: p })
+    const { range: r, userId: uid } = paramsRef.current
+    const { fromMs, toMs } = resolveRange(r)
+    const q = new URLSearchParams({ from: String(fromMs), to: String(toMs) })
     if (uid) q.set("userId", uid)
     return api<SummaryData>(`/siclaw/metrics/summary?${q.toString()}`)
       .then((d) => { setData(d); setLoading(false) })
       .catch(() => setLoading(false))
   }, [])
 
-  useEffect(() => { fetchOnce() }, [period, userId, fetchOnce])
+  useEffect(() => { fetchOnce() }, [range.from, range.to, userId, fetchOnce])
 
   return { data, loading, refresh: fetchOnce }
 }
@@ -156,8 +250,10 @@ interface AuditParams {
   userId?: string
   toolName?: string
   outcome?: string
-  startDate?: string
-  endDate?: string
+  /** Absolute window bounds (unix ms as strings), already resolved + frozen by
+   *  the caller so pagination cursors don't drift on a sliding relative range. */
+  from?: string
+  to?: string
 }
 
 export function useAudit(params: AuditParams): {
@@ -183,8 +279,8 @@ export function useAudit(params: AuditParams): {
     if (p.userId) q.set("userId", p.userId)
     if (p.toolName) q.set("toolName", p.toolName)
     if (p.outcome) q.set("outcome", p.outcome)
-    if (p.startDate) q.set("startDate", p.startDate)
-    if (p.endDate) q.set("endDate", p.endDate)
+    if (p.from) q.set("from", p.from)
+    if (p.to) q.set("to", p.to)
     q.set("limit", "50")
 
     if (append && logsRef.current.length > 0) {
@@ -210,7 +306,7 @@ export function useAudit(params: AuditParams): {
     setLogs([])
     doFetch(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params.userId, params.toolName, params.outcome, params.startDate, params.endDate])
+  }, [params.userId, params.toolName, params.outcome, params.from, params.to])
 
   return { logs, hasMore, loading, loadMore: () => doFetch(true), refresh: () => doFetch(false) }
 }

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -1,25 +1,27 @@
 import { useCallback, useMemo, useState } from "react"
 import { Loader2, RefreshCw } from "lucide-react"
-import { useLive, useSummary, useTimingStats, useUsers } from "../hooks/useMetrics"
+import { useLive, useSummary, useTimingStats, useUsers, rangeLabel, DEFAULT_RANGE, type TimeRange } from "../hooks/useMetrics"
 import { KpiCards } from "../components/metrics/KpiCards"
 import { RankedTable } from "../components/metrics/RankedTable"
 import { TimingStatsCard } from "../components/metrics/TimingStatsCard"
 import { AuditTable } from "../components/metrics/AuditTable"
 import { GrafanaFrame } from "../components/metrics/GrafanaFrame"
+import { TimeRangePicker } from "../components/metrics/TimeRangePicker"
 
 type TabKey = "dashboard" | "audit" | "grafana"
 
 export function Metrics() {
   const [tab, setTab] = useState<TabKey>("dashboard")
   const [userId, setUserId] = useState<string>("")         // "" = All Users
-  const [period, setPeriod] = useState<"today" | "7d" | "30d">("7d")
+  const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_RANGE)
 
   const filterUserId = userId || null
+  const rLabel = rangeLabel(timeRange)
 
   const { users } = useUsers()
   const { data: live, loading: liveLoading, refresh: refreshLive } = useLive(filterUserId)
-  const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(period, filterUserId)
-  const { data: timing, refresh: refreshTiming } = useTimingStats(period, filterUserId)
+  const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(timeRange, filterUserId)
+  const { data: timing, refresh: refreshTiming } = useTimingStats(timeRange, filterUserId)
 
   const [spinning, setSpinning] = useState(false)
   const handleRefresh = useCallback(() => {
@@ -69,15 +71,7 @@ export function Metrics() {
                   <option key={u.id} value={u.id}>{u.username}</option>
                 ))}
               </select>
-              <select
-                value={period}
-                onChange={(e) => setPeriod(e.target.value as "today" | "7d" | "30d")}
-                className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
-              >
-                <option value="today">Today</option>
-                <option value="7d">Last 7 days</option>
-                <option value="30d">Last 30 days</option>
-              </select>
+              <TimeRangePicker value={timeRange} onChange={setTimeRange} />
             </div>
           </div>
 
@@ -113,10 +107,10 @@ export function Metrics() {
                   activeSessions={live?.snapshot.activeSessions ?? 0}
                   wsConnections={live?.snapshot.wsConnections ?? 0}
                   toolCallsTotal={(live?.topTools ?? []).reduce((s, t) => s + t.total, 0)}
-                  period={period}
+                  rangeLabel={rLabel}
                 />
 
-                <TimingStatsCard data={timing} period={period} />
+                <TimingStatsCard data={timing} rangeLabel={rLabel} />
 
                 <div className="grid grid-cols-2 gap-4">
                   <RankedTable
@@ -146,7 +140,7 @@ export function Metrics() {
                 {!filterUserId && summary && summary.byUser.length > 0 && (
                   <RankedTable
                     title="By User"
-                    subtitle={`sessions · messages (period: ${period})`}
+                    subtitle={`sessions · messages (${rLabel})`}
                     items={summary.byUser.map((u) => {
                       const username = users.find((x) => x.id === u.userId)?.username ?? u.userId
                       return {
@@ -165,7 +159,7 @@ export function Metrics() {
         )}
 
         {tab === "audit" && (
-          <AuditTable userFilterId={filterUserId} usernameHint={selectedUsername} />
+          <AuditTable userFilterId={filterUserId} usernameHint={selectedUsername} timeRange={timeRange} />
         )}
 
         {tab === "grafana" && <GrafanaFrame />}

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -323,16 +323,18 @@ describe("siclaw-api misc routes", () => {
       expect([401, 403]).toContain(status);
     });
 
-    it("rejects invalid period (admin)", async () => {
+    it("rejects invalid window (admin)", async () => {
+      // from >= to is rejected by resolveWindow — the from/to contract replaced
+      // the old `period` enum; 4-digit values are read as unix-ms (2000 > 1000).
       const { status } = await runRoute(router, fakeReq({
-        url: "/api/v1/siclaw/metrics/summary?period=bogus",
+        url: "/api/v1/siclaw/metrics/summary?from=2000&to=1000",
         method: "GET",
         headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
       }));
       expect(status).toBe(400);
     });
 
-    it("returns summary for admin with valid period", async () => {
+    it("returns summary for admin with default window", async () => {
       query
         .mockResolvedValueOnce([[{ c: 1 }], []])
         .mockResolvedValueOnce([[{ c: 5 }], []])

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -350,6 +350,40 @@ describe("siclaw-api misc routes", () => {
     });
   });
 
+  // ── Metrics audit ────────────────────────────────────────
+  describe("GET /api/v1/siclaw/metrics/audit", () => {
+    it("rejects non-admin", async () => {
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/audit",
+        method: "GET",
+      }));
+      expect([401, 403]).toContain(status);
+    });
+
+    it("rejects a reversed window with 400, matching summary/timing", async () => {
+      // Regression: audit used `parseTs(...) ?? default` with no `from >= to`
+      // check, so a reversed window silently returned an empty list via BETWEEN
+      // instead of failing the way summary/timing do.
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/audit?from=2000&to=1000",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(400);
+    });
+
+    it("returns logs for admin within a valid window", async () => {
+      query.mockResolvedValueOnce([[], []]);
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/audit?from=1000&to=2000",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(200);
+      expect(Array.isArray(body.logs)).toBe(true);
+    });
+  });
+
   // ── System config ────────────────────────────────────────
   describe("GET /api/v1/siclaw/system/config", () => {
     it("rejects non-admin", async () => {

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2805,11 +2805,32 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
   // Metrics — summary + audit (admin-only, Portal owns the data)
   // ================================================================
 
-  const PERIODS: Record<string, number> = {
-    today: 86_400_000,
-    "7d": 7 * 86_400_000,
-    "30d": 30 * 86_400_000,
-  };
+  // Parse a single timestamp query param: unix-ms (all-digits → `new Date(Number)`)
+  // or any Date-parseable string (ISO, for manual curl/debug); the portal-web
+  // frontend always sends absolute ms. Returns null when absent or unparseable.
+  // Shared by resolveWindow and the audit handler so the two never drift.
+  function parseTs(v: string | undefined): Date | null {
+    if (!v) return null;
+    const d = /^\d+$/.test(v) ? new Date(Number(v)) : new Date(v);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+
+  // Resolve a [from, to] window from query params, replacing the old `period`
+  // enum. Both missing → trailing 7d. Returns null on an unparseable value or
+  // `from >= to`, so the caller can fail-fast with 400 — no silent fallback to
+  // a default window on bad input.
+  function resolveWindow(query: Record<string, string>): { from: Date; to: Date } | null {
+    const fromRaw = query.from;
+    const toRaw = query.to;
+    if (!fromRaw && !toRaw) {
+      const now = Date.now();
+      return { from: new Date(now - 7 * 86_400_000), to: new Date(now) };
+    }
+    const from = parseTs(fromRaw);
+    const to = toRaw ? parseTs(toRaw) : new Date();
+    if (!from || !to || from.getTime() >= to.getTime()) return null;
+    return { from, to };
+  }
 
   // GET /api/v1/siclaw/metrics/summary
   router.get("/api/v1/siclaw/metrics/summary", async (req, res) => {
@@ -2817,24 +2838,23 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
 
     const query = parseQuery(req.url ?? "");
-    const period = query.period || "7d";
-    const rangeMs = PERIODS[period];
-    if (!rangeMs) { sendJson(res, 400, { error: "Invalid period" }); return; }
-    const cutoff = new Date(Date.now() - rangeMs);
+    const window = resolveWindow(query);
+    if (!window) { sendJson(res, 400, { error: "Invalid time range" }); return; }
+    const { from, to } = window;
     const userFilter = query.userId || null;
 
     const db = getDb();
 
-    const sessionParams: unknown[] = [cutoff];
-    let totalSessionsSql = "SELECT COUNT(*) AS c FROM chat_sessions WHERE created_at >= ? AND (origin IS NULL OR origin NOT IN ('task', 'delegation'))";
+    const sessionParams: unknown[] = [from, to];
+    let totalSessionsSql = "SELECT COUNT(*) AS c FROM chat_sessions WHERE created_at >= ? AND created_at <= ? AND (origin IS NULL OR origin NOT IN ('task', 'delegation'))";
     if (userFilter) { totalSessionsSql += " AND user_id = ?"; sessionParams.push(userFilter); }
     const [sRows] = await db.query(totalSessionsSql, sessionParams) as [Array<{ c: number }>, unknown];
     const totalSessions = Number(sRows[0]?.c ?? 0);
 
-    const pParams: unknown[] = [cutoff];
+    const pParams: unknown[] = [from, to];
     let totalPromptsSql = `SELECT COUNT(*) AS c FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
-      WHERE m.role = 'user' AND m.created_at >= ?
+      WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
         AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
         AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
     if (userFilter) { totalPromptsSql += " AND s.user_id = ?"; pParams.push(userFilter); }
@@ -2845,10 +2865,10 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (!userFilter) {
       const [uRows] = await db.query(
         `SELECT s.user_id AS userId, COUNT(DISTINCT s.id) AS sessions, SUM(s.message_count) AS messages
-         FROM chat_sessions s WHERE s.created_at >= ?
+         FROM chat_sessions s WHERE s.created_at >= ? AND s.created_at <= ?
            AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
          GROUP BY s.user_id ORDER BY sessions DESC LIMIT 50`,
-        [cutoff],
+        [from, to],
       ) as any;
       byUser = uRows.map((r: any) => ({ userId: r.userId, sessions: Number(r.sessions), messages: Number(r.messages ?? 0) }));
     }
@@ -2873,10 +2893,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
 
     const query = parseQuery(req.url ?? "");
-    const period = query.period || "7d";
-    const rangeMs = PERIODS[period];
-    if (!rangeMs) { sendJson(res, 400, { error: "Invalid period" }); return; }
-    const cutoff = new Date(Date.now() - rangeMs);
+    const window = resolveWindow(query);
+    if (!window) { sendJson(res, 400, { error: "Invalid time range" }); return; }
+    const { from, to } = window;
     const userFilter = query.userId || null;
 
     const db = getDb();
@@ -2902,11 +2921,11 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // /metrics/summary stay responsive while this one is in flight.
 
     // Assistant rows: pull metadata JSON, parse client-side, harvest ttft/thinking.
-    const aParams: unknown[] = [cutoff];
+    const aParams: unknown[] = [from, to];
     let assistantSql = `SELECT m.metadata
       FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
-      WHERE m.role = 'assistant' AND m.created_at >= ? AND m.metadata IS NOT NULL
+      WHERE m.role = 'assistant' AND m.created_at >= ? AND m.created_at <= ? AND m.metadata IS NOT NULL
         AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
     if (userFilter) { assistantSql += " AND s.user_id = ?"; aParams.push(userFilter); }
     assistantSql += " ORDER BY m.created_at DESC LIMIT ?";
@@ -2916,12 +2935,12 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // just bash) so the dashboard can rank by invocation count — the actual
     // top-N filtering happens client-side so the user can flip 3↔5↔10
     // without re-querying.
-    const tParams: unknown[] = [cutoff];
+    const tParams: unknown[] = [from, to];
     let toolSql = `SELECT m.tool_name AS toolName, m.duration_ms AS durationMs
       FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
       WHERE m.role = 'tool' AND m.tool_name IS NOT NULL AND m.duration_ms IS NOT NULL
-        AND m.created_at >= ?
+        AND m.created_at >= ? AND m.created_at <= ?
         AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
     if (userFilter) { toolSql += " AND s.user_id = ?"; tParams.push(userFilter); }
     toolSql += " ORDER BY m.created_at DESC LIMIT ?";
@@ -2985,11 +3004,15 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
 
     const query = parseQuery(req.url ?? "");
     const limit = Math.min(200, Math.max(1, parseInt(query.limit || "50", 10)));
-    const startDate = query.startDate ? new Date(query.startDate) : new Date(Date.now() - 86_400_000);
-    const endDate = query.endDate ? new Date(query.endDate) : new Date();
+    // Audit uses the same from/to window contract as summary/timing, via the
+    // shared parseTs. It keeps a lenient trailing-24h default (and BETWEEN
+    // semantics) when a bound is absent — the frontend always sends an explicit,
+    // frozen window, so the lenient default is only hit by manual callers.
+    const from = parseTs(query.from) ?? new Date(Date.now() - 86_400_000);
+    const to = parseTs(query.to) ?? new Date();
 
     const conds: string[] = ["m.role = 'tool'", "m.created_at BETWEEN ? AND ?"];
-    const params: unknown[] = [startDate, endDate];
+    const params: unknown[] = [from, to];
     if (query.userId) { conds.push("s.user_id = ?"); params.push(query.userId); }
     if (query.toolName) { conds.push("m.tool_name = ?"); params.push(query.toolName); }
     if (query.outcome) { conds.push("m.outcome = ?"); params.push(query.outcome); }

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2819,6 +2819,11 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
   // enum. Both missing → trailing 7d. Returns null on an unparseable value or
   // `from >= to`, so the caller can fail-fast with 400 — no silent fallback to
   // a default window on bad input.
+  //
+  // Single open bound is intentionally asymmetric: missing `to` → now (a natural
+  // trailing window), but missing `from` (with `to` present) → null/400 rather
+  // than guessing a start for an otherwise-unbounded window. The portal-web
+  // frontend always sends both bounds, so this only constrains manual callers.
   function resolveWindow(query: Record<string, string>): { from: Date; to: Date } | null {
     const fromRaw = query.from;
     const toRaw = query.to;
@@ -3007,9 +3012,12 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // Audit uses the same from/to window contract as summary/timing, via the
     // shared parseTs. It keeps a lenient trailing-24h default (and BETWEEN
     // semantics) when a bound is absent — the frontend always sends an explicit,
-    // frozen window, so the lenient default is only hit by manual callers.
+    // frozen window, so the lenient default is only hit by manual callers. The
+    // reversed-window check below matches summary/timing's 400 so the same
+    // malformed input fails the same way everywhere (no silent empty list).
     const from = parseTs(query.from) ?? new Date(Date.now() - 86_400_000);
     const to = parseTs(query.to) ?? new Date();
+    if (from.getTime() >= to.getTime()) { sendJson(res, 400, { error: "Invalid time range" }); return; }
 
     const conds: string[] = ["m.role = 'tool'", "m.created_at BETWEEN ? AND ?"];
     const params: unknown[] = [from, to];


### PR DESCRIPTION
## What

Ports the Grafana-style time range picker to the Metrics dashboard, replacing the 3-option `period` enum (today/7d/30d) with quick relative ranges + an absolute From/To, and unifying the `/api/v1` metrics endpoints on a single `from`/`to` timestamp contract.

## Why

The dashboard filtered time with a `period` enum while the Audit tab carried its own independent range selector, so the two could silently disagree, and neither could express an absolute window. This mirrors the picker already shipped on the downstream sicore dashboard.

## Changes

**Backend — `src/portal/siclaw-api.ts`**
- `resolveWindow` + a shared `parseTs` helper (unix-ms or ISO; both-missing → trailing 7d; invalid / `from >= to` → 400, fail-fast, no silent fallback)
- `summary` + `timing`: drop the `period` enum, add a `created_at <= to` upper bound to all five windowed queries
- `audit`: rename `startDate`/`endDate` → `from`/`to` (keeps `BETWEEN`)
- The `/api/internal` adapter (downstream sicore Portal contract) is **left untouched**

**Frontend — `portal-web`**
- `useMetrics`: `TimeRange` model + `resolveRange`/`rangeLabel`/`isValidRange`; relative expressions resolve at fetch time (on range change or manual Refresh), so a relative range re-resolves to the current `now` on each fetch while an absolute one stays fixed. (The `/live` card polls every 30s but is window-less; the summary/timing cards do not poll on a timer.)
- `TimeRangePicker` (new): hand-rolled popover (no shadcn/date-fns in this repo) with a dependency-free mini calendar + searchable quick-range list; `buildMonthGrid` is unit-tested
- Audit tab unified under the header picker (drops its own range select); the window is frozen per filter change so pagination cursors don't drift on a sliding range

## Testing

- Backend: `tsc --noEmit` clean; 53 portal tests pass (incl. the migrated invalid-window → 400 test)
- Frontend: `tsc --noEmit` clean; 120 portal-web tests pass (incl. 7 new `buildMonthGrid` tests covering leap year / month rollover / DST); `vite build` succeeds

Design notes: `docs/design/2026-06-15-metrics-time-range-picker.md`
