### PR TITLE
Add A2A gateway for Siclaw agents

### DIFF
--- a/docs/a2a-integration-guide.md
+++ b/docs/a2a-integration-guide.md
@@ -1,0 +1,281 @@
+# Calling Siclaw from Another Agent (A2A Integration Guide)
+
+This guide is for an **external agent** (an LLM agent, an orchestrator, a workflow)
+that wants to delegate SRE diagnosis to Siclaw and get a streamed or polled result
+back — without coupling to Siclaw's internal chat event schema.
+
+Siclaw exposes an [A2A](https://a2a-protocol.org/)-aligned HTTP+JSON gateway. The
+contract here (`task` / `statusUpdate` / `artifactUpdate`) is stable: Siclaw's
+internal runtime events can change without breaking your integration.
+
+---
+
+## 1. What you need
+
+Three things, nothing else:
+
+1. **An Agent Card URL** — describes the agent, its skills, capabilities, and the
+   base URL for all operations.
+2. **An API key** — `Authorization: Bearer sk-...`. The key is bound to one agent.
+3. **A natural-language problem** — e.g. "pods in kube-system keep restarting on node X".
+
+Base path (all routes are per-agent, because one Portal can host many agents):
+
+```
+https://<portal-host>/api/v1/a2a/agents/<agentId>
+```
+
+Every JSON response carries an `A2A-Version: 1.0` header and
+`Content-Type: application/a2a+json; charset=utf-8`.
+
+---
+
+## 2. Discover the agent (Agent Card)
+
+```bash
+curl -s "https://<portal-host>/api/v1/a2a/agents/<agentId>/.well-known/agent-card.json"
+# alias: .../agent-card.json
+```
+
+Returns (abridged):
+
+```jsonc
+{
+  "name": "Siclaw SRE Agent",
+  "version": "1.0",
+  "capabilities": { "streaming": true, "pushNotifications": false },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/markdown", "text/plain"],
+  "supportedInterfaces": [
+    { "url": "https://<portal-host>/api/v1/a2a/agents/<agentId>",
+      "protocolBinding": "HTTP+JSON", "protocolVersion": "1.0" }
+  ],
+  "securitySchemes": {
+    "siclawApiKey": { "httpAuthSecurityScheme": { "scheme": "Bearer" } }
+  },
+  "skills": [
+    { "id": "sre_cluster_diagnosis", "name": "SRE Cluster Diagnosis",
+      "examples": ["Diagnose why pods in kube-system are restarting.", "..."] }
+  ]
+}
+```
+
+The card route is **public** (no auth) and exposes no secrets.
+
+> Note: discovery is **agent-scoped** (`/api/v1/a2a/agents/<agentId>/.well-known/...`),
+> not the A2A canonical host-root `/.well-known/agent-card.json`. An off-the-shelf
+> A2A client that auto-discovers at the host root will not find it — use the
+> agent-scoped URL you were given.
+
+---
+
+## 3. Authentication
+
+```
+Authorization: Bearer sk-...
+```
+
+- The key is bound to exactly one `agentId`; using it on a different agent's route
+  returns `403 PERMISSION_DENIED`.
+- A missing/invalid key returns `401 UNAUTHENTICATED`.
+- Tasks are scoped to the **key that created them** — you can only read/cancel
+  tasks your own key started.
+
+---
+
+## 4. Two ways to consume — pick by who reads the output
+
+### 4a. Headless (recommended for agent-to-agent)
+
+Your agent just wants the final diagnosis to feed back into its own reasoning.
+**No SSE needed.** Submit, then poll until terminal.
+
+```bash
+# 1) submit (returns immediately with a WORKING task — this is NOT the result yet)
+curl -s -X POST "https://<host>/api/v1/a2a/agents/<agentId>/message:send" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -d '{"message":{"role":"ROLE_USER","parts":[{"text":"diagnose kube-system restarts"}]}}'
+# -> { "task": { "id": "<taskId>", "contextId": "<ctx>", "status": { "state": "TASK_STATE_WORKING" } } }
+
+# 2) poll until terminal
+curl -s "https://<host>/api/v1/a2a/agents/<agentId>/tasks/<taskId>" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+When `status.state` is terminal, the answer is in `artifacts`:
+
+```jsonc
+{ "task": {
+  "id": "<taskId>",
+  "status": { "state": "TASK_STATE_COMPLETED" },
+  "artifacts": [
+    { "artifactId": "assistant-text", "name": "Siclaw diagnosis",
+      "parts": [{ "text": "## Diagnosis\n...", "mediaType": "text/markdown" }] }
+  ]
+}}
+```
+
+> `message:send` is **non-blocking**: it returns a `WORKING` task right away, not
+> the finished result. Always poll `GET .../tasks/<taskId>` (or stream) for the
+> outcome.
+
+Minimal poll loop:
+
+```python
+import time, requests
+H = {"Authorization": f"Bearer {API_KEY}"}
+base = "https://<host>/api/v1/a2a/agents/<agentId>"
+task = requests.post(f"{base}/message:send", headers=H,
+                     json={"message": {"role": "ROLE_USER",
+                                       "parts": [{"text": "diagnose kube-system restarts"}]}}).json()["task"]
+tid = task["id"]
+TERMINAL = {"TASK_STATE_COMPLETED", "TASK_STATE_FAILED", "TASK_STATE_CANCELED", "TASK_STATE_REJECTED"}
+while True:
+    t = requests.get(f"{base}/tasks/{tid}", headers=H).json()["task"]
+    if t["status"]["state"] in TERMINAL:
+        break
+    time.sleep(2)
+print(t.get("artifacts", [{}])[0].get("parts", [{}])[0].get("text", ""))
+```
+
+### 4b. Streaming (when a human watches progress)
+
+Use SSE when you relay live progress (tool calls, partial text) to a person.
+
+```bash
+curl -sS -N -X POST "https://<host>/api/v1/a2a/agents/<agentId>/message:stream" \
+  -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"message":{"role":"ROLE_USER","parts":[{"text":"diagnose kube-system restarts"}]}}'
+```
+
+A2A SSE uses **unnamed `data:` frames**, each holding one typed object. There is
+no `event:` line. The first frame is always the `task` snapshot:
+
+```
+data: {"task":{"id":"<taskId>","contextId":"<ctx>","status":{"state":"TASK_STATE_WORKING"}}}
+
+data: {"statusUpdate":{"taskId":"<taskId>","status":{"state":"TASK_STATE_WORKING"},"metadata":{"currentTool":"restricted_bash"}}}
+
+data: {"artifactUpdate":{"taskId":"<taskId>","artifact":{"artifactId":"assistant-text","parts":[{"text":"## Diag","mediaType":"text/markdown"}]},"append":true,"lastChunk":false}}
+
+data: {"artifactUpdate":{"taskId":"<taskId>","artifact":{"artifactId":"assistant-text","parts":[{"text":""}]},"append":true,"lastChunk":true}}
+
+data: {"statusUpdate":{"taskId":"<taskId>","status":{"state":"TASK_STATE_COMPLETED"}}}
+
+: keepalive
+```
+
+Consumer rules:
+
+- **Frame type** = the single top-level key: `task` | `statusUpdate` | `artifactUpdate`.
+- `artifactUpdate` with `append: true` → **concatenate** `artifact.parts[].text` to
+  build the answer. `lastChunk: true` marks the final chunk.
+- `statusUpdate` with a terminal `status.state` → the stream is done.
+- Lines starting with `:` are heartbeat comments (every ~25s) — ignore them.
+
+Python consumer:
+
+```python
+import json, requests
+buf = []
+with requests.post(f"{base}/message:stream", headers=H, stream=True,
+                   json={"message": {"role": "ROLE_USER",
+                                     "parts": [{"text": "diagnose kube-system restarts"}]}}) as r:
+    for line in r.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        obj = json.loads(line[6:])
+        if "artifactUpdate" in obj:
+            for p in obj["artifactUpdate"]["artifact"].get("parts", []):
+                buf.append(p.get("text", ""))
+        elif "statusUpdate" in obj:
+            state = obj["statusUpdate"]["status"]["state"]
+            if state.startswith("TASK_STATE_") and state not in ("TASK_STATE_SUBMITTED", "TASK_STATE_WORKING"):
+                break
+print("".join(buf))
+```
+
+---
+
+## 5. Continue, reconnect, cancel, list
+
+- **Continue the same investigation thread**: pass the same `contextId` on the next
+  `message:send`/`message:stream`. Omit it to start fresh (the server generates one
+  and returns it on the task). Each call still creates a new task; the `contextId`
+  reuses the underlying session.
+- **Reconnect a dropped stream**: `POST .../tasks/<taskId>:subscribe` (only while the
+  task is non-terminal; a terminal task returns `400`). Or just fall back to polling
+  `GET .../tasks/<taskId>` — polling always works.
+- **Cancel**: `POST .../tasks/<taskId>:cancel` → aborts the run, returns the task in
+  `TASK_STATE_CANCELED`.
+- **List your tasks**: `GET .../tasks?pageSize=20&pageToken=0&contextId=<ctx>&status=TASK_STATE_WORKING`.
+  Returns `{ tasks, totalSize, pageSize, nextPageToken }`. `pageSize` is 1–100
+  (default 20); `pageToken` is an integer offset; empty `nextPageToken` means no more.
+
+Task states: `TASK_STATE_SUBMITTED`, `TASK_STATE_WORKING`, `TASK_STATE_COMPLETED`,
+`TASK_STATE_FAILED`, `TASK_STATE_CANCELED`, `TASK_STATE_REJECTED`.
+
+---
+
+## 6. Errors
+
+JSON error envelope (google.rpc shape):
+
+```jsonc
+{ "error": {
+  "code": 403,
+  "status": "PERMISSION_DENIED",
+  "message": "API key is not authorized for this agent",
+  "details": [{ "reason": "FORBIDDEN", "domain": "a2a-protocol.org",
+                "metadata": { "timestamp": "2026-06-22T..." } }]
+}}
+```
+
+| HTTP | `status` | When |
+|------|----------|------|
+| 400  | `INVALID_ARGUMENT` | bad body, empty/oversized ids, non-text parts, bad pageSize |
+| 401  | `UNAUTHENTICATED` | missing/invalid key |
+| 403  | `PERMISSION_DENIED` | key not bound to this `agentId` |
+| 404  | `NOT_FOUND` | task does not exist (or not yours) |
+| 413  | `RESOURCE_EXHAUSTED` | body over 1 MB |
+| 502  | `UNAVAILABLE`/runtime error | runtime command failed |
+| 503  | `UNAVAILABLE` | agent runtime not connected |
+
+---
+
+## 7. Constraints (MVP)
+
+- **Text parts only.** `message.parts[].text`; `raw`/`url`/`data`/file parts are rejected.
+- `message.role`, if present, must be `ROLE_USER`.
+- Body ≤ **1 MB**; any id (`messageId`/`contextId`) ≤ **255 bytes**.
+- `message.taskId` continuation / `input-required` is **not** supported yet — start a
+  new task in the same `contextId` instead.
+- Push notifications, Agent Card signing, OAuth/mTLS, and the full A2A JSON-RPC
+  binding are deferred. This is a documented HTTP+JSON contract, not a drop-in for
+  every A2A SDK — implement against the schemas above (or use the client snippets).
+
+---
+
+## 8. Embedding Siclaw as a tool in your agent
+
+The cleanest way to let an LLM agent use Siclaw is to expose it as a single tool
+that wraps the flow above (send+poll for headless, stream for human-facing):
+
+```jsonc
+{
+  "name": "siclaw_diagnose",
+  "description": "Delegate a Kubernetes / GPU / host / network / storage SRE problem to Siclaw and return an operational diagnosis with evidence.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "problem":    { "type": "string", "description": "Natural-language symptom, e.g. 'pods in kube-system keep restarting on node X'." },
+      "context_id": { "type": "string", "description": "Reuse to continue the same investigation thread; omit to start fresh." }
+    },
+    "required": ["problem"]
+  }
+}
+```
+
+Tool body: `POST message:send` → poll `GET tasks/<taskId>` to terminal → return
+`artifacts[0].parts[0].text`. (OpenAI function-calling format is analogous.)

--- a/docs/design/2026-06-18-a2a-gateway.md
+++ b/docs/design/2026-06-18-a2a-gateway.md
@@ -1,0 +1,163 @@
+# Siclaw A2A Gateway Design
+
+Date: 2026-06-18
+
+## Goal
+
+Expose Siclaw OSS as an A2A-compatible server so another agent can delegate SRE
+diagnosis work to Siclaw, stream progress, poll task state, and cancel a
+running task without depending on Siclaw's internal chat event schema.
+
+This is a boundary adapter. It does not replace Siclaw's internal Runtime,
+AgentBox, MCP tools, chat persistence, or Portal UI APIs.
+
+## Standards Snapshot
+
+The A2A v1.0 line is the primary agent-to-agent contract to follow:
+
+- Agent discovery is via an Agent Card. The canonical well-known discovery path
+  is `/.well-known/agent-card.json`, and direct card configuration is also
+  valid for multi-tenant deployments.
+- `Task` is the core action unit. It has `id`, `contextId`, `status`,
+  optional `history`, optional `artifacts`, and metadata.
+- Streaming uses SSE. `SendStreamingMessage` starts a task and streams updates;
+  `SubscribeToTask` reconnects to an existing active task.
+- Polling uses `GetTask`.
+- Cancellation uses `CancelTask`.
+- Push notifications are the right shape for disconnected, very long running
+  jobs, but they require webhook validation, authentication, retry, and SSRF
+  controls, so they are not in the first OSS cut.
+
+References:
+
+- https://a2a-protocol.org/latest/specification/
+- https://a2a-protocol.org/latest/topics/streaming-and-async/
+- https://a2a-protocol.org/latest/topics/agent-cards/
+
+## Siclaw Placement
+
+Implement the A2A adapter in Portal, not Runtime:
+
+```text
+A2A client
+  -> Portal A2A routes
+    -> RuntimeConnectionMap
+      -> Runtime chat.send / chat.abort / chat.sessionStatus
+        -> AgentBox
+          -> MCP/tools/cluster diagnosis
+```
+
+Reasons:
+
+- Portal owns external auth, API keys, DB, and public HTTP routing.
+- Runtime already exposes a stable `chat.send` command and a `chat.event`
+  stream through the phone-home WebSocket.
+- Runtime should stay DB-free and execution-focused.
+- The contract is a self-contained boundary adapter, so a downstream platform can
+  later re-host it by proxying to these Portal A2A routes or by porting the adapter
+  shape into its own gateway.
+
+## OSS MVP
+
+Expose a per-agent A2A base path:
+
+```text
+GET  /api/v1/a2a/agents/:agentId/.well-known/agent-card.json
+GET  /api/v1/a2a/agents/:agentId/agent-card.json
+POST /api/v1/a2a/agents/:agentId/message:send
+POST /api/v1/a2a/agents/:agentId/message:stream
+GET  /api/v1/a2a/agents/:agentId/tasks
+GET  /api/v1/a2a/agents/:agentId/tasks/:taskId
+POST /api/v1/a2a/agents/:agentId/tasks/:taskId:subscribe
+POST /api/v1/a2a/agents/:agentId/tasks/:taskId:cancel
+```
+
+The path includes `agentId` because Siclaw Portal can host many agents behind
+one domain. The returned Agent Card points its HTTP+JSON interface at that
+per-agent base URL.
+
+Authentication:
+
+- Reuse Siclaw agent API keys: `Authorization: Bearer sk-...`.
+- The key's `agent_id` must match the route `:agentId`.
+- Public Agent Card routes do not require auth and must not expose secrets.
+
+Supported payload:
+
+- Text parts only in the MVP: `message.parts[].text`.
+- `message.messageId` is accepted when provided. The adapter also tolerates
+  clients that omit it because several official HTTP examples do so.
+- `message.contextId` is the external A2A conversation context.
+- Siclaw stores the external `contextId` separately and maps it to an internal
+  UUID `sessionId`; repeat calls with the same `contextId` reuse the latest
+  internal session for that API key.
+- If no `contextId` is provided, Siclaw creates one UUID and uses it as both the
+  A2A `contextId` and internal `sessionId`.
+- `message.taskId` continuation/input-required semantics are deferred until
+  Siclaw has an explicit interrupt/input-required state.
+
+## Task Projection
+
+Add a lightweight Portal-owned task projection table:
+
+```text
+a2a_tasks
+- id
+- agent_id
+- user_id
+- api_key_id
+- context_id
+- session_id
+- state
+- status_message
+- artifact_text
+- error
+- created_at
+- updated_at
+- last_event_at
+- completed_at
+```
+
+This table is an A2A projection, not a Runtime checkpoint. Runtime resume still
+belongs to AgentBox/pi-agent state. `chat_messages` remains the visible audit
+history, while `a2a_tasks` answers protocol-level state queries. The table keeps
+both `context_id` and `session_id` because A2A clients may use non-UUID context
+identifiers, while Siclaw's internal chat session storage remains UUID-shaped.
+
+## Event Mapping
+
+| Siclaw chat.event | A2A output |
+| --- | --- |
+| `message_update` text delta | `artifactUpdate` append chunk |
+| `agent_message` text | `artifactUpdate` append chunk |
+| `tool_execution_start` | `statusUpdate` working, current tool metadata |
+| `tool_execution_end` | `statusUpdate` working, tool finished metadata |
+| `stream_error` | `statusUpdate` failed |
+| `prompt_done` / `done` | `statusUpdate` completed unless already failed/canceled |
+| cancel route | `statusUpdate` canceled + Runtime `chat.abort` |
+
+`GetTask` returns the projected `Task`. During a running task it also asks
+Runtime `chat.sessionStatus`; if Runtime still reports running, the task stays
+`TASK_STATE_WORKING` even if no recent DB row changed.
+
+## Re-hosting Behind a Gateway (Future)
+
+This contract is intentionally a self-contained boundary adapter, so a downstream
+platform that already terminates external auth can offer the same A2A surface under
+its own domain in one of two ways:
+
+1. Proxy mode: the gateway authenticates the caller, resolves the Siclaw agent, and
+   forwards A2A calls to these Portal routes.
+2. Native facade mode: the gateway ports this adapter shape onto its own runtime
+   connection and maps its own credentials/access model into A2A auth.
+
+For OSS, the Portal-native implementation here is the first and reference cut.
+
+## Deferred Work
+
+- Push notification config and outbound webhook delivery.
+- Agent Card signing.
+- OAuth/OIDC/mTLS for cross-organization deployments.
+- File/raw/url/data A2A parts.
+- Multi-turn `taskId` continuation and `input-required`.
+- Full A2A JSON-RPC binding.

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -71,6 +71,10 @@ runtime:
 # -- Portal (standalone web UI, replaces Upstream)
 portal:
   enabled: true
+  # Keep at 1. Live chat/A2A SSE streaming and the in-process A2A task trackers
+  # (src/portal/a2a-gateway.ts) are process-local, and a Runtime phone-homes to a
+  # single Portal instance — so >1 replica would scatter streams across pods that
+  # don't hold the Runtime connection. Horizontal scale needs a shared pub/sub first.
   replicas: 1
   jwtSecret: ""         # Portal's JWT signing key (Portal is the auth boundary)
   portalSecret: ""      # shared with Runtime; verifies Runtime phone-home X-Auth-Token

--- a/src/gateway/rest-router.test.ts
+++ b/src/gateway/rest-router.test.ts
@@ -63,6 +63,30 @@ describe("createRestRouter.handle", () => {
     expect(got).toEqual({ name: "hello world" });
   });
 
+  it("keeps colon operation suffixes literal", async () => {
+    const router = createRestRouter();
+    const called = vi.fn();
+    router.post("/message:send", called);
+
+    const handled = router.handle(makeReq("POST", "/message:send"), asHttpRes(new FakeRes()));
+
+    expect(handled).toBe(true);
+    await new Promise((r) => setImmediate(r));
+    expect(called).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports params with colon operation suffixes", async () => {
+    const router = createRestRouter();
+    let got: Record<string, string> | undefined;
+    router.post("/tasks/:id:cancel", (_req, _res, params) => { got = params; });
+
+    const handled = router.handle(makeReq("POST", "/tasks/task-123:cancel"), asHttpRes(new FakeRes()));
+
+    expect(handled).toBe(true);
+    await new Promise((r) => setImmediate(r));
+    expect(got).toEqual({ id: "task-123" });
+  });
+
   it("returns false when no route matches", () => {
     const router = createRestRouter();
     router.get("/a", () => {});

--- a/src/gateway/rest-router.ts
+++ b/src/gateway/rest-router.ts
@@ -29,12 +29,18 @@ interface CompiledRoute {
   handler: RouteHandler;
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function compilePath(path: string): { pattern: RegExp; paramNames: string[] } {
   const paramNames: string[] = [];
-  const patternStr = path.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_match, name) => {
-    paramNames.push(name);
-    return "([^/]+)";
-  });
+  const patternStr = path.split("/").map((segment) => {
+    const match = segment.match(/^:([a-zA-Z_][a-zA-Z0-9_]*)(.*)$/);
+    if (!match) return escapeRegex(segment);
+    paramNames.push(match[1]);
+    return `([^/]+)${escapeRegex(match[2])}`;
+  }).join("/");
   return { pattern: new RegExp(`^${patternStr}$`), paramNames };
 }
 

--- a/src/portal/a2a-gateway.test.ts
+++ b/src/portal/a2a-gateway.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import crypto from "node:crypto";
+import { initDb, closeDb, getDb } from "../gateway/db.js";
+import { createRestRouter } from "../gateway/rest-router.js";
+import { runPortalMigrations } from "./migrate.js";
+import { registerA2aRoutes, __resetA2aGatewayState } from "./a2a-gateway.js";
+import type { RuntimeConnectionMap } from "./runtime-connection.js";
+
+const API_KEY = "sk-a2a-test-key";
+
+function keyHash(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function fakeReq(opts: { url: string; method: string; headers?: Record<string, string>; body?: unknown }): any {
+  const em = new EventEmitter() as any;
+  em.url = opts.url;
+  em.method = opts.method;
+  em.headers = { host: "siclaw.test", ...(opts.headers ?? {}) };
+  em.socket = { setNoDelay: vi.fn() };
+  const originalOn = em.on.bind(em);
+  em.on = (ev: string, listener: any) => {
+    originalOn(ev, listener);
+    if (ev === "data" && !em._emitted) {
+      em._emitted = true;
+      setImmediate(() => {
+        if (opts.body !== undefined) em.emit("data", Buffer.from(JSON.stringify(opts.body)));
+        em.emit("end");
+      });
+    }
+    return em;
+  };
+  return em;
+}
+
+function fakeRes() {
+  const r: any = new EventEmitter();
+  r._status = 0;
+  r._headers = {};
+  r._body = "";
+  r._chunks = [] as string[];
+  r.headersSent = false;
+  r.writableEnded = false;
+  r.destroyed = false;
+  r.socket = { setNoDelay: vi.fn() };
+  r.writeHead = vi.fn((status: number, headers?: Record<string, string>) => {
+    r._status = status;
+    r._headers = headers ?? {};
+    r.headersSent = true;
+    return r;
+  });
+  r.write = vi.fn((chunk: string) => {
+    r._chunks.push(chunk);
+    return true;
+  });
+  r.end = vi.fn((body?: string) => {
+    if (body) r._body += body;
+    r.writableEnded = true;
+    r.emit("finish");
+    return r;
+  });
+  return r;
+}
+
+function parseJsonBody(res: any): any {
+  return res._body ? JSON.parse(res._body) : null;
+}
+
+function parseSseDataChunks(res: any): any[] {
+  return res._chunks
+    .flatMap((chunk: string) => chunk.split("\n\n"))
+    .filter((frame: string) => frame.startsWith("data: "))
+    .map((frame: string) => JSON.parse(frame.slice("data: ".length)));
+}
+
+function runRoute(router: ReturnType<typeof createRestRouter>, req: any, res = fakeRes()): Promise<any> {
+  return new Promise((resolve, reject) => {
+    res.on("finish", () => resolve(res));
+    const origEnd = res.end;
+    res.end = (body?: string) => {
+      origEnd.call(res, body);
+      resolve(res);
+      return res;
+    };
+    try { if (!router.handle(req, res)) reject(new Error("no route")); } catch (err) { reject(err); }
+  });
+}
+
+function makeConnMap() {
+  const handlers = new Set<(data: unknown) => void>();
+  const map: RuntimeConnectionMap = {
+    register: vi.fn(),
+    unregister: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(true),
+    sendCommand: vi.fn(async (_agentId: string, method: string, params: any) => {
+      if (method === "chat.sessionStatus") return { ok: true, payload: { running: false } };
+      if (method === "chat.send") return { ok: true, payload: { sessionId: params.sessionId } };
+      if (method === "chat.abort") return { ok: true, payload: { ok: true } };
+      return { ok: false, error: `unexpected method ${method}` };
+    }),
+    notify: vi.fn(),
+    notifyMany: vi.fn(),
+    subscribe: vi.fn((_agentId: string, channel: string, handler: (data: unknown) => void) => {
+      expect(channel).toBe("chat.event");
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    }),
+    connectedAgentIds: vi.fn().mockReturnValue(["runtime"]),
+  };
+  return {
+    map,
+    emit(data: unknown) {
+      for (const handler of handlers) handler(data);
+    },
+  };
+}
+
+async function seedPortal(): Promise<void> {
+  const db = getDb();
+  await db.query("INSERT INTO siclaw_users (id, username, password_hash, role) VALUES (?, ?, ?, ?)", ["u1", "alice", "x", "user"]);
+  await db.query(
+    "INSERT INTO agents (id, name, model_provider, model_id, created_by) VALUES (?, ?, ?, ?, ?)",
+    ["a1", "SRE", "openai", "gpt-4.1", "u1"],
+  );
+  await db.query(
+    "INSERT INTO agents (id, name, model_provider, model_id, created_by) VALUES (?, ?, ?, ?, ?)",
+    ["a2", "Other", "openai", "gpt-4.1", "u1"],
+  );
+  await db.query(
+    "INSERT INTO model_providers (id, name, base_url, api_key, api_type) VALUES (?, ?, ?, ?, ?)",
+    ["p1", "openai", "https://api.openai.com/v1", "sk-provider", "openai-completions"],
+  );
+  await db.query(
+    "INSERT INTO model_entries (id, provider_id, model_id, name, reasoning, context_window, max_tokens) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ["m1", "p1", "gpt-4.1", "GPT-4.1", 0, 128000, 4096],
+  );
+  await db.query(
+    "INSERT INTO agent_api_keys (id, agent_id, name, key_hash, key_plain, key_prefix, created_by) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ["k1", "a1", "a2a", keyHash(API_KEY), API_KEY, "sk-a2a-te", "u1"],
+  );
+}
+
+async function makeRouter() {
+  initDb("sqlite::memory:");
+  await runPortalMigrations();
+  await seedPortal();
+  const router = createRestRouter();
+  const conn = makeConnMap();
+  registerA2aRoutes(router, conn.map);
+  return { router, conn };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // A2A trackers/subscribers/orphan timers are module-level; clear them so tasks created in
+  // one test never leak in-memory state (e.g. a live tracker) into the next.
+  __resetA2aGatewayState();
+});
+
+afterEach(async () => {
+  __resetA2aGatewayState();
+  await closeDb();
+});
+
+describe("registerA2aRoutes", () => {
+  it("serves an Agent Card for a Siclaw agent", async () => {
+    const { router } = await makeRouter();
+    const res = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/.well-known/agent-card.json",
+      method: "GET",
+    }));
+
+    expect(res._status).toBe(200);
+    expect(res._headers["A2A-Version"]).toBe("1.0");
+    const body = parseJsonBody(res);
+    expect(body.name).toBe("Siclaw SRE Agent");
+    expect(body.capabilities.streaming).toBe(true);
+    expect(body.supportedInterfaces[0].url).toBe("http://siclaw.test/api/v1/a2a/agents/a1");
+  });
+
+  it("rejects an API key for a different agent", async () => {
+    const { router } = await makeRouter();
+    const res = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a2/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", parts: [{ text: "hi" }] } },
+    }));
+
+    expect(res._status).toBe(403);
+    expect(res._headers["Content-Type"]).toContain("application/a2a+json");
+    const error = parseJsonBody(res).error;
+    expect(error.code).toBe(403);
+    expect(error.status).toBe("PERMISSION_DENIED");
+    expect(error.details[0].reason).toBe("FORBIDDEN");
+  });
+
+  it("creates an A2A task and dispatches chat.send", async () => {
+    const { router, conn } = await makeRouter();
+    const res = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", contextId: "ctx-1", parts: [{ text: "diagnose kube-system" }] } },
+    }));
+
+    expect(res._status).toBe(200);
+    const body = parseJsonBody(res);
+    expect(body.task.contextId).toBe("ctx-1");
+    expect(body.task.status.state).toBe("TASK_STATE_WORKING");
+    expect(conn.map.sendCommand).toHaveBeenCalledWith("a1", "chat.send", expect.objectContaining({
+      agentId: "a1",
+      userId: "u1",
+      text: "diagnose kube-system",
+      sessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      mode: "a2a",
+    }));
+
+    const [rows] = await getDb().query<Array<{ state: string; context_id: string; session_id: string }>>(
+      "SELECT state, context_id, session_id FROM a2a_tasks WHERE id = ?",
+      [body.task.id],
+    );
+    expect(rows[0]).toMatchObject({ state: "TASK_STATE_WORKING", context_id: "ctx-1" });
+    expect(rows[0].session_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("maps a non-UUID A2A context to a stable internal Siclaw session", async () => {
+    const { router, conn } = await makeRouter();
+    const first = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", contextId: "external-context", parts: [{ text: "first" }] } },
+    }));
+    const second = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", contextId: "external-context", parts: [{ text: "second" }] } },
+    }));
+
+    expect(first._status).toBe(200);
+    expect(second._status).toBe(200);
+    const sendCalls = (conn.map.sendCommand as any).mock.calls.filter((call: any[]) => call[1] === "chat.send");
+    expect(sendCalls).toHaveLength(2);
+    expect(sendCalls[0][2].sessionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(sendCalls[1][2].sessionId).toBe(sendCalls[0][2].sessionId);
+    expect(parseJsonBody(second).task.contextId).toBe("external-context");
+  });
+
+  it("rejects oversized A2A context identifiers before dispatching", async () => {
+    const { router, conn } = await makeRouter();
+    const res = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", contextId: "x".repeat(256), parts: [{ text: "too long" }] } },
+    }));
+
+    expect(res._status).toBe(400);
+    expect(parseJsonBody(res).error.details[0].reason).toBe("INVALID_ARGUMENT");
+    expect(conn.map.sendCommand).not.toHaveBeenCalledWith("a1", "chat.send", expect.anything());
+  });
+
+  it("returns RESOURCE_EXHAUSTED for bodies over the A2A size limit", async () => {
+    const { router, conn } = await makeRouter();
+    const res = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", parts: [{ text: "x".repeat(1024 * 1024) }] } },
+    }));
+
+    expect(res._status).toBe(413);
+    const error = parseJsonBody(res).error;
+    expect(error.status).toBe("RESOURCE_EXHAUSTED");
+    expect(error.details[0].reason).toBe("RESOURCE_EXHAUSTED");
+    expect(conn.map.sendCommand).not.toHaveBeenCalledWith("a1", "chat.send", expect.anything());
+  });
+
+  it("streams Siclaw text deltas and terminal status as A2A events", async () => {
+    const { router, conn } = await makeRouter();
+    const res = fakeRes();
+    router.handle(fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:stream",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", parts: [{ text: "stream it" }] } },
+    }), res);
+
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    const sent = (conn.map.sendCommand as any).mock.calls.find((call: any[]) => call[1] === "chat.send");
+    const sessionId = sent[2].sessionId;
+    conn.emit({ sessionId, event: { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hello" } } });
+    conn.emit({ sessionId, event: { type: "prompt_done" } });
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    const frames = parseSseDataChunks(res);
+    expect(frames.some((f) => f.task?.status?.state === "TASK_STATE_WORKING")).toBe(true);
+    expect(frames.some((f) => f.artifactUpdate?.artifact?.parts?.[0]?.text === "hello")).toBe(true);
+    expect(frames.some((f) => f.statusUpdate?.status?.state === "TASK_STATE_COMPLETED")).toBe(true);
+    expect(res.writableEnded).toBe(true);
+  });
+
+  it("lists A2A tasks with context and status filters", async () => {
+    const { router } = await makeRouter();
+    const createRes = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", contextId: "ctx-list", parts: [{ text: "list me" }] } },
+    }));
+    const created = parseJsonBody(createRes).task;
+
+    const listRes = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/tasks?contextId=ctx-list&status=TASK_STATE_WORKING&pageSize=10",
+      method: "GET",
+      headers: { authorization: `Bearer ${API_KEY}` },
+    }));
+
+    expect(listRes._status).toBe(200);
+    const body = parseJsonBody(listRes);
+    expect(body.totalSize).toBe(1);
+    expect(body.tasks[0].id).toBe(created.id);
+    expect(body.tasks[0].contextId).toBe("ctx-list");
+  });
+
+  it("rejects subscribe after a task reaches a terminal state", async () => {
+    const { router, conn } = await makeRouter();
+    const createRes = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", parts: [{ text: "finish quickly" }] } },
+    }));
+    const taskId = parseJsonBody(createRes).task.id;
+    const sent = (conn.map.sendCommand as any).mock.calls.find((call: any[]) => call[1] === "chat.send");
+    conn.emit({ sessionId: sent[2].sessionId, event: { type: "prompt_done" } });
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    const subscribeRes = await runRoute(router, fakeReq({
+      url: `/api/v1/a2a/agents/a1/tasks/${taskId}:subscribe`,
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: {},
+    }));
+
+    expect(subscribeRes._status).toBe(400);
+    expect(parseJsonBody(subscribeRes).error.details[0].reason).toBe("UNSUPPORTED_OPERATION");
+  });
+
+  it("cancels a running A2A task via chat.abort", async () => {
+    const { router, conn } = await makeRouter();
+    const createRes = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", parts: [{ text: "long check" }] } },
+    }));
+    const taskId = parseJsonBody(createRes).task.id;
+
+    const cancelRes = await runRoute(router, fakeReq({
+      url: `/api/v1/a2a/agents/a1/tasks/${taskId}:cancel`,
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: {},
+    }));
+
+    expect(cancelRes._status).toBe(200);
+    expect(parseJsonBody(cancelRes).task.status.state).toBe("TASK_STATE_CANCELED");
+    expect(conn.map.sendCommand).toHaveBeenCalledWith("a1", "chat.abort", expect.objectContaining({
+      agentId: "a1",
+      userId: "u1",
+    }));
+  });
+
+  it("keeps a freshly disconnected task WORKING within the grace window", async () => {
+    const { router, conn } = await makeRouter();
+    const createRes = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", parts: [{ text: "transient blip" }] } },
+    }));
+    const taskId = parseJsonBody(createRes).task.id;
+
+    // Runtime momentarily unreachable (phone-home blip). Inside the grace window the task
+    // must NOT be failed — chat.sessionStatus fails safe to running:false, so disconnect
+    // alone is not proof the turn is dead.
+    (conn.map.isConnected as any).mockReturnValue(false);
+    const getRes = await runRoute(router, fakeReq({
+      url: `/api/v1/a2a/agents/a1/tasks/${taskId}`,
+      method: "GET",
+      headers: { authorization: `Bearer ${API_KEY}` },
+    }));
+
+    expect(getRes._status).toBe(200);
+    expect(parseJsonBody(getRes).task.status.state).toBe("TASK_STATE_WORKING");
+  });
+
+  it("fails an orphaned task once the runtime stays disconnected past the grace window", async () => {
+    const prev = process.env.SICLAW_A2A_ORPHAN_GRACE_MS;
+    process.env.SICLAW_A2A_ORPHAN_GRACE_MS = "0";
+    try {
+      const { router, conn } = await makeRouter();
+      const createRes = await runRoute(router, fakeReq({
+        url: "/api/v1/a2a/agents/a1/message:send",
+        method: "POST",
+        headers: { authorization: `Bearer ${API_KEY}` },
+        body: { message: { role: "ROLE_USER", parts: [{ text: "orphan me" }] } },
+      }));
+      const taskId = parseJsonBody(createRes).task.id;
+
+      (conn.map.isConnected as any).mockReturnValue(false);
+      const getRes = await runRoute(router, fakeReq({
+        url: `/api/v1/a2a/agents/a1/tasks/${taskId}`,
+        method: "GET",
+        headers: { authorization: `Bearer ${API_KEY}` },
+      }));
+
+      expect(getRes._status).toBe(200);
+      expect(parseJsonBody(getRes).task.status.state).toBe("TASK_STATE_FAILED");
+      const [rows] = await getDb().query<Array<{ state: string }>>(
+        "SELECT state FROM a2a_tasks WHERE id = ?",
+        [taskId],
+      );
+      expect(rows[0].state).toBe("TASK_STATE_FAILED");
+    } finally {
+      if (prev === undefined) delete process.env.SICLAW_A2A_ORPHAN_GRACE_MS;
+      else process.env.SICLAW_A2A_ORPHAN_GRACE_MS = prev;
+    }
+  });
+
+  it("fails a task orphaned by a Portal restart even while the runtime stays connected", async () => {
+    const prev = process.env.SICLAW_A2A_ORPHAN_GRACE_MS;
+    process.env.SICLAW_A2A_ORPHAN_GRACE_MS = "0";
+    try {
+      const { router, conn } = await makeRouter();
+      const createRes = await runRoute(router, fakeReq({
+        url: "/api/v1/a2a/agents/a1/message:send",
+        method: "POST",
+        headers: { authorization: `Bearer ${API_KEY}` },
+        body: { message: { role: "ROLE_USER", parts: [{ text: "survive a restart" }] } },
+      }));
+      const taskId = parseJsonBody(createRes).task.id;
+
+      // Simulate a Portal restart: the in-memory tracker driving the task is gone, but the
+      // a2a_tasks row is still WORKING. The Runtime is reconnected (isConnected stays true)
+      // and reports the session not running (default sessionStatus mock). Without the
+      // no-tracker reconciliation this task would be stuck WORKING forever.
+      __resetA2aGatewayState();
+
+      const getRes = await runRoute(router, fakeReq({
+        url: `/api/v1/a2a/agents/a1/tasks/${taskId}`,
+        method: "GET",
+        headers: { authorization: `Bearer ${API_KEY}` },
+      }));
+
+      expect(conn.map.isConnected).toHaveReturnedWith(true);
+      expect(getRes._status).toBe(200);
+      expect(parseJsonBody(getRes).task.status.state).toBe("TASK_STATE_FAILED");
+    } finally {
+      if (prev === undefined) delete process.env.SICLAW_A2A_ORPHAN_GRACE_MS;
+      else process.env.SICLAW_A2A_ORPHAN_GRACE_MS = prev;
+    }
+  });
+
+  it("sends the initial task snapshot before live deltas even when the snapshot is slow", async () => {
+    const { router, conn } = await makeRouter();
+
+    // Gate the snapshot's chat.sessionStatus round-trip so a delta can arrive while the
+    // initial Task frame is still being produced.
+    let releaseStatus: () => void = () => {};
+    const statusGate = new Promise<void>((resolve) => { releaseStatus = resolve; });
+    (conn.map.sendCommand as any).mockImplementation(async (_agentId: string, method: string, params: any) => {
+      if (method === "chat.send") return { ok: true, payload: { sessionId: params.sessionId } };
+      if (method === "chat.sessionStatus") { await statusGate; return { ok: true, payload: { running: true } }; }
+      if (method === "chat.abort") return { ok: true, payload: { ok: true } };
+      return { ok: false, error: `unexpected method ${method}` };
+    });
+
+    const res = fakeRes();
+    router.handle(fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:stream",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", parts: [{ text: "stream it" }] } },
+    }), res);
+
+    // Let the handler reach streamTask (subscription is registered, snapshot is gated).
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+    const sent = (conn.map.sendCommand as any).mock.calls.find((call: any[]) => call[1] === "chat.send");
+    const sessionId = sent[2].sessionId;
+
+    // Delta arrives before the snapshot is released — it must be buffered, not raced ahead.
+    conn.emit({ sessionId, event: { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "early" } } });
+    await new Promise((r) => setImmediate(r));
+    releaseStatus();
+    for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r));
+
+    const frames = parseSseDataChunks(res);
+    const taskIdx = frames.findIndex((f) => f.task);
+    const artIdx = frames.findIndex((f) => f.artifactUpdate?.artifact?.parts?.[0]?.text === "early");
+    expect(taskIdx).toBe(0);
+    expect(artIdx).toBeGreaterThan(taskIdx);
+  });
+});

--- a/src/portal/a2a-gateway.ts
+++ b/src/portal/a2a-gateway.ts
@@ -1,0 +1,1014 @@
+import crypto from "node:crypto";
+import type http from "node:http";
+import {
+  parseBody,
+  parseQuery,
+  RequestBodyTooLargeError,
+  type RestRouter,
+} from "../gateway/rest-router.js";
+import { getDb } from "../gateway/db.js";
+import type { RuntimeConnectionMap } from "./runtime-connection.js";
+import { authenticateApiKey, type ApiKeyAuthResult } from "./api-key-auth.js";
+import { resolveAgentModelBinding } from "./chat-gateway.js";
+
+const A2A_VERSION = "1.0";
+const A2A_JSON = "application/a2a+json; charset=utf-8";
+const MAX_A2A_BODY_BYTES = 1024 * 1024;
+const MAX_A2A_ID_BYTES = 255;
+const ASSISTANT_ARTIFACT_ID = "assistant-text";
+
+type A2aTaskState =
+  | "TASK_STATE_SUBMITTED"
+  | "TASK_STATE_WORKING"
+  | "TASK_STATE_COMPLETED"
+  | "TASK_STATE_FAILED"
+  | "TASK_STATE_CANCELED"
+  | "TASK_STATE_REJECTED";
+
+const A2A_TASK_STATES = new Set<A2aTaskState>([
+  "TASK_STATE_SUBMITTED",
+  "TASK_STATE_WORKING",
+  "TASK_STATE_COMPLETED",
+  "TASK_STATE_FAILED",
+  "TASK_STATE_CANCELED",
+  "TASK_STATE_REJECTED",
+]);
+
+interface A2aMessage {
+  messageId?: string;
+  contextId?: string;
+  taskId?: string;
+  role?: string;
+  parts?: Array<{ text?: string; raw?: string; url?: string; data?: unknown; mediaType?: string }>;
+  metadata?: Record<string, unknown>;
+}
+
+interface NormalizedA2aMessage extends A2aMessage {
+  messageId: string;
+  contextId?: string;
+}
+
+interface SendMessageRequest {
+  message?: A2aMessage;
+  configuration?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+interface A2aTaskRecord {
+  id: string;
+  agentId: string;
+  userId: string;
+  apiKeyId: string | null;
+  contextId: string;
+  sessionId: string;
+  state: A2aTaskState;
+  statusMessage: string | null;
+  artifactText: string;
+  error: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  lastEventAt: string | null;
+  completedAt: string | null;
+}
+
+type A2aStreamResponse =
+  | { task: Record<string, unknown> }
+  | { message: Record<string, unknown> }
+  | { statusUpdate: Record<string, unknown> }
+  | { artifactUpdate: Record<string, unknown> };
+
+interface ActiveTracker {
+  unsubscribe: () => void;
+  artifactText: string;
+}
+
+const activeTrackers = new Map<string, ActiveTracker>();
+const streamSubscribers = new Map<string, Set<(response: A2aStreamResponse) => void>>();
+
+class A2aHttpError extends Error {
+  constructor(readonly status: number, readonly code: string, message: string) {
+    super(message);
+  }
+}
+
+function isTerminalState(state: A2aTaskState): boolean {
+  return state === "TASK_STATE_COMPLETED"
+    || state === "TASK_STATE_FAILED"
+    || state === "TASK_STATE_CANCELED"
+    || state === "TASK_STATE_REJECTED";
+}
+
+function sendA2aJson(res: http.ServerResponse, status: number, data: unknown): void {
+  const body = JSON.stringify(data);
+  res.writeHead(status, {
+    "Content-Type": A2A_JSON,
+    "A2A-Version": A2A_VERSION,
+    "Content-Length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function sendA2aError(res: http.ServerResponse, err: A2aHttpError): void {
+  sendA2aJson(res, err.status, {
+    error: {
+      code: err.status,
+      status: grpcStatusForHttp(err.status),
+      message: err.message,
+      details: [{
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        reason: err.code,
+        domain: "a2a-protocol.org",
+        metadata: {
+          timestamp: new Date().toISOString(),
+        },
+      }],
+    },
+  });
+}
+
+function respondA2aError(req: http.IncomingMessage, res: http.ServerResponse, err: unknown): void {
+  if (err instanceof A2aHttpError) {
+    sendA2aError(res, err);
+    return;
+  }
+  // Unexpected internal failure (DB error, programming bug). Each A2A handler catches
+  // before the REST router's own catch can see it, so without logging here the 500
+  // would be completely invisible server-side.
+  console.error(`[a2a-gateway] ${req.method ?? "?"} ${(req.url ?? "").split("?")[0]} failed:`, err);
+  sendA2aError(res, new A2aHttpError(500, "INTERNAL", "Internal server error"));
+}
+
+function writeA2aSseHead(res: http.ServerResponse): void {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "A2A-Version": A2A_VERSION,
+    "X-Accel-Buffering": "no",
+  });
+  res.socket?.setNoDelay(true);
+}
+
+function grpcStatusForHttp(status: number): string {
+  switch (status) {
+    case 400: return "INVALID_ARGUMENT";
+    case 401: return "UNAUTHENTICATED";
+    case 403: return "PERMISSION_DENIED";
+    case 404: return "NOT_FOUND";
+    case 409: return "ABORTED";
+    case 413:
+    case 429: return "RESOURCE_EXHAUSTED";
+    case 500: return "INTERNAL";
+    case 501: return "UNIMPLEMENTED";
+    case 502:
+    case 503:
+    case 504:
+      return "UNAVAILABLE";
+    default:
+      return status >= 500 ? "INTERNAL" : "UNKNOWN";
+  }
+}
+
+function writeA2aSse(res: http.ServerResponse, data: A2aStreamResponse): void {
+  if (res.writableEnded || res.destroyed) return;
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function externalOrigin(req: http.IncomingMessage): string {
+  const forwardedProto = String(req.headers["x-forwarded-proto"] ?? "").split(",")[0].trim();
+  const forwardedHost = String(req.headers["x-forwarded-host"] ?? "").split(",")[0].trim();
+  const proto = forwardedProto || ((req.socket as any).encrypted ? "https" : "http");
+  const host = forwardedHost || req.headers.host || "localhost";
+  return `${proto}://${host}`;
+}
+
+function buildAgentCard(req: http.IncomingMessage, agentId: string): Record<string, unknown> {
+  const baseUrl = `${externalOrigin(req)}/api/v1/a2a/agents/${encodeURIComponent(agentId)}`;
+  return {
+    name: "Siclaw SRE Agent",
+    description: "Delegates Kubernetes and infrastructure diagnostics to a Siclaw SRE agent.",
+    supportedInterfaces: [
+      {
+        url: baseUrl,
+        protocolBinding: "HTTP+JSON",
+        protocolVersion: A2A_VERSION,
+        tenant: agentId,
+      },
+    ],
+    provider: {
+      organization: "Siclaw",
+      url: "https://github.com/scitix/siclaw",
+    },
+    version: A2A_VERSION,
+    documentationUrl: "https://github.com/scitix/siclaw",
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+      extendedAgentCard: false,
+    },
+    securitySchemes: {
+      siclawApiKey: {
+        httpAuthSecurityScheme: {
+          scheme: "Bearer",
+          bearerFormat: "Siclaw agent API key",
+          description: "Use an agent API key generated in Siclaw Portal.",
+        },
+      },
+    },
+    securityRequirements: [{ siclawApiKey: [] }],
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/markdown", "text/plain"],
+    skills: [
+      {
+        id: "sre_cluster_diagnosis",
+        name: "SRE Cluster Diagnosis",
+        description: "Investigate Kubernetes, host, GPU, network, storage, and service health issues and return an operational diagnosis.",
+        tags: ["sre", "kubernetes", "diagnostics", "operations"],
+        examples: [
+          "Diagnose why pods in kube-system are restarting.",
+          "Check whether a GPU node is healthy and summarize the evidence.",
+        ],
+        inputModes: ["text/plain"],
+        outputModes: ["text/markdown", "text/plain"],
+        securityRequirements: [{ siclawApiKey: [] }],
+      },
+    ],
+  };
+}
+
+async function requireAgentApiKey(
+  req: http.IncomingMessage,
+  agentId: string,
+): Promise<ApiKeyAuthResult> {
+  const auth = await authenticateApiKey(req);
+  if (!auth) throw new A2aHttpError(401, "AUTHENTICATION_REQUIRED", "A valid Siclaw agent API key is required");
+  if (auth.agentId !== agentId) {
+    throw new A2aHttpError(403, "FORBIDDEN", "API key is not authorized for this agent");
+  }
+  return auth;
+}
+
+async function parseA2aBody(req: http.IncomingMessage): Promise<SendMessageRequest> {
+  try {
+    return await parseBody<SendMessageRequest>(req, { maxBytes: MAX_A2A_BODY_BYTES });
+  } catch (err) {
+    if (err instanceof RequestBodyTooLargeError) {
+      throw new A2aHttpError(413, "RESOURCE_EXHAUSTED", "A2A JSON body is too large");
+    }
+    throw new A2aHttpError(400, "INVALID_ARGUMENT", "Invalid A2A JSON body");
+  }
+}
+
+function optionalStringId(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    throw new A2aHttpError(400, "INVALID_ARGUMENT", `${field} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) throw new A2aHttpError(400, "INVALID_ARGUMENT", `${field} must not be empty`);
+  if (Buffer.byteLength(trimmed, "utf8") > MAX_A2A_ID_BYTES) {
+    throw new A2aHttpError(400, "INVALID_ARGUMENT", `${field} must be ${MAX_A2A_ID_BYTES} bytes or less`);
+  }
+  return trimmed;
+}
+
+function extractTextMessage(body: SendMessageRequest): { text: string; message: NormalizedA2aMessage } {
+  const message = body.message;
+  if (!message) throw new A2aHttpError(400, "INVALID_ARGUMENT", "message is required");
+  const messageId = optionalStringId(message.messageId, "message.messageId") ?? crypto.randomUUID();
+  const contextId = optionalStringId(message.contextId, "message.contextId");
+  const taskId = optionalStringId(message.taskId, "message.taskId");
+  if (message.role && message.role !== "ROLE_USER") {
+    throw new A2aHttpError(400, "INVALID_ARGUMENT", "message.role must be ROLE_USER");
+  }
+  if (taskId) {
+    throw new A2aHttpError(400, "UNSUPPORTED_OPERATION", "taskId continuation is not supported in the first A2A cut; use contextId for a new task in the same conversation");
+  }
+  const parts = Array.isArray(message.parts) ? message.parts : [];
+  const textParts: string[] = [];
+  for (const part of parts) {
+    if (!part || typeof part !== "object") {
+      throw new A2aHttpError(400, "INVALID_ARGUMENT", "message.parts must contain objects");
+    }
+    const hasText = typeof part.text === "string";
+    const hasOther = part.raw !== undefined || part.url !== undefined || part.data !== undefined;
+    if (!hasText || hasOther) {
+      throw new A2aHttpError(400, "UNSUPPORTED_OPERATION", "Only text parts are supported by this Siclaw A2A endpoint");
+    }
+    if (part.text?.trim()) textParts.push(part.text);
+  }
+  const text = textParts.join("\n\n").trim();
+  if (!text) throw new A2aHttpError(400, "INVALID_ARGUMENT", "message.parts must include non-empty text");
+  return { text, message: { ...message, messageId, ...(contextId ? { contextId } : {}) } };
+}
+
+function toNullableIso(value: unknown): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+function rowToTask(row: Record<string, unknown>): A2aTaskRecord {
+  return {
+    id: String(row.id),
+    agentId: String(row.agent_id),
+    userId: String(row.user_id),
+    apiKeyId: row.api_key_id == null ? null : String(row.api_key_id),
+    contextId: String(row.context_id),
+    sessionId: String(row.session_id),
+    state: String(row.state) as A2aTaskState,
+    statusMessage: row.status_message == null ? null : String(row.status_message),
+    artifactText: row.artifact_text == null ? "" : String(row.artifact_text),
+    error: row.error == null ? null : String(row.error),
+    createdAt: toNullableIso(row.created_at),
+    updatedAt: toNullableIso(row.updated_at),
+    lastEventAt: toNullableIso(row.last_event_at),
+    completedAt: toNullableIso(row.completed_at),
+  };
+}
+
+async function createTaskRecord(params: {
+  id: string;
+  agentId: string;
+  userId: string;
+  apiKeyId: string;
+  contextId: string;
+  sessionId: string;
+}): Promise<A2aTaskRecord> {
+  const db = getDb();
+  await db.query(
+    `INSERT INTO a2a_tasks
+       (id, agent_id, user_id, api_key_id, context_id, session_id, state, status_message)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      params.id,
+      params.agentId,
+      params.userId,
+      params.apiKeyId,
+      params.contextId,
+      params.sessionId,
+      "TASK_STATE_SUBMITTED",
+      "Task submitted to Siclaw",
+    ],
+  );
+  return {
+    id: params.id,
+    agentId: params.agentId,
+    userId: params.userId,
+    apiKeyId: params.apiKeyId,
+    contextId: params.contextId,
+    sessionId: params.sessionId,
+    state: "TASK_STATE_SUBMITTED",
+    statusMessage: "Task submitted to Siclaw",
+    artifactText: "",
+    error: null,
+    createdAt: null,
+    updatedAt: null,
+    lastEventAt: null,
+    completedAt: null,
+  };
+}
+
+async function loadTaskRecord(agentId: string, taskId: string, apiKeyId: string): Promise<A2aTaskRecord | null> {
+  const db = getDb();
+  const [rows] = await db.query(
+    `SELECT id, agent_id, user_id, api_key_id, context_id, session_id, state,
+            status_message, artifact_text, error, created_at, updated_at, last_event_at, completed_at
+       FROM a2a_tasks
+      WHERE id = ? AND agent_id = ? AND api_key_id = ?
+      LIMIT 1`,
+    [taskId, agentId, apiKeyId],
+  ) as any;
+  return rows.length ? rowToTask(rows[0]) : null;
+}
+
+async function loadSessionIdForContext(agentId: string, apiKeyId: string, contextId: string): Promise<string | null> {
+  const db = getDb();
+  const [rows] = await db.query(
+    `SELECT session_id
+       FROM a2a_tasks
+      WHERE agent_id = ? AND api_key_id = ? AND context_id = ?
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1`,
+    [agentId, apiKeyId, contextId],
+  ) as any;
+  return rows.length ? String(rows[0].session_id) : null;
+}
+
+async function loadTaskRecordById(taskId: string): Promise<A2aTaskRecord | null> {
+  const db = getDb();
+  const [rows] = await db.query(
+    `SELECT id, agent_id, user_id, api_key_id, context_id, session_id, state,
+            status_message, artifact_text, error, created_at, updated_at, last_event_at, completed_at
+       FROM a2a_tasks
+      WHERE id = ?
+      LIMIT 1`,
+    [taskId],
+  ) as any;
+  return rows.length ? rowToTask(rows[0]) : null;
+}
+
+async function listTaskRecords(params: {
+  agentId: string;
+  apiKeyId: string;
+  contextId?: string;
+  status?: A2aTaskState;
+  pageSize: number;
+  pageToken: number;
+}): Promise<{ tasks: A2aTaskRecord[]; totalSize: number; nextPageToken: string }> {
+  const where = ["agent_id = ?", "api_key_id = ?"];
+  const values: unknown[] = [params.agentId, params.apiKeyId];
+  if (params.contextId) {
+    where.push("context_id = ?");
+    values.push(params.contextId);
+  }
+  if (params.status) {
+    where.push("state = ?");
+    values.push(params.status);
+  }
+
+  const db = getDb();
+  const whereSql = where.join(" AND ");
+  const [countRows] = await db.query(
+    `SELECT COUNT(*) AS c FROM a2a_tasks WHERE ${whereSql}`,
+    values,
+  ) as any;
+  const totalSize = Number(countRows[0]?.c ?? 0);
+  const [rows] = await db.query(
+    `SELECT id, agent_id, user_id, api_key_id, context_id, session_id, state,
+            status_message, artifact_text, error, created_at, updated_at, last_event_at, completed_at
+       FROM a2a_tasks
+      WHERE ${whereSql}
+      ORDER BY created_at DESC, id DESC
+      LIMIT ? OFFSET ?`,
+    [...values, params.pageSize, params.pageToken],
+  ) as any;
+  const nextOffset = params.pageToken + rows.length;
+  return {
+    tasks: rows.map(rowToTask),
+    totalSize,
+    nextPageToken: nextOffset < totalSize ? String(nextOffset) : "",
+  };
+}
+
+async function setTaskState(
+  taskId: string,
+  state: A2aTaskState,
+  statusMessage: string,
+  error?: string | null,
+): Promise<void> {
+  const terminal = isTerminalState(state);
+  const db = getDb();
+  const sql = terminal
+    ? `UPDATE a2a_tasks
+          SET state = ?, status_message = ?, error = ?, updated_at = CURRENT_TIMESTAMP,
+              last_event_at = CURRENT_TIMESTAMP, completed_at = CURRENT_TIMESTAMP
+        WHERE id = ?`
+    : `UPDATE a2a_tasks
+          SET state = ?, status_message = ?, error = ?, updated_at = CURRENT_TIMESTAMP,
+              last_event_at = CURRENT_TIMESTAMP
+        WHERE id = ?`;
+  await db.query(sql, [state, statusMessage, error ?? null, taskId]);
+}
+
+async function setTaskArtifact(taskId: string, artifactText: string): Promise<void> {
+  const db = getDb();
+  await db.query(
+    `UPDATE a2a_tasks
+        SET artifact_text = ?, updated_at = CURRENT_TIMESTAMP, last_event_at = CURRENT_TIMESTAMP
+      WHERE id = ?`,
+    [artifactText, taskId],
+  );
+}
+
+function buildStatusMessage(task: A2aTaskRecord, text: string): Record<string, unknown> {
+  return {
+    messageId: `status-${task.id}`,
+    contextId: task.contextId,
+    taskId: task.id,
+    role: "ROLE_AGENT",
+    parts: [{ text }],
+  };
+}
+
+function buildTask(task: A2aTaskRecord, stateOverride?: A2aTaskState): Record<string, unknown> {
+  const state = stateOverride ?? task.state;
+  const statusText = task.statusMessage ?? (state === "TASK_STATE_WORKING" ? "Siclaw is working" : "Task submitted to Siclaw");
+  const result: Record<string, unknown> = {
+    id: task.id,
+    contextId: task.contextId,
+    status: {
+      state,
+      message: buildStatusMessage(task, statusText),
+      timestamp: task.lastEventAt ?? task.updatedAt ?? new Date().toISOString(),
+    },
+    metadata: {
+      agentId: task.agentId,
+      sessionId: task.sessionId,
+      lastEventAt: task.lastEventAt,
+      completedAt: task.completedAt,
+    },
+  };
+  if (task.artifactText) {
+    result.artifacts = [{
+      artifactId: ASSISTANT_ARTIFACT_ID,
+      name: "Siclaw diagnosis",
+      parts: [{ text: task.artifactText, mediaType: "text/markdown" }],
+    }];
+  }
+  return result;
+}
+
+function buildStatusUpdate(
+  task: A2aTaskRecord,
+  state: A2aTaskState,
+  text: string,
+  metadata?: Record<string, unknown>,
+): A2aStreamResponse {
+  return {
+    statusUpdate: {
+      taskId: task.id,
+      contextId: task.contextId,
+      status: {
+        state,
+        message: buildStatusMessage(task, text),
+        timestamp: new Date().toISOString(),
+      },
+      ...(metadata ? { metadata } : {}),
+    },
+  };
+}
+
+function buildArtifactUpdate(task: A2aTaskRecord, delta: string, lastChunk = false): A2aStreamResponse {
+  return {
+    artifactUpdate: {
+      taskId: task.id,
+      contextId: task.contextId,
+      artifact: {
+        artifactId: ASSISTANT_ARTIFACT_ID,
+        name: "Siclaw diagnosis",
+        parts: [{ text: delta, mediaType: "text/markdown" }],
+      },
+      append: true,
+      lastChunk,
+    },
+  };
+}
+
+function subscribeTask(taskId: string, callback: (response: A2aStreamResponse) => void): () => void {
+  let set = streamSubscribers.get(taskId);
+  if (!set) {
+    set = new Set();
+    streamSubscribers.set(taskId, set);
+  }
+  set.add(callback);
+  return () => {
+    set!.delete(callback);
+    if (set!.size === 0) streamSubscribers.delete(taskId);
+  };
+}
+
+function emitTask(taskId: string, response: A2aStreamResponse): void {
+  const set = streamSubscribers.get(taskId);
+  if (!set) return;
+  for (const cb of set) {
+    try { cb(response); } catch { /* one broken stream must not break others */ }
+  }
+}
+
+function extractDelta(evt: Record<string, unknown>): string {
+  if (evt.type === "agent_message" && typeof evt.text === "string") return evt.text;
+  if (evt.type === "message_update") {
+    const ame = (evt as any).assistantMessageEvent;
+    if (ame?.type === "text_delta" && typeof ame.delta === "string") return ame.delta;
+  }
+  return "";
+}
+
+function toolName(evt: Record<string, unknown>): string | undefined {
+  const name = (evt as any).toolName ?? (evt as any).name;
+  return typeof name === "string" && name ? name : undefined;
+}
+
+function streamErrorMessage(evt: Record<string, unknown>): string {
+  const err = (evt as any).error;
+  if (typeof err?.message === "string") return err.message;
+  if (typeof err === "string") return err;
+  return "Siclaw stream failed";
+}
+
+function ensureTaskTracker(task: A2aTaskRecord, connectionMap: RuntimeConnectionMap): void {
+  if (activeTrackers.has(task.id)) return;
+
+  const tracker: ActiveTracker = {
+    artifactText: task.artifactText,
+    unsubscribe: () => {},
+  };
+
+  tracker.unsubscribe = connectionMap.subscribe(task.agentId, "chat.event", (data: unknown) => {
+    const envelope = data as { sessionId?: string; event?: Record<string, unknown> } | undefined;
+    if (!envelope?.event) return;
+    if (envelope.sessionId && envelope.sessionId !== task.sessionId) return;
+    void handleTrackedEvent(task, tracker, envelope.event).catch((err) => {
+      console.error(`[a2a-gateway] tracked-event handling failed for task ${task.id}:`, err);
+    });
+  });
+
+  activeTrackers.set(task.id, tracker);
+}
+
+async function handleTrackedEvent(
+  task: A2aTaskRecord,
+  tracker: ActiveTracker,
+  evt: Record<string, unknown>,
+): Promise<void> {
+  // Text deltas accumulate in the in-memory tracker and are flushed to a2a_tasks.artifact_text
+  // only at terminal events (prompt_done / stream_error). The a2a_tasks row is a protocol
+  // projection, not the durable transcript — chat_messages is the audit source of truth — so a
+  // crash mid-turn loses the partial artifact from the projection but never from chat history.
+  const delta = extractDelta(evt);
+  if (delta) {
+    tracker.artifactText += delta;
+    emitTask(task.id, buildArtifactUpdate(task, delta));
+    return;
+  }
+
+  if (evt.type === "tool_execution_start") {
+    const name = toolName(evt);
+    const text = name ? `Running tool: ${name}` : "Running a Siclaw tool";
+    await setTaskState(task.id, "TASK_STATE_WORKING", text);
+    emitTask(task.id, buildStatusUpdate(task, "TASK_STATE_WORKING", text, name ? { currentTool: name } : undefined));
+    return;
+  }
+
+  if (evt.type === "tool_execution_end") {
+    const name = toolName(evt);
+    const text = name ? `Finished tool: ${name}` : "Siclaw tool finished";
+    await setTaskState(task.id, "TASK_STATE_WORKING", text);
+    emitTask(task.id, buildStatusUpdate(task, "TASK_STATE_WORKING", text, name ? { currentTool: name } : undefined));
+    return;
+  }
+
+  if (evt.type === "stream_error") {
+    const message = streamErrorMessage(evt);
+    await setTaskArtifact(task.id, tracker.artifactText);
+    await setTaskState(task.id, "TASK_STATE_FAILED", message, message);
+    emitTask(task.id, buildStatusUpdate(task, "TASK_STATE_FAILED", message));
+    stopTaskTracker(task.id);
+    return;
+  }
+
+  if (evt.type === "prompt_done" || evt.type === "done") {
+    const latest = await loadTaskRecordById(task.id);
+    if (latest && isTerminalState(latest.state)) {
+      stopTaskTracker(task.id);
+      return;
+    }
+    await setTaskArtifact(task.id, tracker.artifactText);
+    await setTaskState(task.id, "TASK_STATE_COMPLETED", "Siclaw task completed");
+    emitTask(task.id, buildArtifactUpdate(task, "", true));
+    emitTask(task.id, buildStatusUpdate(task, "TASK_STATE_COMPLETED", "Siclaw task completed"));
+    stopTaskTracker(task.id);
+  }
+}
+
+function stopTaskTracker(taskId: string): void {
+  const tracker = activeTrackers.get(taskId);
+  if (!tracker) return;
+  activeTrackers.delete(taskId);
+  tracker.unsubscribe();
+}
+
+async function submitA2aTask(params: {
+  agentId: string;
+  auth: ApiKeyAuthResult;
+  text: string;
+  message: NormalizedA2aMessage;
+  connectionMap: RuntimeConnectionMap;
+}): Promise<A2aTaskRecord> {
+  const { agentId, auth, text, message, connectionMap } = params;
+  if (!connectionMap.isConnected(agentId)) {
+    throw new A2aHttpError(503, "UNAVAILABLE", "Agent runtime is not connected");
+  }
+
+  const modelBinding = await resolveAgentModelBinding(agentId);
+  if (!modelBinding) {
+    throw new A2aHttpError(400, "FAILED_PRECONDITION", "Agent has no model configured");
+  }
+
+  const taskId = crypto.randomUUID();
+  const contextId = message.contextId || crypto.randomUUID();
+  const sessionId = message.contextId
+    ? (await loadSessionIdForContext(agentId, auth.keyId, contextId)) ?? crypto.randomUUID()
+    : contextId;
+  const task = await createTaskRecord({
+    id: taskId,
+    agentId,
+    userId: auth.createdBy,
+    apiKeyId: auth.keyId,
+    contextId,
+    sessionId,
+  });
+
+  ensureTaskTracker(task, connectionMap);
+
+  const result = await connectionMap.sendCommand(agentId, "chat.send", {
+    agentId,
+    userId: auth.createdBy,
+    text,
+    sessionId,
+    mode: "a2a",
+    modelProvider: modelBinding.modelProvider,
+    modelId: modelBinding.modelId,
+    modelConfig: modelBinding.modelConfig,
+    modelRouting: modelBinding.modelRouting,
+    turnStartMs: Date.now(),
+  });
+
+  if (!result.ok) {
+    stopTaskTracker(task.id);
+    await setTaskState(task.id, "TASK_STATE_FAILED", result.error ?? "Runtime command failed", result.error ?? null);
+    throw new A2aHttpError(502, "RUNTIME_ERROR", result.error ?? "Runtime command failed");
+  }
+
+  await setTaskState(task.id, "TASK_STATE_WORKING", "Siclaw is working");
+  emitTask(task.id, buildStatusUpdate(task, "TASK_STATE_WORKING", "Siclaw is working"));
+  return { ...task, state: "TASK_STATE_WORKING", statusMessage: "Siclaw is working" };
+}
+
+async function loadAuthorizedTask(
+  req: http.IncomingMessage,
+  agentId: string,
+  taskId: string,
+): Promise<{ auth: ApiKeyAuthResult; task: A2aTaskRecord }> {
+  const auth = await requireAgentApiKey(req, agentId);
+  const task = await loadTaskRecord(agentId, taskId, auth.keyId);
+  if (!task) throw new A2aHttpError(404, "NOT_FOUND", "A2A task not found");
+  return { auth, task };
+}
+
+function orphanGraceMs(): number {
+  const v = Number(process.env.SICLAW_A2A_ORPHAN_GRACE_MS ?? 60_000);
+  return Number.isFinite(v) && v >= 0 ? v : 60_000;
+}
+
+// A non-terminal task whose Runtime has disconnected can never reach a terminal event on
+// its own (a Runtime restart drops the in-memory turn; pi-agent does not resume it). But a
+// brief phone-home blip would also read as "disconnected", so we only fail the task after
+// observing the disconnect for a full grace window across polls. App-clock only — never
+// parse DB timestamps here (SQLite/MySQL store CURRENT_TIMESTAMP in the DB's own zone).
+const orphanFirstSeenMs = new Map<string, number>();
+
+async function reconcileOrphanedTask(task: A2aTaskRecord): Promise<A2aTaskRecord | null> {
+  const now = Date.now();
+  const firstSeen = orphanFirstSeenMs.get(task.id) ?? now;
+  if (!orphanFirstSeenMs.has(task.id)) orphanFirstSeenMs.set(task.id, now);
+  if (now - firstSeen < orphanGraceMs()) return null;
+  orphanFirstSeenMs.delete(task.id);
+  const message = "Siclaw runtime disconnected before the task finished";
+  await setTaskState(task.id, "TASK_STATE_FAILED", message, message);
+  emitTask(task.id, buildStatusUpdate(task, "TASK_STATE_FAILED", message));
+  stopTaskTracker(task.id);
+  return { ...task, state: "TASK_STATE_FAILED", statusMessage: message, error: message };
+}
+
+/** Drop all in-memory A2A state. For graceful shutdown and to isolate tests from each other. */
+export function __resetA2aGatewayState(): void {
+  for (const tracker of activeTrackers.values()) {
+    try { tracker.unsubscribe(); } catch { /* best-effort */ }
+  }
+  activeTrackers.clear();
+  streamSubscribers.clear();
+  orphanFirstSeenMs.clear();
+}
+
+async function currentTaskForResponse(
+  task: A2aTaskRecord,
+  connectionMap: RuntimeConnectionMap,
+): Promise<Record<string, unknown>> {
+  if (task.state === "TASK_STATE_SUBMITTED" || task.state === "TASK_STATE_WORKING") {
+    if (!connectionMap.isConnected(task.agentId)) {
+      const reconciled = await reconcileOrphanedTask(task);
+      return buildTask(reconciled ?? task);
+    }
+    const result = await connectionMap.sendCommand(task.agentId, "chat.sessionStatus", {
+      agentId: task.agentId,
+      userId: task.userId,
+      sessionId: task.sessionId,
+    }, 10_000);
+    if (result.ok && (result.payload as any)?.running) {
+      orphanFirstSeenMs.delete(task.id);
+      return buildTask(task, "TASK_STATE_WORKING");
+    }
+    // Connected but the Runtime is not running this session. If an in-process tracker is
+    // still driving the task, a terminal event is imminent (this poll just raced the
+    // done/stream_error event) — keep it WORKING and let the tracker finish it. With no
+    // tracker the task is orphaned: Portal restarted (in-memory trackers are gone) or the
+    // terminal event was missed, so it would otherwise stay WORKING forever. Fail it through
+    // the same grace window the disconnect path uses.
+    if (!activeTrackers.has(task.id)) {
+      const reconciled = await reconcileOrphanedTask(task);
+      return buildTask(reconciled ?? task);
+    }
+    orphanFirstSeenMs.delete(task.id);
+  }
+  return buildTask(task);
+}
+
+function streamTask(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  task: A2aTaskRecord,
+  connectionMap: RuntimeConnectionMap,
+): void {
+  writeA2aSseHead(res);
+
+  // Already terminal: emit the final snapshot once and close. No tracker, no live stream.
+  if (isTerminalState(task.state)) {
+    void currentTaskForResponse(task, connectionMap)
+      .then((snapshot) => writeA2aSse(res, { task: snapshot }))
+      .catch(() => writeA2aSse(res, { task: buildTask(task) }))
+      .finally(() => { if (!res.writableEnded && !res.destroyed) res.end(); });
+    return;
+  }
+
+  // Keep a tracker advancing the task's DB/state for its whole lifetime, independent of
+  // this client connection (so a disconnecting client never strands the task).
+  ensureTaskTracker(task, connectionMap);
+
+  let closed = false;
+  let snapshotSent = false;
+  const buffered: A2aStreamResponse[] = [];
+  let unsubscribe: () => void = () => {};
+
+  const heartbeat = setInterval(() => {
+    if (closed || res.writableEnded || res.destroyed) {
+      clearInterval(heartbeat);
+      return;
+    }
+    try { res.write(": keepalive\n\n"); } catch { clearInterval(heartbeat); }
+  }, 25_000);
+  heartbeat.unref?.();
+
+  const endStream = () => {
+    if (closed) return;
+    closed = true;
+    clearInterval(heartbeat);
+    unsubscribe();
+    if (!res.writableEnded && !res.destroyed) res.end();
+  };
+
+  const writeEvent = (event: A2aStreamResponse) => {
+    if (closed) return;
+    writeA2aSse(res, event);
+    const state = (event as any).statusUpdate?.status?.state as A2aTaskState | undefined;
+    if (state && isTerminalState(state)) endStream();
+  };
+
+  // Subscribe synchronously so no live event is dropped while the snapshot loads, but hold
+  // events in a buffer until the initial Task frame is written. A2A clients expect the
+  // snapshot as the first stream event, and producing it involves an awaited Runtime
+  // round-trip — without buffering a fast first delta could race ahead of the snapshot.
+  unsubscribe = subscribeTask(task.id, (event) => {
+    if (closed) return;
+    if (!snapshotSent) { buffered.push(event); return; }
+    writeEvent(event);
+  });
+
+  req.on("close", endStream);
+  res.on("close", endStream);
+  res.on("error", endStream);
+
+  const flushAfterSnapshot = (snapshotState: A2aTaskState | undefined) => {
+    snapshotSent = true;
+    if (closed) return;
+    if (snapshotState && isTerminalState(snapshotState)) { endStream(); return; }
+    for (const event of buffered.splice(0)) {
+      if (closed) break;
+      writeEvent(event);
+    }
+  };
+
+  void currentTaskForResponse(task, connectionMap).then((snapshot) => {
+    if (!closed) writeA2aSse(res, { task: snapshot });
+    flushAfterSnapshot((snapshot as any)?.status?.state as A2aTaskState | undefined);
+  }).catch(() => {
+    if (!closed) writeA2aSse(res, { task: buildTask(task) });
+    flushAfterSnapshot(isTerminalState(task.state) ? task.state : undefined);
+  });
+}
+
+export function registerA2aRoutes(
+  router: RestRouter,
+  connectionMap: RuntimeConnectionMap,
+): void {
+  router.get("/api/v1/a2a/agents/:agentId/.well-known/agent-card.json", (req, res, params) => {
+    sendA2aJson(res, 200, buildAgentCard(req, params.agentId));
+  });
+
+  router.get("/api/v1/a2a/agents/:agentId/agent-card.json", (req, res, params) => {
+    sendA2aJson(res, 200, buildAgentCard(req, params.agentId));
+  });
+
+  router.post("/api/v1/a2a/agents/:agentId/message:send", async (req, res, params) => {
+    try {
+      const auth = await requireAgentApiKey(req, params.agentId);
+      const body = await parseA2aBody(req);
+      const { text, message } = extractTextMessage(body);
+      const task = await submitA2aTask({ agentId: params.agentId, auth, text, message, connectionMap });
+      sendA2aJson(res, 200, { task: buildTask(task) });
+    } catch (err) {
+      respondA2aError(req, res, err);
+    }
+  });
+
+  router.post("/api/v1/a2a/agents/:agentId/message:stream", async (req, res, params) => {
+    try {
+      const auth = await requireAgentApiKey(req, params.agentId);
+      const body = await parseA2aBody(req);
+      const { text, message } = extractTextMessage(body);
+      const task = await submitA2aTask({ agentId: params.agentId, auth, text, message, connectionMap });
+      streamTask(req, res, task, connectionMap);
+    } catch (err) {
+      respondA2aError(req, res, err);
+    }
+  });
+
+  router.get("/api/v1/a2a/agents/:agentId/tasks/:taskId", async (req, res, params) => {
+    try {
+      const { task } = await loadAuthorizedTask(req, params.agentId, params.taskId);
+      sendA2aJson(res, 200, { task: await currentTaskForResponse(task, connectionMap) });
+    } catch (err) {
+      respondA2aError(req, res, err);
+    }
+  });
+
+  router.get("/api/v1/a2a/agents/:agentId/tasks", async (req, res, params) => {
+    try {
+      const auth = await requireAgentApiKey(req, params.agentId);
+      const query = parseQuery(req.url ?? "");
+      const rawPageSize = query.pageSize ? Number(query.pageSize) : 20;
+      if (!Number.isFinite(rawPageSize) || rawPageSize < 1 || rawPageSize > 100) {
+        throw new A2aHttpError(400, "INVALID_ARGUMENT", "pageSize must be between 1 and 100");
+      }
+      const rawPageToken = query.pageToken ? Number(query.pageToken) : 0;
+      if (!Number.isFinite(rawPageToken) || rawPageToken < 0 || Math.floor(rawPageToken) !== rawPageToken) {
+        throw new A2aHttpError(400, "INVALID_ARGUMENT", "pageToken must be a non-negative integer offset");
+      }
+      const status = query.status as A2aTaskState | undefined;
+      if (status && !A2A_TASK_STATES.has(status)) {
+        throw new A2aHttpError(400, "INVALID_ARGUMENT", `Invalid status: ${status}`);
+      }
+
+      const result = await listTaskRecords({
+        agentId: params.agentId,
+        apiKeyId: auth.keyId,
+        contextId: query.contextId,
+        status,
+        pageSize: Math.floor(rawPageSize),
+        pageToken: rawPageToken,
+      });
+      sendA2aJson(res, 200, {
+        tasks: result.tasks.map((task) => buildTask(task)),
+        totalSize: result.totalSize,
+        pageSize: Math.floor(rawPageSize),
+        nextPageToken: result.nextPageToken,
+      });
+    } catch (err) {
+      respondA2aError(req, res, err);
+    }
+  });
+
+  router.post("/api/v1/a2a/agents/:agentId/tasks/:taskId:subscribe", async (req, res, params) => {
+    try {
+      const { task } = await loadAuthorizedTask(req, params.agentId, params.taskId);
+      if (isTerminalState(task.state)) {
+        throw new A2aHttpError(400, "UNSUPPORTED_OPERATION", "Cannot subscribe to a terminal A2A task");
+      }
+      streamTask(req, res, task, connectionMap);
+    } catch (err) {
+      respondA2aError(req, res, err);
+    }
+  });
+
+  router.post("/api/v1/a2a/agents/:agentId/tasks/:taskId:cancel", async (req, res, params) => {
+    try {
+      const { auth, task } = await loadAuthorizedTask(req, params.agentId, params.taskId);
+      if (!isTerminalState(task.state)) {
+        const result = await connectionMap.sendCommand(params.agentId, "chat.abort", {
+          agentId: params.agentId,
+          userId: auth.createdBy,
+          sessionId: task.sessionId,
+        });
+        if (!result.ok) throw new A2aHttpError(502, "RUNTIME_ERROR", result.error ?? "Runtime cancel failed");
+        await setTaskState(task.id, "TASK_STATE_CANCELED", "Task canceled by A2A client");
+        emitTask(task.id, buildStatusUpdate(task, "TASK_STATE_CANCELED", "Task canceled by A2A client"));
+        stopTaskTracker(task.id);
+      }
+      const latest = await loadTaskRecord(params.agentId, params.taskId, auth.keyId) ?? task;
+      sendA2aJson(res, 200, { task: buildTask(latest) });
+    } catch (err) {
+      respondA2aError(req, res, err);
+    }
+  });
+}

--- a/src/portal/api-key-auth.ts
+++ b/src/portal/api-key-auth.ts
@@ -1,0 +1,34 @@
+import crypto from "node:crypto";
+import type http from "node:http";
+import { getDb } from "../gateway/db.js";
+
+export interface ApiKeyAuthResult {
+  agentId: string;
+  keyId: string;
+  keyName: string;
+  createdBy: string;
+}
+
+export async function authenticateApiKey(req: http.IncomingMessage): Promise<ApiKeyAuthResult | null> {
+  const auth = req.headers.authorization;
+  if (!auth?.startsWith("Bearer sk-")) return null;
+
+  const plaintext = auth.slice(7);
+  const keyHash = crypto.createHash("sha256").update(plaintext).digest("hex");
+
+  const db = getDb();
+  const [rows] = await db.query(
+    `SELECT id, agent_id, name, expires_at, created_by
+     FROM agent_api_keys WHERE key_hash = ? LIMIT 1`,
+    [keyHash],
+  ) as any;
+
+  if (rows.length === 0) return null;
+  const key = rows[0];
+
+  if (key.expires_at && new Date(key.expires_at) < new Date()) return null;
+
+  db.query("UPDATE agent_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?", [key.id]).catch(() => {});
+
+  return { agentId: key.agent_id, keyId: key.id, keyName: key.name, createdBy: key.created_by };
+}

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -26,6 +26,7 @@ import {
 } from "../lib/error-envelope.js";
 import { defaultProviderModelCompat } from "../core/model-compat.js";
 import { resolveAgentModelRouting } from "./model-routing-config.js";
+import { authenticateApiKey } from "./api-key-auth.js";
 
 interface ChatAttachment {
   kind?: string;
@@ -277,7 +278,7 @@ async function parseChatRequestBody(
 }
 
 /** Resolve model binding directly from Portal's own DB. */
-async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelBinding | null> {
+export async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelBinding | null> {
   const db = getDb();
   const [agentRows] = await db.query(
     "SELECT model_provider, model_id, model_routing FROM agents WHERE id = ?",
@@ -330,38 +331,6 @@ async function resolveAgentModelBinding(agentId: string): Promise<ResolvedModelB
   };
 }
 
-// ── API key authentication ──────────────────────────────────
-
-interface ApiKeyAuthResult {
-  agentId: string;
-  keyId: string;
-  keyName: string;
-  createdBy: string;
-}
-
-async function authenticateApiKey(req: http.IncomingMessage): Promise<ApiKeyAuthResult | null> {
-  const auth = req.headers.authorization;
-  if (!auth?.startsWith("Bearer sk-")) return null;
-
-  const plaintext = auth.slice(7);
-  const keyHash = crypto.createHash("sha256").update(plaintext).digest("hex");
-
-  const db = getDb();
-  const [rows] = await db.query(
-    `SELECT id, agent_id, name, expires_at, created_by
-     FROM agent_api_keys WHERE key_hash = ? LIMIT 1`,
-    [keyHash],
-  ) as any;
-
-  if (rows.length === 0) return null;
-  const key = rows[0];
-
-  if (key.expires_at && new Date(key.expires_at) < new Date()) return null;
-
-  db.query("UPDATE agent_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE id = ?", [key.id]).catch(() => {});
-
-  return { agentId: key.agent_id, keyId: key.id, keyName: key.name, createdBy: key.created_by };
-}
 import type { RuntimeConnectionMap } from "./runtime-connection.js";
 
 /**

--- a/src/portal/migrate-sqlite.test.ts
+++ b/src/portal/migrate-sqlite.test.ts
@@ -11,7 +11,7 @@ describe("runPortalMigrations on SQLite :memory:", () => {
     await closeDb();
   });
 
-  it("creates all 27 tables without error", async () => {
+  it("creates all 33 tables without error", async () => {
     await runPortalMigrations();
     const db = getDb();
     const [rows] = await db.query<Array<{ name: string }>>(
@@ -20,6 +20,7 @@ describe("runPortalMigrations on SQLite :memory:", () => {
     const tableNames = rows.map((r) => r.name);
 
     const expected = [
+      "a2a_tasks",
       "agent_api_keys",
       "agent_channel_auth",
       "agent_clusters",
@@ -76,6 +77,9 @@ describe("runPortalMigrations on SQLite :memory:", () => {
       "idx_chat_messages_audit",
       "idx_chat_messages_parent",
       "idx_chat_messages_delegation",
+      "idx_a2a_tasks_agent",
+      "idx_a2a_tasks_session",
+      "idx_a2a_tasks_context",
       "idx_notifications_user",
       "idx_api_keys_hash",
       "idx_agent_task_runs_task",

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -312,6 +312,26 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     CONSTRAINT fk_chat_messages_session FOREIGN KEY (session_id) REFERENCES chat_sessions(id) ON DELETE CASCADE
   )`,
 
+  // A2A task projection. This is protocol state for external agent clients,
+  // not an AgentBox/pi-agent checkpoint.
+  `CREATE TABLE IF NOT EXISTS a2a_tasks (
+    id CHAR(36) PRIMARY KEY,
+    agent_id CHAR(36) NOT NULL,
+    user_id CHAR(36) NOT NULL,
+    api_key_id CHAR(36) DEFAULT NULL,
+    context_id VARCHAR(255) NOT NULL,
+    session_id CHAR(36) NOT NULL,
+    state VARCHAR(40) NOT NULL,
+    status_message TEXT,
+    artifact_text TEXT,
+    error TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_event_at TIMESTAMP NULL DEFAULT NULL,
+    completed_at TIMESTAMP NULL DEFAULT NULL,
+    CONSTRAINT fk_a2a_tasks_agent FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+  )`,
+
   // Model Providers
   `CREATE TABLE IF NOT EXISTS model_providers (
     id CHAR(36) PRIMARY KEY,
@@ -469,6 +489,10 @@ async function createIndexes(): Promise<void> {
   await ensureIndex(db, "chat_messages", "idx_chat_messages_audit", "role, created_at");
   await ensureIndex(db, "chat_messages", "idx_chat_messages_parent", "parent_session_id, created_at");
   await ensureIndex(db, "chat_messages", "idx_chat_messages_delegation", "delegation_id");
+  // a2a_tasks
+  await ensureIndex(db, "a2a_tasks", "idx_a2a_tasks_agent", "agent_id, created_at");
+  await ensureIndex(db, "a2a_tasks", "idx_a2a_tasks_session", "session_id");
+  await ensureIndex(db, "a2a_tasks", "idx_a2a_tasks_context", "context_id, created_at");
   // notifications
   await ensureIndex(db, "notifications", "idx_notifications_user", "user_id, read_at, created_at");
   // agent_api_keys

--- a/src/portal/server.ts
+++ b/src/portal/server.ts
@@ -19,6 +19,7 @@ import { registerChannelRoutes } from "./channel-api.js";
 import { registerNotificationRoutes, registerNotificationWs } from "./notification-api.js";
 import { registerSiclawRoutes } from "./siclaw-api.js";
 import { registerRuntimeWs } from "./runtime-connection.js";
+import { registerA2aRoutes } from "./a2a-gateway.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -180,6 +181,7 @@ export function startPortal(config: PortalConfig): http.Server {
   registerClusterRoutes(router, config.jwtSecret, connectionMap);
   registerHostRoutes(router, config.jwtSecret, connectionMap);
   registerChatRoutes(router, connectionMap, config.jwtSecret);
+  registerA2aRoutes(router, connectionMap);
   registerSiclawRoutes(router, {
     jwtSecret: config.jwtSecret,
     portalSecret: config.portalSecret,


### PR DESCRIPTION
## Summary

- add a Portal-hosted A2A HTTP+JSON gateway for Siclaw agents
- expose Agent Card discovery, message send/stream, task polling/listing, subscribe, and cancel routes
- add an `a2a_tasks` projection table plus tests for auth, streaming, task lifecycle, context mapping, and route parsing
- document the A2A design, standards alignment, deferred work, and future Sicore enablement options

## Validation

- `npm run build`
- `npm test -- src/portal/a2a-gateway.test.ts src/portal/migrate-sqlite.test.ts src/gateway/rest-router.test.ts src/portal/chat-gateway.test.ts src/portal/chat-gateway-events.test.ts`
- `npm test`
- `git diff --check`