### PR TITLE
feat(channels): Feishu group auto-bind + authorized gating + live progress card

### DIFF
--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -39,17 +39,44 @@ export interface ResolvedChannelBinding {
   routeType: "group" | "user";
 }
 
-/** Resolve agent_id for a (channel_id, route_key) pair via RPC. */
+/**
+ * Non-binding result from `channel.resolveBinding`: the Portal recognised the
+ * channel but turned the sender away (sicore_authorized group, sender unbound or
+ * without read access to the agent). The Runtime should reply a short hint
+ * rather than silently ignore. Distinct from `null` (ignore: no binding at all).
+ */
+export interface ChannelAccessDenied {
+  walled: true;
+  reason?: string;
+  authorizeUrl?: string;
+}
+
+export function isChannelAccessDenied(
+  value: ResolvedChannelBinding | ChannelAccessDenied | null,
+): value is ChannelAccessDenied {
+  return value !== null && (value as ChannelAccessDenied).walled === true;
+}
+
+/**
+ * Resolve agent_id for a (channel_id, route_key) pair via RPC.
+ *
+ * `senderOpenId` is threaded so the Portal can resolve a per-sender identity
+ * for authorized group bots and choose the effective session key server-side
+ * (open groups → shared chat session; authorized → per-user). It is separate
+ * from `sessionKey` because the server may override the session key it returns.
+ */
 export async function resolveBinding(
   channelId: string,
   routeKey: string,
   frontendClient: FrontendWsClient,
   sessionKey?: string,
-): Promise<ResolvedChannelBinding | null> {
+  senderOpenId?: string,
+): Promise<ResolvedChannelBinding | ChannelAccessDenied | null> {
   const data = await frontendClient.request("channel.resolveBinding", {
     channel_id: channelId,
     route_key: routeKey,
     ...(sessionKey ? { session_key: sessionKey } : {}),
+    ...(senderOpenId ? { sender_open_id: senderOpenId } : {}),
   });
   return data.binding ?? null;
 }

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -30,6 +30,8 @@ const handlePairingCodeMock = vi.fn();
 vi.mock("../channel-manager.js", () => ({
   resolveBinding: (...args: unknown[]) => resolveBindingMock(...args),
   handlePairingCode: (...args: unknown[]) => handlePairingCodeMock(...args),
+  isChannelAccessDenied: (v: unknown) =>
+    v !== null && typeof v === "object" && (v as { walled?: unknown }).walled === true,
 }));
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -35,7 +35,7 @@ import crypto from "node:crypto";
 import type { AgentBoxManager } from "../agentbox/manager.js";
 import { AgentBoxClient, type PromptOptions } from "../agentbox/client.js";
 import type { ChannelHandler } from "../channel-manager.js";
-import { resolveBinding, handlePairingCode } from "../channel-manager.js";
+import { resolveBinding, handlePairingCode, isChannelAccessDenied } from "../channel-manager.js";
 import { resolveAgentSystemPrompt } from "../agent-model-binding.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
@@ -268,7 +268,7 @@ export async function handleDingTalkMessage(
 
   // Look up binding for this conversation.
   const binding = await resolveBinding(channelId, conversationId, frontendClient!);
-  if (!binding) {
+  if (!binding || isChannelAccessDenied(binding)) {
     console.log(`[dingtalk] No binding for channel=${channelId} conversation=${conversationId} — ignoring`);
     return;
   }
@@ -366,7 +366,7 @@ async function handleNewCommand(
     // are released. Needs the bound agent to locate the right AgentBox.
     try {
       const binding = await resolveBinding(channelId, conversationId, frontendClient!);
-      if (binding) {
+      if (binding && !isChannelAccessDenied(binding)) {
         const handle = await agentBoxManager.getOrCreate(binding.agentId);
         const client = new AgentBoxClient(handle.endpoint, 120_000, tlsOptions);
         await client.closeSession(oldSessionId);

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -4,6 +4,7 @@ import {
   openTypingCard,
   updateCardContent,
   finalizeCard,
+  buildMilestoneCardMarkdown,
   DEFAULT_PLACEHOLDER,
   EMPTY_RESULT_NOTICE,
   PLACEHOLDER_BY_LOCALE,
@@ -279,5 +280,46 @@ describe("finalizeCard", () => {
     const { client, contentSpy } = makeLarkClient();
     await finalizeCard(client as any, { cardId: "C", elementId: "md_main", sequence: 0 }, EMPTY_RESULT_NOTICE);
     expect(contentSpy.mock.calls[0][0].data.content).toBe(EMPTY_RESULT_NOTICE);
+  });
+});
+
+describe("buildMilestoneCardMarkdown", () => {
+  it("marks earlier milestones done (✅) and the latest in progress (⏳) while streaming", () => {
+    const md = buildMilestoneCardMarkdown({ milestones: ["pulled diff", "queried datadog", "writing summary"] });
+    const lines = md.split("\n");
+    expect(lines).toEqual([
+      "✅ pulled diff",
+      "✅ queried datadog",
+      "⏳ writing summary",
+    ]);
+  });
+
+  it("renders all milestones done + a blank line + the conclusion when final", () => {
+    const md = buildMilestoneCardMarkdown({ milestones: ["step 1", "step 2"], finalText: "Root cause: X. Roll back #4821." });
+    expect(md).toBe("✅ step 1\n✅ step 2\n\nRoot cause: X. Roll back #4821.");
+  });
+
+  it("is just the conclusion when there are no milestones (legacy behavior)", () => {
+    expect(buildMilestoneCardMarkdown({ milestones: [], finalText: "done." })).toBe("done.");
+  });
+
+  it("ignores blank milestone entries", () => {
+    const md = buildMilestoneCardMarkdown({ milestones: ["  ", "real step", ""] });
+    expect(md).toBe("⏳ real step");
+  });
+
+  it("preserves inline code so chips render", () => {
+    const md = buildMilestoneCardMarkdown({ milestones: ["502s isolated to `cart-service`"] });
+    expect(md).toContain("`cart-service`");
+  });
+
+  it("caps to the most recent maxVisible with a (+k) overflow prefix", () => {
+    const milestones = Array.from({ length: 14 }, (_, i) => `step ${i + 1}`);
+    const md = buildMilestoneCardMarkdown({ milestones, maxVisible: 10 });
+    const lines = md.split("\n");
+    expect(lines[0]).toBe("… (+4)"); // 14 - 10 hidden
+    expect(lines).toHaveLength(11); // overflow line + 10 shown
+    expect(md).toContain("step 14"); // newest kept
+    expect(md).not.toContain("✅ step 1\n"); // oldest dropped
   });
 });

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -159,13 +159,21 @@ export async function openTypingCard(
       return null;
     }
 
-    await larkClient.im.message.reply({
+    // Posting the card into the chat. The SDK does NOT throw on a non-zero API
+    // code (e.g. the app lacks the im:message send scope) — the card would be
+    // created in CardKit but never appear in the chat, with no error. Surface
+    // the code and fall back to a plain-text reply so the failure is visible.
+    const replyRes = await larkClient.im.message.reply({
       path: { message_id: messageId },
       data: {
         msg_type: "interactive",
         content: JSON.stringify({ type: "card", data: { card_id: cardId } }),
       },
     });
+    if (replyRes && typeof replyRes.code === "number" && replyRes.code !== 0) {
+      console.error(`[lark-card] posting card to chat failed for messageId=${messageId}: code=${replyRes.code} msg=${replyRes.msg} (does the app have the im:message send scope?)`);
+      return null;
+    }
     return { cardId, elementId: MD_ELEMENT_ID, sequence: 0 };
   } catch (err) {
     console.error(`[lark-card] openTypingCard failed for messageId=${messageId}:`, err);

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -59,6 +59,45 @@ export function localeForDomain(domain: string | undefined): LarkLocale {
 /** Primary markdown element id — shared between create and patch calls. */
 const MD_ELEMENT_ID = "md_main";
 
+/**
+ * Render the Claude-tag style progress body: accumulated `channel_update`
+ * milestones as a checklist, then the final conclusion on completion.
+ *
+ * - Streaming (finalText == null): earlier milestones render ✅ (done), the
+ *   latest renders ⏳ (the current step), giving the live "✓ done / ✱ doing"
+ *   look without needing a separate current-step signal.
+ * - Final (finalText set): all milestones render ✅, a blank line, then the
+ *   conclusion. With no milestones this is just the conclusion (legacy behavior).
+ *
+ * Only the most recent `maxVisible` milestones are shown (with a `…(+k)` prefix
+ * for the rest) so a long SRE investigation stays within the card's size limits.
+ * Milestone text passes through verbatim, so an agent writing inline code
+ * (`` `cart-service` ``) gets rendered chips for free.
+ */
+export function buildMilestoneCardMarkdown(opts: {
+  milestones: string[];
+  finalText?: string | null;
+  maxVisible?: number;
+}): string {
+  const all = opts.milestones.map((m) => (m ?? "").trim()).filter(Boolean);
+  const isFinal = opts.finalText != null;
+  const maxVisible = opts.maxVisible ?? 10;
+  const hidden = Math.max(0, all.length - maxVisible);
+  const shown = hidden > 0 ? all.slice(all.length - maxVisible) : all;
+  const lines: string[] = [];
+  if (hidden > 0) lines.push(`… (+${hidden})`);
+  shown.forEach((m, i) => {
+    const inProgress = !isFinal && i === shown.length - 1;
+    lines.push(`${inProgress ? "⏳" : "✅"} ${m}`);
+  });
+  if (isFinal) {
+    const final = opts.finalText!.trim();
+    if (lines.length && final) lines.push("");
+    if (final) lines.push(final);
+  }
+  return lines.join("\n");
+}
+
 /** Handle returned by `openTypingCard` and consumed by `finalizeCard`. */
 export interface CardSession {
   cardId: string;

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -44,6 +44,8 @@ vi.mock("../channel-manager.js", () => ({
   resolvePersonalBinding: (...args: unknown[]) => resolvePersonalBindingMock(...args),
   handlePersonalPairingCode: (...args: unknown[]) => handlePersonalPairingCodeMock(...args),
   resetPersonalSession: (...args: unknown[]) => resetPersonalSessionMock(...args),
+  isChannelAccessDenied: (v: unknown) =>
+    v !== null && typeof v === "object" && (v as { walled?: unknown }).walled === true,
 }));
 
 const ensureChatSessionMock = vi.fn();
@@ -509,7 +511,7 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     resolveBindingMock.mockResolvedValue(null);
     const mgr = makeAgentBoxManager();
     await handleLarkMessage(makeTextEvent("hello"), makeLarkClient(), "lark", mgr as any, undefined, {} as any);
-    expect(resolveBindingMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "open_id:ou_user_1");
+    expect(resolveBindingMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "open_id:ou_user_1", "ou_user_1");
     expect(mgr.getOrCreate).not.toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();
   });
@@ -537,8 +539,35 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       },
     );
 
-    expect(resolveBindingMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "open_id:ou_user_1");
+    expect(resolveBindingMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "open_id:ou_user_1", "ou_user_1");
     expect(resolvePersonalBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("authorized group: a walled sender gets a hint and no agent runs", async () => {
+    resolveBindingMock.mockResolvedValue({ walled: true, reason: "unbound", authorizeUrl: "https://sicore.example/auth" });
+    const lark = makeLarkClient();
+    const mgr = makeAgentBoxManager();
+    await handleLarkMessage(
+      makeTextEvent("hi"),
+      lark,
+      "lark-runtime",
+      mgr as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      {
+        app_id: "cli_x",
+        app_secret: "secret",
+        group_channel_id: "lark:personal:pb-1",
+        personal_bot: { channel_id: "pb-1", agent_id: "a1", access_mode: "sicore_authorized", owner_user_id: "owner-1" },
+      },
+    );
+
+    const replyArg = lark.im.message.reply.mock.calls[0][0];
+    const text = JSON.parse(replyArg.data.content).text as string;
+    expect(text).toContain("https://sicore.example/auth");
+    expect(mgr.getOrCreate).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
   });
 
   it("with binding → getOrCreate uses agentId alone, and registers the durable channel session owner", async () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -959,7 +959,7 @@ describe("handleLarkMessage — streaming card flow", () => {
     clearBackgroundChannelDelivery(sessionId);
   });
 
-  it("lets the agent explicitly update the visible card, while Gateway caps non-final updates", async () => {
+  it("accumulates agent milestones into a Claude-tag checklist on the card", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-explicit-channel" });
     let releaseStream: () => void = () => {};
@@ -1006,10 +1006,15 @@ describe("handleLarkMessage — streaming card flow", () => {
       })).resolves.toBe(true);
 
       const inFlightContentCalls = lark.cardkit.v1.cardElement.content.mock.calls;
-      expect(inFlightContentCalls).toHaveLength(2);
-      expect(inFlightContentCalls[0][0].data.content).toContain("里程碑 1");
-      expect(inFlightContentCalls[1][0].data.content).toContain("产物提示");
-      expect(inFlightContentCalls[1][0].data.content).not.toContain("压掉");
+      // New behavior: milestones accumulate into a checklist (no 2-cap). Each
+      // update re-renders the whole list; earlier steps render ✅, the latest ⏳.
+      expect(inFlightContentCalls).toHaveLength(3);
+      const latest = inFlightContentCalls[2][0].data.content as string;
+      expect(latest).toContain("里程碑 1");
+      expect(latest).toContain("产物提示");
+      expect(latest).toContain("压掉"); // no longer suppressed — it accumulates
+      expect(latest).toContain("✅"); // earlier steps marked done
+      expect(latest).toContain("⏳"); // latest step in progress
       expect(lark.cardkit.v1.card.settings).not.toHaveBeenCalled();
       expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
       expect(lark.im.message.reply.mock.calls[0][0].data.msg_type).toBe("interactive");
@@ -1020,8 +1025,13 @@ describe("handleLarkMessage — streaming card flow", () => {
     }
 
     const contentCalls = lark.cardkit.v1.cardElement.content.mock.calls;
-    expect(contentCalls).toHaveLength(3);
-    expect(contentCalls.at(-1)[0].data.content).toContain("最终结论");
+    // 3 milestone updates + 1 final = 4 content writes.
+    expect(contentCalls).toHaveLength(4);
+    const finalContent = contentCalls.at(-1)[0].data.content as string;
+    expect(finalContent).toContain("最终结论");
+    // final card preserves the accumulated checklist (all milestones done).
+    expect(finalContent).toContain("里程碑 1");
+    expect(finalContent).toContain("压掉");
     expect(lark.cardkit.v1.card.settings).toHaveBeenCalledTimes(1);
   });
 
@@ -1679,6 +1689,24 @@ describe("collectResponse — SSE event flattening", () => {
     ];
     const text = await collectResponse(fakeClient(events), "s4");
     expect(text).toBe("");
+  });
+
+  it("surfaces intermediate assistant turns as milestones (first line), keeping the last as the answer", async () => {
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "## 先看 node 状态\n详细…" }] } },
+      { type: "message_end", message: { role: "toolResult", content: [{ type: "text", text: "{...}" }] } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "node 正常,继续查 `sichek`" }] } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "结论:GPU#3 fatal,建议换卡。" }] } },
+    ];
+    const milestones: string[] = [];
+    const collected = await collectChannelResponse(fakeClient(events), "s-ms", "lark", {
+      onMilestone: (m) => milestones.push(m),
+    });
+    // Only the two NON-final assistant turns become milestones; heading marker
+    // stripped, first line only, inline code kept.
+    expect(milestones).toEqual(["先看 node 状态", "node 正常,继续查 `sichek`"]);
+    // The final turn is the answer, not a milestone.
+    expect(collected.text).toBe("结论:GPU#3 fatal,建议换卡。");
   });
 
   it("ignores non-text blocks (e.g. tool_use blocks) inside an assistant message", async () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -132,6 +132,9 @@ function makeBinding(overrides: Record<string, unknown> = {}) {
     agentId: "a1",
     bindingId: "b",
     sessionId: "session-fixed",
+    // Server-authoritative per-sender session key (open group → open_id:<sender>);
+    // the Runtime uses this for queueing + /new, not the local default.
+    sessionKey: "open_id:ou_user_1",
     createdBy: "user-1",
     routeType: "group",
     ...overrides,
@@ -749,6 +752,26 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     expect(lark.im.message.reply.mock.calls[0][0].data.content).toContain("已开启新会话");
   });
 
+  it("/new resets the SERVER session key (authorized group → sicore_user:<id>), not the local open_id", async () => {
+    // Contract: the Runtime must reset whatever session key the resolver
+    // returned, so an authorized group resets the sender's sicore_user session
+    // and an open group resets open_id:<sender> — never the local default.
+    resolveBindingMock.mockResolvedValue(makeBinding({ sessionId: "old-session", sessionKey: "sicore_user:u42" }));
+    resetBindingSessionMock.mockResolvedValue({ success: true, agentId: "a1", oldSessionId: "old-session", sessionId: "new-session" });
+    const mgr = makeAgentBoxManager("a1");
+
+    await handleLarkMessage(
+      makeTextEvent("/new"),
+      makeLarkClient(),
+      "lark",
+      mgr as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(resetBindingSessionMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "sicore_user:u42");
+  });
+
   it("queues concurrent messages for the same sender instead of starting a second prompt", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ sessionId: "queued-session" }));
     let releaseFirst!: () => void;
@@ -828,6 +851,73 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     releaseFirst();
     await Promise.all([first, ...queued]);
     expect(promptMock).toHaveBeenCalledTimes(21);
+  });
+});
+
+describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => {
+  const BOT = "ou_bot_self";
+
+  // A realistic group event carries chat_type:"group" + a mentions[] array.
+  function groupEvent(text: string, mentions: any[]) {
+    return makeTextEvent(text, { chat_type: "group", mentions });
+  }
+
+  it("routes when THIS bot is individually @-mentioned (open_id match)", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const data = groupEvent("@_user_1 查一下集群", [
+      { key: "@_user_1", id: { open_id: BOT } },
+    ]);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock).toHaveBeenCalled();
+  });
+
+  it("IGNORES @所有人 announcements (key @_all, not the bot's open_id)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    const data = groupEvent("@_all 基础功能都搞过来了", [
+      { key: "@_all", id: {} },
+    ]);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("IGNORES a message that @-mentions someone else (not the bot)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    const data = groupEvent("@_user_2 你看下", [
+      { key: "@_user_2", id: { open_id: "ou_someone_else" } },
+    ]);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("IGNORES a plain group message with no mention at all", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    const data = groupEvent("随便聊两句", []);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("degraded (botOpenId unknown): still drops @所有人 by its @_all key", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    const data = groupEvent("@_all 通知一下", [{ key: "@_all", id: {} }]);
+    // No botOpenId passed (bot-info fetch failed at start).
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("degraded (botOpenId unknown): a non-@_all mention still routes", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const data = groupEvent("@_user_1 帮我查", [{ key: "@_user_1", id: { open_id: "ou_whoever" } }]);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any);
+    expect(resolveBindingMock).toHaveBeenCalled();
+  });
+
+  it("does NOT gate p2p messages — DMs never carry an @bot mention", async () => {
+    // p2p path is personal-bot only; with no personal_bot config it bails
+    // *before* resolveBinding, but it must NOT be dropped by the group gate.
+    const data = makeTextEvent("私聊问个问题", { chat_type: "p2p" });
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    // group resolveBinding is never reached on the p2p branch
+    expect(resolveBindingMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -663,10 +663,16 @@ function formatPersonalPairReply(
 
 async function replyToLark(larkClient: any, messageId: string, text: string): Promise<void> {
   try {
-    await larkClient.im.message.reply({
+    // Feishu's SDK does NOT throw on a non-zero API code (e.g. missing
+    // im:message send scope) — it returns {code,msg} in the body. Surface it,
+    // otherwise a permission failure looks like a silent no-op.
+    const resp = await larkClient.im.message.reply({
       path: { message_id: messageId },
       data: { content: JSON.stringify({ text }), msg_type: "text" },
     });
+    if (resp && typeof resp.code === "number" && resp.code !== 0) {
+      console.error(`[lark] reply API returned non-zero code for messageId=${messageId}: code=${resp.code} msg=${resp.msg}`);
+    }
   } catch (err) {
     console.error(`[lark] Failed to reply to messageId=${messageId}:`, err);
   }

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -27,6 +27,7 @@ import {
   openTypingCard,
   updateCardContent,
   finalizeCard,
+  buildMilestoneCardMarkdown,
   PLACEHOLDER_BY_LOCALE,
   EMPTY_RESULT_NOTICE_BY_LOCALE,
   localeForDomain,
@@ -65,7 +66,10 @@ const GROUP_ACCESS_DENIED_NOTICE_BY_LOCALE = {
   "zh-CN": "❌ 你没有这个助手的访问权限，请联系管理员授权。",
   "en-US": "❌ You don't have access to this assistant. Ask an admin to grant access.",
 } as const;
-const MAX_AGENT_SELECTED_UPDATES = 2;
+// Max milestones kept in the accumulating Claude-tag checklist. channel_update
+// milestones are meant to be sparse; if an agent over-emits we drop the oldest
+// so the card stays within Feishu's element size limits.
+const MILESTONE_CAP = 20;
 const MAX_LARK_BINDING_QUEUE = 20;
 
 interface QueuedLarkTask {
@@ -279,6 +283,11 @@ export async function handleLarkMessage(
   const senderOpenId = getLarkSenderOpenId(data);
   const sessionKey = buildLarkSessionKey(senderOpenId, chatId);
 
+  // Raw receipt log: fires for EVERY delivered event before any drop, so a
+  // group message that arrives but is filtered (non-text, empty after @-strip)
+  // is still visible. Lets us tell "never delivered" from "silently dropped".
+  console.log(`[lark] recv event chat=${chatId} chat_type=${chatType} msg_type=${msgType} sender=${senderOpenId ?? "?"} channelCfg=${channelId}`);
+
   if (msgType !== "text") return;
 
   let text: string;
@@ -477,30 +486,75 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   // once the agent is done (preserves the pre-card behaviour).
   const cardSession = await openTypingCard(larkClient, messageId, PLACEHOLDER_BY_LOCALE[locale]);
   let deliveredTextChars = 0;
-  let deliveredAgentUpdates = 0;
+  // Accumulating Claude-tag checklist. Two milestone sources feed one list:
+  // explicit channel_update tool calls (agent-curated) AND auto-derived first
+  // lines of intermediate assistant turns (collectChannelResponse.onMilestone).
+  // Card re-renders are coalesced (never concurrent) to respect Feishu's update
+  // rate; earlier steps render ✅, the latest ⏳, then the answer on finalize.
+  const milestones: string[] = [];
+  let cardFlushInflight = false;
+  let cardFlushDirty = false;
+  let cardFinalizing = false;
+  let cardFlushPromise: Promise<void> | null = null;
+  const flushMilestoneCard = (): Promise<void> => {
+    if (!cardSession || cardFinalizing) return Promise.resolve();
+    if (cardFlushInflight) { cardFlushDirty = true; return cardFlushPromise ?? Promise.resolve(); }
+    cardFlushInflight = true;
+    cardFlushPromise = (async () => {
+      try {
+        do {
+          cardFlushDirty = false;
+          const md = buildMilestoneCardMarkdown({ milestones });
+          if (md.trim()) await updateCardContent(larkClient, cardSession, md);
+        } while (cardFlushDirty && !cardFinalizing);
+      } catch (err) {
+        console.warn(`[lark] milestone card flush failed for session=${sessionId}:`, err);
+      } finally {
+        cardFlushInflight = false;
+      }
+    })();
+    return cardFlushPromise;
+  };
+  // Returns a promise the channel_update path awaits (deterministic delivered
+  // bool); the narration onMilestone path ignores it (must not block the SSE
+  // loop). Bursts coalesce — a flush in flight just marks the card dirty.
+  const addMilestone = (text: string): Promise<void> => {
+    const t = (text ?? "").trim();
+    if (!t || milestones[milestones.length - 1] === t) return Promise.resolve(); // skip empty/dup
+    milestones.push(t);
+    if (milestones.length > MILESTONE_CAP) milestones.shift();
+    return flushMilestoneCard();
+  };
   registerBackgroundChannelDelivery(sessionId, async (backgroundMessage) => {
     if ("text" in backgroundMessage) {
-      const display = stripVisualBlocks(backgroundMessage.text) || EMPTY_RESULT_NOTICE_BY_LOCALE[locale];
-      if (!shouldDeliverAgentSelectedUpdate(backgroundMessage.kind, display, deliveredAgentUpdates)) return true;
-      if (backgroundMessage.kind !== "final") deliveredAgentUpdates += 1;
-      const terminal = backgroundMessage.kind === "final";
-      const delivered = await deliverVisibleChannelText(larkClient, messageId, cardSession, display, terminal);
-      if (delivered) deliveredTextChars = display.length;
-      return delivered;
+      const display = stripVisualBlocks(backgroundMessage.text);
+      if (!display || !display.trim()) return true;
+
+      if (backgroundMessage.kind === "final") {
+        const md = buildMilestoneCardMarkdown({ milestones, finalText: display });
+        const delivered = await deliverVisibleChannelText(larkClient, messageId, cardSession, md, true);
+        if (delivered) deliveredTextChars = md.length;
+        return delivered;
+      }
+
+      // milestone / artifact → accumulate into the checklist (coalesced render).
+      await addMilestone(display);
+      return true;
     }
 
     const display = stripVisualBlocks(backgroundMessage.content) || EMPTY_RESULT_NOTICE_BY_LOCALE[locale];
     if (!shouldDeliverBackgroundReply(display, deliveredTextChars)) return true;
+    const md = buildMilestoneCardMarkdown({ milestones, finalText: display });
     if (cardSession) {
-      const ok = await finalizeCard(larkClient, cardSession, display);
+      const ok = await finalizeCard(larkClient, cardSession, md);
       if (ok) {
-        deliveredTextChars = display.length;
+        deliveredTextChars = md.length;
         return true;
       }
       console.warn(`[lark] Background card update failed for session=${sessionId}; falling back to text reply`);
     }
-    await replyToLark(larkClient, messageId, display);
-    deliveredTextChars = display.length;
+    await replyToLark(larkClient, messageId, md);
+    deliveredTextChars = md.length;
     return true;
   });
 
@@ -514,7 +568,10 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   let agentError: Error | null = null;
   try {
     const promptResult = await client.prompt(promptOpts);
-    const collected = await collectChannelResponse(client, promptResult.sessionId, "lark", { includeImages: true });
+    const collected = await collectChannelResponse(client, promptResult.sessionId, "lark", {
+      includeImages: true,
+      onMilestone: addMilestone,
+    });
     resultText = collected.text;
     replyImages = collected.images;
   } catch (err) {
@@ -530,10 +587,20 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   if (agentError) replyImages = [];
   const displayBody = stripVisualBlocks(finalBody, { stripSourceBlocks: replyImages.length > 0 })
     || VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
+  // Render the accumulated milestone checklist (✅) followed by the conclusion,
+  // so the final card preserves the visible investigation trail. With no
+  // milestones this is just the conclusion (legacy behavior).
+  const finalCardBody = buildMilestoneCardMarkdown({ milestones, finalText: displayBody });
+
+  // Stop any further coalesced milestone renders and let the in-flight one
+  // settle, so finalizeCard isn't overwritten by a later (higher-sequence)
+  // milestone-only update.
+  cardFinalizing = true;
+  if (cardFlushPromise) { try { await cardFlushPromise; } catch { /* logged in flush */ } }
 
   if (cardSession) {
-    const ok = await finalizeCard(larkClient, cardSession, displayBody);
-    deliveredTextChars = displayBody.length;
+    const ok = await finalizeCard(larkClient, cardSession, finalCardBody);
+    deliveredTextChars = finalCardBody.length;
     if (!ok) {
       // Partial-failure path: the card is visible but stuck in streaming
       // state. We log but do NOT post a second reply — that would produce
@@ -542,9 +609,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     }
   } else if (resultText || agentError) {
     // Card could not be opened; fall back to a plain text reply with
-    // whatever we have (final answer or error).
-    await replyToLark(larkClient, messageId, displayBody);
-    deliveredTextChars = displayBody.length;
+    // whatever we have (final answer or error) + any accumulated milestones.
+    await replyToLark(larkClient, messageId, finalCardBody);
+    deliveredTextChars = finalCardBody.length;
   }
 
   await replyVisualImages(larkClient, messageId, replyImages);
@@ -684,12 +751,6 @@ function shouldDeliverBackgroundReply(text: string, previousChars: number): bool
   return !(previousChars > 80 && chars < 120 && chars < previousChars * 0.75);
 }
 
-function shouldDeliverAgentSelectedUpdate(kind: "milestone" | "final" | "artifact", text: string, deliveredUpdates: number): boolean {
-  if (!text.trim()) return false;
-  if (kind !== "final" && deliveredUpdates >= MAX_AGENT_SELECTED_UPDATES) return false;
-  return true;
-}
-
 async function deliverVisibleChannelText(
   larkClient: any,
   messageId: string,
@@ -736,7 +797,7 @@ export async function collectChannelResponse(
   client: AgentBoxClient,
   sessionId: string,
   logPrefix = "lark",
-  options: { includeImages?: boolean } = {},
+  options: { includeImages?: boolean; onMilestone?: (text: string) => void } = {},
 ): Promise<CollectedChannelResponse> {
   const parts: string[] = [];
   const images: RenderedReplyImage[] = [];
@@ -762,7 +823,17 @@ export async function collectChannelResponse(
         const blocks = Array.isArray(ev.message.content) ? ev.message.content : [];
         if (options.includeImages) collectImageAttachments(blocks, images, seenImageKeys);
         const turnText = contentBlocksToMarkdown(blocks);
-        if (turnText) lastAssistantText = turnText;
+        if (turnText) {
+          // A NEW assistant turn means the PREVIOUS one was an intermediate
+          // step (the agent narrated, then called a tool) — surface its first
+          // line as a progress milestone. The final turn is never followed by
+          // another, so it stays the answer, not a milestone.
+          if (lastAssistantText && options.onMilestone) {
+            const m = condenseMilestone(lastAssistantText);
+            if (m) options.onMilestone(m);
+          }
+          lastAssistantText = turnText;
+        }
       }
     }
   } catch (err) {
@@ -772,6 +843,18 @@ export async function collectChannelResponse(
   // brain only emits content_block_delta events.
   const text = lastAssistantText || parts.join("");
   return { text, images };
+}
+
+/**
+ * Condense an intermediate assistant turn into a one-line progress milestone:
+ * first non-empty line, strip a leading heading marker, cap length. Inline
+ * code/bold pass through so chips still render.
+ */
+function condenseMilestone(text: string): string {
+  const firstLine = text.split("\n").map((s) => s.trim()).find(Boolean) ?? "";
+  const clean = firstLine.replace(/^#{1,6}\s+/, "").trim();
+  if (!clean) return "";
+  return clean.length > 90 ? `${clean.slice(0, 88)}…` : clean;
 }
 
 function contentBlocksToMarkdown(blocks: unknown[]): string {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -16,7 +16,9 @@ import {
   resolvePersonalBinding,
   handlePersonalPairingCode,
   resetPersonalSession,
+  isChannelAccessDenied,
   type ResolvedChannelBinding,
+  type ChannelAccessDenied,
 } from "../channel-manager.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
@@ -53,6 +55,16 @@ const PERSONAL_BIND_REQUIRED_NOTICE_BY_LOCALE = {
   "zh-CN": "❌ 这个个人机器人需要先绑定 Sicore 账号。请打开 Sicore 的 Agent Channels 页面，点击“授权飞书账号”后再回来私聊。",
   "en-US": "❌ This personal bot requires Sicore authorization. Open the Sicore Agent Channels page, click “Authorize Feishu account”, then come back to this chat.",
 } as const;
+// sicore_authorized group: sender hasn't linked their Feishu account to Sicore.
+const GROUP_ACCESS_UNBOUND_NOTICE_BY_LOCALE = {
+  "zh-CN": "❌ 你的飞书账号还没绑定 Sicore，无法在群里使用这个助手。请打开 Sicore 的 Agent Channels 页面授权飞书账号后再试。",
+  "en-US": "❌ Your Feishu account isn't linked to Sicore yet, so you can't use this assistant here. Open the Sicore Agent Channels page to authorize, then try again.",
+} as const;
+// sicore_authorized group: sender is linked but lacks read access to the agent.
+const GROUP_ACCESS_DENIED_NOTICE_BY_LOCALE = {
+  "zh-CN": "❌ 你没有这个助手的访问权限，请联系管理员授权。",
+  "en-US": "❌ You don't have access to this assistant. Ask an admin to grant access.",
+} as const;
 const MAX_AGENT_SELECTED_UPDATES = 2;
 const MAX_LARK_BINDING_QUEUE = 20;
 
@@ -82,6 +94,7 @@ export interface LarkChannelConfig {
     access_mode: "open" | "sicore_authorized";
     owner_user_id?: string;
     authorize_url?: string;
+    group_auto_bind?: boolean;
   };
 }
 
@@ -354,8 +367,16 @@ export async function handleLarkMessage(
     return;
   }
 
-  // Look up binding for this chat
-  const binding = await resolveBinding(groupChannelId, chatId, frontendClient!, sessionKey);
+  // Look up binding for this chat. Pass sender_open_id so the Portal can
+  // auto-bind / per-sender resolve group bots and pick the session key.
+  const binding = await resolveBinding(groupChannelId, chatId, frontendClient!, sessionKey, senderOpenId ?? undefined);
+  if (isChannelAccessDenied(binding)) {
+    // sicore_authorized group: this sender isn't allowed. Feishu only delivers
+    // @-mentioned group messages, so the message is already directed at the bot
+    // — a single short hint is fine, not spam.
+    await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(binding, locale));
+    return;
+  }
   if (!binding) {
     console.log(`[lark] No binding for channel=${groupChannelId} chat=${chatId} — ignoring`);
     // Don't spam the group with "not paired" for every message.
@@ -541,7 +562,25 @@ async function resolveQueuedBinding(
     if (!senderOpenId) return null;
     return resolvePersonalBinding(channelId, senderOpenId, frontendClient);
   }
-  return resolveBinding(channelId, chatId, frontendClient, sessionKey);
+  const result = await resolveBinding(channelId, chatId, frontendClient, sessionKey, senderOpenId ?? undefined);
+  // If access was revoked between enqueue and run, treat as gone (the queued
+  // task then skips). The pre-enqueue check already replied any access hint.
+  return isChannelAccessDenied(result) ? null : result;
+}
+
+/**
+ * Build the access-denied reply for a sicore_authorized group, in the channel's
+ * locale. Appends the authorize URL for the "unbound" case.
+ */
+function formatGroupAccessDeniedReply(
+  denied: ChannelAccessDenied,
+  locale: "zh-CN" | "en-US",
+): string {
+  if (denied.reason === "denied") {
+    return GROUP_ACCESS_DENIED_NOTICE_BY_LOCALE[locale];
+  }
+  const base = GROUP_ACCESS_UNBOUND_NOTICE_BY_LOCALE[locale];
+  return denied.authorizeUrl ? `${base}\n${denied.authorizeUrl}` : base;
 }
 
 async function handleNewCommand(

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -137,6 +137,25 @@ export function createLarkHandler(
         domain,
       });
 
+      // Fetch the bot's own open_id once at start. Group-message handling needs
+      // it to tell an individual "@bot" from "@所有人": Feishu delivers @所有人
+      // to an @bot-scoped app too (it mentions everyone, the bot included), so
+      // at the event layer an @所有人 announcement is indistinguishable from a
+      // real @bot unless we match the bot's own open_id. Best-effort: on
+      // failure we fall back to @_all-exclusion (see isBotMentioned).
+      let botOpenId: string | undefined;
+      try {
+        const botInfo: any = await (larkClient as any).request({
+          method: "GET",
+          url: "/open-apis/bot/v3/info",
+        });
+        botOpenId = botInfo?.bot?.open_id ?? botInfo?.data?.bot?.open_id;
+        console.log(`[lark] Channel ${channelId} bot open_id=${botOpenId ?? "(unknown)"}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[lark] Could not fetch bot info for channel ${channelId}; group @-mention gating falls back to @_all-exclusion: ${msg}`);
+      }
+
       const dispatcher = new lark.EventDispatcher({
         verificationToken: config.verification_token,
         encryptKey: config.encrypt_key,
@@ -151,7 +170,7 @@ export function createLarkHandler(
         // ACK ships in <1ms and redelivery never triggers.
         "im.message.receive_v1": (data: any) => {
           setImmediate(() => {
-            handleLarkMessage(data, larkClient, channelId, agentBoxManager, tlsOptions, frontendClient, localeForDomain(config.domain), config)
+            handleLarkMessage(data, larkClient, channelId, agentBoxManager, tlsOptions, frontendClient, localeForDomain(config.domain), config, botOpenId)
               .catch((err) => {
                 console.error(`[lark] Error handling message for channel=${channelId}:`, err);
               });
@@ -240,6 +259,30 @@ function buildLarkSessionKey(senderOpenId: string | null, chatId: string): strin
   return senderOpenId ? `open_id:${senderOpenId}` : `chat:${chatId}`;
 }
 
+/**
+ * Whether a group message is actually directed at THIS bot.
+ *
+ * Feishu delivers a group message to an app scoped to "receive @bot messages"
+ * whenever the bot is mentioned — but "@所有人" (@all) mentions *everyone*, the
+ * bot included, so an @所有人 announcement is delivered too and looks identical
+ * to a real @bot at the event layer. We must match the bot's own open_id:
+ * "@所有人" carries key "@_all" and never the bot's open_id, so a strict
+ * open_id match excludes it (and any "@someone-else").
+ *
+ * Degraded path — bot-info fetch failed, so `botOpenId` is unknown: we can't
+ * positively identify the bot, but we can still drop "@所有人" explicitly by
+ * its "@_all" key. This kills the reported announcement-spam case without
+ * muting the bot when its open_id couldn't be resolved.
+ */
+function isBotMentioned(message: any, botOpenId?: string): boolean {
+  const mentions = message?.mentions as
+    | Array<{ id?: { open_id?: string }; key?: string }>
+    | undefined;
+  if (!mentions || mentions.length === 0) return false;
+  if (botOpenId) return mentions.some((m) => m.id?.open_id === botOpenId);
+  return mentions.some((m) => m.key !== "@_all");
+}
+
 export function buildChannelTurnPrompt(text: string): string {
   return [
     "<channel-turn>",
@@ -269,6 +312,7 @@ export async function handleLarkMessage(
   frontendClient?: FrontendWsClient,
   locale: "zh-CN" | "en-US" = "zh-CN",
   channelConfig?: LarkChannelConfig,
+  botOpenId?: string,
 ): Promise<void> {
   // @larksuiteoapi/node-sdk EventDispatcher flattens the event payload before
   // dispatching: `event.*` fields land on the top level and `data.event`
@@ -376,6 +420,18 @@ export async function handleLarkMessage(
     return;
   }
 
+  // Only respond when THIS bot is individually @-mentioned. Feishu also
+  // delivers "@所有人" to an @bot-scoped app (it mentions everyone, the bot
+  // included), so an @所有人 announcement arrives looking just like a real
+  // @bot — without this gate the bot replies to group-wide announcements that
+  // were never aimed at it. Skips "@所有人" and "@someone-else"; PAIR above is
+  // exempt (explicit command). Gated on chat_type==="group" so the binding/
+  // access checks below stay reachable only for messages aimed at the bot.
+  if (chatType === "group" && !isBotMentioned(message, botOpenId)) {
+    console.log(`[lark] Group message not directed at bot (chat=${chatId}) — ignoring (@所有人 / @others / no @bot)`);
+    return;
+  }
+
   // Look up binding for this chat. Pass sender_open_id so the Portal can
   // auto-bind / per-sender resolve group bots and pick the session key.
   const binding = await resolveBinding(groupChannelId, chatId, frontendClient!, sessionKey, senderOpenId ?? undefined);
@@ -393,13 +449,20 @@ export async function handleLarkMessage(
     return;
   }
 
-  const queueKey = `${binding.bindingId}:${binding.sessionKey ?? sessionKey}`;
+  // Use the SERVER-authoritative session key (not the local open_id default) for
+  // both the queue and the queued context, so the two-path contract holds:
+  //   - open group     → open_id:<sender>  (per-sender: concurrent + isolated)
+  //   - authorized group → sicore_user:<id> (per-user)
+  //   - legacy single binding session → "" (binding-level queue + /new reset)
+  // /new then resets the right session, and same-session senders serialize.
+  const effectiveSessionKey = binding.sessionKey ?? "";
+  const queueKey = `${binding.bindingId}:${binding.sessionKey ?? "__binding__"}`;
   const queued = enqueueBindingTask(queueKey, () => processQueuedLarkMessage({
     text,
     messageId,
     chatId,
     senderOpenId,
-    sessionKey,
+    sessionKey: effectiveSessionKey,
     channelId: groupChannelId,
     route: "group",
     larkClient,

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1348,6 +1348,24 @@ describe("channel.list", () => {
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe("ch1");
   });
+
+  it("injects group_channel_id for an open personal-bot channel", async () => {
+    mockQuery([{
+      id: "ch-personal", name: "bot", status: "active", created_at: "2024-01-01",
+      config: JSON.stringify({ app_id: "x", personal_bot: { agent_id: "a1", access_mode: "open" } }),
+    }]);
+    const result = await getHandler("channel.list")({}, "a1");
+    expect(result.data[0].config.group_channel_id).toBe("ch-personal");
+  });
+
+  it("does not inject group_channel_id when group_auto_bind is false", async () => {
+    mockQuery([{
+      id: "ch-personal", name: "bot", status: "active", created_at: "2024-01-01",
+      config: JSON.stringify({ app_id: "x", personal_bot: { agent_id: "a1", access_mode: "open", group_auto_bind: false } }),
+    }]);
+    const result = await getHandler("channel.list")({}, "a1");
+    expect(result.data[0].config.group_channel_id).toBeUndefined();
+  });
 });
 
 describe("channel.resolveBinding", () => {
@@ -1406,10 +1424,46 @@ describe("channel.resolveBinding", () => {
   });
 
   it("returns null binding when not found", async () => {
-    mockQuery([]);
+    // No explicit binding, and the channel is not a personal-bot channel
+    // (selectPersonalChannel → none), so the open-group fallback also yields null.
+    mockQuery([], []);
 
     const result = await getHandler("channel.resolveBinding")(
       { channel_id: "ch1", route_key: "group-999" }, "a1",
+    );
+    expect(result).toEqual({ binding: null });
+  });
+
+  it("open personal-bot auto-binds a group with a shared per-chat session", async () => {
+    mockQuery(
+      [],                                                                  // selectChannelBinding → none
+      [{ id: "ch1", created_by: "owner-1", config: JSON.stringify({ personal_bot: { agent_id: "a1", access_mode: "open" } }) }], // selectPersonalChannel
+      [],                                                                  // participant session lookup → none
+      [],                                                                  // insert participant session
+      [{ session_id: "chat-session" }],                                    // participant session reload
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      { channel_id: "ch1", route_key: "group-123", session_key: "open_id:ou_1", sender_open_id: "ou_1" }, "a1",
+    );
+    expect(result.binding).toEqual({
+      agentId: "a1",
+      bindingId: "ch1",
+      sessionId: "chat-session",
+      sessionKey: "chat:group-123",
+      createdBy: "owner-1",
+      routeType: "group",
+    });
+  });
+
+  it("punts (null) on a sicore_authorized personal bot in standalone", async () => {
+    mockQuery(
+      [],                                                                  // selectChannelBinding → none
+      [{ id: "ch1", created_by: "owner-1", config: JSON.stringify({ personal_bot: { agent_id: "a1", access_mode: "sicore_authorized" } }) }],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      { channel_id: "ch1", route_key: "group-123", sender_open_id: "ou_1" }, "a1",
     );
     expect(result).toEqual({ binding: null });
   });

--- a/src/portal/adapter.routes.test.ts
+++ b/src/portal/adapter.routes.test.ts
@@ -308,7 +308,8 @@ describe("registerAdapterRoutes — auth + routing", () => {
   // ── Channel RPC endpoints ───────────────────────────────────────────
 
   it("POST channel/resolve-binding returns null shape when no match", async () => {
-    query.mockResolvedValueOnce([[], []]);
+    query.mockResolvedValueOnce([[], []]); // selectChannelBinding → none
+    query.mockResolvedValueOnce([[], []]); // open-group fallback selectPersonalChannel → none
     const { status, body } = await runRoute(router, fakeReq({
       url: "/api/internal/siclaw/channel/resolve-binding",
       method: "POST",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -76,7 +76,11 @@ async function resolveChannelBinding(
   sessionKey?: string | null,
 ): Promise<ResolvedChannelBinding | null> {
   const row = await selectChannelBinding(db, channelId, routeKey);
-  if (!row) return null;
+  if (!row) {
+    // No explicit binding. A per-agent open bot auto-serves any group it joins
+    // (standalone supports open only — authorized requires Sicore's im_bindings).
+    return resolveOpenGroupBinding(db, channelId, routeKey);
+  }
 
   const session = sessionKey
     ? await resolveChannelBindingParticipantSession(db, row.id, sessionKey)
@@ -251,6 +255,9 @@ interface PersonalChannelConfig {
     agent_id?: string;
     access_mode?: "open" | "sicore_authorized";
     owner_user_id?: string;
+    // When not explicitly false, an open per-agent bot also auto-serves any
+    // group it is added to (no PAIR). Mirrors Sicore's group_auto_bind.
+    group_auto_bind?: boolean;
   };
 }
 
@@ -291,6 +298,34 @@ async function resolvePersonalChannelBinding(
     sessionKey: session.sessionKey,
     createdBy: personalBot.owner_user_id ?? channel.created_by,
     routeType: "user",
+  };
+}
+
+/**
+ * Open-mode group fallback: a per-agent open bot answers in any group it joins
+ * without a PAIR. All senders in one group share a single session (keyed by
+ * chat id, distinct from the DM `open_id:` keys), and every turn runs as the
+ * fixed owner. Authorized mode is punted here (Sicore-only).
+ */
+async function resolveOpenGroupBinding(
+  db: Db,
+  channelId: string,
+  routeKey: string,
+): Promise<ResolvedChannelBinding | null> {
+  const channel = await selectPersonalChannel(db, channelId);
+  const personalBot = channel?.config.personal_bot;
+  if (!channel || !personalBot?.agent_id) return null;
+  if (personalBot.access_mode !== "open") return null;
+  if (personalBot.group_auto_bind === false) return null;
+  const sessionKey = `chat:${routeKey}`;
+  const session = await resolveChannelBindingParticipantSession(db, channel.id, sessionKey);
+  return {
+    agentId: personalBot.agent_id,
+    bindingId: channel.id,
+    sessionId: session.sessionId,
+    sessionKey: session.sessionKey,
+    createdBy: personalBot.owner_user_id ?? channel.created_by,
+    routeType: "group",
   };
 }
 
@@ -2611,6 +2646,18 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     ) as any;
     for (const row of rows as any[]) {
       if (row.config !== undefined) row.config = safeParseJson(row.config, null);
+      // A per-agent open bot also serves the groups it joins. Advertise
+      // group_channel_id so the Runtime stops ignoring group messages (lark.ts
+      // gates the group path on it). DM-only bots set group_auto_bind:false.
+      const cfg = row.config;
+      if (
+        cfg && typeof cfg === "object" &&
+        cfg.personal_bot && typeof cfg.personal_bot === "object" &&
+        cfg.personal_bot.group_auto_bind !== false &&
+        !cfg.group_channel_id
+      ) {
+        cfg.group_channel_id = row.id;
+      }
     }
     return { data: rows };
   });


### PR DESCRIPTION
Runtime side of the Feishu channel work (companion to sicore MR k8s/sicore!546).

## 1. Group routing + open-group auto-bind (`818be80`)
- `channel-manager`/`lark`: thread `sender_open_id` through `channel.resolveBinding` so the Portal can auto-bind groups and pick the session key.
- standalone `adapter`: `channel.list` injects `group_channel_id` for open personal-bot channels; `resolveChannelBinding` adds an open-group fallback (one shared session per chat). Authorized stays Sicore-only.

## 2. Authorized-group access hint (`1c11aac`)
- `channel.resolveBinding` can return a `walled` result (sender unbound / no read access). `channel-manager` exports `ChannelAccessDenied` + `isChannelAccessDenied`; `lark` replies a short locale-aware hint instead of silently ignoring.

## 3. Surface Feishu send errors (`16df084`)
- The Feishu SDK doesn't throw on non-zero API codes. `openTypingCard`'s card-post and `replyToLark` now check the code and log it — a missing `im:message` scope used to look like a silent no-op.

## 4. Claude-tag progress card (`e276bb8`, `e1aa0f4`)
- Long channel investigations render an evolving checklist: ✅ done steps, ⏳ current, then the answer — instead of a "thinking…" spinner that jumps straight to the final reply.
- Milestones are **auto-derived from the agent's own narration** (first line of each intermediate assistant turn) — no reliance on the model calling a tool, no prompt nudge. Explicit `channel_update` milestones feed the same list.
- Bounded + safe: card shows the last 10 (`… (+k)` overflow), coalesced updates (never concurrent → respects Feishu's card update rate), consecutive-dedup.

## Tests
Full `vitest run`: 3805 passed. New cases: open-group / authorized resolution, walled hint, milestone derivation + checklist render + overflow cap.

## Verified live
open-group auto-bind, authorized DM, and the progress card all exercised on the sendong-sicore-test deployment (real Feishu group).

## Review fixes (session contract)
- **[P1]** open group now uses a **per-sender session** (`open_id:<sender>`, runs as the fixed owner) instead of a binding-level shared one; the group path threads the **server-authoritative `binding.sessionKey`** into the queue key + `/new` (open_id / sicore_user / "" binding-level). Fixes: concurrent writes to one shared session, and `/new` resetting the wrong/empty key (open + authorized). (sicore: per-sender open branch.)
- **[P2]** tests updated to the per-sender contract + added authorized `/new` reset (`sicore_user:<id>`).