### PR TITLE
Add native PDF media input support

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -199,6 +199,25 @@ async function flushAsync(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
+function modelConfigWithInput(input: string[]) {
+  return {
+    name: "test-provider",
+    baseUrl: "https://api.openai.com/v1",
+    apiKey: "sk-test",
+    api: "openai-completions",
+    authHeader: false,
+    models: [{
+      id: "gpt-4",
+      name: "GPT-4",
+      reasoning: false,
+      input,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 4096,
+    }],
+  };
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────
 
 let server: http.Server | https.Server;
@@ -274,12 +293,15 @@ describe("http-server — prompt + session lifecycle", () => {
     const r = await getJson(port, "/api/prompt", "POST", {
       text: "what is in this image?",
       sessionId: "img-1",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      modelConfig: modelConfigWithInput(["text", "image"]),
       images: [{ mimeType: "image/png", data: "aW1n" }],
     });
     expect(r.status).toBe(200);
     expect(session.brain.prompt).toHaveBeenCalledWith(
       "what is in this image?",
-      [{ mimeType: "image/png", data: "aW1n" }],
+      { images: [{ mimeType: "image/png", data: "aW1n" }] },
     );
   });
 
@@ -287,12 +309,15 @@ describe("http-server — prompt + session lifecycle", () => {
     const session = await sm.getOrCreate("img-only");
     const r = await getJson(port, "/api/prompt", "POST", {
       sessionId: "img-only",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      modelConfig: modelConfigWithInput(["text", "image"]),
       images: [{ mimeType: "image/png", data: "aW1n" }],
     });
     expect(r.status).toBe(200);
     expect(session.brain.prompt).toHaveBeenCalledWith(
       "Please analyze the attached image.",
-      [{ mimeType: "image/png", data: "aW1n" }],
+      { images: [{ mimeType: "image/png", data: "aW1n" }] },
     );
   });
 
@@ -310,6 +335,23 @@ describe("http-server — prompt + session lifecycle", () => {
     });
     expect(r.status).toBe(400);
     expect(r.data.error).toMatch(/Missing.*text/);
+  });
+
+  it("POST /api/prompt accepts PDF-only prompts and forwards files to the brain", async () => {
+    const r = await getJson(port, "/api/prompt", "POST", {
+      sessionId: "pdf1",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      modelConfig: modelConfigWithInput(["text", "pdf"]),
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
+    await flushAsync();
+
+    expect(r.status).toBe(200);
+    const s = sm.sessions.get("pdf1")!;
+    expect(s.brain.prompt).toHaveBeenCalledWith("Please analyze the attached PDF.", {
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
   });
 
   it("resolves the active operating mode from DP markers and passes it to getOrCreate", async () => {
@@ -865,6 +907,31 @@ describe("http-server — steer / abort / clear-queue", () => {
     const r = await getJson(port, "/api/sessions/st2/steer", "POST", { text: "stop" });
     expect(r.status).toBe(200);
     expect(s.brain.steer).toHaveBeenCalledWith("stop");
+  });
+
+  it("POST /api/sessions/:id/steer forwards images to brain.steer", async () => {
+    await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "st-img" });
+    const s = sm.sessions.get("st-img")!;
+    const r = await getJson(port, "/api/sessions/st-img/steer", "POST", {
+      text: "这个呢",
+      images: [{ mimeType: "image/png", data: "aGVsbG8=" }],
+    });
+    expect(r.status).toBe(200);
+    expect(s.brain.steer).toHaveBeenCalledWith("这个呢", {
+      images: [{ mimeType: "image/png", data: "aGVsbG8=" }],
+    });
+  });
+
+  it("POST /api/sessions/:id/steer forwards PDF files to brain.steer", async () => {
+    await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "st-pdf" });
+    const s = sm.sessions.get("st-pdf")!;
+    const r = await getJson(port, "/api/sessions/st-pdf/steer", "POST", {
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
+    expect(r.status).toBe(200);
+    expect(s.brain.steer).toHaveBeenCalledWith("Please analyze the attached PDF.", {
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
   });
 
   it("POST /api/sessions/:id/abort calls brain.abort AND stops the session's background jobs", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -22,15 +22,21 @@ import { getSyncHandler, createClusterHandler, createHostHandler } from "./sync-
 import { GATEWAY_SYNC_DESCRIPTORS, type AgentBoxSyncHandler, type GatewaySyncType } from "../shared/gateway-sync.js";
 import { detectLanguage } from "../shared/detect-language.js";
 import {
+  candidateSupportsPromptMedia,
   clearModelRouteUserSelectionIfDifferent,
+  filterCandidatesForPromptMedia,
   markModelRouteUserSelection,
+  normalizeCandidates,
   normalizeModelRoutePolicy,
+  requiredInputsForPromptMedia,
   runPromptWithModelRouting,
   shouldUseModelRouteRunner,
+  unsupportedPromptMediaMessage,
+  type ModelRouteCandidate,
   type ModelRouteEvent,
   type ModelRoutePolicy,
 } from "../core/model-routing.js";
-import type { BrainSession, PromptImage } from "../core/brain-session.js";
+import type { BrainSession, PromptFile, PromptImage, PromptMedia } from "../core/brain-session.js";
 
 type RequestHandler = (
   req: http.IncomingMessage,
@@ -56,40 +62,8 @@ interface PromptRequestBody {
   modelRouting?: ModelRoutePolicy;
   /** Image attachments forwarded as vision input (vision-capable models only). */
   images?: PromptImage[];
-}
-
-// Defense-in-depth bound; the sicore proxy already caps attachments, but the
-// agentbox /prompt is also reachable directly so re-validate here.
-// MUST stay consistent with MAX_BODY_SIZE (parseJsonBody, below): the whole JSON
-// body is rejected at MAX_BODY_SIZE *before* this runs, so MAX_PROMPT_IMAGES ×
-// MAX_PROMPT_IMAGE_BASE64_CHARS must fit under it with headroom for the JSON
-// envelope + text. 4 × 2MB = 8MB < 10MB MAX_BODY_SIZE → all advertised images
-// are actually deliverable (raising one without the other reintroduces the
-// "limit unreachable" mismatch).
-const MAX_PROMPT_IMAGES = 4;
-const MAX_PROMPT_IMAGE_BASE64_CHARS = 2 * 1024 * 1024;
-const SUPPORTED_PROMPT_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/webp"]);
-
-// Standard base64 (optionally padded). PromptImage.data is raw base64 with no
-// `data:` URL prefix; a non-base64 string would only fail later at the provider.
-const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
-
-/** Keep only well-formed, supported image parts; drop anything malformed. */
-function sanitizePromptImages(raw: unknown): PromptImage[] | undefined {
-  if (!Array.isArray(raw)) return undefined;
-  const out: PromptImage[] = [];
-  for (const item of raw) {
-    if (out.length >= MAX_PROMPT_IMAGES) break;
-    if (!item || typeof item !== "object") continue;
-    const mimeType = (item as { mimeType?: unknown }).mimeType;
-    const data = (item as { data?: unknown }).data;
-    if (typeof mimeType !== "string" || typeof data !== "string") continue;
-    if (!SUPPORTED_PROMPT_IMAGE_MIMES.has(mimeType.toLowerCase())) continue;
-    if (data.length === 0 || data.length > MAX_PROMPT_IMAGE_BASE64_CHARS) continue;
-    if (data.length % 4 !== 0 || !BASE64_RE.test(data)) continue; // reject non-base64
-    out.push({ mimeType: mimeType.toLowerCase(), data });
-  }
-  return out.length > 0 ? out : undefined;
+  /** PDF attachments forwarded as native file input (PDF-capable models only). */
+  files?: PromptFile[];
 }
 
 /**
@@ -128,6 +102,88 @@ const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10MB
 const BODY_TIMEOUT_MS = 30_000; // 30s
 const DP_ACTIVATION_MARKER = "[Deep Investigation]\n";
 const DP_EXIT_MARKER = "[DP_EXIT]";
+const MAX_PROMPT_IMAGES = 4;
+const MAX_PROMPT_IMAGE_BASE64_CHARS = 2 * 1024 * 1024;
+const SUPPORTED_PROMPT_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/webp"]);
+const MAX_PROMPT_FILES = 4;
+const MAX_PROMPT_FILE_BASE64_CHARS = 8 * 1024 * 1024;
+const SUPPORTED_PROMPT_FILE_MIMES = new Set(["application/pdf"]);
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function sanitizePromptImages(raw: unknown): PromptImage[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: PromptImage[] = [];
+  for (const item of raw) {
+    if (out.length >= MAX_PROMPT_IMAGES) break;
+    if (!item || typeof item !== "object") continue;
+    const mimeType = (item as { mimeType?: unknown }).mimeType;
+    const data = (item as { data?: unknown }).data;
+    if (typeof mimeType !== "string" || typeof data !== "string") continue;
+    const normalizedMime = mimeType.toLowerCase();
+    if (!SUPPORTED_PROMPT_IMAGE_MIMES.has(normalizedMime)) continue;
+    if (data.length === 0 || data.length > MAX_PROMPT_IMAGE_BASE64_CHARS) continue;
+    if (data.length % 4 !== 0 || !BASE64_RE.test(data)) continue;
+    out.push({ mimeType: normalizedMime, data });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function sanitizePromptFiles(raw: unknown): PromptFile[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: PromptFile[] = [];
+  for (const item of raw) {
+    if (out.length >= MAX_PROMPT_FILES) break;
+    if (!item || typeof item !== "object") continue;
+    const mimeType = (item as { mimeType?: unknown }).mimeType;
+    const filename = (item as { filename?: unknown }).filename;
+    const data = (item as { data?: unknown }).data;
+    if (typeof mimeType !== "string" || typeof filename !== "string" || typeof data !== "string") continue;
+    const normalizedMime = mimeType.toLowerCase();
+    if (!SUPPORTED_PROMPT_FILE_MIMES.has(normalizedMime)) continue;
+    if (filename.trim() === "") continue;
+    if (data.length === 0 || data.length > MAX_PROMPT_FILE_BASE64_CHARS) continue;
+    if (data.length % 4 !== 0 || !BASE64_RE.test(data)) continue;
+    out.push({ mimeType: normalizedMime, filename: sanitizePromptFilename(filename), data });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function sanitizePromptFilename(value: string): string {
+  const basename = value.split(/[\\/]/).filter(Boolean).pop()?.trim() || "attachment.pdf";
+  return basename.replace(/[\r\n\t]/g, "_").slice(0, 160) || "attachment.pdf";
+}
+
+function buildPromptMedia(images?: PromptImage[], files?: PromptFile[]): PromptMedia | undefined {
+  if ((!images || images.length === 0) && (!files || files.length === 0)) return undefined;
+  return {
+    ...(images && images.length > 0 ? { images } : {}),
+    ...(files && files.length > 0 ? { files } : {}),
+  };
+}
+
+function defaultPromptTextForMedia(media?: PromptMedia): string {
+  const hasImages = !!media?.images?.length;
+  const hasFiles = !!media?.files?.length;
+  if (hasImages && hasFiles) return "Please analyze the attached image and PDF.";
+  if (hasFiles) return "Please analyze the attached PDF.";
+  if (hasImages) return "Please analyze the attached image.";
+  return "";
+}
+
+function singleCandidateForMediaPreflight(
+  body: PromptRequestBody,
+  policy: ModelRoutePolicy | undefined,
+): ModelRouteCandidate | undefined {
+  if (body.modelProvider && body.modelId) {
+    return {
+      provider: body.modelProvider,
+      modelId: body.modelId,
+      modelConfig: body.modelConfig,
+    };
+  }
+  const candidates = normalizeCandidates(policy?.candidates);
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
 
 /**
  * Resolve the session's active operating mode for this prompt, so getOrCreate can
@@ -376,10 +432,12 @@ export function createHttpServer(
     const body = (await parseJsonBody(req)) as PromptRequestBody;
 
     const promptImages = sanitizePromptImages(body.images);
+    const promptFiles = sanitizePromptFiles(body.files);
+    const promptMedia = buildPromptMedia(promptImages, promptFiles);
 
-    // An image-only message is valid (vision models read the picture directly);
-    // only reject when there is neither text nor a usable image.
-    if (!body.text && !promptImages) {
+    // Media-only messages are valid; reject only when there is neither text nor
+    // usable image/PDF media after validation.
+    if (!body.text && !promptMedia) {
       sendJson(res, 400, { error: "Missing 'text' field" });
       return;
     }
@@ -529,11 +587,23 @@ export function createHttpServer(
         });
       }
 
-      // Image-only messages arrive with empty text; give the model a minimal
-      // default instruction so the turn isn't a bare image with no ask.
+      if (requiredInputsForPromptMedia(promptMedia).length > 0) {
+        if (routeEnabled) {
+          const candidates = normalizeCandidates(configuredModelRouting?.candidates);
+          if (filterCandidatesForPromptMedia(candidates, promptMedia).length === 0) {
+            throw new Error(unsupportedPromptMediaMessage(promptMedia));
+          }
+        } else {
+          const candidate = singleCandidateForMediaPreflight(body, configuredModelRouting);
+          if (!candidate || !candidateSupportsPromptMedia(candidate, promptMedia)) {
+            throw new Error(unsupportedPromptMediaMessage(promptMedia));
+          }
+        }
+      }
+
       promptText = body.text && body.text.length > 0
         ? body.text
-        : (promptImages ? "Please analyze the attached image." : "");
+        : defaultPromptTextForMedia(promptMedia);
     } catch (err) {
       releasePromptLockOnSetupFailure(err);
       return;
@@ -699,9 +769,9 @@ export function createHttpServer(
             onStateChange: () => sessionManager.persistModelRouteState(managed.id, managed.modelRouteState),
             shouldAbort: () => managed._aborted,
           },
-          promptImages,
+          promptMedia,
         )
-      : managed.brain.prompt(promptText, promptImages);
+      : managed.brain.prompt(promptText, promptMedia);
 
     promptPromise.then((result) => {
       // The routing runner reports exhaustion (and user aborts) as a result,
@@ -886,15 +956,25 @@ export function createHttpServer(
       return;
     }
 
-    const body = (await parseJsonBody(req)) as { text?: string };
-    if (!body.text) {
+    const body = (await parseJsonBody(req)) as { text?: string; images?: PromptImage[]; files?: PromptFile[] };
+    const promptImages = sanitizePromptImages(body.images);
+    const promptFiles = sanitizePromptFiles(body.files);
+    const promptMedia = buildPromptMedia(promptImages, promptFiles);
+    if (!body.text && !promptMedia) {
       sendJson(res, 400, { error: "Missing 'text' field" });
       return;
     }
 
-    console.log(`[agentbox-http] Steering session ${sessionId}: ${body.text.slice(0, 80)}`);
+    const steerText = body.text && body.text.length > 0
+      ? body.text
+      : defaultPromptTextForMedia(promptMedia);
+    console.log(`[agentbox-http] Steering session ${sessionId}: ${steerText.slice(0, 80)}`);
     try {
-      await managed.brain.steer(body.text);
+      if (promptMedia) {
+        await managed.brain.steer(steerText, promptMedia);
+      } else {
+        await managed.brain.steer(steerText);
+      }
       sendJson(res, 200, { ok: true });
     } catch (err) {
       console.error(`[agentbox-http] Steer error for session ${sessionId}:`, err);

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -38,6 +38,7 @@ import lsExtension from "./extensions/ls.js";
 import agentExtension from "./extensions/agent.js";
 import { PiAgentBrain } from "./brains/pi-agent-brain.js";
 import type { BrainSession } from "./brain-session.js";
+import { convertOpenAIPdfPayload } from "./openai-file-payload.js";
 import { McpClientManager } from "./mcp-client.js";
 import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryEnabled } from "./config.js";
 import { initExtraCommands } from "../tools/infra/extra-commands.js";
@@ -684,6 +685,17 @@ export async function createSiclawSession(
   // session_start fires again — but the DP handler resets state first
   // (dpActive=false) then restores from JSONL, so double-fire is idempotent.
   await session.bindExtensions({});
+
+  const agentWithPayloadHook = session.agent as unknown as {
+    onPayload?: (payload: unknown, model: unknown) => unknown | Promise<unknown>;
+  };
+  const previousOnPayload = agentWithPayloadHook.onPayload;
+  agentWithPayloadHook.onPayload = async (payload, model) => {
+    const converted = convertOpenAIPdfPayload(payload);
+    if (!previousOnPayload) return converted;
+    const next = await previousOnPayload(converted, model);
+    return convertOpenAIPdfPayload(next ?? converted);
+  };
 
   // ── Guard pipeline: unified guard registration and installation ──
   const contextWindow = configuredModel?.contextWindow ?? 128_000;

--- a/src/core/brain-session.ts
+++ b/src/core/brain-session.ts
@@ -17,12 +17,22 @@ export type BrainType = "pi-agent";
 /**
  * An image attachment to send alongside a prompt. `data` is raw base64 (no
  * `data:` URL prefix); the provider layer builds the data URL. Only carried
- * through to vision-capable models — pi-ai downgrades images to a text
- * placeholder when the model's `input` does not include "image".
+ * through to vision-capable models.
  */
 export interface PromptImage {
   mimeType: string;
   data: string;
+}
+
+export interface PromptFile {
+  mimeType: string;
+  filename: string;
+  data: string;
+}
+
+export interface PromptMedia {
+  images?: PromptImage[];
+  files?: PromptFile[];
 }
 
 export interface BrainModelInfo {
@@ -75,9 +85,8 @@ export interface BrainContextPreflightResult {
 export interface BrainSession {
   readonly brainType: BrainType;
 
-  /** Send a prompt to the agent. Resolves when the agent finishes responding.
-   *  `images` are passed to the model as vision input (vision-capable models only). */
-  prompt(text: string, images?: PromptImage[]): Promise<void>;
+  /** Send a prompt to the agent. Resolves when the agent finishes responding. */
+  prompt(text: string, media?: PromptMedia): Promise<void>;
 
   /** Abort the current agent run. */
   abort(): Promise<void>;
@@ -89,7 +98,7 @@ export interface BrainSession {
   reload(): Promise<void>;
 
   /** Interrupt mid-run and inject a user message. */
-  steer(text: string): Promise<void>;
+  steer(text: string, media?: PromptMedia): Promise<void>;
 
   /**
    * Queue a message delivered only after the agent finishes its current run (no

--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -80,7 +80,7 @@ describe("PiAgentBrain", () => {
       session.__emit({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } });
     });
     const brain = new PiAgentBrain(session);
-    await brain.prompt("describe", [{ mimeType: "image/png", data: "aW1n" }]);
+    await brain.prompt("describe", { images: [{ mimeType: "image/png", data: "aW1n" }] });
     expect(session.prompt).toHaveBeenCalledWith("describe", {
       images: [{ type: "image", data: "aW1n", mimeType: "image/png" }],
     });
@@ -222,6 +222,45 @@ describe("PiAgentBrain", () => {
     const brain = new PiAgentBrain(session);
     await brain.steer("steer me");
     expect(session.steer).toHaveBeenCalledWith("steer me");
+  });
+
+  it("steer forwards images through prompt streaming steer", async () => {
+    const session = makeFakeSession();
+    const brain = new PiAgentBrain(session);
+    await brain.steer("steer image", { images: [{ mimeType: "image/png", data: "aGVsbG8=" }] });
+    expect(session.steer).not.toHaveBeenCalled();
+    expect(session.prompt).toHaveBeenCalledWith("steer image", {
+      streamingBehavior: "steer",
+      images: [{ type: "image", mimeType: "image/png", data: "aGVsbG8=" }],
+    });
+  });
+
+  it("prompt forwards PDF files through pi-agent content options", async () => {
+    const session = makeFakeSession();
+    session.prompt = vi.fn(async (_text: string) => {
+      session.__emit({ type: "message_start", message: { role: "assistant" } });
+      session.__emit({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } });
+    });
+    const brain = new PiAgentBrain(session);
+    await brain.prompt("read pdf", {
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
+    expect(session.prompt).toHaveBeenCalledWith("read pdf", {
+      images: [{ type: "file", mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
+  });
+
+  it("steer forwards PDF files through prompt streaming steer", async () => {
+    const session = makeFakeSession();
+    const brain = new PiAgentBrain(session);
+    await brain.steer("steer pdf", {
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
+    expect(session.steer).not.toHaveBeenCalled();
+    expect(session.prompt).toHaveBeenCalledWith("steer pdf", {
+      streamingBehavior: "steer",
+      images: [{ type: "file", mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
   });
 
   it("clearQueue delegates", () => {

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -14,9 +14,10 @@ import type {
   BrainSessionStats,
   BrainProviderResponse,
   BrainContextPreflightResult,
-  PromptImage,
+  PromptMedia,
 } from "../brain-session.js";
 import { estimateMessagesTokens } from "../compaction.js";
+import { rememberPromptFiles } from "../openai-file-payload.js";
 
 /** Valid pi thinking levels; guards reasoningEffort coming off the wire. */
 const THINKING_LEVELS = new Set(["off", "minimal", "low", "medium", "high", "xhigh"]);
@@ -38,6 +39,23 @@ export class PiAgentBrain implements BrainSession {
   constructor(readonly session: AgentSession) {}
 
   private static readonly MAX_EMPTY_RETRIES = 2;
+
+  private promptOptionsForMedia(media?: PromptMedia): any | undefined {
+    const content: Array<Record<string, string>> = [];
+    if (media?.images && media.images.length > 0) {
+      content.push(...media.images.map((img) => ({ type: "image", data: img.data, mimeType: img.mimeType })));
+    }
+    if (media?.files && media.files.length > 0) {
+      rememberPromptFiles(media.files);
+      content.push(...media.files.map((file) => ({
+        type: "file",
+        data: file.data,
+        mimeType: file.mimeType,
+        filename: file.filename,
+      })));
+    }
+    return content.length > 0 ? { images: content } : undefined;
+  }
   private static readonly RETRY_DELAY_MS = 2000;
   private static readonly PROMPT_PREFLIGHT_SAFETY_TOKENS = 2048;
 
@@ -55,18 +73,12 @@ export class PiAgentBrain implements BrainSession {
     });
   }
 
-  async prompt(text: string, images?: PromptImage[]): Promise<void> {
+  async prompt(text: string, media?: PromptMedia): Promise<void> {
     this.aborted = false;
     let lastAssistantHadContent = false;
     let lastAssistantMessage: any = null;
 
-    // pi-coding-agent appends these to the user message content; the
-    // openai-codex-responses provider serializes them to `input_image` data
-    // URLs. Dropped (replaced with a placeholder) by pi-ai when the active
-    // model's `input` lacks "image", so non-vision models degrade gracefully.
-    const promptOptions = images && images.length > 0
-      ? { images: images.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType })) }
-      : undefined;
+    const promptOptions = this.promptOptionsForMedia(media);
 
     const unsub = this.session.subscribe((event: any) => {
       if (event.type === "message_start" && event.message?.role === "assistant") {
@@ -184,8 +196,12 @@ export class PiAgentBrain implements BrainSession {
     return this.session.reload();
   }
 
-  steer(text: string): Promise<void> {
-    return this.session.steer(text);
+  steer(text: string, media?: PromptMedia): Promise<void> {
+    const promptOptions = this.promptOptionsForMedia(media);
+    if (!promptOptions) {
+      return this.session.steer(text);
+    }
+    return this.session.prompt(text, { ...promptOptions, streamingBehavior: "steer" });
   }
 
   followUp(text: string): Promise<void> {

--- a/src/core/model-routing.test.ts
+++ b/src/core/model-routing.test.ts
@@ -46,6 +46,24 @@ function makePolicy(): ModelRoutePolicy {
   };
 }
 
+function candidateWithInput(provider: string, modelId: string, input: string[]): NonNullable<ModelRoutePolicy["candidates"]>[number] {
+  return {
+    provider,
+    modelId,
+    modelConfig: {
+      models: [{
+        id: modelId,
+        name: modelId,
+        reasoning: false,
+        input,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 4096,
+      }],
+    },
+  };
+}
+
 type BrainOutcome =
   | "ok"
   | "rate_limit"
@@ -727,6 +745,102 @@ describe("runPromptWithModelRouting", () => {
     });
     expect(brain.promptModels).toEqual(["anthropic/claude"]);
     expect(state.activeCandidateKey).toBe("anthropic/claude");
+  });
+
+  it("skips non-image-capable fallback candidates when images are present", async () => {
+    const brain = makeBrain(["rate_limit", "ok"]);
+    const state = createModelRouteState();
+    const policy: ModelRoutePolicy = {
+      ...makePolicy(),
+      candidates: [
+        candidateWithInput("openai", "gpt-4", ["text", "image"]),
+        candidateWithInput("anthropic", "claude", ["text"]),
+        candidateWithInput("deepseek", "deepseek-chat", ["text", "image"]),
+      ],
+    };
+    const images = [{ mimeType: "image/png", data: "aGVsbG8=" }];
+    const media = { images };
+
+    const result = await runPromptWithModelRouting(brain, "what is in this image?", policy, state, { now: () => 10_000 }, media);
+
+    expect(result.success).toBe(true);
+    expect(brain.promptModels).toEqual(["openai/gpt-4", "deepseek/deepseek-chat"]);
+    expect(brain.prompt).toHaveBeenNthCalledWith(1, "what is in this image?", media);
+    expect(brain.prompt).toHaveBeenNthCalledWith(2, "what is in this image?", media);
+    expect(state.activeCandidateKey).toBe("deepseek/deepseek-chat");
+  });
+
+  it("returns a clear failure when an image prompt has no image-capable candidates", async () => {
+    const brain = makeBrain(["ok"]);
+    const state = createModelRouteState();
+    const policy: ModelRoutePolicy = {
+      ...makePolicy(),
+      candidates: [
+        candidateWithInput("openai", "gpt-4", ["text"]),
+        candidateWithInput("anthropic", "claude", ["text"]),
+      ],
+    };
+
+    const result = await runPromptWithModelRouting(
+      brain,
+      "what is in this image?",
+      policy,
+      state,
+      { now: () => 10_000 },
+      { images: [{ mimeType: "image/png", data: "aGVsbG8=" }] },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.exhausted).toBe(true);
+    expect(result.finalFailureKind).toBe("format_error");
+    expect(result.finalErrorMessage).toContain("No image-capable model route candidate");
+    expect(brain.prompt).not.toHaveBeenCalled();
+  });
+
+  it("skips non-PDF-capable fallback candidates when PDF files are present", async () => {
+    const brain = makeBrain(["rate_limit", "ok"]);
+    const state = createModelRouteState();
+    const policy: ModelRoutePolicy = {
+      ...makePolicy(),
+      candidates: [
+        candidateWithInput("openai", "gpt-4", ["text", "pdf"]),
+        candidateWithInput("anthropic", "claude", ["text", "image"]),
+        candidateWithInput("deepseek", "deepseek-chat", ["text", "pdf"]),
+      ],
+    };
+    const media = { files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }] };
+
+    const result = await runPromptWithModelRouting(brain, "summarize this PDF", policy, state, { now: () => 10_000 }, media);
+
+    expect(result.success).toBe(true);
+    expect(brain.promptModels).toEqual(["openai/gpt-4", "deepseek/deepseek-chat"]);
+    expect(brain.prompt).toHaveBeenNthCalledWith(1, "summarize this PDF", media);
+    expect(brain.prompt).toHaveBeenNthCalledWith(2, "summarize this PDF", media);
+    expect(state.activeCandidateKey).toBe("deepseek/deepseek-chat");
+  });
+
+  it("requires both image and PDF capability for mixed media prompts", async () => {
+    const brain = makeBrain(["ok"]);
+    const state = createModelRouteState();
+    const policy: ModelRoutePolicy = {
+      ...makePolicy(),
+      candidates: [
+        candidateWithInput("openai", "gpt-4", ["text", "image"]),
+        candidateWithInput("anthropic", "claude", ["text", "pdf"]),
+        candidateWithInput("deepseek", "deepseek-chat", ["text", "image", "pdf"]),
+      ],
+    };
+    const media = {
+      images: [{ mimeType: "image/png", data: "aGVsbG8=" }],
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    };
+
+    const result = await runPromptWithModelRouting(brain, "compare these", policy, state, { now: () => 10_000 }, media);
+
+    expect(result.success).toBe(true);
+    expect(brain.promptModels).toEqual(["deepseek/deepseek-chat"]);
+    expect(brain.prompt).toHaveBeenCalledWith("compare these", media);
+    expect(state.activeCandidateKey).toBe("deepseek/deepseek-chat");
   });
 
   it("returns exhausted instead of throwing when every candidate is missing from the model registry", async () => {

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -1,4 +1,4 @@
-import type { BrainModelInfo, BrainProviderResponse, BrainSession, PromptImage } from "./brain-session.js";
+import type { BrainModelInfo, BrainProviderResponse, BrainSession, PromptMedia } from "./brain-session.js";
 
 export type ModelRouteFailureKind =
   | "billing"
@@ -331,6 +331,41 @@ export function normalizeCandidates(candidates: unknown): ModelRouteCandidate[] 
   return normalized;
 }
 
+function candidateInputSet(candidate: ModelRouteCandidate): Set<string> {
+  const models = candidate.modelConfig?.models;
+  if (!Array.isArray(models)) return new Set();
+  const exactModel = models.find((model) => isRecord(model) && model.id === candidate.modelId);
+  const model = exactModel ?? models.find(isRecord);
+  if (!isRecord(model) || !Array.isArray(model.input)) return new Set();
+  return new Set(model.input.filter((input): input is string => typeof input === "string"));
+}
+
+export function requiredInputsForPromptMedia(media?: PromptMedia): string[] {
+  const required: string[] = [];
+  if (media?.images && media.images.length > 0) required.push("image");
+  if (media?.files && media.files.length > 0) required.push("pdf");
+  return required;
+}
+
+export function candidateSupportsPromptMedia(candidate: ModelRouteCandidate, media?: PromptMedia): boolean {
+  const required = requiredInputsForPromptMedia(media);
+  if (required.length === 0) return true;
+  const inputs = candidateInputSet(candidate);
+  return required.every((input) => inputs.has(input));
+}
+
+export function filterCandidatesForPromptMedia(candidates: ModelRouteCandidate[], media?: PromptMedia): ModelRouteCandidate[] {
+  const required = requiredInputsForPromptMedia(media);
+  if (required.length === 0) return candidates;
+  return candidates.filter((candidate) => candidateSupportsPromptMedia(candidate, media));
+}
+
+export function unsupportedPromptMediaMessage(media?: PromptMedia): string {
+  const required = requiredInputsForPromptMedia(media);
+  if (required.length === 0) return "No model route candidate is available for this prompt.";
+  return `No ${required.join("+")}-capable model route candidate is available for this input.`;
+}
+
 export function markModelRouteUserSelection(
   state: ModelRouteState,
   candidate: Pick<ModelRouteCandidate, "provider" | "modelId">,
@@ -506,14 +541,24 @@ export async function runPromptWithModelRouting(
   policy: ModelRoutePolicy | undefined,
   state: ModelRouteState,
   options: RunPromptWithModelRoutingOptions = {},
-  images?: PromptImage[],
+  media?: PromptMedia,
 ): Promise<ModelRouteRunResult> {
   if (!isModelRoutePolicyEnabled(policy)) {
-    await brain.prompt(text, images);
+    await brain.prompt(text, media);
     return { success: true, exhausted: false, attempted: [] };
   }
 
-  const candidates = normalizeCandidates(policy.candidates);
+  const candidates = filterCandidatesForPromptMedia(normalizeCandidates(policy.candidates), media);
+  if (requiredInputsForPromptMedia(media).length > 0 && candidates.length === 0) {
+    return {
+      success: false,
+      exhausted: true,
+      attempted: [],
+      activeCandidateKey: state.activeCandidateKey,
+      finalFailureKind: "format_error",
+      finalErrorMessage: unsupportedPromptMediaMessage(media),
+    };
+  }
   const primaryCandidate = candidates[0]!;
   const primaryCandidateKey = candidateKey(primaryCandidate);
   const emitEvent = options.emitEvent ?? (() => {});
@@ -598,7 +643,7 @@ export async function runPromptWithModelRouting(
     // buffer every attempt, since a live failed attempt would leak into the
     // turn they persist from collected events.
     const streamFromStart = optimisticPrimaryStream && i === 0;
-    const attemptResult = await runAttempt(brain, text, candidate, emitBrainEvent, streamFromStart, images);
+    const attemptResult = await runAttempt(brain, text, candidate, emitBrainEvent, streamFromStart, media);
     const failure = attemptResult.failure;
     attempt.finishedAt = now();
 
@@ -780,7 +825,7 @@ async function runAttempt(
   candidate: ModelRouteCandidate,
   emitBrainEvent: (event: unknown) => void,
   streamFromStart: boolean,
-  images?: PromptImage[],
+  media?: PromptMedia,
 ): Promise<AttemptResult> {
   const checkpoint = brain.createPromptCheckpoint?.();
   let lastProviderResponse: BrainProviderResponse | undefined;
@@ -890,7 +935,7 @@ async function runAttempt(
         },
       };
     }
-    await brain.prompt(text, images);
+    await brain.prompt(text, media);
   } catch (err) {
     const message = errorMessage(err);
     return {

--- a/src/core/openai-file-payload.test.ts
+++ b/src/core/openai-file-payload.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { convertOpenAIPdfPayload, rememberPromptFiles } from "./openai-file-payload.js";
+
+const pdfData = "aGVsbG8=";
+const pdfUrl = `data:application/pdf;base64,${pdfData}`;
+
+describe("openai-file-payload", () => {
+  it("converts Responses PDF image placeholders into input_file blocks", () => {
+    rememberPromptFiles([{ mimeType: "application/pdf", filename: "runbook.pdf", data: pdfData }]);
+
+    const payload = {
+      input: [{
+        role: "user",
+        content: [
+          { type: "input_text", text: "read this" },
+          { type: "input_image", image_url: pdfUrl },
+        ],
+      }],
+    };
+
+    expect(convertOpenAIPdfPayload(payload)).toEqual({
+      input: [{
+        role: "user",
+        content: [
+          { type: "input_text", text: "read this" },
+          { type: "input_file", filename: "runbook.pdf", file_data: pdfUrl },
+        ],
+      }],
+    });
+  });
+
+  it("converts Chat Completions PDF image placeholders into file blocks", () => {
+    rememberPromptFiles([{ mimeType: "application/pdf", filename: "manual.pdf", data: pdfData }]);
+
+    const payload = {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "read this" },
+          { type: "image_url", image_url: { url: pdfUrl } },
+        ],
+      }],
+    };
+
+    expect(convertOpenAIPdfPayload(payload)).toEqual({
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "read this" },
+          { type: "file", file: { filename: "manual.pdf", file_data: pdfUrl } },
+        ],
+      }],
+    });
+  });
+
+  it("leaves normal image payloads unchanged", () => {
+    const payload = {
+      input: [{ role: "user", content: [{ type: "input_image", image_url: "data:image/png;base64,aGVsbG8=" }] }],
+    };
+
+    expect(convertOpenAIPdfPayload(payload)).toBe(payload);
+  });
+});

--- a/src/core/openai-file-payload.ts
+++ b/src/core/openai-file-payload.ts
@@ -1,0 +1,126 @@
+import type { PromptFile } from "./brain-session.js";
+
+const PDF_DATA_URL_PREFIX = "data:application/pdf;base64,";
+const DEFAULT_PDF_FILENAME = "attachment.pdf";
+const MAX_REMEMBERED_FILES = 256;
+const rememberedPdfFilenames = new Map<string, string>();
+
+export function pdfDataUrl(file: Pick<PromptFile, "mimeType" | "data">): string | undefined {
+  if (file.mimeType.toLowerCase() !== "application/pdf" || !file.data) return undefined;
+  return `${PDF_DATA_URL_PREFIX}${file.data}`;
+}
+
+export function rememberPromptFiles(files?: PromptFile[]): void {
+  if (!files || files.length === 0) return;
+  for (const file of files) {
+    const url = pdfDataUrl(file);
+    if (!url) continue;
+    rememberedPdfFilenames.set(url, sanitizePdfFilename(file.filename));
+    while (rememberedPdfFilenames.size > MAX_REMEMBERED_FILES) {
+      const oldest = rememberedPdfFilenames.keys().next().value;
+      if (!oldest) break;
+      rememberedPdfFilenames.delete(oldest);
+    }
+  }
+}
+
+export function convertOpenAIPdfPayload(payload: unknown): unknown {
+  if (!isRecord(payload)) return payload;
+  let changed = false;
+  const clone = { ...payload };
+
+  if (Array.isArray(clone.input)) {
+    const { value, didChange } = convertResponsesInput(clone.input);
+    if (didChange) {
+      clone.input = value;
+      changed = true;
+    }
+  }
+
+  if (Array.isArray(clone.messages)) {
+    const { value, didChange } = convertChatMessages(clone.messages);
+    if (didChange) {
+      clone.messages = value;
+      changed = true;
+    }
+  }
+
+  return changed ? clone : payload;
+}
+
+function convertResponsesInput(input: unknown[]): { value: unknown[]; didChange: boolean } {
+  let didChange = false;
+  const value = input.map((message) => {
+    if (!isRecord(message) || !Array.isArray(message.content)) return message;
+    const { value: content, didChange: contentChanged } = convertResponsesContent(message.content);
+    if (!contentChanged) return message;
+    didChange = true;
+    return { ...message, content };
+  });
+  return { value, didChange };
+}
+
+function convertResponsesContent(content: unknown[]): { value: unknown[]; didChange: boolean } {
+  let didChange = false;
+  const value = content.map((part) => {
+    if (!isRecord(part) || part.type !== "input_image") return part;
+    const imageUrl = typeof part.image_url === "string" ? part.image_url : undefined;
+    if (!isPdfDataUrl(imageUrl)) return part;
+    didChange = true;
+    return {
+      type: "input_file",
+      filename: filenameForPdfDataUrl(imageUrl),
+      file_data: imageUrl,
+    };
+  });
+  return { value, didChange };
+}
+
+function convertChatMessages(messages: unknown[]): { value: unknown[]; didChange: boolean } {
+  let didChange = false;
+  const value = messages.map((message) => {
+    if (!isRecord(message) || !Array.isArray(message.content)) return message;
+    const { value: content, didChange: contentChanged } = convertChatContent(message.content);
+    if (!contentChanged) return message;
+    didChange = true;
+    return { ...message, content };
+  });
+  return { value, didChange };
+}
+
+function convertChatContent(content: unknown[]): { value: unknown[]; didChange: boolean } {
+  let didChange = false;
+  const value = content.map((part) => {
+    if (!isRecord(part) || part.type !== "image_url" || !isRecord(part.image_url)) return part;
+    const imageUrl = typeof part.image_url.url === "string" ? part.image_url.url : undefined;
+    if (!isPdfDataUrl(imageUrl)) return part;
+    didChange = true;
+    return {
+      type: "file",
+      file: {
+        filename: filenameForPdfDataUrl(imageUrl),
+        file_data: imageUrl,
+      },
+    };
+  });
+  return { value, didChange };
+}
+
+function filenameForPdfDataUrl(dataUrl: string): string {
+  return rememberedPdfFilenames.get(dataUrl) ?? DEFAULT_PDF_FILENAME;
+}
+
+function isPdfDataUrl(value: unknown): value is string {
+  return typeof value === "string" && value.toLowerCase().startsWith(PDF_DATA_URL_PREFIX);
+}
+
+function sanitizePdfFilename(value: string): string {
+  const basename = value.split(/[\\/]/).filter(Boolean).pop()?.trim() || DEFAULT_PDF_FILENAME;
+  const cleaned = basename.replace(/[\r\n\t]/g, "_");
+  if (!cleaned.toLowerCase().endsWith(".pdf")) return `${cleaned}.pdf`;
+  return cleaned;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/gateway/agentbox/client.test.ts
+++ b/src/gateway/agentbox/client.test.ts
@@ -139,6 +139,19 @@ describe("AgentBoxClient — prompt + session CRUD", () => {
     });
   });
 
+  it("prompt() preserves native PDF files", async () => {
+    await client.prompt({
+      text: "read this",
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
+
+    const req = srv.captures[srv.captures.length - 1];
+    expect(req.url).toBe("/api/prompt");
+    expect(JSON.parse(req.body).files).toEqual([
+      { mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" },
+    ]);
+  });
+
   it("listSessions() returns the parsed sessions array", async () => {
     const r = await client.listSessions();
     expect(r.sessions).toHaveLength(1);
@@ -157,6 +170,20 @@ describe("AgentBoxClient — prompt + session CRUD", () => {
     const req = srv.captures.find((c) => c.url === "/api/sessions/s1/steer")!;
     expect(req.method).toBe("POST");
     expect(JSON.parse(req.body)).toEqual({ text: "stop the pod" });
+  });
+
+  it("steerSession() preserves media payloads", async () => {
+    await client.steerSession("s1", "inspect these", {
+      images: [{ mimeType: "image/png", data: "aGVsbG8=" }],
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
+    const req = srv.captures[srv.captures.length - 1];
+    expect(req.url).toBe("/api/sessions/s1/steer");
+    expect(JSON.parse(req.body)).toEqual({
+      text: "inspect these",
+      images: [{ mimeType: "image/png", data: "aGVsbG8=" }],
+      files: [{ mimeType: "application/pdf", filename: "runbook.pdf", data: "aGVsbG8=" }],
+    });
   });
 
   it("abortSession() posts to the abort endpoint", async () => {

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -52,7 +52,11 @@ export interface PromptOptions {
   modelRouting?: ModelRoutePolicy;
   /** Image attachments (raw base64, no data: prefix) forwarded as vision input. */
   images?: Array<{ mimeType: string; data: string }>;
+  /** File attachments forwarded as native model file input. */
+  files?: Array<{ mimeType: string; filename: string; data: string }>;
 }
+
+export type PromptMediaOptions = Pick<PromptOptions, "images" | "files">;
 
 export interface PromptResponse {
   ok: boolean;
@@ -181,11 +185,17 @@ export class AgentBoxClient {
   /**
    * Send a steer instruction (inserts a user message after interrupting the current tool)
    */
-  async steerSession(sessionId: string, text: string): Promise<void> {
+  async steerSession(sessionId: string, text: string, media?: PromptMediaOptions): Promise<void> {
+    const images = media?.images;
+    const files = media?.files;
     await this.fetch(`/api/sessions/${sessionId}/steer`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
+      body: JSON.stringify({
+        text,
+        ...(images && images.length > 0 ? { images } : {}),
+        ...(files && files.length > 0 ? { files } : {}),
+      }),
     });
   }
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -172,6 +172,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const modelConfig = params.modelConfig as PromptOptions["modelConfig"];
     const modelRouting = params.modelRouting as PromptOptions["modelRouting"];
     const images = params.images as PromptOptions["images"];
+    const files = params.files as PromptOptions["files"];
     const promptOpts: PromptOptions = {
       sessionId,
       text,
@@ -183,6 +184,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       modelConfig,
       modelRouting,
       images,
+      files,
     };
 
     // Async-ack protocol: return { ok, sessionId } within milliseconds; do
@@ -227,7 +229,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           // prompt will fire its own when it actually finishes, and an
           // extra one would close the frontend stream prematurely.
           if (err instanceof Error && err.message.includes("Session is already running")) {
-            await client.steerSession(sessionId, text);
+            await client.steerSession(sessionId, text, { images, files });
             return;
           }
           throw err;
@@ -323,6 +325,8 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const agentId = params.agentId as string;
     const sessionId = params.sessionId as string;
     const text = params.text as string;
+    const images = params.images as PromptOptions["images"];
+    const files = params.files as PromptOptions["files"];
     if (!agentId || !sessionId || !text) throw new Error("agentId, sessionId, text required");
 
     // Persist the steer as a user message BEFORE injecting it, mirroring
@@ -337,7 +341,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
 
     const handle = await agentBoxManager.getOrCreate(agentId);
     const client = new AgentBoxClient(handle.endpoint, 10000, agentBoxTlsOptions);
-    await client.steerSession(sessionId, text);
+    await client.steerSession(sessionId, text, { images, files });
     return { ok: true };
   });
 


### PR DESCRIPTION
## Summary
- Add unified prompt media support for images and PDF files through AgentBox HTTP, gateway RPC, brain sessions, and model routing.
- Route PDF-capable requests only to candidates that advertise `pdf` input, while preserving image capability filtering.
- Convert PDF media into OpenAI file payload shapes for Responses and Chat Completions paths.

## Tests
- `npm run build`
- `npm test -- --run src/agentbox/http-server.test.ts src/core/model-routing.test.ts src/core/brains/pi-agent-brain.test.ts src/gateway/agentbox/client.test.ts src/core/openai-file-payload.test.ts`