### PR TITLE
fix(chat): restore context-usage meter on session open/refresh

### DIFF
--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -412,6 +412,25 @@ export function buildPilotMessages(items: ChatMessage[]): PilotMessage[] {
   return annotateSubagentCompletions(annotateExecJobCompletions(annotateDelegationSynthesis(items.map(toPilotMessage))))
 }
 
+/**
+ * Recover the most recent persisted context-usage snapshot from loaded history.
+ * The Runtime stores it on the latest assistant row's `metadata.context_usage`
+ * (see sse-consumer.ts agent_end handling), so the context meter can render on
+ * session open/refresh instead of staying blank until the next live turn.
+ * Items are chronological (oldest first), so scan from the end.
+ */
+function latestContextUsageFromItems(items: ChatMessage[]): ContextUsage | null {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const md = normalizeMetadata(items[i]?.metadata)
+    const cu = md?.context_usage as ContextUsage | undefined
+    // Require percent > 0 to match the meter's render guard (InputArea), so a
+    // zero-percent snapshot (e.g. usage-less turn) doesn't shadow an earlier
+    // real one and leave the meter blank.
+    if (cu && typeof cu === "object" && typeof cu.percent === "number" && cu.percent > 0) return cu
+  }
+  return null
+}
+
 export function toPilotMessage(m: ChatMessage): PilotMessage {
   const toolArgs = m.tool_input ? tryParseJson(m.tool_input) : undefined
   const metadata = normalizeMetadata(m.metadata)
@@ -829,6 +848,13 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
         if (cancelled) return
         setMessages(pilotMsgs)
+        // Restore the context meter from persisted history so it shows on open/
+        // refresh — without it the meter stays blank until the next live
+        // agent_end. Only set when a snapshot is found: never blank an existing
+        // value (a cache-hit restore at line ~833, or a live agent_end that
+        // landed while this fetch was in flight).
+        const restoredUsage = latestContextUsageFromItems(items)
+        if (restoredUsage) setContextUsage(restoredUsage)
         setHasMore(items.length >= PAGE_SIZE)
         const hasRunning = hasRunningPersistedMessages(pilotMsgs)
 

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -100,6 +100,32 @@ describe("consumeAgentSse — assistant message flow", () => {
     expect(assistantRow.sessionId).toBe("sid");
   });
 
+  it("merges the agent_end context-usage snapshot onto the last assistant row's metadata", async () => {
+    // Lets the frontend restore the context meter on session reopen/refresh.
+    const cu = { tokens: 24144, contextWindow: 100000, percent: 24.1, inputTokens: 24118, outputTokens: 26 };
+    const events = [
+      { type: "message_start" },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "Hi" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "Hi" }] } },
+      { type: "agent_end", contextUsage: cu },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true });
+    const upd = updateCalls.find((u) => u.metadata?.context_usage);
+    expect(upd).toBeDefined();
+    expect(upd.metadata.context_usage).toEqual(cu);
+    expect(upd.messageId).toBe("msg-1"); // the assistant row's id
+    expect(upd.content).toBe("Hi"); // original content re-sent (handler does content ?? "" → must not wipe)
+  });
+
+  it("does not update on agent_end when no contextUsage is present", async () => {
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "Hi" }] } },
+      { type: "agent_end" },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true });
+    expect(updateCalls.find((u) => u.metadata?.context_usage)).toBeUndefined();
+  });
+
   it("skips assistant persistence when cleaned text is empty (pi-agent diagnostic)", async () => {
     const events = [
       { type: "message_start" },
@@ -346,6 +372,27 @@ describe("consumeAgentSse — routed turn commit gating", () => {
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true });
     expect(appendCalls.filter((r) => r.role === "assistant" && r.content === "hello")).toHaveLength(1);
+  });
+
+  it("folds the context-usage snapshot into the deferred assistant row (agent_end precedes commit)", async () => {
+    // Real ordering: agent_end fires BEFORE model_route_success, and the assistant
+    // persist is deferred to the commit — so the snapshot must ride the append, not
+    // a post-hoc updateMessage (the row doesn't exist yet at agent_end).
+    const cu = { tokens: 24252, contextWindow: 100000, percent: 24.25, inputTokens: 24230, outputTokens: 22 };
+    const events = [
+      { type: "model_route_start" },
+      { type: "message_start" },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }], stopReason: "stop" } },
+      { type: "agent_end", contextUsage: cu },
+      { type: "model_route_success", attempt: 1, candidateKey: "openai/gpt-4", provider: "openai", modelId: "gpt-4", isFallback: false, primaryCandidateKey: "openai/gpt-4" },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true });
+    const row = appendCalls.find((r) => r.role === "assistant" && r.content === "hi");
+    expect(row).toBeDefined();
+    expect(row.metadata.context_usage).toEqual(cu);
+    // No post-hoc patch needed on the routed path.
+    expect(updateCalls.find((u) => u.metadata?.context_usage)).toBeUndefined();
   });
 
   it("discards a failed primary's partial reply and error on rollback, persisting only the fallback's answer", async () => {

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -378,6 +378,21 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   // make a naive UI sum double-count the same interval N times. Tracked
   // and only emitted once.
   let firstAssistantPersisted = false;
+  // Latest persisted assistant message of the turn — so the `agent_end`
+  // context-usage snapshot can be merged onto its metadata. Persisting the
+  // snapshot lets the frontend restore the context meter when a session is
+  // reopened/refreshed (it otherwise only has it from a live agent_end, which a
+  // cold session never replays). Overwritten on each assistant message_end, so
+  // by agent_end these point at the turn's final assistant message.
+  let lastAssistantDbMessageId: string | undefined;
+  let lastAssistantContent: string | undefined;
+  let lastAssistantMetadata: Record<string, unknown> | undefined;
+  // Latest agent_end context-usage snapshot of the turn. agent_end fires BEFORE
+  // model_route_success (the commit point that runs the deferred assistant
+  // persist on routed turns — i.e. every turn), so the assistant row usually
+  // isn't written yet when agent_end arrives. We therefore stash the snapshot
+  // here and let the deferred persistAssistant fold it into the row's metadata.
+  let capturedContextUsage: Record<string, unknown> | undefined;
   let latestModelRouteSwitch: Record<string, unknown> | null = null;
   let currentModelRouteMetadata: Record<string, unknown> | null = null;
 
@@ -401,6 +416,35 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
     }
 
     let dbMessageId: string | undefined;
+
+    // ── Capture context-usage snapshot from agent_end ──────────────────────
+    // The brain computes {tokens, contextWindow, percent, inputTokens, ...} and
+    // attaches it to agent_end (enrichAgentEndEvent in agentbox/http-server.ts).
+    // Persisting it in the last assistant row's metadata lets the frontend
+    // restore the context meter on session reopen/refresh (otherwise it's blank
+    // until the next live turn). Two delivery orders:
+    //   • routed turn (default): agent_end precedes the deferred persist, so the
+    //     row isn't written yet — persistAssistant folds capturedContextUsage in.
+    //   • immediate persist (non-routed): the row already exists, so patch it now.
+    // Best-effort: a persistence failure must never break the SSE stream.
+    if (eventType === "agent_end" && persist) {
+      const contextUsage = (evt as Record<string, unknown>).contextUsage;
+      if (contextUsage && typeof contextUsage === "object") {
+        capturedContextUsage = contextUsage as Record<string, unknown>;
+        if (lastAssistantDbMessageId) {
+          try {
+            await updateMessage({
+              messageId: lastAssistantDbMessageId,
+              sessionId,
+              content: lastAssistantContent ?? "",
+              metadata: { ...(lastAssistantMetadata ?? {}), context_usage: capturedContextUsage },
+            });
+          } catch (err) {
+            console.warn(`[sse-consumer] ${userId}: failed to persist context_usage:`, err);
+          }
+        }
+      }
+    }
 
     // ── Model route audit + UI notices ──────────────
     if (eventType === "model_route_start") {
@@ -763,12 +807,23 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
               ...(currentModelRouteMetadata ? { model_route: currentModelRouteMetadata } : {}),
             };
             const persistAssistant = async () => {
-              await appendMessage({
+              // Fold in the context-usage snapshot if agent_end already arrived
+              // (the routed/default order — agent_end precedes this commit). The
+              // closure reads capturedContextUsage at RUN time, not definition time.
+              const rowMetadata = capturedContextUsage
+                ? { ...assistantRowMetadata, context_usage: capturedContextUsage }
+                : assistantRowMetadata;
+              const id = await appendMessage({
                 sessionId,
                 role: "assistant",
                 content: assistantRowContent,
-                metadata: assistantRowMetadata,
+                metadata: rowMetadata,
               });
+              // Remember the turn's latest assistant row so a later agent_end (the
+              // immediate/non-routed order) can patch the snapshot onto its metadata.
+              lastAssistantDbMessageId = id;
+              lastAssistantContent = assistantRowContent;
+              lastAssistantMetadata = rowMetadata;
               await incrementMessageCount(sessionId);
             };
             // Flip the first-assistant flag NOW (not inside the deferred op):


### PR DESCRIPTION
## What

The chat composer's context-usage meter was populated **only** from a live `agent_end` event, so opening or refreshing a session (or reopening a cold one after idle self-destruct) showed nothing until the next turn. `chat_messages` never persisted token usage and the frontend never restored it from history.

This persists the `agent_end` context-usage snapshot onto the turn's **last assistant message metadata** (reusing the existing `chat.*` RPC + `metadata` field — **no schema change, no new RPC, no sicore Go change**), and restores it on the frontend when a session loads.

## Why

Backend + provider `usage` were verified healthy on siclaw-inner (the meter shows correctly *after* a live turn, `Context 24/100k`); the gap was purely persist/restore. This is **not** a usage or compaction issue — earlier "missing usage / estimate-fallback" theories were disproven and reverted.

## How

- **`src/gateway/sse-consumer.ts`** — capture `contextUsage` at `agent_end`. Ordering matters: every turn is routed, and `agent_end` fires **before** the commit (`model_route_success`) that runs the deferred assistant persist — so the row isn't written yet at `agent_end`. We stash the snapshot (`capturedContextUsage`) and the deferred `persistAssistant` folds it into the row's metadata; the immediate/non-routed path patches via `updateMessage` (re-sending content so the handler's `content ?? ""` doesn't wipe it). Best-effort — a persistence failure never breaks the SSE stream.
- **`portal-web/src/hooks/usePilotChat.ts`** — `latestContextUsageFromItems()` restores the meter from the most recent persisted snapshot on load. Guarded to (a) only set when a snapshot is found (never blank a cached/live value) and (b) require `percent > 0` to match the composer's render condition.

## Tests

- `sse-consumer.test.ts`: snapshot folded into the deferred row (routed order) + patched (immediate order) + no-op without usage. 83 pass.
- `tsc` clean (backend + portal); portal hook tests pass.

## Verified on siclaw-inner (Playwright, real session)

After a turn completes → **full page reload, no new message** → meter renders immediately: `↑24.3k ↓138 24% (Context 24,316/100,000)`. Restored from DB.

## Out of scope

- The SDK usage-gated mid-turn compaction trigger (separate; backend usage is healthy).
- sicore dashboards / Go apiserver.
- Any `chat_sessions` schema change (deliberate — keeps the change deployment-agnostic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)