### PR TITLE
feat(lark): accept inbound images; resolve text image URLs at the gateway boundary

### DIFF
--- a/src/core/model-routing.test.ts
+++ b/src/core/model-routing.test.ts
@@ -8,6 +8,7 @@ import {
   createModelRouteState,
   isModelRoutePolicyEnabled,
   markModelRouteUserSelection,
+  modelOptionsSupportImageInput,
   normalizeCandidates,
   normalizeModelRoutePolicy,
   normalizeModelRouteState,
@@ -1384,6 +1385,70 @@ describe("runPromptWithModelRouting", () => {
       lastSuccessAt: 2,
       lastFailureAt: undefined,
     });
+  });
+});
+
+describe("modelOptionsSupportImageInput", () => {
+  const visionModelConfig = { models: [{ id: "gpt-4o", input: ["text", "image"] }] };
+  const textModelConfig = { models: [{ id: "deepseek-chat", input: ["text"] }] };
+
+  it("single model: true when modelConfig declares image input", () => {
+    expect(
+      modelOptionsSupportImageInput({ modelProvider: "openai", modelId: "gpt-4o", modelConfig: visionModelConfig }),
+    ).toBe(true);
+  });
+
+  it("single model: false when modelConfig declares only text", () => {
+    expect(
+      modelOptionsSupportImageInput({ modelProvider: "deepseek", modelId: "deepseek-chat", modelConfig: textModelConfig }),
+    ).toBe(false);
+  });
+
+  it("routed: true when ANY candidate is image-capable", () => {
+    const modelRouting: ModelRoutePolicy = {
+      enabled: true,
+      candidates: [
+        { provider: "deepseek", modelId: "deepseek-chat", modelConfig: textModelConfig },
+        { provider: "openai", modelId: "gpt-4o", modelConfig: visionModelConfig },
+      ],
+    };
+    expect(modelOptionsSupportImageInput({ modelRouting })).toBe(true);
+  });
+
+  it("routed: false when no candidate is image-capable", () => {
+    const modelRouting: ModelRoutePolicy = {
+      enabled: true,
+      candidates: [{ provider: "deepseek", modelId: "deepseek-chat", modelConfig: textModelConfig }],
+    };
+    expect(modelOptionsSupportImageInput({ modelRouting })).toBe(false);
+  });
+
+  it("false when no model info at all", () => {
+    expect(modelOptionsSupportImageInput({})).toBe(false);
+    expect(modelOptionsSupportImageInput({ modelProvider: "openai", modelId: "gpt-4o" })).toBe(false);
+  });
+
+  it("routing candidates take precedence over single-model fields", () => {
+    const modelRouting: ModelRoutePolicy = {
+      enabled: true,
+      candidates: [{ provider: "openai", modelId: "gpt-4o", modelConfig: visionModelConfig }],
+    };
+    expect(
+      modelOptionsSupportImageInput({ modelProvider: "x", modelId: "y", modelConfig: textModelConfig, modelRouting }),
+    ).toBe(true);
+  });
+
+  it("disabled routing: vision candidates ignored, falls back to single model", () => {
+    const modelRouting: ModelRoutePolicy = {
+      enabled: false,
+      candidates: [{ provider: "openai", modelId: "gpt-4o", modelConfig: visionModelConfig }],
+    };
+    // disabled policy won't use its candidates → must not report vision from them
+    expect(modelOptionsSupportImageInput({ modelRouting })).toBe(false);
+    // disabled → judged by the single model's own declared input instead
+    expect(
+      modelOptionsSupportImageInput({ modelRouting, modelProvider: "openai", modelId: "gpt-4o", modelConfig: visionModelConfig }),
+    ).toBe(true);
   });
 });
 

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -394,6 +394,44 @@ export function filterCandidatesForPromptMedia(candidates: ModelRouteCandidate[]
   return candidates.filter((candidate) => candidateSupportsPromptMedia(candidate, media));
 }
 
+/**
+ * Does the model selected for this prompt declare `image` input support? Used by
+ * `AgentBoxClient` to gate text-URL image resolution: only resolve URLs into
+ * vision images when a capable model exists; otherwise leave the URL as plain
+ * text (no fail-closed).
+ *
+ * Enabled routing: image-capable if ANY candidate declares image — in the
+ * fallback-runner path, media filtering routes a turn-with-images only to such a
+ * candidate. NOTE: this is an OPTIMISTIC, gateway-side guess; it cannot see the
+ * session's user-pinned candidate (held in the AgentBox modelRouteState), so a
+ * pinned text-primary + vision-fallback turn can still reach the single-model
+ * preflight and fail closed (documented residual edge — see DESIGN risk table).
+ * Disabled routing: candidates won't be used → judge by the single model + its
+ * modelConfig instead.
+ * No model info: conservatively false (do not resolve URLs).
+ */
+export function modelOptionsSupportImageInput(opts: {
+  modelProvider?: string;
+  modelId?: string;
+  modelConfig?: unknown;
+  modelRouting?: ModelRoutePolicy;
+}): boolean {
+  const candidates = isModelRoutePolicyEnabled(opts.modelRouting)
+    ? normalizeCandidates(opts.modelRouting?.candidates)
+    : [];
+  if (candidates.length > 0) {
+    return candidates.some((candidate) => candidateInputSet(candidate).has("image"));
+  }
+  if (opts.modelProvider && opts.modelId && isRecord(opts.modelConfig)) {
+    return candidateInputSet({
+      provider: opts.modelProvider,
+      modelId: opts.modelId,
+      modelConfig: opts.modelConfig,
+    }).has("image");
+  }
+  return false;
+}
+
 export function unsupportedPromptMediaMessage(media?: PromptMedia): string {
   const required = requiredInputsForPromptMedia(media);
   if (required.length === 0) return "No model route candidate is available for this prompt.";

--- a/src/gateway/agentbox/client.test.ts
+++ b/src/gateway/agentbox/client.test.ts
@@ -466,4 +466,17 @@ describe("AgentBoxClient — prompt image URL resolution (vision-gated)", () => 
     const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
     expect(JSON.parse(req.body).images).toHaveLength(1);
   });
+
+  it("redacts signed-URL credentials from the forwarded text (fetch still used the full URL)", async () => {
+    await client.prompt({
+      text: "see https://oss.siflow.cn/a.png?Signature=secret&AccessKeyId=key",
+      modelProvider: "openai", modelId: "gpt-4o", modelConfig: mkModelConfig(["text", "image"], "gpt-4o"),
+    });
+    const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
+    const body = JSON.parse(req.body);
+    expect(body.text).toContain("oss.siflow.cn/a.png");
+    expect(body.text).not.toContain("Signature"); // creds stripped from model/history text
+    expect(body.text).not.toContain("secret");
+    expect(body.images).toHaveLength(1); // ...but the image was still resolved (full URL fetched)
+  });
 });

--- a/src/gateway/agentbox/client.test.ts
+++ b/src/gateway/agentbox/client.test.ts
@@ -386,3 +386,84 @@ describe("AgentBoxClient — streamEvents (SSE)", () => {
     } finally { await srv.close(); }
   });
 });
+
+describe("AgentBoxClient — prompt image URL resolution (vision-gated)", () => {
+  const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
+  function imageResponse(buf: Buffer) {
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "image/png" }),
+      arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+    } as unknown as Response;
+  }
+  function mkModelConfig(input: string[], id: string) {
+    return {
+      name: "prov", baseUrl: "http://x", apiKey: "k", api: "openai", authHeader: false,
+      models: [{ id, name: id, reasoning: false, input, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000, maxTokens: 100 }],
+    };
+  }
+
+  let srv: Srv;
+  let client: AgentBoxClient;
+  let realFetch: typeof globalThis.fetch;
+
+  beforeAll(async () => {
+    srv = await startServer((req, res) => {
+      if (req.method === "POST" && req.url === "/api/prompt") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, sessionId: "s1" }));
+      } else { res.writeHead(404); res.end(); }
+    });
+    client = new AgentBoxClient(`http://127.0.0.1:${srv.port}`);
+  });
+  afterAll(async () => { await srv.close(); });
+
+  beforeEach(() => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    realFetch = globalThis.fetch.bind(globalThis);
+    // Host-split: image URLs are stubbed; the agentbox POST is forwarded to the real local server.
+    vi.stubGlobal("fetch", vi.fn(async (url: any, init: any) => {
+      if (String(url).includes("oss.siflow.cn")) return imageResponse(PNG);
+      return realFetch(url, init);
+    }));
+  });
+  afterEach(() => {
+    delete process.env.SICLAW_IMAGE_URL_ALLOWLIST;
+    vi.unstubAllGlobals();
+  });
+
+  it("vision model: resolves an allowlisted URL into images; URL stays in text", async () => {
+    await client.prompt({
+      text: "see https://oss.siflow.cn/a.png",
+      modelProvider: "openai", modelId: "gpt-4o", modelConfig: mkModelConfig(["text", "image"], "gpt-4o"),
+    });
+    const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
+    const body = JSON.parse(req.body);
+    expect(body.images).toEqual([{ mimeType: "image/png", data: PNG.toString("base64") }]);
+    expect(body.text).toContain("oss.siflow.cn/a.png"); // original URL left in text
+  });
+
+  it("non-vision model: does NOT resolve; no images, URL stays as plain text", async () => {
+    await client.prompt({
+      text: "see https://oss.siflow.cn/a.png",
+      modelProvider: "deepseek", modelId: "deepseek-chat", modelConfig: mkModelConfig(["text"], "deepseek-chat"),
+    });
+    const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
+    const body = JSON.parse(req.body);
+    expect(body.images).toBeUndefined();
+    expect(body.text).toContain("oss.siflow.cn/a.png");
+  });
+
+  it("vision routing candidate (no single-model fields): still resolves", async () => {
+    await client.prompt({
+      text: "see https://oss.siflow.cn/a.png",
+      modelRouting: {
+        enabled: true,
+        candidates: [{ provider: "openai", modelId: "gpt-4o", modelConfig: mkModelConfig(["text", "image"], "gpt-4o") }],
+      },
+    });
+    const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
+    expect(JSON.parse(req.body).images).toHaveLength(1);
+  });
+});

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -8,7 +8,7 @@
 import https from "node:https";
 import { GATEWAY_SYNC_DESCRIPTORS, type GatewaySyncType } from "../../shared/gateway-sync.js";
 import { modelOptionsSupportImageInput, type ModelRoutePolicy } from "../../core/model-routing.js";
-import { enrichImagesFromText } from "./image-url-ingest.js";
+import { enrichImagesFromText, redactImageUrlsInText } from "./image-url-ingest.js";
 
 export interface AgentBoxTlsOptions {
   cert: string;
@@ -146,11 +146,21 @@ export class AgentBoxClient {
    * process and never reach here, so this never scans system text. The fetch +
    * SSRF allowlist stay in the Gateway process (the AgentBox pod is
    * network-isolated and must not fetch arbitrary user URLs).
+   *
+   * The text forwarded to AgentBox (model context + session history) has any
+   * signed-URL credentials stripped — the fetch above already used the full URL,
+   * so resolution is unaffected, but `Signature`/`AccessKeyId` don't get
+   * persisted/sent in plaintext.
    */
   async #withResolvedImageUrls(opts: PromptOptions): Promise<PromptOptions> {
-    if (!modelOptionsSupportImageInput(opts)) return opts;
-    const images = await enrichImagesFromText(opts.text, opts.images ?? []);
-    return images.length ? { ...opts, images } : opts;
+    const images = modelOptionsSupportImageInput(opts)
+      ? await enrichImagesFromText(opts.text, opts.images ?? [])
+      : opts.images;
+    const text = redactImageUrlsInText(opts.text);
+    if (text === opts.text && images === opts.images) return opts;
+    const next: PromptOptions = { ...opts, text };
+    if (images && images.length) next.images = images;
+    return next;
   }
 
   /**

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -7,7 +7,8 @@
 
 import https from "node:https";
 import { GATEWAY_SYNC_DESCRIPTORS, type GatewaySyncType } from "../../shared/gateway-sync.js";
-import type { ModelRoutePolicy } from "../../core/model-routing.js";
+import { modelOptionsSupportImageInput, type ModelRoutePolicy } from "../../core/model-routing.js";
+import { enrichImagesFromText } from "./image-url-ingest.js";
 
 export interface AgentBoxTlsOptions {
   cert: string;
@@ -133,14 +134,34 @@ export class AgentBoxClient {
   }
 
   /**
+   * Resolve image URLs in the prompt text into vision `images`, but ONLY when the
+   * prompt's model/route can take image input (see DESIGN decision 1). Non-vision:
+   * the URL is left as plain text — the model replies it can't open it; no
+   * fail-closed turn.
+   *
+   * This is the SINGLE backend place text-URL images are resolved, covering all
+   * Gateway front-ends (Feishu / Web chat / a2a / cron). Only user→agent prompts
+   * flow through THIS client; system/synthetic prompts run inside the AgentBox
+   * process and never reach here, so this never scans system text. The fetch +
+   * SSRF allowlist stay in the Gateway process (the AgentBox pod is
+   * network-isolated and must not fetch arbitrary user URLs).
+   */
+  async #withResolvedImageUrls(opts: PromptOptions): Promise<PromptOptions> {
+    if (!modelOptionsSupportImageInput(opts)) return opts;
+    const images = await enrichImagesFromText(opts.text, opts.images ?? []);
+    return images.length ? { ...opts, images } : opts;
+  }
+
+  /**
    * Send a prompt
    */
   async prompt(opts: PromptOptions): Promise<PromptResponse> {
-    console.log(`[agentbox-client] prompt sessionId=${opts.sessionId ?? "new"}`);
+    const sendOpts = await this.#withResolvedImageUrls(opts);
+    console.log(`[agentbox-client] prompt sessionId=${sendOpts.sessionId ?? "new"}`);
     const resp = await this.fetch("/api/prompt", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(opts),
+      body: JSON.stringify(sendOpts),
     });
     const result: PromptResponse = await resp.json();
     console.log(`[agentbox-client] prompt → ok=${result.ok} sessionId=${result.sessionId}`);

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -139,8 +139,9 @@ export class AgentBoxClient {
    * the URL is left as plain text — the model replies it can't open it; no
    * fail-closed turn.
    *
-   * This is the SINGLE backend place text-URL images are resolved, covering all
-   * Gateway front-ends (Feishu / Web chat / a2a / cron). Only user→agent prompts
+   * This is the SINGLE backend place text-URL images are resolved, covering ALL
+   * front-ends that reach AgentBox via this client — Feishu, DingTalk, Web chat,
+   * a2a, and cron (every `client.prompt` caller). Only user→agent prompts
    * flow through THIS client; system/synthetic prompts run inside the AgentBox
    * process and never reach here, so this never scans system text. The fetch +
    * SSRF allowlist stay in the Gateway process (the AgentBox pod is

--- a/src/gateway/agentbox/image-url-ingest.test.ts
+++ b/src/gateway/agentbox/image-url-ingest.test.ts
@@ -4,6 +4,7 @@ import {
   assertAllowedImageUrl,
   enrichImagesFromText,
   extractImageUrls,
+  redactImageUrlsInText,
   sniffImageMime,
   type InboundImage,
 } from "./image-url-ingest.js";
@@ -225,5 +226,22 @@ describe("enrichImagesFromText", () => {
     const out = await enrichImagesFromText("https://oss.siflow.cn/a.png https://oss.siflow.cn/b.png https://oss.siflow.cn/c.png", existing);
     expect(out).toHaveLength(4);
     expect(fetchMock).toHaveBeenCalledTimes(2); // 4 - 2 existing = 2 slots → only 2 fetches
+  });
+});
+
+describe("redactImageUrlsInText", () => {
+  it("strips signed-URL query (Signature/AccessKeyId) but keeps host+path", () => {
+    expect(
+      redactImageUrlsInText("see https://oss.siflow.cn/a.jpg?Signature=secret&AccessKeyId=key here"),
+    ).toBe("see https://oss.siflow.cn/a.jpg here");
+  });
+  it("redacts multiple image URLs and leaves other text intact", () => {
+    expect(
+      redactImageUrlsInText("a https://h.cn/x.png?s=1 b https://h.cn/y.webp?t=2"),
+    ).toBe("a https://h.cn/x.png b https://h.cn/y.webp");
+  });
+  it("leaves non-image / extensionless URLs and empty text untouched", () => {
+    expect(redactImageUrlsInText("hello https://h.cn/page")).toBe("hello https://h.cn/page");
+    expect(redactImageUrlsInText("")).toBe("");
   });
 });

--- a/src/gateway/agentbox/image-url-ingest.test.ts
+++ b/src/gateway/agentbox/image-url-ingest.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Readable } from "node:stream";
+import {
+  assertAllowedImageUrl,
+  enrichImagesFromText,
+  extractImageUrls,
+  sniffImageMime,
+  type InboundImage,
+} from "./image-url-ingest.js";
+
+// ── Fixtures: minimal valid image byte signatures ──────────────────────────
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const WEBP = Buffer.concat([
+  Buffer.from("RIFF", "ascii"),
+  Buffer.from([0x00, 0x00, 0x00, 0x00]),
+  Buffer.from("WEBP", "ascii"),
+]);
+const NOT_IMAGE = Buffer.from("hello world this is text", "utf8");
+
+function imageResponse(buf: Buffer, contentType = "image/png", extraHeaders: Record<string, string> = {}) {
+  const headers = new Headers({ "content-type": contentType, ...extraHeaders });
+  return {
+    ok: true,
+    status: 200,
+    headers,
+    arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+  } as unknown as Response;
+}
+
+const ENV_KEYS = [
+  "SICLAW_IMAGE_URL_ALLOWLIST",
+  "SICLAW_IMAGE_URL_ALLOW_HTTP",
+  "SICLAW_IMAGE_URL_FETCH_TIMEOUT_MS",
+];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ── sniffImageMime ──────────────────────────────────────────────────────────
+describe("sniffImageMime", () => {
+  it("recognises png / jpeg / webp by magic bytes", () => {
+    expect(sniffImageMime(PNG)).toBe("image/png");
+    expect(sniffImageMime(JPEG)).toBe("image/jpeg");
+    expect(sniffImageMime(WEBP)).toBe("image/webp");
+  });
+  it("returns null for non-image bytes", () => {
+    expect(sniffImageMime(NOT_IMAGE)).toBeNull();
+    expect(sniffImageMime(Buffer.from([0x01, 0x02]))).toBeNull();
+  });
+});
+
+// ── extractImageUrls ────────────────────────────────────────────────────────
+describe("extractImageUrls", () => {
+  it("extracts image URLs incl. OSS signed (ext before query)", () => {
+    const text = "see https://oss.siflow.cn/a/b.jpg?OSSAccessKeyId=x&Signature=y here";
+    expect(extractImageUrls(text)).toEqual(["https://oss.siflow.cn/a/b.jpg?OSSAccessKeyId=x&Signature=y"]);
+  });
+  it("dedups repeats and matches png/jpeg/webp", () => {
+    const url = "https://oss.siflow.cn/x.png";
+    expect(extractImageUrls(`${url} ${url}`)).toEqual([url]);
+    expect(extractImageUrls("https://h.cn/a.webp https://h.cn/b.jpeg")).toHaveLength(2);
+  });
+  it("ignores non-image and extensionless URLs", () => {
+    expect(extractImageUrls("https://h.cn/page.html https://h.cn/raw")).toEqual([]);
+    expect(extractImageUrls("")).toEqual([]);
+  });
+});
+
+// ── assertAllowedImageUrl (SSRF guard) ──────────────────────────────────────
+describe("assertAllowedImageUrl", () => {
+  it("is fail-closed when no allowlist configured", () => {
+    expect(() => assertAllowedImageUrl("https://oss.siflow.cn/a.jpg")).toThrow(/fail-closed/);
+  });
+  it("allows exact and wildcard allowlist hosts", () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "oss.siflow.cn, *.example.com";
+    expect(() => assertAllowedImageUrl("https://oss.siflow.cn/a.jpg")).not.toThrow();
+    expect(() => assertAllowedImageUrl("https://img.example.com/a.jpg")).not.toThrow();
+  });
+  it("rejects hosts outside the allowlist", () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    expect(() => assertAllowedImageUrl("https://evil.com/a.jpg")).toThrow(/not in allowlist/);
+    // apex is not a subdomain of *.siflow.cn
+    expect(() => assertAllowedImageUrl("https://siflow.cn/a.jpg")).toThrow(/not in allowlist/);
+  });
+  it("rejects http by default, allows it only when opted in", () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "oss.siflow.cn";
+    expect(() => assertAllowedImageUrl("http://oss.siflow.cn/a.jpg")).toThrow(/protocol/);
+    process.env.SICLAW_IMAGE_URL_ALLOW_HTTP = "true";
+    expect(() => assertAllowedImageUrl("http://oss.siflow.cn/a.jpg")).not.toThrow();
+  });
+  it("rejects private/metadata hosts (not on allowlist)", () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    expect(() => assertAllowedImageUrl("https://169.254.169.254/latest/meta-data")).toThrow(/not in allowlist/);
+    expect(() => assertAllowedImageUrl("https://127.0.0.1/a.jpg")).toThrow(/not in allowlist/);
+  });
+});
+
+// ── enrichImagesFromText (text image URLs) ─────────────────────────────────
+describe("enrichImagesFromText", () => {
+  it("returns existing untouched when text has no image URL", async () => {
+    const existing: InboundImage[] = [{ mimeType: "image/png", data: "AAAA" }];
+    const out = await enrichImagesFromText("plain text, no urls", existing);
+    expect(out).toEqual(existing);
+    expect(out).not.toBe(existing); // new array
+  });
+
+  it("fetches an allowlisted url image", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    vi.stubGlobal("fetch", vi.fn(async () => imageResponse(PNG, "image/png")));
+    const out = await enrichImagesFromText("look https://oss.siflow.cn/a.png", []);
+    expect(out).toEqual([{ mimeType: "image/png", data: PNG.toString("base64") }]);
+  });
+
+  it("skips a url rejected by the SSRF guard (no allowlist)", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    expect(out).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled(); // guard throws before fetch
+  });
+
+  it("skips a non-image content-type", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    vi.stubGlobal("fetch", vi.fn(async () => imageResponse(NOT_IMAGE, "text/html")));
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    expect(out).toEqual([]);
+  });
+
+  it("skips an oversize image (declared content-length)", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => imageResponse(PNG, "image/png", { "content-length": String(50 * 1024 * 1024) })),
+    );
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    expect(out).toEqual([]);
+  });
+
+  it("skips an oversize url image even with no/lying content-length (streamed)", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    const huge = Buffer.alloc(7 * 1024 * 1024, 0x89); // > 6MiB raw cap
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "image/png" }), // no content-length
+        body: Readable.from([huge]),
+      }) as unknown as Response),
+    );
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    expect(out).toEqual([]);
+  });
+
+  it("re-validates the allowlist on redirect (rejects off-allowlist hop)", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    const fetchMock = vi.fn(async () => ({
+      status: 302,
+      ok: false,
+      headers: new Headers({ location: "https://evil.com/a.png" }),
+    }) as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    expect(out).toEqual([]); // off-allowlist redirect target rejected on next hop
+  });
+
+  it("appends url images AFTER existing, sharing the 4-image budget", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    vi.stubGlobal("fetch", vi.fn(async () => imageResponse(JPEG, "image/jpeg")));
+    const existing: InboundImage[] = [{ mimeType: "image/png", data: PNG.toString("base64") }];
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.jpeg", existing);
+    expect(out.map((i) => i.mimeType)).toEqual(["image/png", "image/jpeg"]);
+  });
+
+  it("does not exceed 4 images when existing already fills the budget", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    const fetchMock = vi.fn(async () => imageResponse(JPEG, "image/jpeg"));
+    vi.stubGlobal("fetch", fetchMock);
+    const existing: InboundImage[] = Array.from({ length: 4 }, () => ({ mimeType: "image/png", data: "x" }));
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.jpeg", existing);
+    expect(out).toHaveLength(4);
+    expect(fetchMock).not.toHaveBeenCalled(); // budget full → never fetches
+  });
+});

--- a/src/gateway/agentbox/image-url-ingest.test.ts
+++ b/src/gateway/agentbox/image-url-ingest.test.ts
@@ -206,4 +206,24 @@ describe("enrichImagesFromText", () => {
     // bounded by the ~100ms total budget, NOT 2×(per-hop 5s) run sequentially
     expect(Date.now() - start).toBeLessThan(2000);
   });
+
+  it("bounds the parallel fan-out to the media budget (does not fetch every URL)", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    const fetchMock = vi.fn(async () => imageResponse(PNG));
+    vi.stubGlobal("fetch", fetchMock);
+    const manyUrls = Array.from({ length: 50 }, (_, i) => `https://oss.siflow.cn/img${i}.png`).join(" ");
+    const out = await enrichImagesFromText(manyUrls, []);
+    expect(out).toHaveLength(4); // capped at MAX_INBOUND_IMAGES
+    expect(fetchMock).toHaveBeenCalledTimes(4); // only 4 fetches fired, not 50 — bounded BEFORE fan-out
+  });
+
+  it("bounds the fan-out by the remaining budget when existing images are present", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    const fetchMock = vi.fn(async () => imageResponse(PNG));
+    vi.stubGlobal("fetch", fetchMock);
+    const existing: InboundImage[] = [{ mimeType: "image/png", data: "x" }, { mimeType: "image/png", data: "y" }];
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png https://oss.siflow.cn/b.png https://oss.siflow.cn/c.png", existing);
+    expect(out).toHaveLength(4);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 4 - 2 existing = 2 slots → only 2 fetches
+  });
 });

--- a/src/gateway/agentbox/image-url-ingest.test.ts
+++ b/src/gateway/agentbox/image-url-ingest.test.ts
@@ -32,6 +32,7 @@ const ENV_KEYS = [
   "SICLAW_IMAGE_URL_ALLOWLIST",
   "SICLAW_IMAGE_URL_ALLOW_HTTP",
   "SICLAW_IMAGE_URL_FETCH_TIMEOUT_MS",
+  "SICLAW_IMAGE_URL_TOTAL_TIMEOUT_MS",
 ];
 
 beforeEach(() => {
@@ -188,5 +189,21 @@ describe("enrichImagesFromText", () => {
     const out = await enrichImagesFromText("https://oss.siflow.cn/a.jpeg", existing);
     expect(out).toHaveLength(4);
     expect(fetchMock).not.toHaveBeenCalled(); // budget full → never fetches
+  });
+
+  it("bounds the whole step by a total timeout and fetches in parallel (hanging host doesn't stall)", async () => {
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_TOTAL_TIMEOUT_MS = "100";
+    // fetch that honours the abort signal but otherwise never resolves
+    const fetchMock = vi.fn((_url: any, init: any) => new Promise((_res, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const start = Date.now();
+    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png https://oss.siflow.cn/b.png", []);
+    expect(out).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // both fired in parallel, not gated one-by-one
+    // bounded by the ~100ms total budget, NOT 2×(per-hop 5s) run sequentially
+    expect(Date.now() - start).toBeLessThan(2000);
   });
 });

--- a/src/gateway/agentbox/image-url-ingest.ts
+++ b/src/gateway/agentbox/image-url-ingest.ts
@@ -1,0 +1,247 @@
+import type { Readable } from "node:stream";
+
+/**
+ * Prompt-text image URL ingestion — the SINGLE backend place that turns image
+ * URLs found in a prompt's text into the `{ mimeType, data }` shape that
+ * `PromptOptions.images` (AgentBox vision input) expects.
+ *
+ * Why it lives here, in the AgentBox client layer (not in each channel, not in
+ * the AgentBox pod):
+ *   - Every Gateway→AgentBox prompt funnels through `AgentBoxClient.prompt()`
+ *     (Feishu directly; Portal Web chat / a2a / cron via the gateway `chat.send`
+ *     RPC), so enriching here covers all front-ends with one implementation.
+ *   - The outbound fetch + SSRF allowlist belong in the Gateway process, which
+ *     already has an egress path. The AgentBox pod is network-isolated (only
+ *     dials the Gateway over mTLS) — fetching arbitrary user URLs from inside it
+ *     would breach that isolation and hand SSRF reach into the cluster.
+ *
+ * Native Lark images (the receive-side resource download) are channel-specific
+ * and stay in `channels/inbound-image.ts`; they share the size/sniff helpers
+ * below but cannot be generalised across front-ends.
+ *
+ * Whether to run this at all is a VISION decision made by the caller
+ * (`AgentBoxClient`): only when the prompt's model/route can take image input do
+ * we resolve URLs; otherwise the URL is left as plain text for the model to see.
+ */
+
+/** Same shape as AgentBox `PromptOptions.images[]` (base64, no `data:` prefix). */
+export interface InboundImage {
+  mimeType: string;
+  data: string;
+}
+
+// AgentBox contract (src/agentbox/http-server.ts): MAX_PROMPT_MEDIA_ITEMS = 4
+// (images + files share the budget), single item base64 ≤ 8MB, mime ∈
+// {png,jpeg,webp}. Mirror the caps here to fail fast before hitting AgentBox.
+export const MAX_INBOUND_IMAGES = 4;
+export const MAX_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
+// 6MiB raw → ≤8MiB base64, so the AgentBox base64 cap can never be exceeded.
+export const MAX_IMAGE_BYTES = 6 * 1024 * 1024;
+const MAX_REDIRECTS = 3;
+const DEFAULT_FETCH_TIMEOUT_MS = 5000;
+
+// Extension-anchored: an OSS signed URL keeps its `.jpg` before the `?query`.
+// Extensionless URLs are intentionally out of scope for v1 (no HEAD probe).
+const IMAGE_URL_RE = /https?:\/\/[^\s<>"']+?\.(?:jpe?g|png|webp)(?:\?[^\s<>"']*)?/gi;
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Strip query for logging — a signed image URL may carry creds (Signature, AccessKeyId). */
+function safeUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return "(invalid url)";
+  }
+}
+
+function fetchTimeoutMs(): number {
+  const raw = process.env.SICLAW_IMAGE_URL_FETCH_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_FETCH_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_FETCH_TIMEOUT_MS;
+}
+
+/**
+ * Magic-byte sniff. The Content-Type from Lark/OSS is unreliable
+ * (`application/octet-stream` is common), and AgentBox only accepts a strict
+ * enum, so we derive the mime from the bytes and reject anything else.
+ */
+export function sniffImageMime(buf: Buffer): string | null {
+  if (buf.length >= 8 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) {
+    return "image/png";
+  }
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    buf.length >= 12 &&
+    buf.toString("ascii", 0, 4) === "RIFF" &&
+    buf.toString("ascii", 8, 12) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+function imageUrlAllowlist(): string[] {
+  const raw = process.env.SICLAW_IMAGE_URL_ALLOWLIST?.trim();
+  if (!raw) return [];
+  return raw.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+}
+
+function hostMatchesAllowlist(host: string, allowlist: string[]): boolean {
+  return allowlist.some((entry) => {
+    if (entry.startsWith("*.")) {
+      // "*.siflow.cn" → any subdomain (mirrors dingtalk.ts isAllowedWebhookHost).
+      return host.endsWith(entry.slice(1));
+    }
+    return host === entry;
+  });
+}
+
+/**
+ * SSRF guard for prompt-text image URLs. Aligns with `dingtalk.ts` (host
+ * allowlist, no IP/CIDR logic): under undici's `fetch` the resolved IP is
+ * neither exposed nor pinnable, so a DNS→IP netmask check is TOCTOU security
+ * theatre. The allowlist is fail-closed — with no `SICLAW_IMAGE_URL_ALLOWLIST`
+ * configured, every URL is rejected (text-URL ingestion disabled; native Lark
+ * images unaffected). Throws on rejection.
+ */
+export function assertAllowedImageUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`invalid url: ${url}`);
+  }
+  const allowHttp = process.env.SICLAW_IMAGE_URL_ALLOW_HTTP === "true";
+  const protoOk = parsed.protocol === "https:" || (allowHttp && parsed.protocol === "http:");
+  if (!protoOk) throw new Error(`protocol not allowed: ${parsed.protocol}`);
+
+  const allowlist = imageUrlAllowlist();
+  if (allowlist.length === 0) {
+    throw new Error("image URL allowlist not configured (fail-closed)");
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!hostMatchesAllowlist(host, allowlist)) {
+    throw new Error(`host not in allowlist: ${host}`);
+  }
+}
+
+/** Extract dedup'd image URLs from prompt text. Exported for tests. */
+export function extractImageUrls(text: string): string[] {
+  if (!text) return [];
+  const matches = text.match(IMAGE_URL_RE) ?? [];
+  return [...new Set(matches)];
+}
+
+/** Aggregate a readable stream into a Buffer, aborting past `maxBytes`. */
+export async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += b.length;
+    if (total > maxBytes) {
+      stream.destroy();
+      throw new Error(`image exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(b);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function readLimitedBody(res: Response, maxBytes: number): Promise<Buffer> {
+  const declared = Number(res.headers.get("content-length") ?? "");
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(`image exceeds ${maxBytes} bytes (declared ${declared})`);
+  }
+  // Stream incrementally and abort on overflow — a missing/lying content-length
+  // must not let an unbounded body buffer into memory (mirrors streamToBuffer).
+  if (!res.body) {
+    const ab = await res.arrayBuffer();
+    if (ab.byteLength > maxBytes) throw new Error(`image exceeds ${maxBytes} bytes (actual ${ab.byteLength})`);
+    return Buffer.from(ab);
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let exceeded = false;
+  for await (const chunk of res.body as unknown as AsyncIterable<Uint8Array>) {
+    const b = Buffer.from(chunk);
+    total += b.length;
+    if (total > maxBytes) {
+      exceeded = true;
+      break; // breaking the async-iterator cancels the underlying stream
+    }
+    chunks.push(b);
+  }
+  if (exceeded) throw new Error(`image exceeds ${maxBytes} bytes`);
+  return Buffer.concat(chunks);
+}
+
+/** Fetch an image URL behind the SSRF guard, following redirects manually. */
+export async function fetchUrlImage(url: string): Promise<InboundImage> {
+  const timeoutMs = fetchTimeoutMs();
+  let current = url;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    assertAllowedImageUrl(current); // re-validate every hop (redirect can't escape the allowlist)
+    const res = await fetch(current, {
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get("location");
+      if (!loc) throw new Error(`redirect without location: ${safeUrl(current)}`);
+      current = new URL(loc, current).toString();
+      continue;
+    }
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${safeUrl(current)}`);
+    const contentType = (res.headers.get("content-type") ?? "").toLowerCase();
+    if (!contentType.startsWith("image/")) {
+      throw new Error(`non-image content-type: ${contentType || "(none)"}`);
+    }
+    const buf = await readLimitedBody(res, MAX_IMAGE_BYTES);
+    const mime = sniffImageMime(buf);
+    if (!mime) throw new Error(`unrecognized image bytes for ${safeUrl(current)}`);
+    return { mimeType: mime, data: buf.toString("base64") };
+  }
+  throw new Error(`too many redirects: ${safeUrl(url)}`);
+}
+
+/**
+ * Append images parsed from prompt-text URLs to any pre-existing images (e.g.
+ * native Lark images a channel already downloaded). The combined total is
+ * capped at the AgentBox media budget; a single URL failure (SSRF rejection,
+ * timeout, oversize, non-image bytes) is skipped with a warning and never
+ * aborts the turn. Returns the merged list (a new array; `existing` untouched).
+ *
+ * The caller decides WHETHER to call this (vision-capability gate); this only
+ * decides WHICH URLs resolve.
+ */
+export async function enrichImagesFromText(
+  text: string,
+  existing: InboundImage[] = [],
+): Promise<InboundImage[]> {
+  const out: InboundImage[] = [...existing];
+  const urls = extractImageUrls(text);
+  if (urls.length === 0) return out;
+
+  for (const url of urls) {
+    if (out.length >= MAX_INBOUND_IMAGES) break;
+    try {
+      const img = await fetchUrlImage(url);
+      if (img.data.length > MAX_IMAGE_BASE64_CHARS) {
+        console.warn(`[image-url-ingest] skip oversize image (url=${safeUrl(url)}): ${img.data.length} base64 chars`);
+        continue;
+      }
+      out.push(img);
+    } catch (err) {
+      console.warn(`[image-url-ingest] url image failed url=${safeUrl(url)}: ${errMsg(err)}`);
+    }
+  }
+  return out;
+}

--- a/src/gateway/agentbox/image-url-ingest.ts
+++ b/src/gateway/agentbox/image-url-ingest.ts
@@ -150,6 +150,17 @@ export function extractImageUrls(text: string): string[] {
   return [...new Set(matches)];
 }
 
+/**
+ * Strip the query (signed-URL creds like `Signature` / `AccessKeyId`) from any
+ * image URL in the text, keeping host+path. Used before the text is persisted or
+ * sent to the model — the fetch itself uses the full URL, so this never affects
+ * resolution. Mirrors `safeUrl()` on the logging path.
+ */
+export function redactImageUrlsInText(text: string): string {
+  if (!text) return text;
+  return text.replace(IMAGE_URL_RE, (m) => safeUrl(m));
+}
+
 /** Aggregate a readable stream into a Buffer, aborting past `maxBytes`. */
 export async function streamToBuffer(stream: Readable, maxBytes: number): Promise<Buffer> {
   const chunks: Buffer[] = [];

--- a/src/gateway/agentbox/image-url-ingest.ts
+++ b/src/gateway/agentbox/image-url-ingest.ts
@@ -244,8 +244,13 @@ export async function enrichImagesFromText(
   existing: InboundImage[] = [],
 ): Promise<InboundImage[]> {
   const out: InboundImage[] = [...existing];
-  if (out.length >= MAX_INBOUND_IMAGES) return out;
-  const urls = extractImageUrls(text);
+  const budget = MAX_INBOUND_IMAGES - out.length;
+  if (budget <= 0) return out;
+  // Bound the fan-out BEFORE firing requests: at most `budget` concurrent fetches,
+  // not one per extracted URL. extractImageUrls dedups but does not cap count, so
+  // a message with many URLs would otherwise open N outbound connections at once
+  // (transient memory / DoS / SSRF amplification).
+  const urls = extractImageUrls(text).slice(0, budget);
   if (urls.length === 0) return out;
 
   // One deadline for the whole step (a slow allowlisted host must not stall the
@@ -262,9 +267,6 @@ export async function enrichImagesFromText(
       }
     }),
   );
-  for (const img of settled) {
-    if (out.length >= MAX_INBOUND_IMAGES) break;
-    if (img) out.push(img);
-  }
+  for (const img of settled) if (img) out.push(img);
   return out;
 }

--- a/src/gateway/agentbox/image-url-ingest.ts
+++ b/src/gateway/agentbox/image-url-ingest.ts
@@ -34,11 +34,15 @@ export interface InboundImage {
 // (images + files share the budget), single item base64 ≤ 8MB, mime ∈
 // {png,jpeg,webp}. Mirror the caps here to fail fast before hitting AgentBox.
 export const MAX_INBOUND_IMAGES = 4;
-export const MAX_IMAGE_BASE64_CHARS = 8 * 1024 * 1024;
-// 6MiB raw → ≤8MiB base64, so the AgentBox base64 cap can never be exceeded.
+// 6MiB raw → ≤8MiB base64, comfortably under AgentBox's 8MiB base64 item cap
+// (so no separate base64-length check is needed anywhere downstream).
 export const MAX_IMAGE_BYTES = 6 * 1024 * 1024;
 const MAX_REDIRECTS = 3;
 const DEFAULT_FETCH_TIMEOUT_MS = 5000;
+// Overall deadline for resolving ALL URLs in one prompt, so a slow-but-allowlisted
+// host can't stall the turn (the per-fetch timeout alone bounds one hop, not the
+// whole sequential/parallel batch).
+const DEFAULT_TOTAL_TIMEOUT_MS = 8000;
 
 // Extension-anchored: an OSS signed URL keeps its `.jpg` before the `?query`.
 // Extensionless URLs are intentionally out of scope for v1 (no HEAD probe).
@@ -63,6 +67,13 @@ function fetchTimeoutMs(): number {
   if (!raw) return DEFAULT_FETCH_TIMEOUT_MS;
   const parsed = Number(raw);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_FETCH_TIMEOUT_MS;
+}
+
+function totalTimeoutMs(): number {
+  const raw = process.env.SICLAW_IMAGE_URL_TOTAL_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_TOTAL_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_TOTAL_TIMEOUT_MS;
 }
 
 /**
@@ -183,19 +194,25 @@ async function readLimitedBody(res: Response, maxBytes: number): Promise<Buffer>
   return Buffer.concat(chunks);
 }
 
-/** Fetch an image URL behind the SSRF guard, following redirects manually. */
-export async function fetchUrlImage(url: string): Promise<InboundImage> {
+/**
+ * Fetch an image URL behind the SSRF guard, following redirects manually.
+ * `overallSignal` (optional) is the caller's batch-wide deadline, combined with
+ * the per-hop timeout so one slow hop can't outlive the whole resolution budget.
+ */
+export async function fetchUrlImage(url: string, overallSignal?: AbortSignal): Promise<InboundImage> {
   const timeoutMs = fetchTimeoutMs();
   let current = url;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
     assertAllowedImageUrl(current); // re-validate every hop (redirect can't escape the allowlist)
-    const res = await fetch(current, {
-      redirect: "manual",
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    const perHop = AbortSignal.timeout(timeoutMs);
+    const signal = overallSignal ? AbortSignal.any([perHop, overallSignal]) : perHop;
+    const res = await fetch(current, { redirect: "manual", signal });
     if (res.status >= 300 && res.status < 400) {
       const loc = res.headers.get("location");
       if (!loc) throw new Error(`redirect without location: ${safeUrl(current)}`);
+      // Drain the redirect body so undici releases the connection instead of
+      // holding it until GC.
+      await res.body?.cancel().catch(() => {});
       current = new URL(loc, current).toString();
       continue;
     }
@@ -227,21 +244,27 @@ export async function enrichImagesFromText(
   existing: InboundImage[] = [],
 ): Promise<InboundImage[]> {
   const out: InboundImage[] = [...existing];
+  if (out.length >= MAX_INBOUND_IMAGES) return out;
   const urls = extractImageUrls(text);
   if (urls.length === 0) return out;
 
-  for (const url of urls) {
-    if (out.length >= MAX_INBOUND_IMAGES) break;
-    try {
-      const img = await fetchUrlImage(url);
-      if (img.data.length > MAX_IMAGE_BASE64_CHARS) {
-        console.warn(`[image-url-ingest] skip oversize image (url=${safeUrl(url)}): ${img.data.length} base64 chars`);
-        continue;
+  // One deadline for the whole step (a slow allowlisted host must not stall the
+  // turn), and fetch the URLs in parallel rather than sequentially. The raw-byte
+  // cap in fetchUrlImage (MAX_IMAGE_BYTES) already bounds each image's size.
+  const overall = AbortSignal.timeout(totalTimeoutMs());
+  const settled = await Promise.all(
+    urls.map(async (url) => {
+      try {
+        return await fetchUrlImage(url, overall);
+      } catch (err) {
+        console.warn(`[image-url-ingest] url image failed url=${safeUrl(url)}: ${errMsg(err)}`);
+        return null;
       }
-      out.push(img);
-    } catch (err) {
-      console.warn(`[image-url-ingest] url image failed url=${safeUrl(url)}: ${errMsg(err)}`);
-    }
+    }),
+  );
+  for (const img of settled) {
+    if (out.length >= MAX_INBOUND_IMAGES) break;
+    if (img) out.push(img);
   }
   return out;
 }

--- a/src/gateway/channels/inbound-image.test.ts
+++ b/src/gateway/channels/inbound-image.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Readable } from "node:stream";
+import { collectInboundImages } from "./inbound-image.js";
+
+// Native-Lark image download. The text-URL path and the shared byte helpers
+// moved to `agentbox/image-url-ingest.ts` — see image-url-ingest.test.ts.
+
+// ── Fixtures: minimal valid image byte signatures ──────────────────────────
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const NOT_IMAGE = Buffer.from("hello world this is text", "utf8");
+
+function makeLarkClient(getImpl: (payload: any) => any) {
+  return { im: { messageResource: { get: vi.fn(getImpl) } } };
+}
+
+function resourceResponse(buf: Buffer) {
+  return { getReadableStream: () => Readable.from([buf]), writeFile: vi.fn(), headers: {} };
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("collectInboundImages — native lark images", () => {
+  it("downloads a lark image and returns {mimeType,data}", async () => {
+    const larkClient = makeLarkClient(() => resourceResponse(PNG));
+    const out = await collectInboundImages({
+      imageRefs: [{ imageKey: "img_k1" }],
+      larkClient,
+      messageId: "m1",
+    });
+    expect(out).toEqual([{ mimeType: "image/png", data: PNG.toString("base64") }]);
+    expect(larkClient.im.messageResource.get).toHaveBeenCalledWith({
+      path: { message_id: "m1", file_key: "img_k1" },
+      params: { type: "image" },
+    });
+  });
+
+  it("falls back to im.v1.messageResource", async () => {
+    const get = vi.fn(() => resourceResponse(JPEG));
+    const larkClient = { im: { v1: { messageResource: { get } } } };
+    const out = await collectInboundImages({ imageRefs: [{ imageKey: "k" }], larkClient, messageId: "m" });
+    expect(out).toEqual([{ mimeType: "image/jpeg", data: JPEG.toString("base64") }]);
+  });
+
+  it("skips a bad image_key but keeps the rest", async () => {
+    const larkClient = makeLarkClient((p: any) =>
+      p.path.file_key === "bad" ? Promise.reject(new Error("boom")) : resourceResponse(PNG),
+    );
+    const out = await collectInboundImages({
+      imageRefs: [{ imageKey: "bad" }, { imageKey: "good" }],
+      larkClient,
+      messageId: "m",
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].mimeType).toBe("image/png");
+  });
+
+  it("skips non-image bytes from a lark resource", async () => {
+    const larkClient = makeLarkClient(() => resourceResponse(NOT_IMAGE));
+    const out = await collectInboundImages({ imageRefs: [{ imageKey: "k" }], larkClient, messageId: "m" });
+    expect(out).toEqual([]);
+  });
+
+  it("caps total images at 4", async () => {
+    const larkClient = makeLarkClient(() => resourceResponse(PNG));
+    const refs = Array.from({ length: 6 }, (_, i) => ({ imageKey: `k${i}` }));
+    const out = await collectInboundImages({ imageRefs: refs, larkClient, messageId: "m" });
+    expect(out).toHaveLength(4);
+  });
+
+  it("skips an oversize lark image (stream exceeds the byte cap)", async () => {
+    // 7MiB > 6MiB raw cap → streamToBuffer aborts mid-stream.
+    const huge = Buffer.alloc(7 * 1024 * 1024, 0x89);
+    const larkClient = makeLarkClient(() => resourceResponse(huge));
+    const out = await collectInboundImages({ imageRefs: [{ imageKey: "big" }], larkClient, messageId: "m" });
+    expect(out).toEqual([]);
+  });
+});

--- a/src/gateway/channels/inbound-image.ts
+++ b/src/gateway/channels/inbound-image.ts
@@ -1,0 +1,99 @@
+import type { Readable } from "node:stream";
+import {
+  type InboundImage,
+  MAX_INBOUND_IMAGES,
+  MAX_IMAGE_BASE64_CHARS,
+  MAX_IMAGE_BYTES,
+  sniffImageMime,
+  streamToBuffer,
+} from "../agentbox/image-url-ingest.js";
+
+/**
+ * Native Lark/Feishu image download — the channel-specific half of inbound
+ * image handling.
+ *
+ * A native Lark image (or a post-embedded image) is downloaded via the
+ * receive-side `im.messageResource.get` API (NOT `im.images`, which only serves
+ * resources THIS app uploaded). This needs the Lark SDK + the message id, so it
+ * cannot be generalised across front-ends and stays here.
+ *
+ * The OTHER inbound source — image URLs in the message text — is NOT handled
+ * here. It is generic across every front-end and lives in
+ * `agentbox/image-url-ingest.ts`, applied once at the `AgentBoxClient.prompt()`
+ * boundary so Feishu, Portal Web chat, a2a and cron all share one implementation.
+ */
+
+export type { InboundImage } from "../agentbox/image-url-ingest.js";
+
+/** Lightweight reference to a Lark-hosted image, resolved at download time. */
+export interface LarkImageRef {
+  imageKey: string;
+}
+
+export interface CollectInboundImagesOptions {
+  /** Native Lark image refs already parsed from the message in the handler. */
+  imageRefs: LarkImageRef[];
+  /** Lazily-imported `@larksuiteoapi/node-sdk` client. */
+  larkClient: any;
+  /** Needed by the receive-side resource API. */
+  messageId: string;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Download a Lark-hosted image via the receive-side resource API. */
+async function fetchLarkResource(
+  larkClient: any,
+  messageId: string,
+  imageKey: string,
+): Promise<InboundImage> {
+  const resourceApi = larkClient?.im?.messageResource ?? larkClient?.im?.v1?.messageResource;
+  if (!resourceApi?.get) {
+    throw new Error("im.messageResource.get is unavailable");
+  }
+  // MUST be the receive-side resource endpoint; `im.images.get` only serves
+  // resources THIS app uploaded. file_key === the message's image_key.
+  const resp = await resourceApi.get({
+    path: { message_id: messageId, file_key: imageKey },
+    params: { type: "image" },
+  });
+  const stream: Readable | undefined = resp?.getReadableStream?.();
+  if (!stream) {
+    throw new Error("messageResource.get returned no readable stream");
+  }
+  const buf = await streamToBuffer(stream, MAX_IMAGE_BYTES);
+  const mime = sniffImageMime(buf);
+  if (!mime) throw new Error(`unrecognized image bytes for image_key=${imageKey}`);
+  return { mimeType: mime, data: buf.toString("base64") };
+}
+
+/**
+ * Collect native Lark images for one Feishu turn. The total is capped at the
+ * AgentBox media budget; a single failure (bad key, oversize, non-image bytes)
+ * is skipped with a warning and never aborts the turn. Text image URLs are
+ * appended later, generically, at the `AgentBoxClient.prompt()` boundary.
+ */
+export async function collectInboundImages(
+  opts: CollectInboundImagesOptions,
+): Promise<InboundImage[]> {
+  const { imageRefs, larkClient, messageId } = opts;
+  const out: InboundImage[] = [];
+
+  for (const ref of imageRefs) {
+    if (out.length >= MAX_INBOUND_IMAGES) break;
+    try {
+      const img = await fetchLarkResource(larkClient, messageId, ref.imageKey);
+      if (img.data.length > MAX_IMAGE_BASE64_CHARS) {
+        console.warn(`[lark-inbound-image] skip oversize image (image_key=${ref.imageKey}): ${img.data.length} base64 chars`);
+        continue;
+      }
+      out.push(img);
+    } catch (err) {
+      console.warn(`[lark-inbound-image] lark resource failed image_key=${ref.imageKey}: ${errMsg(err)}`);
+    }
+  }
+
+  return out;
+}

--- a/src/gateway/channels/inbound-image.ts
+++ b/src/gateway/channels/inbound-image.ts
@@ -2,7 +2,6 @@ import type { Readable } from "node:stream";
 import {
   type InboundImage,
   MAX_INBOUND_IMAGES,
-  MAX_IMAGE_BASE64_CHARS,
   MAX_IMAGE_BYTES,
   sniffImageMime,
   streamToBuffer,
@@ -84,12 +83,8 @@ export async function collectInboundImages(
   for (const ref of imageRefs) {
     if (out.length >= MAX_INBOUND_IMAGES) break;
     try {
-      const img = await fetchLarkResource(larkClient, messageId, ref.imageKey);
-      if (img.data.length > MAX_IMAGE_BASE64_CHARS) {
-        console.warn(`[lark-inbound-image] skip oversize image (image_key=${ref.imageKey}): ${img.data.length} base64 chars`);
-        continue;
-      }
-      out.push(img);
+      // fetchLarkResource bounds raw bytes at MAX_IMAGE_BYTES, so no extra base64 cap needed.
+      out.push(await fetchLarkResource(larkClient, messageId, ref.imageKey));
     } catch (err) {
       console.warn(`[lark-inbound-image] lark resource failed image_key=${ref.imageKey}: ${errMsg(err)}`);
     }

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -2190,6 +2190,27 @@ describe("handleLarkMessage — inbound images", () => {
     expect(arg).not.toHaveProperty("images");
     expect(arg.text).toContain("https://oss.siflow.cn/x.png");
   });
+
+  it("persists the user row with signed-URL credentials stripped (prompt keeps the full URL)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ agentId: "a1", sessionId: "session-fixed" }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleLarkMessage(
+      makeTextEvent("look https://oss.siflow.cn/x.png?Signature=secret"),
+      makeLarkClient(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const userRow = appendMessageMock.mock.calls.find((c) => c[0].role === "user")?.[0];
+    expect(userRow.content).toContain("oss.siflow.cn/x.png");
+    expect(userRow.content).not.toContain("Signature"); // creds stripped from the persisted row
+    // the prompt forwarded to AgentBoxClient keeps the full signed URL (client.prompt fetches it)
+    expect(promptMock.mock.calls[0][0].text).toContain("Signature=secret");
+  });
 });
 
 describe("extractInbound — post receive shapes", () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Readable } from "node:stream";
 import {
   buildChannelTurnPrompt,
   createLarkHandler,
@@ -221,9 +222,16 @@ describe("handleLarkMessage — payload shape guards", () => {
     expect(larkClient.im.message.reply).not.toHaveBeenCalled();
   });
 
-  it("bails on non-text message types (image, file, sticker, …)", async () => {
+  it("bails on unsupported message types (audio, file, sticker, …)", async () => {
     const larkClient = makeLarkClient();
-    const data = makeTextEvent("irrelevant", { message_type: "image" });
+    const data = makeTextEvent("irrelevant", { message_type: "audio" });
+    await handleLarkMessage(data, larkClient, "lark", makeAgentBoxManager() as any);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("bails on an image message that carries no image_key", async () => {
+    const larkClient = makeLarkClient();
+    const data = { message: { message_id: "m", chat_id: "oc_x", message_type: "image", content: "{}" } };
     await handleLarkMessage(data, larkClient, "lark", makeAgentBoxManager() as any);
     expect(resolveBindingMock).not.toHaveBeenCalled();
   });
@@ -2022,5 +2030,119 @@ describe("collectChannelResponse — audit persistence", () => {
     ];
     const collected = await collectChannelResponse(fakeClient(events), "s-fail", "lark", { persist: { agentId: "a1" } });
     expect(collected.text).toBe("still replies");
+  });
+});
+
+// ── Inbound images (text URLs + native lark) ───────────────────────────────
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
+const PNG_B64 = PNG_BYTES.toString("base64");
+
+/** Lark client whose receive-side resource API returns a PNG stream. */
+function makeLarkClientWithResource() {
+  return {
+    im: {
+      message: { reply: vi.fn().mockResolvedValue({}) },
+      messageResource: {
+        get: vi.fn().mockResolvedValue({
+          getReadableStream: () => Readable.from([PNG_BYTES]),
+          writeFile: vi.fn(),
+          headers: {},
+        }),
+      },
+    },
+  };
+}
+
+function makeImageEvent(imageKey: string, overrides: Record<string, unknown> = {}) {
+  return {
+    sender: { sender_id: { open_id: "ou_user_1" } },
+    message: {
+      message_id: "mid-img",
+      chat_id: "oc_abc123",
+      message_type: "image",
+      content: JSON.stringify({ image_key: imageKey }),
+      ...overrides,
+    },
+  };
+}
+
+function makePostEvent(text: string, imageKey: string) {
+  return {
+    sender: { sender_id: { open_id: "ou_user_1" } },
+    message: {
+      message_id: "mid-post",
+      chat_id: "oc_abc123",
+      message_type: "post",
+      content: JSON.stringify({
+        title: "",
+        content: [[{ tag: "text", text }, { tag: "img", image_key: imageKey }]],
+      }),
+    },
+  };
+}
+
+describe("handleLarkMessage — inbound images", () => {
+  it("native image message → prompt carries images + placeholder text persisted", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ agentId: "a1", sessionId: "session-fixed" }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleLarkMessage(
+      makeImageEvent("img_k1"),
+      makeLarkClientWithResource(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+      images: [{ mimeType: "image/png", data: PNG_B64 }],
+      mode: "channel",
+    }));
+    // image-only message → placeholder, not an empty user row
+    expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({ role: "user", content: "[image]" }));
+  });
+
+  it("post with embedded image → prompt carries images AND the caption text", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ agentId: "a1", sessionId: "session-fixed" }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleLarkMessage(
+      makePostEvent("look at this error", "img_k2"),
+      makeLarkClientWithResource(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const arg = promptMock.mock.calls[0][0];
+    expect(arg.images).toEqual([{ mimeType: "image/png", data: PNG_B64 }]);
+    expect(arg.text).toContain("look at this error");
+  });
+
+  it("text image URL → left in prompt text for the unified layer (lark no longer resolves it)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ agentId: "a1", sessionId: "session-fixed" }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleLarkMessage(
+      makeTextEvent("check this https://oss.siflow.cn/x.png"),
+      makeLarkClient(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    // The channel hands the raw URL text to AgentBoxClient.prompt; URL→image
+    // resolution (vision-gated) happens THERE, not in the channel. So no images
+    // are attached here, and the URL survives in the prompt text.
+    const arg = promptMock.mock.calls[0][0];
+    expect(arg).not.toHaveProperty("images");
+    expect(arg.text).toContain("https://oss.siflow.cn/x.png");
   });
 });

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -2165,6 +2165,8 @@ describe("handleLarkMessage — inbound images", () => {
     // but the placeholder still records that the user sent an image
     expect(arg).not.toHaveProperty("images");
     expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({ role: "user", content: "[image]" }));
+    // and the prompt tells the model an image was attached but can't be read
+    expect(arg.text).toContain("cannot read images");
   });
 
   it("text image URL → left in prompt text for the unified layer (lark no longer resolves it)", async () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -6,6 +6,7 @@ import {
   handleLarkMessage,
   collectResponse,
   collectChannelResponse,
+  extractInbound,
   resetLarkBindingQueuesForTest,
 } from "./lark.js";
 import {
@@ -2083,6 +2084,19 @@ function makePostEvent(text: string, imageKey: string) {
 }
 
 describe("handleLarkMessage — inbound images", () => {
+  // Native images are vision-gated now; default the binding to a vision-capable model.
+  const VISION_BINDING = {
+    modelProvider: "openai",
+    modelId: "gpt-4o",
+    modelConfig: {
+      name: "p", baseUrl: "", apiKey: "", api: "openai", authHeader: false,
+      models: [{ id: "gpt-4o", name: "gpt-4o", reasoning: false, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000, maxTokens: 100 }],
+    },
+  };
+  beforeEach(() => {
+    resolveAgentModelBindingMock.mockResolvedValue(VISION_BINDING);
+  });
+
   it("native image message → prompt carries images + placeholder text persisted", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ agentId: "a1", sessionId: "session-fixed" }));
     promptMock.mockResolvedValue({ sessionId: "session-fixed" });
@@ -2124,6 +2138,35 @@ describe("handleLarkMessage — inbound images", () => {
     expect(arg.text).toContain("look at this error");
   });
 
+  it("native image + non-vision model → no images attached, placeholder still recorded", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ agentId: "a1", sessionId: "session-fixed" }));
+    resolveAgentModelBindingMock.mockResolvedValue({
+      modelProvider: "deepseek",
+      modelId: "deepseek-chat",
+      modelConfig: {
+        name: "p", baseUrl: "", apiKey: "", api: "openai", authHeader: false,
+        models: [{ id: "deepseek-chat", name: "deepseek-chat", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000, maxTokens: 100 }],
+      },
+    });
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleLarkMessage(
+      makeImageEvent("img_k1"),
+      makeLarkClientWithResource(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const arg = promptMock.mock.calls[0][0];
+    // non-vision → native image not downloaded/attached (mirrors the text-URL path),
+    // but the placeholder still records that the user sent an image
+    expect(arg).not.toHaveProperty("images");
+    expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({ role: "user", content: "[image]" }));
+  });
+
   it("text image URL → left in prompt text for the unified layer (lark no longer resolves it)", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ agentId: "a1", sessionId: "session-fixed" }));
     promptMock.mockResolvedValue({ sessionId: "session-fixed" });
@@ -2144,5 +2187,34 @@ describe("handleLarkMessage — inbound images", () => {
     const arg = promptMock.mock.calls[0][0];
     expect(arg).not.toHaveProperty("images");
     expect(arg.text).toContain("https://oss.siflow.cn/x.png");
+  });
+});
+
+describe("extractInbound — post receive shapes", () => {
+  it("parses locale-nested post content instead of silently dropping it", () => {
+    const message = {
+      message_type: "post",
+      content: JSON.stringify({
+        zh_cn: { title: "Title", content: [[{ tag: "text", text: "hello" }, { tag: "img", image_key: "img_k9" }]] },
+      }),
+    };
+    const { text, imageRefs } = extractInbound(message);
+    expect(imageRefs).toEqual([{ imageKey: "img_k9" }]);
+    expect(text).toContain("hello");
+    expect(text).toContain("Title"); // title surfaced
+  });
+
+  it("parses the flat post shape and surfaces a hyperlink href + title", () => {
+    const message = {
+      message_type: "post",
+      content: JSON.stringify({
+        title: "Report",
+        content: [[{ tag: "a", text: "see", href: "https://oss.siflow.cn/x.png" }]],
+      }),
+    };
+    const { text } = extractInbound(message);
+    expect(text).toContain("Report");
+    expect(text).toContain("see");
+    expect(text).toContain("https://oss.siflow.cn/x.png"); // href surfaced for the unified URL resolver
   });
 });

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -36,6 +36,7 @@ import {
 } from "./lark-card.js";
 import { collectImageAttachments, stripVisualBlocks, type RenderedReplyImage } from "./visual-image.js";
 import { replyImageToLark } from "./lark-image.js";
+import { collectInboundImages, type LarkImageRef } from "./inbound-image.js";
 import { registerBackgroundChannelDelivery } from "./background-delivery.js";
 
 const VISUAL_ONLY_NOTICE_BY_LOCALE = {
@@ -285,6 +286,67 @@ function isBotMentioned(message: any, botOpenId?: string): boolean {
   return mentions.some((m) => m.key !== "@_all");
 }
 
+/**
+ * Placeholder text for an image-only message (no caption). Keeps the user
+ * message row, session title, and prompt non-empty so the audit transcript
+ * still shows "user sent image(s)".
+ */
+const IMAGE_ONLY_PLACEHOLDER = "[image]";
+
+/**
+ * Pull the user text and any inbound image references out of a Feishu message.
+ * This is the ONLY place message content is parsed — `imageRefs` is carried
+ * through the queue as a structured value (no re-parse downstream).
+ *
+ *   - text  → `content.text`
+ *   - image → `content.image_key`
+ *   - post  → rich text whose `content` is a `Node[][]` (array of paragraphs of
+ *             nodes); flatten and split by `tag`: img → image_key, text → text.
+ *
+ * Unknown types yield empty text + no refs (caller drops them).
+ */
+export function extractInbound(message: any): { text: string; imageRefs: LarkImageRef[] } {
+  const msgType: string = message?.message_type;
+  let raw: any;
+  try {
+    raw = JSON.parse(message?.content ?? "");
+  } catch {
+    return { text: "", imageRefs: [] };
+  }
+
+  if (msgType === "text") {
+    return { text: stripMentions(typeof raw?.text === "string" ? raw.text : ""), imageRefs: [] };
+  }
+
+  if (msgType === "image") {
+    const imageKey = typeof raw?.image_key === "string" ? raw.image_key : null;
+    return { text: "", imageRefs: imageKey ? [{ imageKey }] : [] };
+  }
+
+  if (msgType === "post") {
+    const imageRefs: LarkImageRef[] = [];
+    const textParts: string[] = [];
+    // im.message.receive_v1 delivers post content already locale-resolved as
+    // `{ title, content: Node[][] }` (the `{zh_cn:{…}}` nesting is a SEND-API
+    // shape, not a receive event), so parse the flat form directly.
+    const paragraphs: any[][] = Array.isArray(raw?.content) ? raw.content : [];
+    for (const node of paragraphs.flat()) {
+      if (node?.tag === "img" && typeof node?.image_key === "string") {
+        imageRefs.push({ imageKey: node.image_key });
+      } else if (node?.tag === "text" && typeof node?.text === "string") {
+        textParts.push(node.text);
+      }
+    }
+    return { text: stripMentions(textParts.join(" ")), imageRefs };
+  }
+
+  return { text: "", imageRefs: [] };
+}
+
+function stripMentions(text: string): string {
+  return text.replace(/@_user_\d+/g, "").trim();
+}
+
 export function buildChannelTurnPrompt(text: string): string {
   return [
     "<channel-turn>",
@@ -334,17 +396,14 @@ export async function handleLarkMessage(
   // is still visible. Lets us tell "never delivered" from "silently dropped".
   console.log(`[lark] recv event chat=${chatId} chat_type=${chatType} msg_type=${msgType} sender=${senderOpenId ?? "?"} channelCfg=${channelId}`);
 
-  if (msgType !== "text") return;
+  // Accept text, native image, and rich-text (post, may embed images). Other
+  // types (audio/file/sticker/…) are still dropped.
+  if (msgType !== "text" && msgType !== "image" && msgType !== "post") return;
 
-  let text: string;
-  try {
-    const content = JSON.parse(message.content);
-    text = content.text;
-  } catch { return; }
-
-  if (!text || text.trim().length === 0) return;
-  text = text.replace(/@_user_\d+/g, "").trim();
-  if (text.length === 0) return;
+  const { text, imageRefs } = extractInbound(message);
+  // Drop only when there is neither text NOR an image — an image-only message
+  // has empty text but must continue.
+  if (text.length === 0 && imageRefs.length === 0) return;
 
   const personalBot = channelConfig?.personal_bot;
   const personalChannelId = personalBot?.channel_id ?? channelId;
@@ -386,6 +445,7 @@ export async function handleLarkMessage(
     const queueKey = `${binding.bindingId}:${personalSessionKey}`;
     const queued = enqueueBindingTask(queueKey, () => processQueuedLarkMessage({
       text,
+      imageRefs,
       messageId,
       chatId,
       senderOpenId,
@@ -461,6 +521,7 @@ export async function handleLarkMessage(
   const queueKey = `${binding.bindingId}:${binding.sessionKey ?? "__binding__"}`;
   const queued = enqueueBindingTask(queueKey, () => processQueuedLarkMessage({
     text,
+    imageRefs,
     messageId,
     chatId,
     senderOpenId,
@@ -482,6 +543,7 @@ export async function handleLarkMessage(
 
 interface QueuedLarkMessageContext {
   text: string;
+  imageRefs: LarkImageRef[];
   messageId: string;
   chatId: string;
   senderOpenId: string | null;
@@ -498,6 +560,7 @@ interface QueuedLarkMessageContext {
 async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<void> {
   const {
     text,
+    imageRefs,
     messageId,
     chatId,
     senderOpenId,
@@ -516,6 +579,11 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     return;
   }
 
+  // After the command branch: an image-only message has empty text, so give it a
+  // placeholder. Replace `text` uniformly here (not just in promptOpts) so the
+  // session title, persisted user row, and logs all show "user sent image(s)".
+  const effectiveText = text.length === 0 && imageRefs.length > 0 ? IMAGE_ONLY_PLACEHOLDER : text;
+
   const binding = await resolveQueuedBinding(route, channelId, chatId, senderOpenId, frontendClient!, sessionKey);
   if (!binding) {
     console.log(`[lark] Binding disappeared before queued run channel=${channelId} chat=${chatId} route=${route}`);
@@ -530,14 +598,14 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const sessionId = binding.sessionId;
   sessionRegistry.remember(sessionId, binding.createdBy, agentId);
 
-  console.log(`[lark] Message channel=${channelId} chat=${chatId} sender=${senderOpenId ?? "unknown"} → agent=${agentId} session=${sessionId}: "${text.slice(0, 80)}"`);
+  console.log(`[lark] Message channel=${channelId} chat=${chatId} sender=${senderOpenId ?? "unknown"} → agent=${agentId} session=${sessionId}: "${effectiveText.slice(0, 80)}" images=${imageRefs.length}`);
 
   try {
-    await ensureChatSession(sessionId, agentId, binding.createdBy, text, text, "channel");
+    await ensureChatSession(sessionId, agentId, binding.createdBy, effectiveText, effectiveText, "channel");
     await appendMessage({
       sessionId,
       role: "user",
-      content: text,
+      content: effectiveText,
       metadata: { source: "lark", channelId, chatId, messageId, bindingId: binding.bindingId, senderOpenId, sessionKey, route },
     });
   } catch (err) {
@@ -634,8 +702,13 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const modelBinding = frontendClient
     ? await resolveAgentModelBinding(agentId, frontendClient)
     : null;
+  // Download native Lark images at execution time — close to the prompt, and
+  // skipped entirely when the queue rejects. Text image URLs are NOT handled
+  // here: they are resolved generically (and vision-gated) at the
+  // `AgentBoxClient.prompt()` boundary, shared with Portal Web chat / a2a / cron.
+  const images = await collectInboundImages({ imageRefs, larkClient, messageId });
   const promptOpts: PromptOptions = {
-    text: buildChannelTurnPrompt(text),
+    text: buildChannelTurnPrompt(effectiveText),
     agentId,
     mode: "channel",
     sessionId,
@@ -644,6 +717,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     modelConfig: modelBinding?.modelConfig,
     modelRouting: modelBinding?.modelRouting,
     systemPromptTemplate: modelBinding?.systemPrompt?.trim() || undefined,
+    ...(images.length ? { images } : {}),
   };
   let resultText = "";
   let replyImages: RenderedReplyImage[] = [];

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -38,6 +38,7 @@ import { collectImageAttachments, stripVisualBlocks, type RenderedReplyImage } f
 import { replyImageToLark } from "./lark-image.js";
 import { collectInboundImages, type LarkImageRef } from "./inbound-image.js";
 import { modelOptionsSupportImageInput } from "../../core/model-routing.js";
+import { redactImageUrlsInText } from "../agentbox/image-url-ingest.js";
 import { registerBackgroundChannelDelivery } from "./background-delivery.js";
 
 const VISUAL_ONLY_NOTICE_BY_LOCALE = {
@@ -623,12 +624,16 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
 
   console.log(`[lark] Message channel=${channelId} chat=${chatId} sender=${senderOpenId ?? "unknown"} → agent=${agentId} session=${sessionId}: "${effectiveText.slice(0, 80)}" images=${imageRefs.length}`);
 
+  // Persist with signed-URL credentials stripped (the prompt still uses the full
+  // URL — see promptText below — so resolution is unaffected). Keeps DB rows /
+  // session title free of plaintext Signature/AccessKeyId.
+  const persistedText = redactImageUrlsInText(effectiveText);
   try {
-    await ensureChatSession(sessionId, agentId, binding.createdBy, effectiveText, effectiveText, "channel");
+    await ensureChatSession(sessionId, agentId, binding.createdBy, persistedText, persistedText, "channel");
     await appendMessage({
       sessionId,
       role: "user",
-      content: effectiveText,
+      content: persistedText,
       metadata: { source: "lark", channelId, chatId, messageId, bindingId: binding.bindingId, senderOpenId, sessionKey, route },
     });
   } catch (err) {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -741,8 +741,14 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const images = visionCapable
     ? await collectInboundImages({ imageRefs, larkClient, messageId })
     : [];
+  // Non-vision model + the user sent native image(s): they were dropped (can't be
+  // used). Tell the model so it can inform the user — mirroring the text-URL path,
+  // where a non-vision model at least sees the URL and can say it can't open it.
+  const promptText = !visionCapable && imageRefs.length > 0
+    ? `${effectiveText}\n[Note: the user attached ${imageRefs.length} image(s), but the current model cannot read images.]`
+    : effectiveText;
   const promptOpts: PromptOptions = {
-    text: buildChannelTurnPrompt(effectiveText),
+    text: buildChannelTurnPrompt(promptText),
     agentId,
     mode: "channel",
     sessionId,

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -37,6 +37,7 @@ import {
 import { collectImageAttachments, stripVisualBlocks, type RenderedReplyImage } from "./visual-image.js";
 import { replyImageToLark } from "./lark-image.js";
 import { collectInboundImages, type LarkImageRef } from "./inbound-image.js";
+import { modelOptionsSupportImageInput } from "../../core/model-routing.js";
 import { registerBackgroundChannelDelivery } from "./background-delivery.js";
 
 const VISUAL_ONLY_NOTICE_BY_LOCALE = {
@@ -326,15 +327,24 @@ export function extractInbound(message: any): { text: string; imageRefs: LarkIma
   if (msgType === "post") {
     const imageRefs: LarkImageRef[] = [];
     const textParts: string[] = [];
-    // im.message.receive_v1 delivers post content already locale-resolved as
-    // `{ title, content: Node[][] }` (the `{zh_cn:{…}}` nesting is a SEND-API
-    // shape, not a receive event), so parse the flat form directly.
-    const paragraphs: any[][] = Array.isArray(raw?.content) ? raw.content : [];
+    // Post content is normally delivered flat as `{ title, content: Node[][] }`,
+    // but some Feishu API/SDK versions deliver the locale-nested send-shape
+    // `{ zh_cn: { title, content }, en_us: {…} }` on receive — accept both so a
+    // nested payload is not silently dropped (it would otherwise yield neither
+    // text nor image and the whole turn would be discarded).
+    const post = Array.isArray(raw?.content) ? raw : firstLocalePost(raw);
+    if (typeof post?.title === "string" && post.title) textParts.push(post.title);
+    const paragraphs: any[][] = Array.isArray(post?.content) ? post.content : [];
     for (const node of paragraphs.flat()) {
       if (node?.tag === "img" && typeof node?.image_key === "string") {
         imageRefs.push({ imageKey: node.image_key });
-      } else if (node?.tag === "text" && typeof node?.text === "string") {
+      } else if ((node?.tag === "text" || node?.tag === "a") && typeof node?.text === "string") {
         textParts.push(node.text);
+      }
+      // A hyperlink's href may itself be an image URL — surface it so the unified
+      // text-URL resolver (AgentBoxClient.prompt) can pick it up.
+      if (node?.tag === "a" && typeof node?.href === "string") {
+        textParts.push(node.href);
       }
     }
     return { text: stripMentions(textParts.join(" ")), imageRefs };
@@ -345,6 +355,16 @@ export function extractInbound(message: any): { text: string; imageRefs: LarkIma
 
 function stripMentions(text: string): string {
   return text.replace(/@_user_\d+/g, "").trim();
+}
+
+/** Feishu post may arrive locale-nested as `{ zh_cn: { content: Node[][] } }`;
+ *  pick the first locale block that carries a `content` array. */
+function firstLocalePost(raw: any): any {
+  if (!raw || typeof raw !== "object") return undefined;
+  for (const v of Object.values(raw)) {
+    if (v && typeof v === "object" && Array.isArray((v as any).content)) return v;
+  }
+  return undefined;
 }
 
 export function buildChannelTurnPrompt(text: string): string {
@@ -579,9 +599,12 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     return;
   }
 
-  // After the command branch: an image-only message has empty text, so give it a
-  // placeholder. Replace `text` uniformly here (not just in promptOpts) so the
-  // session title, persisted user row, and logs all show "user sent image(s)".
+  // After the command branch (matched on the raw text): an image whose caption
+  // is exactly a command word (e.g. "/new") is routed as that command and its
+  // image dropped — an accepted edge, since commands are exact-match only.
+  // An image-only message has empty text, so give it a placeholder. Replace
+  // `text` uniformly here (not just in promptOpts) so the session title,
+  // persisted user row, and logs all show "user sent image(s)".
   const effectiveText = text.length === 0 && imageRefs.length > 0 ? IMAGE_ONLY_PLACEHOLDER : text;
 
   const binding = await resolveQueuedBinding(route, channelId, chatId, senderOpenId, frontendClient!, sessionKey);
@@ -702,11 +725,22 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const modelBinding = frontendClient
     ? await resolveAgentModelBinding(agentId, frontendClient)
     : null;
-  // Download native Lark images at execution time — close to the prompt, and
-  // skipped entirely when the queue rejects. Text image URLs are NOT handled
-  // here: they are resolved generically (and vision-gated) at the
-  // `AgentBoxClient.prompt()` boundary, shared with Portal Web chat / a2a / cron.
-  const images = await collectInboundImages({ imageRefs, larkClient, messageId });
+  // Native Lark images are vision-gated too, mirroring the text-URL path: a
+  // non-vision model can't use them and would fail-closed at AgentBox media
+  // filtering, so skip the download entirely for non-vision models (the [image]
+  // placeholder in effectiveText still records that the user sent an image).
+  // Text image URLs are NOT handled here — they are resolved generically (and
+  // vision-gated) at the `AgentBoxClient.prompt()` boundary, shared with Portal
+  // Web chat / a2a / cron.
+  const visionCapable = modelOptionsSupportImageInput({
+    modelProvider: modelBinding?.modelProvider,
+    modelId: modelBinding?.modelId,
+    modelConfig: modelBinding?.modelConfig,
+    modelRouting: modelBinding?.modelRouting,
+  });
+  const images = visionCapable
+    ? await collectInboundImages({ imageRefs, larkClient, messageId })
+    : [];
   const promptOpts: PromptOptions = {
     text: buildChannelTurnPrompt(effectiveText),
     agentId,


### PR DESCRIPTION
## What

The Feishu/Lark channel could only **send** images out — images a user posted were dropped at the non-text gate and never reached the agent. This adds an inbound pipeline that fills `PromptOptions.images`, with **text-image-URL resolution unified at the `AgentBoxClient.prompt` boundary** so every front-end that reaches AgentBox via this client (Feishu / DingTalk / Portal Web chat / a2a / cron) shares one implementation.

## Changes

- **`extractInbound()`** parses `text` / `image` / `post` messages into `{ text, imageRefs }`; `post` rich-text is walked for embedded `img` nodes (and accepts the locale-nested receive shape, surfacing title + hyperlink href). The handler gate accepts `text/image/post` and only drops a turn with **neither** text nor image.
- **Native Lark images** (`channels/inbound-image.ts`): downloaded via the receive-side `im.messageResource.get` (`getReadableStream`, aggregated in memory — never the upload-side `im.images` endpoint). **Vision-gated** like the URL path — skipped for non-vision models (the `[image]` placeholder still records the image).
- **Text image URLs** are resolved generically in the new **`agentbox/image-url-ingest.ts`**, applied once at `AgentBoxClient.prompt` (NOT in the channel), covering Feishu / DingTalk / Web chat / a2a / cron:
  - **Vision-gated** via `modelOptionsSupportImageInput`: resolve only when the prompt's model/route declares image input. A non-vision model leaves the URL as **plain text** (the model replies it can't open it) — no fail-closed turn, no OCR fallback.
  - **Fail-closed host-allowlist SSRF guard** (`SICLAW_IMAGE_URL_ALLOWLIST`): https-only, per-redirect re-validation, streamed size cap, `Content-Type` + magic-byte checks. URLs are fetched **in parallel under one overall timeout** (`SICLAW_IMAGE_URL_TOTAL_TIMEOUT_MS`, default 8s) so a slow allowlisted host can't stall the turn. The outbound fetch + allowlist stay in the **Gateway process** (the AgentBox pod is network-isolated and must not fetch arbitrary user URLs).
  - Per-image failures are skipped with a warning; total capped at the AgentBox media budget.
- An **image-only turn** gets a placeholder caption so the session title, persisted user row, and prompt stay non-empty (audit transcript intact).

## Notes

- **Env renamed (no compat shim):** `SICLAW_LARK_IMAGE_URL_ALLOWLIST` → `SICLAW_IMAGE_URL_ALLOWLIST` (plus `_ALLOW_HTTP` / `_FETCH_TIMEOUT_MS`). **Deployment values that set the old names must be updated**, otherwise text-URL resolution stays fail-closed.
- Group `@`-mention gating is **unchanged**: pure drag-in images apply to p2p personal bots; groups use `post(@bot+img)` or text image URLs.

## Tests

- `src/gateway/agentbox/image-url-ingest.test.ts` (new) — URL extraction, SSRF allowlist, redirect re-validation, size caps, budget merge, parallel + overall-timeout bound
- `src/core/model-routing.test.ts` — `modelOptionsSupportImageInput` (single model / routed / disabled)
- `src/gateway/agentbox/client.test.ts` — vision-gated resolution at `prompt()`
- `src/gateway/channels/{inbound-image,lark}.test.ts` — native download (vision-gated), post receive shapes (nested/flat/href), channel hands URL text to the unified layer
