### PR TITLE
Pass agent model binding to Lark channel prompts

### DIFF
--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -48,6 +48,12 @@ vi.mock("../channel-manager.js", () => ({
     v !== null && typeof v === "object" && (v as { walled?: unknown }).walled === true,
 }));
 
+const resolveAgentModelBindingMock = vi.fn();
+
+vi.mock("../agent-model-binding.js", () => ({
+  resolveAgentModelBinding: (...args: unknown[]) => resolveAgentModelBindingMock(...args),
+}));
+
 const ensureChatSessionMock = vi.fn();
 const appendMessageMock = vi.fn();
 
@@ -181,8 +187,10 @@ beforeEach(() => {
   resolvePersonalBindingMock.mockReset();
   handlePersonalPairingCodeMock.mockReset();
   resetPersonalSessionMock.mockReset();
+  resolveAgentModelBindingMock.mockReset();
   ensureChatSessionMock.mockReset();
   appendMessageMock.mockReset();
+  resolveAgentModelBindingMock.mockResolvedValue(null);
   ensureChatSessionMock.mockResolvedValue(undefined);
   appendMessageMock.mockResolvedValue("msg-db-1");
   resetLarkBindingQueuesForTest();
@@ -630,6 +638,60 @@ describe("handleLarkMessage — routing to AgentBox", () => {
 
     const promptArg = promptMock.mock.calls[0][0];
     expect(promptArg).not.toHaveProperty("userId");
+  });
+
+  it("passes the resolved agent model binding into the AgentBox prompt payload", async () => {
+    const modelConfig = {
+      name: "custom",
+      baseUrl: "https://llm.example/v1",
+      apiKey: "sk-test",
+      api: "openai-completions",
+      authHeader: true,
+      models: [
+        {
+          id: "deepseek-ai/DeepSeek-V4-Pro",
+          name: "DeepSeek V4 Pro",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128000,
+          maxTokens: 8192,
+        },
+      ],
+    };
+    const modelRouting = {
+      enabled: true,
+      strategy: "ordered_fallback",
+      candidates: [{ provider: "fallback", modelId: "backup" }],
+    };
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    resolveAgentModelBindingMock.mockResolvedValue({
+      modelProvider: "sicore-custom-254e68c4",
+      modelId: "deepseek-ai/DeepSeek-V4-Pro",
+      modelConfig,
+      modelRouting,
+      systemPrompt: "  custom prompt  ",
+    });
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleLarkMessage(
+      makeTextEvent("ping"),
+      makeLarkClient(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(resolveAgentModelBindingMock).toHaveBeenCalledWith("a1", expect.anything());
+    expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+      modelProvider: "sicore-custom-254e68c4",
+      modelId: "deepseek-ai/DeepSeek-V4-Pro",
+      modelConfig,
+      modelRouting,
+      systemPromptTemplate: "custom prompt",
+    }));
   });
 
   it("persists channel sessions/messages before prompting and wraps the current request", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -24,6 +24,7 @@ import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
 import { appendMessage, ensureChatSession } from "../chat-repo.js";
 import { buildRedactionConfigForModelConfig, redactText } from "../output-redactor.js";
+import { resolveAgentModelBinding } from "../agent-model-binding.js";
 import {
   openTypingCard,
   updateCardContent,
@@ -630,7 +631,20 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const handle = await agentBoxManager.getOrCreate(agentId);
   const client = new AgentBoxClient(handle.endpoint, 120_000, tlsOptions);
 
-  const promptOpts: PromptOptions = { text: buildChannelTurnPrompt(text), agentId, mode: "channel", sessionId };
+  const modelBinding = frontendClient
+    ? await resolveAgentModelBinding(agentId, frontendClient)
+    : null;
+  const promptOpts: PromptOptions = {
+    text: buildChannelTurnPrompt(text),
+    agentId,
+    mode: "channel",
+    sessionId,
+    modelProvider: modelBinding?.modelProvider,
+    modelId: modelBinding?.modelId,
+    modelConfig: modelBinding?.modelConfig,
+    modelRouting: modelBinding?.modelRouting,
+    systemPromptTemplate: modelBinding?.systemPrompt?.trim() || undefined,
+  };
   let resultText = "";
   let replyImages: RenderedReplyImage[] = [];
   let agentError: Error | null = null;
@@ -642,7 +656,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       // Audit: persist assistant + tool rows so the channel transcript matches
       // web/api/a2a (origin="channel" set on the session above). Tool output on
       // this stream is already sanitized at the agentbox boundary.
-      persist: { agentId },
+      persist: { agentId, modelConfig: modelBinding?.modelConfig },
     });
     resultText = collected.text;
     replyImages = collected.images;


### PR DESCRIPTION
## Summary

- Resolve each Lark channel message's agent model binding before prompting AgentBox.
- Forward `modelProvider`, `modelId`, `modelConfig`, `modelRouting`, and the agent system prompt into the channel prompt payload.
- Reuse the resolved model config for channel audit redaction.
- Add a Lark channel regression test that verifies the model binding reaches `AgentBoxClient.prompt`.

## Root Cause

Web chat already forwards the Sicore-resolved model binding to Runtime, so AgentBox switches to the agent's configured model. The Lark channel path only sent `text`, `agentId`, `mode`, and `sessionId`, so AgentBox fell back to its default model. In the test environment that default model was Kimi with an invalid API key, producing `401 authorization api key not valid` and an empty Feishu reply card.

## Validation

- `npm test -- src/gateway/channels/lark.test.ts`
- `npm run build`
