### PR TITLE
Support visual Lark replies without source noise

### DIFF
--- a/src/gateway/channels/chart-image.test.ts
+++ b/src/gateway/channels/chart-image.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   extractChartSpec,
   maybeRenderChartPng,
+  maybeRenderVisualImages,
   renderChartPng,
+  stripFencedChartBlocks,
+  stripVisualBlocks,
   type ChartSpec,
 } from "./chart-image.js";
 
@@ -103,5 +106,122 @@ describe("maybeRenderChartPng", () => {
 
     expect(png).not.toBeNull();
     expect([...png!.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+});
+
+describe("maybeRenderVisualImages", () => {
+  it("renders MCP/Sicore bar chart specs from fenced chart blocks", async () => {
+    const markdown = [
+      "结论：East 增长最高。",
+      "",
+      "```chart",
+      JSON.stringify({
+        type: "bar",
+        title: "Incidents by Region",
+        data: {
+          categories: ["East", "West"],
+          series: [
+            { name: "P0", values: [1, 2] },
+            { name: "P1", values: [4, 3] },
+          ],
+        },
+      }),
+      "```",
+    ].join("\n");
+
+    const images = await maybeRenderVisualImages(markdown);
+    expect(images).toHaveLength(1);
+    expect(images[0].kind).toBe("chart");
+    expect([...images[0].image.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("renders Mermaid flowcharts as PNG images", async () => {
+    const images = await maybeRenderVisualImages([
+      "```mermaid",
+      "flowchart TD",
+      "  A[Check pod] --> B{Ready?}",
+      "  B -->|No| C[Inspect events]",
+      "  B -->|Yes| D[Done]",
+      "```",
+    ].join("\n"));
+
+    expect(images).toHaveLength(1);
+    expect(images[0].kind).toBe("mermaid");
+    expect([...images[0].image.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("forwards final-answer data URI images as image attachments", async () => {
+    const onePixelPng =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+    const images = await maybeRenderVisualImages(`结论卡片：\n\n![card](${onePixelPng})`);
+
+    expect(images).toHaveLength(1);
+    expect(images[0].kind).toBe("image");
+    expect([...images[0].image.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+});
+
+describe("stripFencedChartBlocks", () => {
+  it("removes fenced chart JSON from display markdown only", () => {
+    const markdown = [
+      "结论：P1 最多。",
+      "",
+      "```chart",
+      "{\"title\":\"Incidents\",\"labels\":[\"P0\",\"P1\"],\"values\":[1,4]}",
+      "```",
+      "",
+      "后续建议：优先处理 P1。",
+    ].join("\n");
+
+    expect(stripFencedChartBlocks(markdown)).toBe([
+      "结论：P1 最多。",
+      "",
+      "后续建议：优先处理 P1。",
+    ].join("\n"));
+  });
+});
+
+describe("stripVisualBlocks", () => {
+  it("removes visual source blocks and data images from display markdown", () => {
+    const onePixelPng =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    const markdown = [
+      "结论：需要扩容。",
+      "",
+      "```chart",
+      "{\"title\":\"Pods\",\"labels\":[\"ready\",\"pending\"],\"values\":[8,2]}",
+      "```",
+      "",
+      "```mermaid",
+      "flowchart LR",
+      "A[Check] --> B[Scale]",
+      "```",
+      "",
+      `![card](${onePixelPng})`,
+      "",
+      "保留普通正文。",
+    ].join("\n");
+
+    const display = stripVisualBlocks(markdown);
+
+    expect(display).toBe([
+      "结论：需要扩容。",
+      "",
+      "保留普通正文。",
+    ].join("\n"));
+  });
+
+  it("keeps readable markdown tables in the card body", () => {
+    const markdown = [
+      "统计如下：",
+      "",
+      "| Region | Count |",
+      "|---|---:|",
+      "| East | 12 |",
+      "| West | 7 |",
+    ].join("\n");
+
+    expect(stripVisualBlocks(markdown)).toBe(markdown);
   });
 });

--- a/src/gateway/channels/chart-image.ts
+++ b/src/gateway/channels/chart-image.ts
@@ -6,49 +6,263 @@ export interface ChartSpec {
   values: number[];
 }
 
+export interface RenderedReplyImage {
+  kind: "chart" | "mermaid" | "image";
+  image: Buffer;
+}
+
+interface RenderableChartSpec {
+  title?: string;
+  labels: string[];
+  series: Array<{
+    name?: string;
+    values: number[];
+  }>;
+}
+
+interface MermaidNode {
+  id: string;
+  label: string;
+  shape: "rect" | "diamond" | "oval";
+}
+
+interface MermaidEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+interface MermaidGraph {
+  direction: "LR" | "TD";
+  nodes: MermaidNode[];
+  edges: MermaidEdge[];
+}
+
 const MAX_CHART_ROWS = 12;
+const MAX_CHART_SERIES = 4;
 const MAX_LABEL_LENGTH = 28;
+const MAX_REPLY_IMAGES = 3;
+const MAX_MERMAID_NODES = 20;
+const MAX_MERMAID_EDGES = 32;
 const FEISHU_IMAGE_LIMIT_BYTES = 10 * 1024 * 1024;
 
+const DATA_IMAGE_URL_PATTERN =
+  "data:image\\/(?:png|jpe?g|webp|svg\\+xml)(?:;charset=[^;,\\s)]+)?(?:;base64)?,[^\\s)]+";
+const MARKDOWN_DATA_IMAGE_RE = new RegExp(
+  `!\\[[^\\]]*\\]\\(\\s*(${DATA_IMAGE_URL_PATTERN})\\s*(?:["'][^)]*["'])?\\)`,
+  "gi",
+);
+const RAW_DATA_IMAGE_RE = new RegExp(`(^|\\s)(${DATA_IMAGE_URL_PATTERN})`, "gi");
+
 export function extractChartSpec(markdown: string): ChartSpec | null {
-  const fenced = extractFencedChart(markdown);
-  if (fenced) return normalizeChartSpec(fenced);
+  const fenced = extractFencedChartSpecs(markdown)[0];
+  if (fenced) return toSimpleChartSpec(fenced);
   return extractTableChart(markdown);
 }
 
 export async function renderChartPng(spec: ChartSpec): Promise<Buffer> {
-  const normalized = normalizeChartSpec(spec);
+  const normalized = normalizeSimpleChartSpec(spec);
   if (!normalized) throw new Error("invalid chart spec");
-
-  const svg = renderChartSvg(normalized);
-  return new Resvg(svg, {
-    background: "#ffffff",
-    fitTo: { mode: "original" },
-    font: {
-      loadSystemFonts: true,
-      sansSerifFamily: "Arial",
-    },
-  }).render().asPng();
+  return renderSvgPng(renderChartSvg(normalized));
 }
 
 export async function maybeRenderChartPng(markdown: string): Promise<Buffer | null> {
   const spec = extractChartSpec(markdown);
   if (!spec) return null;
   const png = await renderChartPng(spec);
-  return png.length <= FEISHU_IMAGE_LIMIT_BYTES ? png : null;
+  return withinFeishuLimit(png) ? png : null;
 }
 
-function extractFencedChart(markdown: string): unknown | null {
-  const match = markdown.match(/```chart\s*\n([\s\S]*?)```/i);
-  if (!match) return null;
-  try {
-    return JSON.parse(match[1]);
-  } catch {
-    return null;
+export function stripFencedChartBlocks(markdown: string): string {
+  return stripFences(markdown, "chart");
+}
+
+export function stripVisualBlocks(markdown: string): string {
+  const withoutCharts = stripFences(markdown, "chart");
+  const withoutMermaid = stripFences(withoutCharts, "mermaid", (source) => parseMermaidFlowchart(source) !== null);
+  const withoutDataImages = stripDataImages(withoutMermaid);
+  return cleanupMarkdown(withoutDataImages);
+}
+
+export async function maybeRenderVisualImages(markdown: string): Promise<RenderedReplyImage[]> {
+  const images: RenderedReplyImage[] = [];
+
+  for (const dataUrl of extractDataImageUrls(markdown)) {
+    const image = await imageFromDataUrl(dataUrl);
+    if (image && withinFeishuLimit(image)) images.push({ kind: "image", image });
+    if (images.length >= MAX_REPLY_IMAGES) return images;
   }
+
+  for (const spec of extractFencedChartSpecs(markdown)) {
+    const png = await renderSvgPng(renderChartSvg(spec));
+    if (withinFeishuLimit(png)) images.push({ kind: "chart", image: png });
+    if (images.length >= MAX_REPLY_IMAGES) return images;
+  }
+
+  for (const graph of extractMermaidGraphs(markdown)) {
+    const png = await renderSvgPng(renderMermaidSvg(graph));
+    if (withinFeishuLimit(png)) images.push({ kind: "mermaid", image: png });
+    if (images.length >= MAX_REPLY_IMAGES) return images;
+  }
+
+  if (images.length === 0) {
+    const tableChart = extractTableChart(markdown);
+    if (tableChart) {
+      const png = await renderChartPng(tableChart);
+      if (withinFeishuLimit(png)) images.push({ kind: "chart", image: png });
+    }
+  }
+
+  return images;
 }
 
-function normalizeChartSpec(value: unknown): ChartSpec | null {
+function extractFencedChartSpecs(markdown: string): RenderableChartSpec[] {
+  const specs: RenderableChartSpec[] = [];
+  for (const source of extractFenceBodies(markdown, "chart")) {
+    try {
+      const parsed = JSON.parse(source);
+      const spec = normalizeRenderableChartSpec(parsed);
+      if (spec) specs.push(spec);
+    } catch {
+      // Invalid chart JSON should not break the primary markdown reply.
+    }
+  }
+  return specs;
+}
+
+function extractMermaidGraphs(markdown: string): MermaidGraph[] {
+  const graphs: MermaidGraph[] = [];
+  for (const source of extractFenceBodies(markdown, "mermaid")) {
+    const graph = parseMermaidFlowchart(source);
+    if (graph) graphs.push(graph);
+  }
+  return graphs;
+}
+
+function extractFenceBodies(markdown: string, language: string): string[] {
+  const bodies: string[] = [];
+  const re = fenceRegex(language);
+  markdown.replace(re, (_full, _prefix: string, body: string) => {
+    bodies.push(body.trim());
+    return _full;
+  });
+  return bodies;
+}
+
+function stripFences(
+  markdown: string,
+  language: string,
+  shouldStrip: (source: string) => boolean = () => true,
+): string {
+  let removed = false;
+  const stripped = markdown.replace(fenceRegex(language), (full, prefix: string, body: string) => {
+    if (!shouldStrip(body.trim())) return full;
+    removed = true;
+    return prefix ? prefix : "";
+  });
+  return removed ? cleanupMarkdown(stripped) : markdown;
+}
+
+function fenceRegex(language: string): RegExp {
+  return new RegExp(`(^|\\r?\\n)[ \\t]*\`\`\`${language}[ \\t]*\\r?\\n([\\s\\S]*?)\`\`\`[ \\t]*(?=\\r?\\n|$)`, "gi");
+}
+
+function stripDataImages(markdown: string): string {
+  let removed = false;
+  let output = markdown.replace(MARKDOWN_DATA_IMAGE_RE, (_full, dataUrl: string) => {
+    if (!isSupportedDataImageUrl(dataUrl)) return _full;
+    removed = true;
+    return "";
+  });
+  output = output.replace(RAW_DATA_IMAGE_RE, (full, prefix: string, dataUrl: string) => {
+    if (!isSupportedDataImageUrl(dataUrl)) return full;
+    removed = true;
+    return prefix || "";
+  });
+  return removed ? cleanupMarkdown(output) : markdown;
+}
+
+function extractDataImageUrls(markdown: string): string[] {
+  const urls = new Set<string>();
+  markdown.replace(MARKDOWN_DATA_IMAGE_RE, (_full, dataUrl: string) => {
+    if (isSupportedDataImageUrl(dataUrl)) urls.add(dataUrl);
+    return _full;
+  });
+  markdown.replace(RAW_DATA_IMAGE_RE, (_full, _prefix: string, dataUrl: string) => {
+    if (isSupportedDataImageUrl(dataUrl)) urls.add(dataUrl);
+    return _full;
+  });
+  return [...urls];
+}
+
+function isSupportedDataImageUrl(dataUrl: string): boolean {
+  return /^data:image\/(?:png|jpe?g|webp|svg\+xml)(?:;charset=[^;,]+)?(?:;base64)?,/i.test(dataUrl);
+}
+
+async function imageFromDataUrl(dataUrl: string): Promise<Buffer | null> {
+  const match = dataUrl.match(/^data:(image\/(?:png|jpe?g|webp|svg\+xml))(?:;charset=[^;,]+)?(;base64)?,([\s\S]*)$/i);
+  if (!match) return null;
+
+  const mime = match[1].toLowerCase();
+  const isBase64 = Boolean(match[2]);
+  const payload = match[3];
+  if (mime === "image/svg+xml") {
+    const svg = isBase64
+      ? Buffer.from(payload.replace(/\s+/g, ""), "base64").toString("utf8")
+      : decodeURIComponent(payload);
+    return renderSvgPng(svg);
+  }
+
+  if (!isBase64) return null;
+  const image = Buffer.from(payload.replace(/\s+/g, ""), "base64");
+  return image.length > 0 ? image : null;
+}
+
+function normalizeRenderableChartSpec(value: unknown): RenderableChartSpec | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as {
+    title?: unknown;
+    labels?: unknown;
+    values?: unknown;
+    type?: unknown;
+    data?: unknown;
+  };
+
+  const simple = normalizeSimpleChartSpec(raw);
+  if (simple) return simple;
+
+  if (raw.type !== "bar" || !raw.data || typeof raw.data !== "object") return null;
+  const data = raw.data as { categories?: unknown; series?: unknown };
+  if (!Array.isArray(data.categories) || !Array.isArray(data.series)) return null;
+
+  const labels = data.categories
+    .slice(0, MAX_CHART_ROWS)
+    .map((label) => normalizeLabel(label))
+    .filter(Boolean);
+  if (labels.length === 0) return null;
+
+  const series = data.series.slice(0, MAX_CHART_SERIES).flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const row = entry as { name?: unknown; values?: unknown };
+    if (!Array.isArray(row.values)) return [];
+    const rowValues = row.values;
+    const values = labels.map((_, i) => parseNumber(rowValues[i]) ?? 0);
+    if (!values.some((n) => Number.isFinite(n))) return [];
+    return [{
+      name: typeof row.name === "string" ? normalizeLabel(row.name) : undefined,
+      values,
+    }];
+  });
+  if (series.length === 0) return null;
+
+  return {
+    title: normalizeTitle(raw.title),
+    labels,
+    series,
+  };
+}
+
+function normalizeSimpleChartSpec(value: unknown): RenderableChartSpec | null {
   if (!value || typeof value !== "object") return null;
   const raw = value as { title?: unknown; labels?: unknown; values?: unknown };
   if (!Array.isArray(raw.labels) || !Array.isArray(raw.values)) return null;
@@ -62,11 +276,29 @@ function normalizeChartSpec(value: unknown): ChartSpec | null {
   }
   if (rows.length === 0) return null;
 
-  const title = typeof raw.title === "string" ? raw.title.trim().slice(0, 80) : undefined;
   return {
-    title: title || undefined,
+    title: normalizeTitle(raw.title),
     labels: rows.map((row) => row.label),
-    values: rows.map((row) => row.value),
+    series: [{ values: rows.map((row) => row.value) }],
+  };
+}
+
+function toSimpleChartSpec(spec: RenderableChartSpec): ChartSpec {
+  if (spec.series.length === 1) {
+    return {
+      title: spec.title,
+      labels: spec.labels,
+      values: spec.series[0].values,
+    };
+  }
+
+  const values = spec.labels.map((_, index) =>
+    spec.series.reduce((sum, series) => sum + (series.values[index] ?? 0), 0),
+  );
+  return {
+    title: spec.title,
+    labels: spec.labels,
+    values,
   };
 }
 
@@ -146,40 +378,60 @@ function parseNumber(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+function normalizeTitle(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const title = value.replace(/\s+/g, " ").trim().slice(0, 80);
+  return title || undefined;
+}
+
 function normalizeLabel(value: unknown): string {
   if (value === null || value === undefined) return "";
   const label = String(value).replace(/\s+/g, " ").trim();
   return label.length > MAX_LABEL_LENGTH ? `${label.slice(0, MAX_LABEL_LENGTH - 3)}...` : label;
 }
 
-function renderChartSvg(spec: ChartSpec): string {
+function renderChartSvg(spec: RenderableChartSpec): string {
   const width = 960;
   const height = 560;
-  const margin = { top: 78, right: 44, bottom: 106, left: 82 };
+  const margin = { top: spec.series.length > 1 ? 102 : 78, right: 44, bottom: 106, left: 82 };
   const plotWidth = width - margin.left - margin.right;
   const plotHeight = height - margin.top - margin.bottom;
-  const minValue = Math.min(0, ...spec.values);
-  const maxValue = Math.max(0, ...spec.values);
+  const allValues = spec.series.flatMap((series) => series.values);
+  const minValue = Math.min(0, ...allValues);
+  const maxValue = Math.max(0, ...allValues);
   const range = maxValue === minValue ? 1 : maxValue - minValue;
   const niceMax = maxValue + range * 0.08;
   const niceMin = minValue - range * 0.08;
   const niceRange = niceMax - niceMin || 1;
   const zeroY = valueToY(0, niceMin, niceRange, margin.top, plotHeight);
-  const band = plotWidth / spec.values.length;
-  const barWidth = Math.max(24, Math.min(72, band * 0.58));
+  const band = plotWidth / spec.labels.length;
+  const groupWidth = Math.max(28, Math.min(90, band * 0.7));
+  const barGap = spec.series.length > 1 ? 4 : 0;
+  const barWidth = Math.max(8, Math.min(72, (groupWidth - barGap * (spec.series.length - 1)) / spec.series.length));
   const gridLines = 5;
+  const showValueLabels = spec.labels.length * spec.series.length <= 18;
 
-  const bars = spec.values.map((value, i) => {
-    const x = margin.left + i * band + (band - barWidth) / 2;
-    const y = valueToY(Math.max(value, 0), niceMin, niceRange, margin.top, plotHeight);
-    const y0 = valueToY(Math.min(value, 0), niceMin, niceRange, margin.top, plotHeight);
-    const h = Math.max(2, Math.abs(y0 - y));
-    const labelX = margin.left + i * band + band / 2;
-    const labelY = value >= 0 ? y - 10 : y0 + h + 18;
+  const bars = spec.labels.map((label, labelIndex) => {
+    const groupX = margin.left + labelIndex * band + (band - groupWidth) / 2;
+    const labelX = margin.left + labelIndex * band + band / 2;
+    const seriesBars = spec.series.map((series, seriesIndex) => {
+      const value = series.values[labelIndex] ?? 0;
+      const x = groupX + seriesIndex * (barWidth + barGap);
+      const y = valueToY(Math.max(value, 0), niceMin, niceRange, margin.top, plotHeight);
+      const y0 = valueToY(Math.min(value, 0), niceMin, niceRange, margin.top, plotHeight);
+      const h = Math.max(2, Math.abs(y0 - y));
+      const valueY = value >= 0 ? y - 10 : y0 + h + 18;
+      const valueLabel = showValueLabels
+        ? `<text x="${(x + barWidth / 2).toFixed(1)}" y="${valueY.toFixed(1)}" text-anchor="middle" class="value">${escapeXml(formatValue(value))}</text>`
+        : "";
+      return `
+        <rect x="${x.toFixed(1)}" y="${Math.min(y, y0).toFixed(1)}" width="${barWidth.toFixed(1)}" height="${h.toFixed(1)}" rx="7" fill="${chartColor(seriesIndex)}"/>
+        ${valueLabel}
+      `;
+    }).join("");
     return `
-      <rect x="${x.toFixed(1)}" y="${Math.min(y, y0).toFixed(1)}" width="${barWidth.toFixed(1)}" height="${h.toFixed(1)}" rx="8" fill="#2563eb"/>
-      <text x="${labelX.toFixed(1)}" y="${labelY.toFixed(1)}" text-anchor="middle" class="value">${escapeXml(formatValue(value))}</text>
-      <text x="${labelX.toFixed(1)}" y="${height - 54}" text-anchor="end" transform="rotate(-28 ${labelX.toFixed(1)} ${height - 54})" class="label">${escapeXml(spec.labels[i])}</text>
+      ${seriesBars}
+      <text x="${labelX.toFixed(1)}" y="${height - 54}" text-anchor="end" transform="rotate(-28 ${labelX.toFixed(1)} ${height - 54})" class="label">${escapeXml(label)}</text>
     `;
   }).join("");
 
@@ -192,24 +444,274 @@ function renderChartSvg(spec: ChartSpec): string {
     `;
   }).join("");
 
+  const legend = spec.series.length > 1
+    ? `<g transform="translate(44 72)">${spec.series.map((series, i) => `
+        <rect x="${i * 170}" y="0" width="14" height="14" rx="4" fill="${chartColor(i)}"/>
+        <text x="${i * 170 + 22}" y="12" class="legend">${escapeXml(series.name || `Series ${i + 1}`)}</text>
+      `).join("")}</g>`
+    : "";
+
   return `
 <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
   <style>
-    .title { font: 700 30px Arial, sans-serif; fill: #0f172a; }
-    .subtitle { font: 400 14px Arial, sans-serif; fill: #64748b; }
-    .axis { font: 400 13px Arial, sans-serif; fill: #64748b; }
-    .label { font: 500 14px Arial, sans-serif; fill: #334155; }
-    .value { font: 700 14px Arial, sans-serif; fill: #0f172a; }
+    text { font-family: Arial, sans-serif; }
+    .title { font-size: 30px; font-weight: 700; fill: #0f172a; }
+    .subtitle { font-size: 14px; font-weight: 400; fill: #64748b; }
+    .axis { font-size: 13px; font-weight: 400; fill: #64748b; }
+    .label { font-size: 14px; font-weight: 500; fill: #334155; }
+    .value { font-size: 13px; font-weight: 700; fill: #0f172a; }
+    .legend { font-size: 14px; font-weight: 600; fill: #334155; }
     .grid { stroke: #e2e8f0; stroke-width: 1; }
     .baseline { stroke: #94a3b8; stroke-width: 2; }
   </style>
-  <rect width="100%" height="100%" rx="0" fill="#ffffff"/>
+  <rect width="100%" height="100%" fill="#ffffff"/>
   <text x="44" y="45" class="title">${escapeXml(spec.title || "Chart")}</text>
   <text x="44" y="68" class="subtitle">Generated from Siclaw response data</text>
+  ${legend}
   ${grids}
   <line x1="${margin.left}" x2="${width - margin.right}" y1="${zeroY.toFixed(1)}" y2="${zeroY.toFixed(1)}" class="baseline"/>
   ${bars}
 </svg>`;
+}
+
+function parseMermaidFlowchart(source: string): MermaidGraph | null {
+  const rawLines = source
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("%%"));
+  const headerIndex = rawLines.findIndex((line) => /^(flowchart|graph)\b/i.test(line));
+  if (headerIndex < 0) return null;
+
+  const header = rawLines[headerIndex];
+  const directionMatch = header.match(/^(?:flowchart|graph)\s+([A-Z]{2})/i);
+  const direction = normalizeMermaidDirection(directionMatch?.[1]);
+  const nodes = new Map<string, MermaidNode>();
+  const edges: MermaidEdge[] = [];
+
+  for (const line of rawLines.slice(headerIndex + 1)) {
+    if (shouldSkipMermaidLine(line)) continue;
+    const edge = parseMermaidEdge(line);
+    if (edge) {
+      nodes.set(edge.from.id, edge.from);
+      nodes.set(edge.to.id, edge.to);
+      edges.push({ from: edge.from.id, to: edge.to.id, label: edge.label });
+    } else {
+      const node = parseMermaidNode(line);
+      if (node) nodes.set(node.id, node);
+    }
+    if (nodes.size >= MAX_MERMAID_NODES || edges.length >= MAX_MERMAID_EDGES) break;
+  }
+
+  if (nodes.size === 0 || edges.length === 0) return null;
+  return {
+    direction,
+    nodes: [...nodes.values()],
+    edges,
+  };
+}
+
+function normalizeMermaidDirection(direction?: string): "LR" | "TD" {
+  const normalized = direction?.toUpperCase();
+  return normalized === "LR" || normalized === "RL" ? "LR" : "TD";
+}
+
+function shouldSkipMermaidLine(line: string): boolean {
+  return /^(subgraph|end\b|classDef\b|class\b|style\b|linkStyle\b|click\b)/i.test(line);
+}
+
+function parseMermaidEdge(line: string): { from: MermaidNode; to: MermaidNode; label?: string } | null {
+  const clean = line.replace(/;$/, "").trim();
+  const patterns: RegExp[] = [
+    /^(.+?)\s*-->\s*\|([^|]+)\|\s*(.+)$/,
+    /^(.+?)\s*--\s*([^>-|]+?)\s*-->\s*(.+)$/,
+    /^(.+?)\s*(?:-->|---|==>|-.->)\s*(.+)$/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = clean.match(pattern);
+    if (!match) continue;
+    const from = parseMermaidNode(match[1]);
+    const to = parseMermaidNode(match[3] ?? match[2]);
+    if (!from || !to) return null;
+    const label = match.length >= 4 ? normalizeLabel(match[2]) : undefined;
+    return { from, to, label };
+  }
+  return null;
+}
+
+function parseMermaidNode(token: string): MermaidNode | null {
+  const clean = token.replace(/;$/, "").trim();
+  const match = clean.match(/^([A-Za-z0-9_:.~-]+)(.*)$/);
+  if (!match) return null;
+
+  const id = match[1];
+  const rest = match[2].trim();
+  if (!rest) return { id, label: id, shape: "rect" };
+
+  const shapeText = extractMermaidShape(rest);
+  if (!shapeText) return { id, label: id, shape: "rect" };
+  return {
+    id,
+    label: normalizeMermaidLabel(shapeText.label),
+    shape: shapeText.shape,
+  };
+}
+
+function extractMermaidShape(rest: string): { label: string; shape: MermaidNode["shape"] } | null {
+  if (rest.startsWith("{") && rest.endsWith("}")) return { label: rest.slice(1, -1), shape: "diamond" };
+  if (rest.startsWith("((") && rest.endsWith("))")) return { label: rest.slice(2, -2), shape: "oval" };
+  if (rest.startsWith("(") && rest.endsWith(")")) return { label: rest.slice(1, -1), shape: "oval" };
+  if (rest.startsWith("[") && rest.endsWith("]")) return { label: rest.slice(1, -1), shape: "rect" };
+  return null;
+}
+
+function normalizeMermaidLabel(label: string): string {
+  const trimmed = label.trim().replace(/^["']|["']$/g, "");
+  return normalizeLabel(trimmed || "Node");
+}
+
+function renderMermaidSvg(graph: MermaidGraph): string {
+  const nodeW = 176;
+  const nodeH = 58;
+  const padding = 56;
+  const colGap = graph.direction === "LR" ? 240 : 218;
+  const rowGap = graph.direction === "LR" ? 94 : 118;
+  const levels = computeMermaidLevels(graph);
+  const grouped = groupNodesByLevel(graph.nodes, levels);
+  const levelEntries = [...grouped.entries()].sort(([a], [b]) => a - b);
+  const levelCount = Math.max(1, levelEntries.length);
+  const maxRows = Math.max(1, ...levelEntries.map(([, nodes]) => nodes.length));
+  const width = graph.direction === "LR"
+    ? Math.max(700, padding * 2 + nodeW + (levelCount - 1) * colGap)
+    : Math.max(700, padding * 2 + nodeW * maxRows + rowGap * (maxRows - 1));
+  const height = graph.direction === "LR"
+    ? Math.max(420, padding * 2 + nodeH * maxRows + rowGap * (maxRows - 1))
+    : Math.max(420, padding * 2 + nodeH + (levelCount - 1) * rowGap);
+
+  const positions = new Map<string, { x: number; y: number; w: number; h: number }>();
+  for (const [level, nodes] of levelEntries) {
+    nodes.forEach((node, index) => {
+      const x = graph.direction === "LR"
+        ? padding + level * colGap
+        : (width - (nodes.length * nodeW + (nodes.length - 1) * 38)) / 2 + index * (nodeW + 38);
+      const y = graph.direction === "LR"
+        ? (height - (nodes.length * nodeH + (nodes.length - 1) * rowGap)) / 2 + index * (nodeH + rowGap)
+        : padding + level * rowGap;
+      positions.set(node.id, { x, y, w: nodeW, h: nodeH });
+    });
+  }
+
+  const edges = graph.edges.map((edge) => renderMermaidEdge(edge, positions, graph.direction)).join("");
+  const nodes = graph.nodes.map((node) => renderMermaidNode(node, positions.get(node.id))).join("");
+
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <style>
+    text { font-family: Arial, sans-serif; }
+    .node { fill: #f8fafc; stroke: #2563eb; stroke-width: 2; }
+    .decision { fill: #fef9c3; stroke: #ca8a04; stroke-width: 2; }
+    .edge { fill: none; stroke: #64748b; stroke-width: 2.2; }
+    .nodeText { font-size: 14px; font-weight: 700; fill: #0f172a; }
+    .edgeText { font-size: 12px; font-weight: 600; fill: #475569; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+      <path d="M2,2 L10,6 L2,10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+  <rect width="100%" height="100%" fill="#ffffff"/>
+  ${edges}
+  ${nodes}
+</svg>`;
+}
+
+function computeMermaidLevels(graph: MermaidGraph): Map<string, number> {
+  const levels = new Map(graph.nodes.map((node): [string, number] => [node.id, 0]));
+  for (let pass = 0; pass < graph.nodes.length; pass++) {
+    let changed = false;
+    for (const edge of graph.edges) {
+      const fromLevel = levels.get(edge.from) ?? 0;
+      const toLevel = levels.get(edge.to) ?? 0;
+      if (toLevel <= fromLevel) {
+        levels.set(edge.to, fromLevel + 1);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return levels;
+}
+
+function groupNodesByLevel(nodes: MermaidNode[], levels: Map<string, number>): Map<number, MermaidNode[]> {
+  const grouped = new Map<number, MermaidNode[]>();
+  for (const node of nodes) {
+    const level = levels.get(node.id) ?? 0;
+    grouped.set(level, [...(grouped.get(level) ?? []), node]);
+  }
+  return grouped;
+}
+
+function renderMermaidEdge(
+  edge: MermaidEdge,
+  positions: Map<string, { x: number; y: number; w: number; h: number }>,
+  direction: "LR" | "TD",
+): string {
+  const from = positions.get(edge.from);
+  const to = positions.get(edge.to);
+  if (!from || !to) return "";
+
+  const start = direction === "LR"
+    ? { x: from.x + from.w, y: from.y + from.h / 2 }
+    : { x: from.x + from.w / 2, y: from.y + from.h };
+  const end = direction === "LR"
+    ? { x: to.x, y: to.y + to.h / 2 }
+    : { x: to.x + to.w / 2, y: to.y };
+  const mid = direction === "LR"
+    ? { x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 }
+    : { x: (start.x + end.x) / 2, y: (start.y + end.y) / 2 };
+  const path = direction === "LR"
+    ? `M ${start.x.toFixed(1)} ${start.y.toFixed(1)} C ${mid.x.toFixed(1)} ${start.y.toFixed(1)}, ${mid.x.toFixed(1)} ${end.y.toFixed(1)}, ${end.x.toFixed(1)} ${end.y.toFixed(1)}`
+    : `M ${start.x.toFixed(1)} ${start.y.toFixed(1)} C ${start.x.toFixed(1)} ${mid.y.toFixed(1)}, ${end.x.toFixed(1)} ${mid.y.toFixed(1)}, ${end.x.toFixed(1)} ${end.y.toFixed(1)}`;
+  const label = edge.label
+    ? `<text x="${mid.x.toFixed(1)}" y="${(mid.y - 8).toFixed(1)}" text-anchor="middle" class="edgeText">${escapeXml(edge.label)}</text>`
+    : "";
+  return `<path d="${path}" class="edge" marker-end="url(#arrow)"/>${label}`;
+}
+
+function renderMermaidNode(node: MermaidNode, position?: { x: number; y: number; w: number; h: number }): string {
+  if (!position) return "";
+  const { x, y, w, h } = position;
+  const centerX = x + w / 2;
+  const centerY = y + h / 2;
+  const label = renderCenteredText(node.label, centerX, centerY);
+  if (node.shape === "diamond") {
+    const points = `${centerX},${y} ${x + w},${centerY} ${centerX},${y + h} ${x},${centerY}`;
+    return `<polygon points="${points}" class="decision"/>${label}`;
+  }
+  const rx = node.shape === "oval" ? h / 2 : 12;
+  return `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${w}" height="${h}" rx="${rx}" class="node"/>${label}`;
+}
+
+function renderCenteredText(label: string, x: number, y: number): string {
+  const words = label.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length > 18 && current) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) lines.push(current);
+  const visibleLines = lines.slice(0, 2);
+  if (lines.length > 2) visibleLines[1] = `${visibleLines[1].slice(0, 15)}...`;
+  const startY = y - ((visibleLines.length - 1) * 17) / 2 + 5;
+  return visibleLines
+    .map((line, i) => `<text x="${x.toFixed(1)}" y="${(startY + i * 17).toFixed(1)}" text-anchor="middle" class="nodeText">${escapeXml(line)}</text>`)
+    .join("");
 }
 
 function valueToY(value: number, min: number, range: number, top: number, height: number): number {
@@ -220,6 +722,29 @@ function formatValue(value: number): string {
   if (Math.abs(value) >= 1000) return Math.round(value).toLocaleString("en-US");
   if (Math.abs(value) >= 10) return Number(value.toFixed(1)).toString();
   return Number(value.toFixed(2)).toString();
+}
+
+function chartColor(index: number): string {
+  return ["#2563eb", "#16a34a", "#f59e0b", "#dc2626"][index % 4];
+}
+
+function renderSvgPng(svg: string): Buffer {
+  return new Resvg(svg, {
+    background: "#ffffff",
+    fitTo: { mode: "original" },
+    font: {
+      loadSystemFonts: true,
+      sansSerifFamily: "Arial",
+    },
+  }).render().asPng();
+}
+
+function withinFeishuLimit(image: Buffer): boolean {
+  return image.length > 0 && image.length <= FEISHU_IMAGE_LIMIT_BYTES;
+}
+
+function cleanupMarkdown(markdown: string): string {
+  return markdown.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
 }
 
 function escapeXml(value: string): string {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -406,6 +406,171 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(JSON.parse(imageReply.data.content)).toEqual({ image_key: "img-chart-1" });
   });
 
+  it("uses fenced chart JSON only for image rendering and hides it from the card", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-chart-json" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "结论：P1 事件最多。",
+              "",
+              "```chart",
+              "{\"title\":\"Incidents\",\"labels\":[\"P0\",\"P1\"],\"values\":[1,4]}",
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("结论：P1 事件最多。");
+    expect(cardContent).not.toContain("```chart");
+    expect(cardContent).not.toContain("\"labels\"");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders MCP bar chart specs as images and hides chart JSON from the card", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-mcp-chart" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "统计结论：P1 集中在 East。",
+              "",
+              "```chart",
+              JSON.stringify({
+                type: "bar",
+                title: "Incidents by Region",
+                data: {
+                  categories: ["East", "West"],
+                  series: [{ name: "P1", values: [4, 2] }],
+                },
+              }),
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("统计结论");
+    expect(cardContent).not.toContain("```chart");
+    expect(cardContent).not.toContain("\"type\":\"bar\"");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders Mermaid flowcharts as images and hides Mermaid source from the card", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-mermaid" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "排查路径如下：",
+              "",
+              "```mermaid",
+              "flowchart TD",
+              "  A[Check pod] --> B{Ready?}",
+              "  B -->|No| C[Inspect events]",
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("排查路径如下");
+    expect(cardContent).not.toContain("```mermaid");
+    expect(cardContent).not.toContain("flowchart TD");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards conclusion-card data URI images and hides data URLs from the card", async () => {
+    const onePixelPng =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-card-image" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "结论卡片如下：",
+              "",
+              `![card](${onePixelPng})`,
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("结论卡片如下");
+    expect(cardContent).not.toContain("data:image/png");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+  });
+
   it("does not reply with an image when the final answer has no chart-worthy data", async () => {
     resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
     promptMock.mockResolvedValue({ sessionId: "s-no-chart" });

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -20,8 +20,13 @@ import {
   EMPTY_RESULT_NOTICE_BY_LOCALE,
   localeForDomain,
 } from "./lark-card.js";
-import { maybeRenderChartPng } from "./chart-image.js";
+import { maybeRenderVisualImages, stripVisualBlocks } from "./chart-image.js";
 import { replyImageToLark } from "./lark-image.js";
+
+const VISUAL_ONLY_NOTICE_BY_LOCALE = {
+  "zh-CN": "已生成图片如下。",
+  "en-US": "Image generated below.",
+} as const;
 
 export interface LarkChannelConfig {
   domain?: "feishu" | "lark";  // feishu = China (default), lark = Global
@@ -204,9 +209,10 @@ export async function handleLarkMessage(
   const finalBody = agentError
     ? `\u274C ${agentError.message.slice(0, 500)}`
     : (resultText || EMPTY_RESULT_NOTICE_BY_LOCALE[locale]);
+  const displayBody = stripVisualBlocks(finalBody) || VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
 
   if (cardSession) {
-    const ok = await finalizeCard(larkClient, cardSession, finalBody);
+    const ok = await finalizeCard(larkClient, cardSession, displayBody);
     if (!ok) {
       // Partial-failure path: the card is visible but stuck in streaming
       // state. We log but do NOT post a second reply — that would produce
@@ -216,10 +222,10 @@ export async function handleLarkMessage(
   } else if (resultText || agentError) {
     // Card could not be opened; fall back to a plain text reply with
     // whatever we have (final answer or error).
-    await replyToLark(larkClient, messageId, finalBody);
+    await replyToLark(larkClient, messageId, displayBody);
   }
 
-  await maybeReplyChartImage(larkClient, messageId, finalBody);
+  await maybeReplyVisualImages(larkClient, messageId, finalBody);
 }
 
 /**
@@ -252,16 +258,17 @@ async function replyToLark(larkClient: any, messageId: string, text: string): Pr
   }
 }
 
-async function maybeReplyChartImage(larkClient: any, messageId: string, finalBody: string): Promise<void> {
+async function maybeReplyVisualImages(larkClient: any, messageId: string, finalBody: string): Promise<void> {
   try {
-    const png = await maybeRenderChartPng(finalBody);
-    if (!png) return;
-    const ok = await replyImageToLark(larkClient, messageId, png);
-    if (!ok) {
-      console.warn(`[lark] Chart image reply failed for messageId=${messageId}; markdown card remains primary`);
+    const images = await maybeRenderVisualImages(finalBody);
+    for (const { kind, image } of images) {
+      const ok = await replyImageToLark(larkClient, messageId, image);
+      if (!ok) {
+        console.warn(`[lark] ${kind} image reply failed for messageId=${messageId}; markdown card remains primary`);
+      }
     }
   } catch (err) {
-    console.error(`[lark] Chart image rendering failed for messageId=${messageId}:`, err);
+    console.error(`[lark] Visual image rendering failed for messageId=${messageId}:`, err);
   }
 }
 


### PR DESCRIPTION
## Summary
- extend Lark visual replies beyond table/chart JSON to support MCP/Sicore bar chart specs, Mermaid flowcharts, and final-answer data image payloads
- strip chart JSON, Mermaid source, and data URIs from the CardKit/plain-text body while keeping readable markdown
- keep Feishu image upload/reply as a non-fatal Runtime side effect

## Tests
- npx tsc --noEmit --pretty false
- npm test -- src/gateway/channels/lark.test.ts src/gateway/channels/lark-card.test.ts src/gateway/channels/chart-image.test.ts src/gateway/channels/lark-image.test.ts