### PR TITLE
fix(channels,a2a): forward agent model binding to DingTalk + system prompt to A2A

### DIFF
--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -378,6 +378,42 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
     sessionRegistry.forget(promptArg.sessionId);
   });
 
+  it("passes the resolved agent model binding into the AgentBox prompt payload", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-mb", bindingId: "b1" });
+    promptMock.mockResolvedValue({ sessionId: "s-mb" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    const modelConfig = {
+      name: "custom",
+      baseUrl: "https://llm.example/v1",
+      apiKey: "sk-test",
+      api: "openai-completions",
+      authHeader: true,
+      models: [{
+        id: "deepseek-ai/DeepSeek-V4-Pro", name: "DeepSeek V4 Pro", reasoning: true,
+        input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000, maxTokens: 8192,
+      }],
+    };
+    const modelRouting = { enabled: true, strategy: "ordered_fallback", candidates: [{ provider: "fallback", modelId: "backup" }] };
+    // Method-aware mock: config.getModelBinding → full binding; config.getAgent → system prompt.
+    const frontend = { request: vi.fn(async (method: string) => {
+      if (method === "config.getModelBinding") {
+        return { binding: { modelProvider: "sicore-custom-x", modelId: "deepseek-ai/DeepSeek-V4-Pro", modelConfig, modelRouting, systemPrompt: "p" } };
+      }
+      return { system_prompt: "p" };
+    }) };
+
+    await handleDingTalkMessage(makeDownstream("hi"), "ch", makeAgentBoxManager("agent-mb") as any, undefined, frontend as any);
+
+    expect(frontend.request).toHaveBeenCalledWith("config.getModelBinding", { agentId: "agent-mb" });
+    const promptArg = promptMock.mock.calls[0][0] as any;
+    expect(promptArg.modelProvider).toBe("sicore-custom-x");
+    expect(promptArg.modelId).toBe("deepseek-ai/DeepSeek-V4-Pro");
+    expect(promptArg.modelConfig).toEqual(modelConfig);
+    expect(promptArg.modelRouting).toEqual(modelRouting);
+    sessionRegistry.forget(promptArg.sessionId);
+  });
+
   it("does not pass userId into the AgentBox prompt payload", async () => {
     resolveBindingMock.mockResolvedValue({ agentId: "a", bindingId: "b" });
     promptMock.mockResolvedValue({ sessionId: "s" });

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -36,7 +36,7 @@ import type { AgentBoxManager } from "../agentbox/manager.js";
 import { AgentBoxClient, type PromptOptions } from "../agentbox/client.js";
 import type { ChannelHandler } from "../channel-manager.js";
 import { resolveBinding, handlePairingCode, isChannelAccessDenied } from "../channel-manager.js";
-import { resolveAgentSystemPrompt } from "../agent-model-binding.js";
+import { resolveAgentModelBinding, resolveAgentSystemPrompt } from "../agent-model-binding.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
 import { appendMessage, ensureChatSession } from "../chat-repo.js";
@@ -310,6 +310,14 @@ export async function handleDingTalkMessage(
   // at session creation, so an existing 1:1 multi-turn session keeps the prompt
   // it was created with until /new.
   const systemPromptTemplate = await resolveAgentSystemPrompt(agentId, frontendClient);
+  // Forward the agent's bound model so AgentBox uses it instead of its built-in
+  // default (mirrors web/api/a2a/lark — without this a model-bound agent fell
+  // back to AgentBox's default model, e.g. an invalid-key Kimi → 401 / empty
+  // reply). null-tolerant: a default-model agent leaves these undefined and
+  // keeps the default. System prompt stays sourced from resolveAgentSystemPrompt
+  // above, which (unlike the model binding) is populated for default-model
+  // agents too — so this does not regress custom prompts.
+  const modelBinding = frontendClient ? await resolveAgentModelBinding(agentId, frontendClient) : null;
 
   // Audit: persist the session + inbound user message so DingTalk sessions are
   // visible in the audit (they were previously invisible — no chat_messages at
@@ -331,7 +339,17 @@ export async function handleDingTalkMessage(
     }
   }
 
-  const promptOpts: PromptOptions = { text, agentId, mode: "channel", sessionId, systemPromptTemplate };
+  const promptOpts: PromptOptions = {
+    text,
+    agentId,
+    mode: "channel",
+    sessionId,
+    modelProvider: modelBinding?.modelProvider,
+    modelId: modelBinding?.modelId,
+    modelConfig: modelBinding?.modelConfig,
+    modelRouting: modelBinding?.modelRouting,
+    systemPromptTemplate,
+  };
   let resultText = "";
   let replyImages: RenderedReplyImage[] = [];
   let agentError: Error | null = null;
@@ -341,7 +359,7 @@ export async function handleDingTalkMessage(
     // session row exists) AND image artifacts for channel delivery.
     const collected = await collectChannelResponse(client, promptResult.sessionId, "dingtalk", {
       includeImages: true,
-      persist: auditable ? { agentId } : undefined,
+      persist: auditable ? { agentId, modelConfig: modelBinding?.modelConfig } : undefined,
     });
     resultText = collected.text;
     replyImages = collected.images;

--- a/src/portal/a2a-gateway.test.ts
+++ b/src/portal/a2a-gateway.test.ts
@@ -226,6 +226,20 @@ describe("registerA2aRoutes", () => {
     expect(rows[0].session_id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
+  it("forwards the agent's system prompt into chat.send", async () => {
+    const { router, conn } = await makeRouter();
+    await getDb().query("UPDATE agents SET system_prompt = ? WHERE id = ?", ["你是 SRE 专家。", "a1"]);
+    const res = await runRoute(router, fakeReq({
+      url: "/api/v1/a2a/agents/a1/message:send",
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+      body: { message: { role: "ROLE_USER", contextId: "ctx-sp", parts: [{ text: "hi" }] } },
+    }));
+    expect(res._status).toBe(200);
+    const sent = (conn.map.sendCommand as any).mock.calls.find((c: any[]) => c[1] === "chat.send");
+    expect(sent[2].systemPrompt).toBe("你是 SRE 专家。");
+  });
+
   it("maps a non-UUID A2A context to a stable internal Siclaw session", async () => {
     const { router, conn } = await makeRouter();
     const first = await runRoute(router, fakeReq({

--- a/src/portal/a2a-gateway.ts
+++ b/src/portal/a2a-gateway.ts
@@ -754,6 +754,7 @@ async function submitA2aTask(params: {
     modelId: modelBinding.modelId,
     modelConfig: modelBinding.modelConfig,
     modelRouting: modelBinding.modelRouting,
+    systemPrompt: modelBinding.systemPrompt ?? undefined,
     turnStartMs: Date.now(),
   });
 


### PR DESCRIPTION
## What

Follow-up to #364 (Lark). I audited **every** prompt-send surface for the resolved agent binding; two gaps remained on `main`:

| Surface | model fields | systemPrompt | Before |
|---|---|---|---|
| web | ✅ | ✅ | OK |
| api (`/api/v1/run`) | ✅ | ✅ | OK |
| Lark | ✅ | ✅ | OK (#364) |
| **A2A** | ✅ | ❌ | **default system prompt** |
| **DingTalk** | ❌ | (only template) | **default model → 401/empty** |
| background-delivery | n/a (not a prompt path) | — | — |

## Fixes

- **DingTalk** (`dingtalk.ts`): forward the full model binding (`modelProvider/modelId/modelConfig/modelRouting`) via `resolveAgentModelBinding`, and pass `modelConfig` into the audit persist for redaction — same shape as Lark/#364. Without this, a model-bound DingTalk agent fell back to AgentBox's default model (the invalid-key Kimi → `401 / empty reply` symptom #364 fixed for Lark).
  - **Note:** the system prompt stays sourced from `resolveAgentSystemPrompt` (`config.getAgent`), not from the model binding. The binding (`config.getModelBinding`) returns `null` for default-model agents, so taking the prompt from it would *regress* custom prompts on default-model agents. Keeping both calls preserves the prompt for all agents while adding the model.

- **A2A** (`a2a-gateway.ts`): forward `systemPrompt` (it already forwarded the model fields). One line, mirrors web/api.

## Verified unchanged

web / api / Lark already forward the full binding. `background-delivery.ts` is not a prompt path.

## Note on Lark consistency (optional follow-up, not in this PR)

Lark (#364) sources the system prompt from the model binding only, so a **default-model** Lark agent with a custom prompt won't get it (not a regression — Lark never sent a prompt before #364). DingTalk here is deliberately more robust (keeps `resolveAgentSystemPrompt`). Lark could adopt the same for full parity if desired.

## Tests

- DingTalk: asserts the model binding reaches `AgentBoxClient.prompt`.
- A2A: asserts `systemPrompt` reaches `chat.send`.
- `npx tsc --noEmit` clean; dingtalk + a2a-gateway suites pass (66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)