### PR TITLE
feat(dingtalk): reply with agent-produced images via robot OpenAPI

### DIFF
--- a/src/gateway/channels/dingtalk-api.test.ts
+++ b/src/gateway/channels/dingtalk-api.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getAccessToken,
+  uploadImageMedia,
+  resetDingTalkTokenCacheForTest,
+} from "./dingtalk-api.js";
+import type { DingTalkChannelConfig } from "./dingtalk.js";
+
+const config: DingTalkChannelConfig = { client_id: "app-key-1", client_secret: "app-secret-1" };
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetDingTalkTokenCacheForTest();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("getAccessToken", () => {
+  it("fetches a token and caches it for subsequent calls", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accessToken: "tok-abc", expireIn: 7200 }));
+
+    const first = await getAccessToken(config);
+    const second = await getAccessToken(config);
+
+    expect(first).toBe("tok-abc");
+    expect(second).toBe("tok-abc");
+    // Cached: only one network call for two getAccessToken invocations.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.dingtalk.com/v1.0/oauth2/accessToken");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      appKey: "app-key-1",
+      appSecret: "app-secret-1",
+    });
+  });
+
+  it("returns null on HTTP failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 401));
+    expect(await getAccessToken(config)).toBeNull();
+  });
+
+  it("returns null when the response has no accessToken", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ expireIn: 7200 }));
+    expect(await getAccessToken(config)).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNRESET"));
+    expect(await getAccessToken(config)).toBeNull();
+  });
+});
+
+describe("uploadImageMedia", () => {
+  // Plain function (not a vi.fn) so afterEach's restoreAllMocks can't wipe its
+  // implementation between cases.
+  const getToken = async () => "tok-xyz";
+
+  it("uploads a PNG and returns its media_id", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ errcode: 0, media_id: "@media-123" }));
+
+    const mediaId = await uploadImageMedia(config, Buffer.from([1, 2, 3]), "image/png", getToken);
+
+    expect(mediaId).toBe("@media-123");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("https://oapi.dingtalk.com/media/upload");
+    expect(url).toContain("type=image");
+    expect(url).toContain("access_token=tok-xyz");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as RequestInit).body).toBeInstanceOf(FormData);
+  });
+
+  it("rejects an unsupported mime type without calling the network", async () => {
+    const mediaId = await uploadImageMedia(config, Buffer.from([1]), "image/gif", getToken);
+    expect(mediaId).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty buffer without calling the network", async () => {
+    const mediaId = await uploadImageMedia(config, Buffer.alloc(0), "image/png", getToken);
+    expect(mediaId).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversize buffer without calling the network", async () => {
+    const big = Buffer.alloc(20 * 1024 * 1024 + 1);
+    const mediaId = await uploadImageMedia(config, big, "image/png", getToken);
+    expect(mediaId).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when token resolution fails", async () => {
+    const noToken = vi.fn().mockResolvedValue(null);
+    const mediaId = await uploadImageMedia(config, Buffer.from([1]), "image/png", noToken);
+    expect(mediaId).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when DingTalk rejects the upload (errcode != 0)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ errcode: 40078, errmsg: "invalid media" }));
+    const mediaId = await uploadImageMedia(config, Buffer.from([1]), "image/png", getToken);
+    expect(mediaId).toBeNull();
+  });
+});

--- a/src/gateway/channels/dingtalk-api.ts
+++ b/src/gateway/channels/dingtalk-api.ts
@@ -1,0 +1,173 @@
+/**
+ * DingTalk OpenAPI helpers shared by the channel handler.
+ *
+ * Phase 1 scope: an access-token cache plus image media upload, which together
+ * let the handler turn an agent-produced image (a binary artifact, NOT an
+ * agent-authored URL) into a DingTalk `media_id`. That `media_id` is then
+ * embedded into the `sessionWebhook` markdown reply (`![alt](media_id)`) the
+ * same way the upstream `@soimy/dingtalk` plugin's `sendBySession` does.
+ *
+ * Security note: every call here runs in the trusted Runtime process (inside
+ * the cluster), never in the agent sandbox. We only ever talk to the pinned
+ * DingTalk OpenAPI hosts (`api.dingtalk.com` for the token, `oapi.dingtalk.com`
+ * for media upload). The bytes we upload come from the agent's structured image
+ * blocks collected by `collectChannelResponse`, so this path does not reopen
+ * the prompt-injection / data-exfiltration hole that markdown image-stripping
+ * closes — arbitrary agent-authored image URLs are still stripped.
+ */
+
+import type { DingTalkChannelConfig } from "./dingtalk.js";
+
+/** DingTalk OpenAPI endpoints (pinned — do not accept these from frame data). */
+const TOKEN_URL = "https://api.dingtalk.com/v1.0/oauth2/accessToken";
+const MEDIA_UPLOAD_URL = "https://oapi.dingtalk.com/media/upload";
+
+/** DingTalk hard limit for image media uploads. */
+const IMAGE_UPLOAD_MAX_BYTES = 20 * 1024 * 1024;
+
+/** Network timeout for OpenAPI calls (token + upload). */
+const OPENAPI_TIMEOUT_MS = 10_000;
+
+/** Supported outbound image MIME types and the filename extension we tag them with. */
+const IMAGE_MIME_EXTENSION: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+};
+
+interface TokenCacheEntry {
+  accessToken: string;
+  /** Epoch ms at which the cached token should be considered stale. */
+  expiresAt: number;
+}
+
+/**
+ * Access-token cache keyed by clientId so multiple DingTalk channels (each a
+ * distinct app) keep independent tokens. In-memory only: a Runtime restart
+ * simply re-fetches on first use.
+ */
+const tokenCache = new Map<string, TokenCacheEntry>();
+
+/** Test-only helper to clear the token cache between cases. */
+export function resetDingTalkTokenCacheForTest(): void {
+  tokenCache.clear();
+}
+
+/**
+ * Redact secrets from any string before it reaches a log collector. The token
+ * endpoint takes the AppSecret in the request body and the upload endpoint puts
+ * the access token in the query string, so a naive error dump could leak both.
+ */
+export function redactSecrets(input: string): string {
+  return input
+    .replace(/(appSecret|appsecret|access_token|accessToken)["=:\s]+[^"&\s,}]+/gi, "$1=***");
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = OPENAPI_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch (or return a cached) DingTalk access token for the given channel app.
+ * Refreshes one minute before expiry to avoid near-boundary failures. Returns
+ * `null` on any failure so callers degrade gracefully (text/markdown reply
+ * without the image) rather than throwing into the message handler.
+ */
+export async function getAccessToken(
+  config: DingTalkChannelConfig,
+): Promise<string | null> {
+  const cacheKey = config.client_id;
+  const now = Date.now();
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAt > now + 60_000) {
+    return cached.accessToken;
+  }
+
+  try {
+    const res = await fetchWithTimeout(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ appKey: config.client_id, appSecret: config.client_secret }),
+    });
+    if (!res.ok) {
+      console.error(`[dingtalk-api] accessToken request failed: HTTP ${res.status}`);
+      return null;
+    }
+    const data = (await res.json()) as { accessToken?: string; expireIn?: number };
+    if (!data.accessToken || typeof data.accessToken !== "string") {
+      console.error("[dingtalk-api] accessToken response missing accessToken");
+      return null;
+    }
+    const expireInMs = (typeof data.expireIn === "number" ? data.expireIn : 7200) * 1000;
+    tokenCache.set(cacheKey, { accessToken: data.accessToken, expiresAt: now + expireInMs });
+    return data.accessToken;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[dingtalk-api] accessToken error: ${redactSecrets(msg)}`);
+    return null;
+  }
+}
+
+/**
+ * Upload one image to DingTalk's media server and return its `media_id`.
+ * Returns `null` on any failure (unsupported type, oversize, network/API
+ * error) so the caller can fall back to a text-only reply.
+ *
+ * `getToken` is injectable for unit testing; it defaults to {@link getAccessToken}.
+ */
+export async function uploadImageMedia(
+  config: DingTalkChannelConfig,
+  image: Buffer,
+  mimeType: string,
+  getToken: (config: DingTalkChannelConfig) => Promise<string | null> = getAccessToken,
+): Promise<string | null> {
+  const ext = IMAGE_MIME_EXTENSION[mimeType.toLowerCase()];
+  if (!ext) {
+    console.error(`[dingtalk-api] unsupported image mime type for upload: ${mimeType}`);
+    return null;
+  }
+  if (image.length === 0) {
+    console.error("[dingtalk-api] refusing to upload empty image buffer");
+    return null;
+  }
+  if (image.length > IMAGE_UPLOAD_MAX_BYTES) {
+    const mb = (image.length / (1024 * 1024)).toFixed(2);
+    console.error(`[dingtalk-api] image too large to upload: ${mb}MB exceeds 20MB`);
+    return null;
+  }
+
+  const token = await getToken(config);
+  if (!token) return null;
+
+  try {
+    const form = new FormData();
+    form.append("media", new Blob([new Uint8Array(image)], { type: mimeType }), `image.${ext}`);
+
+    const url = `${MEDIA_UPLOAD_URL}?access_token=${encodeURIComponent(token)}&type=image`;
+    const res = await fetchWithTimeout(url, { method: "POST", body: form });
+    if (!res.ok) {
+      console.error(`[dingtalk-api] media upload failed: HTTP ${res.status}`);
+      return null;
+    }
+    const data = (await res.json()) as { errcode?: number; media_id?: string; errmsg?: string };
+    if (data.errcode === 0 && typeof data.media_id === "string" && data.media_id) {
+      return data.media_id;
+    }
+    console.error(`[dingtalk-api] media upload rejected: errcode=${data.errcode} errmsg=${data.errmsg ?? ""}`);
+    return null;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[dingtalk-api] media upload error: ${redactSecrets(msg)}`);
+    return null;
+  }
+}

--- a/src/gateway/channels/dingtalk-image.test.ts
+++ b/src/gateway/channels/dingtalk-image.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Keep the real fetchWithTimeout/redactSecrets, but control token + upload.
+const getAccessTokenMock = vi.fn();
+const uploadImageMediaMock = vi.fn();
+
+vi.mock("./dingtalk-api.js", async () => {
+  const actual = await vi.importActual<typeof import("./dingtalk-api.js")>("./dingtalk-api.js");
+  return {
+    ...actual,
+    getAccessToken: (...args: unknown[]) => getAccessTokenMock(...args),
+    uploadImageMedia: (...args: unknown[]) => uploadImageMediaMock(...args),
+  };
+});
+
+import { sendImageMessage, deliverImages } from "./dingtalk-image.js";
+import type { DingTalkChannelConfig } from "./dingtalk.js";
+import type { RenderedReplyImage } from "./visual-image.js";
+
+const config: DingTalkChannelConfig = { client_id: "robot-1", client_secret: "sec" };
+
+function okResponse(body: unknown = { processQueryKey: "q-1" }): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  getAccessTokenMock.mockReset().mockResolvedValue("tok-1");
+  uploadImageMediaMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("sendImageMessage", () => {
+  const token = async () => "tok-1";
+
+  it("sends a 1:1 image via oToMessages/batchSend with userIds + sampleImageMsg", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse());
+
+    const ok = await sendImageMessage(
+      config,
+      { routeType: "user", senderStaffId: "staff-42" },
+      "@media-1",
+      token,
+    );
+
+    expect(ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.robotCode).toBe("robot-1");
+    expect(body.userIds).toEqual(["staff-42"]);
+    expect(body.msgKey).toBe("sampleImageMsg");
+    expect(JSON.parse(body.msgParam)).toEqual({ photoURL: "@media-1" });
+    expect((init as RequestInit).headers).toMatchObject({ "x-acs-dingtalk-access-token": "tok-1" });
+  });
+
+  it("sends a group image via groupMessages/send with openConversationId", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse());
+
+    const ok = await sendImageMessage(
+      config,
+      { routeType: "group", openConversationId: "cidGROUP" },
+      "@media-2",
+      token,
+    );
+
+    expect(ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.dingtalk.com/v1.0/robot/groupMessages/send");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.openConversationId).toBe("cidGROUP");
+    expect(body.userIds).toBeUndefined();
+  });
+
+  it("returns false when a 1:1 reply has no senderStaffId (no network call)", async () => {
+    const ok = await sendImageMessage(config, { routeType: "user" }, "@media-3", token);
+    expect(ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false when a group reply has no openConversationId (no network call)", async () => {
+    const ok = await sendImageMessage(config, { routeType: "group" }, "@media-4", token);
+    expect(ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false when token resolution fails", async () => {
+    const ok = await sendImageMessage(
+      config,
+      { routeType: "group", openConversationId: "cidGROUP" },
+      "@media-5",
+      async () => null,
+    );
+    expect(ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false on HTTP failure", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) } as unknown as Response);
+    const ok = await sendImageMessage(config, { routeType: "group", openConversationId: "c" }, "@m", token);
+    expect(ok).toBe(false);
+  });
+
+  it("returns false on a business error payload (code present)", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse({ code: "Forbidden", message: "no permission" }));
+    const ok = await sendImageMessage(config, { routeType: "group", openConversationId: "c" }, "@m", token);
+    expect(ok).toBe(false);
+  });
+});
+
+describe("deliverImages", () => {
+  const images: RenderedReplyImage[] = [
+    { kind: "image", mimeType: "image/png", image: Buffer.from([1]) },
+    { kind: "image", mimeType: "image/png", image: Buffer.from([2]) },
+  ];
+
+  it("uploads and sends each image, returning the delivered count", async () => {
+    uploadImageMediaMock.mockResolvedValueOnce("@m-1").mockResolvedValueOnce("@m-2");
+    fetchMock.mockResolvedValue(okResponse());
+
+    const count = await deliverImages(config, { routeType: "group", openConversationId: "cidG" }, images);
+
+    expect(count).toBe(2);
+    expect(uploadImageMediaMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips an image whose upload fails but still delivers the rest", async () => {
+    uploadImageMediaMock.mockResolvedValueOnce(null).mockResolvedValueOnce("@m-2");
+    fetchMock.mockResolvedValue(okResponse());
+
+    const count = await deliverImages(config, { routeType: "group", openConversationId: "cidG" }, images);
+
+    expect(count).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/channels/dingtalk-image.ts
+++ b/src/gateway/channels/dingtalk-image.ts
@@ -1,0 +1,118 @@
+/**
+ * DingTalk image reply delivery (Phase 1, mechanism "B").
+ *
+ * Mirrors how Lark replies with images (`lark-image.ts` → separate image
+ * message) rather than inlining into markdown: agent-produced image artifacts
+ * are uploaded to DingTalk's media server (`dingtalk-api.ts` → media_id) and
+ * then sent as standalone robot messages via the DingTalk OpenAPI:
+ *
+ *   - 1:1 chat  → POST /v1.0/robot/oToMessages/batchSend  (userIds)
+ *   - group     → POST /v1.0/robot/groupMessages/send     (openConversationId)
+ *
+ * Both use the `sampleImageMsg` template with `photoURL` set to the uploaded
+ * media_id. Unlike the markdown reply (which goes over the temporary
+ * `sessionWebhook`), these calls are authenticated with an access token and
+ * require the robot message-send permission plus `robotCode` (= the app's
+ * ClientID / AppKey).
+ *
+ * Security: same trust boundary as `dingtalk-api.ts` — these calls run in the
+ * trusted Runtime process against pinned DingTalk OpenAPI hosts, and the bytes
+ * come from the agent's structured image blocks, not agent-authored URLs.
+ *
+ * Every function degrades gracefully (returns false / logs) instead of
+ * throwing, so a failed image never breaks the primary text/markdown reply.
+ */
+
+import type { DingTalkChannelConfig } from "./dingtalk.js";
+import type { RenderedReplyImage } from "./visual-image.js";
+import { getAccessToken, uploadImageMedia, fetchWithTimeout, redactSecrets } from "./dingtalk-api.js";
+
+const ROBOT_OTO_URL = "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend";
+const ROBOT_GROUP_URL = "https://api.dingtalk.com/v1.0/robot/groupMessages/send";
+
+/** Where an image reply should be delivered, derived from the inbound frame. */
+export interface DingTalkImageTarget {
+  routeType: "user" | "group";
+  /** Group chats: the inbound `conversationId` doubles as the openConversationId. */
+  openConversationId?: string;
+  /** 1:1 chats: the sender's staff id (only the sender can receive the reply). */
+  senderStaffId?: string;
+}
+
+/**
+ * Send one already-uploaded image (`mediaId`) to the conversation via the robot
+ * OpenAPI. Returns true on success. `getToken` is injectable for testing.
+ */
+export async function sendImageMessage(
+  config: DingTalkChannelConfig,
+  target: DingTalkImageTarget,
+  mediaId: string,
+  getToken: (config: DingTalkChannelConfig) => Promise<string | null> = getAccessToken,
+): Promise<boolean> {
+  const isGroup = target.routeType === "group";
+  if (isGroup && !target.openConversationId) {
+    console.error("[dingtalk-image] group image reply missing openConversationId");
+    return false;
+  }
+  if (!isGroup && !target.senderStaffId) {
+    console.error("[dingtalk-image] 1:1 image reply missing senderStaffId");
+    return false;
+  }
+
+  const token = await getToken(config);
+  if (!token) return false;
+
+  const payload: Record<string, unknown> = {
+    robotCode: config.client_id,
+    msgKey: "sampleImageMsg",
+    msgParam: JSON.stringify({ photoURL: mediaId }),
+  };
+  if (isGroup) {
+    payload.openConversationId = target.openConversationId;
+  } else {
+    payload.userIds = [target.senderStaffId];
+  }
+
+  const url = isGroup ? ROBOT_GROUP_URL : ROBOT_OTO_URL;
+  try {
+    const res = await fetchWithTimeout(url, {
+      method: "POST",
+      headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      console.error(`[dingtalk-image] image send failed: HTTP ${res.status}`);
+      return false;
+    }
+    // Success responses carry a processQueryKey; business errors carry code/message.
+    const data = (await res.json().catch(() => ({}))) as { processQueryKey?: string; code?: string; message?: string };
+    if (data.code) {
+      console.error(`[dingtalk-image] image send rejected: code=${data.code} message=${data.message ?? ""}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[dingtalk-image] image send error: ${redactSecrets(msg)}`);
+    return false;
+  }
+}
+
+/**
+ * Upload and deliver all collected reply images, in order. Best-effort: each
+ * image is independent, and any failure is logged without aborting the rest or
+ * the primary text reply. Returns the count successfully delivered.
+ */
+export async function deliverImages(
+  config: DingTalkChannelConfig,
+  target: DingTalkImageTarget,
+  images: RenderedReplyImage[],
+): Promise<number> {
+  let delivered = 0;
+  for (const { image, mimeType } of images) {
+    const mediaId = await uploadImageMedia(config, image, mimeType);
+    if (!mediaId) continue;
+    if (await sendImageMessage(config, target, mediaId)) delivered += 1;
+  }
+  return delivered;
+}

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -40,7 +40,9 @@ import { resolveAgentSystemPrompt } from "../agent-model-binding.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
 import { appendMessage, ensureChatSession } from "../chat-repo.js";
-import { collectResponse } from "./lark.js";
+import { collectChannelResponse } from "./lark.js";
+import type { RenderedReplyImage } from "./visual-image.js";
+import { deliverImages } from "./dingtalk-image.js";
 import {
   buildMarkdownMessage,
   buildTextMessage,
@@ -94,6 +96,12 @@ interface DingTalkRobotMessage {
   conversationType?: string;  // "1" = 1:1, "2" = group
   sessionWebhook: string;
   msgId?: string;
+  /**
+   * Sender's staff id. Required to address a 1:1 image reply via the robot
+   * OpenAPI (`oToMessages/batchSend` takes `userIds`); absent/irrelevant for
+   * group replies, which address the group by `conversationId`.
+   */
+  senderStaffId?: string;
 }
 
 /**
@@ -161,7 +169,7 @@ export function createDingTalkHandler(
           ackDingTalkCallback(dwClient, downstream);
           // Run the actual work detached so the WS read loop is never blocked.
           setImmediate(() => {
-            handleDingTalkMessage(downstream, channelId, agentBoxManager, tlsOptions, frontendClient)
+            handleDingTalkMessage(downstream, channelId, agentBoxManager, tlsOptions, frontendClient, config)
               .catch((err) => {
                 console.error(`[dingtalk] Error handling message for channel=${channelId}:`, err);
               });
@@ -227,6 +235,7 @@ export async function handleDingTalkMessage(
   agentBoxManager: AgentBoxManager,
   tlsOptions?: { cert: string; key: string; ca: string },
   frontendClient?: FrontendWsClient,
+  config?: DingTalkChannelConfig,
 ): Promise<void> {
   let message: DingTalkRobotMessage;
   try {
@@ -324,14 +333,18 @@ export async function handleDingTalkMessage(
 
   const promptOpts: PromptOptions = { text, agentId, mode: "channel", sessionId, systemPromptTemplate };
   let resultText = "";
+  let replyImages: RenderedReplyImage[] = [];
   let agentError: Error | null = null;
   try {
     const promptResult = await client.prompt(promptOpts);
-    // Persist assistant + tool rows too (full transcript), only when the session
-    // row exists (createdBy present), so the audit shows the agent's actions.
-    resultText = await collectResponse(client, promptResult.sessionId, "dingtalk", {
+    // Collect the reply with audit persistence (assistant + tool rows, when the
+    // session row exists) AND image artifacts for channel delivery.
+    const collected = await collectChannelResponse(client, promptResult.sessionId, "dingtalk", {
+      includeImages: true,
       persist: auditable ? { agentId } : undefined,
     });
+    resultText = collected.text;
+    replyImages = collected.images;
   } catch (err) {
     agentError = err instanceof Error ? err : new Error(String(err));
     console.error(`[dingtalk] Agent execution failed for session=${sessionId}:`, agentError);
@@ -359,6 +372,27 @@ export async function handleDingTalkMessage(
     ? buildTextMessage(finalBody)
     : (resultText ? buildMarkdownMessage(finalBody) : buildTextMessage(finalBody));
   await replyToDingTalk(sessionWebhook, body);
+
+  // Deliver any agent-produced images as separate robot messages (mirrors
+  // Lark's replyVisualImages). Best-effort and post-text: image delivery needs
+  // an access token + robot-send permission (config), and a failed image must
+  // never break the primary reply. Skipped when the agent errored, produced no
+  // images, or the channel config was not threaded through (older callers).
+  if (!agentError && config && replyImages.length > 0) {
+    const target = {
+      routeType,
+      openConversationId: routeType === "group" ? conversationId : undefined,
+      senderStaffId: message.senderStaffId,
+    };
+    try {
+      const delivered = await deliverImages(config, target, replyImages);
+      if (delivered < replyImages.length) {
+        console.warn(`[dingtalk] Delivered ${delivered}/${replyImages.length} reply images for session=${sessionId}`);
+      }
+    } catch (err) {
+      console.error(`[dingtalk] Image delivery failed for session=${sessionId}: ${safeErrorMessage(err)}`);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

DingTalk replies were text/markdown only, so agent-produced image artifacts (charts, screenshots, etc.) were silently dropped. This adds image delivery for the DingTalk channel, mirroring the existing Lark pattern (`replyVisualImages`): images are sent as **separate robot messages**, not inlined into markdown.

Only images that the agent produces as **structured image content blocks** (collected via `collectChannelResponse({ includeImages: true })`) are delivered. Arbitrary agent-authored markdown image URLs are still stripped by `sanitizeMarkdownForDingTalk`, so the prompt-injection / data-exfiltration surface is unchanged.

## 上线效果 / Screenshots

<!-- 把上线效果图拖拽或粘贴到这一行下面，GitHub 会自动上传并生成链接 -->
<img width="2236" height="1616" alt="image" src="https://github.com/user-attachments/assets/79d14259-0be3-474f-adde-056a89e89afd" />


## What changed

- **`dingtalk-api.ts` (new)** — DingTalk OpenAPI helpers:
  - `getAccessToken` — clientId-scoped token cache, refreshes 1 min before expiry.
  - `uploadImageMedia` — uploads a PNG/JPEG/WebP buffer to DingTalk media (`/media/upload`) → `media_id`. Enforces 20MB / supported-type limits.
- **`dingtalk-image.ts` (new)** — robot-message image delivery:
  - `sendImageMessage` — `sampleImageMsg` (`photoURL=media_id`) via `oToMessages/batchSend` (1:1, `userIds`) or `groupMessages/send` (group, `openConversationId`).
  - `deliverImages` — uploads + sends each collected image; best-effort, returns delivered count.
- **`dingtalk.ts`** — capture `senderStaffId` from the inbound frame; thread channel `config` into the handler; switch to `collectChannelResponse({ includeImages: true, persist })` to collect text + images while preserving the existing audit persistence; deliver images as separate messages **after** the text reply.
- Unit tests for both new modules.

## How it works

```
tool returns image block → collectChannelResponse collects RenderedReplyImage[]
   → uploadImageMedia (media_id) → sendImageMessage (robot OpenAPI) → DingTalk
```

Text reply goes out first (over `sessionWebhook`), images follow as separate robot messages.

## Security

- All OpenAPI calls run in the trusted Runtime against pinned DingTalk hosts (`api.dingtalk.com`, `oapi.dingtalk.com`); token/secret are redacted in logs.
- Image bytes come only from the agent's structured image blocks, never from agent-authored URLs.
- Image delivery is best-effort and post-text: a failed upload/send (e.g. missing permission) never breaks the primary reply — it degrades to text-only.

## Testing

- `npx tsc --noEmit` — clean.
- `vitest` — 68 passing (10 `dingtalk-api`, 9 `dingtalk-image`, 49 existing `dingtalk` handler suite incl. audit persistence).
- Real-device build pushed and exercised: image replies were received in DingTalk.

## Requires (DingTalk console)

- **Media file upload** + **robot message send** permissions (without them token resolves but send is rejected → degrades to text-only).

## Known limitations / follow-ups

- `senderStaffId` (1:1) and group `conversationId`-as-`openConversationId` are validated against the live frame shape; covered by the degradation path if a field is absent.
- AI streaming card (image blocks inside a live card) remains a separate Phase 2 (reserved `DingTalkStreamingCard` seam).
- Non-multimodal model routing (`api: openai-completions`) cannot feed tool-result images back into the model context, so the agent may not "see" the image it just sent — orthogonal to delivery, tracked separately.
