### PR TITLE
feat(metrics): external-facing showcase dashboard with daily trend charts

### DIFF
--- a/portal-web/src/components/metrics/KpiCards.tsx
+++ b/portal-web/src/components/metrics/KpiCards.tsx
@@ -1,12 +1,14 @@
-import { MessageSquare, Bot, Activity, Wrench } from "lucide-react"
+import { Users, MessageSquare, Activity, Wrench, Zap, Package, Server, FileCode, BookOpen, Bot, Plug } from "lucide-react"
 
 interface Props {
+  rangeLabel: string
+  distinctUsers: number
   totalSessions: number
   totalPrompts: number
-  activeSessions: number
-  wsConnections: number
-  toolCallsTotal: number
-  rangeLabel: string
+  toolCalls: number
+  skillsUsed: number
+  skillsUsedApprox?: boolean
+  inventory: { clusters: number; hosts: number; skills: number; knowledgeRepos: number; agents: number; mcpServers: number }
 }
 
 function fmt(n: number): string {
@@ -16,39 +18,38 @@ function fmt(n: number): string {
 }
 
 export function KpiCards(p: Props) {
-  const plabel = p.rangeLabel
   return (
-    <div className="grid grid-cols-4 gap-4">
-      <KpiCard
-        label={`Sessions · ${plabel}`}
-        value={fmt(p.totalSessions)}
-        hint={`active now · ${p.activeSessions}`}
-        icon={<Activity className="h-3.5 w-3.5" style={{ color: "#fbbf24" }} />}
-        accent="#fbbf24"
-      />
-      <KpiCard
-        label={`Prompts · ${plabel}`}
-        value={fmt(p.totalPrompts)}
-        hint="user messages"
-        icon={<MessageSquare className="h-3.5 w-3.5" style={{ color: "#34d399" }} />}
-        accent="#34d399"
-      />
-      <KpiCard
-        label="Tool Calls · live"
-        value={fmt(p.toolCallsTotal)}
-        hint="top-N total"
-        icon={<Wrench className="h-3.5 w-3.5" style={{ color: "#a78bfa" }} />}
-        accent="#a78bfa"
-      />
-      <KpiCard
-        label="WS Connections · live"
-        value={String(p.wsConnections)}
-        hint="connected clients"
-        icon={<Bot className="h-3.5 w-3.5" style={{ color: "#60a5fa" }} />}
-        accent="#60a5fa"
-      />
+    <div className="space-y-5">
+      {/* 纳管规模 — 当前快照(置顶)*/}
+      <div>
+        <GroupLabel>Managed scale · current</GroupLabel>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+          <KpiCard label="Clusters" value={fmt(p.inventory.clusters)} hint="connected" icon={<Package className="h-3.5 w-3.5" style={{ color: "#22d3ee" }} />} accent="#22d3ee" />
+          <KpiCard label="Hosts" value={fmt(p.inventory.hosts)} hint="connected" icon={<Server className="h-3.5 w-3.5" style={{ color: "#60a5fa" }} />} accent="#60a5fa" />
+          <KpiCard label="Skills" value={fmt(p.inventory.skills)} hint="in catalog" icon={<FileCode className="h-3.5 w-3.5" style={{ color: "#a78bfa" }} />} accent="#a78bfa" />
+          <KpiCard label="Knowledge" value={fmt(p.inventory.knowledgeRepos)} hint="repositories" icon={<BookOpen className="h-3.5 w-3.5" style={{ color: "#34d399" }} />} accent="#34d399" />
+          <KpiCard label="Agents" value={fmt(p.inventory.agents)} hint="agents" icon={<Bot className="h-3.5 w-3.5" style={{ color: "#fbbf24" }} />} accent="#fbbf24" />
+          <KpiCard label="MCP" value={fmt(p.inventory.mcpServers)} hint="servers" icon={<Plug className="h-3.5 w-3.5" style={{ color: "#f472b6" }} />} accent="#f472b6" />
+        </div>
+      </div>
+
+      {/* 使用规模 — 随时间窗 */}
+      <div>
+        <GroupLabel>Usage · {p.rangeLabel}</GroupLabel>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+          <KpiCard label="Users" value={fmt(p.distinctUsers)} hint="distinct" icon={<Users className="h-3.5 w-3.5" style={{ color: "#60a5fa" }} />} accent="#60a5fa" />
+          <KpiCard label="Sessions" value={fmt(p.totalSessions)} hint="conversations" icon={<Activity className="h-3.5 w-3.5" style={{ color: "#fbbf24" }} />} accent="#fbbf24" />
+          <KpiCard label="Prompts" value={fmt(p.totalPrompts)} hint="user messages" icon={<MessageSquare className="h-3.5 w-3.5" style={{ color: "#34d399" }} />} accent="#34d399" />
+          <KpiCard label="Tool Calls" value={fmt(p.toolCalls)} hint="executed" icon={<Wrench className="h-3.5 w-3.5" style={{ color: "#a78bfa" }} />} accent="#a78bfa" />
+          <KpiCard label="Skills Used" value={fmt(p.skillsUsed)} hint={p.skillsUsedApprox ? "distinct · sampled" : "distinct"} icon={<Zap className="h-3.5 w-3.5" style={{ color: "#f472b6" }} />} accent="#f472b6" />
+        </div>
+      </div>
     </div>
   )
+}
+
+function GroupLabel({ children }: { children: React.ReactNode }) {
+  return <h3 className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-2">{children}</h3>
 }
 
 function KpiCard({ label, value, hint, icon, accent }: { label: string; value: string; hint: string; icon: React.ReactNode; accent: string }) {

--- a/portal-web/src/components/metrics/TrendChart.tsx
+++ b/portal-web/src/components/metrics/TrendChart.tsx
@@ -1,0 +1,120 @@
+interface Point { date: string; value: number }
+
+interface Props {
+  title: string
+  subtitle: string
+  data: Point[]
+  color: string // hex, e.g. "#34d399"
+}
+
+// viewBox geometry — the SVG scales to its container width, so these are
+// abstract units, not pixels.
+const VBW = 640
+const VBH = 220
+const PAD = { left: 34, right: 12, top: 14, bottom: 26 }
+const PLOT_W = VBW - PAD.left - PAD.right
+const PLOT_H = VBH - PAD.top - PAD.bottom
+
+/** Catmull-Rom → cubic-bezier so the line reads as a smooth curve. */
+function smoothLine(pts: { x: number; y: number }[]): string {
+  if (pts.length === 0) return ""
+  if (pts.length === 1) return `M${pts[0].x},${pts[0].y}`
+  let d = `M${pts[0].x},${pts[0].y}`
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]
+    const p1 = pts[i]
+    const p2 = pts[i + 1]
+    const p3 = pts[i + 2] ?? pts[i + 1]
+    const cp1x = p1.x + (p2.x - p0.x) / 6
+    const cp1y = p1.y + (p2.y - p0.y) / 6
+    const cp2x = p2.x - (p3.x - p1.x) / 6
+    const cp2y = p2.y - (p3.y - p1.y) / 6
+    d += ` C${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`
+  }
+  return d
+}
+
+export function TrendChart({ title, subtitle, data, color }: Props) {
+  const n = data.length
+  const values = data.map((d) => d.value)
+  const maxV = Math.max(...values, 1)
+  const step = Math.max(1, Math.ceil(maxV / 4))
+  const axisMax = step * 4
+  const ticks = [0, 1, 2, 3, 4].map((k) => k * step)
+
+  const xAt = (i: number) => (n > 1 ? PAD.left + (i / (n - 1)) * PLOT_W : PAD.left + PLOT_W / 2)
+  const yAt = (v: number) => PAD.top + (1 - v / axisMax) * PLOT_H
+
+  const pts = data.map((d, i) => ({ x: xAt(i), y: yAt(d.value) }))
+  const linePath = smoothLine(pts)
+  const baseY = PAD.top + PLOT_H
+  const areaPath = pts.length
+    ? `${linePath} L${pts[pts.length - 1].x.toFixed(1)},${baseY} L${pts[0].x.toFixed(1)},${baseY} Z`
+    : ""
+
+  // X labels: ≤8 points show all; otherwise ~7 evenly-spaced indices (the even
+  // division naturally includes first + last without forcing an adjacent last
+  // tick, which is what made the 30-day axis collide at the right edge).
+  const labelIdx = n <= 8
+    ? data.map((_, i) => i)
+    : [...new Set(Array.from({ length: 7 }, (_, k) => Math.round((k * (n - 1)) / 6)))]
+  const gradId = `trend-grad-${color.replace("#", "")}`
+
+  const total = values.reduce((s, v) => s + v, 0)
+  const avg = n > 0 ? total / n : 0
+  const peak = Math.max(...values, 0)
+
+  return (
+    <div className="border border-border rounded-lg bg-card p-4">
+      <div className="flex items-baseline justify-between mb-2">
+        <h3 className="text-[13px] font-semibold">{title}</h3>
+        <span className="text-[11px] text-muted-foreground">{subtitle}</span>
+      </div>
+
+      <svg viewBox={`0 0 ${VBW} ${VBH}`} className="w-full h-auto" preserveAspectRatio="xMidYMid meet">
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.35} />
+            <stop offset="100%" stopColor={color} stopOpacity={0.02} />
+          </linearGradient>
+        </defs>
+
+        {/* Y gridlines + labels */}
+        {ticks.map((t) => {
+          const y = yAt(t)
+          return (
+            <g key={t}>
+              <line x1={PAD.left} y1={y} x2={VBW - PAD.right} y2={y} stroke="currentColor" strokeOpacity={0.08} strokeWidth={1} />
+              <text x={PAD.left - 6} y={y + 3} textAnchor="end" className="fill-current text-muted-foreground" fontSize={10}>{t}</text>
+            </g>
+          )
+        })}
+
+        {/* Area + line */}
+        {areaPath && <path d={areaPath} fill={`url(#${gradId})`} stroke="none" />}
+        {linePath && <path d={linePath} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />}
+
+        {/* X labels — "MM-DD" only (year is redundant within the window and the
+            full date overflowed); edges anchored inward so they don't clip. */}
+        {labelIdx.map((i) => (
+          <text
+            key={data[i].date}
+            x={xAt(i)}
+            y={VBH - 8}
+            textAnchor={i === 0 ? "start" : i === n - 1 ? "end" : "middle"}
+            className="fill-current text-muted-foreground"
+            fontSize={10}
+          >
+            {data[i].date.slice(5)}
+          </text>
+        ))}
+      </svg>
+
+      <div className="flex items-center gap-4 mt-2 text-[11px] text-muted-foreground">
+        <span>Total <span className="text-foreground font-medium tabular-nums">{total.toLocaleString()}</span></span>
+        <span>Daily avg <span className="text-foreground font-medium tabular-nums">{avg.toFixed(1)}</span></span>
+        <span>Peak <span className="text-foreground font-medium tabular-nums">{peak.toLocaleString()}</span></span>
+      </div>
+    </div>
+  )
+}

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -32,7 +32,15 @@ export interface LiveData {
 export interface SummaryData {
   totalSessions: number
   totalPrompts: number
-  byUser: Array<{ userId: string; sessions: number; messages: number }>
+  // —— 对外展示新增,随时间窗 ——
+  distinctUsers: number
+  toolCalls: number
+  skillsUsed: number
+  skillsUsedApprox?: boolean
+  // —— 当前快照,不随时间窗 ——
+  inventory: { clusters: number; hosts: number; skills: number; knowledgeRepos: number; agents: number; mcpServers: number }
+  // —— 日级趋势(随时间窗)——
+  dailySeries: Array<{ date: string; prompts: number; toolCalls: number }>
 }
 
 /**

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useMemo, useState } from "react"
 import { Loader2, RefreshCw } from "lucide-react"
-import { useLive, useSummary, useTimingStats, useUsers, rangeLabel, DEFAULT_RANGE, type TimeRange } from "../hooks/useMetrics"
+import { useSummary, useUsers, rangeLabel, DEFAULT_RANGE, type TimeRange } from "../hooks/useMetrics"
 import { KpiCards } from "../components/metrics/KpiCards"
-import { RankedTable } from "../components/metrics/RankedTable"
-import { TimingStatsCard } from "../components/metrics/TimingStatsCard"
+import { TrendChart } from "../components/metrics/TrendChart"
 import { AuditTable } from "../components/metrics/AuditTable"
 import { GrafanaFrame } from "../components/metrics/GrafanaFrame"
 import { TimeRangePicker } from "../components/metrics/TimeRangePicker"
@@ -12,24 +11,24 @@ type TabKey = "dashboard" | "audit" | "grafana"
 
 export function Metrics() {
   const [tab, setTab] = useState<TabKey>("dashboard")
-  const [userId, setUserId] = useState<string>("")         // "" = All Users
+  const [userId, setUserId] = useState<string>("")         // "" = All Users (Audit filter only)
   const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_RANGE)
 
   const filterUserId = userId || null
   const rLabel = rangeLabel(timeRange)
 
   const { users } = useUsers()
-  const { data: live, loading: liveLoading, refresh: refreshLive } = useLive(filterUserId)
-  const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(timeRange, filterUserId)
-  const { data: timing, refresh: refreshTiming } = useTimingStats(timeRange, filterUserId)
+  // Dashboard is an external-facing showcase: aggregate only, never scoped to
+  // an individual — so summary is fetched without a user filter.
+  const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(timeRange, null)
 
   const [spinning, setSpinning] = useState(false)
   const handleRefresh = useCallback(() => {
     setSpinning(true)
-    Promise.all([refreshLive(), refreshSummary(), refreshTiming()]).finally(() => {
+    Promise.resolve(refreshSummary()).finally(() => {
       setTimeout(() => setSpinning(false), 600)
     })
-  }, [refreshLive, refreshSummary, refreshTiming])
+  }, [refreshSummary])
 
   const selectedUsername = useMemo(() => {
     if (!userId) return null
@@ -44,34 +43,33 @@ export function Metrics() {
           <div className="flex items-center justify-between">
             <div>
               <h2 className="text-lg font-semibold tracking-tight">Metrics</h2>
-              <p className="text-[12px] text-muted-foreground mt-0.5">Runtime telemetry · admin-only</p>
+              <p className="text-[12px] text-muted-foreground mt-0.5">Adoption &amp; impact · admin-only</p>
             </div>
             <div className="flex items-center gap-2">
-              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse"></span>
-                live · auto-refresh 30s
-              </div>
               {tab === "dashboard" && (
-                <button
-                  onClick={handleRefresh}
-                  title="Sync now"
-                  className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition"
-                >
-                  <RefreshCw className={`h-3.5 w-3.5 transition-transform duration-500 ${spinning ? "animate-spin" : ""}`} />
-                </button>
+                <>
+                  <button
+                    onClick={handleRefresh}
+                    title="Sync now"
+                    className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition"
+                  >
+                    <RefreshCw className={`h-3.5 w-3.5 transition-transform duration-500 ${spinning ? "animate-spin" : ""}`} />
+                  </button>
+                  <TimeRangePicker value={timeRange} onChange={setTimeRange} />
+                </>
               )}
-              <div className="w-px h-4 bg-border mx-2"></div>
-              <select
-                value={userId}
-                onChange={(e) => setUserId(e.target.value)}
-                className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
-              >
-                <option value="">All Users</option>
-                {users.map((u) => (
-                  <option key={u.id} value={u.id}>{u.username}</option>
-                ))}
-              </select>
-              <TimeRangePicker value={timeRange} onChange={setTimeRange} />
+              {tab === "audit" && (
+                <select
+                  value={userId}
+                  onChange={(e) => setUserId(e.target.value)}
+                  className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
+                >
+                  <option value="">All Users</option>
+                  {users.map((u) => (
+                    <option key={u.id} value={u.id}>{u.username}</option>
+                  ))}
+                </select>
+              )}
             </div>
           </div>
 
@@ -97,61 +95,42 @@ export function Metrics() {
       <div className="flex-1 overflow-y-auto">
         {tab === "dashboard" && (
           <section className="px-6 py-6 space-y-6">
-            {liveLoading || summaryLoading ? (
+            {summaryLoading ? (
               <div className="flex items-center justify-center py-12"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>
             ) : (
               <>
                 <KpiCards
+                  rangeLabel={rLabel}
+                  distinctUsers={summary?.distinctUsers ?? 0}
                   totalSessions={summary?.totalSessions ?? 0}
                   totalPrompts={summary?.totalPrompts ?? 0}
-                  activeSessions={live?.snapshot.activeSessions ?? 0}
-                  wsConnections={live?.snapshot.wsConnections ?? 0}
-                  toolCallsTotal={(live?.topTools ?? []).reduce((s, t) => s + t.total, 0)}
-                  rangeLabel={rLabel}
+                  toolCalls={summary?.toolCalls ?? 0}
+                  skillsUsed={summary?.skillsUsed ?? 0}
+                  skillsUsedApprox={summary?.skillsUsedApprox}
+                  inventory={summary?.inventory ?? { clusters: 0, hosts: 0, skills: 0, knowledgeRepos: 0, agents: 0, mcpServers: 0 }}
                 />
 
-                <TimingStatsCard data={timing} rangeLabel={rLabel} />
-
-                <div className="grid grid-cols-2 gap-4">
-                  <RankedTable
-                    title="Top Tools"
-                    subtitle="by invocation count"
-                    items={(live?.topTools ?? []).map((t) => ({
-                      name: t.toolName,
-                      subtitle: t.agentId ? `agent · ${t.agentId}` : undefined,
-                      total: t.total,
-                      success: t.success,
-                      error: t.error,
-                    }))}
-                  />
-                  <RankedTable
-                    title="Top Skills"
-                    subtitle="by invocation count · avg ms"
-                    items={(live?.topSkills ?? []).map((s) => ({
-                      name: s.skillName,
-                      subtitle: `${s.scope} · avg ${s.avgDurationMs}ms`,
-                      total: s.total,
-                      success: s.success,
-                      error: s.error,
-                    }))}
-                  />
-                </div>
-
-                {!filterUserId && summary && summary.byUser.length > 0 && (
-                  <RankedTable
-                    title="By User"
-                    subtitle={`sessions · messages (${rLabel})`}
-                    items={summary.byUser.map((u) => {
-                      const username = users.find((x) => x.id === u.userId)?.username ?? u.userId
-                      return {
-                        name: username,
-                        subtitle: `${u.messages} messages`,
-                        total: u.sessions,
-                        success: u.sessions,
-                        error: 0,
-                      }
-                    })}
-                  />
+                {/* Daily trend — hidden for sub-day windows that yield a single point. */}
+                {summary && summary.dailySeries.length > 1 && (
+                  <div>
+                    <h3 className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-2">
+                      Usage trend · daily · {rLabel}
+                    </h3>
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                      <TrendChart
+                        title="Prompts"
+                        subtitle="user messages per day"
+                        color="#34d399"
+                        data={summary.dailySeries.map((d) => ({ date: d.date, value: d.prompts }))}
+                      />
+                      <TrendChart
+                        title="Tool Calls"
+                        subtitle="tool executions per day"
+                        color="#a78bfa"
+                        data={summary.dailySeries.map((d) => ({ date: d.date, value: d.toolCalls }))}
+                      />
+                    </div>
+                  </div>
                 )}
               </>
             )}

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1445,21 +1445,21 @@ describe("agent.listForHost", () => {
 // ================================================================
 
 describe("metrics.summary", () => {
-  it("returns summary with default 7d period", async () => {
+  it("returns summary with default 7d period (no per-user breakdown)", async () => {
     const query = mockQuery(
       [{ c: 10 }],   // total sessions
       [{ c: 50 }],   // total prompts
-      [{ userId: "u1", sessions: 5, messages: 30 }],  // by user
     );
 
     const result = await getHandler("metrics.summary")({}, "a1");
     expect(result.totalSessions).toBe(10);
     expect(result.totalPrompts).toBe(50);
-    expect(result.byUser).toEqual([{ userId: "u1", sessions: 5, messages: 30 }]);
+    // byUser was dropped — this mirror must not ship raw per-user data.
+    expect(result).not.toHaveProperty("byUser");
     expect(query.mock.calls[1][0]).toContain('metadata NOT LIKE \'%"kind":"delegation_event"%\'');
   });
 
-  it("skips byUser query when userId filter is set", async () => {
+  it("runs only the two scalar queries (no byUser) with a userId filter", async () => {
     const query = mockQuery(
       [{ c: 3 }],
       [{ c: 15 }],
@@ -1468,8 +1468,8 @@ describe("metrics.summary", () => {
     const result = await getHandler("metrics.summary")({ period: "today", userId: "u1" }, "a1");
     expect(result.totalSessions).toBe(3);
     expect(result.totalPrompts).toBe(15);
-    expect(result.byUser).toEqual([]);
-    expect(query).toHaveBeenCalledTimes(2);  // no third call for byUser
+    expect(result).not.toHaveProperty("byUser");
+    expect(query).toHaveBeenCalledTimes(2);
   });
 
   it("throws for invalid period", async () => {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1393,18 +1393,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     const [pRows] = await db.query(totalPromptsSql, pParams) as any;
     const totalPrompts = Number(pRows[0]?.c ?? 0);
 
-    let byUser: Array<{ userId: string; sessions: number; messages: number }> = [];
-    if (!userFilter) {
-      const [uRows] = await db.query(
-        `SELECT s.user_id AS userId, COUNT(DISTINCT s.id) AS sessions, SUM(s.message_count) AS messages
-         FROM chat_sessions s WHERE s.created_at >= ?
-           AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
-         GROUP BY s.user_id ORDER BY sessions DESC LIMIT 50`,
-        [cutoff],
-      ) as any;
-      byUser = uRows.map((r: any) => ({ userId: r.userId, sessions: Number(r.sessions), messages: Number(r.messages ?? 0) }));
-    }
-    sendJson(res, 200, { totalSessions, totalPrompts, byUser });
+    sendJson(res, 200, { totalSessions, totalPrompts });
   });
 
   // GET /api/internal/siclaw/metrics/audit
@@ -2478,18 +2467,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     const [pRows] = await db.query(totalPromptsSql, pParams) as any;
     const totalPrompts = Number(pRows[0]?.c ?? 0);
 
-    let byUser: Array<{ userId: string; sessions: number; messages: number }> = [];
-    if (!userFilter) {
-      const [uRows] = await db.query(
-        `SELECT s.user_id AS userId, COUNT(DISTINCT s.id) AS sessions, SUM(s.message_count) AS messages
-         FROM chat_sessions s WHERE s.created_at >= ?
-           AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
-         GROUP BY s.user_id ORDER BY sessions DESC LIMIT 50`,
-        [cutoff],
-      ) as any;
-      byUser = uRows.map((r: any) => ({ userId: r.userId, sessions: Number(r.sessions), messages: Number(r.messages ?? 0) }));
-    }
-    return { totalSessions, totalPrompts, byUser };
+    return { totalSessions, totalPrompts };
   });
 
   handlers.set("metrics.audit", async (params) => {

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -14,7 +14,7 @@ vi.mock("../gateway/db.js", () => ({
 import { getDb } from "../gateway/db.js";
 import { createRestRouter } from "../gateway/rest-router.js";
 import { signToken } from "./auth.js";
-import { registerSiclawRoutes } from "./siclaw-api.js";
+import { registerSiclawRoutes, sqlDayKey } from "./siclaw-api.js";
 import type { RuntimeConnectionMap } from "./runtime-connection.js";
 
 const JWT_SECRET = "test-siclaw-misc";
@@ -335,10 +335,12 @@ describe("siclaw-api misc routes", () => {
     });
 
     it("returns summary for admin with default window", async () => {
+      // Default for distinctUsers / toolCalls / skillsUsed / inventory / series;
+      // the two Once values are the asserted scalar totals (byUser is gone).
+      query.mockResolvedValue([[{ c: 0 }], []]);
       query
         .mockResolvedValueOnce([[{ c: 1 }], []])
-        .mockResolvedValueOnce([[{ c: 5 }], []])
-        .mockResolvedValueOnce([[], []]);
+        .mockResolvedValueOnce([[{ c: 5 }], []]);
       const { status, body } = await runRoute(router, fakeReq({
         url: "/api/v1/siclaw/metrics/summary",
         method: "GET",
@@ -347,6 +349,104 @@ describe("siclaw-api misc routes", () => {
       expect(status).toBe(200);
       expect(body.totalSessions).toBe(1);
       expect(query.mock.calls[1][0]).toContain('metadata NOT LIKE \'%"kind":"delegation_event"%\'');
+      // Desensitized: no raw per-user data on the wire.
+      expect(body).not.toHaveProperty("byUser");
+      // External-showcase fields present.
+      expect(body).toHaveProperty("distinctUsers");
+      expect(body).toHaveProperty("toolCalls");
+      expect(body).toHaveProperty("skillsUsed");
+      expect(body.inventory).toMatchObject({ clusters: 0, hosts: 0, skills: 0, knowledgeRepos: 0, agents: 0, mcpServers: 0 });
+      // Daily trend series: default 7d window → 8 gap-filled points, each shaped.
+      expect(Array.isArray(body.dailySeries)).toBe(true);
+      expect(body.dailySeries).toHaveLength(8);
+      expect(body.dailySeries[0]).toMatchObject({ prompts: 0, toolCalls: 0 });
+      expect(typeof body.dailySeries[0].date).toBe("string");
+    });
+
+    it("counts distinct skills from tool_input (parse, regex fallback, dedup, skip missing)", async () => {
+      query.mockResolvedValue([[{ c: 0 }], []]); // inventory fall-through
+      query
+        .mockResolvedValueOnce([[{ c: 2 }], []])   // totalSessions
+        .mockResolvedValueOnce([[{ c: 9 }], []])   // totalPrompts
+        .mockResolvedValueOnce([[{ c: 3 }], []])   // distinctUsers
+        .mockResolvedValueOnce([[{ c: 42 }], []])  // toolCalls
+        .mockResolvedValueOnce([[                   // skillsUsed rows
+          { toolInput: JSON.stringify({ skill: "volcano-queue-diagnose", script: "x.sh" }) },
+          { toolInput: JSON.stringify({ skill: "volcano-queue-diagnose", script: "y.sh" }) }, // dup
+          { toolInput: JSON.stringify({ skill: "roce-perftest", script: "z.sh" }) },
+          { toolInput: JSON.stringify({ script: "user-script.sh" }) },                        // no skill → skip
+          { toolInput: 'broken json "skill":"regex-only" trailing' },                          // parse fail → regex
+          { toolInput: null },                                                                 // null → skip
+        ], []]);
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/summary",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(200);
+      expect(body.distinctUsers).toBe(3);
+      expect(body.toolCalls).toBe(42);
+      expect(body.skillsUsed).toBe(3); // volcano + roce + regex-only, deduped, missing/null skipped
+      expect(body.skillsUsedApprox).toBe(false);
+      // Lock decision #3: inventory.skills excludes per-agent overlay shadows.
+      expect(query.mock.calls.some((c: unknown[]) => typeof c[0] === "string" && c[0].includes("overlay_of IS NULL"))).toBe(true);
+    });
+
+    it("daily series gap-fills the window and sums to the period totals", async () => {
+      // Inject two days of buckets within the default 7-day window, computed
+      // relative to now so the test is date-agnostic. Use the SAME local-day
+      // derivation as the handler's sqlDayKey (NOT toISOString) so keys match.
+      const dayKey = (back: number) => {
+        const d = new Date();
+        d.setDate(d.getDate() - back);
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      };
+      const kA = dayKey(2);
+      const kB = dayKey(5);
+      query.mockResolvedValue([[{ c: 0 }], []]);
+      query
+        .mockResolvedValueOnce([[{ c: 4 }], []])   // totalSessions
+        .mockResolvedValueOnce([[{ c: 14 }], []])  // totalPrompts
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // distinctUsers
+        .mockResolvedValueOnce([[{ c: 20 }], []])  // toolCalls
+        .mockResolvedValueOnce([[], []])           // skillsUsed rows
+        .mockResolvedValueOnce([[{ c: 3 }], []])   // inv clusters
+        .mockResolvedValueOnce([[{ c: 4 }], []])   // inv hosts
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // inv skills
+        .mockResolvedValueOnce([[{ c: 0 }], []])   // inv knowledge
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // inv agents
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // inv mcp
+        .mockResolvedValueOnce([[{ day: kA, c: 6 }, { day: kB, c: 8 }], []])   // dailyPrompts
+        .mockResolvedValueOnce([[{ day: kA, c: 9 }, { day: kB, c: 11 }], []]); // dailyTools
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/summary",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(200);
+      expect(body.inventory).toMatchObject({ agents: 1, mcpServers: 1 });
+      expect(body.dailySeries.reduce((s: number, d: { prompts: number }) => s + d.prompts, 0)).toBe(14);
+      expect(body.dailySeries.reduce((s: number, d: { toolCalls: number }) => s + d.toolCalls, 0)).toBe(20);
+    });
+
+    it("flags skillsUsedApprox when the skill-row cap is exceeded", async () => {
+      const ROW_LIMIT = 50_000; // mirrors SKILL_ROW_LIMIT in the handler
+      query.mockResolvedValue([[{ c: 0 }], []]);
+      query
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // totalSessions
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // totalPrompts
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // distinctUsers
+        .mockResolvedValueOnce([[{ c: 1 }], []])   // toolCalls
+        // skillsUsed: one row over the cap (handler LIMITs at ROW_LIMIT+1), all same skill
+        .mockResolvedValueOnce([Array.from({ length: ROW_LIMIT + 1 }, () => ({ toolInput: '{"skill":"s"}' })), []]);
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/summary",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(200);
+      expect(body.skillsUsedApprox).toBe(true);
+      expect(body.skillsUsed).toBe(1); // capped slice still de-dupes
     });
   });
 
@@ -448,5 +548,26 @@ describe("siclaw-api misc routes", () => {
       }));
       expect([401, 403]).toContain(status);
     });
+  });
+});
+
+describe("sqlDayKey", () => {
+  it("reads LOCAL day components from a Date (mysql2 default), not UTC", () => {
+    // A Date built from local components keys to that same local day on any
+    // machine TZ — the old toISOString() path shifted this under a non-UTC DB
+    // (prod is UTC+8), which dropped edge rows and broke chart Total == KPI.
+    expect(sqlDayKey(new Date(2026, 5, 15, 0, 30))).toBe("2026-06-15"); // month is 0-based → June
+    expect(sqlDayKey(new Date(2026, 0, 5))).toBe("2026-01-05");          // zero-pads
+  });
+  it("takes the date part verbatim from a string (SQLite / mysql2 dateStrings)", () => {
+    expect(sqlDayKey("2026-06-15")).toBe("2026-06-15");
+    expect(sqlDayKey("2026-06-15 23:59:59")).toBe("2026-06-15");
+  });
+  it("returns null for unparseable / too-short / non-date input", () => {
+    expect(sqlDayKey(new Date("nope"))).toBeNull();
+    expect(sqlDayKey("2026")).toBeNull();
+    expect(sqlDayKey(null)).toBeNull();
+    expect(sqlDayKey(undefined)).toBeNull();
+    expect(sqlDayKey(12345)).toBeNull();
   });
 });

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -257,6 +257,25 @@ export interface SiclawApiContext {
   notifyMcpAgents?: (mcpId: string, resources: string[]) => void;
 }
 
+/**
+ * Day-bucket key ('YYYY-MM-DD') for a value returned by SQL `DATE(...)`.
+ * SQLite (and mysql2 with dateStrings) hand back a 'YYYY-MM-DD' string — used
+ * verbatim. mysql2's default returns a JS Date at the connection-local midnight;
+ * we read LOCAL components, NOT toISOString() — the latter is UTC and would
+ * shift the day by one under a non-UTC DB (the prod clusters are UTC+8),
+ * dropping edge rows. The same function keys both the DB buckets and the
+ * gap-fill range, so they never disagree and the series always sums to the
+ * scalar COUNT.
+ */
+export function sqlDayKey(raw: unknown): string | null {
+  if (typeof raw === "string") return raw.length >= 10 ? raw.slice(0, 10) : null;
+  if (raw instanceof Date) {
+    if (Number.isNaN(raw.getTime())) return null;
+    return `${raw.getFullYear()}-${String(raw.getMonth() + 1).padStart(2, "0")}-${String(raw.getDate()).padStart(2, "0")}`;
+  }
+  return null;
+}
+
 export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, ctx?: SiclawApiContext): void {
   const P = "/api/v1/siclaw";
 
@@ -2866,19 +2885,134 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const [pRows] = await db.query(totalPromptsSql, pParams) as [Array<{ c: number }>, unknown];
     const totalPrompts = Number(pRows[0]?.c ?? 0);
 
-    let byUser: Array<{ userId: string; sessions: number; messages: number }> = [];
-    if (!userFilter) {
-      const [uRows] = await db.query(
-        `SELECT s.user_id AS userId, COUNT(DISTINCT s.id) AS sessions, SUM(s.message_count) AS messages
-         FROM chat_sessions s WHERE s.created_at >= ? AND s.created_at <= ?
-           AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
-         GROUP BY s.user_id ORDER BY sessions DESC LIMIT 50`,
-        [from, to],
-      ) as any;
-      byUser = uRows.map((r: any) => ({ userId: r.userId, sessions: Number(r.sessions), messages: Number(r.messages ?? 0) }));
-    }
+    // ── distinctUsers (window) ──
+    const duParams: unknown[] = [from, to];
+    let distinctUsersSql = `SELECT COUNT(DISTINCT user_id) AS c FROM chat_sessions
+      WHERE created_at >= ? AND created_at <= ? AND (origin IS NULL OR origin NOT IN ('task', 'delegation'))`;
+    if (userFilter) { distinctUsersSql += " AND user_id = ?"; duParams.push(userFilter); }
+    const [duRows] = await db.query(distinctUsersSql, duParams) as [Array<{ c: number }>, unknown];
+    const distinctUsers = Number(duRows[0]?.c ?? 0);
 
-    sendJson(res, 200, { totalSessions, totalPrompts, byUser });
+    // ── toolCalls: total tool-row count (window) ──
+    const tcParams: unknown[] = [from, to];
+    let toolCallsSql = `SELECT COUNT(*) AS c FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
+        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+    if (userFilter) { toolCallsSql += " AND s.user_id = ?"; tcParams.push(userFilter); }
+    const [tcRows] = await db.query(toolCallsSql, tcParams) as [Array<{ c: number }>, unknown];
+    const toolCalls = Number(tcRows[0]?.c ?? 0);
+
+    // ── skillsUsed: distinct skills parsed from tool_input JSON (window) ──
+    // The skill name lives inside tool_input (tool_name is the script-exec
+    // tool's own name). role='tool' hits idx_chat_messages_audit; the cap mirrors
+    // /metrics/timing — skill cardinality is tiny so it ~never bites.
+    const SKILL_ROW_LIMIT = 50_000;
+    const suParams: unknown[] = [from, to];
+    let skillsSql = `SELECT m.tool_input AS toolInput FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      WHERE m.role = 'tool'
+        AND m.tool_name IN ('local_script', 'host_script', 'pod_script', 'node_script')
+        AND m.created_at >= ? AND m.created_at <= ?
+        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+    if (userFilter) { skillsSql += " AND s.user_id = ?"; suParams.push(userFilter); }
+    skillsSql += " ORDER BY m.created_at DESC LIMIT ?";
+    suParams.push(SKILL_ROW_LIMIT + 1);
+    const [suRows] = await db.query(skillsSql, suParams) as [Array<{ toolInput: string | null }>, unknown];
+    const skillsUsedApprox = suRows.length > SKILL_ROW_LIMIT;
+    const suSlice = skillsUsedApprox ? suRows.slice(0, SKILL_ROW_LIMIT) : suRows;
+    const skillSet = new Set<string>();
+    for (const r of suSlice) {
+      if (!r.toolInput) continue;
+      let skill: unknown;
+      const parsed = safeParseJson<Record<string, unknown> | null>(r.toolInput, null);
+      if (parsed) {
+        skill = parsed.skill;
+      } else {
+        // tool_input is redacted JSON; fall back to a regex if it failed to parse.
+        const match = /"skill"\s*:\s*"([^"]+)"/.exec(r.toolInput);
+        if (match) skill = match[1];
+      }
+      // skill is Optional on host/pod/node_script (user scripts omit it) — only
+      // count real skill names so a missing field can't inflate the set.
+      if (typeof skill === "string" && skill) skillSet.add(skill);
+    }
+    const skillsUsed = skillSet.size;
+
+    // ── inventory: current-snapshot managed scale, NOT windowed ──
+    const [[invClusters], [invHosts], [invSkills], [invKnowledge], [invAgents], [invMcp]] = await Promise.all([
+      db.query("SELECT COUNT(*) AS c FROM clusters") as Promise<[Array<{ c: number }>, unknown]>,
+      db.query("SELECT COUNT(*) AS c FROM hosts") as Promise<[Array<{ c: number }>, unknown]>,
+      db.query("SELECT COUNT(*) AS c FROM skills WHERE overlay_of IS NULL") as Promise<[Array<{ c: number }>, unknown]>,
+      db.query("SELECT COUNT(*) AS c FROM knowledge_repos") as Promise<[Array<{ c: number }>, unknown]>,
+      db.query("SELECT COUNT(*) AS c FROM agents") as Promise<[Array<{ c: number }>, unknown]>,
+      db.query("SELECT COUNT(*) AS c FROM mcp_servers") as Promise<[Array<{ c: number }>, unknown]>,
+    ]);
+    const inventory = {
+      clusters: Number(invClusters[0]?.c ?? 0),
+      hosts: Number(invHosts[0]?.c ?? 0),
+      skills: Number(invSkills[0]?.c ?? 0),
+      knowledgeRepos: Number(invKnowledge[0]?.c ?? 0),
+      agents: Number(invAgents[0]?.c ?? 0),
+      mcpServers: Number(invMcp[0]?.c ?? 0),
+    };
+
+    // ── dailySeries: per-day prompts & tool calls across [from, to]. Same WHERE
+    // as the scalar cards → each chart's summed Total equals its KPI card. Keyed
+    // by sqlDayKey (local day) and union'd with the gap-fill range so no count is
+    // dropped under a non-UTC DB; capped at ~400 days for pathological windows.
+    const dpParams: unknown[] = [from, to];
+    let dailyPromptsSql = `SELECT DATE(m.created_at) AS day, COUNT(*) AS c FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
+        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
+        AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
+    if (userFilter) { dailyPromptsSql += " AND s.user_id = ?"; dpParams.push(userFilter); }
+    dailyPromptsSql += " GROUP BY DATE(m.created_at)";
+
+    const dtParams: unknown[] = [from, to];
+    let dailyToolsSql = `SELECT DATE(m.created_at) AS day, COUNT(*) AS c FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
+        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+    if (userFilter) { dailyToolsSql += " AND s.user_id = ?"; dtParams.push(userFilter); }
+    dailyToolsSql += " GROUP BY DATE(m.created_at)";
+
+    const [dpRes, dtRes] = await Promise.all([
+      db.query(dailyPromptsSql, dpParams) as Promise<[Array<{ day: unknown; c: number }>, unknown]>,
+      db.query(dailyToolsSql, dtParams) as Promise<[Array<{ day: unknown; c: number }>, unknown]>,
+    ]);
+    const bucketByDay = (rows: Array<{ day: unknown; c: number }>): Map<string, number> => {
+      const m = new Map<string, number>();
+      for (const r of rows) {
+        const key = sqlDayKey(r.day);
+        if (key) m.set(key, Number(r.c));
+      }
+      return m;
+    };
+    const promptByDay = bucketByDay(dpRes[0]);
+    const toolByDay = bucketByDay(dtRes[0]);
+
+    const dayKeys = new Set<string>();
+    const cursor = new Date(from.getFullYear(), from.getMonth(), from.getDate());
+    const lastDay = new Date(to.getFullYear(), to.getMonth(), to.getDate());
+    for (let guard = 0; cursor <= lastDay && guard < 400; guard++) {
+      const key = sqlDayKey(cursor);
+      if (key) dayKeys.add(key);
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    for (const k of promptByDay.keys()) dayKeys.add(k);
+    for (const k of toolByDay.keys()) dayKeys.add(k);
+    const dailySeries = [...dayKeys].sort().map((date) => ({
+      date,
+      prompts: promptByDay.get(date) ?? 0,
+      toolCalls: toolByDay.get(date) ?? 0,
+    }));
+
+    sendJson(res, 200, {
+      totalSessions, totalPrompts,
+      distinctUsers, toolCalls, skillsUsed, skillsUsedApprox, inventory, dailySeries,
+    });
   });
 
   // GET /api/v1/siclaw/metrics/timing


### PR DESCRIPTION
## What

Repurposes the `Metrics → Dashboard` tab from internal ops telemetry into an **external-facing showcase** (scale + value), reading **only Portal DB**, desensitized to counts/distributions/trends — no individual drill-down.

## Changes

**Backend** (`src/portal/siclaw-api.ts` — `/api/v1/siclaw/metrics/summary`)
- New aggregates, all sharing the existing card filters so figures stay consistent:
  - `distinctUsers`, `toolCalls` (total), `skillsUsed` (distinct skills parsed from `tool_input` across the 4 script-exec tools, `ROW_LIMIT`-capped)
  - `inventory` snapshot: clusters / hosts / skills (overlay-excluded) / knowledge / agents / mcp
  - `dailySeries`: per-day prompts & tool calls (same `WHERE` as the scalar cards → each chart's Total equals its KPI card)
- `byUser` kept server-side (adapter REST + RPC mirrors also return it, locked by tests) — front-end simply stops rendering it; no protocol drift.

**Frontend** (`portal-web/`)
- Reorder: Managed scale (snapshot) → Usage (windowed) → Usage trend (daily charts).
- New `TrendChart` SVG component (smooth area + gradient + axis + Total/avg/Peak) — **no chart-lib dependency**.
- `KpiCards` split into two labelled groups; live / timing / By-User cards removed from the dashboard.
- User filter scoped to the Audit tab (external view never drills into individuals / exposes usernames).
- Trend shown for all periods (1–2 points at 24h); long-range x-axis uses ~7 evenly-spaced `MM-DD` labels with edge-anchored ends.

## Boundary / design

- Stays entirely within the Portal DB (no gateway/agentbox coupling); window queries are fixed-width so cost is bounded by recent activity, not total history.
- No new dependencies; chart is hand-rolled SVG.

## Testing

- `src/portal/siclaw-api.misc.test.ts` extended: skill-name parsing (JSON + regex fallback + dedup + skip-missing), daily-series gap-fill summing to period totals, inventory shape. **30/30 pass.**
- Type-clean on all touched files.