### PR TITLE
fix(chat): reject idle steers before persistence

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -866,9 +866,25 @@ describe("http-server — steer / abort / clear-queue", () => {
   it("POST /api/sessions/:id/steer calls brain.steer", async () => {
     await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "st2" });
     const s = sm.sessions.get("st2")!;
+    s.isAgentActive = true;
     const r = await getJson(port, "/api/sessions/st2/steer", "POST", { text: "stop" });
     expect(r.status).toBe(200);
     expect(s.brain.steer).toHaveBeenCalledWith("stop");
+  });
+
+  it("POST /api/sessions/:id/steer rejects idle sessions without queueing", async () => {
+    const s = await sm.getOrCreate("idle-steer");
+    s._promptDone = true;
+    s._promptInflight = null;
+    s.isAgentActive = false;
+    s.isCompacting = false;
+    s.isRetrying = false;
+
+    const r = await getJson(port, "/api/sessions/idle-steer/steer", "POST", { text: "late" });
+
+    expect(r.status).toBe(409);
+    expect(r.data.error.code).toBe("SESSION_IDLE");
+    expect(s.brain.steer).not.toHaveBeenCalled();
   });
 
   it("POST /api/sessions/:id/abort calls brain.abort AND stops the session's background jobs", async () => {
@@ -996,6 +1012,7 @@ describe("http-server — session status (liveness)", () => {
     const r = await getJson(port, "/api/sessions/st1/status");
     expect(r.status).toBe(200);
     expect(r.data.running).toBe(false);
+    expect(r.data.canSteer).toBe(false);
   });
 
   it("returns running:true when any activity flag is set", async () => {
@@ -1007,13 +1024,29 @@ describe("http-server — session status (liveness)", () => {
       const r = await getJson(port, "/api/sessions/st2/status");
       expect(r.status).toBe(200);
       expect(r.data.running).toBe(true);
+      expect(r.data.canSteer).toBe(true);
     }
+  });
+
+  it("returns canSteer:true while the prompt mutex is held before agent_start", async () => {
+    const s = await sm.getOrCreate("prompt-lock");
+    s._promptDone = true;
+    s._promptInflight = new Promise<void>(() => {});
+    s.isAgentActive = false;
+    s.isCompacting = false;
+    s.isRetrying = false;
+
+    const r = await getJson(port, "/api/sessions/prompt-lock/status");
+
+    expect(r.status).toBe(200);
+    expect(r.data).toMatchObject({ running: true, canSteer: true });
   });
 
   it("returns running:false for an unknown (never-created / released) session", async () => {
     const r = await getJson(port, "/api/sessions/ghost/status");
     expect(r.status).toBe(200);
     expect(r.data.running).toBe(false);
+    expect(r.data.canSteer).toBe(false);
   });
 });
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -194,6 +194,18 @@ function sendJson(res: http.ServerResponse, status: number, data: unknown): void
   res.end(JSON.stringify(data));
 }
 
+function sessionActivity(managed: {
+  isAgentActive: boolean;
+  isCompacting: boolean;
+  isRetrying: boolean;
+  _promptDone: boolean;
+  _promptInflight: Promise<void> | null;
+} | undefined): { running: boolean; canSteer: boolean } {
+  const activity = !!managed && (managed.isAgentActive || managed.isCompacting || managed.isRetrying);
+  const promptBusy = !!managed && (!managed._promptDone || !!managed._promptInflight);
+  return { running: activity || promptBusy, canSteer: activity || promptBusy };
+}
+
 const ABORT_ENDPOINT_TIMEOUT_MS = 2_000;
 
 function waitMs(ms: number): Promise<void> {
@@ -902,6 +914,19 @@ export function createHttpServer(
       return;
     }
 
+    const { canSteer } = sessionActivity(managed);
+    if (!canSteer) {
+      sendJson(res, 409, {
+        ok: false,
+        error: {
+          code: "SESSION_IDLE",
+          message: "Session is not running; send a new prompt instead of steering.",
+          retriable: false,
+        },
+      });
+      return;
+    }
+
     console.log(`[agentbox-http] Steering session ${sessionId}: ${body.text.slice(0, 80)}`);
     try {
       await managed.brain.steer(body.text);
@@ -944,17 +969,17 @@ export function createHttpServer(
    * GET /api/sessions/:sessionId/status — explicit liveness for the in-progress turn.
    *
    * Source of truth for "is this session's turn still running" used by the Portal
-   * reconnect-after-refresh flow. MUST be the agentbox's own activity flags, NOT inferred
+   * reconnect-after-refresh flow and for "can this request be a steer". MUST be the
+   * agentbox's own prompt/activity flags, NOT inferred
    * from persisted chat rows: siclaw is end-only persistence, so a turn that is thinking or
    * streaming text with no tool in flight has no "running" row — a row heuristic would miss
    * it and the page would stop following a live turn. A not-yet-created / already-released
-   * session has no managed entry → not running.
+   * session has no managed entry → not running and cannot be steered.
    */
   addRoute("GET", "/api/sessions/:sessionId/status", async (_req, res, params) => {
     const { sessionId } = params;
     const managed = sessionManager.get(sessionId);
-    const running = !!managed && (managed.isAgentActive || managed.isCompacting || managed.isRetrying);
-    sendJson(res, 200, { running });
+    sendJson(res, 200, sessionActivity(managed));
   });
 
   /**

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -241,7 +241,7 @@ export class AgentBoxClient {
    * Liveness of a session's in-progress turn (agentbox activity flags). Used by the Portal
    * reconnect-after-refresh flow to decide whether to re-attach to the live event stream.
    */
-  async sessionStatus(sessionId: string): Promise<{ running: boolean }> {
+  async sessionStatus(sessionId: string): Promise<{ running: boolean; canSteer?: boolean }> {
     const resp = await this.fetch(`/api/sessions/${sessionId}/status`);
     return resp.json();
   }

--- a/src/gateway/server-session-status.test.ts
+++ b/src/gateway/server-session-status.test.ts
@@ -21,18 +21,23 @@ vi.mock("./sse-consumer.js", () => ({
   consumeAgentSse: vi.fn(async () => ({ resultText: "", taskReportText: "", errorMessage: "", eventCount: 0, durationMs: 0 })),
 }));
 
-// sessionStatus behaviour is swapped per-test via this hook.
-let statusImpl: (sessionId: string) => Promise<{ running: boolean }>;
+// sessionStatus / steer behaviour is swapped per-test via these hooks.
+let statusImpl: (sessionId: string) => Promise<{ running: boolean; canSteer?: boolean }>;
+const steerSessionCalls: Array<{ sessionId: string; text: string }> = [];
 vi.mock("./agentbox/client.js", () => ({
   AgentBoxClient: class {
     endpoint: string;
     constructor(endpoint: string) { this.endpoint = endpoint; }
     sessionStatus = vi.fn((sessionId: string) => statusImpl(sessionId));
+    steerSession = vi.fn(async (sessionId: string, text: string) => {
+      steerSessionCalls.push({ sessionId, text });
+    });
     streamEvents = async function* () {};
   },
 }));
 
 const { startRuntime } = await import("./server.js");
+const chatRepo = await import("./chat-repo.js");
 
 function fakeFrontendClient() {
   return { request: vi.fn(async () => ({ found: false })), onCommand: vi.fn(), emitEvent: vi.fn(), close: vi.fn() } as any;
@@ -64,6 +69,7 @@ afterEach(async () => {
   if (server) await server.close();
   server = undefined;
   nextHandle = null;
+  steerSessionCalls.length = 0;
   vi.clearAllMocks();
 });
 
@@ -73,16 +79,16 @@ describe("startRuntime — chat.sessionStatus", () => {
     server = await bootRuntime();
     const status = server.rpcMethods.get("chat.sessionStatus")!;
     const res = await status({ agentId: "a", sessionId: "S" });
-    expect(res).toMatchObject({ ok: true, running: false });
+    expect(res).toMatchObject({ ok: true, running: false, canSteer: false });
   });
 
   it("returns the agentbox running flag when a box exists", async () => {
     nextHandle = { endpoint: "https://fake.internal" };
-    statusImpl = async () => ({ running: true });
+    statusImpl = async () => ({ running: true, canSteer: true });
     server = await bootRuntime();
     const status = server.rpcMethods.get("chat.sessionStatus")!;
     const res = await status({ agentId: "a", sessionId: "S" });
-    expect(res).toMatchObject({ ok: true, running: true });
+    expect(res).toMatchObject({ ok: true, running: true, canSteer: true });
   });
 
   it("fails safe to running:false when the agentbox probe throws", async () => {
@@ -91,12 +97,57 @@ describe("startRuntime — chat.sessionStatus", () => {
     server = await bootRuntime();
     const status = server.rpcMethods.get("chat.sessionStatus")!;
     const res = await status({ agentId: "a", sessionId: "S" });
-    expect(res).toMatchObject({ ok: true, running: false });
+    expect(res).toMatchObject({ ok: true, running: false, canSteer: false });
   });
 
   it("rejects when agentId/sessionId are missing", async () => {
     server = await bootRuntime();
     const status = server.rpcMethods.get("chat.sessionStatus")!;
     await expect(status({ agentId: "a" })).rejects.toThrow(/required/);
+  });
+});
+
+describe("startRuntime — chat.steer liveness", () => {
+  it("returns SESSION_IDLE without spawning or persisting when no box exists", async () => {
+    nextHandle = null;
+    server = await bootRuntime();
+    const steer = server.rpcMethods.get("chat.steer")!;
+
+    const res = await steer({ agentId: "a", sessionId: "S", text: "late" });
+
+    expect(res).toMatchObject({ ok: false, error: { code: "SESSION_IDLE" } });
+    expect(chatRepo.appendMessage).not.toHaveBeenCalled();
+    expect(steerSessionCalls).toHaveLength(0);
+  });
+
+  it("returns SESSION_IDLE without persisting when the session cannot be steered", async () => {
+    nextHandle = { endpoint: "https://fake.internal" };
+    statusImpl = async () => ({ running: false, canSteer: false });
+    server = await bootRuntime();
+    const steer = server.rpcMethods.get("chat.steer")!;
+
+    const res = await steer({ agentId: "a", sessionId: "S", text: "late" });
+
+    expect(res).toMatchObject({ ok: false, error: { code: "SESSION_IDLE" } });
+    expect(chatRepo.appendMessage).not.toHaveBeenCalled();
+    expect(steerSessionCalls).toHaveLength(0);
+  });
+
+  it("accepts steer before persisting and falls back to running for old status payloads", async () => {
+    nextHandle = { endpoint: "https://fake.internal" };
+    statusImpl = async () => ({ running: true });
+    server = await bootRuntime();
+    const steer = server.rpcMethods.get("chat.steer")!;
+
+    const res = await steer({ agentId: "a", sessionId: "S", text: "interrupt" });
+
+    expect(res).toMatchObject({ ok: true });
+    expect(steerSessionCalls).toEqual([{ sessionId: "S", text: "interrupt" }]);
+    expect(chatRepo.appendMessage).toHaveBeenCalledWith({
+      sessionId: "S",
+      role: "user",
+      content: "interrupt",
+      metadata: { kind: "steer" },
+    });
   });
 });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -327,19 +327,33 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const text = params.text as string;
     if (!agentId || !sessionId || !text) throw new Error("agentId, sessionId, text required");
 
-    // Persist the steer as a user message BEFORE injecting it, mirroring
-    // chat.send (L198). Without this the steer only rides the running prompt's
-    // SSE stream and is rendered optimistically by the frontend, but never lands
-    // in chat_messages — so it vanishes on the next history reload. metadata.kind
-    // = "steer" lets the frontend render it as a steer bubble, not a plain user
-    // message. No ensureChatSession: a steer always targets an already-running
-    // session, so the row exists and we must not clobber its title/preview.
+    const handle = await agentBoxManager.getAsync(agentId);
+    if (!handle) {
+      return {
+        ok: false,
+        error: { code: "SESSION_IDLE", message: "Session is not running; send a new prompt instead.", retriable: false },
+      };
+    }
+    const client = new AgentBoxClient(handle.endpoint, 10000, agentBoxTlsOptions);
+    const status = await client.sessionStatus(sessionId);
+    const canSteer = status.canSteer ?? status.running;
+    if (!canSteer) {
+      return {
+        ok: false,
+        error: { code: "SESSION_IDLE", message: "Session is not running; send a new prompt instead.", retriable: false },
+      };
+    }
+
+    await client.steerSession(sessionId, text);
+
+    // Persist only after Runtime accepts the steer. This keeps an idle/raced steer
+    // from becoming a dangling final user row in chat_messages. metadata.kind =
+    // "steer" lets the frontend render it as a steer bubble, not a plain user
+    // message. No ensureChatSession: a steer targets an existing session, so the
+    // row exists and we must not clobber its title/preview.
     await appendMessage({ sessionId, role: "user", content: text, metadata: { kind: "steer" } });
     await incrementMessageCount(sessionId);
 
-    const handle = await agentBoxManager.getOrCreate(agentId);
-    const client = new AgentBoxClient(handle.endpoint, 10000, agentBoxTlsOptions);
-    await client.steerSession(sessionId, text);
     return { ok: true };
   });
 
@@ -364,14 +378,14 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     if (!agentId || !sessionId) throw new Error("agentId, sessionId required");
 
     const handle = await agentBoxManager.getAsync(agentId);
-    if (!handle) return { ok: true, running: false };
+    if (!handle) return { ok: true, running: false, canSteer: false };
     try {
       const client = new AgentBoxClient(handle.endpoint, 10000, agentBoxTlsOptions);
-      const { running } = await client.sessionStatus(sessionId);
-      return { ok: true, running: !!running };
+      const { running, canSteer } = await client.sessionStatus(sessionId);
+      return { ok: true, running: !!running, canSteer: !!(canSteer ?? running) };
     } catch (err: any) {
       console.warn(`[rpc] chat.sessionStatus: agent=${agentId} session=${sessionId} probe failed: ${err?.message ?? err}`);
-      return { ok: true, running: false };
+      return { ok: true, running: false, canSteer: false };
     }
   });
 

--- a/src/portal/chat-gateway.test.ts
+++ b/src/portal/chat-gateway.test.ts
@@ -567,6 +567,31 @@ describe("chat-gateway routes", () => {
       }));
       expect(res._status).toBe(502);
     });
+
+    it("returns 409 when runtime reports an idle steer", async () => {
+      connMap.sendCommand = vi.fn().mockResolvedValue({
+        ok: true,
+        payload: { ok: false, error: { code: "SESSION_IDLE", message: "idle" } },
+      });
+      const res = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/steer",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: { session_id: "s1", text: "x" },
+      }));
+      expect(res._status).toBe(409);
+    });
+
+    it("returns 409 when runtime throws an idle steer error", async () => {
+      connMap.sendCommand = vi.fn().mockResolvedValue({ ok: false, error: "SESSION_IDLE: idle" });
+      const res = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/steer",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: { session_id: "s1", text: "x" },
+      }));
+      expect(res._status).toBe(409);
+    });
   });
 
   // ── chat.abort ───────────────────────────────────────────
@@ -613,13 +638,23 @@ describe("chat-gateway routes", () => {
 
     it("maps payload.running to the response on a new (unowned) session", async () => {
       query.mockResolvedValue([[], []]); // brand-new session → no row → allowed
+      connMap.sendCommand = vi.fn().mockResolvedValue({ ok: true, payload: { running: true, canSteer: true } });
+      const res = await runRoute(router, fakeReq({
+        url, method: "GET", headers: { authorization: `Bearer ${USER_TOKEN}` },
+      }));
+      expect(res._status).toBe(200);
+      expect(JSON.parse(res._body)).toEqual({ running: true, canSteer: true });
+      expect(connMap.sendCommand).toHaveBeenCalledWith("a1", "chat.sessionStatus", expect.objectContaining({ sessionId: "s1" }));
+    });
+
+    it("defaults canSteer from running for older runtime payloads", async () => {
+      query.mockResolvedValue([[], []]);
       connMap.sendCommand = vi.fn().mockResolvedValue({ ok: true, payload: { running: true } });
       const res = await runRoute(router, fakeReq({
         url, method: "GET", headers: { authorization: `Bearer ${USER_TOKEN}` },
       }));
       expect(res._status).toBe(200);
-      expect(JSON.parse(res._body)).toEqual({ running: true });
-      expect(connMap.sendCommand).toHaveBeenCalledWith("a1", "chat.sessionStatus", expect.objectContaining({ sessionId: "s1" }));
+      expect(JSON.parse(res._body)).toEqual({ running: true, canSteer: true });
     });
 
     it("fails safe to running:false when the runtime RPC fails", async () => {
@@ -629,7 +664,7 @@ describe("chat-gateway routes", () => {
         url, method: "GET", headers: { authorization: `Bearer ${USER_TOKEN}` },
       }));
       expect(res._status).toBe(200);
-      expect(JSON.parse(res._body)).toEqual({ running: false });
+      expect(JSON.parse(res._body)).toEqual({ running: false, canSteer: false });
     });
   });
 

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -609,7 +609,12 @@ export function registerChatRoutes(
       userId: auth.userId,
       sessionId: params.sessionId,
     });
-    sendJson(res, 200, { running: result.ok && !!(result.payload as Record<string, unknown> | undefined)?.running });
+    const payload = result.payload as Record<string, unknown> | undefined;
+    const running = result.ok && !!payload?.running;
+    sendJson(res, 200, {
+      running,
+      canSteer: result.ok && !!(payload?.canSteer ?? running),
+    });
   });
 
   // POST /api/v1/siclaw/agents/:id/chat/steer — inject steer message
@@ -629,7 +634,11 @@ export function registerChatRoutes(
       text: promptText,
     });
 
-    sendJson(res, result.ok ? 200 : 502, result);
+    const payload = result.payload as Record<string, unknown> | undefined;
+    const payloadError = payload?.error as Record<string, unknown> | undefined;
+    const idle = result.ok && payload?.ok === false && payloadError?.code === "SESSION_IDLE";
+    const thrownIdle = !result.ok && typeof result.error === "string" && result.error.includes("SESSION_IDLE");
+    sendJson(res, idle || thrownIdle ? 409 : result.ok ? 200 : 502, result);
   });
 
   // POST /api/v1/siclaw/agents/:id/chat/abort — abort current execution


### PR DESCRIPTION
## Summary

- Add an explicit `canSteer` runtime status signal alongside `running`.
- Reject idle steer requests with `SESSION_IDLE` before they reach `brain.steer`.
- Persist steer user messages only after Runtime accepts the steer, avoiding dangling final user rows when the session already ended.
- Map the idle steer contract through Gateway and Portal while preserving compatibility with older status payloads.

## Validation

- `/Users/sdliu/project/improve_siclaw/siclaw/node_modules/.bin/vitest run src/portal/chat-gateway.test.ts src/gateway/server-session-status.test.ts src/agentbox/http-server.test.ts`
- `npm run build`
