### PR TITLE
fix(agentbox): reject invalid native media payloads

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -325,20 +325,45 @@ describe("http-server — prompt + session lifecycle", () => {
     );
   });
 
-  it("POST /api/prompt drops malformed images and rejects when nothing usable remains", async () => {
+  it("POST /api/prompt forwards large valid images to brain.prompt", async () => {
+    const session = await sm.getOrCreate("img-large");
+    const data = "A".repeat(3 * 1024 * 1024);
     const r = await getJson(port, "/api/prompt", "POST", {
-      images: [{ mimeType: "image/gif", data: "aW1n" }], // unsupported mime → dropped
+      sessionId: "img-large",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      modelConfig: modelConfigWithInput(["text", "image"]),
+      images: [{ mimeType: "image/jpeg", data }],
     });
-    expect(r.status).toBe(400);
-    expect(r.data.error).toMatch(/Missing.*text/);
+    expect(r.status).toBe(200);
+    expect(session.brain.prompt).toHaveBeenCalledWith(
+      "Please analyze the attached image.",
+      { images: [{ mimeType: "image/jpeg", data }] },
+    );
   });
 
-  it("POST /api/prompt drops images whose data is not valid base64", async () => {
+  it("POST /api/prompt rejects malformed images instead of dropping them", async () => {
     const r = await getJson(port, "/api/prompt", "POST", {
-      images: [{ mimeType: "image/png", data: "not base64!!!" }], // bad base64 → dropped
+      images: [{ mimeType: "image/gif", data: "aW1n" }],
     });
     expect(r.status).toBe(400);
-    expect(r.data.error).toMatch(/Missing.*text/);
+    expect(r.data.error).toMatch(/images\[0\]\.mimeType/);
+  });
+
+  it("POST /api/prompt rejects images whose data is not valid base64", async () => {
+    const r = await getJson(port, "/api/prompt", "POST", {
+      images: [{ mimeType: "image/png", data: "not base64!!!" }],
+    });
+    expect(r.status).toBe(400);
+    expect(r.data.error).toMatch(/images\[0\]\.data.*base64/);
+  });
+
+  it("POST /api/prompt rejects images that exceed the media item limit", async () => {
+    const r = await getJson(port, "/api/prompt", "POST", {
+      images: [{ mimeType: "image/png", data: "A".repeat(8 * 1024 * 1024 + 4) }],
+    });
+    expect(r.status).toBe(400);
+    expect(r.data.error).toMatch(/images\[0\]\.data exceeds 8 MiB/);
   });
 
   it("POST /api/prompt accepts PDF-only prompts and forwards files to the brain", async () => {
@@ -924,6 +949,17 @@ describe("http-server — steer / abort / clear-queue", () => {
     expect(s.brain.steer).toHaveBeenCalledWith("这个呢", {
       images: [{ mimeType: "image/png", data: "aGVsbG8=" }],
     });
+  });
+
+  it("POST /api/sessions/:id/steer rejects invalid images instead of dropping them", async () => {
+    await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "st-img-invalid" });
+    const s = sm.sessions.get("st-img-invalid")!;
+    const r = await getJson(port, "/api/sessions/st-img-invalid/steer", "POST", {
+      images: [{ mimeType: "image/png", data: "not base64!!!" }],
+    });
+    expect(r.status).toBe(400);
+    expect(r.data.error).toMatch(/images\[0\]\.data.*base64/);
+    expect(s.brain.steer).not.toHaveBeenCalled();
   });
 
   it("POST /api/sessions/:id/steer forwards PDF files to brain.steer", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -320,7 +320,7 @@ async function parseJsonBody(req: http.IncomingMessage): Promise<unknown> {
       if (size > MAX_BODY_SIZE) {
         clearTimeout(timer);
         req.destroy();
-        reject(new HttpRequestError(413, `Body exceeds ${formatBytes(MAX_BODY_SIZE)} byte limit`));
+        reject(new HttpRequestError(413, `Body exceeds ${formatBytes(MAX_BODY_SIZE)} limit`));
         return;
       }
       body += chunk;

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -98,54 +98,153 @@ function enrichAgentEndEvent(brain: BrainSession, event: any): any {
 /**
  * Parse JSON body
  */
-const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_PROMPT_MEDIA_ITEMS = 4;
+const MAX_PROMPT_MEDIA_BASE64_CHARS = 8 * 1024 * 1024;
+const MAX_BODY_SIZE = MAX_PROMPT_MEDIA_ITEMS * MAX_PROMPT_MEDIA_BASE64_CHARS + 512 * 1024;
 const BODY_TIMEOUT_MS = 30_000; // 30s
 const DP_ACTIVATION_MARKER = "[Deep Investigation]\n";
 const DP_EXIT_MARKER = "[DP_EXIT]";
-const MAX_PROMPT_IMAGES = 4;
-const MAX_PROMPT_IMAGE_BASE64_CHARS = 2 * 1024 * 1024;
+const MAX_PROMPT_IMAGES = MAX_PROMPT_MEDIA_ITEMS;
+const MAX_PROMPT_IMAGE_BASE64_CHARS = MAX_PROMPT_MEDIA_BASE64_CHARS;
 const SUPPORTED_PROMPT_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/webp"]);
-const MAX_PROMPT_FILES = 4;
-const MAX_PROMPT_FILE_BASE64_CHARS = 8 * 1024 * 1024;
+const MAX_PROMPT_FILES = MAX_PROMPT_MEDIA_ITEMS;
+const MAX_PROMPT_FILE_BASE64_CHARS = MAX_PROMPT_MEDIA_BASE64_CHARS;
 const SUPPORTED_PROMPT_FILE_MIMES = new Set(["application/pdf"]);
 const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 
-function sanitizePromptImages(raw: unknown): PromptImage[] | undefined {
-  if (!Array.isArray(raw)) return undefined;
-  const out: PromptImage[] = [];
-  for (const item of raw) {
-    if (out.length >= MAX_PROMPT_IMAGES) break;
-    if (!item || typeof item !== "object") continue;
-    const mimeType = (item as { mimeType?: unknown }).mimeType;
-    const data = (item as { data?: unknown }).data;
-    if (typeof mimeType !== "string" || typeof data !== "string") continue;
-    const normalizedMime = mimeType.toLowerCase();
-    if (!SUPPORTED_PROMPT_IMAGE_MIMES.has(normalizedMime)) continue;
-    if (data.length === 0 || data.length > MAX_PROMPT_IMAGE_BASE64_CHARS) continue;
-    if (data.length % 4 !== 0 || !BASE64_RE.test(data)) continue;
-    out.push({ mimeType: normalizedMime, data });
+class HttpRequestError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpRequestError";
   }
-  return out.length > 0 ? out : undefined;
 }
 
-function sanitizePromptFiles(raw: unknown): PromptFile[] | undefined {
-  if (!Array.isArray(raw)) return undefined;
+interface PromptMediaValidationResult<T> {
+  items?: T[];
+  error?: string;
+}
+
+interface PromptMediaValidation {
+  images?: PromptImage[];
+  files?: PromptFile[];
+  error?: string;
+}
+
+function validatePromptMedia(imagesRaw: unknown, filesRaw: unknown): PromptMediaValidation {
+  const imagesResult = validatePromptImages(imagesRaw);
+  if (imagesResult.error) return { error: imagesResult.error };
+
+  const filesResult = validatePromptFiles(filesRaw);
+  if (filesResult.error) return { error: filesResult.error };
+
+  const totalItems = (imagesResult.items?.length ?? 0) + (filesResult.items?.length ?? 0);
+  if (totalItems > MAX_PROMPT_MEDIA_ITEMS) {
+    return { error: `prompt media supports at most ${MAX_PROMPT_MEDIA_ITEMS} item(s)` };
+  }
+
+  return {
+    images: imagesResult.items,
+    files: filesResult.items,
+  };
+}
+
+function validatePromptImages(raw: unknown): PromptMediaValidationResult<PromptImage> {
+  if (raw === undefined || raw === null) return {};
+  if (!Array.isArray(raw)) return { error: "images must be an array" };
+  if (raw.length > MAX_PROMPT_IMAGES) {
+    return { error: `images supports at most ${MAX_PROMPT_IMAGES} item(s)` };
+  }
+
+  const out: PromptImage[] = [];
+  for (const [index, item] of raw.entries()) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return { error: `images[${index}] must be an object` };
+    }
+
+    const mimeType = (item as { mimeType?: unknown }).mimeType;
+    const data = (item as { data?: unknown }).data;
+    if (typeof mimeType !== "string") {
+      return { error: `images[${index}].mimeType must be a string` };
+    }
+    if (typeof data !== "string") {
+      return { error: `images[${index}].data must be a base64 string` };
+    }
+
+    const normalizedMime = normalizePromptImageMime(mimeType);
+    if (!SUPPORTED_PROMPT_IMAGE_MIMES.has(normalizedMime)) {
+      return { error: `images[${index}].mimeType must be one of: image/png, image/jpeg, image/webp` };
+    }
+    const dataError = validateBase64Data(`images[${index}].data`, data, MAX_PROMPT_IMAGE_BASE64_CHARS);
+    if (dataError) return { error: dataError };
+
+    out.push({ mimeType: normalizedMime, data });
+  }
+  return out.length > 0 ? { items: out } : {};
+}
+
+function validatePromptFiles(raw: unknown): PromptMediaValidationResult<PromptFile> {
+  if (raw === undefined || raw === null) return {};
+  if (!Array.isArray(raw)) return { error: "files must be an array" };
+  if (raw.length > MAX_PROMPT_FILES) {
+    return { error: `files supports at most ${MAX_PROMPT_FILES} item(s)` };
+  }
+
   const out: PromptFile[] = [];
-  for (const item of raw) {
-    if (out.length >= MAX_PROMPT_FILES) break;
-    if (!item || typeof item !== "object") continue;
+  for (const [index, item] of raw.entries()) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return { error: `files[${index}] must be an object` };
+    }
+
     const mimeType = (item as { mimeType?: unknown }).mimeType;
     const filename = (item as { filename?: unknown }).filename;
     const data = (item as { data?: unknown }).data;
-    if (typeof mimeType !== "string" || typeof filename !== "string" || typeof data !== "string") continue;
-    const normalizedMime = mimeType.toLowerCase();
-    if (!SUPPORTED_PROMPT_FILE_MIMES.has(normalizedMime)) continue;
-    if (filename.trim() === "") continue;
-    if (data.length === 0 || data.length > MAX_PROMPT_FILE_BASE64_CHARS) continue;
-    if (data.length % 4 !== 0 || !BASE64_RE.test(data)) continue;
+    if (typeof mimeType !== "string") {
+      return { error: `files[${index}].mimeType must be a string` };
+    }
+    if (typeof filename !== "string") {
+      return { error: `files[${index}].filename must be a string` };
+    }
+    if (typeof data !== "string") {
+      return { error: `files[${index}].data must be a base64 string` };
+    }
+
+    const normalizedMime = mimeType.trim().toLowerCase();
+    if (!SUPPORTED_PROMPT_FILE_MIMES.has(normalizedMime)) {
+      return { error: `files[${index}].mimeType must be application/pdf` };
+    }
+    if (filename.trim() === "") {
+      return { error: `files[${index}].filename must not be empty` };
+    }
+    const dataError = validateBase64Data(`files[${index}].data`, data, MAX_PROMPT_FILE_BASE64_CHARS);
+    if (dataError) return { error: dataError };
+
     out.push({ mimeType: normalizedMime, filename: sanitizePromptFilename(filename), data });
   }
-  return out.length > 0 ? out : undefined;
+  return out.length > 0 ? { items: out } : {};
+}
+
+function normalizePromptImageMime(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  return normalized === "image/jpg" ? "image/jpeg" : normalized;
+}
+
+function validateBase64Data(field: string, data: string, maxChars: number): string | undefined {
+  if (data.length === 0) return `${field} must not be empty`;
+  if (data.length > maxChars) {
+    return `${field} exceeds ${formatBytes(maxChars)} base64 character limit`;
+  }
+  if (data.length % 4 !== 0 || !BASE64_RE.test(data)) {
+    return `${field} must be valid base64`;
+  }
+  return undefined;
+}
+
+function formatBytes(value: number): string {
+  const mib = value / (1024 * 1024);
+  return `${Number.isInteger(mib) ? mib : mib.toFixed(1)} MiB`;
 }
 
 function sanitizePromptFilename(value: string): string {
@@ -212,7 +311,7 @@ async function parseJsonBody(req: http.IncomingMessage): Promise<unknown> {
     const timer = setTimeout(() => {
       timedOut = true;
       req.destroy();
-      reject(new Error("Body read timeout"));
+      reject(new HttpRequestError(408, "Body read timeout"));
     }, BODY_TIMEOUT_MS);
 
     req.on("data", (chunk: Buffer | string) => {
@@ -221,7 +320,7 @@ async function parseJsonBody(req: http.IncomingMessage): Promise<unknown> {
       if (size > MAX_BODY_SIZE) {
         clearTimeout(timer);
         req.destroy();
-        reject(new Error(`Body exceeds ${MAX_BODY_SIZE} byte limit`));
+        reject(new HttpRequestError(413, `Body exceeds ${formatBytes(MAX_BODY_SIZE)} byte limit`));
         return;
       }
       body += chunk;
@@ -232,7 +331,7 @@ async function parseJsonBody(req: http.IncomingMessage): Promise<unknown> {
       try {
         resolve(body ? JSON.parse(body) : {});
       } catch (e) {
-        reject(new Error("Invalid JSON"));
+        reject(new HttpRequestError(400, "Invalid JSON"));
       }
     });
     req.on("error", (err) => {
@@ -441,9 +540,12 @@ export function createHttpServer(
   addRoute("POST", "/api/prompt", async (req, res) => {
     const body = (await parseJsonBody(req)) as PromptRequestBody;
 
-    const promptImages = sanitizePromptImages(body.images);
-    const promptFiles = sanitizePromptFiles(body.files);
-    const promptMedia = buildPromptMedia(promptImages, promptFiles);
+    const promptMediaValidation = validatePromptMedia(body.images, body.files);
+    if (promptMediaValidation.error) {
+      sendJson(res, 400, { error: promptMediaValidation.error });
+      return;
+    }
+    const promptMedia = buildPromptMedia(promptMediaValidation.images, promptMediaValidation.files);
 
     // Media-only messages are valid; reject only when there is neither text nor
     // usable image/PDF media after validation.
@@ -967,9 +1069,12 @@ export function createHttpServer(
     }
 
     const body = (await parseJsonBody(req)) as { text?: string; images?: PromptImage[]; files?: PromptFile[] };
-    const promptImages = sanitizePromptImages(body.images);
-    const promptFiles = sanitizePromptFiles(body.files);
-    const promptMedia = buildPromptMedia(promptImages, promptFiles);
+    const promptMediaValidation = validatePromptMedia(body.images, body.files);
+    if (promptMediaValidation.error) {
+      sendJson(res, 400, { error: promptMediaValidation.error });
+      return;
+    }
+    const promptMedia = buildPromptMedia(promptMediaValidation.images, promptMediaValidation.files);
     if (!body.text && !promptMedia) {
       sendJson(res, 400, { error: "Missing 'text' field" });
       return;
@@ -1371,6 +1476,14 @@ export function createHttpServer(
       try {
         await route.handler(req, res, params);
       } catch (err) {
+        if (err instanceof HttpRequestError) {
+          console.warn(`[agentbox-http] Rejected ${method} ${pathname}: ${err.message}`);
+          if (!res.headersSent) {
+            sendJson(res, err.status, { error: err.message });
+          }
+          return;
+        }
+
         console.error(`[agentbox-http] Error handling ${method} ${pathname}:`, err);
         if (!res.headersSent) {
           sendJson(res, 500, { error: "Internal server error" });


### PR DESCRIPTION
## Summary
AgentBox now validates native image/PDF prompt media instead of silently dropping malformed or oversized blocks. Valid images up to the media item limit are forwarded to the brain, while invalid media receives a clear 400 response.

## Problem
The prompt media sanitizer skipped unsupported, invalid, or oversized image blocks and continued with the remaining text. That made media-only or media-dependent prompts look like plain text prompts when the image was not forwarded.

## Solution
- Align AgentBox media/body limits with the four-attachment prompt contract.
- Replace silent media skipping with explicit validation errors.
- Return clear request errors for malformed JSON, body timeouts, and oversized bodies.
- Cover large valid images and invalid media for prompt/steer requests.

## Compatibility Notes
- The media cap is intentional: image items now use the same 8 MiB base64 ceiling as PDF items, and the JSON body limit allows up to four media items plus request overhead. This is an AgentBox ingress ceiling; provider-specific media limits may still be lower and will surface as provider errors instead of being hidden by a silent drop.
- Invalid media is now a hard request error for `/api/prompt` and `/api/sessions/:id/steer`. Non-frontend clients that previously sent unsupported or malformed media alongside text should now fix the payload instead of relying on lenient drop-and-continue behavior.

## Test Plan
- [x] `npm test -- --run src/agentbox/http-server.test.ts`
- [x] `npm run build`
