### PR TITLE
Handle Chart.js chart fences in Lark replies

### DIFF
--- a/src/gateway/channels/chart-image.test.ts
+++ b/src/gateway/channels/chart-image.test.ts
@@ -57,6 +57,34 @@ describe("extractChartSpec", () => {
     });
   });
 
+  it("extracts Chart.js-style fenced bar chart JSON", () => {
+    const spec = extractChartSpec([
+      "```chart",
+      JSON.stringify({
+        type: "bar",
+        data: {
+          labels: ["1月", "2月", "3月"],
+          datasets: [{ label: "销售额", data: [120, 190, 150] }],
+        },
+        options: {
+          plugins: {
+            title: {
+              display: true,
+              text: "2026 上半年销售额",
+            },
+          },
+        },
+      }),
+      "```",
+    ].join("\n"));
+
+    expect(spec).toEqual({
+      title: "2026 上半年销售额",
+      labels: ["1月", "2月", "3月"],
+      values: [120, 190, 150],
+    });
+  });
+
   it("caps rows and clamps long labels", () => {
     const rows = Array.from({ length: 16 }, (_, i) =>
       `| Extremely long region label ${i} with extra suffix | ${i + 1} |`,
@@ -124,6 +152,30 @@ describe("maybeRenderVisualImages", () => {
             { name: "P0", values: [1, 2] },
             { name: "P1", values: [4, 3] },
           ],
+        },
+      }),
+      "```",
+    ].join("\n");
+
+    const images = await maybeRenderVisualImages(markdown);
+    expect(images).toHaveLength(1);
+    expect(images[0].kind).toBe("chart");
+    expect([...images[0].image.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("renders Chart.js-style bar chart specs from fenced chart blocks", async () => {
+    const markdown = [
+      "```chart",
+      JSON.stringify({
+        type: "bar",
+        data: {
+          labels: ["1月", "2月", "3月"],
+          datasets: [{ label: "销售额", data: [120, 190, 150] }],
+        },
+        options: {
+          plugins: {
+            title: { display: true, text: "2026 上半年销售额" },
+          },
         },
       }),
       "```",
@@ -238,6 +290,40 @@ describe("stripVisualBlocks", () => {
       "",
       "保留普通正文。",
     ].join("\n"));
+  });
+
+  it("removes Chart.js-style chart JSON only when it can be rendered", () => {
+    const markdown = [
+      "```chart",
+      JSON.stringify({
+        type: "bar",
+        data: {
+          labels: ["1月", "2月"],
+          datasets: [{ label: "销售额", data: [120, 190] }],
+        },
+      }),
+      "```",
+      "",
+      "图表结论：2月更高。",
+    ].join("\n");
+
+    expect(stripVisualBlocks(markdown)).toBe("图表结论：2月更高。");
+  });
+
+  it("keeps unsupported chart source visible instead of swallowing the reply", () => {
+    const markdown = [
+      "```chart",
+      JSON.stringify({
+        type: "line",
+        data: {
+          labels: ["1月", "2月"],
+          datasets: [{ label: "销售额", data: [120, 190] }],
+        },
+      }),
+      "```",
+    ].join("\n");
+
+    expect(stripVisualBlocks(markdown)).toBe(markdown);
   });
 
   it("keeps readable markdown tables in the card body", () => {

--- a/src/gateway/channels/chart-image.ts
+++ b/src/gateway/channels/chart-image.ts
@@ -83,12 +83,16 @@ export async function maybeRenderChartPng(markdown: string): Promise<Buffer | nu
 }
 
 export function stripFencedChartBlocks(markdown: string): string {
-  return stripFences(markdown, "chart");
+  return stripFences(markdown, "chart", isRenderableChartSource);
 }
 
 export function stripVisualBlocks(markdown: string): string {
-  const withoutCards = stripFences(stripFences(markdown, "siclaw-card"), "conclusion-card");
-  const withoutCharts = stripFences(withoutCards, "chart");
+  const withoutCards = stripFences(
+    stripFences(markdown, "siclaw-card", isRenderableConclusionCardSource),
+    "conclusion-card",
+    isRenderableConclusionCardSource,
+  );
+  const withoutCharts = stripFences(withoutCards, "chart", isRenderableChartSource);
   const withoutMermaid = stripFences(withoutCharts, "mermaid", (source) => parseMermaidFlowchart(source) !== null);
   const withoutDataImages = stripDataImages(withoutMermaid);
   return cleanupMarkdown(withoutDataImages);
@@ -160,6 +164,22 @@ function extractFencedChartSpecs(markdown: string): RenderableChartSpec[] {
     }
   }
   return specs;
+}
+
+function isRenderableConclusionCardSource(source: string): boolean {
+  try {
+    return normalizeConclusionCardSpec(JSON.parse(source)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+function isRenderableChartSource(source: string): boolean {
+  try {
+    return normalizeRenderableChartSpec(JSON.parse(source)) !== null;
+  } catch {
+    return false;
+  }
 }
 
 function extractMermaidGraphs(markdown: string): MermaidGraph[] {
@@ -258,10 +278,14 @@ function normalizeRenderableChartSpec(value: unknown): RenderableChartSpec | nul
     values?: unknown;
     type?: unknown;
     data?: unknown;
+    options?: unknown;
   };
 
   const simple = normalizeSimpleChartSpec(raw);
   if (simple) return simple;
+
+  const chartJs = normalizeChartJsBarSpec(raw);
+  if (chartJs) return chartJs;
 
   if (raw.type !== "bar" || !raw.data || typeof raw.data !== "object") return null;
   const data = raw.data as { categories?: unknown; series?: unknown };
@@ -278,8 +302,9 @@ function normalizeRenderableChartSpec(value: unknown): RenderableChartSpec | nul
     const row = entry as { name?: unknown; values?: unknown };
     if (!Array.isArray(row.values)) return [];
     const rowValues = row.values;
-    const values = labels.map((_, i) => parseNumber(rowValues[i]) ?? 0);
-    if (!values.some((n) => Number.isFinite(n))) return [];
+    const parsedValues = labels.map((_, i) => parseNumber(rowValues[i]));
+    if (!parsedValues.some((n) => n !== null)) return [];
+    const values = parsedValues.map((n) => n ?? 0);
     return [{
       name: typeof row.name === "string" ? normalizeLabel(row.name) : undefined,
       values,
@@ -289,6 +314,42 @@ function normalizeRenderableChartSpec(value: unknown): RenderableChartSpec | nul
 
   return {
     title: normalizeTitle(raw.title),
+    labels,
+    series,
+  };
+}
+
+function normalizeChartJsBarSpec(raw: { title?: unknown; type?: unknown; data?: unknown; options?: unknown }): RenderableChartSpec | null {
+  const type = typeof raw.type === "string" ? raw.type.trim().toLowerCase() : undefined;
+  if (type && type !== "bar") return null;
+  if (!raw.data || typeof raw.data !== "object") return null;
+
+  const data = raw.data as { labels?: unknown; datasets?: unknown };
+  if (!Array.isArray(data.labels) || !Array.isArray(data.datasets)) return null;
+
+  const labels = data.labels
+    .slice(0, MAX_CHART_ROWS)
+    .map((label) => normalizeLabel(label))
+    .filter(Boolean);
+  if (labels.length === 0) return null;
+
+  const series = data.datasets.slice(0, MAX_CHART_SERIES).flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const dataset = entry as { label?: unknown; data?: unknown };
+    const dataPoints = dataset.data;
+    if (!Array.isArray(dataPoints)) return [];
+    const parsedValues = labels.map((_, i) => parseChartJsNumber(dataPoints[i]));
+    if (!parsedValues.some((n) => n !== null)) return [];
+    const values = parsedValues.map((n) => n ?? 0);
+    return [{
+      name: typeof dataset.label === "string" ? normalizeLabel(dataset.label) : undefined,
+      values,
+    }];
+  });
+  if (series.length === 0) return null;
+
+  return {
+    title: normalizeTitle(raw.title) ?? normalizeTitle(extractChartJsTitle(raw.options)),
     labels,
     series,
   };
@@ -408,6 +469,23 @@ function parseNumber(value: unknown): number | null {
   if (!/^[-+]?(?:\d+\.?\d*|\.\d+)$/.test(cleaned)) return null;
   const n = Number(cleaned);
   return Number.isFinite(n) ? n : null;
+}
+
+function parseChartJsNumber(value: unknown): number | null {
+  const direct = parseNumber(value);
+  if (direct !== null) return direct;
+  if (!value || typeof value !== "object") return null;
+  const point = value as { y?: unknown };
+  return parseNumber(point.y);
+}
+
+function extractChartJsTitle(options: unknown): unknown {
+  if (!options || typeof options !== "object") return undefined;
+  const plugins = (options as { plugins?: unknown }).plugins;
+  if (!plugins || typeof plugins !== "object") return undefined;
+  const title = (plugins as { title?: unknown }).title;
+  if (!title || typeof title !== "object") return undefined;
+  return (title as { text?: unknown }).text;
 }
 
 function normalizeTitle(value: unknown): string | undefined {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -492,6 +492,98 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(lark.im.image.create).toHaveBeenCalledTimes(1);
   });
 
+  it("renders Chart.js-style bar chart specs as images and hides chart JSON from the card", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-chartjs-chart" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "```chart",
+              JSON.stringify({
+                type: "bar",
+                data: {
+                  labels: ["1月", "2月", "3月"],
+                  datasets: [{ label: "销售额", data: [120, 190, 150] }],
+                },
+                options: {
+                  plugins: {
+                    title: { display: true, text: "2026 上半年销售额" },
+                  },
+                },
+              }),
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("已生成图片如下");
+    expect(cardContent).not.toContain("```chart");
+    expect(cardContent).not.toContain("datasets");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps unsupported chart JSON visible and does not reply with an image", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-unsupported-chart" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "```chart",
+              JSON.stringify({
+                type: "line",
+                data: {
+                  labels: ["1月", "2月"],
+                  datasets: [{ label: "销售额", data: [120, 190] }],
+                },
+              }),
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("```chart");
+    expect(cardContent).toContain("\"type\":\"line\"");
+    expect(lark.im.image.create).not.toHaveBeenCalled();
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
+  });
+
   it("renders Mermaid flowcharts as images and hides Mermaid source from the card", async () => {
     resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
     promptMock.mockResolvedValue({ sessionId: "s-mermaid" });


### PR DESCRIPTION
## Summary
- support Chart.js-style fenced bar chart specs in Lark visual image replies
- only hide fenced chart/card source when Runtime can render it into an image
- add regression coverage for Chart.js chart fences and unsupported chart source fallback

## Tests
- npx tsc --noEmit --pretty false
- npm test -- src/core/prompt.test.ts src/gateway/channels/lark.test.ts src/gateway/channels/lark-card.test.ts src/gateway/channels/chart-image.test.ts src/gateway/channels/lark-image.test.ts