### PR TITLE
feat(tools): per-agent tool capabilities via capability groups

### DIFF
--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -17,7 +17,10 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
-# Copy backend source only (AgentBox + core + tools + minimal gateway modules)
+# Copy backend source only (AgentBox runtime graph: agentbox-main + core + tools).
+# Gateway code (spawners, security, db) is intentionally NOT built here — the
+# agentbox image runs only agentbox-main.ts, which never imports src/gateway/*.
+# Those modules are compiled in the runtime/portal images instead.
 COPY tsconfig.json tsconfig.agentbox.json ./
 COPY src/agentbox-main.ts ./src/
 COPY src/agentbox/ ./src/agentbox/
@@ -26,10 +29,6 @@ COPY src/cron/ ./src/cron/
 COPY src/memory/ ./src/memory/
 COPY src/shared/ ./src/shared/
 COPY src/tools/ ./src/tools/
-COPY src/gateway/config.ts src/gateway/jwt.ts \
-     src/gateway/metrics-aggregator.ts src/gateway/ws-protocol.ts ./src/gateway/
-COPY src/gateway/agentbox/ ./src/gateway/agentbox/
-COPY src/gateway/security/ ./src/gateway/security/
 # Type-only file consumed by core/agent-factory.ts and core/extensions/* —
 # keeps Portal runtime code (db, rest-router) out of the agentbox tsc graph.
 COPY src/portal/cli-snapshot-types.ts ./src/portal/

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -421,7 +421,6 @@ interface ToolEntry {
   category: "cmd-exec" | "script-exec" | "query" | "workflow";
   create: (refs: ToolRefs) => ToolDefinition;
   modes?: SessionMode[];      // omit = all modes
-  platform?: boolean;          // exempt from allowedTools filtering
   available?: (refs: ToolRefs) => boolean;  // runtime guard
 }
 ```
@@ -436,14 +435,41 @@ Conditions are declared in each tool's `registration`, not in agent-factory:
 | `skill_preview` | `modes` | `["web", "channel"]` | Reads draft files from disk, renders side panel |
 | `memory_search`, `memory_get` | `available` | `(refs) => !!refs.memoryIndexer` | Depends on indexer instance |
 
-### Platform Tool Exemption
+### allowedTools — Sole Availability Axis
 
-Tools with `platform: true` (`manage_schedule`, `credential_list`,
-`cluster_list`, `save_feedback`) are exempt from workspace
-allow-list filtering — they must always be available regardless of workspace
-configuration. This is declared in each tool's registration, not in a central set.
+`allowedTools` is the only control over tool availability after mode/`available`
+filtering — there are no exemptions. A `null`/omitted `allowedTools` passes every
+tool through (the default); a non-null array passes only the tools it names.
+
+**Per-agent source**: `allowedTools` is resolved from the agent's selected
+capability groups (`agents.tool_capabilities`) at the Gateway boundary
+(`resolveCapabilities`); null/empty selection → `null` = unrestricted. Every tool
+in the registry must belong to some `CAPABILITY_GROUPS` entry, otherwise a
+restricted agent can never reach it — enforced by `tool-capabilities-coverage.test.ts`.
+
+**Global-whitelist caveat**: when a per-agent selection is null, agent-factory
+falls back to the global `config.allowedTools`. With the `platform` exemption
+removed, a deployment that set a *non-null* global whitelist no longer gets the
+former always-on tools (task/memory/schedule/spawn) for free — they are filtered
+unless explicitly listed. The default global is `null`, so existing agents are
+unaffected; only a deployment that opted into a global whitelist must revisit it.
+
+**Initial-fetch failure is fail-open (reviewed policy)**: the per-pod
+tool-capabilities fetch (K8s `agentbox-main.ts`, awaited before `listen` with
+retries) and the spawn-time DB read (Local `local-spawner.ts`) both start the box
+**unrestricted** on unrecoverable error, with a loud warn. Rationale: a fresh box
+has no prior whitelist to preserve, and a failed fetch usually signals broader
+gateway unreachability (skills/MCP can't sync either), so failing open keeps the
+box serviceable rather than bricking it. The reload-PUSH path is *not* fail-open —
+it preserves the prior whitelist on failure. Fail-closed hardening (refuse first
+turn until resolved) is tracked as a separate follow-up.
 
 ### Tools Not in Registry
+
+Both categories are appended after `resolve()` but are still subject to the same
+`allowedTools` name-based whitelist (a non-null `allowedTools` filters them; `null`
+passes all). They carry no `mode`/`available` metadata, so `allowedTools` is their
+sole availability gate.
 
 - **MCP tools**: dynamically discovered at runtime, appended after resolve
 - **File I/O tools** (read/edit/write/grep/find/ls): framework tools with

--- a/portal-web/src/components/AgentSettings.tsx
+++ b/portal-web/src/components/AgentSettings.tsx
@@ -4,6 +4,8 @@ import { api } from "../api"
 import { useToast } from "./toast"
 import { AgentTasks } from "./AgentTasks"
 import { AgentApiKeys } from "./AgentApiKeys"
+import { CapabilityGroupSelector } from "./CapabilityGroupSelector"
+import { toCapabilitySet } from "../lib/toolCapabilities"
 
 interface Agent {
   id: string; name: string; description: string; status: string
@@ -11,6 +13,10 @@ interface Agent {
   is_production: boolean; icon: string; color: string; created_at: string
   model_routing?: unknown
   idle_timeout_sec?: number
+  // Wire form: the raw `agents` TEXT column — a JSON string ('["read_files"]')
+  // or null, not a decoded array (mirrors model_routing). toCapabilitySet
+  // coerces both forms.
+  tool_capabilities?: string | string[] | null
 }
 
 interface AgentResources {
@@ -41,6 +47,7 @@ const ROUTE_COOLDOWN_LABEL = "by condition"
 const TABS = [
   { key: "basic", label: "Basic" },
   { key: "model", label: "Model" },
+  { key: "tools", label: "Tools" },
   { key: "skills", label: "Skills" },
   { key: "mcp", label: "MCP" },
   { key: "knowledge", label: "Knowledge" },
@@ -165,6 +172,7 @@ export function AgentSettings({ agent, onUpdate, initialTab }: AgentSettingsProp
   const [systemPrompt, setSystemPrompt] = useState(agent.system_prompt || "")
   const [isProduction, setIsProduction] = useState(agent.is_production)
   const [idleTimeoutSec, setIdleTimeoutSec] = useState<number>(agent.idle_timeout_sec ?? 300)
+  const [selectedCapabilities, setSelectedCapabilities] = useState<Set<string>>(toCapabilitySet(agent.tool_capabilities))
 
   // ── Data ──
   const [providers, setProviders] = useState<Provider[]>([])
@@ -196,6 +204,7 @@ export function AgentSettings({ agent, onUpdate, initialTab }: AgentSettingsProp
     setFallbackCandidates(normalizeRouteCandidates(modelRouting, agent.model_provider || "", agent.model_id || ""))
     setSystemPrompt(agent.system_prompt || ""); setIsProduction(agent.is_production)
     setIdleTimeoutSec(agent.idle_timeout_sec ?? 300)
+    setSelectedCapabilities(toCapabilitySet(agent.tool_capabilities))
   }, [agent])
 
   // Load data
@@ -251,7 +260,7 @@ export function AgentSettings({ agent, onUpdate, initialTab }: AgentSettingsProp
     try {
       const updated = await api<Agent>(`/agents/${agent.id}`, {
         method: "PUT",
-        body: { name: name.trim(), description: description.trim(), model_provider: modelProvider.trim(), model_id: modelId.trim(), model_routing: routingEnabled ? modelRouting : null, system_prompt: systemPrompt.trim(), is_production: isProduction, idle_timeout_sec: Number.isFinite(idleTimeoutSec) ? idleTimeoutSec : 300 },
+        body: { name: name.trim(), description: description.trim(), model_provider: modelProvider.trim(), model_id: modelId.trim(), model_routing: routingEnabled ? modelRouting : null, system_prompt: systemPrompt.trim(), is_production: isProduction, idle_timeout_sec: Number.isFinite(idleTimeoutSec) ? idleTimeoutSec : 300, tool_capabilities: Array.from(selectedCapabilities) },
       })
       await api(`/agents/${agent.id}/resources`, {
         method: "PUT",
@@ -265,7 +274,7 @@ export function AgentSettings({ agent, onUpdate, initialTab }: AgentSettingsProp
   }
 
   // Tabs that need the Save button
-  const saveTabs: TabKey[] = ["basic", "model", "skills", "mcp", "knowledge", "resources", "channels"]
+  const saveTabs: TabKey[] = ["basic", "model", "tools", "skills", "mcp", "knowledge", "resources", "channels"]
   const showSave = saveTabs.includes(activeTab)
 
   return (
@@ -303,6 +312,15 @@ export function AgentSettings({ agent, onUpdate, initialTab }: AgentSettingsProp
       <div className="flex-1 overflow-auto">
         {activeTab === "basic" && <BasicTab name={name} setName={setName} description={description} setDescription={setDescription} systemPrompt={systemPrompt} setSystemPrompt={setSystemPrompt} isProduction={isProduction} setIsProduction={setIsProduction} idleTimeoutSec={idleTimeoutSec} setIdleTimeoutSec={setIdleTimeoutSec} />}
         {activeTab === "model" && <ModelTab providers={providers} modelProvider={modelProvider} setModelProvider={setModelProvider} modelId={modelId} setModelId={setModelId} availableModels={availableModels} routingEnabled={routingEnabled} setRoutingEnabled={setRoutingEnabled} fallbackCandidates={fallbackCandidates} setFallbackCandidates={setFallbackCandidates} />}
+        {activeTab === "tools" && (
+          <div className="px-6 py-6 space-y-4 max-w-2xl">
+            <div>
+              <h3 className="text-[13px] font-medium text-foreground">Tool capabilities</h3>
+              <p className="text-[12px] text-muted-foreground mt-0.5">Restrict which built-in tools this agent can use. Changes apply live — the running agent reloads on save.</p>
+            </div>
+            <CapabilityGroupSelector selected={selectedCapabilities} onChange={setSelectedCapabilities} />
+          </div>
+        )}
         {activeTab === "skills" && <SkillsTab allSkills={allSkills} selectedSkillIds={selectedSkillIds} setSelectedSkillIds={setSelectedSkillIds} skillLabelFilter={skillLabelFilter} setSkillLabelFilter={setSkillLabelFilter} isProduction={isProduction} loading={loadingSkills || loadingResources} />}
         {activeTab === "mcp" && <McpTab allMcpServers={allMcpServers} selectedMcpIds={selectedMcpIds} setSelectedMcpIds={setSelectedMcpIds} loading={loadingMcp || loadingResources} />}
         {activeTab === "knowledge" && <KnowledgeTab allRepos={allKnowledgeRepos} selectedIds={selectedKnowledgeRepoIds} setSelectedIds={setSelectedKnowledgeRepoIds} loading={loadingKnowledge || loadingResources} />}

--- a/portal-web/src/components/CapabilityGroupSelector.test.tsx
+++ b/portal-web/src/components/CapabilityGroupSelector.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+import { CapabilityGroupSelector } from "./CapabilityGroupSelector"
+import { CAPABILITY_GROUPS } from "../lib/toolCapabilities"
+
+// portal-web ships neither @testing-library/react nor a DOM environment
+// (jsdom/happy-dom), so we cannot dispatch click/change events to exercise the
+// toggle / Select All / Clear onChange callbacks here. Those handlers are thin
+// Set operations over `selected`; rather than re-derive them in the test, we
+// assert the component's *render contract* against react-dom/server (already a
+// dependency): banner state, group/tool counts, and per-group checkbox
+// reflection — everything that is a pure function of the `selected` prop.
+// Adding a DOM env to cover the callbacks would mean a new dependency, which
+// this phase explicitly avoids.
+
+const render = (selected: Set<string>) =>
+  renderToStaticMarkup(<CapabilityGroupSelector selected={selected} onChange={() => {}} />)
+
+// A controlled checkbox renders `checked=""` in static markup; count them to
+// verify the box state reflects `selected` exactly.
+const countChecked = (html: string) => (html.match(/checked=""/g) || []).length
+
+// react-dom/server HTML-escapes text nodes (e.g. "&" → "&amp;"); match the
+// escaped form when asserting label text.
+const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+
+describe("CapabilityGroupSelector — render contract", () => {
+  it("shows the Unrestricted banner and no checked boxes for an empty selection", () => {
+    const html = render(new Set())
+    expect(html).toContain("Unrestricted")
+    expect(html).not.toContain("Restricted")
+    expect(html).toContain("agent can use ALL tools")
+    expect(html).toContain("Capability groups (0 / 10)")
+    expect(countChecked(html)).toBe(0)
+  })
+
+  it("shows the Restricted banner with the singular group label + tool count", () => {
+    const html = render(new Set(["read_files"]))
+    expect(html).toContain("Restricted")
+    expect(html).not.toContain("Unrestricted")
+    // read_files grants 4 tools; "1 group" must be singular.
+    expect(html).toContain("1 group · 4 tools")
+    expect(html).toContain("Capability groups (1 / 10)")
+    expect(countChecked(html)).toBe(1)
+  })
+
+  it("pluralizes groups and sums the deduped tool count for a multi-group selection", () => {
+    const html = render(new Set(["read_files", "run_commands"]))
+    // 4 + 4 distinct tools, plural "groups".
+    expect(html).toContain("2 groups · 8 tools")
+    expect(html).toContain("Capability groups (2 / 10)")
+    expect(countChecked(html)).toBe(2)
+  })
+
+  it("checks every box and reports all groups when the full set is selected", () => {
+    const all = new Set(CAPABILITY_GROUPS.map((g) => g.key))
+    const html = render(all)
+    expect(html).toContain(`Capability groups (${CAPABILITY_GROUPS.length} / ${CAPABILITY_GROUPS.length})`)
+    expect(html).toContain(`${CAPABILITY_GROUPS.length} groups`)
+    expect(countChecked(html)).toBe(CAPABILITY_GROUPS.length)
+  })
+
+  it("renders every group's name, description and tool chips", () => {
+    const html = render(new Set())
+    for (const g of CAPABILITY_GROUPS) {
+      expect(html).toContain(esc(g.name))
+      expect(html).toContain(esc(g.description))
+      for (const tool of g.tools) {
+        expect(html).toContain(`>${tool}<`)
+      }
+    }
+  })
+
+  it("states the MCP-exemption rule", () => {
+    const html = render(new Set())
+    expect(html).toContain("MCP server tools are controlled separately")
+  })
+})

--- a/portal-web/src/components/CapabilityGroupSelector.tsx
+++ b/portal-web/src/components/CapabilityGroupSelector.tsx
@@ -1,0 +1,88 @@
+import { ShieldCheck, Globe } from "lucide-react"
+import { CAPABILITY_GROUPS, countToolsForSelection } from "../lib/toolCapabilities"
+
+/**
+ * Reusable capability-group multi-select. Used in both the agent create dialog
+ * and the agent edit page (Tools tab).
+ *
+ * Backend semantics: an EMPTY selection means "unrestricted — all tools". The
+ * banner makes that explicit so an empty checkbox list is not mistaken for
+ * "no tools". A non-empty selection restricts the agent to the union of the
+ * selected groups' tools.
+ */
+export function CapabilityGroupSelector({
+  selected,
+  onChange,
+}: {
+  selected: Set<string>
+  onChange: (next: Set<string>) => void
+}) {
+  const restricted = selected.size > 0
+  const toolCount = countToolsForSelection(selected)
+  const allSelected = selected.size === CAPABILITY_GROUPS.length
+
+  const toggle = (key: string) => {
+    const next = new Set(selected)
+    next.has(key) ? next.delete(key) : next.add(key)
+    onChange(next)
+  }
+  const selectAll = () => onChange(new Set(CAPABILITY_GROUPS.map((g) => g.key)))
+  const clear = () => onChange(new Set())
+
+  return (
+    <div className="space-y-3">
+      {/* Effective-state banner — teaches the empty = unrestricted rule */}
+      {restricted ? (
+        <div className="flex items-start gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2">
+          <ShieldCheck className="h-4 w-4 text-primary mt-0.5 shrink-0" />
+          <div className="text-[12px]">
+            <span className="font-medium text-foreground">Restricted</span>
+            <span className="text-muted-foreground"> — {selected.size} group{selected.size > 1 ? "s" : ""} · {toolCount} tools. Everything else (except MCP) is blocked.</span>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2">
+          <Globe className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
+          <div className="text-[12px]">
+            <span className="font-medium text-foreground">Unrestricted</span>
+            <span className="text-muted-foreground"> — agent can use ALL tools (default). Select groups below to restrict it.</span>
+          </div>
+        </div>
+      )}
+
+      {/* Bulk actions */}
+      <div className="flex items-center justify-between">
+        <span className="text-[12px] text-muted-foreground font-medium">Capability groups ({selected.size} / {CAPABILITY_GROUPS.length})</span>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={selectAll} disabled={allSelected} className="h-7 px-2 text-[11px] rounded border border-border text-muted-foreground hover:text-foreground disabled:opacity-40">Select All</button>
+          <button type="button" onClick={clear} disabled={!restricted} className="h-7 px-2 text-[11px] rounded border border-border text-muted-foreground hover:text-foreground disabled:opacity-40">Clear (unrestricted)</button>
+        </div>
+      </div>
+
+      {/* Group checkbox list */}
+      <div className="max-h-[52vh] overflow-auto border border-border rounded-md divide-y divide-border">
+        {CAPABILITY_GROUPS.map((g) => {
+          const checked = selected.has(g.key)
+          return (
+            <label key={g.key} className="flex items-start gap-2.5 px-3 py-2.5 hover:bg-secondary/30 cursor-pointer">
+              <input type="checkbox" checked={checked} onChange={() => toggle(g.key)} className="rounded mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <span className="text-[12px] font-medium text-foreground">{g.name}</span>
+                <p className="text-[11px] text-muted-foreground">{g.description}</p>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {g.tools.map((t) => (
+                    <span key={t} className="px-1 py-0.5 rounded text-[9px] font-mono bg-secondary text-muted-foreground">{t}</span>
+                  ))}
+                </div>
+              </div>
+            </label>
+          )
+        })}
+      </div>
+
+      <p className="text-[11px] text-muted-foreground">
+        MCP server tools are controlled separately (per-agent MCP bindings) and are never blocked by these groups.
+      </p>
+    </div>
+  )
+}

--- a/portal-web/src/lib/toolCapabilities.test.ts
+++ b/portal-web/src/lib/toolCapabilities.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest"
+import {
+  CAPABILITY_GROUPS,
+  countToolsForSelection,
+  toCapabilitySet,
+} from "./toolCapabilities"
+
+const KNOWN_KEYS = CAPABILITY_GROUPS.map((g) => g.key)
+
+describe("CAPABILITY_GROUPS shape", () => {
+  it("declares exactly the 10 designed groups", () => {
+    expect(CAPABILITY_GROUPS).toHaveLength(10)
+    expect([...KNOWN_KEYS].sort()).toEqual([
+      "inspect_infra",
+      "plan_tasks",
+      "read_files",
+      "run_commands",
+      "run_scripts",
+      "scheduling",
+      "search_memory",
+      "session_output",
+      "spawn_subagents",
+      "write_sandbox",
+    ])
+  })
+
+  it("has unique group keys", () => {
+    expect(new Set(KNOWN_KEYS).size).toBe(KNOWN_KEYS.length)
+  })
+
+  it("gives every group a non-empty, internally-unique tool list, a name and a description", () => {
+    for (const g of CAPABILITY_GROUPS) {
+      expect(g.tools.length).toBeGreaterThan(0)
+      expect(new Set(g.tools).size).toBe(g.tools.length)
+      expect(g.name.trim()).not.toBe("")
+      expect(g.description.trim()).not.toBe("")
+    }
+  })
+
+  it("assigns each tool to exactly one group (no cross-group overlap)", () => {
+    const all = CAPABILITY_GROUPS.flatMap((g) => g.tools)
+    expect(new Set(all).size).toBe(all.length)
+  })
+})
+
+describe("toCapabilitySet", () => {
+  it("returns an empty Set for null / undefined / non-array, non-string values", () => {
+    expect(toCapabilitySet(null).size).toBe(0)
+    expect(toCapabilitySet(undefined).size).toBe(0)
+    expect(toCapabilitySet(123).size).toBe(0)
+    expect(toCapabilitySet({}).size).toBe(0)
+    expect(toCapabilitySet(true).size).toBe(0)
+  })
+
+  it("accepts an already-parsed array of known keys", () => {
+    expect(toCapabilitySet(["read_files", "run_commands"])).toEqual(
+      new Set(["read_files", "run_commands"]),
+    )
+  })
+
+  it("filters unknown keys and non-string entries out of an array", () => {
+    expect(toCapabilitySet(["read_files", "does_not_exist", 42, null, "scheduling"])).toEqual(
+      new Set(["read_files", "scheduling"]),
+    )
+  })
+
+  it("parses the raw JSON-string wire form (GET returns TEXT, not an array)", () => {
+    // Regression: the portal API returns tool_capabilities as the raw TEXT
+    // column — a JSON string, not a decoded array. Echo must still work.
+    expect(toCapabilitySet('["read_files","run_commands"]')).toEqual(
+      new Set(["read_files", "run_commands"]),
+    )
+  })
+
+  it("filters unknown keys out of the JSON-string form too", () => {
+    expect(toCapabilitySet('["read_files","ghost"]')).toEqual(new Set(["read_files"]))
+  })
+
+  it("returns an empty Set for a malformed JSON string", () => {
+    expect(toCapabilitySet("not json").size).toBe(0)
+    expect(toCapabilitySet("[unterminated").size).toBe(0)
+  })
+
+  it("returns an empty Set when a JSON string parses to a non-array", () => {
+    expect(toCapabilitySet('"read_files"').size).toBe(0)
+    expect(toCapabilitySet("123").size).toBe(0)
+    expect(toCapabilitySet("null").size).toBe(0)
+    expect(toCapabilitySet('{"read_files":true}').size).toBe(0)
+  })
+
+  it("treats an empty selection (array or JSON string) as the empty Set", () => {
+    expect(toCapabilitySet([]).size).toBe(0)
+    expect(toCapabilitySet("[]").size).toBe(0)
+  })
+})
+
+describe("countToolsForSelection", () => {
+  it("is 0 for an empty selection", () => {
+    expect(countToolsForSelection(new Set())).toBe(0)
+  })
+
+  it("counts a single group's tools", () => {
+    expect(countToolsForSelection(new Set(["read_files"]))).toBe(4)
+    expect(countToolsForSelection(new Set(["scheduling"]))).toBe(1)
+  })
+
+  it("counts the deduped union across multiple groups", () => {
+    // read_files (4) + search_memory (2), no shared tools → 6 distinct.
+    expect(countToolsForSelection(new Set(["read_files", "search_memory"]))).toBe(6)
+  })
+
+  it("ignores unknown keys in the selection", () => {
+    expect(countToolsForSelection(new Set(["read_files", "ghost"]))).toBe(4)
+    expect(countToolsForSelection(new Set(["ghost"]))).toBe(0)
+  })
+
+  it("counts every distinct built-in tool when all groups are selected", () => {
+    const all = countToolsForSelection(new Set(KNOWN_KEYS))
+    const distinct = new Set(CAPABILITY_GROUPS.flatMap((g) => g.tools)).size
+    expect(all).toBe(distinct)
+    // Groups never share a tool, so the union equals the simple sum.
+    const sum = CAPABILITY_GROUPS.reduce((n, g) => n + g.tools.length, 0)
+    expect(all).toBe(sum)
+  })
+})

--- a/portal-web/src/lib/toolCapabilities.ts
+++ b/portal-web/src/lib/toolCapabilities.ts
@@ -1,0 +1,67 @@
+// Frontend catalog of tool capability groups, mirroring the backend
+// CAPABILITY_GROUPS in src/core/tool-capabilities.ts. The backend is the source
+// of truth for the resolution; this copy only adds human-readable labels +
+// descriptions for the UI. The `tools` arrays must stay in sync with the
+// backend (capability groups are stable code constants — update both together).
+//
+// Semantics (backend): an agent stores the selected group KEYS in its
+// `tool_capabilities` field. null / empty = unrestricted (all tools, the
+// backward-compatible default). A non-null, non-empty selection restricts the
+// agent to the union of those groups' tools. MCP tools are exempt (governed by
+// the agent_mcp_servers binding).
+
+export interface CapabilityGroup {
+  key: string
+  name: string
+  description: string
+  tools: string[]
+}
+
+export const CAPABILITY_GROUPS: CapabilityGroup[] = [
+  { key: "read_files", name: "Read files", description: "Read & search files and knowledge pages", tools: ["read", "grep", "find", "ls"] },
+  { key: "write_sandbox", name: "Write & author skills", description: "Write/edit scratch files and author skills (sandboxed to user-data)", tools: ["write", "edit", "skill_preview"] },
+  { key: "inspect_infra", name: "Inspect infrastructure", description: "Read-only probes of clusters and hosts", tools: ["cluster_list", "cluster_probe", "host_list", "resolve_pod_netns"] },
+  { key: "run_commands", name: "Run commands", description: "Execute whitelisted shell commands (kubectl read-only)", tools: ["bash", "node_exec", "pod_exec", "host_exec"] },
+  { key: "run_scripts", name: "Run scripts", description: "Execute scripts on node / pod / host", tools: ["node_script", "pod_script", "local_script", "host_script"] },
+  { key: "search_memory", name: "Search memory", description: "Semantic search over long-term memory", tools: ["memory_search", "memory_get"] },
+  { key: "plan_tasks", name: "Plan tasks", description: "Create and track a task ledger", tools: ["task_create", "task_update", "task_list", "task_get"] },
+  { key: "spawn_subagents", name: "Spawn sub-agents", description: "Fan out work to sub-agents (privilege amplification)", tools: ["spawn_subagent", "task_output", "job_stop"] },
+  { key: "scheduling", name: "Scheduling", description: "Manage scheduled / recurring runs", tools: ["manage_schedule"] },
+  { key: "session_output", name: "Session output", description: "Report findings, post channel updates & submit feedback", tools: ["task_report", "save_feedback", "channel_update"] },
+]
+
+/** Total distinct tools across the selected group keys (for the UI summary). */
+export function countToolsForSelection(selected: Set<string>): number {
+  const tools = new Set<string>()
+  for (const g of CAPABILITY_GROUPS) {
+    if (selected.has(g.key)) g.tools.forEach((t) => tools.add(t))
+  }
+  return tools.size
+}
+
+/**
+ * Coerce a stored tool_capabilities value to a Set of known group keys.
+ *
+ * The agent REST API decodes JSON-in-TEXT columns (agent-api `decodeAgentRow`),
+ * so `tool_capabilities` normally arrives as a decoded array. This coercer stays
+ * tolerant of the raw JSON-string form too — defense in depth against any path
+ * that hasn't been decoded (and the historical bug it fixed: an undecoded string
+ * made the edit page echo "unrestricted", which a save would then persist,
+ * wiping the restriction). Accept both the wire-string and already-parsed array.
+ * Unknown / malformed values degrade to an empty Set — this is a
+ * tolerant boundary coercion (signature is `unknown`), so a bad DB value must
+ * not crash the render; the swallowed parse error is intentional here.
+ */
+export function toCapabilitySet(value: unknown): Set<string> {
+  let parsed: unknown = value
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      return new Set()
+    }
+  }
+  if (!Array.isArray(parsed)) return new Set()
+  const known = new Set(CAPABILITY_GROUPS.map((g) => g.key))
+  return new Set(parsed.filter((k): k is string => typeof k === "string" && known.has(k)))
+}

--- a/portal-web/src/pages/Agents.tsx
+++ b/portal-web/src/pages/Agents.tsx
@@ -6,6 +6,7 @@ import { useToast } from "../components/toast"
 import { Tooltip } from "../components/tooltip"
 import { useConfirm } from "../components/confirm-dialog"
 import { buildChatPath, chatSessionForAgent } from "../lib/chatSelection"
+import { CapabilityGroupSelector } from "../components/CapabilityGroupSelector"
 
 interface Agent {
   id: string; name: string; description: string; status: string
@@ -26,7 +27,8 @@ export function Agents() {
   const [providers, setProviders] = useState<Provider[]>([])
   const [loading, setLoading] = useState(true)
   const [showCreate, setShowCreate] = useState(false)
-  const [form, setForm] = useState({ name: "", description: "", model_provider: "", model_id: "", is_production: true })
+  const [form, setForm] = useState({ name: "", description: "", model_provider: "", model_id: "", is_production: true, tool_capabilities: [] as string[] })
+  const [restrictTools, setRestrictTools] = useState(false)
   const [creating, setCreating] = useState(false)
   const navigate = useNavigate()
   const toast = useToast()
@@ -49,7 +51,8 @@ export function Agents() {
       const a = await api<Agent>("/agents", { method: "POST", body: form })
       setAgents((prev) => [...prev, a])
       setShowCreate(false)
-      setForm({ name: "", description: "", model_provider: "", model_id: "", is_production: true })
+      setRestrictTools(false)
+      setForm({ name: "", description: "", model_provider: "", model_id: "", is_production: true, tool_capabilities: [] })
     } catch (err: any) { toast.error(err.message) } finally { setCreating(false) }
   }
 
@@ -102,7 +105,8 @@ export function Agents() {
       </div>
 
       {showCreate && (
-        <div className="mx-6 my-4 p-4 rounded-lg border border-border bg-card space-y-4">
+        <div className="mx-6 my-4 rounded-lg border border-border bg-card flex flex-col max-h-[calc(100vh-120px)]">
+          <div className="p-4 space-y-4 overflow-y-auto">
           <div>
             <label className="block text-sm font-medium mb-1">Agent Name</label>
             <input placeholder="e.g. sre-copilot" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background" />
@@ -152,9 +156,36 @@ export function Agents() {
               <p className="text-xs text-muted-foreground">Production agents only receive approved skills and can only access production clusters/hosts. Dev agents see draft skills and dev resources.</p>
             </div>
           </div>
-          <div className="flex gap-2">
+          <div>
+            <div className="flex items-start gap-3">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={restrictTools}
+                onClick={() => {
+                  const next = !restrictTools
+                  setRestrictTools(next)
+                  if (!next) setForm({ ...form, tool_capabilities: [] })
+                }}
+                className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors mt-0.5 ${restrictTools ? "bg-primary" : "bg-muted"}`}
+              >
+                <span className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${restrictTools ? "translate-x-4" : "translate-x-0"}`} />
+              </button>
+              <div>
+                <label className="block text-sm font-medium">Restrict tool access</label>
+                <p className="text-xs text-muted-foreground">Off = full access to all built-in tools (default). On = pick capability groups. Editable later under the agent's Tools tab.</p>
+              </div>
+            </div>
+            {restrictTools && (
+              <div className="mt-3">
+                <CapabilityGroupSelector selected={new Set(form.tool_capabilities)} onChange={(next) => setForm({ ...form, tool_capabilities: Array.from(next) })} />
+              </div>
+            )}
+          </div>
+          </div>
+          <div className="flex gap-2 p-4 border-t border-border shrink-0">
             <button onClick={handleCreate} disabled={creating || !form.name} className="h-8 px-4 text-sm rounded-md bg-primary text-primary-foreground disabled:opacity-50">{creating ? "..." : "Create"}</button>
-            <button onClick={() => setShowCreate(false)} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
+            <button onClick={() => { setShowCreate(false); setRestrictTools(false); setForm({ ...form, tool_capabilities: [] }) }} className="h-8 px-4 text-sm rounded-md border border-border text-muted-foreground">Cancel</button>
           </div>
         </div>
       )}

--- a/src/agentbox-main.ts
+++ b/src/agentbox-main.ts
@@ -12,7 +12,8 @@ import { createHttpServer } from "./agentbox/http-server.js";
 import { AgentBoxSessionManager } from "./agentbox/session.js";
 import { loadConfig, reloadConfig, getConfigPath } from "./core/config.js";
 import { GatewayClient } from "./agentbox/gateway-client.js";
-import { syncAllResources } from "./agentbox/resource-sync.js";
+import { syncAllResources, syncResource } from "./agentbox/resource-sync.js";
+import { createToolsHandler } from "./agentbox/sync-handlers.js";
 import { debugPodCache } from "./tools/infra/debug-pod.js";
 
 // Side-effect: register metrics subscriber. Also imported in http-server.ts,
@@ -119,6 +120,37 @@ async function main() {
   const server = createHttpServer(sessionManager, {
     onIdleShutdown: () => { void shutdown(); },
   });
+
+  // Per-pod initial tool-capabilities fetch. The tools sync type is
+  // initialSync:false (its handler is per-box, not in the module-level registry
+  // that syncAllResources walks, and needs the sessionManager that doesn't exist
+  // at the syncAllResources call site above). This is the K8s analog of
+  // LocalSpawner's spawn-time injection: resolve the agent's whitelist into
+  // sessionManager.allowedToolsState so a restricted agent is restricted from
+  // its FIRST turn — not only after the next admin-triggered reload push.
+  //
+  // Awaited BEFORE server.listen (like syncAllResources above) so the box never
+  // accepts a prompt before its whitelist lands — first-turn restriction is the
+  // whole point of a security-relevant tool gate. On failure (after retries) the
+  // agent starts unrestricted (allowedToolsState stays null) until the next
+  // reload push — the safe-open default.
+  if (sessionManager.gatewayClient) {
+    const boxClient = sessionManager.gatewayClient.toClientLike();
+    try {
+      // Reuse syncResource's exponential-backoff retry (descriptor.retry =
+      // 3 attempts, 1s base) to shrink the fail-open window from a transient
+      // gateway blip. Pass the per-box handler since `tools` is not in the
+      // module-level registry that syncResource would otherwise look up.
+      const count = await syncResource("tools", boxClient, createToolsHandler(sessionManager, boxClient));
+      console.log(`[agentbox] Initial tool-capabilities synced: ${count === 0 ? "unrestricted" : `${count} tools`}`);
+    } catch (err) {
+      // Fail-open after all retries: a fresh box has no prior whitelist to fall
+      // back to, and a failed fetch usually means broader gateway unreachability
+      // (MCP/skills can't sync either). Loud warn so the gap is observable.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[agentbox] Initial tool-capabilities sync failed after retries (starting unrestricted): ${msg}`);
+    }
+  }
 
   const protocol = server instanceof https.Server ? "https" : "http";
   server.listen(PORT, () => {

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -65,6 +65,15 @@ vi.mock("./sync-handlers.js", () => ({
   getSyncHandler: () => undefined,
   createClusterHandler: () => ({ type: "cluster", fetch: async () => 0, materialize: async (n: number) => n }),
   createHostHandler: () => ({ type: "host", fetch: async () => 0, materialize: async (n: number) => n }),
+  createToolsHandler: (target: { allowedToolsState: string[] | null }) => ({
+    type: "tools",
+    fetch: async () => ({ allowedTools: null }),
+    materialize: async (p: { allowedTools: string[] | null }) => {
+      target.allowedToolsState = Array.isArray(p?.allowedTools) ? p.allowedTools : null;
+      return target.allowedToolsState ? target.allowedToolsState.length : 0;
+    },
+    postReload: async () => {},
+  }),
 }));
 
 vi.mock("./credential-broker.js", () => ({
@@ -1200,6 +1209,14 @@ describe("http-server — reload routes delegate to handlers", () => {
     // falls through to 500 (no handler). We accept either, as long as the
     // route is wired.
     expect([200, 500]).toContain(r.status);
+  });
+
+  it("POST /api/reload-tools is wired (descriptor loop) and short-circuits without a gateway URL", async () => {
+    const r = await getJson(port, "/api/reload-tools", "POST");
+    // tools is requiresGatewayClient:true; with no SICLAW_GATEWAY_URL the route
+    // short-circuits to 200 count:0 before ever calling the per-box handler.
+    expect(r.status).toBe(200);
+    expect(r.data).toMatchObject({ ok: true, count: 0, type: "tools" });
   });
 });
 

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -18,7 +18,7 @@ import { checkMetricsAuth } from "../shared/metrics.js"; // also registers metri
 import { GatewayClient } from "./gateway-client.js";
 import { CredentialBroker } from "./credential-broker.js";
 import { HttpTransport } from "./credential-transport.js";
-import { getSyncHandler, createClusterHandler, createHostHandler } from "./sync-handlers.js";
+import { getSyncHandler, createClusterHandler, createHostHandler, createToolsHandler } from "./sync-handlers.js";
 import { GATEWAY_SYNC_DESCRIPTORS, type AgentBoxSyncHandler, type GatewaySyncType } from "../shared/gateway-sync.js";
 import { detectLanguage } from "../shared/detect-language.js";
 import {
@@ -441,6 +441,16 @@ export function createHttpServer(
     perServerHandlers.cluster = createClusterHandler(sessionManager.credentialBroker);
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
   }
+  // tools handler — same per-box rationale as cluster/host. It writes the
+  // resolved allowedTools into THIS box's sessionManager and fetches with THIS
+  // box's GatewayClient (correct mTLS cert → correct agentId), avoiding the
+  // route loop's last-spawn-wins SICLAW_CERT_PATH client. Bound even when
+  // gatewayClient is absent (TUI/no-gateway): the reload route gates on
+  // requiresGatewayClient and skips before fetch in that case.
+  perServerHandlers.tools = createToolsHandler(
+    sessionManager,
+    sessionManager.gatewayClient ? sessionManager.gatewayClient.toClientLike() : null,
+  );
 
   // ── Idle self-destruct: shut down when no SSE connections and no sessions ──
   // Window is configurable (config.server.idleTimeoutSec / SICLAW_AGENTBOX_IDLE_TIMEOUT).

--- a/src/agentbox/resource-sync.ts
+++ b/src/agentbox/resource-sync.ts
@@ -6,7 +6,7 @@
  * resource-type-agnostic implementation.
  */
 
-import type { GatewaySyncClientLike, GatewaySyncType } from "../shared/gateway-sync.js";
+import type { GatewaySyncClientLike, GatewaySyncType, AgentBoxSyncHandler } from "../shared/gateway-sync.js";
 import { GATEWAY_SYNC_DESCRIPTORS } from "../shared/gateway-sync.js";
 import { getSyncHandler } from "./sync-handlers.js";
 
@@ -16,15 +16,20 @@ import { getSyncHandler } from "./sync-handlers.js";
  * Uses exponential backoff as configured in the resource descriptor:
  *   delay = baseDelayMs * 2^attempt  (0-indexed)
  *
+ * @param handlerOverride  Optional per-box handler. Pass this for sync types
+ *   whose handler is NOT in the module-level registry (e.g. `tools`, which is
+ *   per-box like cluster/host) so they can still reuse this retry/backoff loop.
+ *   Defaults to the module-level `getSyncHandler(type)`.
  * @returns The count returned by the handler's materialize() (e.g. server count).
  * @throws  If all retry attempts are exhausted.
  */
 export async function syncResource(
   type: GatewaySyncType,
   client: GatewaySyncClientLike,
+  handlerOverride?: AgentBoxSyncHandler,
 ): Promise<number> {
   const descriptor = GATEWAY_SYNC_DESCRIPTORS[type];
-  const handler = getSyncHandler(type);
+  const handler = handlerOverride ?? getSyncHandler(type);
   if (!handler) {
     throw new Error(`[gateway-sync] No handler registered for sync type "${type}"`);
   }

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -225,6 +225,22 @@ export class AgentBoxSessionManager {
    */
   credentialsDir?: string;
 
+  /**
+   * Per-agent tool capability whitelist — the resolved `allowedTools` list for
+   * this AgentBox's agent (see core/tool-capabilities.ts).
+   *
+   * `null` (the default) = no restriction: createSiclawSession falls back to the
+   * global `config.allowedTools`, i.e. exactly the behaviour before this feature
+   * existed. A non-null array restricts the agent to those tool names.
+   *
+   * This state is PER-AGENT by construction: one AgentBoxSessionManager instance
+   * per agent (K8s = one pod; LocalSpawner = one `new AgentBoxSessionManager()`
+   * per agent). It is filled at startup (K8s: explicit fetch in agentbox-main;
+   * Local: LocalSpawner injection) and refreshed on POST /api/reload-tools via a
+   * per-box handler that writes here — never via loadConfig/writeConfig/process.env.
+   */
+  allowedToolsState: string[] | null = null;
+
   /** Callback fired after a session is released — used by http-server to check idle status */
   onSessionRelease?: () => void;
 
@@ -1263,6 +1279,12 @@ export class AgentBoxSessionManager {
       memoryIndexer: this._sharedMemoryIndexer ?? undefined,
       userId: this.userId,
       agentId,
+      // A spawned sub-agent must never be broader than its parent: inherit the
+      // parent's per-agent tool whitelist. Without this, a restricted agent that
+      // has the `spawn_subagents` capability could escalate by spawning a child
+      // that falls back to the global config.allowedTools (all tools). null
+      // (unrestricted parent) stays null — identical to pre-feature behaviour.
+      allowedTools: this.allowedToolsState,
       // The plan is parent-owned: sub-agents have no task tools (isSubagent hides
       // them), so the child neither reads nor writes the ledger — the parent marks
       // tasks complete as children report back. The parent's taskListId is therefore
@@ -1656,6 +1678,10 @@ export class AgentBoxSessionManager {
       memoryIndexer: this._sharedMemoryIndexer ?? undefined,
       userId: this.userId,
       agentId: this.agentId ?? null,
+      // Per-agent tool capability whitelist. null = unrestricted (falls back to
+      // global config.allowedTools in agent-factory — today's behaviour for any
+      // agent that never set tool_capabilities).
+      allowedTools: this.allowedToolsState,
       systemPromptTemplate,
       // Stable per-session ledger key so the plan survives release/rebuild
       // (a fresh random id would orphan the prior in-memory ledger every turn).

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -5,10 +5,12 @@ import path from "node:path";
 import {
   createClusterHandler,
   createHostHandler,
+  createToolsHandler,
   knowledgeHandler,
   mcpHandler,
   skillsHandler,
 } from "./sync-handlers.js";
+import type { GatewaySyncClientLike } from "../shared/gateway-sync.js";
 import { CredentialBroker } from "./credential-broker.js";
 import type {
   CredentialTransport,
@@ -145,6 +147,97 @@ describe("per-broker isolation", () => {
       broker2.dispose();
       fs.rmSync(dir2, { recursive: true, force: true });
     }
+  });
+});
+
+describe("createToolsHandler", () => {
+  /** A fake GatewaySyncClientLike that returns a canned tool-capabilities body. */
+  function fakeClient(body: unknown): GatewaySyncClientLike & { calls: Array<[string, string]> } {
+    const calls: Array<[string, string]> = [];
+    return {
+      calls,
+      request: (p: string, m: "GET" | "POST") => {
+        calls.push([p, m]);
+        return Promise.resolve(body);
+      },
+    };
+  }
+
+  it("handler type is 'tools'", () => {
+    expect(createToolsHandler({ allowedToolsState: null }, null).type).toBe("tools");
+  });
+
+  it("fetch uses the per-box client and hits /api/internal/tool-capabilities", async () => {
+    const boxClient = fakeClient({ allowedTools: ["read", "ls"] });
+    // Pass a DIFFERENT client into fetch() to prove the box client wins.
+    const otherClient = fakeClient({ allowedTools: ["should_not_be_used"] });
+    const handler = createToolsHandler({ allowedToolsState: null }, boxClient);
+    const payload = await handler.fetch(otherClient);
+    expect(payload).toEqual({ allowedTools: ["read", "ls"] });
+    expect(boxClient.calls).toEqual([["/api/internal/tool-capabilities", "GET"]]);
+    expect(otherClient.calls).toEqual([]);
+  });
+
+  it("materialize writes a non-null list into the target state and returns its length", async () => {
+    const target = { allowedToolsState: null as string[] | null };
+    const handler = createToolsHandler(target, null);
+    const count = await handler.materialize({ allowedTools: ["read", "ls", "grep"] });
+    expect(count).toBe(3);
+    expect(target.allowedToolsState).toEqual(["read", "ls", "grep"]);
+  });
+
+  it("materialize treats null as 'no restriction' (whitelist off), returns 0", async () => {
+    const target = { allowedToolsState: ["read"] as string[] | null };
+    const handler = createToolsHandler(target, null);
+    const count = await handler.materialize({ allowedTools: null });
+    expect(count).toBe(0);
+    expect(target.allowedToolsState).toBeNull();
+  });
+
+  it("materialize coerces a malformed (non-array) payload to null, not a crash", async () => {
+    const target = { allowedToolsState: ["read"] as string[] | null };
+    const handler = createToolsHandler(target, null);
+    // Simulate a skeleton/garbage response.
+    const count = await handler.materialize({ allowedTools: undefined } as any);
+    expect(count).toBe(0);
+    expect(target.allowedToolsState).toBeNull();
+  });
+
+  it("postReload invalidates every session (mirrors mcpHandler)", async () => {
+    const dummyBrain = { reload: async () => {} };
+    const inv1 = vi.fn();
+    const inv2 = vi.fn();
+    const handler = createToolsHandler({ allowedToolsState: null }, null);
+    await handler.postReload!({
+      sessions: [
+        { id: "s1", brain: dummyBrain, invalidate: inv1 },
+        { id: "s2", brain: dummyBrain, invalidate: inv2 },
+      ],
+    });
+    expect(inv1).toHaveBeenCalledOnce();
+    expect(inv2).toHaveBeenCalledOnce();
+  });
+
+  it("postReload is a no-op with no sessions and tolerates a missing invalidate", async () => {
+    const dummyBrain = { reload: async () => {} };
+    const handler = createToolsHandler({ allowedToolsState: null }, null);
+    await expect(handler.postReload!({})).resolves.toBeUndefined();
+    await expect(handler.postReload!({ sessions: [] })).resolves.toBeUndefined();
+    await expect(
+      handler.postReload!({ sessions: [{ id: "s1", brain: dummyBrain }] }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does NOT touch loadConfig/writeConfig — materialize is a pure in-memory no-op", async () => {
+    // The config mock at the top of this file throws nothing, but we assert the
+    // contract structurally: two independent targets stay isolated, proving no
+    // process-global state is involved.
+    const a = { allowedToolsState: null as string[] | null };
+    const b = { allowedToolsState: null as string[] | null };
+    await createToolsHandler(a, null).materialize({ allowedTools: ["read"] });
+    await createToolsHandler(b, null).materialize({ allowedTools: ["bash"] });
+    expect(a.allowedToolsState).toEqual(["read"]);
+    expect(b.allowedToolsState).toEqual(["bash"]);
   });
 });
 

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -414,6 +414,77 @@ export function createHostHandler(broker: CredentialBroker): AgentBoxSyncHandler
   };
 }
 
+// ── Tools handler (factory, per-box session-manager-bound) ────────────
+
+/**
+ * Payload shape returned by the Gateway's /api/internal/tool-capabilities:
+ * the already-resolved concrete allowedTools list (null = no restriction).
+ */
+interface ToolsPayload {
+  allowedTools: string[] | null;
+}
+
+/**
+ * Minimal structural target the tools handler writes to. Deliberately NOT the
+ * concrete AgentBoxSessionManager: importing session.ts here would drag in
+ * agent-factory's transitive ssh2 dependency and break this module's vitest
+ * suite. Structural typing keeps sync-handlers.ts a leaf module.
+ */
+export interface ToolsStateTarget {
+  allowedToolsState: string[] | null;
+}
+
+/**
+ * tools handler — per-box, like cluster/host (NOT in the module-level registry).
+ *
+ * Why per-box and not a module singleton: the AgentBoxSessionManager is the
+ * per-agent state holder (K8s = one pod; Local = one manager per agent). The
+ * handler writes the resolved allowedTools into THIS box's manager, and fetches
+ * with THIS box's GatewayClient so the mTLS cert resolves to the correct
+ * agentId. The route loop's lazily-built reload client re-reads
+ * SICLAW_CERT_PATH (last-spawn-wins in Local mode) and would fetch the wrong
+ * agent's list — hence we close over the box client and ignore the passed one.
+ *
+ * materialize() is a PURE in-memory no-op w.r.t. the filesystem: it writes only
+ * `target.allowedToolsState`. It must never touch loadConfig/writeConfig/
+ * process.env (process-global shared state under LocalSpawner's multi-spawn).
+ */
+export function createToolsHandler(
+  target: ToolsStateTarget,
+  boxClient: GatewaySyncClientLike | null,
+): AgentBoxSyncHandler<ToolsPayload> {
+  return {
+    type: "tools",
+
+    async fetch(client: GatewaySyncClientLike | null): Promise<ToolsPayload> {
+      // Prefer the per-box client (correct cert → correct agentId).
+      const c = boxClient ?? client;
+      if (!c) throw new Error("[tools] GatewaySyncClientLike required but missing");
+      const data = await c.request(GATEWAY_SYNC_DESCRIPTORS.tools.gatewayPath, "GET");
+      return (data ?? { allowedTools: null }) as ToolsPayload;
+    },
+
+    async materialize(payload: ToolsPayload): Promise<number> {
+      // null / non-array → no restriction (whitelist off). Mirrors
+      // resolveCapabilities(null) === null and agent-factory's null=all-tools.
+      const allowed = Array.isArray(payload?.allowedTools) ? payload.allowedTools : null;
+      target.allowedToolsState = allowed;
+      return allowed ? allowed.length : 0;
+    },
+
+    async postReload(context: ReloadContext): Promise<void> {
+      // Identical contract to mcpHandler: the tool-set is baked into each
+      // session at creation time, so a live session must be rebuilt to pick up
+      // a new whitelist. invalidate() defers the release until any in-flight
+      // prompt completes, so tool execution is not torn down mid-turn.
+      if (!context.sessions?.length) return;
+      for (const session of context.sessions) {
+        session.invalidate?.();
+      }
+    },
+  };
+}
+
 // ── Registry ──────────────────────────────────────────────────────────
 
 const handlers = new Map<GatewaySyncType, AgentBoxSyncHandler<any>>([

--- a/src/cli-main.ts
+++ b/src/cli-main.ts
@@ -214,6 +214,9 @@ const buildSiclawOpts = (sm: SessionManager) => ({
   // When the snapshot is scoped to an agent that carries a custom
   // system_prompt, swap out siclaw's default SRE prompt for the agent's.
   systemPromptTemplate: portalSnapshot?.activeAgent?.systemPrompt ?? undefined,
+  // Per-agent tool whitelist (resolved from capability groups by the snapshot).
+  // Absent/null = unrestricted → agent-factory falls back to config.allowedTools.
+  allowedTools: portalSnapshot?.activeAgent?.allowedTools ?? null,
   portalActiveAgent: portalSnapshot?.activeAgent ?? null,
   portalAvailableAgents: portalSnapshot?.availableAgents ?? [],
   portalUrl: portalSnapshot?.portalUrl,

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -27,6 +27,7 @@ import {
 import { globSync } from "glob";
 import { createMemoryIndexer, type MemoryIndexer, type MemoryIndexerOpts } from "../memory/index.js";
 import { ToolRegistry, type AgentMode } from "./tool-registry.js";
+import { appendAllowedTools } from "./tool-append.js";
 import { allToolEntries } from "../tools/all-entries.js";
 import { buildSreSystemPrompt } from "./prompt.js";
 import contextPruningExtension from "./extensions/context-pruning.js";
@@ -443,15 +444,13 @@ export async function createSiclawSession(
   } else {
     console.log(`[agent-factory] No MCP config found, skipping MCP tools`);
   }
-  // MCP tools subject to allowedTools (original behavior: MCP appended before filter)
-  if (mcpTools.length > 0) {
-    if (Array.isArray(allowedTools)) {
-      const allowed = new Set(allowedTools);
-      customTools.push(...mcpTools.filter(t => allowed.has(t.name)));
-    } else {
-      customTools.push(...mcpTools);
-    }
-  }
+  // MCP tools are EXEMPT from the per-agent `allowedTools` capability whitelist.
+  // MCP availability is governed by an orthogonal axis — the `agent_mcp_servers`
+  // binding — so a capability group selection must not gate them. (Dynamic MCP
+  // tool names can't be statically enumerated into a capability group anyway.)
+  // The whole `mcpTools` array is MCP by construction, so an unconditional push
+  // is simpler than and equivalent to skipping by an `mcp__` name prefix.
+  customTools.push(...mcpTools);
 
   // -- Path-restricted file I/O tools --
   // Whitelist: only skills directories + user-data + reports + repos + docs (no credentials, no config)
@@ -519,8 +518,24 @@ export async function createSiclawSession(
       },
     }),
   ];
-  // Push into customTools so they override framework defaults via extension mechanism
-  customTools.push(...restrictedFileTools);
+  // Push into customTools so they override framework defaults via extension mechanism.
+  // Subject to allowedTools (same chokepoint as MCP append above): file tools are
+  // created outside the registry, so the shared name-based whitelist is applied here.
+  appendAllowedTools(customTools, restrictedFileTools, allowedTools);
+
+  // Final model-visible tool set (registry-resolved + MCP + file tools, after the
+  // whitelist is applied at every chokepoint). Logged by NAME when restricted so a
+  // capability-group change is verifiable straight from the box log — this is the
+  // ground truth the model is given as function schemas. It deliberately differs
+  // from any tool list the model recites in chat: a session restored from JSONL
+  // carries earlier turns where it held more tools, and the model may parrot those
+  // stale names even though they are no longer in this list and cannot be invoked.
+  if (Array.isArray(allowedTools)) {
+    console.log(
+      `[agent-factory] Restricted tools visible to model (${customTools.length}): ` +
+      `${customTools.map((t) => t.name).join(", ") || "(none)"}`,
+    );
+  }
 
   // Skills: when userId is set (local mode), use per-user directory for isolation;
   // otherwise "." collapses to skillsBase/user/ (K8s single-user pod).

--- a/src/core/tool-append.test.ts
+++ b/src/core/tool-append.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { appendAllowedTools } from "./tool-append.js";
+
+const tool = (name: string): ToolDefinition => ({ name }) as ToolDefinition;
+
+describe("appendAllowedTools", () => {
+  it("null allowedTools passes every tool through (whitelist off)", () => {
+    const target = [tool("existing")];
+    appendAllowedTools(target, [tool("read"), tool("write")], null);
+    expect(target.map((t) => t.name)).toEqual(["existing", "read", "write"]);
+  });
+
+  it("undefined allowedTools passes every tool through", () => {
+    const target: ToolDefinition[] = [];
+    appendAllowedTools(target, [tool("read"), tool("write")], undefined);
+    expect(target.map((t) => t.name)).toEqual(["read", "write"]);
+  });
+
+  it("array whitelist passes only listed tools; no exemptions", () => {
+    const target: ToolDefinition[] = [];
+    appendAllowedTools(target, [tool("read"), tool("write"), tool("edit")], ["read", "edit"]);
+    expect(target.map((t) => t.name)).toEqual(["read", "edit"]);
+  });
+
+  it("empty array yields zero appended tools", () => {
+    const target = [tool("kept")];
+    appendAllowedTools(target, [tool("read"), tool("write")], []);
+    expect(target.map((t) => t.name)).toEqual(["kept"]);
+  });
+
+  it("appends to (does not replace) the existing target list", () => {
+    const target = [tool("a"), tool("b")];
+    appendAllowedTools(target, [tool("read")], ["read"]);
+    expect(target.map((t) => t.name)).toEqual(["a", "b", "read"]);
+  });
+
+  it("a name in the whitelist that is absent from tools adds nothing", () => {
+    const target: ToolDefinition[] = [];
+    appendAllowedTools(target, [tool("read")], ["read", "nonexistent"]);
+    expect(target.map((t) => t.name)).toEqual(["read"]);
+  });
+});

--- a/src/core/tool-append.ts
+++ b/src/core/tool-append.ts
@@ -1,0 +1,31 @@
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Append externally-created tools (MCP, file I/O) to the resolved tool list,
+ * applying the same name-based `allowedTools` whitelist that `ToolRegistry.resolve()`
+ * applies to registered tools.
+ *
+ * These tools live outside `ToolRegistry` (MCP is discovered dynamically; file I/O
+ * tools are framework factories injected after resolve), so they bypass `resolve()`.
+ * This helper is the single chokepoint that keeps them under the same availability
+ * axis — without it they would be silently exempt from the whitelist.
+ *
+ * Semantics mirror `resolve()`:
+ *  - `null`/`undefined` allowedTools → every tool passes (the default; whitelist off).
+ *  - an array → only tools whose `name` is listed pass; no exemptions.
+ *
+ * The appended tools carry no `mode`/`available` metadata (universal across modes,
+ * no ref dependency), so `allowedTools` is their sole availability gate.
+ */
+export function appendAllowedTools(
+  target: ToolDefinition[],
+  tools: ToolDefinition[],
+  allowedTools: string[] | null | undefined,
+): void {
+  if (Array.isArray(allowedTools)) {
+    const allowed = new Set(allowedTools);
+    target.push(...tools.filter((t) => allowed.has(t.name)));
+  } else {
+    target.push(...tools);
+  }
+}

--- a/src/core/tool-capabilities-coverage.test.ts
+++ b/src/core/tool-capabilities-coverage.test.ts
@@ -1,0 +1,34 @@
+// Coverage guard: every tool in the registry (allToolEntries) must belong to
+// some CAPABILITY_GROUPS entry. A registered-but-ungrouped tool can never be
+// reached by a restricted agent (and "Select All" can't grant it either),
+// silently dropping a capability — exactly the regression that the Feishu merge
+// introduced for `channel_update`. This test fails loudly with the offending
+// name the moment a new tool is added without a group.
+//
+// Lives in its own file (not tool-capabilities.test.ts) so the heavy
+// allToolEntries import graph stays out of the pure-module unit test.
+import { describe, it, expect } from "vitest";
+import { allToolEntries } from "../tools/all-entries.js";
+import { CAPABILITY_GROUPS } from "./tool-capabilities.js";
+import type { ToolRefs } from "./tool-registry.js";
+
+// Tools deliberately left out of every group, with the reason. Keep EMPTY unless
+// a tool is intentionally ungovernable by capability groups (none today).
+const INTENTIONALLY_UNGROUPED = new Set<string>([]);
+
+describe("capability-group registry coverage", () => {
+  it("every registered tool belongs to some capability group", () => {
+    const grouped = new Set(Object.values(CAPABILITY_GROUPS).flat());
+    // Minimal stub: tool factories read executor refs lazily inside execute(),
+    // not at construction, so an empty-ish refs object is enough to read .name.
+    const stubRefs = { sessionIdRef: { current: "coverage-probe" } } as unknown as ToolRefs;
+
+    const missing: string[] = [];
+    for (const entry of allToolEntries) {
+      const name = entry.create(stubRefs).name;
+      if (!grouped.has(name) && !INTENTIONALLY_UNGROUPED.has(name)) missing.push(name);
+    }
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/core/tool-capabilities.test.ts
+++ b/src/core/tool-capabilities.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  CAPABILITY_GROUPS,
+  resolveCapabilities,
+  encodeToolCapabilitiesForDb,
+} from "./tool-capabilities.js";
+// Frontend catalog (the hand-maintained UI copy). Imported directly so the
+// drift guard below compares the live constants — refactor-safe and
+// type-checked, unlike text-parsing the source. This import only resolves under
+// vitest (esbuild); the tsc build/typecheck exclude **/*.test.ts, so the
+// cross-tree `.ts` import never reaches the Node16 build resolver.
+import { CAPABILITY_GROUPS as FRONTEND_CAPABILITY_GROUPS } from "../../portal-web/src/lib/toolCapabilities.ts";
+
+describe("resolveCapabilities", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("null / [] / undefined all resolve to null (whitelist off)", () => {
+    expect(resolveCapabilities(null)).toBeNull();
+    expect(resolveCapabilities([])).toBeNull();
+    expect(resolveCapabilities(undefined)).toBeNull();
+  });
+
+  it("a single group resolves to exactly that group's tools", () => {
+    expect(resolveCapabilities(["read_files"])).toEqual(["read", "grep", "find", "ls"]);
+  });
+
+  it("multiple groups resolve to the union of their tools", () => {
+    const result = resolveCapabilities(["read_files", "search_memory"]);
+    expect(new Set(result)).toEqual(
+      new Set(["read", "grep", "find", "ls", "memory_search", "memory_get"]),
+    );
+  });
+
+  it("overlapping groups produce a deduped union", () => {
+    // Construct overlap synthetically would require shared tools; instead assert
+    // no duplicates appear when the same group is listed twice.
+    const result = resolveCapabilities(["read_files", "read_files"]);
+    expect(result).toEqual(["read", "grep", "find", "ls"]);
+    expect(result!.length).toBe(new Set(result).size);
+  });
+
+  it("unknown group keys are warned + ignored, valid subset is used", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolveCapabilities(["read_files", "does_not_exist"]);
+    expect(result).toEqual(["read", "grep", "find", "ls"]);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain("does_not_exist");
+  });
+
+  it("a selection of only unknown keys resolves to an empty list (not null)", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // All keys invalid → valid subset is empty → [] (a real, restrictive
+    // whitelist), distinct from the null=all-tools case.
+    expect(resolveCapabilities(["nope"])).toEqual([]);
+  });
+
+  it("no baseline tools are injected (only selected groups appear)", () => {
+    const result = resolveCapabilities(["scheduling"]);
+    expect(result).toEqual(["manage_schedule"]);
+  });
+
+  it("CAPABILITY_GROUPS contains the 10 designed groups", () => {
+    expect(Object.keys(CAPABILITY_GROUPS).sort()).toEqual([
+      "inspect_infra",
+      "plan_tasks",
+      "read_files",
+      "run_commands",
+      "run_scripts",
+      "scheduling",
+      "search_memory",
+      "session_output",
+      "spawn_subagents",
+      "write_sandbox",
+    ]);
+  });
+});
+
+describe("encodeToolCapabilitiesForDb", () => {
+  it("encodes an empty selection as null (the unrestricted / backward-compat hinge)", () => {
+    // Both submit flows send `Array.from(selectedCapabilities)`; an empty
+    // selection MUST collapse to null so an un-configured agent stays
+    // unrestricted (resolveCapabilities(null) === null).
+    expect(encodeToolCapabilitiesForDb([])).toBeNull();
+    expect(encodeToolCapabilitiesForDb(null)).toBeNull();
+  });
+
+  it("omits the field (undefined) when the value is undefined — leave stored value untouched", () => {
+    expect(encodeToolCapabilitiesForDb(undefined)).toBeUndefined();
+  });
+
+  it("encodes a non-empty selection as a deduped JSON array of keys", () => {
+    expect(encodeToolCapabilitiesForDb(["read_files", "read_files", "run_commands"]))
+      .toBe(JSON.stringify(["read_files", "run_commands"]));
+  });
+
+  it("round-trips through resolveCapabilities for a real selection", () => {
+    const encoded = encodeToolCapabilitiesForDb(["read_files"]);
+    expect(encoded).not.toBeNull();
+    const decoded = JSON.parse(encoded as string) as string[];
+    expect(resolveCapabilities(decoded)).toEqual(["read", "grep", "find", "ls"]);
+  });
+
+  it("rejects non-array, non-null/undefined values (HTTP 400 at the boundary)", () => {
+    expect(() => encodeToolCapabilitiesForDb("read_files")).toThrow();
+    expect(() => encodeToolCapabilitiesForDb({})).toThrow();
+    expect(() => encodeToolCapabilitiesForDb(["read_files", 42])).toThrow();
+  });
+});
+
+/**
+ * Anti-drift guard: the frontend catalog
+ * (`portal-web/src/lib/toolCapabilities.ts`) is a hand-maintained copy of this
+ * module's CAPABILITY_GROUPS — the backend stays the source of truth for
+ * resolution; the frontend only adds labels/descriptions for the UI. There is
+ * no shared module across the two builds, so without this guard the backend
+ * could add/rename a group or tool and the UI would silently desync (offering a
+ * group that grants nothing, or hiding a real one). We compare `{key → sorted
+ * tools}` on both sides; any mismatch fails with a precise diff.
+ */
+describe("frontend ↔ backend CAPABILITY_GROUPS parity", () => {
+  /** Normalize a catalog to `{ key: sortedToolNames }`, ignoring tool order. */
+  const normalizeBackend = (groups: Record<string, string[]>): Record<string, string[]> =>
+    Object.fromEntries(Object.entries(groups).map(([key, tools]) => [key, [...tools].sort()]));
+
+  const normalizeFrontend = (
+    groups: ReadonlyArray<{ key: string; tools: string[] }>,
+  ): Record<string, string[]> =>
+    Object.fromEntries(groups.map((g) => [g.key, [...g.tools].sort()]));
+
+  it("expose the same group keys", () => {
+    const backendKeys = Object.keys(CAPABILITY_GROUPS).sort();
+    const frontendKeys = FRONTEND_CAPABILITY_GROUPS.map((g) => g.key).sort();
+    // Equal-as-sets AND no duplicate keys on the frontend side.
+    expect(frontendKeys).toEqual(backendKeys);
+    expect(new Set(frontendKeys).size).toBe(frontendKeys.length);
+  });
+
+  it("map each group key to the identical set of tools", () => {
+    // toEqual on the full normalized maps yields a per-group, per-tool diff on
+    // failure, naming exactly which group/tool drifted.
+    expect(normalizeFrontend(FRONTEND_CAPABILITY_GROUPS)).toEqual(
+      normalizeBackend(CAPABILITY_GROUPS),
+    );
+  });
+});

--- a/src/core/tool-capabilities.ts
+++ b/src/core/tool-capabilities.ts
@@ -1,0 +1,100 @@
+/**
+ * Per-Agent Tool Capabilities — registry + resolution
+ *
+ * Capability groups are the user-visible, multi-selectable configuration unit.
+ * They decouple the vocabulary an admin reasons about ("read files", "run
+ * commands") from the internal tool names, so tools can be renamed or
+ * regrouped without invalidating an agent's stored selection.
+ *
+ * This is a pure module (no heavy deps) by design — mirroring `tool-append.ts`
+ * — so it stays unit-testable. `agent-factory.ts` pulls in ssh2 transitively
+ * and cannot be imported under vitest; keep the resolution logic here.
+ *
+ * Semantics mirror `appendAllowedTools` / `ToolRegistry.resolve()`:
+ *   null / empty selection → null (whitelist OFF; every tool passes).
+ * "Selecting nothing defaults to selecting everything" — this is the
+ * backward-compatibility hinge: an agent that never set `tool_capabilities`
+ * resolves to null and keeps today's full tool set.
+ */
+
+/**
+ * Capability group key → the internal tool names it grants.
+ *
+ * Copied verbatim from the design (per-agent-tool-capabilities-DESIGN.md
+ * "接口与数据结构"). The group keys are the stable contract stored in
+ * `agents.tool_capabilities`; the tool-name arrays may evolve as tools are
+ * added/renamed without changing stored selections.
+ */
+export const CAPABILITY_GROUPS: Record<string, string[]> = {
+  read_files:      ["read", "grep", "find", "ls"],
+  write_sandbox:   ["write", "edit", "skill_preview"],   // 含技能创作
+  inspect_infra:   ["cluster_list", "cluster_probe", "host_list", "resolve_pod_netns"],
+  run_commands:    ["bash", "node_exec", "pod_exec", "host_exec"],
+  run_scripts:     ["node_script", "pod_script", "local_script", "host_script"],
+  search_memory:   ["memory_search", "memory_get"],
+  plan_tasks:      ["task_create", "task_update", "task_list", "task_get"],     // 拆分①
+  spawn_subagents: ["spawn_subagent", "task_output", "job_stop"],               // 拆分①（权限放大）
+  scheduling:      ["manage_schedule"],
+  session_output:  ["task_report", "save_feedback", "channel_update"],   // 含 IM 渠道可见更新
+};
+
+/**
+ * Resolve a set of capability group keys to a concrete `allowedTools` list.
+ *
+ * - `null` / `undefined` / `[]` → `null` (whitelist off — all tools allowed).
+ *   "Selecting nothing defaults to selecting everything." This is the
+ *   backward-compatibility invariant: `resolveCapabilities(null) === null`,
+ *   strictly aligned with `tool-append.ts`'s null = whitelist-off semantics.
+ * - non-empty → the deduped union of the selected groups' tool names.
+ *   Unknown group keys fail loud (warn) and are ignored — the valid subset
+ *   is still used. No baseline injection (decision #2 / #3): a misconfigured
+ *   selection yields exactly what was selected, nothing forced in.
+ */
+export function resolveCapabilities(
+  groupKeys: string[] | null | undefined,
+): string[] | null {
+  if (!Array.isArray(groupKeys) || groupKeys.length === 0) return null;
+
+  const tools = new Set<string>();
+  for (const key of groupKeys) {
+    const group = CAPABILITY_GROUPS[key];
+    if (!group) {
+      console.warn(
+        `[tool-capabilities] Unknown capability group "${key}" ignored; ` +
+        `using the valid subset of the selection.`,
+      );
+      continue;
+    }
+    for (const tool of group) tools.add(tool);
+  }
+
+  return [...tools];
+}
+
+/**
+ * Encode a `tool_capabilities` value for storage in the `agents` TEXT column.
+ *
+ * Validate-at-boundary (the only write site is the admin agent-update API):
+ *   - `undefined`           → `undefined` (field omitted from the SET clause —
+ *                             leave the stored value untouched).
+ *   - `null` / `[]`         → `null` (clear the selection = unrestricted).
+ *   - an array of strings   → deduped JSON array of group keys.
+ *   - anything else         → throw (rejected as HTTP 400 by the caller).
+ *
+ * Unknown group keys are NOT rejected here: `resolveCapabilities` already
+ * tolerates them (warn + ignore), and a key absent today may become valid in a
+ * later release — storing it forward-compatibly beats a hard 400.
+ */
+export function encodeToolCapabilitiesForDb(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (!Array.isArray(value)) {
+    throw new Error("tool_capabilities must be null or an array of capability group keys");
+  }
+  if (value.some((k) => typeof k !== "string")) {
+    throw new Error("tool_capabilities must contain only string group keys");
+  }
+  const deduped = [...new Set(value as string[])];
+  if (deduped.length === 0) return null; // empty selection = unrestricted
+  return JSON.stringify(deduped);
+}

--- a/src/core/tool-registry.test.ts
+++ b/src/core/tool-registry.test.ts
@@ -60,19 +60,19 @@ describe("ToolRegistry", () => {
     expect(createB).toHaveBeenCalledTimes(1);
   });
 
-  it("allowedTools filters non-platform tools; platform tools pass through", () => {
+  it("allowedTools whitelist passes only listed tools; no exemptions", () => {
     const reg = new ToolRegistry();
     reg.register(
       { category: "query", create: () => stubToolDef("a") },
       { category: "query", create: () => stubToolDef("b") },
-      { category: "workflow", create: () => stubToolDef("platform_one"), platform: true },
+      { category: "workflow", create: () => stubToolDef("c") },
     );
     const tools = reg.resolve({
       mode: "web",
       refs: stubRefs(),
-      allowedTools: ["a"], // only "a" from non-platform tools, plus platform tool always
+      allowedTools: ["a"], // only "a"; "b" and "c" are excluded
     });
-    expect(tools.map((t) => t.name).sort()).toEqual(["a", "platform_one"]);
+    expect(tools.map((t) => t.name).sort()).toEqual(["a"]);
   });
 
   it("allowedTools = null disables whitelist (all tools passing mode+available included)", () => {
@@ -85,14 +85,14 @@ describe("ToolRegistry", () => {
     expect(tools.map((t) => t.name)).toEqual(["a", "b"]);
   });
 
-  it("empty allowedTools array filters out non-platform tools only", () => {
+  it("empty allowedTools array yields zero tools", () => {
     const reg = new ToolRegistry();
     reg.register(
       { category: "query", create: () => stubToolDef("a") },
-      { category: "workflow", create: () => stubToolDef("p"), platform: true },
+      { category: "workflow", create: () => stubToolDef("p") },
     );
     const tools = reg.resolve({ mode: "web", refs: stubRefs(), allowedTools: [] });
-    expect(tools.map((t) => t.name)).toEqual(["p"]);
+    expect(tools.map((t) => t.name)).toEqual([]);
   });
 
   it("register supports variadic entries", () => {

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -2,7 +2,7 @@
  * Tool Registry — declarative tool registration and resolution.
  *
  * Each tool file exports a `registration: ToolEntry` that declares its
- * metadata (category, modes, platform exemption, availability guard).
+ * metadata (category, modes, availability guard).
  * The registry collects all entries and resolves the final tool list
  * in one pass: mode filter → available check → instantiate → allowedTools filter.
  */
@@ -299,9 +299,6 @@ export interface ToolEntry {
    */
   modes?: SessionMode[];
 
-  /** Platform tool — exempt from allowedTools workspace filtering. */
-  platform?: boolean;
-
   /**
    * Runtime permission metadata.
    *
@@ -353,7 +350,7 @@ export class ToolRegistry {
    * Resolve the final tool list in one pass:
    * 1. Filter by mode + available guard (zero cost — create not called)
    * 2. Instantiate only the tools that passed filtering
-   * 3. Apply allowedTools whitelist (platform tools exempt)
+   * 3. Apply allowedTools whitelist (sole availability axis; no exemptions)
    */
   resolve(opts: {
     mode: SessionMode;
@@ -378,20 +375,15 @@ export class ToolRegistry {
       if (e.requiresUserApproval) {
         def.requiresUserApproval = true;
       }
-      return {
-        def,
-        platform: e.platform ?? false,
-      };
+      return def;
     });
 
-    // 3. allowedTools whitelist (platform tools exempt)
+    // 3. allowedTools whitelist (sole availability axis; no exemptions)
     if (Array.isArray(allowedTools)) {
       const allowed = new Set(allowedTools);
-      return tools
-        .filter((t) => t.platform || allowed.has(t.def.name))
-        .map((t) => t.def);
+      return tools.filter((d) => allowed.has(d.name));
     }
 
-    return tools.map((t) => t.def);
+    return tools;
   }
 }

--- a/src/gateway/agentbox/local-spawner.test.ts
+++ b/src/gateway/agentbox/local-spawner.test.ts
@@ -46,9 +46,17 @@ vi.mock("../../agentbox/session.js", () => ({
     userId?: string;
     agentId?: string;
     credentialsDir?: string;
+    allowedToolsState: string[] | null = null;
     credentialBroker = { dispose: () => { sessionManagerShutdownCalls.push("broker.dispose"); } };
     async closeAll(): Promise<void> { sessionManagerShutdownCalls.push("closeAll"); }
   },
+}));
+
+// DB mock — LocalSpawner reads agents.tool_capabilities at spawn time to resolve
+// the agent's tool whitelist. Tests set `dbToolCapabilitiesRow` to control it.
+let dbQueryImpl: (sql: string, params: unknown[]) => Promise<[unknown[], unknown]>;
+vi.mock("../db.js", () => ({
+  getDb: () => ({ query: (sql: string, params: unknown[]) => dbQueryImpl(sql, params) }),
 }));
 
 // Import the SUT after mocks.
@@ -71,6 +79,8 @@ beforeEach(() => {
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
   sessionManagerShutdownCalls.length = 0;
+  // Default: agent has no tool_capabilities row value → unrestricted.
+  dbQueryImpl = async () => [[{ tool_capabilities: null }], undefined];
 
   origCwd = process.cwd();
   tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "local-spawner-")));
@@ -181,6 +191,37 @@ describe("LocalSpawner — per-agent credential isolation", () => {
     expect(b1.sessionManager.credentialsDir).toContain(path.join(".siclaw", "credentials", "a1"));
     expect(b2.sessionManager.credentialsDir).toContain(path.join(".siclaw", "credentials", "a2"));
     expect(b1.sessionManager.credentialsDir).not.toBe(b2.sessionManager.credentialsDir);
+  });
+});
+
+describe("LocalSpawner — tool-capabilities injection", () => {
+  it("resolves a restricted agent's capabilities into allowedToolsState at spawn", async () => {
+    dbQueryImpl = async (_sql, params) => {
+      expect(params).toEqual(["a1"]);
+      return [[{ tool_capabilities: JSON.stringify(["read_files", "search_memory"]) }], undefined];
+    };
+    const spawner = new LocalSpawner(new FakeCertManager() as any, "https://127.0.0.1:3002", 5000);
+    const handle = await spawner.spawn({ agentId: "a1" });
+    const box = (spawner as any).boxes.get(handle.boxId);
+    expect(new Set(box.sessionManager.allowedToolsState)).toEqual(
+      new Set(["read", "grep", "find", "ls", "memory_search", "memory_get"]),
+    );
+  });
+
+  it("leaves allowedToolsState null for an agent with no selection (unrestricted)", async () => {
+    dbQueryImpl = async () => [[{ tool_capabilities: null }], undefined];
+    const spawner = new LocalSpawner(new FakeCertManager() as any, "https://127.0.0.1:3002", 5000);
+    const handle = await spawner.spawn({ agentId: "a1" });
+    const box = (spawner as any).boxes.get(handle.boxId);
+    expect(box.sessionManager.allowedToolsState).toBeNull();
+  });
+
+  it("fails safe-open (null) when the DB lookup throws", async () => {
+    dbQueryImpl = async () => { throw new Error("db down"); };
+    const spawner = new LocalSpawner(new FakeCertManager() as any, "https://127.0.0.1:3002", 5000);
+    const handle = await spawner.spawn({ agentId: "a1" });
+    const box = (spawner as any).boxes.get(handle.boxId);
+    expect(box.sessionManager.allowedToolsState).toBeNull();
   });
 });
 

--- a/src/gateway/agentbox/local-spawner.ts
+++ b/src/gateway/agentbox/local-spawner.ts
@@ -16,6 +16,9 @@ import { AgentBoxSessionManager } from "../../agentbox/session.js";
 import { GatewayClient } from "../../agentbox/gateway-client.js";
 import { syncResource } from "../../agentbox/resource-sync.js";
 import type { CertificateManager } from "../security/cert-manager.js";
+import { getDb } from "../db.js";
+import { safeParseJson } from "../dialect-helpers.js";
+import { resolveCapabilities } from "../../core/tool-capabilities.js";
 
 interface LocalBox {
   agentId: string;
@@ -85,6 +88,34 @@ export class LocalSpawner implements BoxSpawner {
       ".siclaw/credentials",
       agentId,
     );
+
+    // Inject the resolved tool whitelist at spawn time. The tools sync type is
+    // initialSync:false, so the framework's syncAllResources never pulls it
+    // (and isn't even run in Local mode). LocalSpawner lives inside the Gateway
+    // process with direct DB access, so it resolves capabilities here — before
+    // createHttpServer + the first session — so a restricted agent is restricted
+    // from its very first turn (not unrestricted-until-next-reload). This also
+    // avoids a GET round-trip and the Local-mode cert last-spawn-wins hazard.
+    // null/empty selection → null = unrestricted (today's behaviour).
+    try {
+      const db = getDb();
+      const [rows] = await db.query(
+        "SELECT tool_capabilities FROM agents WHERE id = ?",
+        [agentId],
+      ) as [Array<{ tool_capabilities?: unknown }>, unknown];
+      const groupKeys = rows.length > 0
+        ? safeParseJson<string[] | null>(rows[0].tool_capabilities, null)
+        : null;
+      sessionManager.allowedToolsState = resolveCapabilities(groupKeys);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Fail safe-open: an agent that can't resolve its whitelist starts
+      // unrestricted rather than failing to spawn. The next reload push will
+      // correct it.
+      console.warn(`[local-spawner] tool-capabilities resolve failed for agent=${agentId} (starting unrestricted): ${msg}`);
+      sessionManager.allowedToolsState = null;
+    }
+
     // disableIdleShutdown: LocalSpawner runs AgentBox in the same process as
     // the Portal — the 5-min idle timer's `process.exit(0)` would take the
     // whole `siclaw local` down and strand the web UI.
@@ -160,7 +191,7 @@ export class LocalSpawner implements BoxSpawner {
       boxId,
       agentId: box.agentId,
       status: "running",
-      endpoint: `http://127.0.0.1:${box.port}`,
+      endpoint: `https://127.0.0.1:${box.port}`,
       createdAt: box.createdAt,
       lastActiveAt: box.createdAt,
     };
@@ -173,7 +204,7 @@ export class LocalSpawner implements BoxSpawner {
         boxId,
         agentId: box.agentId,
         status: "running",
-        endpoint: `http://127.0.0.1:${box.port}`,
+        endpoint: `https://127.0.0.1:${box.port}`,
         createdAt: box.createdAt,
         lastActiveAt: box.createdAt,
       });

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import {
   handleSettings,
   handleMcpServers,
+  handleToolCapabilities,
   handleSkillsBundle,
   handleKnowledgeBundle,
   handleAgentTasksList,
@@ -162,6 +163,47 @@ describe("handleMcpServers", () => {
     }) as typeof frontend.request;
     const res = new FakeRes();
     await handleMcpServers(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
+    expect(res.statusCode).toBe(500);
+    errSpy.mockRestore();
+  });
+});
+
+// ── handleToolCapabilities ────────────────────────────────
+
+describe("handleToolCapabilities", () => {
+  it("resolves the agent's capability groups to a concrete allowedTools list", async () => {
+    frontend.responses.set("config.getAgent", { tool_capabilities: ["read_files", "search_memory"] });
+    const res = new FakeRes();
+    await handleToolCapabilities(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(new Set(body.allowedTools)).toEqual(
+      new Set(["read", "grep", "find", "ls", "memory_search", "memory_get"]),
+    );
+    // agentId comes from the cert identity, never the body.
+    expect(frontend.calls[0]).toEqual({ method: "config.getAgent", params: { agentId: "agent-1" } });
+  });
+
+  it("returns allowedTools:null for an agent with no capability selection (backward compat)", async () => {
+    frontend.responses.set("config.getAgent", { tool_capabilities: null });
+    const res = new FakeRes();
+    await handleToolCapabilities(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ allowedTools: null });
+  });
+
+  it("treats an empty selection as null (whitelist off)", async () => {
+    frontend.responses.set("config.getAgent", { tool_capabilities: [] });
+    const res = new FakeRes();
+    await handleToolCapabilities(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
+    expect(JSON.parse(res.body)).toEqual({ allowedTools: null });
+  });
+
+  it("500 when the agent lookup fails", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    frontend.nextError = new Error("agent lookup down");
+    const res = new FakeRes();
+    await handleToolCapabilities(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
     expect(res.statusCode).toBe(500);
     errSpy.mockRestore();
   });

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -25,6 +25,7 @@ import {
   hasBackgroundChannelDelivery,
 } from "./channels/background-delivery.js";
 import { validateSchedule } from "../cron/cron-limits.js";
+import { resolveCapabilities } from "../core/tool-capabilities.js";
 import type {
   DelegationAppendMessagePayload,
   DelegationEventPayload,
@@ -224,6 +225,41 @@ export async function handleMcpServers(
     sendJson(res, 200, { mcpServers: data.mcpServers });
   } catch (err) {
     console.error("[internal-api] mcp-servers error:", err);
+    sendJson(res, 500, { error: "Internal server error" });
+  }
+}
+
+/**
+ * GET /api/internal/tool-capabilities
+ *
+ * Returns the agent's resolved tool whitelist (the concrete allowedTools list).
+ * The Gateway resolves capability group keys → tool names at this boundary so
+ * the AgentBox stays oblivious to capability groups (mirrors ssh jump_host_id→
+ * name and MCP boundary resolution).
+ *
+ * `{ allowedTools: null }` means "no restriction" — the agent never selected
+ * any capability groups, so it keeps the global default tool set. The agentId
+ * comes from the mTLS cert identity (never the request body) so a box cannot
+ * read another agent's whitelist.
+ */
+export async function handleToolCapabilities(
+  _req: http.IncomingMessage,
+  res: http.ServerResponse,
+  identity: CertificateIdentity,
+  frontendClient: FrontendWsClient,
+): Promise<void> {
+  try {
+    const agent = await frontendClient.request("config.getAgent", {
+      agentId: identity.agentId,
+    });
+    // tool_capabilities is the stored group-key array (null/empty = unrestricted).
+    // resolveCapabilities(null/[]) === null keeps the backward-compatible default.
+    const allowedTools = resolveCapabilities(
+      (agent?.tool_capabilities ?? null) as string[] | null,
+    );
+    sendJson(res, 200, { allowedTools });
+  } catch (err) {
+    console.error("[internal-api] tool-capabilities error:", err);
     sendJson(res, 500, { error: "Internal server error" });
   }
 }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -40,6 +40,7 @@ import { clearAgentMemory } from "./memory-cleanup.js";
 import {
   handleSettings,
   handleMcpServers,
+  handleToolCapabilities,
   handleSkillsBundle,
   handleKnowledgeBundle,
   handleAgentTasksList,
@@ -702,6 +703,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           if (url === "/api/internal/mcp-servers" && method === "GET") {
             if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
             handleMcpServers(req, res, identity, frontendClient);
+            return;
+          }
+
+          // Tool capabilities — resolved allowedTools for the agent (via RPC)
+          if (url === "/api/internal/tool-capabilities" && method === "GET") {
+            if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
+            handleToolCapabilities(req, res, identity, frontendClient);
             return;
           }
 

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -47,7 +47,21 @@ describe("config.getAgent", () => {
       id: "a1", name: "Agent 1", description: "desc", status: "active",
       model_provider: "openai", model_id: "gpt-4", system_prompt: "You are helpful",
       icon: "bot", color: "#fff", idle_timeout_sec: 300,
+      // No tool_capabilities column on this row → unrestricted (null).
+      tool_capabilities: null,
     });
+  });
+
+  it("parses a stored tool_capabilities JSON array (TEXT column)", async () => {
+    mockQuery([{
+      id: "a1", name: "Agent 1", description: "desc", status: "active",
+      model_provider: "openai", model_id: "gpt-4", system_prompt: "p",
+      icon: "bot", color: "#fff",
+      tool_capabilities: JSON.stringify(["read_files", "run_commands"]),
+    }]);
+
+    const result = await getHandler("config.getAgent")({ agentId: "a1" }, "a1") as { tool_capabilities: unknown };
+    expect(result.tool_capabilities).toEqual(["read_files", "run_commands"]);
   });
 
   it("throws when agent not found", async () => {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1756,6 +1756,11 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
       icon: agent.icon,
       color: agent.color,
       idle_timeout_sec: agent.idle_timeout_sec,
+      // Per-agent tool capability group keys (JSON array; null/empty = no
+      // restriction). Parsed defensively across the three JSON-column states
+      // (legacy MySQL JSON, new MySQL TEXT, SQLite TEXT). The Gateway resolves
+      // these group keys → concrete allowedTools at its boundary.
+      tool_capabilities: safeParseJson<string[] | null>(agent.tool_capabilities, null),
     };
   });
 

--- a/src/portal/agent-api.test.ts
+++ b/src/portal/agent-api.test.ts
@@ -135,6 +135,36 @@ describe("registerAgentRoutes", () => {
     });
   });
 
+  // ── JSON-in-TEXT decoding on agent responses ─────────────
+  describe("agent response decodes JSON-in-TEXT columns", () => {
+    it("GET /:id decodes model_routing + tool_capabilities to object/array (not raw strings)", async () => {
+      query.mockResolvedValueOnce([[{
+        id: "a1", name: "A",
+        model_routing: '{"enabled":true,"strategy":"ordered_fallback"}',
+        tool_capabilities: '["read_files","inspect_infra"]',
+      }], []]);
+      const { status, body } = await runRoute(router, fakeReq({ url: "/api/v1/agents/a1", method: "GET" }));
+      expect(status).toBe(200);
+      expect(body.model_routing).toEqual({ enabled: true, strategy: "ordered_fallback" });
+      expect(body.tool_capabilities).toEqual(["read_files", "inspect_infra"]);
+    });
+
+    it("decodes null columns to null (not the literal string)", async () => {
+      query.mockResolvedValueOnce([[{ id: "a1", name: "A", model_routing: null, tool_capabilities: null }], []]);
+      const { body } = await runRoute(router, fakeReq({ url: "/api/v1/agents/a1", method: "GET" }));
+      expect(body.model_routing).toBeNull();
+      expect(body.tool_capabilities).toBeNull();
+    });
+
+    it("tolerates malformed JSON by falling back to null (no crash)", async () => {
+      query.mockResolvedValueOnce([[{ id: "a1", name: "A", model_routing: "{not json", tool_capabilities: "oops" }], []]);
+      const { status, body } = await runRoute(router, fakeReq({ url: "/api/v1/agents/a1", method: "GET" }));
+      expect(status).toBe(200);
+      expect(body.model_routing).toBeNull();
+      expect(body.tool_capabilities).toBeNull();
+    });
+  });
+
   // ── POST /api/v1/agents ──────────────────────────────────
   describe("POST /api/v1/agents", () => {
     it("rejects non-admin", async () => {
@@ -343,6 +373,72 @@ describe("registerAgentRoutes", () => {
         cooldownMsByKind: { rate_limit: 0 },
         candidates: [{ provider: "openai", modelId: "gpt-4" }],
       });
+    });
+
+    it("stores tool_capabilities and pushes a tools reload on change", async () => {
+      query
+        .mockResolvedValueOnce([undefined, []])
+        .mockResolvedValueOnce([[{ id: "a1" }], []]);
+
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/agents/a1",
+        method: "PUT",
+        body: { tool_capabilities: ["read_files", "run_commands", "read_files"] },
+      }));
+
+      expect(status).toBe(200);
+      expect(query.mock.calls[0][0]).toContain("tool_capabilities = ?");
+      // Deduped JSON array of group keys.
+      expect(JSON.parse(query.mock.calls[0][1][0])).toEqual(["read_files", "run_commands"]);
+      expect(connMap.notify).toHaveBeenCalledWith("a1", "agent.reload", {
+        agentId: "a1",
+        resources: ["tools"],
+      });
+    });
+
+    it("clears tool_capabilities (empty array → null) and still pushes a reload", async () => {
+      query
+        .mockResolvedValueOnce([undefined, []])
+        .mockResolvedValueOnce([[{ id: "a1" }], []]);
+
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/agents/a1",
+        method: "PUT",
+        body: { tool_capabilities: [] },
+      }));
+
+      expect(status).toBe(200);
+      expect(query.mock.calls[0][0]).toContain("tool_capabilities = ?");
+      expect(query.mock.calls[0][1][0]).toBeNull();
+      expect(connMap.notify).toHaveBeenCalledWith("a1", "agent.reload", {
+        agentId: "a1",
+        resources: ["tools"],
+      });
+    });
+
+    it("does not push a tools reload when tool_capabilities is absent", async () => {
+      query
+        .mockResolvedValueOnce([undefined, []])
+        .mockResolvedValueOnce([[{ id: "a1" }], []]);
+
+      await runRoute(router, fakeReq({
+        url: "/api/v1/agents/a1",
+        method: "PUT",
+        body: { name: "rename-only" },
+      }));
+
+      expect(connMap.notify).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-array tool_capabilities with 400", async () => {
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/agents/a1",
+        method: "PUT",
+        body: { tool_capabilities: "read_files" },
+      }));
+
+      expect(status).toBe(400);
+      expect(body.error).toContain("tool_capabilities");
     });
   });
 

--- a/src/portal/agent-api.ts
+++ b/src/portal/agent-api.ts
@@ -18,6 +18,28 @@ import {
 import { requireAdmin } from "./auth.js";
 import type { RuntimeConnectionMap } from "./runtime-connection.js";
 import { encodeModelRoutingForDb } from "./model-routing-config.js";
+import { encodeToolCapabilitiesForDb } from "../core/tool-capabilities.js";
+import { safeParseJson } from "../gateway/dialect-helpers.js";
+
+/**
+ * Decode an `agents` row's JSON-in-TEXT columns so the REST response carries
+ * real objects/arrays, not raw JSON strings. These columns (`model_routing`,
+ * `tool_capabilities`) are stored as TEXT-of-JSON (no JSON column type); a raw
+ * `SELECT *` returns the undecoded string, which every Web client then has to
+ * remember to JSON.parse — a forgotten parse silently mis-renders (see the
+ * tool_capabilities echo bug). Decoding here is the single boundary that keeps
+ * the wire honest. `safeParseJson` tolerates null / TEXT-string / pre-parsed
+ * object, so this is safe across MySQL + SQLite and non-breaking for the
+ * already-tolerant frontend coercers.
+ */
+function decodeAgentRow<T extends Record<string, unknown>>(row: T): T {
+  if (!row) return row;
+  return {
+    ...row,
+    model_routing: safeParseJson(row.model_routing, null),
+    tool_capabilities: safeParseJson(row.tool_capabilities, null),
+  };
+}
 
 /**
  * Coerce an idle-timeout request value to a non-negative integer (seconds).
@@ -89,16 +111,18 @@ export function registerAgentRoutes(
     const id = crypto.randomUUID();
     const db = getDb();
     let modelRouting: string | null | undefined;
+    let toolCapabilities: string | null | undefined;
     try {
       modelRouting = encodeModelRoutingForDb(body.model_routing);
+      toolCapabilities = encodeToolCapabilitiesForDb(body.tool_capabilities);
     } catch (err) {
       sendJson(res, 400, { error: err instanceof Error ? err.message : String(err) });
       return;
     }
 
     await db.query(
-      `INSERT INTO agents (id, name, description, status, model_provider, model_id, model_routing, system_prompt, is_production, idle_timeout_sec, icon, color, created_by)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO agents (id, name, description, status, model_provider, model_id, model_routing, tool_capabilities, system_prompt, is_production, idle_timeout_sec, icon, color, created_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         body.name,
@@ -107,6 +131,7 @@ export function registerAgentRoutes(
         body.model_provider ?? null,
         body.model_id ?? null,
         modelRouting ?? null,
+        toolCapabilities ?? null,
         body.system_prompt ?? null,
         body.is_production ?? 1,
         clampIdleTimeoutSec(body.idle_timeout_sec),
@@ -134,7 +159,7 @@ export function registerAgentRoutes(
     }
 
     const [rows] = await db.query("SELECT * FROM agents WHERE id = ?", [id]) as any;
-    sendJson(res, 201, rows[0]);
+    sendJson(res, 201, decodeAgentRow(rows[0]));
   });
 
   // GET /api/v1/agents/:id — get by id
@@ -150,7 +175,7 @@ export function registerAgentRoutes(
       return;
     }
 
-    sendJson(res, 200, rows[0]);
+    sendJson(res, 200, decodeAgentRow(rows[0]));
   });
 
   // PUT /api/v1/agents/:id — update (admin only)
@@ -188,6 +213,21 @@ export function registerAgentRoutes(
       }
     }
 
+    let toolCapabilitiesChanged = false;
+    if ("tool_capabilities" in body) {
+      try {
+        const toolCapabilities = encodeToolCapabilitiesForDb(body.tool_capabilities);
+        if (toolCapabilities !== undefined) {
+          setClauses.push("tool_capabilities = ?");
+          values.push(toolCapabilities);
+          toolCapabilitiesChanged = true;
+        }
+      } catch (err) {
+        sendJson(res, 400, { error: err instanceof Error ? err.message : String(err) });
+        return;
+      }
+    }
+
     if (setClauses.length === 0) {
       sendJson(res, 400, { error: "No fields to update" });
       return;
@@ -205,13 +245,19 @@ export function registerAgentRoutes(
       return;
     }
 
-    sendJson(res, 200, rows[0]);
+    sendJson(res, 200, decodeAgentRow(rows[0]));
 
     // is_production change affects skills bundle (prod=approved only, dev=all)
     // and also the visible cluster/host set — credential-list filters out
     // cross-env bindings, so the AgentBox must drop its cached list.
     if ("is_production" in body) {
       connectionMap.notify(params.id, "agent.reload", { resources: ["skills", "cluster", "host"] });
+    }
+
+    // tool_capabilities change → push a tools reload so the active AgentBox
+    // re-fetches its whitelist and invalidates live sessions (mid-turn-safe).
+    if (toolCapabilitiesChanged) {
+      connectionMap.notify(params.id, "agent.reload", { agentId: params.id, resources: ["tools"] });
     }
   });
 
@@ -493,7 +539,7 @@ export function registerAgentRoutes(
     }
 
     const [newRows] = await db.query("SELECT * FROM agents WHERE id = ?", [newId]) as any;
-    sendJson(res, 201, newRows[0]);
+    sendJson(res, 201, decodeAgentRow(newRows[0]));
   });
 
   // ================================================================

--- a/src/portal/cli-snapshot-api.test.ts
+++ b/src/portal/cli-snapshot-api.test.ts
@@ -552,6 +552,40 @@ describe("GET /api/v1/cli-snapshot", () => {
     expect(body.activeAgent.modelRouting.candidates[0].provider).toBe("openai");
   });
 
+  it("resolves a scoped agent's tool_capabilities into activeAgent.allowedTools", async () => {
+    const db = getDb();
+    await db.query(
+      "INSERT INTO agents (id, name, status, tool_capabilities, is_production, created_by) VALUES (?, ?, ?, ?, ?, ?)",
+      ["ag-tools", "tools-agent", "active", JSON.stringify(["read_files", "scheduling"]), 1, "u"],
+    );
+
+    const { status, body } = await runRoute(
+      router,
+      fakeReq({ url: "/api/v1/cli-snapshot?agent=tools-agent", headers: authedHeaders() }),
+    );
+
+    expect(status).toBe(200);
+    expect(new Set(body.activeAgent.allowedTools)).toEqual(
+      new Set(["read", "grep", "find", "ls", "manage_schedule"]),
+    );
+  });
+
+  it("omits allowedTools for an agent with no tool_capabilities (unrestricted)", async () => {
+    const db = getDb();
+    await db.query(
+      "INSERT INTO agents (id, name, status, is_production, created_by) VALUES (?, ?, ?, ?, ?)",
+      ["ag-plain", "plain-agent", "active", 1, "u"],
+    );
+
+    const { status, body } = await runRoute(
+      router,
+      fakeReq({ url: "/api/v1/cli-snapshot?agent=plain-agent", headers: authedHeaders() }),
+    );
+
+    expect(status).toBe(200);
+    expect(body.activeAgent.allowedTools).toBeUndefined();
+  });
+
   it("suppresses builtin skills that have an overlay", async () => {
     const db = getDb();
     const base = "---\nname: shared-name\n---\nbase";

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -30,7 +30,9 @@ import { timingSafeEqual } from "node:crypto";
 import type { RestRouter } from "../gateway/rest-router.js";
 import { sendJson } from "../gateway/rest-router.js";
 import { getDb, type Db } from "../gateway/db.js";
+import { safeParseJson } from "../gateway/dialect-helpers.js";
 import { defaultProviderModelCompat } from "../core/model-compat.js";
+import { resolveCapabilities } from "../core/tool-capabilities.js";
 import type {
   CliSnapshotKnowledgeRepo,
   CliSnapshotClusterCredential,
@@ -196,6 +198,7 @@ interface AgentRow {
   model_provider: string | null;
   model_id: string | null;
   model_routing: unknown;
+  tool_capabilities: unknown;
   system_prompt: string | null;
   icon: string | null;
   color: string | null;
@@ -265,7 +268,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
     // the request is scoped, so the TUI can render its picker without a
     // second round-trip.
     const [allAgents] = await db.query<AgentRow[]>(
-      "SELECT id, name, description, status, model_provider, model_id, model_routing, system_prompt, icon, color FROM agents WHERE status = 'active' ORDER BY name",
+      "SELECT id, name, description, status, model_provider, model_id, model_routing, tool_capabilities, system_prompt, icon, color FROM agents WHERE status = 'active' ORDER BY name",
     );
 
     // Resolve the scoping agent (if any). Return 404 early so the client
@@ -530,6 +533,14 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
       color: a.color,
     }));
 
+    // Resolve the agent's capability groups → concrete allowedTools at this
+    // boundary (the AgentBox/TUI stays oblivious to group keys). null/empty =
+    // unrestricted; we only emit the field when non-null to keep the payload
+    // compact (TUI treats absent as null).
+    const allowedToolsOut = activeAgent
+      ? resolveCapabilities(safeParseJson<string[] | null>(activeAgent.tool_capabilities, null))
+      : null;
+
     const activeAgentOut: CliSnapshotActiveAgent | null = activeAgent
       ? {
           name: activeAgent.name,
@@ -538,6 +549,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
           modelProvider: activeAgent.model_provider,
           modelId: activeAgent.model_id,
           ...(modelRoutingOut ? { modelRouting: modelRoutingOut } : {}),
+          ...(allowedToolsOut ? { allowedTools: allowedToolsOut } : {}),
         }
       : null;
 

--- a/src/portal/cli-snapshot-types.ts
+++ b/src/portal/cli-snapshot-types.ts
@@ -69,6 +69,13 @@ export interface CliSnapshotActiveAgent {
   modelProvider: string | null;
   modelId: string | null;
   modelRouting?: ModelRoutePolicy;
+  /**
+   * Per-agent tool whitelist, already resolved from capability groups to
+   * concrete tool names. `null` = no restriction (the agent selected no
+   * capability groups). Omitted when null so the wire payload stays compact;
+   * the TUI treats an absent field as null = unrestricted.
+   */
+  allowedTools?: string[] | null;
 }
 
 export interface CliSnapshotSkill {

--- a/src/portal/migrate-sqlite.test.ts
+++ b/src/portal/migrate-sqlite.test.ts
@@ -200,6 +200,13 @@ describe("runPortalMigrations on SQLite :memory:", () => {
     expect(cols).toContain("session_id");
   });
 
+  it("agents.tool_capabilities column exists after migration", async () => {
+    await runPortalMigrations();
+    const db = getDb();
+    const [rows] = await db.query<Array<{ name: string }>>("PRAGMA table_info(agents)");
+    expect(rows.map((r) => r.name)).toContain("tool_capabilities");
+  });
+
   it("skills and skill_versions files columns exist after migration", async () => {
     await runPortalMigrations();
     const db = getDb();

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -37,6 +37,7 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     model_provider VARCHAR(100),
     model_id VARCHAR(255),
     model_routing TEXT,
+    tool_capabilities TEXT,
     system_prompt TEXT,
     is_production TINYINT(1) NOT NULL DEFAULT 1,
     idle_timeout_sec INT NOT NULL DEFAULT 300,
@@ -546,6 +547,10 @@ export async function runPortalMigrations(): Promise<void> {
   await safeAlterTable(db, "clusters", "debug_image", "VARCHAR(500) DEFAULT NULL");
   await safeAlterTable(db, "agents", "model_routing", "TEXT DEFAULT NULL");
   await safeAlterTable(db, "agents", "idle_timeout_sec", "INT NOT NULL DEFAULT 300");
+  // Per-agent tool capability groups (JSON array of group keys). TEXT (not a
+  // JSON column type) for MySQL+SQLite dual-compat. NULL = no selection = all
+  // tools (backward-compatible with agents predating this feature).
+  await safeAlterTable(db, "agents", "tool_capabilities", "TEXT DEFAULT NULL");
   await safeAlterTable(db, "agent_task_runs", "session_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "agent_tasks", "last_manual_run_at", "TIMESTAMP NULL DEFAULT NULL");
   await safeAlterTable(db, "skills", "is_builtin", "TINYINT(1) NOT NULL DEFAULT 0");

--- a/src/shared/__tests__/gateway-sync.test.ts
+++ b/src/shared/__tests__/gateway-sync.test.ts
@@ -6,9 +6,9 @@ import {
 } from "../gateway-sync.js";
 
 describe("GATEWAY_SYNC_DESCRIPTORS", () => {
-  const expectedTypes: GatewaySyncType[] = ["mcp", "skills", "cluster", "host", "knowledge"];
+  const expectedTypes: GatewaySyncType[] = ["mcp", "skills", "cluster", "host", "knowledge", "tools"];
 
-  it("contains exactly the five expected syncable types", () => {
+  it("contains exactly the six expected syncable types", () => {
     const actual = Object.keys(GATEWAY_SYNC_DESCRIPTORS).sort();
     expect(actual).toEqual([...expectedTypes].sort());
   });
@@ -76,6 +76,14 @@ describe("GATEWAY_SYNC_DESCRIPTORS", () => {
     expect(d.requiresGatewayClient).toBe(true);
     expect(d.initialSync).toBe(true);
     expect(d.gatewayPath).toBe("/api/internal/knowledge/bundle");
+  });
+
+  it("tools: requires Gateway client but skips initial sync (per-box handler, K8s fetches out-of-band)", () => {
+    const d = GATEWAY_SYNC_DESCRIPTORS.tools;
+    expect(d.requiresGatewayClient).toBe(true);
+    expect(d.initialSync).toBe(false);
+    expect(d.gatewayPath).toBe("/api/internal/tool-capabilities");
+    expect(d.reloadPath).toBe("/api/reload-tools");
   });
 
   it("all reload paths are unique", () => {

--- a/src/shared/gateway-sync.ts
+++ b/src/shared/gateway-sync.ts
@@ -15,7 +15,7 @@
 // ── Scalar types ──────────────────────────────────────────────────────
 
 /** Every syncable type is identified by a well-known key. */
-export type GatewaySyncType = "mcp" | "skills" | "cluster" | "host" | "knowledge";
+export type GatewaySyncType = "mcp" | "skills" | "cluster" | "host" | "knowledge" | "tools";
 
 // ── Config / descriptor interfaces ────────────────────────────────────
 
@@ -165,5 +165,23 @@ export const GATEWAY_SYNC_DESCRIPTORS: Record<GatewaySyncType, GatewaySyncDescri
     retry: { maxRetries: 3, baseDelayMs: 1000 },
     requiresGatewayClient: true,
     initialSync: true,
+  },
+  tools: {
+    type: "tools",
+    gatewayPath: "/api/internal/tool-capabilities",
+    reloadPath: "/api/reload-tools",
+    retry: { maxRetries: 3, baseDelayMs: 1000 },
+    requiresGatewayClient: true,
+    // initialSync:false — like cluster/host, the tools handler is per-box
+    // (closes over THIS server's sessionManager + GatewayClient) and is NOT in
+    // the module-level registry that syncAllResources() walks. It also needs the
+    // sessionManager to exist, which it does not at the syncAllResources() call
+    // site in agentbox-main.ts. The initial value is therefore filled out-of-band:
+    //   • K8s   — an explicit per-pod fetch in agentbox-main.ts after the
+    //             sessionManager + httpServer are constructed.
+    //   • Local — LocalSpawner resolves capabilities and injects directly at spawn.
+    // The reload PUSH path (POST /api/reload-tools) still routes through the
+    // per-box handler regardless of this flag.
+    initialSync: false,
   },
 };

--- a/src/tools/query/cluster-list.ts
+++ b/src/tools/query/cluster-list.ts
@@ -102,5 +102,4 @@ clusters; when several remain, ask the user which to use rather than guessing.`,
 export const registration: ToolEntry = {
   category: "query",
   create: (refs) => createClusterListTool(refs.kubeconfigRef),
-  platform: true,
 };

--- a/src/tools/query/cluster-probe.ts
+++ b/src/tools/query/cluster-probe.ts
@@ -63,5 +63,4 @@ Returns { name, reachable, server_version?, probe_error? }.`,
 export const registration: ToolEntry = {
   category: "query",
   create: (refs) => createClusterProbeTool(refs.kubeconfigRef),
-  platform: true,
 };

--- a/src/tools/query/host-list.ts
+++ b/src/tools/query/host-list.ts
@@ -97,5 +97,4 @@ The response includes "total" (full match count) and "next_cursor": if total exc
 export const registration: ToolEntry = {
   category: "query",
   create: (refs) => createHostListTool(refs.kubeconfigRef),
-  platform: true,
 };

--- a/src/tools/query/memory-get.ts
+++ b/src/tools/query/memory-get.ts
@@ -117,6 +117,5 @@ Parameters:
 export const registration: ToolEntry = {
   category: "query",
   create: (refs) => createMemoryGetTool(refs.memoryDir!),
-  platform: true,
   available: (refs) => isMemoryEnabled() && !!refs.memoryIndexer && !!refs.memoryDir,
 };

--- a/src/tools/query/memory-search.ts
+++ b/src/tools/query/memory-search.ts
@@ -111,6 +111,5 @@ Returns matching memory chunks with file path, heading context, content snippet,
 export const registration: ToolEntry = {
   category: "query",
   create: (refs) => createMemorySearchTool(refs.memoryIndexer!),
-  platform: true,
   available: (refs) => isMemoryEnabled() && !!refs.memoryIndexer,
 };

--- a/src/tools/workflow/channel-update.test.ts
+++ b/src/tools/workflow/channel-update.test.ts
@@ -19,7 +19,6 @@ const text = (r: any) => (r.content[0] as any).text as string;
 
 describe("channel_update tool", () => {
   it("is channel-only and unavailable without a channel message executor", () => {
-    expect(registration.platform).toBe(true);
     expect(registration.modes).toEqual(["channel"]);
     expect(registration.available?.(makeRefs(undefined))).toBe(false);
     expect(registration.available?.(makeRefs(vi.fn() as any))).toBe(true);

--- a/src/tools/workflow/channel-update.ts
+++ b/src/tools/workflow/channel-update.ts
@@ -62,6 +62,5 @@ export const registration: ToolEntry = {
   category: "workflow",
   create: createChannelUpdateTool,
   modes: ["channel"],
-  platform: true,
   available: (refs) => Boolean(refs.channelMessageExecutor && refs.sessionIdRef),
 };

--- a/src/tools/workflow/job-stop.ts
+++ b/src/tools/workflow/job-stop.ts
@@ -46,7 +46,6 @@ export const registration: ToolEntry = {
   category: "workflow",
   create: (refs) => createJobStopTool(refs),
   modes: ["web", "channel", "cli"],
-  platform: true,
   // Available once either background mode is on AND the runtime injected a stop executor
   // (so a job_id can actually exist). Hidden otherwise.
   available: (refs) =>

--- a/src/tools/workflow/manage-schedule.ts
+++ b/src/tools/workflow/manage-schedule.ts
@@ -296,5 +296,4 @@ export const registration: ToolEntry = {
   category: "workflow",
   create: (refs) => createManageScheduleTool(refs.kubeconfigRef, refs.sessionIdRef),
   modes: ["web", "channel"],
-  platform: true,
 };

--- a/src/tools/workflow/save-feedback.ts
+++ b/src/tools/workflow/save-feedback.ts
@@ -146,5 +146,4 @@ The report includes overall rating, decision point evaluations, strengths, impro
 export const registration: ToolEntry = {
   category: "workflow",
   create: (refs) => createSaveFeedbackTool(refs.sessionIdRef),
-  platform: true,
 };

--- a/src/tools/workflow/skill-preview.test.ts
+++ b/src/tools/workflow/skill-preview.test.ts
@@ -239,9 +239,8 @@ type: Network
 
   // --- Registration ---
 
-  it("registration has correct modes and platform flag", () => {
+  it("registration has correct modes", () => {
     expect(registration.modes).toEqual(["web", "channel"]);
-    expect(registration.platform).toBe(true);
     expect(registration.category).toBe("workflow");
   });
 });

--- a/src/tools/workflow/skill-preview.ts
+++ b/src/tools/workflow/skill-preview.ts
@@ -138,5 +138,4 @@ export const registration: ToolEntry = {
   category: "workflow",
   create: (_refs) => createSkillPreviewTool(),
   modes: ["web", "channel"],
-  platform: true,
 };

--- a/src/tools/workflow/spawn-subagent.ts
+++ b/src/tools/workflow/spawn-subagent.ts
@@ -182,9 +182,6 @@ export const registration: ToolEntry = {
   category: "workflow",
   create: (refs) => createSpawnSubagentTool(refs),
   modes: ["web", "channel", "cli"],
-  // platform: a core capability — exempt from allowedTools workspace filtering
-  // (like task_*), so it's never silently hidden when an agent has a whitelist.
-  platform: true,
   available: (refs) => Boolean(refs.spawnSubagentExecutor),
   requiresUserApproval: true,
 };

--- a/src/tools/workflow/task-output.ts
+++ b/src/tools/workflow/task-output.ts
@@ -102,7 +102,6 @@ export const registration: ToolEntry = {
   category: "workflow",
   create: (refs) => createTaskOutputTool(refs),
   modes: ["web", "channel", "cli"],
-  platform: true,
   // Available once a background mode is on AND the runtime injected the reader (so a task_id
   // can exist and be looked up). Hidden otherwise.
   available: (refs) =>

--- a/src/tools/workflow/task-report.ts
+++ b/src/tools/workflow/task-report.ts
@@ -47,5 +47,4 @@ export const registration: ToolEntry = {
   category: "workflow",
   create: (_refs) => createTaskReportTool(),
   modes: ["task"],
-  platform: true,
 };

--- a/src/tools/workflow/task-tools.ts
+++ b/src/tools/workflow/task-tools.ts
@@ -205,28 +205,24 @@ const plannerOnly = (refs: ToolRefs) => !refs.isSubagent;
 export const taskCreateRegistration: ToolEntry = {
   category: "workflow",
   create: (refs) => createTaskCreateTool(refs.taskListId, refs.sessionEventEmitter),
-  platform: true,
   availableModes: ["normal"],
   available: plannerOnly,
 };
 export const taskUpdateRegistration: ToolEntry = {
   category: "workflow",
   create: (refs) => createTaskUpdateTool(refs.taskListId, refs.sessionEventEmitter),
-  platform: true,
   availableModes: ["normal"],
   available: plannerOnly,
 };
 export const taskListRegistration: ToolEntry = {
   category: "workflow",
   create: (refs) => createTaskListTool(refs.taskListId),
-  platform: true,
   availableModes: ["normal"],
   available: plannerOnly,
 };
 export const taskGetRegistration: ToolEntry = {
   category: "workflow",
   create: (refs) => createTaskGetTool(refs.taskListId),
-  platform: true,
   availableModes: ["normal"],
   available: plannerOnly,
 };

--- a/tsconfig.agentbox.json
+++ b/tsconfig.agentbox.json
@@ -7,13 +7,7 @@
     "src/cron/**/*.ts",
     "src/memory/**/*.ts",
     "src/shared/**/*.ts",
-    "src/tools/**/*.ts",
-    "src/gateway/agentbox/**/*.ts",
-    "src/gateway/security/**/*.ts",
-    "src/gateway/config.ts",
-    "src/gateway/jwt.ts",
-    "src/gateway/metrics-aggregator.ts",
-    "src/gateway/ws-protocol.ts"
+    "src/tools/**/*.ts"
   ],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Per-agent tool capabilities: restrict each agent to a multi-select of **capability groups** that resolve to an `allowedTools` whitelist. Empty/unset selection = unrestricted (all tools), so the feature is **strictly opt-in** and every existing agent is unaffected.

### Problem

Tool availability had two axes: a hard-coded `ToolEntry.platform` exemption (some tools could never be disabled) and `allowedTools`. There was no way to give one agent a reduced tool set (e.g. a read-only Q&A agent that cannot run commands), and the file I/O tools bypassed `allowedTools` entirely.

### Solution

- **Unify availability under a single `allowedTools` axis** — drop `platform`; file tools + MCP flow through `appendAllowedTools` (no exemptions; `null` = all tools).
- **Capability-group model** stored in `agents.tool_capabilities` (TEXT; null/empty = unrestricted). Group keys → tool names are resolved at the **gateway boundary**; delivered over the gateway-sync framework as a new `tools` sync type (per-box handler, `invalidate`-on-reload — the same session-rebuild contract as MCP). K8s does a per-pod fetch; LocalSpawner injects the whitelist at spawn time.
- **MCP exempt** (governed by `agent_mcp_servers`); spawned sub-agents **inherit the parent whitelist** (privilege-escalation guard).
- Portal REST **decodes JSON-in-TEXT** agent columns at the boundary; frontend adds a capability-group multi-select (create dialog + a **Tools** tab) with a backend/frontend **drift-guard test**.
- Incidental fixes folded in: LocalSpawner `http://`→`https://` (live reload was broken), agentbox image stops compiling gateway code (compile fix), and a diagnostic log of the final restricted tool set.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [ ] `npm test` — **not run in full this session**; frontend capability tests (23) + `npm run build` (tsc && vite) pass
- [x] Manual (`siclaw local`): restricting an agent to `read_files` resolves to exactly `read, grep, find, ls`; live reload re-resolves on save; unrestricted/existing agents unaffected

## Architecture Checklist

- [x] **Deployment mode**: verified in local (LocalSpawner spawn-time inject) and designed for K8s (per-pod fetch in `agentbox-main`); the tools handler is per-box and writes only in-memory `allowedToolsState` (no shared-FS write — safe under LocalSpawner multi-spawn)
- [x] **Security model**: no new shell paths; restriction is a name whitelist; sub-agents inherit the parent whitelist
- [x] **DB parity**: `tool_capabilities TEXT` added via idempotent `safeAlterTable`, MySQL + SQLite compatible; null/empty = unrestricted (backward compatible)
- [x] **Tool protocol**: tools still register through `tool-registry.ts`; the sole availability axis is now the existing `allowedTools` whitelist (no exemptions)

## General Checklist

- [x] Single logical change (per-agent tool capabilities + the unification it requires)
- [x] Conventional Commits
- [x] No unrelated changes (the agentbox compile fix is required to build the images)

> Note: `tool-refract` is currently ~4 commits behind `main`; a rebase touches ~10 shared core files and needs manual conflict resolution (tracked separately).