### PR TITLE
Add Lark chart image replies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@earendil-works/pi-tui": "^0.78.1",
         "@kubernetes/client-node": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@resvg/resvg-js": "^2.6.2",
         "@sinclair/typebox": "^0.34.0",
         "adm-zip": "^0.5.17",
         "diff": "^8.0.3",
@@ -1287,7 +1288,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3323,6 +3324,221 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@earendil-works/pi-tui": "^0.78.1",
     "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@resvg/resvg-js": "^2.6.2",
     "@sinclair/typebox": "^0.34.0",
     "adm-zip": "^0.5.17",
     "diff": "^8.0.3",

--- a/src/gateway/channels/chart-image.test.ts
+++ b/src/gateway/channels/chart-image.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractChartSpec,
+  maybeRenderChartPng,
+  renderChartPng,
+  type ChartSpec,
+} from "./chart-image.js";
+
+describe("extractChartSpec", () => {
+  it("returns null for plain text and non-numeric tables", () => {
+    expect(extractChartSpec("plain answer without structured data")).toBeNull();
+    expect(extractChartSpec([
+      "| Region | Status |",
+      "|---|---|",
+      "| East | ok |",
+      "| West | warning |",
+    ].join("\n"))).toBeNull();
+  });
+
+  it("extracts a bar chart from the first numeric markdown table", () => {
+    const spec = extractChartSpec([
+      "Summary:",
+      "",
+      "| Region | Count |",
+      "|---|---:|",
+      "| East | 12 |",
+      "| West | 7 |",
+      "| North | 4 |",
+    ].join("\n"));
+
+    expect(spec).toEqual({
+      title: "Count by Region",
+      labels: ["East", "West", "North"],
+      values: [12, 7, 4],
+    });
+  });
+
+  it("extracts fenced chart JSON before looking at tables", () => {
+    const spec = extractChartSpec([
+      "```chart",
+      "{\"title\":\"Incidents\",\"labels\":[\"P0\",\"P1\"],\"values\":[1,4]}",
+      "```",
+      "",
+      "| Region | Count |",
+      "|---|---:|",
+      "| East | 12 |",
+      "| West | 7 |",
+    ].join("\n"));
+
+    expect(spec).toEqual({
+      title: "Incidents",
+      labels: ["P0", "P1"],
+      values: [1, 4],
+    });
+  });
+
+  it("caps rows and clamps long labels", () => {
+    const rows = Array.from({ length: 16 }, (_, i) =>
+      `| Extremely long region label ${i} with extra suffix | ${i + 1} |`,
+    );
+    const spec = extractChartSpec([
+      "| Region | Count |",
+      "|---|---:|",
+      ...rows,
+    ].join("\n"));
+
+    expect(spec).not.toBeNull();
+    expect(spec!.labels).toHaveLength(12);
+    expect(spec!.values).toHaveLength(12);
+    expect(spec!.labels[0].length).toBeLessThanOrEqual(28);
+    expect(spec!.labels[0].endsWith("...")).toBe(true);
+  });
+});
+
+describe("renderChartPng", () => {
+  it("returns a non-empty PNG buffer below Feishu's image upload limit", async () => {
+    const spec: ChartSpec = {
+      title: "Count by Region",
+      labels: ["East", "West", "North"],
+      values: [12, 7, 4],
+    };
+
+    const png = await renderChartPng(spec);
+    expect(Buffer.isBuffer(png)).toBe(true);
+    expect(png.length).toBeGreaterThan(1024);
+    expect(png.length).toBeLessThan(10 * 1024 * 1024);
+    expect([...png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+});
+
+describe("maybeRenderChartPng", () => {
+  it("returns null when the markdown has no chart-worthy data", async () => {
+    await expect(maybeRenderChartPng("just text")).resolves.toBeNull();
+  });
+
+  it("renders a PNG when the markdown has a numeric table", async () => {
+    const png = await maybeRenderChartPng([
+      "| Region | Count |",
+      "|---|---:|",
+      "| East | 12 |",
+      "| West | 7 |",
+    ].join("\n"));
+
+    expect(png).not.toBeNull();
+    expect([...png!.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+});

--- a/src/gateway/channels/chart-image.ts
+++ b/src/gateway/channels/chart-image.ts
@@ -1,0 +1,231 @@
+import { Resvg } from "@resvg/resvg-js";
+
+export interface ChartSpec {
+  title?: string;
+  labels: string[];
+  values: number[];
+}
+
+const MAX_CHART_ROWS = 12;
+const MAX_LABEL_LENGTH = 28;
+const FEISHU_IMAGE_LIMIT_BYTES = 10 * 1024 * 1024;
+
+export function extractChartSpec(markdown: string): ChartSpec | null {
+  const fenced = extractFencedChart(markdown);
+  if (fenced) return normalizeChartSpec(fenced);
+  return extractTableChart(markdown);
+}
+
+export async function renderChartPng(spec: ChartSpec): Promise<Buffer> {
+  const normalized = normalizeChartSpec(spec);
+  if (!normalized) throw new Error("invalid chart spec");
+
+  const svg = renderChartSvg(normalized);
+  return new Resvg(svg, {
+    background: "#ffffff",
+    fitTo: { mode: "original" },
+    font: {
+      loadSystemFonts: true,
+      sansSerifFamily: "Arial",
+    },
+  }).render().asPng();
+}
+
+export async function maybeRenderChartPng(markdown: string): Promise<Buffer | null> {
+  const spec = extractChartSpec(markdown);
+  if (!spec) return null;
+  const png = await renderChartPng(spec);
+  return png.length <= FEISHU_IMAGE_LIMIT_BYTES ? png : null;
+}
+
+function extractFencedChart(markdown: string): unknown | null {
+  const match = markdown.match(/```chart\s*\n([\s\S]*?)```/i);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeChartSpec(value: unknown): ChartSpec | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as { title?: unknown; labels?: unknown; values?: unknown };
+  if (!Array.isArray(raw.labels) || !Array.isArray(raw.values)) return null;
+
+  const rows: Array<{ label: string; value: number }> = [];
+  const count = Math.min(raw.labels.length, raw.values.length, MAX_CHART_ROWS);
+  for (let i = 0; i < count; i++) {
+    const label = normalizeLabel(raw.labels[i]);
+    const parsed = parseNumber(raw.values[i]);
+    if (label && parsed !== null) rows.push({ label, value: parsed });
+  }
+  if (rows.length === 0) return null;
+
+  const title = typeof raw.title === "string" ? raw.title.trim().slice(0, 80) : undefined;
+  return {
+    title: title || undefined,
+    labels: rows.map((row) => row.label),
+    values: rows.map((row) => row.value),
+  };
+}
+
+function extractTableChart(markdown: string): ChartSpec | null {
+  const lines = markdown.split(/\r?\n/);
+  for (let i = 0; i < lines.length - 1; i++) {
+    if (!looksLikeTableRow(lines[i]) || !looksLikeSeparator(lines[i + 1])) continue;
+
+    const headers = splitTableRow(lines[i]);
+    const rows: string[][] = [];
+    for (let j = i + 2; j < lines.length; j++) {
+      if (!looksLikeTableRow(lines[j])) break;
+      const row = splitTableRow(lines[j]);
+      if (row.length >= headers.length) rows.push(row);
+    }
+    const spec = tableToChartSpec(headers, rows);
+    if (spec) return spec;
+  }
+  return null;
+}
+
+function tableToChartSpec(headers: string[], rows: string[][]): ChartSpec | null {
+  if (headers.length < 2 || rows.length === 0) return null;
+
+  let valueIndex = -1;
+  let bestNumericCount = 0;
+  for (let col = 0; col < headers.length; col++) {
+    const numericCount = rows.reduce((count, row) => count + (parseNumber(row[col]) === null ? 0 : 1), 0);
+    if (numericCount > bestNumericCount) {
+      bestNumericCount = numericCount;
+      valueIndex = col;
+    }
+  }
+  if (valueIndex < 0 || bestNumericCount < 2) return null;
+
+  const labelIndex = headers.findIndex((_, col) => col !== valueIndex);
+  if (labelIndex < 0) return null;
+
+  const chartRows: Array<{ label: string; value: number }> = [];
+  for (const row of rows) {
+    const label = normalizeLabel(row[labelIndex]);
+    const value = parseNumber(row[valueIndex]);
+    if (label && value !== null) chartRows.push({ label, value });
+    if (chartRows.length >= MAX_CHART_ROWS) break;
+  }
+  if (chartRows.length < 2) return null;
+
+  const labelHeader = normalizeLabel(headers[labelIndex]);
+  const valueHeader = normalizeLabel(headers[valueIndex]);
+  return {
+    title: valueHeader && labelHeader ? `${valueHeader} by ${labelHeader}` : valueHeader || undefined,
+    labels: chartRows.map((row) => row.label),
+    values: chartRows.map((row) => row.value),
+  };
+}
+
+function looksLikeTableRow(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith("|") && trimmed.endsWith("|") && splitTableRow(trimmed).length >= 2;
+}
+
+function looksLikeSeparator(line: string): boolean {
+  const cells = splitTableRow(line);
+  return cells.length >= 2 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.replace(/\s+/g, "")));
+}
+
+function splitTableRow(line: string): string[] {
+  return line.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((cell) => cell.trim());
+}
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string") return null;
+  const cleaned = value.trim().replace(/,/g, "").replace(/%$/, "");
+  if (!/^[-+]?(?:\d+\.?\d*|\.\d+)$/.test(cleaned)) return null;
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+
+function normalizeLabel(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const label = String(value).replace(/\s+/g, " ").trim();
+  return label.length > MAX_LABEL_LENGTH ? `${label.slice(0, MAX_LABEL_LENGTH - 3)}...` : label;
+}
+
+function renderChartSvg(spec: ChartSpec): string {
+  const width = 960;
+  const height = 560;
+  const margin = { top: 78, right: 44, bottom: 106, left: 82 };
+  const plotWidth = width - margin.left - margin.right;
+  const plotHeight = height - margin.top - margin.bottom;
+  const minValue = Math.min(0, ...spec.values);
+  const maxValue = Math.max(0, ...spec.values);
+  const range = maxValue === minValue ? 1 : maxValue - minValue;
+  const niceMax = maxValue + range * 0.08;
+  const niceMin = minValue - range * 0.08;
+  const niceRange = niceMax - niceMin || 1;
+  const zeroY = valueToY(0, niceMin, niceRange, margin.top, plotHeight);
+  const band = plotWidth / spec.values.length;
+  const barWidth = Math.max(24, Math.min(72, band * 0.58));
+  const gridLines = 5;
+
+  const bars = spec.values.map((value, i) => {
+    const x = margin.left + i * band + (band - barWidth) / 2;
+    const y = valueToY(Math.max(value, 0), niceMin, niceRange, margin.top, plotHeight);
+    const y0 = valueToY(Math.min(value, 0), niceMin, niceRange, margin.top, plotHeight);
+    const h = Math.max(2, Math.abs(y0 - y));
+    const labelX = margin.left + i * band + band / 2;
+    const labelY = value >= 0 ? y - 10 : y0 + h + 18;
+    return `
+      <rect x="${x.toFixed(1)}" y="${Math.min(y, y0).toFixed(1)}" width="${barWidth.toFixed(1)}" height="${h.toFixed(1)}" rx="8" fill="#2563eb"/>
+      <text x="${labelX.toFixed(1)}" y="${labelY.toFixed(1)}" text-anchor="middle" class="value">${escapeXml(formatValue(value))}</text>
+      <text x="${labelX.toFixed(1)}" y="${height - 54}" text-anchor="end" transform="rotate(-28 ${labelX.toFixed(1)} ${height - 54})" class="label">${escapeXml(spec.labels[i])}</text>
+    `;
+  }).join("");
+
+  const grids = Array.from({ length: gridLines + 1 }, (_, i) => {
+    const value = niceMin + (niceRange * i) / gridLines;
+    const y = valueToY(value, niceMin, niceRange, margin.top, plotHeight);
+    return `
+      <line x1="${margin.left}" x2="${width - margin.right}" y1="${y.toFixed(1)}" y2="${y.toFixed(1)}" class="grid"/>
+      <text x="${margin.left - 14}" y="${(y + 4).toFixed(1)}" text-anchor="end" class="axis">${escapeXml(formatValue(value))}</text>
+    `;
+  }).join("");
+
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <style>
+    .title { font: 700 30px Arial, sans-serif; fill: #0f172a; }
+    .subtitle { font: 400 14px Arial, sans-serif; fill: #64748b; }
+    .axis { font: 400 13px Arial, sans-serif; fill: #64748b; }
+    .label { font: 500 14px Arial, sans-serif; fill: #334155; }
+    .value { font: 700 14px Arial, sans-serif; fill: #0f172a; }
+    .grid { stroke: #e2e8f0; stroke-width: 1; }
+    .baseline { stroke: #94a3b8; stroke-width: 2; }
+  </style>
+  <rect width="100%" height="100%" rx="0" fill="#ffffff"/>
+  <text x="44" y="45" class="title">${escapeXml(spec.title || "Chart")}</text>
+  <text x="44" y="68" class="subtitle">Generated from Siclaw response data</text>
+  ${grids}
+  <line x1="${margin.left}" x2="${width - margin.right}" y1="${zeroY.toFixed(1)}" y2="${zeroY.toFixed(1)}" class="baseline"/>
+  ${bars}
+</svg>`;
+}
+
+function valueToY(value: number, min: number, range: number, top: number, height: number): number {
+  return top + height - ((value - min) / range) * height;
+}
+
+function formatValue(value: number): string {
+  if (Math.abs(value) >= 1000) return Math.round(value).toLocaleString("en-US");
+  if (Math.abs(value) >= 10) return Number(value.toFixed(1)).toString();
+  return Number(value.toFixed(2)).toString();
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/gateway/channels/lark-image.test.ts
+++ b/src/gateway/channels/lark-image.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { replyImageToLark } from "./lark-image.js";
+
+function makeLarkClient(uploadResponse: unknown = { image_key: "img-123" }) {
+  return {
+    im: {
+      image: {
+        create: vi.fn().mockResolvedValue(uploadResponse),
+      },
+      message: {
+        reply: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+}
+
+describe("replyImageToLark", () => {
+  it("uploads a message image and replies with the returned image_key", async () => {
+    const lark = makeLarkClient();
+    const image = Buffer.from([1, 2, 3]);
+
+    await expect(replyImageToLark(lark, "mid-1", image)).resolves.toBe(true);
+
+    expect(lark.im.image.create).toHaveBeenCalledWith({
+      data: {
+        image_type: "message",
+        image,
+      },
+    });
+    expect(lark.im.message.reply).toHaveBeenCalledWith({
+      path: { message_id: "mid-1" },
+      data: {
+        msg_type: "image",
+        content: JSON.stringify({ image_key: "img-123" }),
+      },
+    });
+  });
+
+  it("accepts SDK responses where image_key is nested under data", async () => {
+    const lark = makeLarkClient({ data: { image_key: "img-nested" } });
+
+    await expect(replyImageToLark(lark, "mid-1", Buffer.from([1]))).resolves.toBe(true);
+
+    const replyArg = lark.im.message.reply.mock.calls[0][0];
+    expect(JSON.parse(replyArg.data.content)).toEqual({ image_key: "img-nested" });
+  });
+
+  it("falls back to the im.v1.image namespace when needed", async () => {
+    const lark = {
+      im: {
+        v1: {
+          image: {
+            create: vi.fn().mockResolvedValue({ image_key: "img-v1" }),
+          },
+        },
+        message: {
+          reply: vi.fn().mockResolvedValue({}),
+        },
+      },
+    };
+
+    await expect(replyImageToLark(lark, "mid-1", Buffer.from([1]))).resolves.toBe(true);
+
+    expect(lark.im.v1.image.create).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(lark.im.message.reply.mock.calls[0][0].data.content)).toEqual({ image_key: "img-v1" });
+  });
+
+  it("logs and returns false when upload returns no image_key", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const lark = makeLarkClient({});
+
+    await expect(replyImageToLark(lark, "mid-1", Buffer.from([1]))).resolves.toBe(false);
+
+    expect(lark.im.message.reply).not.toHaveBeenCalled();
+  });
+
+  it("logs and returns false on upload or reply failures", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const lark = makeLarkClient();
+    lark.im.image.create.mockRejectedValueOnce(new Error("forbidden"));
+
+    await expect(replyImageToLark(lark, "mid-1", Buffer.from([1]))).resolves.toBe(false);
+    expect(lark.im.message.reply).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/channels/lark-image.ts
+++ b/src/gateway/channels/lark-image.ts
@@ -1,0 +1,37 @@
+export async function replyImageToLark(
+  larkClient: any,
+  messageId: string,
+  image: Buffer,
+): Promise<boolean> {
+  try {
+    const imageApi = larkClient?.im?.image ?? larkClient?.im?.v1?.image;
+    if (!imageApi?.create) {
+      console.error("[lark-image] im.image.create is unavailable; cannot upload chart image");
+      return false;
+    }
+
+    const upload = await imageApi.create({
+      data: {
+        image_type: "message",
+        image,
+      },
+    });
+    const imageKey = upload?.image_key ?? upload?.data?.image_key;
+    if (!imageKey || typeof imageKey !== "string") {
+      console.error("[lark-image] image upload returned no image_key");
+      return false;
+    }
+
+    await larkClient.im.message.reply({
+      path: { message_id: messageId },
+      data: {
+        msg_type: "image",
+        content: JSON.stringify({ image_key: imageKey }),
+      },
+    });
+    return true;
+  } catch (err) {
+    console.error(`[lark-image] reply image failed for messageId=${messageId}:`, err);
+    return false;
+  }
+}

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -299,7 +299,10 @@ describe("handleLarkMessage — routing to AgentBox", () => {
 describe("handleLarkMessage — streaming card flow", () => {
   function makeCardAwareLarkClient() {
     return {
-      im: { message: { reply: vi.fn().mockResolvedValue({}) } },
+      im: {
+        image: { create: vi.fn().mockResolvedValue({ image_key: "img-chart-1" }) },
+        message: { reply: vi.fn().mockResolvedValue({}) },
+      },
       cardkit: {
         v1: {
           card: {
@@ -353,6 +356,115 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(lark.cardkit.v1.card.settings).toHaveBeenCalledTimes(1);
     const settingsPayload = JSON.parse(lark.cardkit.v1.card.settings.mock.calls[0][0].data.settings);
     expect(settingsPayload.config.streaming_mode).toBe(false);
+    expect(lark.im.image.create).not.toHaveBeenCalled();
+  });
+
+  it("keeps the markdown card and also replies with one chart image for numeric tables", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-chart" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "统计如下：",
+              "",
+              "| Region | Count |",
+              "|---|---:|",
+              "| East | 12 |",
+              "| West | 7 |",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(lark.cardkit.v1.cardElement.content).toHaveBeenCalledTimes(1);
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+    const uploadArg = lark.im.image.create.mock.calls[0][0];
+    expect(uploadArg.data.image_type).toBe("message");
+    expect(Buffer.isBuffer(uploadArg.data.image)).toBe(true);
+
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(2);
+    expect(lark.im.message.reply.mock.calls[0][0].data.msg_type).toBe("interactive");
+    const imageReply = lark.im.message.reply.mock.calls[1][0];
+    expect(imageReply.path.message_id).toBe("mid-1");
+    expect(imageReply.data.msg_type).toBe("image");
+    expect(JSON.parse(imageReply.data.content)).toEqual({ image_key: "img-chart-1" });
+  });
+
+  it("does not reply with an image when the final answer has no chart-worthy data", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-no-chart" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "只是普通文本答复" }] } };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(lark.cardkit.v1.cardElement.content).toHaveBeenCalledTimes(1);
+    expect(lark.im.image.create).not.toHaveBeenCalled();
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the markdown card successful when chart image upload returns no key", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-chart-fail" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "| Region | Count |",
+              "|---|---:|",
+              "| East | 12 |",
+              "| West | 7 |",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+    lark.im.image.create.mockResolvedValueOnce({});
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(lark.cardkit.v1.cardElement.content).toHaveBeenCalledTimes(1);
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.reply.mock.calls[0][0].data.msg_type).toBe("interactive");
   });
 
   it("falls back to plain text reply when card.create fails (preserves the pre-card UX)", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -20,6 +20,8 @@ import {
   EMPTY_RESULT_NOTICE_BY_LOCALE,
   localeForDomain,
 } from "./lark-card.js";
+import { maybeRenderChartPng } from "./chart-image.js";
+import { replyImageToLark } from "./lark-image.js";
 
 export interface LarkChannelConfig {
   domain?: "feishu" | "lark";  // feishu = China (default), lark = Global
@@ -216,6 +218,8 @@ export async function handleLarkMessage(
     // whatever we have (final answer or error).
     await replyToLark(larkClient, messageId, finalBody);
   }
+
+  await maybeReplyChartImage(larkClient, messageId, finalBody);
 }
 
 /**
@@ -245,6 +249,19 @@ async function replyToLark(larkClient: any, messageId: string, text: string): Pr
     });
   } catch (err) {
     console.error(`[lark] Failed to reply to messageId=${messageId}:`, err);
+  }
+}
+
+async function maybeReplyChartImage(larkClient: any, messageId: string, finalBody: string): Promise<void> {
+  try {
+    const png = await maybeRenderChartPng(finalBody);
+    if (!png) return;
+    const ok = await replyImageToLark(larkClient, messageId, png);
+    if (!ok) {
+      console.warn(`[lark] Chart image reply failed for messageId=${messageId}; markdown card remains primary`);
+    }
+  } catch (err) {
+    console.error(`[lark] Chart image rendering failed for messageId=${messageId}:`, err);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add a Runtime-only chart image reply for Lark/Feishu group answers when the final markdown contains chart-worthy data.
- Detect fenced `chart` JSON first, then fall back to the first numeric GFM table, and render a simple PNG bar chart with `@resvg/resvg-js`.
- Upload the PNG as a Feishu message image and reply with `msg_type=image`, while keeping the CardKit markdown reply as the primary response.

## Failure behavior

Image rendering/upload/reply failures are non-fatal: Siclaw logs the failure and leaves the existing markdown card path successful.

## Validation

- `npm test -- src/gateway/channels/lark.test.ts src/gateway/channels/lark-card.test.ts src/gateway/channels/chart-image.test.ts src/gateway/channels/lark-image.test.ts`
- `npx tsc --noEmit --pretty false`
