### PR TITLE
feat(metrics): maintainer audit — per-entry axis, Sessions/Tools tabs, timing, read-only session snapshot

### DIFF
--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -308,6 +308,9 @@ export interface PilotAreaProps {
   onOpenSchedulePanel?: (msg: PilotMessage) => void
   onOpenSubagent?: (childSessionId: string, status?: string, label?: string) => void
   agentId?: string
+  /** Read-only transcript: hides the composer and edit/steer/dig-deeper affordances.
+   *  Used by the admin session-snapshot view. Message rendering is unchanged. */
+  readOnly?: boolean
 }
 
 export function PilotArea({
@@ -330,6 +333,7 @@ export function PilotArea({
   onOpenSchedulePanel,
   onOpenSubagent,
   agentId,
+  readOnly = false,
 }: PilotAreaProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -657,7 +661,7 @@ export function PilotArea({
           ) : !hasVisibleMessages ? (
             <div className="flex flex-col items-center justify-center py-20 text-muted-foreground/70">
               <MessageSquare className="w-12 h-12 text-gray-200 mb-4" />
-              <p className="text-sm text-muted-foreground">Send a message to start the conversation</p>
+              <p className="text-sm text-muted-foreground">{readOnly ? "No messages in this session" : "Send a message to start the conversation"}</p>
             </div>
           ) : (
             <>
@@ -745,9 +749,9 @@ export function PilotArea({
                         <MessageItem
                           message={msg}
                           sendMessage={wrappedSendMessage}
-                          showSuggestedReplies={msg.id === lastAssistantMsgId && !isLoading}
+                          showSuggestedReplies={!readOnly && msg.id === lastAssistantMsgId && !isLoading}
                           dpActive={dpActive}
-                          canEditMessage={msg.id === latestEditableUserMessageId && !isLoading}
+                          canEditMessage={!readOnly && msg.id === latestEditableUserMessageId && !isLoading}
                           editingContent={editingMessageId === msg.id ? editingDraft : null}
                           onStartEditMessage={startEditingMessage}
                           onEditMessageChange={setEditingDraft}
@@ -788,7 +792,7 @@ export function PilotArea({
 
               {/* Dig deeper — shown when agent produced a conclusion and user may want
                   to trace the root cause upstream. Hidden while a prefix chip is active. */}
-              {showTraceButton && !activePrefix && (
+              {!readOnly && showTraceButton && !activePrefix && (
                 <div className="flex justify-start pl-12 my-2">
                   <button
                     type="button"
@@ -808,24 +812,26 @@ export function PilotArea({
           <div ref={scrollRef} />
         </div>
       </div>
-      <InputArea
-        onSend={wrappedSendMessage}
-        onAbort={wrappedAbort}
-        disabled={false}
-        isLoading={isLoading}
-        hasBackgroundWork={hasBackgroundWork}
-        contextUsage={contextUsage}
-        pendingMessages={pendingMessages}
-        onRemovePending={onRemovePending}
-        dpActive={dpActive}
-        onSetDpActive={onSetDpActive}
-        hasMessages={hasVisibleMessages}
-        draft={chipDraft}
-        draftSeq={chipSeq}
-        historyMessages={userMessageHistory}
-        activePrefix={activePrefix}
-        onClearPrefix={() => setActivePrefix(null)}
-      />
+      {!readOnly && (
+        <InputArea
+          onSend={wrappedSendMessage}
+          onAbort={wrappedAbort}
+          disabled={false}
+          isLoading={isLoading}
+          hasBackgroundWork={hasBackgroundWork}
+          contextUsage={contextUsage}
+          pendingMessages={pendingMessages}
+          onRemovePending={onRemovePending}
+          dpActive={dpActive}
+          onSetDpActive={onSetDpActive}
+          hasMessages={hasVisibleMessages}
+          draft={chipDraft}
+          draftSeq={chipSeq}
+          historyMessages={userMessageHistory}
+          activePrefix={activePrefix}
+          onClearPrefix={() => setActivePrefix(null)}
+        />
+      )}
     </div>
   )
 }

--- a/portal-web/src/components/metrics/AuditTable.tsx
+++ b/portal-web/src/components/metrics/AuditTable.tsx
@@ -5,6 +5,15 @@ import { AuditDetailPanel } from "./AuditDetailPanel"
 
 const TOOL_OPTIONS = ["All", "restricted_bash", "local_script", "pod_exec", "kubectl", "cluster_probe", "cluster_list"]
 const STATUS_OPTIONS = ["All", "success", "error", "blocked"]
+// Session entry-form categories. "web" maps the NULL/"web" origin; "channel"
+// covers IM channels (Feishu/DingTalk). Mirrors chat_sessions.origin.
+const ENTRY_OPTIONS = ["All", "web", "api", "a2a", "channel", "task"]
+const ENTRY_LABELS: Record<string, string> = {
+  web: "Web", api: "API", a2a: "A2A", channel: "Channel", task: "Scheduled", delegation: "Delegation",
+}
+function entryLabel(origin: string | null): string {
+  return ENTRY_LABELS[origin ?? "web"] ?? "Web"
+}
 
 function formatDuration(ms: number | null): string {
   if (ms == null) return "—"
@@ -50,6 +59,7 @@ function OutcomeIcon({ outcome }: { outcome: string | null }) {
 export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilterId: string | null; usernameHint: string | null; timeRange: TimeRange }) {
   const [tool, setTool] = useState("All")
   const [status, setStatus] = useState("All")
+  const [entry, setEntry] = useState("All")
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const { users } = useUsers()
   const userMap = useMemo(() => {
@@ -67,10 +77,11 @@ export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilt
       userId: userFilterId ?? undefined,
       toolName: tool === "All" ? undefined : tool,
       outcome: status === "All" ? undefined : status,
+      origin: entry === "All" ? undefined : entry,
       from: String(fromMs),
       to: String(toMs),
     }
-  }, [tool, status, timeRange.from, timeRange.to, userFilterId])
+  }, [tool, status, entry, timeRange.from, timeRange.to, userFilterId])
 
   const { logs, hasMore, loading, loadMore } = useAudit(params)
 
@@ -98,6 +109,13 @@ export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilt
         >
           {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s === "All" ? "All Status" : s}</option>)}
         </select>
+        <select
+          value={entry}
+          onChange={(e) => setEntry(e.target.value)}
+          className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
+        >
+          {ENTRY_OPTIONS.map((o) => <option key={o} value={o}>{o === "All" ? "All Entries" : entryLabel(o)}</option>)}
+        </select>
         <div className="flex-1"></div>
         <div className="text-[11px] text-muted-foreground font-mono">{logs.length} entries{hasMore ? "+" : ""}</div>
       </div>
@@ -109,6 +127,7 @@ export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilt
               <th className="w-8"></th>
               <th className="text-left px-3 py-2.5 font-medium">Time</th>
               <th className="text-left px-3 py-2.5 font-medium">User</th>
+              <th className="text-left px-3 py-2.5 font-medium">Entry</th>
               <th className="text-left px-3 py-2.5 font-medium">Agent</th>
               <th className="text-left px-3 py-2.5 font-medium">Tool</th>
               <th className="text-left px-3 py-2.5 font-medium">Command</th>
@@ -118,7 +137,7 @@ export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilt
           </thead>
           <tbody className="divide-y divide-border/60">
             {logs.length === 0 && !loading ? (
-              <tr><td colSpan={8} className="text-center py-12 text-muted-foreground text-[12px]">No entries found</td></tr>
+              <tr><td colSpan={9} className="text-center py-12 text-muted-foreground text-[12px]">No entries found</td></tr>
             ) : logs.map((log: AuditLog) => (
               <AuditRow
                 key={log.id}
@@ -162,6 +181,9 @@ function AuditRow({ log, username, expanded, onToggle }: { log: AuditLog; userna
           <span className="mr-1">{formatDate(log.timestamp)}</span>{formatTime(log.timestamp)}
         </td>
         <td className="px-3 py-2.5">{username}</td>
+        <td className="px-3 py-2.5">
+          <span className="px-1.5 py-0.5 rounded text-[10px] bg-secondary text-muted-foreground">{entryLabel(log.origin)}</span>
+        </td>
         <td className="px-3 py-2.5 text-muted-foreground">{log.agentId ?? "—"}</td>
         <td className="px-3 py-2.5">
           <span className="px-1.5 py-0.5 rounded text-[10px] font-mono bg-secondary text-muted-foreground">{log.toolName ?? "—"}</span>
@@ -172,7 +194,7 @@ function AuditRow({ log, username, expanded, onToggle }: { log: AuditLog; userna
       </tr>
       {expanded && (
         <tr className="bg-secondary/20">
-          <td colSpan={8} className="px-6 py-4"><AuditDetailPanel log={log} /></td>
+          <td colSpan={9} className="px-6 py-4"><AuditDetailPanel log={log} /></td>
         </tr>
       )}
     </>

--- a/portal-web/src/components/metrics/AuditTable.tsx
+++ b/portal-web/src/components/metrics/AuditTable.tsx
@@ -1,19 +1,10 @@
 import { useMemo, useState } from "react"
 import { ChevronDown, ChevronRight, CheckCircle, XCircle, Ban, Loader2 } from "lucide-react"
-import { useAudit, useUsers, resolveRange, type AuditLog, type TimeRange } from "../../hooks/useMetrics"
+import { useAudit, useUsers, resolveRange, originLabel, type AuditLog, type EntryMode, type TimeRange } from "../../hooks/useMetrics"
 import { AuditDetailPanel } from "./AuditDetailPanel"
 
 const TOOL_OPTIONS = ["All", "restricted_bash", "local_script", "pod_exec", "kubectl", "cluster_probe", "cluster_list"]
 const STATUS_OPTIONS = ["All", "success", "error", "blocked"]
-// Session entry-form categories. "web" maps the NULL/"web" origin; "channel"
-// covers IM channels (Feishu/DingTalk). Mirrors chat_sessions.origin.
-const ENTRY_OPTIONS = ["All", "web", "api", "a2a", "channel", "task"]
-const ENTRY_LABELS: Record<string, string> = {
-  web: "Web", api: "API", a2a: "A2A", channel: "Channel", task: "Scheduled", delegation: "Delegation",
-}
-function entryLabel(origin: string | null): string {
-  return ENTRY_LABELS[origin ?? "web"] ?? "Web"
-}
 
 function formatDuration(ms: number | null): string {
   if (ms == null) return "—"
@@ -56,10 +47,9 @@ function OutcomeIcon({ outcome }: { outcome: string | null }) {
   }
 }
 
-export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilterId: string | null; usernameHint: string | null; timeRange: TimeRange }) {
+export function AuditTable({ userFilterId, usernameHint, entry, timeRange }: { userFilterId: string | null; usernameHint: string | null; entry: EntryMode; timeRange: TimeRange }) {
   const [tool, setTool] = useState("All")
   const [status, setStatus] = useState("All")
-  const [entry, setEntry] = useState("All")
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const { users } = useUsers()
   const userMap = useMemo(() => {
@@ -77,7 +67,7 @@ export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilt
       userId: userFilterId ?? undefined,
       toolName: tool === "All" ? undefined : tool,
       outcome: status === "All" ? undefined : status,
-      origin: entry === "All" ? undefined : entry,
+      entry,
       from: String(fromMs),
       to: String(toMs),
     }
@@ -108,13 +98,6 @@ export function AuditTable({ userFilterId, usernameHint, timeRange }: { userFilt
           className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
         >
           {STATUS_OPTIONS.map((s) => <option key={s} value={s}>{s === "All" ? "All Status" : s}</option>)}
-        </select>
-        <select
-          value={entry}
-          onChange={(e) => setEntry(e.target.value)}
-          className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
-        >
-          {ENTRY_OPTIONS.map((o) => <option key={o} value={o}>{o === "All" ? "All Entries" : entryLabel(o)}</option>)}
         </select>
         <div className="flex-1"></div>
         <div className="text-[11px] text-muted-foreground font-mono">{logs.length} entries{hasMore ? "+" : ""}</div>
@@ -182,9 +165,9 @@ function AuditRow({ log, username, expanded, onToggle }: { log: AuditLog; userna
         </td>
         <td className="px-3 py-2.5">{username}</td>
         <td className="px-3 py-2.5">
-          <span className="px-1.5 py-0.5 rounded text-[10px] bg-secondary text-muted-foreground">{entryLabel(log.origin)}</span>
+          <span className="px-1.5 py-0.5 rounded text-[10px] bg-secondary text-muted-foreground">{originLabel(log.origin)}</span>
         </td>
-        <td className="px-3 py-2.5 text-muted-foreground">{log.agentId ?? "—"}</td>
+        <td className="px-3 py-2.5 text-muted-foreground">{log.agentName ?? log.agentId ?? "—"}</td>
         <td className="px-3 py-2.5">
           <span className="px-1.5 py-0.5 rounded text-[10px] font-mono bg-secondary text-muted-foreground">{log.toolName ?? "—"}</span>
         </td>

--- a/portal-web/src/components/metrics/EntrySelector.tsx
+++ b/portal-web/src/components/metrics/EntrySelector.tsx
@@ -1,0 +1,21 @@
+import { ENTRY_MODES, ENTRY_LABELS, type EntryMode } from "../../hooks/useMetrics"
+
+/**
+ * Page-level entry-form selector, shared by Dashboard / Sessions / Tools.
+ * "Overview" is the combined interactive family (web+api+a2a+channel); the
+ * remaining options isolate a single entry form, plus Scheduled (cron runs).
+ */
+export function EntrySelector({ value, onChange }: { value: EntryMode; onChange: (v: EntryMode) => void }) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as EntryMode)}
+      title="Entry form"
+      className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
+    >
+      {ENTRY_MODES.map((m) => (
+        <option key={m} value={m}>{ENTRY_LABELS[m]}</option>
+      ))}
+    </select>
+  )
+}

--- a/portal-web/src/components/metrics/SessionSnapshot.tsx
+++ b/portal-web/src/components/metrics/SessionSnapshot.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useMemo } from "react"
+import { Loader2, X } from "lucide-react"
+import { useSessionSnapshot, originLabel } from "../../hooks/useMetrics"
+import { buildPilotMessages } from "../../hooks/usePilotChat"
+import { PilotArea } from "../chat/PilotArea"
+
+function formatTime(ts: string | null): string {
+  if (!ts) return ""
+  const d = new Date(ts)
+  return d.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false })
+}
+
+const noop = () => {}
+
+/**
+ * Read-only transcript snapshot for the Metrics Sessions tab. Admin-only audit
+ * view of ANY user's session — fetched via /audit/sessions/:id/messages (not the
+ * owner-scoped chat endpoint). Centered modal; renders through the SAME PilotArea
+ * the live chat uses (readOnly: no composer / edit / steer) so the content looks
+ * identical to chat. Close returns to the session list.
+ */
+export function SessionSnapshot({ sessionId, onClose }: { sessionId: string; onClose: () => void }) {
+  const { data, loading, error } = useSessionSnapshot(sessionId)
+  const s = data?.session
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose() }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [onClose])
+
+  const messages = useMemo(() => (data ? buildPilotMessages(data.data) : []), [data])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden="true" />
+      <div className="relative flex h-full max-h-[88vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-3 border-b border-border shrink-0">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold tracking-tight truncate">{s?.title || "Session transcript"}</h3>
+            <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
+              {s?.agentName && <span className="text-foreground">{s.agentName}</span>}
+              {s && <span className="px-1.5 py-0.5 rounded text-[10px] bg-secondary">{originLabel(s.origin)}</span>}
+              {s && <span className="font-mono">{s.sessionId.slice(0, 8)}…</span>}
+              {s && <span>{s.messageCount} msgs</span>}
+              {s?.createdAt && <span>{formatTime(s.createdAt)}</span>}
+              <span className="px-1.5 py-0.5 rounded text-[10px] border border-border">Read-only</span>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground shrink-0" title="Close (Esc)">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body — identical rendering to the live chat via PilotArea (readOnly) */}
+        <div className="flex-1 min-h-0 flex flex-col">
+          {loading && (
+            <div className="flex flex-1 items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-muted-foreground" /></div>
+          )}
+          {error && !loading && (
+            <div className="flex flex-1 items-center justify-center text-[12px] text-muted-foreground">Failed to load session transcript.</div>
+          )}
+          {!loading && !error && data && (
+            <PilotArea
+              readOnly
+              messages={messages}
+              isLoading={false}
+              sendMessage={noop}
+              agentId={s?.agentId}
+              sessionKey={sessionId}
+            />
+          )}
+        </div>
+
+        {data?.truncated && (
+          <div className="shrink-0 border-t border-border px-5 py-1.5 text-center text-[11px] text-amber-500">
+            Transcript truncated — showing the first 1000 messages.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/portal-web/src/components/metrics/SessionTable.tsx
+++ b/portal-web/src/components/metrics/SessionTable.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useMemo, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { AlertTriangle, ChevronDown, ChevronRight, Eye, Loader2, MessageSquare, Wrench } from "lucide-react"
+import {
+  resolveRange,
+  useSessions,
+  useUsers,
+  originLabel,
+  type EntryMode,
+  type SessionListItem,
+  type TimeRange,
+} from "../../hooks/useMetrics"
+import { api } from "../../api"
+
+function formatTime(ts: string): string {
+  const d = new Date(ts)
+  return d.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false })
+}
+
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id
+}
+
+interface AgentOption { id: string; name: string }
+interface AgentGroupView { agentKey: string; label: string; sessions: SessionListItem[] }
+
+const DEFAULT_VISIBLE_SESSIONS = 5
+
+export function SessionTable({
+  userFilterId,
+  usernameHint,
+  entry,
+  timeRange,
+}: {
+  userFilterId: string | null
+  usernameHint: string | null
+  entry: EntryMode
+  timeRange: TimeRange
+}) {
+  const navigate = useNavigate()
+  const [agentId, setAgentId] = useState("")
+  const [agents, setAgents] = useState<AgentOption[]>([])
+  const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set())
+  const [visibleCounts, setVisibleCounts] = useState<Record<string, number>>({})
+  const { users } = useUsers()
+  const userMap = useMemo(() => {
+    const m = new Map<string, string>()
+    users.forEach((u) => m.set(u.id, u.username))
+    return m
+  }, [users])
+
+  useEffect(() => {
+    let cancelled = false
+    api<{ data: Array<{ id: string; name: string }> }>("/agents")
+      .then((r) => {
+        if (cancelled) return
+        const list = Array.isArray(r.data) ? r.data : []
+        setAgents(list.map((a) => ({ id: a.id, name: a.name })))
+      })
+      .catch(() => { /* agent names fall back to ids */ })
+    return () => { cancelled = true }
+  }, [])
+
+  const params = useMemo(() => {
+    const { fromMs, toMs } = resolveRange(timeRange)
+    return {
+      userId: userFilterId ?? undefined,
+      agentId: agentId || undefined,
+      from: String(fromMs),
+      to: String(toMs),
+      entry,
+    }
+  }, [agentId, timeRange.from, timeRange.to, userFilterId, entry])
+
+  const { sessions, hasMore, loading, loadMore } = useSessions(params)
+
+  const agentOptions = useMemo(() => {
+    const byId = new Map<string, AgentOption>()
+    agents.forEach((a) => byId.set(a.id, a))
+    sessions.forEach((s) => {
+      if (!byId.has(s.agentId)) byId.set(s.agentId, { id: s.agentId, name: s.agentName ?? s.agentId })
+    })
+    return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name))
+  }, [agents, sessions])
+
+  const groupedAgents = useMemo<AgentGroupView[]>(() => {
+    const byAgent = new Map<string, AgentGroupView>()
+    sessions.forEach((session) => {
+      let g = byAgent.get(session.agentId)
+      if (!g) {
+        g = { agentKey: session.agentId, label: session.agentName ?? session.agentId, sessions: [] }
+        byAgent.set(session.agentId, g)
+      }
+      g.sessions.push(session)
+    })
+    return Array.from(byAgent.values())
+      .map((g) => ({
+        ...g,
+        sessions: [...g.sessions].sort((a, b) => new Date(b.activityAt).getTime() - new Date(a.activityAt).getTime()),
+      }))
+      .sort((a, b) => new Date(b.sessions[0]?.activityAt ?? 0).getTime() - new Date(a.sessions[0]?.activityAt ?? 0).getTime())
+  }, [sessions])
+
+  // Reset expand/visible state whenever the result set's shape changes.
+  const groupSignature = groupedAgents.map((g) => `${g.agentKey}:${g.sessions.length}`).join("|")
+  useEffect(() => {
+    setExpandedAgents(new Set(groupedAgents.map((g) => g.agentKey)))
+    setVisibleCounts(Object.fromEntries(groupedAgents.map((g) => [g.agentKey, Math.min(DEFAULT_VISIBLE_SESSIONS, g.sessions.length)])))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupSignature])
+
+  const toggleAgent = (key: string) =>
+    setExpandedAgents((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  const expandAll = () => setExpandedAgents(new Set(groupedAgents.map((g) => g.agentKey)))
+  const collapseAll = () => setExpandedAgents(new Set())
+  const showMore = (key: string) =>
+    setVisibleCounts((prev) => {
+      const g = groupedAgents.find((x) => x.agentKey === key)
+      return g ? { ...prev, [key]: g.sessions.length } : prev
+    })
+
+  const openSession = (s: SessionListItem) => navigate(`/chat?agent=${s.agentId}&session=${s.sessionId}`)
+  const usernameFor = (s: SessionListItem) => (s.userId ? userMap.get(s.userId) ?? s.userId : "—")
+
+  return (
+    <section className="px-6 py-6 space-y-4">
+      <div className="flex items-center gap-2 flex-wrap">
+        {usernameHint && (
+          <span className="text-[11px] px-2 py-1 rounded bg-secondary border border-border text-muted-foreground">
+            user: <span className="text-foreground font-mono">{usernameHint}</span>
+          </span>
+        )}
+        <select
+          value={agentId}
+          onChange={(e) => setAgentId(e.target.value)}
+          className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
+        >
+          <option value="">All Agents</option>
+          {agentOptions.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+        </select>
+        {groupedAgents.length > 0 && (
+          <div className="inline-flex h-8 rounded-md border border-border bg-secondary p-0.5 text-[12px]">
+            <button onClick={expandAll} className="inline-flex items-center gap-1.5 px-2.5 rounded text-muted-foreground hover:text-foreground hover:bg-background">
+              <ChevronDown className="h-3.5 w-3.5" />Expand all
+            </button>
+            <button onClick={collapseAll} className="inline-flex items-center gap-1.5 px-2.5 rounded text-muted-foreground hover:text-foreground hover:bg-background">
+              <ChevronRight className="h-3.5 w-3.5" />Collapse all
+            </button>
+          </div>
+        )}
+        <div className="flex-1" />
+        <div className="text-[11px] text-muted-foreground font-mono">{sessions.length} sessions{hasMore ? "+" : ""}</div>
+      </div>
+
+      <div className="border border-border rounded-lg bg-card overflow-hidden">
+        <table className="w-full text-[12px] table-fixed">
+          <thead className="bg-secondary/40">
+            <tr className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              <th className="text-left px-4 py-2.5 font-medium w-44">Time</th>
+              <th className="text-left px-3 py-2.5 font-medium">Session</th>
+              <th className="text-right px-3 py-2.5 font-medium w-24">Messages</th>
+              <th className="text-right px-3 py-2.5 font-medium w-20">Tools</th>
+              <th className="text-right px-3 py-2.5 font-medium w-20">Errors</th>
+              <th className="text-right px-4 py-2.5 font-medium w-16">Open</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.length === 0 && !loading ? (
+              <tr><td colSpan={6} className="text-center py-12 text-muted-foreground text-[12px]">No sessions found</td></tr>
+            ) : (
+              groupedAgents.map((g, i) => (
+                <SessionAgentGroup
+                  key={g.agentKey}
+                  group={g}
+                  isFirst={i === 0}
+                  expanded={expandedAgents.has(g.agentKey)}
+                  visibleCount={visibleCounts[g.agentKey] ?? DEFAULT_VISIBLE_SESSIONS}
+                  usernameFor={usernameFor}
+                  onToggle={() => toggleAgent(g.agentKey)}
+                  onShowMore={() => showMore(g.agentKey)}
+                  onOpen={openSession}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+        <div className="flex items-center justify-between px-4 py-3 border-t border-border text-[11px] text-muted-foreground">
+          <span>{loading ? "Loading…" : `Showing ${sessions.length}`}</span>
+          {hasMore && (
+            <button onClick={loadMore} disabled={loading} className="inline-flex items-center gap-1.5 px-3 py-1 rounded border border-border hover:bg-secondary text-foreground disabled:opacity-50">
+              {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : "Load More ↓"}
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function SessionAgentGroup({
+  group,
+  isFirst,
+  expanded,
+  visibleCount,
+  usernameFor,
+  onToggle,
+  onShowMore,
+  onOpen,
+}: {
+  group: AgentGroupView
+  isFirst: boolean
+  expanded: boolean
+  visibleCount: number
+  usernameFor: (s: SessionListItem) => string
+  onToggle: () => void
+  onShowMore: () => void
+  onOpen: (s: SessionListItem) => void
+}) {
+  const visible = group.sessions.slice(0, Math.min(visibleCount, group.sessions.length))
+  const hidden = Math.max(group.sessions.length - visible.length, 0)
+  const totals = useMemo(
+    () => group.sessions.reduce(
+      (acc, s) => ({ messages: acc.messages + s.messageCount, tools: acc.tools + s.toolCallCount, errors: acc.errors + s.errorToolCallCount }),
+      { messages: 0, tools: 0, errors: 0 },
+    ),
+    [group.sessions],
+  )
+  return (
+    <>
+      {!isFirst && (
+        <tr aria-hidden="true" className="h-2 bg-background"><td colSpan={6} className="border-t border-border/70 p-0" /></tr>
+      )}
+      <tr className="border-t border-border bg-secondary/45 hover:bg-secondary/60">
+        <td colSpan={2} className="border-l-2 border-blue-500/40 px-7 py-2.5 text-[11px] text-muted-foreground">
+          <button onClick={onToggle} className="inline-flex items-center gap-2 text-left" aria-expanded={expanded}>
+            {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+            <span className="inline-flex h-5 w-5 items-center justify-center rounded border border-border/70 bg-background text-muted-foreground">
+              <MessageSquare className="h-3.5 w-3.5" />
+            </span>
+            <span className="font-medium text-foreground">{group.label}</span>
+            <span>· {group.sessions.length} sessions</span>
+          </button>
+        </td>
+        <td className="px-3 py-2.5 text-right font-mono text-muted-foreground">{totals.messages}</td>
+        <td className="px-3 py-2.5 text-right font-mono text-muted-foreground">{totals.tools}</td>
+        <td className={`px-3 py-2.5 text-right font-mono ${totals.errors > 0 ? "text-red-400" : "text-muted-foreground"}`}>{totals.errors}</td>
+        <td className="px-4 py-2.5 text-right text-[11px] text-muted-foreground">
+          {expanded ? `${visible.length}/${group.sessions.length}` : "—"}
+        </td>
+      </tr>
+      {expanded && visible.map((s) => (
+        <SessionRow key={s.sessionId} session={s} username={usernameFor(s)} onOpen={() => onOpen(s)} />
+      ))}
+      {expanded && hidden > 0 && (
+        <tr className="border-t border-border/50 bg-background">
+          <td className="px-4 py-2" />
+          <td colSpan={5} className="px-6 py-2 text-[12px]">
+            <button onClick={onShowMore} className="text-muted-foreground hover:text-foreground">Show {hidden} more…</button>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function SessionRow({ session, username, onOpen }: { session: SessionListItem; username: string; onOpen: () => void }) {
+  const title = session.title || "Untitled session"
+  return (
+    <tr className="border-t border-border/50 hover:bg-secondary/20">
+      <td className="py-2.5 pl-8 pr-4 font-mono text-[11px] text-muted-foreground whitespace-nowrap">{formatTime(session.activityAt)}</td>
+      <td className="px-6 py-2.5 min-w-0">
+        <div className="min-w-0">
+          <div className="truncate text-foreground" title={title}>{title}</div>
+          <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
+            <span className="font-mono shrink-0" title={session.sessionId}>{shortId(session.sessionId)}</span>
+            <span className="shrink-0">{username}</span>
+            <span className="px-1.5 py-0.5 rounded text-[10px] bg-secondary shrink-0">{originLabel(session.origin)}</span>
+            {session.preview && <span className="truncate" title={session.preview}>{session.preview}</span>}
+          </div>
+        </div>
+      </td>
+      <td className="px-3 py-2.5 text-right font-mono text-muted-foreground">{session.messageCount}</td>
+      <td className="px-3 py-2.5 text-right">
+        <span className="inline-flex items-center justify-end gap-1 font-mono text-muted-foreground"><Wrench className="h-3 w-3" />{session.toolCallCount}</span>
+      </td>
+      <td className="px-3 py-2.5 text-right">
+        <span className={session.errorToolCallCount > 0 ? "inline-flex items-center justify-end gap-1 font-mono text-red-400" : "font-mono text-muted-foreground"}>
+          {session.errorToolCallCount > 0 && <AlertTriangle className="h-3 w-3" />}{session.errorToolCallCount}
+        </span>
+      </td>
+      <td className="px-4 py-2.5 text-right">
+        <button onClick={onOpen} title="Open in Chat" className="inline-flex items-center gap-1.5 px-2 py-1 rounded border border-border hover:bg-secondary text-foreground">
+          <Eye className="h-3.5 w-3.5" />
+        </button>
+      </td>
+    </tr>
+  )
+}

--- a/portal-web/src/components/metrics/SessionTable.tsx
+++ b/portal-web/src/components/metrics/SessionTable.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from "react"
-import { useNavigate } from "react-router-dom"
 import { AlertTriangle, ChevronDown, ChevronRight, Eye, Loader2, MessageSquare, Wrench } from "lucide-react"
 import {
   resolveRange,
@@ -11,6 +10,7 @@ import {
   type TimeRange,
 } from "../../hooks/useMetrics"
 import { api } from "../../api"
+import { SessionSnapshot } from "./SessionSnapshot"
 
 function formatTime(ts: string): string {
   const d = new Date(ts)
@@ -37,11 +37,11 @@ export function SessionTable({
   entry: EntryMode
   timeRange: TimeRange
 }) {
-  const navigate = useNavigate()
   const [agentId, setAgentId] = useState("")
   const [agents, setAgents] = useState<AgentOption[]>([])
   const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set())
   const [visibleCounts, setVisibleCounts] = useState<Record<string, number>>({})
+  const [snapshotId, setSnapshotId] = useState<string | null>(null)  // open read-only transcript
   const { users } = useUsers()
   const userMap = useMemo(() => {
     const m = new Map<string, string>()
@@ -124,7 +124,7 @@ export function SessionTable({
       return g ? { ...prev, [key]: g.sessions.length } : prev
     })
 
-  const openSession = (s: SessionListItem) => navigate(`/chat?agent=${s.agentId}&session=${s.sessionId}`)
+  const openSession = (s: SessionListItem) => setSnapshotId(s.sessionId)
   const usernameFor = (s: SessionListItem) => (s.userId ? userMap.get(s.userId) ?? s.userId : "—")
 
   return (
@@ -198,6 +198,8 @@ export function SessionTable({
           )}
         </div>
       </div>
+
+      {snapshotId && <SessionSnapshot sessionId={snapshotId} onClose={() => setSnapshotId(null)} />}
     </section>
   )
 }
@@ -294,7 +296,7 @@ function SessionRow({ session, username, onOpen }: { session: SessionListItem; u
         </span>
       </td>
       <td className="px-4 py-2.5 text-right">
-        <button onClick={onOpen} title="Open in Chat" className="inline-flex items-center gap-1.5 px-2 py-1 rounded border border-border hover:bg-secondary text-foreground">
+        <button onClick={onOpen} title="View transcript" className="inline-flex items-center gap-1.5 px-2 py-1 rounded border border-border hover:bg-secondary text-foreground">
           <Eye className="h-3.5 w-3.5" />
         </button>
       </td>

--- a/portal-web/src/components/metrics/TimingStatsCard.tsx
+++ b/portal-web/src/components/metrics/TimingStatsCard.tsx
@@ -1,0 +1,142 @@
+import { useState, type ReactNode } from "react"
+import type { LatencyStats, TimingStats, ToolLatencyStats } from "../../hooks/useMetrics"
+
+type TopN = 3 | 5 | 10
+const TOP_OPTIONS: TopN[] = [3, 5, 10]
+
+const EMPTY_STATS: LatencyStats = { count: 0, avg: 0, min: 0, max: 0, p90: 0 }
+
+function fmtMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "-"
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.round((ms % 60_000) / 1000)
+  return `${minutes}m ${seconds}s`
+}
+
+function StatGrid({ children }: { children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-[minmax(8rem,1.4fr)_repeat(5,minmax(3.75rem,0.65fr))] gap-x-3 gap-y-1.5 text-[11px] items-center">
+      {children}
+    </div>
+  )
+}
+
+function GridHeader() {
+  return (
+    <>
+      <div className="text-muted-foreground">Metric</div>
+      <div className="text-muted-foreground text-right">Count</div>
+      <div className="text-muted-foreground text-right">Avg</div>
+      <div className="text-muted-foreground text-right">Min</div>
+      <div className="text-muted-foreground text-right">Max</div>
+      <div className="text-muted-foreground text-right">P90</div>
+    </>
+  )
+}
+
+function StatRow({ label, hint, stats }: { label: string; hint: string; stats: LatencyStats }) {
+  const empty = stats.count === 0
+  const cell = (v: string) => (
+    <div className={`text-right tabular-nums ${empty ? "text-muted-foreground/50" : "text-foreground"}`}>
+      {empty ? "-" : v}
+    </div>
+  )
+  return (
+    <>
+      <div className="min-w-0">
+        <div className="truncate font-medium text-foreground">{label}</div>
+        <div className="truncate text-[10px] text-muted-foreground">{hint}</div>
+      </div>
+      <div className="text-right tabular-nums text-foreground">{stats.count}</div>
+      {cell(fmtMs(stats.avg))}
+      {cell(fmtMs(stats.min))}
+      {cell(fmtMs(stats.max))}
+      {cell(fmtMs(stats.p90))}
+    </>
+  )
+}
+
+/**
+ * TTFT / thinking / per-tool latency card — count/avg/min/max/p90 from
+ * chat_messages timing metadata + tool duration.
+ */
+export function TimingStatsCard({
+  data,
+  rangeLabel,
+  entryLabel,
+}: {
+  data: TimingStats | null
+  rangeLabel: string
+  entryLabel: string
+}) {
+  const [topN, setTopN] = useState<TopN>(3)
+  const tools = data?.tools ?? []
+  const visibleTools: ToolLatencyStats[] = tools.slice(0, topN)
+
+  return (
+    <div className="border border-border rounded-lg bg-card p-4">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-sm font-semibold tracking-tight">Response timing</h3>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            {entryLabel} · {rangeLabel}
+          </p>
+        </div>
+        {data?.truncated && (
+          <span
+            title="Sampled — too many rows in window; figures from a capped sample"
+            className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-amber-500/40 text-amber-500 select-text"
+          >
+            Sampled
+          </span>
+        )}
+      </div>
+
+      <StatGrid>
+        <GridHeader />
+        <StatRow label="TTFT" hint="time to first token" stats={data?.ttft ?? EMPTY_STATS} />
+        <StatRow label="Thinking" hint="reasoning before output" stats={data?.thinking ?? EMPTY_STATS} />
+      </StatGrid>
+
+      <div className="mt-4 pt-3 border-t border-border">
+        <div className="flex items-center justify-between gap-3 mb-2">
+          <div>
+            <h4 className="text-[11px] font-semibold text-foreground">Tool latency</h4>
+            <p className="text-[10px] text-muted-foreground">
+              Showing {Math.min(topN, tools.length)} of {tools.length}
+            </p>
+          </div>
+          <div className="flex items-center gap-1">
+            {TOP_OPTIONS.map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setTopN(n)}
+                className={`px-2 py-0.5 text-[11px] rounded-md border transition-colors ${
+                  topN === n
+                    ? "border-blue-500 bg-blue-500/10 text-blue-400"
+                    : "border-border bg-secondary text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                Top {n}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {visibleTools.length === 0 ? (
+          <div className="text-[11px] text-muted-foreground/70 py-2 select-text">No tool executions in this window.</div>
+        ) : (
+          <StatGrid>
+            <GridHeader />
+            {visibleTools.map((tool) => (
+              <StatRow key={tool.toolName} label={tool.toolName} hint="tool execution" stats={tool} />
+            ))}
+          </StatGrid>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/portal-web/src/components/metrics/TimingStatsCard.tsx
+++ b/portal-web/src/components/metrics/TimingStatsCard.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from "react"
-import type { LatencyStats, TimingStats, ToolLatencyStats } from "../../hooks/useMetrics"
+import type { EntryMode, LatencyStats, TimingStats, ToolLatencyStats } from "../../hooks/useMetrics"
 
 type TopN = 3 | 5 | 10
 const TOP_OPTIONS: TopN[] = [3, 5, 10]
@@ -66,11 +66,18 @@ export function TimingStatsCard({
   data,
   rangeLabel,
   entryLabel,
+  entry,
 }: {
   data: TimingStats | null
   rangeLabel: string
   entryLabel: string
+  entry: EntryMode
 }) {
+  // TTFT / thinking come from assistant metadata.timing, written only on the
+  // web/api/a2a path (sse-consumer). Channel (IM) sessions persist assistant
+  // rows without it, so those two rows are always empty for entry=channel —
+  // flag it so a count of 0 doesn't read as a bug. Tool latency still populates.
+  const noModelTiming = entry === "channel"
   const [topN, setTopN] = useState<TopN>(3)
   const tools = data?.tools ?? []
   const visibleTools: ToolLatencyStats[] = tools.slice(0, topN)
@@ -99,6 +106,12 @@ export function TimingStatsCard({
         <StatRow label="TTFT" hint="time to first token" stats={data?.ttft ?? EMPTY_STATS} />
         <StatRow label="Thinking" hint="reasoning before output" stats={data?.thinking ?? EMPTY_STATS} />
       </StatGrid>
+
+      {noModelTiming && (
+        <p className="mt-2 text-[10px] text-muted-foreground/80">
+          TTFT &amp; thinking aren&apos;t recorded for channel (IM) sessions — only tool latency below.
+        </p>
+      )}
 
       <div className="mt-4 pt-3 border-t border-border">
         <div className="flex items-center justify-between gap-3 mb-2">

--- a/portal-web/src/hooks/useMetrics.test.ts
+++ b/portal-web/src/hooks/useMetrics.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect } from "vitest"
-import { isRelativeExpr, resolveRange, isValidRange, rangeLabel } from "./useMetrics"
+import { isRelativeExpr, resolveRange, isValidRange, rangeLabel, ENTRY_MODES, ENTRY_LABELS, originLabel } from "./useMetrics"
+
+describe("entry axis", () => {
+  it("exposes the overview + four entry forms + scheduled", () => {
+    expect(ENTRY_MODES).toEqual(["all", "web", "api", "a2a", "channel", "scheduled"])
+  })
+
+  it("labels every mode (Overview for the combined view)", () => {
+    expect(ENTRY_LABELS.all).toBe("Overview")
+    expect(ENTRY_LABELS.web).toBe("Web")
+    expect(ENTRY_LABELS.scheduled).toBe("Scheduled")
+    for (const m of ENTRY_MODES) expect(ENTRY_LABELS[m]).toBeTruthy()
+  })
+})
+
+describe("originLabel", () => {
+  it("maps null/empty/'web' origin to Web", () => {
+    expect(originLabel(null)).toBe("Web")
+    expect(originLabel("")).toBe("Web")
+    expect(originLabel("web")).toBe("Web")
+  })
+  it("maps the raw origin values to display labels", () => {
+    expect(originLabel("api")).toBe("API")
+    expect(originLabel("a2a")).toBe("A2A")
+    expect(originLabel("channel")).toBe("Channel")
+    expect(originLabel("task")).toBe("Scheduled")
+    expect(originLabel("delegation")).toBe("Delegation")
+  })
+  it("passes through an unknown origin verbatim", () => {
+    expect(originLabel("future-mode")).toBe("future-mode")
+  })
+})
 
 describe("isRelativeExpr", () => {
   it("accepts `now` and `now-<n><unit>`", () => {

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { api } from "../api"
+import type { ChatMessage } from "./usePilotChat"
 
 // ── Entry-form axis ──────────────────────────────────────
 //
@@ -119,6 +120,31 @@ export interface SessionListItem {
 export interface SessionListResponse {
   sessions: SessionListItem[]
   hasMore: boolean
+}
+
+// ── Read-only session snapshot (admin audit view) ────────
+//
+// Returns RAW chat_messages rows (same shape the chat endpoint returns) so the
+// snapshot view can map them through the same buildPilotMessages pipeline and
+// render identically to the live chat.
+
+export interface SessionSnapshotHeader {
+  sessionId: string
+  userId: string | null
+  agentId: string
+  agentName: string | null
+  title: string | null
+  preview: string | null
+  origin: string | null
+  messageCount: number
+  createdAt: string
+  lastActiveAt: string | null
+}
+
+export interface SessionSnapshot {
+  session: SessionSnapshotHeader
+  data: ChatMessage[]
+  truncated: boolean
 }
 
 export interface AuditDetail extends AuditLog {
@@ -399,6 +425,27 @@ export function useSessions(params: SessionParams): {
   }, [params.userId, params.agentId, params.entry, params.from, params.to])
 
   return { sessions, hasMore, loading, loadMore: () => doFetch(true), refresh: () => doFetch(false) }
+}
+
+/** Read-only transcript of ANY session (admin audit). null id closes/clears. */
+export function useSessionSnapshot(sessionId: string | null): { data: SessionSnapshot | null; loading: boolean; error: boolean } {
+  const [data, setData] = useState<SessionSnapshot | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    if (!sessionId) { setData(null); setError(false); setLoading(false); return }
+    let cancelled = false
+    setLoading(true)
+    setError(false)
+    setData(null)
+    api<SessionSnapshot>(`/siclaw/audit/sessions/${sessionId}/messages`)
+      .then((d) => { if (!cancelled) { setData(d); setLoading(false) } })
+      .catch(() => { if (!cancelled) { setError(true); setLoading(false) } })
+    return () => { cancelled = true }
+  }, [sessionId])
+
+  return { data, loading, error }
 }
 
 export function useAuditDetail(id: string | null): { detail: AuditDetail | null; loading: boolean } {

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -1,6 +1,48 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { api } from "../api"
 
+// ── Entry-form axis ──────────────────────────────────────
+//
+// Every metrics/audit query scopes to one entry form (or the combined
+// overview). Mirrors `chat_sessions.origin` and the backend's metrics-entry.ts:
+//
+//   all (overview) — web+api+a2a+channel (the interactive family)
+//   web            — origin IS NULL (Portal Web UI)
+//   api            — origin = 'api'  (external API key, /api/v1/run)
+//   a2a            — origin = 'a2a'  (agent-to-agent)
+//   channel        — origin = 'channel' (IM: Feishu / DingTalk)
+//   scheduled      — origin = 'task' (cron / scheduled runs)
+//
+// "all" (overview) is the combined interactive family; the other modes isolate
+// a single entry form, and "scheduled" covers cron runs.
+export type EntryMode = "all" | "web" | "api" | "a2a" | "channel" | "scheduled"
+
+export const ENTRY_MODES: readonly EntryMode[] = ["all", "web", "api", "a2a", "channel", "scheduled"]
+
+export const ENTRY_LABELS: Record<EntryMode, string> = {
+  all: "Overview",
+  web: "Web",
+  api: "API",
+  a2a: "A2A",
+  channel: "Channel",
+  scheduled: "Scheduled",
+}
+
+/** Label for a raw `chat_sessions.origin` value (audit-row badge). */
+export function originLabel(origin: string | null): string {
+  switch (origin) {
+    case null:
+    case "":
+    case "web": return "Web"
+    case "api": return "API"
+    case "a2a": return "A2A"
+    case "channel": return "Channel"
+    case "task": return "Scheduled"
+    case "delegation": return "Delegation"
+    default: return origin
+  }
+}
+
 // ── Types ────────────────────────────────────────────────
 
 export interface SummaryData {
@@ -22,6 +64,7 @@ export interface AuditLog {
   sessionId: string
   userId: string | null
   agentId: string | null
+  agentName: string | null
   toolName: string | null
   toolInput: string | null
   outcome: string | null
@@ -30,6 +73,52 @@ export interface AuditLog {
   // "channel" (IM: Feishu/DingTalk), "task" → Scheduled, "delegation".
   origin: string | null
   timestamp: string
+}
+
+// ── Timing (TTFT / thinking / per-tool latency) ──────────
+
+export interface LatencyStats {
+  count: number
+  avg: number
+  min: number
+  max: number
+  p90: number
+}
+
+export interface ToolLatencyStats extends LatencyStats {
+  toolName: string
+}
+
+export interface TimingStats {
+  ttft: LatencyStats
+  thinking: LatencyStats
+  tools: ToolLatencyStats[]
+  truncated?: boolean
+}
+
+// ── Session audit (per-session counts, grouped by agent) ──
+
+export interface SessionListItem {
+  sessionId: string
+  userId: string | null
+  agentId: string
+  agentName: string | null
+  agentGroupName: string | null  // siclaw has no agent groups → always null
+  title: string | null
+  preview: string | null
+  origin: string | null
+  source: "interactive" | "scheduled"
+  messageCount: number
+  toolCallCount: number
+  errorToolCallCount: number
+  createdAt: string
+  lastActiveAt: string | null
+  activityAt: string
+}
+
+export interface SessionListResponse {
+  sessions: SessionListItem[]
+  hasMore: boolean
 }
 
 export interface AuditDetail extends AuditLog {
@@ -135,24 +224,48 @@ export function rangeLabel(r: TimeRange): string {
 
 // ── Hooks ────────────────────────────────────────────────
 
-export function useSummary(range: TimeRange, userId: string | null): { data: SummaryData | null; loading: boolean; refresh: () => void } {
+export function useSummary(range: TimeRange, userId: string | null, entry: EntryMode = "all"): { data: SummaryData | null; loading: boolean; refresh: () => void } {
   const [data, setData] = useState<SummaryData | null>(null)
   const [loading, setLoading] = useState(true)
-  const paramsRef = useRef({ range, userId })
-  paramsRef.current = { range, userId }
+  const paramsRef = useRef({ range, userId, entry })
+  paramsRef.current = { range, userId, entry }
 
   const fetchOnce = useCallback(() => {
     setLoading(true)
-    const { range: r, userId: uid } = paramsRef.current
+    const { range: r, userId: uid, entry: e } = paramsRef.current
     const { fromMs, toMs } = resolveRange(r)
-    const q = new URLSearchParams({ from: String(fromMs), to: String(toMs) })
+    const q = new URLSearchParams({ from: String(fromMs), to: String(toMs), entry: e })
     if (uid) q.set("userId", uid)
     return api<SummaryData>(`/siclaw/metrics/summary?${q.toString()}`)
       .then((d) => { setData(d); setLoading(false) })
       .catch(() => setLoading(false))
   }, [])
 
-  useEffect(() => { fetchOnce() }, [range.from, range.to, userId, fetchOnce])
+  useEffect(() => { fetchOnce() }, [range.from, range.to, userId, entry, fetchOnce])
+
+  return { data, loading, refresh: fetchOnce }
+}
+
+// ── Timing hook ──────────────────────────────────────────
+
+export function useTiming(range: TimeRange, userId: string | null, entry: EntryMode = "all"): { data: TimingStats | null; loading: boolean; refresh: () => void } {
+  const [data, setData] = useState<TimingStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const paramsRef = useRef({ range, userId, entry })
+  paramsRef.current = { range, userId, entry }
+
+  const fetchOnce = useCallback(() => {
+    setLoading(true)
+    const { range: r, userId: uid, entry: e } = paramsRef.current
+    const { fromMs, toMs } = resolveRange(r)
+    const q = new URLSearchParams({ from: String(fromMs), to: String(toMs), entry: e })
+    if (uid) q.set("userId", uid)
+    return api<TimingStats>(`/siclaw/metrics/timing?${q.toString()}`)
+      .then((d) => { setData(d); setLoading(false) })
+      .catch(() => setLoading(false))
+  }, [])
+
+  useEffect(() => { fetchOnce() }, [range.from, range.to, userId, entry, fetchOnce])
 
   return { data, loading, refresh: fetchOnce }
 }
@@ -161,8 +274,8 @@ interface AuditParams {
   userId?: string
   toolName?: string
   outcome?: string
-  /** Session entry-form filter (chat_sessions.origin). "web" matches NULL/"web". */
-  origin?: string
+  /** Entry-form axis (overview / web / api / a2a / channel / scheduled). */
+  entry?: EntryMode
   /** Absolute window bounds (unix ms as strings), already resolved + frozen by
    *  the caller so pagination cursors don't drift on a sliding relative range. */
   from?: string
@@ -192,7 +305,7 @@ export function useAudit(params: AuditParams): {
     if (p.userId) q.set("userId", p.userId)
     if (p.toolName) q.set("toolName", p.toolName)
     if (p.outcome) q.set("outcome", p.outcome)
-    if (p.origin) q.set("origin", p.origin)
+    if (p.entry) q.set("entry", p.entry)
     if (p.from) q.set("from", p.from)
     if (p.to) q.set("to", p.to)
     q.set("limit", "50")
@@ -220,9 +333,72 @@ export function useAudit(params: AuditParams): {
     setLogs([])
     doFetch(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params.userId, params.toolName, params.outcome, params.origin, params.from, params.to])
+  }, [params.userId, params.toolName, params.outcome, params.entry, params.from, params.to])
 
   return { logs, hasMore, loading, loadMore: () => doFetch(true), refresh: () => doFetch(false) }
+}
+
+// ── Session audit hook (per-session counts, cursor-paginated) ──
+
+export interface SessionParams {
+  userId?: string
+  agentId?: string
+  entry?: EntryMode
+  /** Resolved epoch-ms (as string), frozen by the caller for cursor pagination. */
+  from?: string
+  to?: string
+}
+
+export function useSessions(params: SessionParams): {
+  sessions: SessionListItem[]
+  hasMore: boolean
+  loading: boolean
+  loadMore: () => void
+  refresh: () => void
+} {
+  const [sessions, setSessions] = useState<SessionListItem[]>([])
+  const [hasMore, setHasMore] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const paramsRef = useRef(params)
+  paramsRef.current = params
+  const sessionsRef = useRef<SessionListItem[]>([])
+  sessionsRef.current = sessions
+
+  const doFetch = useCallback((append: boolean) => {
+    setLoading(true)
+    const q = new URLSearchParams()
+    const p = paramsRef.current
+    if (p.userId) q.set("userId", p.userId)
+    if (p.agentId) q.set("agentId", p.agentId)
+    if (p.entry) q.set("entry", p.entry)
+    if (p.from) q.set("from", p.from)
+    if (p.to) q.set("to", p.to)
+    q.set("limit", "50")
+
+    if (append && sessionsRef.current.length > 0) {
+      const last = sessionsRef.current[sessionsRef.current.length - 1]
+      const tsMs = new Date(last.activityAt).getTime()
+      q.set("cursorTs", String(tsMs))
+      q.set("cursorId", last.sessionId)
+    }
+
+    api<SessionListResponse>(`/siclaw/audit/sessions?${q.toString()}`)
+      .then((r) => {
+        if (append) setSessions((prev) => [...prev, ...r.sessions])
+        else setSessions(r.sessions)
+        setHasMore(r.hasMore)
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    setSessions([])
+    doFetch(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.userId, params.agentId, params.entry, params.from, params.to])
+
+  return { sessions, hasMore, loading, loadMore: () => doFetch(true), refresh: () => doFetch(false) }
 }
 
 export function useAuditDetail(id: string | null): { detail: AuditDetail | null; loading: boolean } {

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -26,6 +26,9 @@ export interface AuditLog {
   toolInput: string | null
   outcome: string | null
   durationMs: number | null
+  // Session entry-form for categorization: null/"web" → Web, "api", "a2a",
+  // "channel" (IM: Feishu/DingTalk), "task" → Scheduled, "delegation".
+  origin: string | null
   timestamp: string
 }
 
@@ -158,6 +161,8 @@ interface AuditParams {
   userId?: string
   toolName?: string
   outcome?: string
+  /** Session entry-form filter (chat_sessions.origin). "web" matches NULL/"web". */
+  origin?: string
   /** Absolute window bounds (unix ms as strings), already resolved + frozen by
    *  the caller so pagination cursors don't drift on a sliding relative range. */
   from?: string
@@ -187,6 +192,7 @@ export function useAudit(params: AuditParams): {
     if (p.userId) q.set("userId", p.userId)
     if (p.toolName) q.set("toolName", p.toolName)
     if (p.outcome) q.set("outcome", p.outcome)
+    if (p.origin) q.set("origin", p.origin)
     if (p.from) q.set("from", p.from)
     if (p.to) q.set("to", p.to)
     q.set("limit", "50")
@@ -214,7 +220,7 @@ export function useAudit(params: AuditParams): {
     setLogs([])
     doFetch(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params.userId, params.toolName, params.outcome, params.from, params.to])
+  }, [params.userId, params.toolName, params.outcome, params.origin, params.from, params.to])
 
   return { logs, hasMore, loading, loadMore: () => doFetch(true), refresh: () => doFetch(false) }
 }

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -64,7 +64,7 @@ interface ChatSession {
   updated_at?: string
 }
 
-interface ChatMessage {
+export interface ChatMessage {
   id: string
   role: "user" | "assistant" | "tool"
   content: string
@@ -398,7 +398,18 @@ async function fetchSessionPage1(
     `/siclaw/agents/${agentId}/chat/sessions/${sessionId}/messages?page=1&page_size=${PAGE_SIZE}`,
   )
   const items = Array.isArray(res.data) ? res.data : Array.isArray(res) ? (res as unknown as ChatMessage[]) : []
-  return { items, pilotMsgs: annotateSubagentCompletions(annotateExecJobCompletions(annotateDelegationSynthesis(items.map(toPilotMessage)))) }
+  return { items, pilotMsgs: buildPilotMessages(items) }
+}
+
+/**
+ * Map raw chat_messages rows → rendered PilotMessages with the full annotation
+ * pipeline (delegation synthesis, exec-job + sub-agent completion folding). This
+ * is the exact transform the live chat applies, so any read-only consumer (e.g.
+ * the admin session-snapshot view) renders identically. Input must be in
+ * chronological order (oldest first).
+ */
+export function buildPilotMessages(items: ChatMessage[]): PilotMessage[] {
+  return annotateSubagentCompletions(annotateExecJobCompletions(annotateDelegationSynthesis(items.map(toPilotMessage))))
 }
 
 export function toPilotMessage(m: ChatMessage): PilotMessage {

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -1,34 +1,44 @@
 import { useCallback, useMemo, useState } from "react"
 import { Loader2, RefreshCw } from "lucide-react"
-import { useSummary, useUsers, rangeLabel, DEFAULT_RANGE, type TimeRange } from "../hooks/useMetrics"
+import { useSummary, useTiming, useUsers, rangeLabel, ENTRY_LABELS, DEFAULT_RANGE, type EntryMode, type TimeRange } from "../hooks/useMetrics"
 import { KpiCards } from "../components/metrics/KpiCards"
 import { TrendChart } from "../components/metrics/TrendChart"
+import { TimingStatsCard } from "../components/metrics/TimingStatsCard"
 import { AuditTable } from "../components/metrics/AuditTable"
+import { SessionTable } from "../components/metrics/SessionTable"
 import { GrafanaFrame } from "../components/metrics/GrafanaFrame"
 import { TimeRangePicker } from "../components/metrics/TimeRangePicker"
+import { EntrySelector } from "../components/metrics/EntrySelector"
 
-type TabKey = "dashboard" | "audit" | "grafana"
+type TabKey = "dashboard" | "sessions" | "tools" | "grafana"
+
+const TAB_ORDER: TabKey[] = ["dashboard", "sessions", "tools", "grafana"]
+const TAB_LABEL: Record<TabKey, string> = { dashboard: "Dashboard", sessions: "Sessions", tools: "Tools", grafana: "Grafana" }
 
 export function Metrics() {
   const [tab, setTab] = useState<TabKey>("dashboard")
-  const [userId, setUserId] = useState<string>("")         // "" = All Users (Audit filter only)
+  const [userId, setUserId] = useState<string>("")         // "" = All Users (Sessions/Tools filter only)
   const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_RANGE)
+  const [entry, setEntry] = useState<EntryMode>("all")     // entry-form axis, shared across tabs
 
   const filterUserId = userId || null
   const rLabel = rangeLabel(timeRange)
+  const isAudit = tab === "sessions" || tab === "tools"
+  const showControls = tab !== "grafana"
 
   const { users } = useUsers()
   // Dashboard is an external-facing showcase: aggregate only, never scoped to
-  // an individual — so summary is fetched without a user filter.
-  const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(timeRange, null)
+  // an individual — so summary/timing are fetched without a user filter.
+  const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(timeRange, null, entry)
+  const { data: timing, loading: timingLoading, refresh: refreshTiming } = useTiming(timeRange, null, entry)
 
   const [spinning, setSpinning] = useState(false)
   const handleRefresh = useCallback(() => {
     setSpinning(true)
-    Promise.resolve(refreshSummary()).finally(() => {
+    Promise.all([Promise.resolve(refreshSummary()), Promise.resolve(refreshTiming())]).finally(() => {
       setTimeout(() => setSpinning(false), 600)
     })
-  }, [refreshSummary])
+  }, [refreshSummary, refreshTiming])
 
   const selectedUsername = useMemo(() => {
     if (!userId) return null
@@ -47,18 +57,17 @@ export function Metrics() {
             </div>
             <div className="flex items-center gap-2">
               {tab === "dashboard" && (
-                <>
-                  <button
-                    onClick={handleRefresh}
-                    title="Sync now"
-                    className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition"
-                  >
-                    <RefreshCw className={`h-3.5 w-3.5 transition-transform duration-500 ${spinning ? "animate-spin" : ""}`} />
-                  </button>
-                  <TimeRangePicker value={timeRange} onChange={setTimeRange} />
-                </>
+                <button
+                  onClick={handleRefresh}
+                  title="Sync now"
+                  className="p-1.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition"
+                >
+                  <RefreshCw className={`h-3.5 w-3.5 transition-transform duration-500 ${spinning ? "animate-spin" : ""}`} />
+                </button>
               )}
-              {tab === "audit" && (
+              {/* User filter — audit tabs only (the Dashboard is an outward-facing
+                  board and does not drill down by user). */}
+              {isAudit && (
                 <select
                   value={userId}
                   onChange={(e) => setUserId(e.target.value)}
@@ -70,11 +79,14 @@ export function Metrics() {
                   ))}
                 </select>
               )}
+              {/* Entry-form axis + time window — shared by Dashboard/Sessions/Tools. */}
+              {showControls && <EntrySelector value={entry} onChange={setEntry} />}
+              {showControls && <TimeRangePicker value={timeRange} onChange={setTimeRange} />}
             </div>
           </div>
 
           <div className="flex items-center gap-6 mt-4 -mb-px">
-            {(["dashboard", "audit", "grafana"] as TabKey[]).map((t) => (
+            {TAB_ORDER.map((t) => (
               <button
                 key={t}
                 onClick={() => setTab(t)}
@@ -84,7 +96,7 @@ export function Metrics() {
                     : "text-muted-foreground hover:text-foreground border-transparent"
                 }`}
               >
-                {t === "dashboard" ? "Dashboard" : t === "audit" ? "Audit" : "Grafana"}
+                {TAB_LABEL[t]}
               </button>
             ))}
           </div>
@@ -100,7 +112,7 @@ export function Metrics() {
             ) : (
               <>
                 <KpiCards
-                  rangeLabel={rLabel}
+                  rangeLabel={`${ENTRY_LABELS[entry]} · ${rLabel}`}
                   distinctUsers={summary?.distinctUsers ?? 0}
                   totalSessions={summary?.totalSessions ?? 0}
                   totalPrompts={summary?.totalPrompts ?? 0}
@@ -132,13 +144,24 @@ export function Metrics() {
                     </div>
                   </div>
                 )}
+
+                {/* Response timing — TTFT / thinking / per-tool latency (entry-aware). */}
+                {timingLoading ? (
+                  <div className="flex items-center justify-center py-6"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
+                ) : (
+                  <TimingStatsCard data={timing} rangeLabel={rLabel} entryLabel={ENTRY_LABELS[entry]} />
+                )}
               </>
             )}
           </section>
         )}
 
-        {tab === "audit" && (
-          <AuditTable userFilterId={filterUserId} usernameHint={selectedUsername} timeRange={timeRange} />
+        {tab === "sessions" && (
+          <SessionTable userFilterId={filterUserId} usernameHint={selectedUsername} entry={entry} timeRange={timeRange} />
+        )}
+
+        {tab === "tools" && (
+          <AuditTable userFilterId={filterUserId} usernameHint={selectedUsername} entry={entry} timeRange={timeRange} />
         )}
 
         {tab === "grafana" && <GrafanaFrame />}

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -149,7 +149,7 @@ export function Metrics() {
                 {timingLoading ? (
                   <div className="flex items-center justify-center py-6"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
                 ) : (
-                  <TimingStatsCard data={timing} rangeLabel={rLabel} entryLabel={ENTRY_LABELS[entry]} />
+                  <TimingStatsCard data={timing} rangeLabel={rLabel} entryLabel={ENTRY_LABELS[entry]} entry={entry} />
                 )}
               </>
             )}

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -34,6 +34,16 @@ vi.mock("../channel-manager.js", () => ({
     v !== null && typeof v === "object" && (v as { walled?: unknown }).walled === true,
 }));
 
+// chat-repo: DingTalk now persists the session + user message + (via the shared
+// collectResponse) assistant/tool rows for audit. Mock it to assert the writes.
+const ensureChatSessionMock = vi.fn();
+const appendMessageMock = vi.fn();
+vi.mock("../chat-repo.js", () => ({
+  ensureChatSession: (...args: unknown[]) => ensureChatSessionMock(...args),
+  appendMessage: (...args: unknown[]) => appendMessageMock(...args),
+  incrementMessageCount: () => Promise.resolve(),
+}));
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 const WEBHOOK = "https://oapi.dingtalk.com/robot/sendBySession?session=tok";
@@ -71,6 +81,10 @@ beforeEach(() => {
   closeSessionMock.mockResolvedValue(undefined);
   resolveBindingMock.mockReset();
   handlePairingCodeMock.mockReset();
+  ensureChatSessionMock.mockReset();
+  ensureChatSessionMock.mockResolvedValue(undefined);
+  appendMessageMock.mockReset();
+  appendMessageMock.mockResolvedValue("msg-db-1");
   resetConversationSessionsForTest();
   fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
   vi.stubGlobal("fetch", fetchMock);
@@ -284,6 +298,45 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
 
     rememberSpy.mockRestore();
     sessionRegistry.forget(sessionId as string);
+  });
+
+  it("audits the session: persists origin=channel + user/assistant/tool rows when the binding has an owner", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-7", bindingId: "b1", createdBy: "owner-1" });
+    promptMock.mockResolvedValue({ sessionId: "remote-7" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods" } };
+      yield { type: "tool_execution_end", toolName: "bash", result: { content: [{ type: "text", text: "pods ok" }], details: {} } };
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "done." }] } };
+    });
+
+    await handleDingTalkMessage(makeDownstream("查一下 pod"), "ch", makeAgentBoxManager("agent-7") as any, undefined, {} as any);
+
+    // Session row created with origin="channel" (6th arg), owner as user_id.
+    expect(ensureChatSessionMock).toHaveBeenCalledTimes(1);
+    const ecArgs = ensureChatSessionMock.mock.calls[0];
+    expect(ecArgs[1]).toBe("agent-7");     // agentId
+    expect(ecArgs[2]).toBe("owner-1");     // user_id = binding owner
+    expect(ecArgs[5]).toBe("channel");     // origin
+
+    const rows = appendMessageMock.mock.calls.map((c) => c[0] as any);
+    expect(rows.find((m) => m.role === "user")?.content).toBe("查一下 pod");
+    expect(rows.find((m) => m.role === "user")?.metadata?.source).toBe("dingtalk");
+    expect(rows.filter((m) => m.role === "tool")).toHaveLength(1);
+    expect(rows.find((m) => m.role === "tool")).toMatchObject({ toolName: "bash", outcome: "success" });
+    expect(rows.find((m) => m.role === "assistant")?.content).toBe("done.");
+  });
+
+  it("does NOT persist when the binding has no owner (no false user_id)", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-7", bindingId: "b1" }); // no createdBy
+    promptMock.mockResolvedValue({ sessionId: "remote-7" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } };
+    });
+
+    await handleDingTalkMessage(makeDownstream("hi"), "ch", makeAgentBoxManager("agent-7") as any, undefined, {} as any);
+
+    expect(ensureChatSessionMock).not.toHaveBeenCalled();
+    expect(appendMessageMock).not.toHaveBeenCalled();
   });
 
   it("passes the agent's custom system prompt (config.getAgent) into the prompt payload", async () => {

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -39,6 +39,7 @@ import { resolveBinding, handlePairingCode, isChannelAccessDenied } from "../cha
 import { resolveAgentSystemPrompt } from "../agent-model-binding.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
+import { appendMessage, ensureChatSession } from "../chat-repo.js";
 import { collectResponse } from "./lark.js";
 import {
   buildMarkdownMessage,
@@ -301,12 +302,36 @@ export async function handleDingTalkMessage(
   // it was created with until /new.
   const systemPromptTemplate = await resolveAgentSystemPrompt(agentId, frontendClient);
 
+  // Audit: persist the session + inbound user message so DingTalk sessions are
+  // visible in the audit (they were previously invisible — no chat_messages at
+  // all). origin="channel" unifies IM channels alongside Web/API/A2A. user_id =
+  // the binding owner (a real user UUID), mirroring lark. Best-effort: a persist
+  // failure must NOT break the reply (DingTalk worked without persistence before).
+  const auditable = !!binding.createdBy;
+  if (auditable) {
+    try {
+      await ensureChatSession(sessionId, agentId, binding.createdBy!, text, text, "channel");
+      await appendMessage({
+        sessionId,
+        role: "user",
+        content: text,
+        metadata: { source: "dingtalk", channelId, conversationId, route: routeType },
+      });
+    } catch (err) {
+      console.error(`[dingtalk] Failed to persist channel user message session=${sessionId}:`, err);
+    }
+  }
+
   const promptOpts: PromptOptions = { text, agentId, mode: "channel", sessionId, systemPromptTemplate };
   let resultText = "";
   let agentError: Error | null = null;
   try {
     const promptResult = await client.prompt(promptOpts);
-    resultText = await collectResponse(client, promptResult.sessionId, "dingtalk");
+    // Persist assistant + tool rows too (full transcript), only when the session
+    // row exists (createdBy present), so the audit shows the agent's actions.
+    resultText = await collectResponse(client, promptResult.sessionId, "dingtalk", {
+      persist: auditable ? { agentId } : undefined,
+    });
   } catch (err) {
     agentError = err instanceof Error ? err : new Error(String(err));
     console.error(`[dingtalk] Agent execution failed for session=${sessionId}:`, agentError);

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1905,3 +1905,60 @@ describe("collectResponse — SSE event flattening", () => {
     expect(text).toBe("Generated image:");
   });
 });
+
+describe("collectChannelResponse — audit persistence", () => {
+  function fakeClient(events: unknown[]) {
+    return { streamEvents: async function* () { for (const e of events) yield e; } } as any;
+  }
+
+  it("persists every assistant turn + each tool call when persist is set", async () => {
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "Checking nodes" }] } },
+      { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get nodes" } },
+      { type: "tool_execution_end", toolName: "bash", result: { content: [{ type: "text", text: "node ok" }], details: {} } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "All healthy." }] } },
+    ];
+    const collected = await collectChannelResponse(fakeClient(events), "s-audit", "lark", { persist: { agentId: "a1" } });
+    // Reply text is still the final assistant turn.
+    expect(collected.text).toBe("All healthy.");
+
+    const calls = appendMessageMock.mock.calls.map((c) => c[0] as any);
+    expect(calls.filter((m) => m.role === "assistant").map((m) => m.content)).toEqual(["Checking nodes", "All healthy."]);
+    const toolRows = calls.filter((m) => m.role === "tool");
+    expect(toolRows).toHaveLength(1);
+    expect(toolRows[0]).toMatchObject({ sessionId: "s-audit", toolName: "bash", outcome: "success" });
+    expect(toolRows[0].toolInput).toContain("kubectl get nodes");
+    expect(toolRows[0].content).toBe("node ok");
+  });
+
+  it("does NOT persist anything when persist is omitted (reply-only path)", async () => {
+    const events = [
+      { type: "tool_execution_start", toolName: "bash", args: {} },
+      { type: "tool_execution_end", toolName: "bash", result: { content: [], details: {} } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
+    ];
+    await collectChannelResponse(fakeClient(events), "s-nop", "lark", {});
+    expect(appendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("derives tool outcome (error / blocked) from result.details", async () => {
+    const events = [
+      { type: "tool_execution_start", toolName: "bash", args: {} },
+      { type: "tool_execution_end", toolName: "bash", result: { content: [], details: { error: "boom" } } },
+      { type: "tool_execution_start", toolName: "pod_exec", args: {} },
+      { type: "tool_execution_end", toolName: "pod_exec", result: { content: [], details: { blocked: true } } },
+    ];
+    await collectChannelResponse(fakeClient(events), "s-out", "lark", { persist: { agentId: "a1" } });
+    const toolRows = appendMessageMock.mock.calls.map((c) => c[0] as any).filter((m) => m.role === "tool");
+    expect(toolRows.map((m) => m.outcome)).toEqual(["error", "blocked"]);
+  });
+
+  it("a persist failure does not break the reply (best-effort)", async () => {
+    appendMessageMock.mockRejectedValueOnce(new Error("db down"));
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "still replies" }] } },
+    ];
+    const collected = await collectChannelResponse(fakeClient(events), "s-fail", "lark", { persist: { agentId: "a1" } });
+    expect(collected.text).toBe("still replies");
+  });
+});

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -23,6 +23,7 @@ import {
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
 import { appendMessage, ensureChatSession } from "../chat-repo.js";
+import { buildRedactionConfigForModelConfig, redactText } from "../output-redactor.js";
 import {
   openTypingCard,
   updateCardContent,
@@ -638,6 +639,10 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     const collected = await collectChannelResponse(client, promptResult.sessionId, "lark", {
       includeImages: true,
       onMilestone: addMilestone,
+      // Audit: persist assistant + tool rows so the channel transcript matches
+      // web/api/a2a (origin="channel" set on the session above). Tool output on
+      // this stream is already sanitized at the agentbox boundary.
+      persist: { agentId },
     });
     resultText = collected.text;
     replyImages = collected.images;
@@ -855,15 +860,29 @@ export async function collectResponse(
   client: AgentBoxClient,
   sessionId: string,
   logPrefix = "lark",
+  options: { persist?: ChannelPersistContext } = {},
 ): Promise<string> {
-  return (await collectChannelResponse(client, sessionId, logPrefix)).text;
+  return (await collectChannelResponse(client, sessionId, logPrefix, { persist: options.persist })).text;
+}
+
+/**
+ * Opt-in audit persistence for the channel path. When set, collectChannelResponse
+ * writes the same user/assistant/tool transcript that web/api/a2a get via the
+ * runtime's sse-consumer, so IM-channel sessions are fully auditable (not just
+ * the inbound user message). `modelConfig` drives the same apiKey/baseUrl
+ * redaction the sse-consumer applies. The caller has already persisted the user
+ * message + ensured the session row (origin="channel").
+ */
+export interface ChannelPersistContext {
+  agentId: string;
+  modelConfig?: { apiKey?: string; baseUrl?: string };
 }
 
 export async function collectChannelResponse(
   client: AgentBoxClient,
   sessionId: string,
   logPrefix = "lark",
-  options: { includeImages?: boolean; onMilestone?: (text: string) => void } = {},
+  options: { includeImages?: boolean; onMilestone?: (text: string) => void; persist?: ChannelPersistContext } = {},
 ): Promise<CollectedChannelResponse> {
   const parts: string[] = [];
   const images: RenderedReplyImage[] = [];
@@ -872,14 +891,63 @@ export async function collectChannelResponse(
   // (tool-use turns emit intermediate message_end events that aren't meant
   // for the user). pi-agent's agent_end signals the last turn is complete.
   let lastAssistantText = "";
+
+  // ── Audit persistence (opt-in) ──────────────────────────────────────────
+  // Mirrors the field mapping in sse-consumer.ts so a channel transcript looks
+  // like a web/api/a2a one. Tool content + input are redacted with the same
+  // model-config redactor. Best-effort: a persist failure must never break the
+  // user-facing reply, so each write is wrapped and swallowed-with-log.
+  const persist = options.persist;
+  const redaction = persist ? buildRedactionConfigForModelConfig(persist.modelConfig) : null;
+  const redact = (s: string): string => (redaction ? redactText(s, redaction) : s);
+  // FIFO per-tool queues so parallel tool calls pair start↔end correctly
+  // (same approach as sse-consumer's pendingTool* maps).
+  const toolInputs = new Map<string, string[]>();
+  const toolStarts = new Map<string, number[]>();
+  const pushQ = <T,>(m: Map<string, T[]>, k: string, v: T): void => { const a = m.get(k) ?? []; a.push(v); m.set(k, a); };
+  const shiftQ = <T,>(m: Map<string, T[]>, k: string): T | undefined => m.get(k)?.shift();
+  const persistRow = async (msg: Parameters<typeof appendMessage>[0]): Promise<void> => {
+    try { await appendMessage(msg); }
+    catch (err) { console.warn(`[${logPrefix}] audit persist failed session=${sessionId}:`, err); }
+  };
+
   try {
     for await (const event of client.streamEvents(sessionId)) {
       const ev = event as Record<string, any>;
       if (ev.type === "content_block_delta" && ev.delta?.text) parts.push(ev.delta.text);
       if (ev.type === "text" && typeof ev.text === "string") parts.push(ev.text);
-      if (options.includeImages && (ev.type === "tool_execution_end" || ev.type === "tool_end")) {
-        collectImageAttachments(ev.result?.content, images, seenImageKeys);
+
+      // Capture tool input + start time for the matching tool_execution_end.
+      if (persist && (ev.type === "tool_execution_start" || ev.type === "tool_start")) {
+        const name = (ev.toolName as string) || (ev.name as string) || "tool";
+        pushQ(toolInputs, name, ev.args ? JSON.stringify(ev.args) : "");
+        pushQ(toolStarts, name, Date.now());
       }
+
+      if (ev.type === "tool_execution_end" || ev.type === "tool_end") {
+        if (options.includeImages) collectImageAttachments(ev.result?.content, images, seenImageKeys);
+        if (persist) {
+          const name = (ev.toolName as string) || (ev.name as string) || "tool";
+          const resultText = Array.isArray(ev.result?.content)
+            ? ev.result.content.filter((c: any) => c?.type === "text").map((c: any) => c.text ?? "").join("")
+            : "";
+          let outcome: "success" | "error" | "blocked" = "success";
+          if (ev.result?.details?.blocked) outcome = "blocked";
+          else if (ev.result?.details?.error) outcome = "error";
+          const input = shiftQ(toolInputs, name) || "";
+          const startedAt = shiftQ(toolStarts, name);
+          await persistRow({
+            sessionId,
+            role: "tool",
+            content: redact(resultText),
+            toolName: name,
+            toolInput: input ? redact(input) : null,
+            outcome,
+            durationMs: startedAt != null ? Date.now() - startedAt : null,
+          });
+        }
+      }
+
       if (options.includeImages && ev.type === "message_end" && (ev.message?.role === "toolResult" || ev.message?.role === "tool")) {
         collectImageAttachments(ev.message?.content, images, seenImageKeys);
       }
@@ -899,6 +967,10 @@ export async function collectChannelResponse(
             if (m) options.onMilestone(m);
           }
           lastAssistantText = turnText;
+          // Persist every assistant turn (intermediate narration + final answer),
+          // mirroring sse-consumer. Awaited so its created_at precedes the next
+          // tool row in the transcript.
+          if (persist) await persistRow({ sessionId, role: "assistant", content: redact(turnText) });
         }
       }
     }

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -900,8 +900,10 @@ export async function collectChannelResponse(
   const persist = options.persist;
   const redaction = persist ? buildRedactionConfigForModelConfig(persist.modelConfig) : null;
   const redact = (s: string): string => (redaction ? redactText(s, redaction) : s);
-  // FIFO per-tool queues so parallel tool calls pair start↔end correctly
-  // (same approach as sse-consumer's pendingTool* maps).
+  // FIFO per-tool queues to pair start↔end (same approach as sse-consumer's
+  // pendingTool* maps). Caveat inherited from there: multiple *concurrent*
+  // same-name calls finishing out of order can mispair, skewing that row's
+  // durationMs. Only affects the audit metric, never the reply; acceptable.
   const toolInputs = new Map<string, string[]>();
   const toolStarts = new Map<string, number[]>();
   const pushQ = <T,>(m: Map<string, T[]>, k: string, v: T): void => { const a = m.get(k) ?? []; a.push(v); m.set(k, a); };

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -186,6 +186,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const orgId = params.orgId as string | undefined;
     const text = params.text as string;
     const incomingSessionId = params.sessionId as string | undefined;
+    // Session entry-form for audit categorization (Web / API / A2A). null =
+    // web (default). Portal call sites stamp "api" (/api/v1/run) and "a2a";
+    // channels stamp "channel" via their own ensureChatSession. Only consumed
+    // when THIS handler creates the session row.
+    const origin = params.origin as string | undefined;
     // Portal stamps turnStartMs at POST receipt — closer to user click than
     // the runtime's loop start. Use it as the canonical turn anchor when
     // present; fall back gracefully so direct callers (tests, /run path)
@@ -242,7 +247,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         // Persist user message + ensure session row before any agent events
         // could land. consumeAgentSse writes assistant/tool rows with FK
         // referencing chat_sessions, so the row has to exist first.
-        await ensureChatSession(sessionId, agentId, userId, text);
+        await ensureChatSession(sessionId, agentId, userId, text, undefined, origin);
         await appendMessage({ sessionId, role: "user", content: text });
         await incrementMessageCount(sessionId);
 

--- a/src/portal/a2a-gateway.test.ts
+++ b/src/portal/a2a-gateway.test.ts
@@ -215,6 +215,7 @@ describe("registerA2aRoutes", () => {
       text: "diagnose kube-system",
       sessionId: expect.stringMatching(/^[0-9a-f-]{36}$/),
       mode: "a2a",
+      origin: "a2a", // audit category
     }));
 
     const [rows] = await getDb().query<Array<{ state: string; context_id: string; session_id: string }>>(

--- a/src/portal/a2a-gateway.ts
+++ b/src/portal/a2a-gateway.ts
@@ -749,6 +749,7 @@ async function submitA2aTask(params: {
     text,
     sessionId,
     mode: "a2a",
+    origin: "a2a", // audit category: agent-to-agent sessions
     modelProvider: modelBinding.modelProvider,
     modelId: modelBinding.modelId,
     modelConfig: modelBinding.modelConfig,

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1710,6 +1710,9 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     if (qs.get("userId")) { conds.push("s.user_id = ?"); params.push(qs.get("userId")); }
     if (qs.get("toolName")) { conds.push("m.tool_name = ?"); params.push(qs.get("toolName")); }
     if (qs.get("outcome")) { conds.push("m.outcome = ?"); params.push(qs.get("outcome")); }
+    // Entry-form filter (chat_sessions.origin). "web" matches NULL/"web".
+    if (qs.get("origin") === "web") { conds.push("(s.origin IS NULL OR s.origin = 'web')"); }
+    else if (qs.get("origin")) { conds.push("s.origin = ?"); params.push(qs.get("origin")); }
     if (qs.get("cursorTs") && qs.get("cursorId")) {
       const cursorDate = new Date(parseInt(qs.get("cursorTs")!, 10));
       conds.push("(m.created_at < ? OR (m.created_at = ? AND m.id < ?))");
@@ -1722,7 +1725,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
       `SELECT m.id, m.session_id AS sessionId, m.tool_name AS toolName,
               SUBSTR(m.tool_input, 1, 500) AS toolInput,
               m.outcome, m.duration_ms AS durationMs, m.created_at AS timestamp,
-              s.user_id AS userId, s.agent_id AS agentId
+              s.user_id AS userId, s.agent_id AS agentId, s.origin AS origin
        FROM chat_messages m
        LEFT JOIN chat_sessions s ON m.session_id = s.id
        WHERE ${conds.join(" AND ")}
@@ -1734,7 +1737,8 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     const logs = rows.slice(0, limit).map((r: any) => ({
       id: r.id, sessionId: r.sessionId, userId: r.userId, agentId: r.agentId,
       toolName: r.toolName, toolInput: r.toolInput, outcome: r.outcome,
-      durationMs: r.durationMs, timestamp: r.timestamp instanceof Date ? r.timestamp.toISOString() : r.timestamp,
+      durationMs: r.durationMs, origin: r.origin ?? null,
+      timestamp: r.timestamp instanceof Date ? r.timestamp.toISOString() : r.timestamp,
     }));
     sendJson(res, 200, { logs, hasMore });
   });

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -731,6 +731,7 @@ export function registerChatRoutes(
       text: body.text,
       sessionId,
       mode: "api",
+      origin: "api", // audit category: external API-key sessions (/api/v1/run)
       modelProvider: modelBinding.modelProvider,
       modelId: modelBinding.modelId,
       modelConfig: modelBinding.modelConfig,

--- a/src/portal/metrics-entry.test.ts
+++ b/src/portal/metrics-entry.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  ENTRY_MODES,
+  normalizeEntry,
+  entrySessionPredicate,
+  entryMessagePredicate,
+  type EntryMode,
+} from "./metrics-entry.js";
+
+describe("normalizeEntry", () => {
+  it("passes through the known entry modes", () => {
+    for (const m of ENTRY_MODES) expect(normalizeEntry(m)).toBe(m);
+  });
+  it("maps the legacy 'interactive' source to the overview ('all')", () => {
+    expect(normalizeEntry("interactive")).toBe("all");
+  });
+  it("accepts the raw 'task' origin as a 'scheduled' alias", () => {
+    expect(normalizeEntry("task")).toBe("scheduled");
+  });
+  it("defaults empty / unknown to 'all'", () => {
+    expect(normalizeEntry(undefined)).toBe("all");
+    expect(normalizeEntry(null)).toBe("all");
+    expect(normalizeEntry("")).toBe("all");
+    expect(normalizeEntry("bogus")).toBe("all");
+  });
+});
+
+describe("entrySessionPredicate", () => {
+  const cases: Array<[EntryMode, string]> = [
+    ["web", "s.origin IS NULL"],
+    ["api", "s.origin = 'api'"],
+    ["a2a", "s.origin = 'a2a'"],
+    ["channel", "s.origin = 'channel'"],
+    ["scheduled", "s.origin = 'task'"],
+  ];
+  it.each(cases)("%s → exact origin match", (entry, frag) => {
+    expect(entrySessionPredicate(entry)).toContain(frag);
+  });
+
+  it("'all' (overview) = interactive family: excludes task + delegation", () => {
+    const p = entrySessionPredicate("all");
+    expect(p).toContain("s.origin IS NULL");
+    expect(p).toContain("NOT IN ('task', 'delegation')");
+  });
+
+  it("honors a custom alias", () => {
+    expect(entrySessionPredicate("api", "x")).toContain("x.origin = 'api'");
+  });
+
+  it("never matches delegation under a specific entry (traces excluded)", () => {
+    // A specific entry like "api" is an exact origin match, so origin='delegation'
+    // rows can't satisfy it — they're excluded from session-level queries.
+    expect(entrySessionPredicate("api")).not.toContain("delegation");
+  });
+});
+
+describe("entryMessagePredicate (delegation inheritance)", () => {
+  it("emits a parent join and inherits the parent's entry for delegation rows", () => {
+    const { join, predicate } = entryMessagePredicate("api");
+    expect(join).toBe("LEFT JOIN chat_sessions parent_s ON s.parent_session_id = parent_s.id");
+    // direct match on s OR (delegation child whose parent matches the entry)
+    expect(predicate).toContain("s.origin = 'api'");
+    expect(predicate).toContain("s.origin = 'delegation' AND parent_s.origin = 'api'");
+  });
+
+  it("overview inherits parent for delegation children too", () => {
+    const { predicate } = entryMessagePredicate("all");
+    expect(predicate).toContain("s.origin = 'delegation'");
+    expect(predicate).toContain("parent_s.origin");
+  });
+
+  it("inheritance can be disabled (no join, session-level predicate only)", () => {
+    const { join, predicate } = entryMessagePredicate("web", { delegationInheritance: false });
+    expect(join).toBe("");
+    expect(predicate).toBe(entrySessionPredicate("web"));
+  });
+
+  it("honors custom aliases", () => {
+    const { join, predicate } = entryMessagePredicate("scheduled", { sAlias: "m_s", parentAlias: "p" });
+    expect(join).toContain("LEFT JOIN chat_sessions p ON m_s.parent_session_id = p.id");
+    expect(predicate).toContain("m_s.origin = 'task'");
+    expect(predicate).toContain("m_s.origin = 'delegation' AND p.origin = 'task'");
+  });
+});

--- a/src/portal/metrics-entry.ts
+++ b/src/portal/metrics-entry.ts
@@ -1,0 +1,95 @@
+/**
+ * Entry-form axis for audit / metrics filtering.
+ *
+ * Mirrors `chat_sessions.origin`, which records how a session was created:
+ *   web     → origin IS NULL   (Portal Web UI — the default)
+ *   api     → origin = 'api'   (external API key, /api/v1/run)
+ *   a2a     → origin = 'a2a'   (agent-to-agent)
+ *   channel → origin = 'channel' (IM channels: Feishu / DingTalk)
+ *   scheduled → origin = 'task'   (cron / scheduled runs)
+ *   (delegation → origin = 'delegation' — sub-agent execution traces, never a
+ *    top-level entry; its tool calls inherit the PARENT session's entry.)
+ *
+ * The audit UI can view one entry at a time or the combined **overview**
+ * ("all" = web+api+a2a+channel, the interactive family; scheduled is its own
+ * selectable bucket).
+ *
+ * Two predicate flavours:
+ *  - session-level (`entrySessionPredicate`): for per-session queries (session
+ *    list, session/prompt counts). Delegation sessions are excluded (traces).
+ *  - message-level (`entryMessagePredicate`): for per-message/tool queries
+ *    (tool audit, tool counts, timing). A delegation child's rows are counted
+ *    under its parent's entry via a LEFT JOIN on the parent session.
+ */
+
+export type EntryMode = "all" | "web" | "api" | "a2a" | "channel" | "scheduled";
+
+/** The user-selectable entry buckets (excludes the internal "delegation"). */
+export const ENTRY_MODES: readonly EntryMode[] = ["all", "web", "api", "a2a", "channel", "scheduled"];
+
+/**
+ * Coerce a raw `entry`/`source` query value to an EntryMode. Accepts the entry
+ * modes and `source` aliases ("interactive" → overview, "scheduled" →
+ * scheduled). Unknown / empty → "all" (overview).
+ */
+export function normalizeEntry(raw: string | null | undefined): EntryMode {
+  if (!raw) return "all";
+  if (raw === "interactive") return "all"; // alias: interactive == overview here
+  if (raw === "task") return "scheduled";  // accept the raw origin value as an alias
+  return (ENTRY_MODES as readonly string[]).includes(raw) ? (raw as EntryMode) : "all";
+}
+
+/**
+ * Base origin predicate for one session alias, with NO delegation handling.
+ * "all" (overview) = the interactive family (web+api+a2a+channel): everything
+ * except scheduled (`task`) and `delegation` traces.
+ */
+function baseOriginPredicate(entry: EntryMode, alias: string): string {
+  switch (entry) {
+    case "web": return `${alias}.origin IS NULL`;
+    case "api": return `${alias}.origin = 'api'`;
+    case "a2a": return `${alias}.origin = 'a2a'`;
+    case "channel": return `${alias}.origin = 'channel'`;
+    case "scheduled": return `${alias}.origin = 'task'`;
+    case "all":
+    default: return `(${alias}.origin IS NULL OR ${alias}.origin NOT IN ('task', 'delegation'))`;
+  }
+}
+
+/**
+ * Session-level predicate (per-session queries). Excludes delegation traces.
+ * Returns a parenthesized SQL fragment over the given session alias (default "s").
+ */
+export function entrySessionPredicate(entry: EntryMode, alias = "s"): string {
+  return `(${baseOriginPredicate(entry, alias)})`;
+}
+
+/**
+ * Message-level predicate (per-message / per-tool queries) WITH delegation
+ * inheritance: a delegation child session's rows count under the parent's entry.
+ *
+ * Returns:
+ *  - `join`: a LEFT JOIN clause binding `parentAlias` to `sAlias`'s parent
+ *    session (empty string if inheritance is disabled).
+ *  - `predicate`: a parenthesized fragment to AND into the WHERE clause.
+ *
+ * With inheritance: `<entry on s> OR (s.origin='delegation' AND <entry on parent_s>)`.
+ */
+export function entryMessagePredicate(
+  entry: EntryMode,
+  opts: { sAlias?: string; parentAlias?: string; delegationInheritance?: boolean } = {},
+): { join: string; predicate: string } {
+  const sAlias = opts.sAlias ?? "s";
+  const parentAlias = opts.parentAlias ?? "parent_s";
+  const inherit = opts.delegationInheritance !== false; // default ON
+
+  if (!inherit) {
+    return { join: "", predicate: entrySessionPredicate(entry, sAlias) };
+  }
+
+  const join = `LEFT JOIN chat_sessions ${parentAlias} ON ${sAlias}.parent_session_id = ${parentAlias}.id`;
+  const predicate =
+    `(${baseOriginPredicate(entry, sAlias)} ` +
+    `OR (${sAlias}.origin = 'delegation' AND ${baseOriginPredicate(entry, parentAlias)}))`;
+  return { join, predicate };
+}

--- a/src/portal/metrics-timing.test.ts
+++ b/src/portal/metrics-timing.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { summariseLatency, extractTimingMs } from "./metrics-timing.js";
+
+describe("summariseLatency", () => {
+  it("returns all-zero for an empty sample", () => {
+    expect(summariseLatency([])).toEqual({ count: 0, avg: 0, min: 0, max: 0, p90: 0 });
+  });
+
+  it("summarises a single value", () => {
+    expect(summariseLatency([42])).toEqual({ count: 1, avg: 42, min: 42, max: 42, p90: 42 });
+  });
+
+  it("computes count/avg/min/max + nearest-rank p90 (order-independent)", () => {
+    const vals = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]; // n=10
+    const s = summariseLatency([...vals].reverse());
+    expect(s.count).toBe(10);
+    expect(s.min).toBe(10);
+    expect(s.max).toBe(100);
+    expect(s.avg).toBe(55);
+    // nearest-rank p90: index ceil(0.9*10)-1 = 8 → 90
+    expect(s.p90).toBe(90);
+  });
+
+  it("rounds avg to an integer", () => {
+    expect(summariseLatency([1, 2]).avg).toBe(2); // 1.5 → 2
+  });
+});
+
+describe("extractTimingMs", () => {
+  it("reads timing.<key> from a JSON metadata string", () => {
+    const md = JSON.stringify({ timing: { ttft_ms: 120, thinking_ms: 30 } });
+    expect(extractTimingMs(md, "ttft_ms")).toBe(120);
+    expect(extractTimingMs(md, "thinking_ms")).toBe(30);
+  });
+
+  it("accepts a pre-decoded object", () => {
+    expect(extractTimingMs({ timing: { ttft_ms: 7 } }, "ttft_ms")).toBe(7);
+  });
+
+  it("returns undefined when timing / key is absent", () => {
+    expect(extractTimingMs(JSON.stringify({ pre_thinking_ms: 5 }), "ttft_ms")).toBeUndefined();
+    expect(extractTimingMs(JSON.stringify({ timing: {} }), "ttft_ms")).toBeUndefined();
+  });
+
+  it("returns undefined for null / malformed / negative / non-numeric", () => {
+    expect(extractTimingMs(null, "ttft_ms")).toBeUndefined();
+    expect(extractTimingMs("{not json", "ttft_ms")).toBeUndefined();
+    expect(extractTimingMs(JSON.stringify({ timing: { ttft_ms: -5 } }), "ttft_ms")).toBeUndefined();
+    expect(extractTimingMs(JSON.stringify({ timing: { ttft_ms: "x" } }), "ttft_ms")).toBeUndefined();
+  });
+
+  it("rounds a fractional value", () => {
+    expect(extractTimingMs(JSON.stringify({ timing: { ttft_ms: 12.7 } }), "ttft_ms")).toBe(13);
+  });
+});

--- a/src/portal/metrics-timing.ts
+++ b/src/portal/metrics-timing.ts
@@ -1,0 +1,57 @@
+/**
+ * Latency summarisation for the metrics Timing endpoint.
+ *
+ * siclaw persists per-turn timing in `chat_messages.metadata` (JSON-in-TEXT):
+ *   - assistant rows: `metadata.timing.ttft_ms` / `metadata.timing.thinking_ms`
+ *   - tool rows: `duration_ms` column (+ `metadata.pre_thinking_ms`)
+ * (written by src/gateway/sse-consumer.ts). This module turns a collected list
+ * of millisecond values into the `{count, avg, min, max, p90}` shape the audit
+ * UI renders.
+ */
+
+export interface LatencyStats {
+  count: number;
+  avg: number;
+  min: number;
+  max: number;
+  p90: number;
+}
+
+const EMPTY: LatencyStats = { count: 0, avg: 0, min: 0, max: 0, p90: 0 };
+
+/** Summarise a list of latency samples (ms). Empty → all zeros. */
+export function summariseLatency(values: number[]): LatencyStats {
+  if (values.length === 0) return { ...EMPTY };
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  // Nearest-rank p90: index ceil(0.9*n)-1, clamped.
+  const p90Idx = Math.min(n - 1, Math.max(0, Math.ceil(0.9 * n) - 1));
+  return {
+    count: n,
+    avg: Math.round(sum / n),
+    min: sorted[0],
+    max: sorted[n - 1],
+    p90: sorted[p90Idx],
+  };
+}
+
+/**
+ * Extract a finite, non-negative integer ms value from `metadata.timing[key]`
+ * of a stored chat_messages.metadata string. Returns undefined when absent /
+ * unparseable / negative (absence = "unmeasured", the correct downstream
+ * semantics). `parsed` may be a pre-decoded object too (defensive).
+ */
+export function extractTimingMs(metadata: unknown, key: string): number | undefined {
+  let obj: unknown = metadata;
+  if (typeof metadata === "string") {
+    try { obj = JSON.parse(metadata); } catch { return undefined; }
+  }
+  if (!obj || typeof obj !== "object") return undefined;
+  const timing = (obj as Record<string, unknown>).timing;
+  if (!timing || typeof timing !== "object") return undefined;
+  const v = (timing as Record<string, unknown>)[key];
+  const n = typeof v === "number" ? v : Number(v);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return Math.round(n);
+}

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -566,6 +566,55 @@ describe("siclaw-api misc routes", () => {
     });
   });
 
+  describe("GET /api/v1/siclaw/audit/sessions/:id/messages", () => {
+    it("returns ANY session's transcript (admin, NOT owner-scoped)", async () => {
+      query
+        .mockResolvedValueOnce([[ // session header — note: a session owned by some other user
+          {
+            sessionId: "s9", userId: "someone-else", agentId: "a1", agentName: "Ops Agent",
+            title: "Prod incident", preview: "p", origin: "api", messageCount: 3,
+            createdAt: new Date(1000), lastActiveAt: new Date(5000),
+          },
+        ], []])
+        .mockResolvedValueOnce([[ // messages — RAW chat_messages rows (snake_case)
+          { id: "m1", role: "user", content: "what broke?", tool_name: null, tool_input: null, outcome: null, duration_ms: null, metadata: null, created_at: new Date(1000) },
+          { id: "m2", role: "tool", content: "logs…", tool_name: "restricted_bash", tool_input: "{\"command\":\"kubectl get po\"}", outcome: "success", duration_ms: 120, metadata: null, created_at: new Date(2000) },
+        ], []]);
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/audit/sessions/s9/messages",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(200);
+      // The header query must NOT filter by user_id (admin audit reads any owner's session).
+      const headerSql: string = query.mock.calls[0][0];
+      expect(headerSql).not.toContain("user_id = ?");
+      expect(headerSql).toContain("deleted_at IS NULL");
+      expect(body.session).toMatchObject({ sessionId: "s9", userId: "someone-else", agentName: "Ops Agent", origin: "api" });
+      // Raw rows (same shape the chat endpoint returns) so the UI maps them with toPilotMessage.
+      expect(body.data).toHaveLength(2);
+      expect(body.data[1]).toMatchObject({ role: "tool", tool_name: "restricted_bash", outcome: "success", duration_ms: 120 });
+      expect(body.truncated).toBe(false);
+    });
+
+    it("404s when the session is missing or deleted", async () => {
+      query.mockResolvedValueOnce([[], []]);
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/audit/sessions/nope/messages",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(404);
+    });
+
+    it("rejects non-admin", async () => {
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/audit/sessions/s9/messages", method: "GET",
+      }));
+      expect([401, 403]).toContain(status);
+    });
+  });
+
   // ── System config ────────────────────────────────────────
   describe("GET /api/v1/siclaw/system/config", () => {
     it("rejects non-admin", async () => {

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -482,6 +482,88 @@ describe("siclaw-api misc routes", () => {
       expect(status).toBe(200);
       expect(Array.isArray(body.logs)).toBe(true);
     });
+
+    it("entry=api filters by origin (with delegation inheritance) + joins agents", async () => {
+      query.mockResolvedValueOnce([[], []]);
+      await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/audit?from=1000&to=2000&entry=api",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      const sql: string = query.mock.calls[0][0];
+      expect(sql).toContain("s.origin = 'api'");
+      expect(sql).toContain("s.origin = 'delegation' AND parent_s.origin = 'api'"); // inheritance
+      expect(sql).toContain("LEFT JOIN agents a ON s.agent_id = a.id");             // agentName
+    });
+  });
+
+  describe("GET /api/v1/siclaw/metrics/timing", () => {
+    it("summarises ttft/thinking from assistant metadata + per-tool latency", async () => {
+      query
+        .mockResolvedValueOnce([[ // assistant metadata rows
+          { metadata: JSON.stringify({ timing: { ttft_ms: 100, thinking_ms: 20 } }) },
+          { metadata: JSON.stringify({ timing: { ttft_ms: 300 } }) },
+        ], []])
+        .mockResolvedValueOnce([[ // tool duration rows
+          { toolName: "bash", durationMs: 500 },
+          { toolName: "bash", durationMs: 300 },
+          { toolName: "read", durationMs: 50 },
+        ], []]);
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/timing?from=1000&to=2000",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(200);
+      expect(body.ttft).toMatchObject({ count: 2, min: 100, max: 300, avg: 200 });
+      expect(body.thinking).toMatchObject({ count: 1, avg: 20 });
+      const bash = body.tools.find((t: any) => t.toolName === "bash");
+      expect(bash).toMatchObject({ count: 2, min: 300, max: 500 });
+      // tools sorted by count desc → bash (2) before read (1)
+      expect(body.tools[0].toolName).toBe("bash");
+    });
+
+    it("rejects non-admin", async () => {
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/timing?from=1000&to=2000", method: "GET",
+      }));
+      expect([401, 403]).toContain(status);
+    });
+  });
+
+  describe("GET /api/v1/siclaw/audit/sessions", () => {
+    it("returns per-session rows with tool/error counts + agentName, entry-filtered", async () => {
+      query.mockResolvedValueOnce([[
+        {
+          sessionId: "s1", userId: "u1", agentId: "a1", agentName: "Ops Agent",
+          title: "t", preview: "p", origin: "channel", messageCount: 8,
+          createdAt: new Date(1000), lastActiveAt: new Date(2000),
+          toolCallCount: 5, errorToolCallCount: 2,
+        },
+      ], []]);
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/audit/sessions?from=500&to=3000&entry=channel",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(200);
+      const sql: string = query.mock.calls[0][0];
+      expect(sql).toContain("s.origin = 'channel'");
+      expect(body.sessions).toHaveLength(1);
+      expect(body.sessions[0]).toMatchObject({
+        sessionId: "s1", agentName: "Ops Agent", agentGroupName: null,
+        origin: "channel", messageCount: 8, toolCallCount: 5, errorToolCallCount: 2,
+      });
+    });
+
+    it("rejects a reversed window with 400", async () => {
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/audit/sessions?from=2000&to=1000",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      expect(status).toBe(400);
+    });
   });
 
   // ── System config ────────────────────────────────────────

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -3015,6 +3015,10 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (query.userId) { conds.push("s.user_id = ?"); params.push(query.userId); }
     if (query.toolName) { conds.push("m.tool_name = ?"); params.push(query.toolName); }
     if (query.outcome) { conds.push("m.outcome = ?"); params.push(query.outcome); }
+    // Entry-form filter (chat_sessions.origin). "web" matches the NULL/"web"
+    // default; everything else is an exact origin match.
+    if (query.origin === "web") { conds.push("(s.origin IS NULL OR s.origin = 'web')"); }
+    else if (query.origin) { conds.push("s.origin = ?"); params.push(query.origin); }
     if (query.cursorTs && query.cursorId) {
       const cursorDate = new Date(parseInt(query.cursorTs, 10));
       conds.push("(m.created_at < ? OR (m.created_at = ? AND m.id < ?))");
@@ -3027,7 +3031,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       `SELECT m.id, m.session_id AS sessionId, m.tool_name AS toolName,
               SUBSTR(m.tool_input, 1, 500) AS toolInput,
               m.outcome, m.duration_ms AS durationMs, m.created_at AS timestamp,
-              s.user_id AS userId, s.agent_id AS agentId
+              s.user_id AS userId, s.agent_id AS agentId, s.origin AS origin
        FROM chat_messages m
        LEFT JOIN chat_sessions s ON m.session_id = s.id
        WHERE ${conds.join(" AND ")}
@@ -3040,7 +3044,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const logs = rows.slice(0, limit).map((r: any) => ({
       id: r.id, sessionId: r.sessionId, userId: r.userId, agentId: r.agentId,
       toolName: r.toolName, toolInput: r.toolInput, outcome: r.outcome,
-      durationMs: r.durationMs,
+      durationMs: r.durationMs, origin: r.origin ?? null,
       timestamp: r.timestamp instanceof Date ? r.timestamp.toISOString() : r.timestamp,
     }));
 

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -3219,6 +3219,62 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     sendJson(res, 200, { sessions, hasMore });
   });
 
+  // GET /api/v1/siclaw/audit/sessions/:id/messages — admin-only, READ-ONLY
+  // transcript snapshot of ANY session (NOT scoped to the requesting user, unlike
+  // the user-facing /agents/:id/chat/sessions/:sid/messages path). The Metrics
+  // Sessions tab lists every user's sessions, so opening one must not route
+  // through the owner-scoped chat endpoint (which 404s on other users').
+  router.get("/api/v1/siclaw/audit/sessions/:id/messages", async (req, res, params) => {
+    const admin = requireAdmin(req, config.jwtSecret);
+    if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
+
+    const sessionId = params.id;
+    const MSG_CAP = 1000; // bounded snapshot — admin audit sessions are small
+    const db = getDb();
+
+    const [sRows] = await db.query(
+      `SELECT s.id AS sessionId, s.user_id AS userId, s.agent_id AS agentId, a.name AS agentName,
+              s.title AS title, s.preview AS preview, s.origin AS origin, s.message_count AS messageCount,
+              s.created_at AS createdAt, s.last_active_at AS lastActiveAt
+       FROM chat_sessions s LEFT JOIN agents a ON s.agent_id = a.id
+       WHERE s.id = ? AND s.deleted_at IS NULL`,
+      [sessionId],
+    ) as any;
+    if (sRows.length === 0) { sendJson(res, 404, { error: "Session not found" }); return; }
+    const s = sRows[0];
+    const toIso = (v: unknown) => (v instanceof Date ? v.toISOString() : (v as string | null));
+
+    // Return RAW chat_messages rows (same shape the user-facing chat endpoint
+    // returns) so the frontend can map them through the SAME toPilotMessage /
+    // buildPilotMessages pipeline and render identically to the live chat. Order
+    // chronological (oldest first) — buildPilotMessages expects that.
+    const [mRows] = await db.query(
+      `SELECT id, role, content, tool_name, tool_input, outcome, duration_ms, metadata,
+              from_agent_id, parent_session_id, delegation_id, target_agent_id, created_at
+       FROM chat_messages WHERE session_id = ?
+       ORDER BY created_at ASC, id ASC LIMIT ?`,
+      [sessionId, MSG_CAP + 1],
+    ) as any;
+    const truncated = mRows.length > MSG_CAP;
+    const data = (mRows as any[]).slice(0, MSG_CAP).map((r) => ({
+      ...r,
+      // Parse JSON metadata to an object (legacy MySQL JSON, new TEXT, SQLite TEXT).
+      metadata: safeParseJson(r.metadata, null),
+      created_at: toIso(r.created_at),
+    }));
+
+    sendJson(res, 200, {
+      session: {
+        sessionId: s.sessionId, userId: s.userId, agentId: s.agentId, agentName: s.agentName ?? null,
+        title: s.title ?? null, preview: s.preview ?? null, origin: s.origin ?? null,
+        messageCount: Number(s.messageCount ?? 0),
+        createdAt: toIso(s.createdAt), lastActiveAt: toIso(s.lastActiveAt),
+      },
+      data,
+      truncated,
+    });
+  });
+
   // ================================================================
   // System config — admin-managed key-value store
   // ================================================================

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -54,6 +54,8 @@ import {
   normalizeChatSessionTitle,
   truncateChatSessionTitle,
 } from "./chat-session-fields.js";
+import { normalizeEntry, entrySessionPredicate, entryMessagePredicate } from "./metrics-entry.js";
+import { summariseLatency, extractTimingMs } from "./metrics-timing.js";
 
 /** Trace viewer message limit — matches siclaw_main.cron-limits.MAX_TRACE_MESSAGES */
 const MAX_TRACE_MESSAGES = 200;
@@ -2844,11 +2846,18 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (!window) { sendJson(res, 400, { error: "Invalid time range" }); return; }
     const { from, to } = window;
     const userFilter = query.userId || null;
+    // Entry-form axis: overview (all) / web / api / a2a / channel / scheduled.
+    const entry = normalizeEntry(query.entry ?? query.source);
+    // Session-level (per-session counts): delegation traces excluded.
+    const tablePred = entrySessionPredicate(entry, "chat_sessions");
+    // Message/tool-level: count a delegation child's rows under its PARENT's
+    // entry so sub-agent tool calls stay auditable. msg.join adds the parent LEFT JOIN.
+    const msg = entryMessagePredicate(entry);
 
     const db = getDb();
 
     const sessionParams: unknown[] = [from, to];
-    let totalSessionsSql = "SELECT COUNT(*) AS c FROM chat_sessions WHERE created_at >= ? AND created_at <= ? AND (origin IS NULL OR origin NOT IN ('task', 'delegation'))";
+    let totalSessionsSql = `SELECT COUNT(*) AS c FROM chat_sessions WHERE created_at >= ? AND created_at <= ? AND ${tablePred}`;
     if (userFilter) { totalSessionsSql += " AND user_id = ?"; sessionParams.push(userFilter); }
     const [sRows] = await db.query(totalSessionsSql, sessionParams) as [Array<{ c: number }>, unknown];
     const totalSessions = Number(sRows[0]?.c ?? 0);
@@ -2856,8 +2865,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const pParams: unknown[] = [from, to];
     let totalPromptsSql = `SELECT COUNT(*) AS c FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
+      ${msg.join}
       WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
-        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
+        AND ${msg.predicate}
         AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
     if (userFilter) { totalPromptsSql += " AND s.user_id = ?"; pParams.push(userFilter); }
     const [pRows] = await db.query(totalPromptsSql, pParams) as [Array<{ c: number }>, unknown];
@@ -2866,7 +2876,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // ── distinctUsers (window) ──
     const duParams: unknown[] = [from, to];
     let distinctUsersSql = `SELECT COUNT(DISTINCT user_id) AS c FROM chat_sessions
-      WHERE created_at >= ? AND created_at <= ? AND (origin IS NULL OR origin NOT IN ('task', 'delegation'))`;
+      WHERE created_at >= ? AND created_at <= ? AND ${tablePred}`;
     if (userFilter) { distinctUsersSql += " AND user_id = ?"; duParams.push(userFilter); }
     const [duRows] = await db.query(distinctUsersSql, duParams) as [Array<{ c: number }>, unknown];
     const distinctUsers = Number(duRows[0]?.c ?? 0);
@@ -2875,8 +2885,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const tcParams: unknown[] = [from, to];
     let toolCallsSql = `SELECT COUNT(*) AS c FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
+      ${msg.join}
       WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
-        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+        AND ${msg.predicate}`;
     if (userFilter) { toolCallsSql += " AND s.user_id = ?"; tcParams.push(userFilter); }
     const [tcRows] = await db.query(toolCallsSql, tcParams) as [Array<{ c: number }>, unknown];
     const toolCalls = Number(tcRows[0]?.c ?? 0);
@@ -2889,10 +2900,11 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const suParams: unknown[] = [from, to];
     let skillsSql = `SELECT m.tool_input AS toolInput FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
+      ${msg.join}
       WHERE m.role = 'tool'
         AND m.tool_name IN ('local_script', 'host_script', 'pod_script', 'node_script')
         AND m.created_at >= ? AND m.created_at <= ?
-        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+        AND ${msg.predicate}`;
     if (userFilter) { skillsSql += " AND s.user_id = ?"; suParams.push(userFilter); }
     skillsSql += " ORDER BY m.created_at DESC LIMIT ?";
     suParams.push(SKILL_ROW_LIMIT + 1);
@@ -2942,8 +2954,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const dpParams: unknown[] = [from, to];
     let dailyPromptsSql = `SELECT DATE(m.created_at) AS day, COUNT(*) AS c FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
+      ${msg.join}
       WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
-        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))
+        AND ${msg.predicate}
         AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
     if (userFilter) { dailyPromptsSql += " AND s.user_id = ?"; dpParams.push(userFilter); }
     dailyPromptsSql += " GROUP BY DATE(m.created_at)";
@@ -2951,8 +2964,9 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const dtParams: unknown[] = [from, to];
     let dailyToolsSql = `SELECT DATE(m.created_at) AS day, COUNT(*) AS c FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
+      ${msg.join}
       WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
-        AND (s.origin IS NULL OR s.origin NOT IN ('task', 'delegation'))`;
+        AND ${msg.predicate}`;
     if (userFilter) { dailyToolsSql += " AND s.user_id = ?"; dtParams.push(userFilter); }
     dailyToolsSql += " GROUP BY DATE(m.created_at)";
 
@@ -3010,15 +3024,16 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const to = parseTs(query.to) ?? new Date();
     if (from.getTime() >= to.getTime()) { sendJson(res, 400, { error: "Invalid time range" }); return; }
 
-    const conds: string[] = ["m.role = 'tool'", "m.created_at BETWEEN ? AND ?"];
+    // Entry-form axis (overview / web / api / a2a / channel / scheduled), with
+    // delegation inheritance so sub-agent tool calls count under their parent's
+    // entry. `msg.join` adds the parent-session LEFT JOIN.
+    const entry = normalizeEntry(query.entry ?? query.source ?? query.origin);
+    const msg = entryMessagePredicate(entry);
+    const conds: string[] = ["m.role = 'tool'", "m.created_at BETWEEN ? AND ?", msg.predicate];
     const params: unknown[] = [from, to];
     if (query.userId) { conds.push("s.user_id = ?"); params.push(query.userId); }
     if (query.toolName) { conds.push("m.tool_name = ?"); params.push(query.toolName); }
     if (query.outcome) { conds.push("m.outcome = ?"); params.push(query.outcome); }
-    // Entry-form filter (chat_sessions.origin). "web" matches the NULL/"web"
-    // default; everything else is an exact origin match.
-    if (query.origin === "web") { conds.push("(s.origin IS NULL OR s.origin = 'web')"); }
-    else if (query.origin) { conds.push("s.origin = ?"); params.push(query.origin); }
     if (query.cursorTs && query.cursorId) {
       const cursorDate = new Date(parseInt(query.cursorTs, 10));
       conds.push("(m.created_at < ? OR (m.created_at = ? AND m.id < ?))");
@@ -3031,9 +3046,12 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       `SELECT m.id, m.session_id AS sessionId, m.tool_name AS toolName,
               SUBSTR(m.tool_input, 1, 500) AS toolInput,
               m.outcome, m.duration_ms AS durationMs, m.created_at AS timestamp,
-              s.user_id AS userId, s.agent_id AS agentId, s.origin AS origin
+              s.user_id AS userId, s.agent_id AS agentId, s.origin AS origin,
+              a.name AS agentName
        FROM chat_messages m
        LEFT JOIN chat_sessions s ON m.session_id = s.id
+       ${msg.join}
+       LEFT JOIN agents a ON s.agent_id = a.id
        WHERE ${conds.join(" AND ")}
        ORDER BY m.created_at DESC, m.id DESC
        LIMIT ?`,
@@ -3043,6 +3061,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const hasMore = rows.length > limit;
     const logs = rows.slice(0, limit).map((r: any) => ({
       id: r.id, sessionId: r.sessionId, userId: r.userId, agentId: r.agentId,
+      agentName: r.agentName ?? null,
       toolName: r.toolName, toolInput: r.toolInput, outcome: r.outcome,
       durationMs: r.durationMs, origin: r.origin ?? null,
       timestamp: r.timestamp instanceof Date ? r.timestamp.toISOString() : r.timestamp,
@@ -3074,6 +3093,130 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       outcome: r.outcome, durationMs: r.durationMs,
       timestamp: r.timestamp instanceof Date ? r.timestamp.toISOString() : r.timestamp,
     });
+  });
+
+  // GET /api/v1/siclaw/metrics/timing — TTFT / thinking / per-tool latency, entry-filtered.
+  router.get("/api/v1/siclaw/metrics/timing", async (req, res) => {
+    const admin = requireAdmin(req, config.jwtSecret);
+    if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
+
+    const query = parseQuery(req.url ?? "");
+    const window = resolveWindow(query);
+    if (!window) { sendJson(res, 400, { error: "Invalid time range" }); return; }
+    const { from, to } = window;
+    const userFilter = query.userId || null;
+    const entry = normalizeEntry(query.entry ?? query.source);
+    const msg = entryMessagePredicate(entry); // delegation-inherited (sub-agent tool latency counts)
+    const TIMING_ROW_LIMIT = 50_000;
+    const db = getDb();
+
+    // ── TTFT / thinking from assistant metadata.timing.{ttft_ms,thinking_ms} ──
+    const aParams: unknown[] = [from, to];
+    let aSql = `SELECT m.metadata AS metadata FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      ${msg.join}
+      WHERE m.role = 'assistant' AND m.created_at >= ? AND m.created_at <= ?
+        AND m.metadata IS NOT NULL AND ${msg.predicate}`;
+    if (userFilter) { aSql += " AND s.user_id = ?"; aParams.push(userFilter); }
+    aSql += " ORDER BY m.created_at DESC LIMIT ?";
+    aParams.push(TIMING_ROW_LIMIT + 1);
+    const [aRows] = await db.query(aSql, aParams) as [Array<{ metadata: string | null }>, unknown];
+    const ttftValues: number[] = [];
+    const thinkingValues: number[] = [];
+    for (const r of aRows.slice(0, TIMING_ROW_LIMIT)) {
+      const t = extractTimingMs(r.metadata, "ttft_ms");
+      if (t !== undefined) ttftValues.push(t);
+      const th = extractTimingMs(r.metadata, "thinking_ms");
+      if (th !== undefined) thinkingValues.push(th);
+    }
+
+    // ── Per-tool latency from tool rows' duration_ms ──
+    const tParams: unknown[] = [from, to];
+    let tSql = `SELECT m.tool_name AS toolName, m.duration_ms AS durationMs FROM chat_messages m
+      JOIN chat_sessions s ON m.session_id = s.id
+      ${msg.join}
+      WHERE m.role = 'tool' AND m.tool_name IS NOT NULL AND m.duration_ms IS NOT NULL
+        AND m.created_at >= ? AND m.created_at <= ? AND ${msg.predicate}`;
+    if (userFilter) { tSql += " AND s.user_id = ?"; tParams.push(userFilter); }
+    tSql += " ORDER BY m.created_at DESC LIMIT ?";
+    tParams.push(TIMING_ROW_LIMIT + 1);
+    const [tRows] = await db.query(tSql, tParams) as [Array<{ toolName: string; durationMs: number }>, unknown];
+    const byTool = new Map<string, number[]>();
+    for (const r of tRows.slice(0, TIMING_ROW_LIMIT)) {
+      const arr = byTool.get(r.toolName) ?? [];
+      arr.push(Number(r.durationMs));
+      byTool.set(r.toolName, arr);
+    }
+    const tools = [...byTool.entries()]
+      .map(([toolName, vals]) => ({ toolName, ...summariseLatency(vals) }))
+      .sort((a, b) => b.count - a.count);
+
+    sendJson(res, 200, {
+      ttft: summariseLatency(ttftValues),
+      thinking: summariseLatency(thinkingValues),
+      tools,
+      truncated: aRows.length > TIMING_ROW_LIMIT || tRows.length > TIMING_ROW_LIMIT,
+    });
+  });
+
+  // GET /api/v1/siclaw/audit/sessions — per-session audit rows (counts + agent), entry-filtered.
+  router.get("/api/v1/siclaw/audit/sessions", async (req, res) => {
+    const admin = requireAdmin(req, config.jwtSecret);
+    if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
+
+    const query = parseQuery(req.url ?? "");
+    const limit = Math.min(200, Math.max(1, parseInt(query.limit || "50", 10)));
+    const from = parseTs(query.from) ?? new Date(Date.now() - 86_400_000);
+    const to = parseTs(query.to) ?? new Date();
+    if (from.getTime() >= to.getTime()) { sendJson(res, 400, { error: "Invalid time range" }); return; }
+    const entry = normalizeEntry(query.entry ?? query.source);
+    // Session-level: delegation traces are not standalone sessions.
+    const sPred = entrySessionPredicate(entry, "s");
+
+    // Window + ordering by activity (last_active_at, falling back to created_at).
+    const conds: string[] = ["COALESCE(s.last_active_at, s.created_at) BETWEEN ? AND ?", sPred, "s.deleted_at IS NULL"];
+    const params: unknown[] = [from, to];
+    if (query.userId) { conds.push("s.user_id = ?"); params.push(query.userId); }
+    if (query.agentId) { conds.push("s.agent_id = ?"); params.push(query.agentId); }
+    if (query.cursorTs && query.cursorId) {
+      const cursorDate = new Date(parseInt(query.cursorTs, 10));
+      conds.push("(COALESCE(s.last_active_at, s.created_at) < ? OR (COALESCE(s.last_active_at, s.created_at) = ? AND s.id < ?))");
+      params.push(cursorDate, cursorDate, query.cursorId);
+    }
+    params.push(limit + 1);
+
+    const db = getDb();
+    const [rows] = await db.query(
+      `SELECT s.id AS sessionId, s.user_id AS userId, s.agent_id AS agentId, a.name AS agentName,
+              s.title AS title, s.preview AS preview, s.origin AS origin, s.message_count AS messageCount,
+              s.created_at AS createdAt, s.last_active_at AS lastActiveAt,
+              (SELECT COUNT(*) FROM chat_messages cm WHERE cm.session_id = s.id AND cm.role = 'tool') AS toolCallCount,
+              (SELECT COUNT(*) FROM chat_messages cm WHERE cm.session_id = s.id AND cm.role = 'tool' AND cm.outcome = 'error') AS errorToolCallCount
+       FROM chat_sessions s
+       LEFT JOIN agents a ON s.agent_id = a.id
+       WHERE ${conds.join(" AND ")}
+       ORDER BY COALESCE(s.last_active_at, s.created_at) DESC, s.id DESC
+       LIMIT ?`,
+      params,
+    ) as any;
+
+    const hasMore = rows.length > limit;
+    const toIso = (v: unknown) => (v instanceof Date ? v.toISOString() : (v as string | null));
+    const sessions = rows.slice(0, limit).map((r: any) => ({
+      sessionId: r.sessionId, userId: r.userId, agentId: r.agentId, agentName: r.agentName ?? null,
+      agentGroupName: null, // siclaw has no agent groups
+      title: r.title ?? null, preview: r.preview ?? null,
+      origin: r.origin ?? null,
+      source: r.origin === "task" ? "scheduled" : "interactive",
+      messageCount: Number(r.messageCount ?? 0),
+      toolCallCount: Number(r.toolCallCount ?? 0),
+      errorToolCallCount: Number(r.errorToolCallCount ?? 0),
+      createdAt: toIso(r.createdAt),
+      lastActiveAt: toIso(r.lastActiveAt),
+      activityAt: toIso(r.lastActiveAt) ?? toIso(r.createdAt),
+    }));
+
+    sendJson(res, 200, { sessions, hasMore });
   });
 
   // ================================================================


### PR DESCRIPTION
Builds out the Portal **Metrics** page into a maintainer audit (**Dashboard / Sessions / Tools**) with a **per-entry-form axis** — Web / API / A2A / Channel / Scheduled, plus a combined Overview. Feedback is intentionally left out for now: siclaw has no feedback data source (`save_feedback` is a no-op stub).

## Commits (logical units)

1. **`feat(audit)` — full + categorizable session audit across all entry forms**
   Persist `chat_sessions.origin` for every entry form so the audit can categorize them: web=`NULL`, `api`, `a2a`, `channel` (Feishu/DingTalk unified), `task` (scheduled), `delegation` (sub-agent trace). Previously Feishu only persisted the user message and DingTalk persisted nothing — IM sessions showed up hollow or invisible.

2. **`feat(metrics)` P1 — per-entry audit axis + timing & sessions endpoints**
   - `src/portal/metrics-entry.ts`: shared entry predicates with **delegation inheritance** (a sub-agent's tool calls count under its parent's entry).
   - `metrics-timing.ts`: `summariseLatency` (count/avg/min/max/nearest-rank p90) + `extractTimingMs`.
   - Entry-aware `/metrics/summary` + `/metrics/audit`; new `/metrics/timing` and `/audit/sessions`.

3. **`feat(metrics)` P2/P3 — Sessions tab, shared Entry selector, timing card**
   - Page-level **Entry selector** (Overview / Web / API / A2A / Channel / Scheduled) shared across Dashboard / Sessions / Tools.
   - **Sessions** tab: per-session message/tool/error counts grouped by agent.
   - Dashboard **TimingStatsCard** (TTFT / thinking / per-tool p90).
   - Tools tab (was "Audit") entry-driven; rows show agent name.

4. **`feat(metrics)` — admin read-only session snapshot (modal, chat-identical render)**
   The Sessions tab lists every user's session, but the owner-scoped chat messages endpoint 404s on another user's session. Add an admin-only, read-only `GET /audit/sessions/:id/messages` (not user-scoped) + a centered modal that renders through the **same `PilotArea`** the live chat uses (additive `readOnly` prop hides composer/edit/steer; live chat untouched).

## Notes
- `src/portal/adapter.ts` (the internal mTLS mirror) intentionally **not** extended — portal-web (`siclaw-api.ts`, JWT) is the only consumer of these metrics endpoints.
- All metrics endpoints are `requireAdmin`.
- A >1000-message session shows the oldest 1000 (folding needs contiguous chronological order), flagged by a `truncated` banner. Rare.

## Verification
- `npx tsc --noEmit` clean (backend + portal-web)
- Backend: `siclaw-api.misc.test.ts` (45), `metrics-entry.test.ts`, `metrics-timing.test.ts` green
- portal-web: `npm run build` + vitest (172) green
- E2E on siclaw-inner: entry selector isolates per-entry counts; Sessions snapshot opens any user's transcript read-only in a modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
