### PR TITLE
fix(lark-card): stop down-converting headings & tables for schema-2.0…

### DIFF
--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -29,13 +29,16 @@ describe("sanitizeMarkdownForFeishu", () => {
     expect(sanitizeMarkdownForFeishu(md)).toBe(md);
   });
 
-  it("turns ATX headings into bold lines", () => {
-    expect(sanitizeMarkdownForFeishu("# Title")).toBe("**Title**");
-    expect(sanitizeMarkdownForFeishu("## Subtitle\nbody")).toBe("**Subtitle**\nbody");
-    expect(sanitizeMarkdownForFeishu("### Sec\n### Sec2")).toBe("**Sec**\n**Sec2**");
+  it("passes ATX headings through unchanged (schema-2.0 markdown renders them natively)", () => {
+    expect(sanitizeMarkdownForFeishu("# Title")).toBe("# Title");
+    expect(sanitizeMarkdownForFeishu("## Subtitle\nbody")).toBe("## Subtitle\nbody");
+    expect(sanitizeMarkdownForFeishu("### Sec\n### Sec2")).toBe("### Sec\n### Sec2");
+    // A heading with a leading emoji must NOT become `**…**` (that produced
+    // literal asterisks when the bold marker glued onto the emoji).
+    expect(sanitizeMarkdownForFeishu("### 🔴 Issue 1: disk full")).toBe("### 🔴 Issue 1: disk full");
   });
 
-  it("wraps GFM tables in a fenced code block so columns stay aligned", () => {
+  it("passes GFM tables through unchanged (schema-2.0 markdown renders them natively)", () => {
     const input = [
       "| col1 | col2 |",
       "|------|------|",
@@ -43,11 +46,10 @@ describe("sanitizeMarkdownForFeishu", () => {
       "| c    | d    |",
     ].join("\n") + "\n";
     const out = sanitizeMarkdownForFeishu(input);
-    expect(out.startsWith("```\n")).toBe(true);
-    expect(out).toContain("| col1 | col2 |");
-    expect(out).toContain("|------|------|");
-    expect(out).toContain("| a    | b    |");
-    expect(out.trim().endsWith("```")).toBe(true);
+    // No longer wrapped in a fenced code block — passed through verbatim so the
+    // 2.0 markdown element renders a real table (not a monospace code box).
+    expect(out).toBe(input);
+    expect(out.startsWith("```")).toBe(false);
   });
 
   it("prefixes blockquotes with a full-width pipe", () => {
@@ -68,9 +70,11 @@ describe("sanitizeMarkdownForFeishu", () => {
       "```",
     ].join("\n");
     const out = sanitizeMarkdownForFeishu(md);
-    // Outside transformed
-    expect(out).toContain("**outside**");
-    // Inside preserved verbatim
+    // Outside heading passes through unchanged (rendered natively by 2.0).
+    expect(out).toContain("# outside");
+    expect(out).not.toContain("**outside**");
+    // Inside the fenced code block, everything is preserved verbatim — the
+    // carve-out/restore must still protect code contents.
     expect(out).toContain("# inside code block — MUST be left alone");
     expect(out).toContain("| col | col |");
     expect(out).toContain("> not a real quote");
@@ -217,10 +221,10 @@ describe("finalizeCard", () => {
     const ok = await finalizeCard(client as any, session, "# Heading\ntext **bold**");
     expect(ok).toBe(true);
 
-    // content call gets sanitized text (heading → bold line)
+    // content call gets sanitized text (heading passes through unchanged now)
     const contentArg = contentSpy.mock.calls[0][0];
     expect(contentArg.path).toEqual({ card_id: "CARD-1", element_id: "md_main" });
-    expect(contentArg.data.content).toBe("**Heading**\ntext **bold**");
+    expect(contentArg.data.content).toBe("# Heading\ntext **bold**");
     expect(contentArg.data.sequence).toBe(1);
 
     // settings flips streaming_mode off with a later sequence

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -11,9 +11,14 @@
  *     locks to its terminal state.
  *
  * Design choices:
- *  - Markdown renders natively inside the card's `markdown` element;
- *    features Feishu doesn't support (H1-H3, GFM tables, blockquotes)
- *    are normalised to the closest supported syntax by `sanitizeMarkdownForFeishu`.
+ *  - The card uses CardKit schema "2.0" (see buildPlaceholderCard), whose
+ *    `markdown` element renders ATX headings (H1-H6) and GFM pipe tables
+ *    NATIVELY. We deliberately DO NOT down-convert those — the old
+ *    heading→bold / table→code-block normalisation caused rendering bugs
+ *    (literal `**`, table shown as a truncated monospace box) and must not
+ *    be reintroduced. `sanitizeMarkdownForFeishu` now only rewrites
+ *    blockquotes (`>` → `｜ `); everything else passes through. See that
+ *    function's doc comment for details.
  *  - All failures return `null` / `false` so the caller can fall back
  *    to the legacy plain-text reply — we never throw into the channel
  *    message loop.
@@ -65,10 +70,18 @@ export interface CardSession {
 /**
  * Convert markdown to the subset Feishu's card `markdown` element renders.
  *
- * Unsupported features handled here:
- *  - ATX headings (`#`, `##`, `###`, …) → bold on their own line.
- *  - GFM tables → fenced code block (preserves column alignment visually).
- *  - Blockquotes (`>`) → full-width vertical bar prefix `｜ `.
+ * This card uses CardKit schema "2.0" (see buildPlaceholderCard), whose
+ * `markdown` element renders ATX headings (`#`…`######`) and GFM pipe tables
+ * NATIVELY (Feishu docs: 标题/表格 仅支持 JSON 2.0 富文本组件). We no longer
+ * down-convert them — doing so was actively harmful:
+ *  - heading → `**…**` produced literal `**` when the bold marker ended up
+ *    wedged against adjacent CJK/emoji text (shown as raw asterisks).
+ *  - table → fenced code block rendered as a truncated, line-numbered,
+ *    horizontally-scrolling monospace box instead of a real table.
+ * Headings and tables now pass through unchanged for native rendering.
+ *
+ * Blockquotes (`>`) are still rewritten to a full-width vertical bar prefix
+ * `｜ ` (left as-is in this change).
  *
  * Everything else (bold, italic, strikethrough, lists, fenced code blocks,
  * inline code, links, horizontal rule, `<at>`, emoji shortcodes) is passed
@@ -85,18 +98,10 @@ export function sanitizeMarkdownForFeishu(input: string): string {
     return `\u0000CODEBLOCK${codeBlocks.length - 1}\u0000`;
   });
 
-  // Headings (including leading whitespace, 1-6 #'s) → bold line.
-  text = text.replace(/^\s*#{1,6}\s+(.+?)\s*$/gm, "**$1**");
-
-  // GFM tables: header + separator + rows. Detect the separator row (|---|---|)
-  // as the anchor, then gobble surrounding rows. Wrap the whole block in a
-  // fenced code block so columns stay aligned.
-  text = text.replace(
-    /((?:^\s*\|[^\n]*\|\s*\n)+)(\s*\|(?:\s*:?-+:?\s*\|)+\s*\n)((?:^\s*\|[^\n]*\|\s*\n?)*)/gm,
-    (_match, header: string, sep: string, rows: string) => {
-      return "```\n" + header + sep + rows + "```\n";
-    },
-  );
+  // NOTE: ATX headings (#/##/###) and GFM pipe tables are intentionally passed
+  // THROUGH — the schema-2.0 markdown element renders them natively. (They were
+  // previously down-converted here; that caused the literal-`**` and
+  // table-as-codeblock rendering bugs.)
 
   // Blockquotes → "｜ " prefix (full-width pipe keeps the indent visible
   // without relying on an unsupported tag).


### PR DESCRIPTION
… markdown

The feishu reply card uses CardKit schema 2.0, whose markdown element renders ATX headings and GFM pipe tables natively. The old sanitizer down-converted them, which caused two rendering bugs:
- heading -> **...** emitted literal ** asterisks when the bold marker glued onto adjacent CJK/emoji text;
- table -> fenced code block rendered as a truncated, line-numbered, horizontally-scrolling monospace box instead of a real table.

Pass headings and tables through unchanged so the 2.0 markdown element renders them natively. Blockquote->｜ rewrite kept as-is. Tests updated to assert pass-through.

## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **DB parity**: Schema changes keep `src/portal/migrate.ts` compatible with both MySQL and SQLite (see [`docs/design/invariants.md §5`](../docs/design/invariants.md)).
- [ ] **Tool protocol**: New tools register through `src/core/tool-registry.ts` and use the TypeBox `ToolDefinition` protocol.

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
