### PR TITLE
feat(lark): show only the current step on the Feishu card, replace with the conclusion

### DIFF
--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1049,7 +1049,7 @@ describe("handleLarkMessage — streaming card flow", () => {
     clearBackgroundChannelDelivery(sessionId);
   });
 
-  it("accumulates agent milestones into a Claude-tag checklist on the card", async () => {
+  it("shows only the latest step on the card and replaces it with the conclusion on finalize", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-explicit-channel" });
     let releaseStream: () => void = () => {};
@@ -1096,15 +1096,15 @@ describe("handleLarkMessage — streaming card flow", () => {
       })).resolves.toBe(true);
 
       const inFlightContentCalls = lark.cardkit.v1.cardElement.content.mock.calls;
-      // New behavior: milestones accumulate into a checklist (no 2-cap). Each
-      // update re-renders the whole list; earlier steps render ✅, the latest ⏳.
+      // The card shows ONLY the single latest step — no accumulating checklist.
+      // Each delivery replaces the previous step in place.
       expect(inFlightContentCalls).toHaveLength(3);
       const latest = inFlightContentCalls[2][0].data.content as string;
-      expect(latest).toContain("里程碑 1");
-      expect(latest).toContain("产物提示");
-      expect(latest).toContain("压掉"); // no longer suppressed — it accumulates
-      expect(latest).toContain("✅"); // earlier steps marked done
-      expect(latest).toContain("⏳"); // latest step in progress
+      expect(latest).toContain("压掉"); // only the latest step is shown
+      expect(latest).toContain("⏳"); // marked in progress
+      expect(latest).not.toContain("里程碑 1"); // earlier steps are gone
+      expect(latest).not.toContain("产物提示");
+      expect(latest).not.toContain("✅"); // no done-checklist
       expect(lark.cardkit.v1.card.settings).not.toHaveBeenCalled();
       expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
       expect(lark.im.message.reply.mock.calls[0][0].data.msg_type).toBe("interactive");
@@ -1115,13 +1115,14 @@ describe("handleLarkMessage — streaming card flow", () => {
     }
 
     const contentCalls = lark.cardkit.v1.cardElement.content.mock.calls;
-    // 3 milestone updates + 1 final = 4 content writes.
+    // 3 step updates + 1 final = 4 content writes.
     expect(contentCalls).toHaveLength(4);
     const finalContent = contentCalls.at(-1)[0].data.content as string;
+    // The final card is JUST the conclusion — the step trail is gone.
     expect(finalContent).toContain("最终结论");
-    // final card preserves the accumulated checklist (all milestones done).
-    expect(finalContent).toContain("里程碑 1");
-    expect(finalContent).toContain("压掉");
+    expect(finalContent).not.toContain("里程碑 1");
+    expect(finalContent).not.toContain("压掉");
+    expect(finalContent).not.toContain("⏳");
     expect(lark.cardkit.v1.card.settings).toHaveBeenCalledTimes(1);
   });
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -66,9 +66,9 @@ const GROUP_ACCESS_DENIED_NOTICE_BY_LOCALE = {
   "zh-CN": "❌ 你没有这个助手的访问权限，请联系管理员授权。",
   "en-US": "❌ You don't have access to this assistant. Ask an admin to grant access.",
 } as const;
-// Max milestones kept in the accumulating Claude-tag checklist. channel_update
-// milestones are meant to be sparse; if an agent over-emits we drop the oldest
-// so the card stays within Feishu's element size limits.
+// The card only ever shows the single latest step, so the milestone list is
+// just an internal buffer for dedup against the previous step. Bound it anyway
+// to keep memory flat if an agent over-emits.
 const MILESTONE_CAP = 20;
 const MAX_LARK_BINDING_QUEUE = 20;
 
@@ -549,11 +549,14 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   // once the agent is done (preserves the pre-card behaviour).
   const cardSession = await openTypingCard(larkClient, messageId, PLACEHOLDER_BY_LOCALE[locale]);
   let deliveredTextChars = 0;
-  // Accumulating Claude-tag checklist. Two milestone sources feed one list:
-  // explicit channel_update tool calls (agent-curated) AND auto-derived first
-  // lines of intermediate assistant turns (collectChannelResponse.onMilestone).
-  // Card re-renders are coalesced (never concurrent) to respect Feishu's update
-  // rate; earlier steps render ✅, the latest ⏳, then the answer on finalize.
+  // Live "current step" indicator. Two milestone sources feed it: explicit
+  // channel_update tool calls (agent-curated) AND auto-derived first lines of
+  // intermediate assistant turns (collectChannelResponse.onMilestone). The card
+  // shows ONLY the single latest step (⏳), replaced in place as work proceeds —
+  // no accumulating checklist — and on finalize the step is replaced entirely by
+  // the conclusion. `milestones` is kept only to dedup against the last step;
+  // renders use the latest entry. Re-renders are coalesced to respect Feishu's
+  // update rate.
   const milestones: string[] = [];
   let cardFlushInflight = false;
   let cardFlushDirty = false;
@@ -567,7 +570,8 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       try {
         do {
           cardFlushDirty = false;
-          const md = buildMilestoneCardMarkdown({ milestones });
+          // Render only the single latest step — never an accumulating list.
+          const md = buildMilestoneCardMarkdown({ milestones: milestones.slice(-1) });
           if (md.trim()) await updateCardContent(larkClient, cardSession, md);
         } while (cardFlushDirty && !cardFinalizing);
       } catch (err) {
@@ -594,7 +598,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       if (!display || !display.trim()) return true;
 
       if (backgroundMessage.kind === "final") {
-        const md = buildMilestoneCardMarkdown({ milestones, finalText: display });
+        const md = buildMilestoneCardMarkdown({ milestones: [], finalText: display });
         const delivered = await deliverVisibleChannelText(larkClient, messageId, cardSession, md, true);
         if (delivered) deliveredTextChars = md.length;
         return delivered;
@@ -607,7 +611,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
 
     const display = stripVisualBlocks(backgroundMessage.content) || EMPTY_RESULT_NOTICE_BY_LOCALE[locale];
     if (!shouldDeliverBackgroundReply(display, deliveredTextChars)) return true;
-    const md = buildMilestoneCardMarkdown({ milestones, finalText: display });
+    const md = buildMilestoneCardMarkdown({ milestones: [], finalText: display });
     if (cardSession) {
       const ok = await finalizeCard(larkClient, cardSession, md);
       if (ok) {
@@ -650,10 +654,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   if (agentError) replyImages = [];
   const displayBody = stripVisualBlocks(finalBody, { stripSourceBlocks: replyImages.length > 0 })
     || VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
-  // Render the accumulated milestone checklist (✅) followed by the conclusion,
-  // so the final card preserves the visible investigation trail. With no
-  // milestones this is just the conclusion (legacy behavior).
-  const finalCardBody = buildMilestoneCardMarkdown({ milestones, finalText: displayBody });
+  // The final card is JUST the conclusion — the live step indicator is replaced
+  // entirely, no milestone trail is kept on the card.
+  const finalCardBody = buildMilestoneCardMarkdown({ milestones: [], finalText: displayBody });
 
   // Stop any further coalesced milestone renders and let the in-flight one
   // settle, so finalizeCard isn't overwritten by a later (higher-sequence)


### PR DESCRIPTION
## What
The group progress card accumulated every milestone into a growing checklist, and the final card kept that whole trail above the conclusion. This switches to a live single-step indicator:

- **During work**: the card shows only the latest step (⏳), replaced in place — no accumulating checklist.
- **On finalize**: the step is replaced entirely by the conclusion — no step trail remains on the card.

`milestones[]` is now just an internal dedup buffer; renders use the latest entry only.

## Why
Follow-up to #353. The accumulating checklist made the card verbose and exposed the full intermediate investigation trail in groups; the ask is for the card to show only what's happening now and end as just the answer. This also reduces how much of the intermediate trail is exposed in open groups (addresses the milestone-exposure note from the #353 review).

## Tests
- Updated the `lark.test.ts` integration test to assert latest-step-only rendering and conclusion-only finalize.
- `npx vitest run src/gateway/channels/` — 158 passed.