### PR TITLE
fix(core): pass raw JSON Schema as MCP tool parameters

### DIFF
--- a/src/core/mcp-client.test.ts
+++ b/src/core/mcp-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { jsonSchemaToTypebox, buildMcpToolName, isMcpTool, MCP_TOOL_PREFIX, mcpContentToAgentContent, McpClientManager } from "./mcp-client.js";
+import { jsonSchemaToTypebox, normalizeMcpInputSchema, buildMcpToolName, isMcpTool, MCP_TOOL_PREFIX, mcpContentToAgentContent, McpClientManager } from "./mcp-client.js";
 
 describe("jsonSchemaToTypebox", () => {
   it("converts string type", () => {
@@ -166,5 +166,44 @@ describe("createToolDefinition server description", () => {
   it("applies the server context to the fallback description too", () => {
     const def = makeDef("Monitoring tenant ID: t-123");
     expect(def.description).toBe('[Server "grafana" context: Monitoring tenant ID: t-123]\nMCP tool query from grafana');
+  });
+});
+
+describe("normalizeMcpInputSchema", () => {
+  const TYPEBOX_KIND = Symbol.for("TypeBox.Kind");
+
+  it("returns a plain JSON Schema without TypeBox kind metadata", () => {
+    // This is the core invariant behind scitix/siclaw#355: MCP tool parameters
+    // must NOT carry the @sinclair/typebox Kind symbol, otherwise the pi runtime
+    // (typebox 1.x) skips its JSON-Schema arg coercion and string-encoded integers
+    // like "10" fail validation with "must be integer".
+    const result = normalizeMcpInputSchema({
+      type: "object",
+      properties: { panelId: { type: "integer" } },
+      required: ["panelId"],
+    });
+    expect(Object.getOwnPropertySymbols(result)).not.toContain(TYPEBOX_KIND);
+    // By contrast, the old TypeBox conversion DID carry the symbol.
+    const viaTypebox = jsonSchemaToTypebox({ type: "object", properties: {} });
+    expect(Object.getOwnPropertySymbols(viaTypebox)).toContain(TYPEBOX_KIND);
+  });
+
+  it("preserves properties, required and additionalProperties", () => {
+    const result = normalizeMcpInputSchema({
+      type: "object",
+      properties: { panelId: { type: "integer" }, dashboardUid: { type: "string" } },
+      required: ["panelId", "dashboardUid"],
+      additionalProperties: { type: "string" },
+    }) as any;
+    expect(result.type).toBe("object");
+    expect(result.properties.panelId).toEqual({ type: "integer" });
+    expect(result.required).toEqual(["panelId", "dashboardUid"]);
+    expect(result.additionalProperties).toEqual({ type: "string" });
+  });
+
+  it("guarantees object shape for missing/empty/invalid schemas", () => {
+    expect(normalizeMcpInputSchema(undefined) as any).toMatchObject({ type: "object", properties: {} });
+    expect(normalizeMcpInputSchema({}) as any).toMatchObject({ type: "object", properties: {} });
+    expect(normalizeMcpInputSchema([1, 2]) as any).toMatchObject({ type: "object", properties: {} });
   });
 });

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -1,7 +1,7 @@
 /**
  * MCP Client Manager — connects to external MCP servers and exposes their tools
- * as pi-agent ToolDefinitions (TypeBox schema) for the pi-agent brain,
- * and as raw config for the Claude SDK brain (native MCP support).
+ * as pi-agent ToolDefinitions (raw MCP JSON Schema as parameters) for the
+ * pi-agent brain, and as raw config for the Claude SDK brain (native MCP support).
  *
  * Supports three transport types: stdio, sse, streamable-http.
  * Config loaded from .siclaw/config/settings.json mcpServers field.
@@ -55,12 +55,41 @@ interface ManagedMcpClient {
 }
 
 // ---------------------------------------------------------------------------
+// MCP inputSchema handling
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an MCP tool `inputSchema` into the JSON Schema object passed to the
+ * pi runtime as a tool's `parameters`.
+ *
+ * We intentionally keep this as a *plain JSON Schema* (no TypeBox kind metadata)
+ * so the runtime's argument coercion runs — see the detailed note in
+ * `createToolDefinition` and scitix/siclaw#355. We only guarantee the object
+ * shape the providers and validator expect (`type: "object"` + `properties`),
+ * preserving any other fields (`required`, `additionalProperties`, ...).
+ */
+export function normalizeMcpInputSchema(schema: any): TSchema {
+  const base = schema && typeof schema === "object" && !Array.isArray(schema) ? schema : {};
+  const normalized = {
+    ...base,
+    type: "object" as const,
+    properties: base.properties ?? {},
+  };
+  // Cast: ToolDefinition.parameters is typed as TSchema, but the pi runtime accepts
+  // (and here requires) a raw JSON Schema object at runtime.
+  return normalized as unknown as TSchema;
+}
+
+// ---------------------------------------------------------------------------
 // JSON Schema → TypeBox conversion
 // ---------------------------------------------------------------------------
 
 /**
  * Convert a JSON Schema object (as returned by MCP tool inputSchema) to a
  * TypeBox TSchema. Covers the common subset used by MCP tools.
+ *
+ * NOTE: No longer used for MCP tool `parameters` (see `normalizeMcpInputSchema`
+ * and scitix/siclaw#355). Retained for compatibility / potential reuse.
  */
 export function jsonSchemaToTypebox(schema: any): TSchema {
   if (!schema || typeof schema !== "object") return Type.Any();
@@ -285,7 +314,18 @@ export class McpClientManager {
   ): ToolDefinition {
     const fullName = buildMcpToolName(serverName, mcpTool.name);
     const inputSchema = mcpTool.inputSchema ?? { type: "object", properties: {} };
-    const parameters = jsonSchemaToTypebox(inputSchema);
+    // Pass the MCP inputSchema through as raw JSON Schema instead of converting it
+    // into a @sinclair/typebox TSchema. The pi runtime validates and coerces tool
+    // arguments with a *different* TypeBox package (`typebox` 1.x, bundled under
+    // @earendil-works/pi-ai) whose schema-kind detection (`~kind` string prop) is
+    // incompatible with @sinclair/typebox 0.34's metadata (`Symbol.for('TypeBox.Kind')`).
+    // Converting here silently disables string→number/boolean coercion (e.g. "10" → 10):
+    // `Value.Convert` no-ops and pi-ai's JSON-Schema coercion fallback is skipped because
+    // `hasTypeBoxMetadata` detects the 0.34 symbol — so integer/object params such as
+    // get_panel_image's `panelId` fail validation with "must be integer". Raw JSON Schema
+    // leaves the kind metadata absent, letting pi-ai's coercion path run, and providers
+    // advertise tools straight from `.properties`/`.required`. See scitix/siclaw#355.
+    const parameters = normalizeMcpInputSchema(inputSchema);
 
     // Prepend the admin-provided server description so the model sees server-level
     // context (e.g. monitoring tenant IDs) on every tool from that server.


### PR DESCRIPTION
## Summary

MCP tools that declare `integer`/`object`/`boolean` parameters fail argument validation (`must be integer`) whenever the model emits the value as a string (`"10"`), so the call never reaches the MCP server. This passes the MCP `inputSchema` through as raw JSON Schema instead of converting it to a `@sinclair/typebox` schema, which re-enables the pi runtime's argument coercion.

Closes #355

### Problem

`src/core/mcp-client.ts` built tool parameter schemas with `@sinclair/typebox` 0.34, but the pi runtime (`@earendil-works/pi-ai`) validates and coerces arguments with `typebox` 1.x. The two tag schema "kind" differently (`Symbol.for('TypeBox.Kind')` vs the `~kind` string prop), so:

- `Value.Convert` is a no-op — `"10"` stays a string.
- pi-ai's robust JSON-Schema coercion fallback is skipped, because `hasTypeBoxMetadata` detects the 0.34 symbol.
- The compiled validator still enforces `type: "integer"`, so the call is dropped with `panelId: must be integer` (e.g. Grafana's `get_panel_image`).

A secondary issue: the old `jsonSchemaToTypebox` dropped `additionalProperties` (e.g. the `variables` field), losing schema fidelity.

### Solution

Add `normalizeMcpInputSchema`, which returns a plain JSON Schema (no TypeBox kind metadata) while guaranteeing the `type: "object"` + `properties` shape and preserving `required` / `additionalProperties` / other fields. `createToolDefinition` now uses it for tool `parameters`.

With the kind metadata absent, pi-ai's `coerceWithJsonSchema` runs (`"10"` → `10`), and providers still advertise tools straight from `.properties` / `.required`. `jsonSchemaToTypebox` is retained (no longer used for params) for compatibility.

Rejected alternative: aligning siclaw on `typebox` 1.x — a larger dependency change, deferred to maintainer guidance per the open question in #355.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (`npm run build`) passes
- [x] `vitest run src/core/mcp-client.test.ts` — 22 passed, including new `normalizeMcpInputSchema` cases asserting no TypeBox kind symbol and preserved `additionalProperties`

## Architecture Checklist

- [x] **Tool protocol**: MCP tools continue to register as `ToolDefinition`s; `parameters` now carries raw JSON Schema (accepted by the pi runtime), which fixes the coercion path. Change is confined to shared core (`src/core/mcp-client.ts`), so it applies to all deployment modes.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included