### PR TITLE
feat(agentbox): per-agent PVC persistence (runtime mechanism only)

### DIFF
--- a/helm/siclaw/templates/NOTES.txt
+++ b/helm/siclaw/templates/NOTES.txt
@@ -2,12 +2,18 @@ Thank you for installing {{ include "siclaw.fullname" . }}!
 
 {{- if and (eq (include "siclaw.runtime.enabled" .) "true") .Values.agentbox.persistence.enabled }}
 
-ℹ️  User data persistence is enabled.
+ℹ️  User data persistence is enabled (global default ON).
    Chart-managed PVC: "{{ include "siclaw.dataPvcName" . }}" (ReadWriteMany).
    {{- if not .Values.agentbox.persistence.storageClassName }}
    ⚠️  agentbox.persistence.storageClassName is empty — the PVC will stay Pending until you set it to a RWX-capable StorageClass (e.g. nfs, efs-sc, csi-cephfs).
    {{- end }}
    Gateway will create per-user subdirectories automatically.
+{{- else if and (eq (include "siclaw.runtime.enabled" .) "true") (eq (include "siclaw.persistence.pvcAvailable" .) "true") }}
+
+ℹ️  User data persistence: global default OFF, PVC available for per-agent opt-in.
+   Referencing existing PVC: "{{ include "siclaw.dataPvcName" . }}" (must already exist, ReadWriteMany).
+   Agents are ephemeral (emptyDir) by default; only agents whose caller sends
+   persistence:true mount the PVC. The chart does NOT create this PVC.
 {{- end }}
 
 {{- if eq (include "siclaw.runtime.enabled" .) "true" }}

--- a/helm/siclaw/templates/_helpers.tpl
+++ b/helm/siclaw/templates/_helpers.tpl
@@ -112,6 +112,24 @@ in the same namespace don't collide; users can override via
 {{- end }}
 
 {{/*
+Is a shared PVC available for AgentBox pods to mount? Returns "true" or "".
+
+Decouples PVC availability (infrastructure) from the global default policy
+(persistence.enabled). Available when EITHER:
+  - persistence.enabled       — the chart provisions & mounts its own PVC, or
+  - persistence.claimName set  — the deployer references a pre-existing RWX PVC
+                                 they created out-of-band (mount it, inject the
+                                 claim name) WITHOUT turning the global default on.
+When available, the runtime gets SICLAW_PERSISTENCE_CLAIM_NAME so a per-agent
+opt-in (chat.send persistence:true) can actually mount the PVC even while the
+global default stays off.
+*/}}
+{{- define "siclaw.persistence.pvcAvailable" -}}
+{{- $p := .Values.agentbox.persistence | default dict -}}
+{{- if or $p.enabled (ne ($p.claimName | default "") "") -}}true{{- end -}}
+{{- end }}
+
+{{/*
 Name of the chart-managed Runtime CA Secret.
 */}}
 {{- define "siclaw.runtimeCaSecretName" -}}

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -59,8 +59,14 @@ spec:
               value: {{ .Values.runtime.subagentConcurrency | quote }}
             {{- end }}
             {{- if .Values.agentbox.persistence.enabled }}
+            # Global default policy: callers that omit per-agent persistence use the PVC.
             - name: SICLAW_PERSISTENCE_ENABLED
               value: "true"
+            {{- end }}
+            {{- if eq (include "siclaw.persistence.pvcAvailable" .) "true" }}
+            # PVC availability (infra): present whenever the chart provisions a PVC
+            # OR a pre-existing claim is referenced — independent of the global
+            # default above, so a per-agent persistence:true can mount it.
             - name: SICLAW_PERSISTENCE_CLAIM_NAME
               value: {{ include "siclaw.dataPvcName" . | quote }}
             {{- end }}
@@ -108,7 +114,7 @@ spec:
           volumeMounts:
             - name: skills
               mountPath: /app/.siclaw/skills
-            {{- if .Values.agentbox.persistence.enabled }}
+            {{- if eq (include "siclaw.persistence.pvcAvailable" .) "true" }}
             - name: user-data
               mountPath: /app/.siclaw/user-data
             {{- end }}
@@ -127,7 +133,7 @@ spec:
       volumes:
         - name: skills
           emptyDir: {}
-        {{- if .Values.agentbox.persistence.enabled }}
+        {{- if eq (include "siclaw.persistence.pvcAvailable" .) "true" }}
         - name: user-data
           persistentVolumeClaim:
             claimName: {{ include "siclaw.dataPvcName" . }}

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -157,12 +157,29 @@ ocr:
 agentbox:
   debugImage: ""
   persistence:
+    # PVC persistence has two independent concepts:
+    #   1. PVC availability (infrastructure) — is a shared RWX PVC present that
+    #      agents can mount? Controlled by `enabled` (chart provisions one) OR
+    #      `claimName` (reference one you created out-of-band).
+    #   2. Global default policy — should callers that DON'T set a per-agent
+    #      persistence value use the PVC? Controlled by `enabled` only.
+    # A per-agent opt-in (chat.send persistence:true, e.g. from a product portal)
+    # mounts the PVC whenever it is *available*, regardless of the global default.
+
+    # Global default policy. true ⇒ also chart-provision + mount the PVC below.
     enabled: false
-    # Override the shared PVC name. Empty → "<release-fullname>-data".
+    # Reference a PRE-EXISTING RWX PVC by name. Set this (with enabled:false) to
+    # make the PVC available for per-agent opt-in while keeping the global default
+    # OFF. REQUIRED and has NO default on this path — the name differs per
+    # deployment and must match a PVC you already created; empty ⇒ no PVC to
+    # mount, all agents fall back to emptyDir.
+    # When enabled:true this just overrides the chart-managed PVC name
+    # (empty → "<release-fullname>-data").
     claimName: ""
-    # REQUIRED when enabled: true. Must support ReadWriteMany.
+    # REQUIRED when enabled: true (chart-provisioned PVC). Must support ReadWriteMany.
     # Examples: nfs, efs-sc, csi-cephfs, longhorn (with RWX).
     # Leaving this empty while enabled keeps the PVC in Pending state.
+    # Ignored when referencing an existing PVC via claimName (enabled:false).
     storageClassName: ""
     size: "10Gi"
 

--- a/src/gateway/agent-model-binding.ts
+++ b/src/gateway/agent-model-binding.ts
@@ -31,6 +31,12 @@ export interface ResolvedModelBinding {
   modelRouting?: ModelRoutePolicy;
   /** Agent's custom system prompt template (agents.system_prompt). Null/absent = built-in default. */
   systemPrompt?: string | null;
+  /**
+   * Per-agent session/memory persistence toggle. siclaw core leaves this
+   * undefined (no native per-agent store); a product portal that wants per-agent
+   * persistence resolves it from its own data and carries it over chat.send.
+   */
+  persistence?: boolean;
 }
 
 export async function resolveAgentModelBinding(

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -613,3 +613,95 @@ describe("K8sSpawner — list + cleanup", () => {
     expect(calls.deleteCollectionNamespacedPod[0].labelSelector).toBe("siclaw.io/app=agentbox");
   });
 });
+
+describe("K8sSpawner — per-agent persistence (PVC override)", () => {
+  // Drive readNamespacedPod: first call 404 (new pod), then a Running pod so
+  // spawn() resolves. Lets us inspect the createNamespacedPod body.
+  function readReturnsRunningAfter404() {
+    let r = 0;
+    readPodImpl.fn = async () => {
+      r++;
+      if (r === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return {
+        status: { phase: "Running", podIP: "10.9.9.9", conditions: [{ type: "Ready", status: "True" }] },
+        metadata: { name: "agentbox-default", labels: {} },
+      };
+    };
+  }
+
+  function userDataVolume() {
+    const body = calls.createNamespacedPod[0].body;
+    const vols = body.spec.volumes as any[];
+    return vols.find((v) => v.name === "user-data");
+  }
+
+  function userDataMount() {
+    const body = calls.createNamespacedPod[0].body;
+    const mounts = body.spec.containers[0].volumeMounts as any[];
+    return mounts.find((m) => m.name === "user-data");
+  }
+
+  it("boxConfig.persistence=true mounts the shared PVC with a per-agent subPath", async () => {
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ persistence: { enabled: false, claimName: "siclaw-data" } });
+    s.setCertManager(cm as any);
+    readReturnsRunningAfter404();
+
+    await s.spawn({ agentId: "diagnose-1", persistence: true });
+
+    expect(userDataVolume().persistentVolumeClaim).toEqual({ claimName: "siclaw-data" });
+    expect(userDataVolume().emptyDir).toBeUndefined();
+    expect(userDataMount().subPath).toBe("agents/diagnose-1");
+  });
+
+  it("boxConfig.persistence=false uses emptyDir even when global persistence is enabled", async () => {
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ persistence: { enabled: true, claimName: "siclaw-data" } });
+    s.setCertManager(cm as any);
+    readReturnsRunningAfter404();
+
+    await s.spawn({ agentId: "shopping-1", persistence: false });
+
+    expect(userDataVolume().emptyDir).toEqual({});
+    expect(userDataVolume().persistentVolumeClaim).toBeUndefined();
+    expect(userDataMount().subPath).toBeUndefined();
+  });
+
+  it("undefined boxConfig.persistence falls back to the spawner's global config (enabled)", async () => {
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ persistence: { enabled: true, claimName: "siclaw-data" } });
+    s.setCertManager(cm as any);
+    readReturnsRunningAfter404();
+
+    await s.spawn({ agentId: "legacy-1" });
+
+    expect(userDataVolume().persistentVolumeClaim).toEqual({ claimName: "siclaw-data" });
+    expect(userDataMount().subPath).toBe("agents/legacy-1");
+  });
+
+  it("undefined boxConfig.persistence falls back to the spawner's global config (disabled)", async () => {
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner(); // no persistence config at all
+    s.setCertManager(cm as any);
+    readReturnsRunningAfter404();
+
+    await s.spawn({ agentId: "legacy-2" });
+
+    expect(userDataVolume().emptyDir).toEqual({});
+    expect(userDataMount().subPath).toBeUndefined();
+  });
+
+  it("persistence requested but no claimName configured → falls back to emptyDir (no broken mount)", async () => {
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner(); // global persistence undefined → no claimName
+    s.setCertManager(cm as any);
+    readReturnsRunningAfter404();
+
+    await s.spawn({ agentId: "diagnose-2", persistence: true });
+
+    // Must not emit a PVC volume that can never bind.
+    expect(userDataVolume().persistentVolumeClaim).toBeUndefined();
+    expect(userDataVolume().emptyDir).toEqual({});
+    expect(userDataMount().subPath).toBeUndefined();
+  });
+});

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -216,11 +216,32 @@ export class K8sSpawner implements BoxSpawner {
     // Shared PVC is now scoped per-agent only — all users of the agent share
     // this subdirectory (memory is agent-shared per the 2026-04-18 spec).
     const safeAgentId = this.sanitizePathSegment(agentId);
-    if (this.config.persistence?.enabled) {
+
+    // Persistence decision is per-agent: boxConfig.persistence overrides the
+    // spawner's global config (undefined → fall back to global). Mounting the
+    // PVC requires a claimName, so an agent that requests persistence on a
+    // runtime with no shared PVC configured falls back to emptyDir (with a
+    // warning) rather than spawning a pod that can never mount.
+    const persistenceClaimName = this.config.persistence?.claimName;
+    const wantsPersistence = boxConfig.persistence ?? !!this.config.persistence?.enabled;
+    const persistenceEnabled = wantsPersistence && !!persistenceClaimName;
+    if (wantsPersistence && !persistenceClaimName) {
+      console.warn(
+        `[k8s-spawner] Agent ${agentId} requests persistence but no shared PVC claimName is configured; ` +
+        `falling back to emptyDir (session/memory will NOT survive pod restarts)`,
+      );
+    }
+    if (persistenceEnabled) {
       const subDir = `agents/${safeAgentId}`;
-      console.log(`[k8s-spawner] Persistence enabled: shared PVC "${this.config.persistence.claimName}", subPath "${subDir}"`);
+      console.log(`[k8s-spawner] Persistence enabled for agent ${agentId}: shared PVC "${persistenceClaimName}", subPath "${subDir}"`);
       this.ensureAgentDir(safeAgentId);
     }
+
+    // user-data volume: shared PVC when persistence resolved on (claimName is
+    // narrowed to string by the && below), otherwise an ephemeral emptyDir.
+    const userDataVolume: k8s.V1Volume = persistenceEnabled && persistenceClaimName
+      ? { name: "user-data", persistentVolumeClaim: { claimName: persistenceClaimName } }
+      : { name: "user-data", emptyDir: {} };
 
     // Pod definition
     const pod: k8s.V1Pod = {
@@ -266,15 +287,7 @@ export class K8sSpawner implements BoxSpawner {
             name: "knowledge-local",
             emptyDir: {},
           },
-          this.config.persistence?.enabled
-            ? {
-                name: "user-data",
-                persistentVolumeClaim: { claimName: this.config.persistence.claimName },
-              }
-            : {
-                name: "user-data",
-                emptyDir: {},
-              },
+          userDataVolume,
           {
             name: "client-cert",
             secret: { secretName: certSecretName },
@@ -320,7 +333,7 @@ export class K8sSpawner implements BoxSpawner {
               {
                 name: "user-data",
                 mountPath: "/app/.siclaw/user-data",
-                ...(this.config.persistence?.enabled
+                ...(persistenceEnabled
                   ? { subPath: `agents/${safeAgentId}` }
                   : {}),
               },

--- a/src/gateway/agentbox/manager.test.ts
+++ b/src/gateway/agentbox/manager.test.ts
@@ -215,6 +215,51 @@ describe("AgentBoxManager — K8s mode", () => {
   });
 });
 
+// ── Per-agent persistence is anchored at cold spawn ────────────────────
+//
+// chat.send carries `persistence` per request, but the volume mode is fixed
+// when the pod is created (K8s cannot hot-change a running pod's mounts). A
+// warm pod is reused by agentId WITHOUT spawning, so a changed persistence
+// value must NOT recycle it or reach a new pod spec — it only applies on the
+// next cold spawn. These tests pin that contract. (Cold-spawn volume selection
+// from boxConfig.persistence is covered by k8s-spawner.test.ts.)
+
+describe("AgentBoxManager — persistence anchored at cold spawn (warm reuse ignores it)", () => {
+  it("K8s: a running pod is reused without re-spawning when persistence flips", async () => {
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+    spawner.getReturns.set("agentbox-agent-a", {
+      boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+      endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
+    });
+
+    // Pod already running: neither a true nor a (changed) false value spawns.
+    await mgr.getOrCreate("agent-a", { persistence: true });
+    await mgr.getOrCreate("agent-a", { persistence: false });
+
+    expect(spawner.spawnCalls).toHaveLength(0);
+  });
+
+  it("Local: cached running box is reused without re-spawning when persistence flips", async () => {
+    const spawner = new FakeSpawner("local");
+    const mgr = new AgentBoxManager(spawner);
+
+    // Cold spawn anchors the value; the spawner records exactly one spawn.
+    await mgr.getOrCreate("agent-a", { persistence: true });
+    expect(spawner.spawnCalls).toHaveLength(1);
+    expect(spawner.spawnCalls[0].persistence).toBe(true);
+
+    // Cached box still running → reused; the new false value never re-spawns.
+    spawner.getReturns.set("box-agent-a", {
+      boxId: "box-agent-a", agentId: "agent-a", status: "running",
+      endpoint: "x", createdAt: new Date(), lastActiveAt: new Date(),
+    });
+    await mgr.getOrCreate("agent-a", { persistence: false });
+
+    expect(spawner.spawnCalls).toHaveLength(1); // still just the cold spawn
+  });
+});
+
 // ── Health-check timer (local only) ────────────────────────────────────
 
 describe("AgentBoxManager — health check timer", () => {

--- a/src/gateway/agentbox/manager.test.ts
+++ b/src/gateway/agentbox/manager.test.ts
@@ -260,6 +260,69 @@ describe("AgentBoxManager — persistence anchored at cold spawn (warm reuse ign
   });
 });
 
+// ── Per-agent persistence resolved by agentId (entry-point independent) ─
+//
+// The injected persistenceResolver makes persistence a true agent property:
+// any cold-spawn entry point (chat, channel, cron, abort) that passes NO
+// per-request value still gets the agent's resolved mode. An explicit config
+// value (e.g. task-coordinator's binding.persistence) wins; the resolver is
+// consulted only on a cold spawn, never on warm reuse.
+
+describe("AgentBoxManager — persistence resolved by agentId via resolver", () => {
+  it("K8s: cold spawn with no config uses the resolver's value", async () => {
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+    mgr.setPersistenceResolver(async () => true);
+
+    await mgr.getOrCreate("agent-a"); // no config — mirrors lark/dingtalk/abort
+    expect(spawner.spawnCalls).toHaveLength(1);
+    expect(spawner.spawnCalls[0].persistence).toBe(true);
+  });
+
+  it("Local: cold spawn with no config uses the resolver's value", async () => {
+    const spawner = new FakeSpawner("local");
+    const mgr = new AgentBoxManager(spawner);
+    mgr.setPersistenceResolver(async () => true);
+
+    await mgr.getOrCreate("agent-a");
+    expect(spawner.spawnCalls[0].persistence).toBe(true);
+  });
+
+  it("explicit config.persistence wins over the resolver", async () => {
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+    mgr.setPersistenceResolver(async () => false);
+
+    await mgr.getOrCreate("agent-a", { persistence: true });
+    expect(spawner.spawnCalls[0].persistence).toBe(true);
+  });
+
+  it("no resolver and no config → persistence undefined (global fallback)", async () => {
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+
+    await mgr.getOrCreate("agent-a");
+    expect(spawner.spawnCalls[0].persistence).toBeUndefined();
+  });
+
+  it("resolver is NOT consulted on warm reuse (only cold spawn)", async () => {
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+    let resolverCalls = 0;
+    mgr.setPersistenceResolver(async () => { resolverCalls++; return true; });
+
+    // Pod already running → warm reuse, resolver must not fire.
+    spawner.getReturns.set("agentbox-agent-a", {
+      boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+      endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
+    });
+    await mgr.getOrCreate("agent-a");
+
+    expect(spawner.spawnCalls).toHaveLength(0);
+    expect(resolverCalls).toBe(0);
+  });
+});
+
 // ── Health-check timer (local only) ────────────────────────────────────
 
 describe("AgentBoxManager — health check timer", () => {

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -105,6 +105,15 @@ export class AgentBoxManager {
    * on warm-pod reuse, so the chat hot path and channel/cron paths pay nothing
    * when the pod already exists.
    */
+  /**
+   * Per-agent config (e.g. `config.persistence`) is only consumed on a COLD
+   * spawn. A pod is keyed by agentId; when one is already running it is reused
+   * as-is, so persistence is effectively anchored at the agent's first spawn.
+   * Changing it on a later call does NOT recycle the pod — K8s cannot hot-change
+   * a running pod's volume mounts — and takes effect only on the next cold spawn
+   * (after the pod restarts or is idle-released). Callers are expected to send a
+   * stable value per agent.
+   */
   async getOrCreate(agentId: string, config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
     if (!agentId) throw new Error("AgentBoxManager.getOrCreate requires an agentId");
     if (this.isK8s) {
@@ -118,6 +127,9 @@ export class AgentBoxManager {
 
     const info = await this.spawner.get(name);
     if (info && info.status === "running" && info.endpoint && this.isCertFresh(info)) {
+      // Warm reuse: return the running pod without spawning, so a changed
+      // config.persistence never reaches the pod spec (anchored at cold spawn —
+      // see getOrCreate docstring).
       return { boxId: name, endpoint: info.endpoint, agentId };
     }
     if (info && info.status === "running" && !this.isCertFresh(info)) {
@@ -143,6 +155,8 @@ export class AgentBoxManager {
       existing.lastActiveAt = new Date();
       const info = await this.spawner.get(existing.handle.boxId);
       if (info && info.status === "running") {
+        // Warm reuse: cached running box returned without spawning, so a changed
+        // config.persistence is ignored until the next cold spawn (see getOrCreate).
         return existing.handle;
       }
       this.boxes.delete(agentId);

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -40,6 +40,7 @@ export class AgentBoxManager {
   private healthCheckTimer?: ReturnType<typeof setInterval>;
   private readonly isK8s: boolean;
   private spawnEnvResolver?: (agentId: string) => Promise<Record<string, string> | undefined>;
+  private persistenceResolver?: (agentId: string) => Promise<boolean | undefined>;
 
   constructor(spawner: BoxSpawner, config?: AgentBoxManagerConfig) {
     this.spawner = spawner;
@@ -65,6 +66,22 @@ export class AgentBoxManager {
    */
   setSpawnEnvResolver(fn: (agentId: string) => Promise<Record<string, string> | undefined>): void {
     this.spawnEnvResolver = fn;
+  }
+
+  /**
+   * Inject a resolver for the per-agent PVC persistence mode. Same contract as
+   * setSpawnEnvResolver: consulted on EVERY cold spawn (from any entry point —
+   * chat RPCs, channel webhooks, cron tasks, abort/steer) and NEVER on warm
+   * reuse. This is what makes persistence a true agent-level property: the
+   * value is resolved by agentId, independent of which entry point first
+   * cold-spawns the (one-per-agent) pod. Without it, only entry points that
+   * happened to pass `config.persistence` would honour it, so a pod cold-spawned
+   * by e.g. a Lark message would silently fall to the global default and ignore
+   * the agent's configured mode. Returns undefined to fall back to the global
+   * config (the spawner gates the actual mount on a claimName regardless).
+   */
+  setPersistenceResolver(fn: (agentId: string) => Promise<boolean | undefined>): void {
+    this.persistenceResolver = fn;
   }
 
   startHealthCheck(): void {
@@ -100,19 +117,19 @@ export class AgentBoxManager {
   }
 
   /**
-   * Get a running AgentBox for the agent, or spawn one. On a cold spawn the
-   * injected `spawnEnvResolver` (if any) is consulted for per-agent env — never
-   * on warm-pod reuse, so the chat hot path and channel/cron paths pay nothing
-   * when the pod already exists.
-   */
-  /**
-   * Per-agent config (e.g. `config.persistence`) is only consumed on a COLD
-   * spawn. A pod is keyed by agentId; when one is already running it is reused
-   * as-is, so persistence is effectively anchored at the agent's first spawn.
-   * Changing it on a later call does NOT recycle the pod — K8s cannot hot-change
-   * a running pod's volume mounts — and takes effect only on the next cold spawn
-   * (after the pod restarts or is idle-released). Callers are expected to send a
-   * stable value per agent.
+   * Get a running AgentBox for the agent, or spawn one.
+   *
+   * Per-agent config — the injected `spawnEnvResolver` (env, e.g. idle timeout)
+   * and `persistenceResolver` (PVC mode) — is resolved ONLY on a cold spawn,
+   * never on warm-pod reuse, so the chat hot path and channel/cron paths pay no
+   * RPC when the pod already exists.
+   *
+   * Because a pod is keyed by agentId, the persistence/env mode is resolved on
+   * each cold spawn (including a cert-stale recreate) from the agent-level
+   * resolver — NOT from whichever entry point happens to call first. The volume
+   * mount is fixed at pod creation (K8s cannot hot-change a running pod's
+   * mounts), so a configuration change applies on the agent's next cold spawn
+   * (after restart/idle-release), not immediately on a warm pod.
    */
   async getOrCreate(agentId: string, config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
     if (!agentId) throw new Error("AgentBoxManager.getOrCreate requires an agentId");
@@ -127,9 +144,9 @@ export class AgentBoxManager {
 
     const info = await this.spawner.get(name);
     if (info && info.status === "running" && info.endpoint && this.isCertFresh(info)) {
-      // Warm reuse: return the running pod without spawning, so a changed
-      // config.persistence never reaches the pod spec (anchored at cold spawn —
-      // see getOrCreate docstring).
+      // Warm reuse: return the running pod without spawning. Per-agent config
+      // (env/persistence) is NOT re-resolved here — the pod's volume mount is
+      // already fixed, so a changed mode applies on the next cold spawn.
       return { boxId: name, endpoint: info.endpoint, agentId };
     }
     if (info && info.status === "running" && !this.isCertFresh(info)) {
@@ -142,6 +159,7 @@ export class AgentBoxManager {
     const handle = await this.spawner.spawn({
       ...config,
       agentId,
+      persistence: await this.resolvePersistence(agentId, config?.persistence),
       env: Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined,
     });
 
@@ -155,8 +173,8 @@ export class AgentBoxManager {
       existing.lastActiveAt = new Date();
       const info = await this.spawner.get(existing.handle.boxId);
       if (info && info.status === "running") {
-        // Warm reuse: cached running box returned without spawning, so a changed
-        // config.persistence is ignored until the next cold spawn (see getOrCreate).
+        // Warm reuse: cached running box returned without spawning. Per-agent
+        // config (env/persistence) is NOT re-resolved — applies on next cold spawn.
         return existing.handle;
       }
       this.boxes.delete(agentId);
@@ -168,6 +186,7 @@ export class AgentBoxManager {
     const handle = await this.spawner.spawn({
       ...config,
       agentId,
+      persistence: await this.resolvePersistence(agentId, config?.persistence),
       env: Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined,
     });
 
@@ -183,6 +202,18 @@ export class AgentBoxManager {
   private async resolveEnv(agentId: string, configEnv?: Record<string, string>): Promise<Record<string, string>> {
     const lazy = this.spawnEnvResolver ? (await this.spawnEnvResolver(agentId)) ?? {} : {};
     return { ...lazy, ...(configEnv ?? {}) };
+  }
+
+  /**
+   * Resolve the per-agent PVC persistence mode for a cold spawn. An explicit
+   * `configValue` (e.g. task-coordinator passing `binding.persistence`) wins;
+   * otherwise the injected `persistenceResolver` is consulted by agentId. Either
+   * may be undefined → the spawner falls back to its global config. Only called
+   * on a cold spawn, so warm-pod reuse pays no RPC.
+   */
+  private async resolvePersistence(agentId: string, configValue?: boolean): Promise<boolean | undefined> {
+    if (configValue !== undefined) return configValue;
+    return this.persistenceResolver ? await this.persistenceResolver(agentId) : undefined;
   }
 
   /**

--- a/src/gateway/agentbox/types.ts
+++ b/src/gateway/agentbox/types.ts
@@ -24,6 +24,14 @@ export interface AgentBoxConfig {
     cpu?: string;
     memory?: string;
   };
+  /**
+   * Per-agent session/memory persistence override.
+   * - true  → mount the shared PVC (session JSONL + memory survive pod restarts)
+   * - false → use emptyDir (session cleared on pod restart/idle release)
+   * - undefined → fall back to the spawner's global persistence config
+   * Only honored by K8sSpawner; ignored by Local/Process spawners.
+   */
+  persistence?: boolean;
 }
 
 /** AgentBox information */

--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -73,6 +73,7 @@ function fakeAgentBoxManager() {
   return {
     setCertManager: vi.fn(),
     setSpawnEnvResolver: vi.fn(),
+    setPersistenceResolver: vi.fn(),
     getOrCreate: vi.fn(async () => ({ endpoint: "https://fake.internal" })),
     list: vi.fn(() => []),
     cleanup: vi.fn(async () => {}),

--- a/src/gateway/server-session-status.test.ts
+++ b/src/gateway/server-session-status.test.ts
@@ -44,6 +44,7 @@ function fakeAgentBoxManager() {
   return {
     setCertManager: vi.fn(),
     setSpawnEnvResolver: vi.fn(),
+    setPersistenceResolver: vi.fn(),
     getAsync: vi.fn(async () => nextHandle),
     getOrCreate: vi.fn(async () => { throw new Error("getOrCreate must not be called for liveness"); }),
     list: vi.fn(() => []),

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -58,6 +58,7 @@ import { MetricsAggregator } from "./metrics-aggregator.js";
 import { PromFederationAggregator } from "./prom-federation-aggregator.js";
 import { LocalSpawner } from "./agentbox/local-spawner.js";
 import { sessionRegistry } from "./session-registry.js";
+import { resolveAgentModelBinding } from "./agent-model-binding.js";
 
 export interface RuntimeServer {
   httpServer: http.Server;
@@ -171,6 +172,18 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   };
   agentBoxManager.setSpawnEnvResolver(resolveAgentSpawnEnv);
 
+  // Per-agent PVC persistence is an AGENT property, not a per-request flag:
+  // resolve it server-side by agentId so every cold-spawn entry point (chat,
+  // channel webhooks, cron, abort/steer) lands the same mode for the same agent
+  // — not whichever caller happens to spawn the pod first. Registered on the
+  // shared manager and consulted only on a cold spawn. siclaw core leaves
+  // binding.persistence undefined → global fallback (behaviour identical to
+  // upstream); a product portal fills it in its config.getModelBinding handler.
+  agentBoxManager.setPersistenceResolver(async (agentId) => {
+    const binding = await resolveAgentModelBinding(agentId, frontendClient);
+    return binding?.persistence;
+  });
+
   // Per-session AbortController for the in-flight chat.send SSE consumer, keyed
   // by sessionId. chat.abort looks this up to break the gateway's consumeAgentSse
   // loop so its abort-finalization runs (in-flight tool rows → "stopped", partial
@@ -211,11 +224,6 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const modelRouting = params.modelRouting as PromptOptions["modelRouting"];
     const images = params.images as PromptOptions["images"];
     const files = params.files as PromptOptions["files"];
-    // Per-agent PVC persistence toggle, carried over the chat.send protocol.
-    // siclaw's own portal does not set this (no native per-agent UI); a product
-    // portal (e.g. gpu-cloud) resolves it from its own store and passes it through.
-    // undefined when omitted → spawner falls back to its global config.
-    const persistence = typeof params.persistence === "boolean" ? params.persistence : undefined;
     const promptOpts: PromptOptions = {
       sessionId,
       text,
@@ -256,7 +264,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         await appendMessage({ sessionId, role: "user", content: text });
         await incrementMessageCount(sessionId);
 
-        const handle = await agentBoxManager.getOrCreate(agentId, { persistence });
+        // Persistence is resolved by agentId in the manager's persistenceResolver
+        // (registered in startRuntime), not from per-request params — so every
+        // entry point lands the same mode for the same agent.
+        const handle = await agentBoxManager.getOrCreate(agentId);
         const client = new AgentBoxClient(handle.endpoint, 30000, agentBoxTlsOptions);
 
         let promptResult: Awaited<ReturnType<typeof client.prompt>>;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -211,6 +211,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const modelRouting = params.modelRouting as PromptOptions["modelRouting"];
     const images = params.images as PromptOptions["images"];
     const files = params.files as PromptOptions["files"];
+    // Per-agent PVC persistence toggle, carried over the chat.send protocol.
+    // siclaw's own portal does not set this (no native per-agent UI); a product
+    // portal (e.g. gpu-cloud) resolves it from its own store and passes it through.
+    // undefined when omitted → spawner falls back to its global config.
+    const persistence = typeof params.persistence === "boolean" ? params.persistence : undefined;
     const promptOpts: PromptOptions = {
       sessionId,
       text,
@@ -251,7 +256,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         await appendMessage({ sessionId, role: "user", content: text });
         await incrementMessageCount(sessionId);
 
-        const handle = await agentBoxManager.getOrCreate(agentId);
+        const handle = await agentBoxManager.getOrCreate(agentId, { persistence });
         const client = new AgentBoxClient(handle.endpoint, 30000, agentBoxTlsOptions);
 
         let promptResult: Awaited<ReturnType<typeof client.prompt>>;

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -271,7 +271,7 @@ export class TaskCoordinator {
       // One pod per agent — shared across users who call the agent.
       // Caller/task-owner attribution flows to Upstream via the session registry.
       sessionRegistry.remember(sessionId, userId, agentId);
-      const handle = await this.manager.getOrCreate(agentId);
+      const handle = await this.manager.getOrCreate(agentId, { persistence: binding.persistence });
       const client = new AgentBoxClient(handle.endpoint, 30_000, this.tlsOptions);
 
       const promptOpts: PromptOptions = {

--- a/src/lib/bootstrap-runtime.ts
+++ b/src/lib/bootstrap-runtime.ts
@@ -162,15 +162,21 @@ function createSpawner(
   if (kind === "k8s") {
     const image = opts.k8sImage ?? process.env.SICLAW_AGENTBOX_IMAGE ?? "siclaw-agentbox:latest";
     const namespace = opts.k8sNamespace ?? process.env.SICLAW_K8S_NAMESPACE ?? "default";
-    const claimName =
-      opts.k8sPersistenceClaimName ?? process.env.SICLAW_PERSISTENCE_CLAIM_NAME ?? "siclaw-data";
+    // claimName identifies the shared PVC the deployer actually created — its name
+    // differs per deployment, so there is NO hardcoded default. It is "available"
+    // only when explicitly configured (helm opt or SICLAW_PERSISTENCE_CLAIM_NAME).
+    const claimName = opts.k8sPersistenceClaimName ?? process.env.SICLAW_PERSISTENCE_CLAIM_NAME;
+    const globalEnabled = process.env.SICLAW_PERSISTENCE_ENABLED === "true";
+    // Decouple infrastructure (claimName: is a shared PVC available?) from policy
+    // (enabled: the global default for callers that don't specify per-agent).
+    // Pass claimName whenever it's configured — so a per-agent opt-in
+    // (boxConfig.persistence, e.g. from an external portal) can mount the PVC even
+    // when the global flag is off. The spawner gates the actual mount on claimName,
+    // so when it's absent persistence simply degrades to emptyDir.
     return new K8sSpawner({
       namespace,
       image,
-      persistence:
-        process.env.SICLAW_PERSISTENCE_ENABLED === "true"
-          ? { enabled: true, claimName }
-          : undefined,
+      persistence: claimName ? { enabled: globalEnabled, claimName } : undefined,
     });
   }
   if (kind === "process") return new ProcessSpawner();

--- a/src/lib/bootstrap-runtime.ts
+++ b/src/lib/bootstrap-runtime.ts
@@ -167,6 +167,17 @@ function createSpawner(
     // only when explicitly configured (helm opt or SICLAW_PERSISTENCE_CLAIM_NAME).
     const claimName = opts.k8sPersistenceClaimName ?? process.env.SICLAW_PERSISTENCE_CLAIM_NAME;
     const globalEnabled = process.env.SICLAW_PERSISTENCE_ENABLED === "true";
+    // Behaviour change vs the old hardcoded "siclaw-data" default: a raw-env
+    // deploy that set only SICLAW_PERSISTENCE_ENABLED=true (no claim name) now
+    // silently degrades to emptyDir instead of binding a PVC named "siclaw-data".
+    // Warn once at startup so that regression is visible (Helm always injects the
+    // claim name when a PVC is available, so chart users never hit this).
+    if (globalEnabled && !claimName) {
+      console.warn(
+        "[runtime] SICLAW_PERSISTENCE_ENABLED=true but SICLAW_PERSISTENCE_CLAIM_NAME is unset — " +
+        "persistence falls back to emptyDir (no shared PVC mounted; session/memory will NOT survive pod restarts)",
+      );
+    }
     // Decouple infrastructure (claimName: is a shared PVC available?) from policy
     // (enabled: the global default for callers that don't specify per-agent).
     // Pass claimName whenever it's configured — so a per-agent opt-in


### PR DESCRIPTION
Lower the session/memory persistence decision from a runtime-global env flag to an optional per-agent value, so one runtime can host both ephemeral agents (emptyDir; context cleared on pod restart/idle) and durable agents (PVC-backed; context survives restarts), without siclaw's own portal needing to store or expose the toggle.

Mechanism only — siclaw core does NOT persist or surface a per-agent flag. A downstream portal that wants per-agent persistence fills `binding.persistence` in its own `config.getModelBinding` handler; siclaw resolves it server-side by `agentId` on cold spawn. When the portal does not set it (siclaw's native portal, legacy callers, tests), the value is undefined and the spawner falls back to its global config — behaviour identical to upstream.

- types: AgentBoxConfig.persistence? (per-agent override)
- agent-model-binding: ResolvedModelBinding.persistence? (carried, never set by core)
- manager: setPersistenceResolver(agentId → binding.persistence), consulted only on a cold spawn (mirrors setSpawnEnvResolver); every getOrCreate entry point honours it, so the entry point is irrelevant
- server: register the resolver in startRuntime; chat.send no longer carries a per-request persistence param (single source of truth = the agentId-keyed resolver). task-coordinator still passes binding.persistence explicitly (explicit value wins)
- k8s-spawner: resolve boxConfig.persistence ?? global; mount shared PVC only when a claimName is configured, else degrade to emptyDir + warn (never spawn an unmountable pod)
- bootstrap-runtime: claimName has no hardcoded default (differs per deployment) and is decoupled from the global enabled flag, so a per-agent opt-in can mount the PVC even when the global default is off
- k8s-spawner.test: +5 persistence-matrix cases

Tests: tsc --noEmit clean; full suite 3935 passed / 2 skipped.

## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **DB parity**: Schema changes keep `src/portal/migrate.ts` compatible with both MySQL and SQLite (see [`docs/design/invariants.md §5`](../docs/design/invariants.md)).
- [ ] **Tool protocol**: New tools register through `src/core/tool-registry.ts` and use the TypeBox `ToolDefinition` protocol.

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
