### PR TITLE
fix(tools): drop `setsid -w` for portability across older util-linux/busybox

### DIFF
--- a/src/tools/cmd-exec/host-exec-background.test.ts
+++ b/src/tools/cmd-exec/host-exec-background.test.ts
@@ -87,7 +87,8 @@ describe("host_exec — one-step pod netns", () => {
     // Foreground now runs as a killable, timeout-bounded setsid session (so Stop can reap the
     // remote process group), with the user command still inside `ip netns exec <netns> sh -c`.
     const fgCmd = vi.mocked(sshExec).mock.calls.find((c) => String(c[1]).includes("show_gids"))![1] as string;
-    expect(fgCmd).toContain("setsid -w sh -c");
+    expect(fgCmd).toContain("setsid sh -c");
+    expect(fgCmd).not.toContain("setsid -w");   // portable: no util-linux >= 2.24 dependency
     expect(fgCmd).toContain("timeout 30 ");
     expect(fgCmd).toContain(".pgid");
     expect(fgCmd).toContain("ip netns exec cni-x sh -c '\\''show_gids'\\''");

--- a/src/tools/cmd-exec/host-exec.test.ts
+++ b/src/tools/cmd-exec/host-exec.test.ts
@@ -88,7 +88,8 @@ describe("host_exec", () => {
 
     // (1) The foreground command ran as a setsid session, `timeout`-bounded at the cap, recording a .pgid.
     const fgCmd = vi.mocked(sshExec).mock.calls[0][1] as string;
-    expect(fgCmd).toContain("setsid -w sh -c");
+    expect(fgCmd).toContain("setsid sh -c");
+    expect(fgCmd).not.toContain("setsid -w");   // portable: no util-linux >= 2.24 dependency
     expect(fgCmd).toContain("timeout 90 ");
     expect(fgCmd).toMatch(/\.pgid/);
     expect(fgCmd).toContain("ib_write_bw -D 60 -F");

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -247,6 +247,8 @@ Examples (pass the id from host_list; names shown here for readability):
       // This requires `setsid` + `timeout` on the host — the SAME dependency the background path
       // already takes for every host command (util-linux + coreutils, present on any normal SSH
       // target incl. BusyBox); a host missing them errors visibly rather than orphaning silently.
+      // setsid is invoked WITHOUT `-w` (see wrapBackgroundSession) so it works on older util-linux
+      // (e.g. CentOS 7's 2.23.2) and BusyBox, which don't support the `-w`/`--wait` flag.
       const cap = Math.min(params.timeout_seconds ?? 30, 120);
       const timeout = cap * 1000;
       const fgPgidFile = backgroundPgidFile(toolCallId);

--- a/src/tools/cmd-exec/node-exec-foreground.test.ts
+++ b/src/tools/cmd-exec/node-exec-foreground.test.ts
@@ -37,7 +37,8 @@ describe("node_exec foreground: killable session + abort reap", () => {
     const cmd = (runInDebugPod.mock.calls[0][0] as { command: string[] }).command;
     expect(cmd.slice(0, 3)).toEqual(["nsenter", "-t", "1"]); // host namespace
     const joined = cmd.join(" ");
-    expect(joined).toContain("setsid -w sh -c");
+    expect(joined).toContain("setsid sh -c");
+    expect(joined).not.toContain("setsid -w");   // portable: no util-linux >= 2.24 dependency
     expect(joined).toContain("timeout 90 ");
     expect(joined).toMatch(/\.pgid/);
     expect(joined).toContain("ib_write_bw -D 60 -F");

--- a/src/tools/infra/bg-session.test.ts
+++ b/src/tools/infra/bg-session.test.ts
@@ -24,7 +24,9 @@ describe("bg-session", () => {
 
   it("wraps a command as a setsid session that records its session id and cleans up", () => {
     const wrapped = wrapBackgroundSession("timeout 600 sh -c 'do work'", "/tmp/x.pgid");
-    expect(wrapped.startsWith("setsid -w sh -c ")).toBe(true);
+    expect(wrapped.startsWith("setsid sh -c ")).toBe(true);
+    expect(wrapped).not.toContain("setsid -w");            // no util-linux >= 2.24 dependency
+    expect(wrapped.endsWith("; exit $?")).toBe(true);      // forces a forked (non-leader) setsid child
     expect(wrapped).toContain("echo $$ > /tmp/x.pgid");   // record session id
     expect(wrapped).toContain("timeout 600 sh -c");        // inner command preserved
     expect(wrapped).toContain("rm -f /tmp/x.pgid");        // cleanup on normal exit

--- a/src/tools/infra/bg-session.test.ts
+++ b/src/tools/infra/bg-session.test.ts
@@ -14,6 +14,12 @@ const {
   killRemoteSessionViaSsh,
 } = await import("./bg-session.js");
 
+// NOTE: the assertions below check SHELL-STRING COMPOSITION only — they intentionally do not
+// exercise runtime semantics (real exit-status propagation, or the `pkill -s <sid>` reap chain),
+// which are the two guarantees this wrapper exists to provide. Those depend on `setsid(2)` /
+// process-group behavior that can't be observed without a real Linux shell, so they are verified
+// manually on a CentOS 7 / BusyBox target (see the PR's manual test plan) rather than in CI. A
+// green run of this file alone does not prove the runtime contract holds.
 describe("bg-session", () => {
   it("builds a unique, sanitized pidfile path", () => {
     const a = backgroundPgidFile("functions.host_exec:0");

--- a/src/tools/infra/bg-session.ts
+++ b/src/tools/infra/bg-session.ts
@@ -13,6 +13,14 @@ import { sshExec, type SshTarget } from "./ssh-client.js";
  * process group, so a single `kill -<pgid>` of the launcher's group misses timeout's subtree.
  * setsid starts a new session whose id every descendant inherits (across timeout's sub-group),
  * so `pkill -s <sid>` reaps them all.
+ *
+ * Why NOT `setsid -w`: the `-w`/`--wait` flag only exists in util-linux >= 2.24 (2013). CentOS 7 /
+ * RHEL 7 ship util-linux 2.23.2, and busybox `setsid` has no `-w` either, so `setsid -w` aborts
+ * with "setsid: invalid option -- 'w'" and the command never runs. We get the same "wait + real
+ * exit status" behavior portably by running setsid as a NON process-group-leader child (see
+ * {@link wrapBackgroundSession}): when its caller isn't a process-group leader, setsid exec's the
+ * program in place (no fork), so the launching shell's `wait` observes the real exit status on any
+ * setsid version. The session is still created, so `pkill -s <sid>` reaping is unchanged.
  */
 
 /** A unique pidfile path holding the setsid session id (`$$` of the leader) for one job. */
@@ -25,10 +33,22 @@ export function backgroundPgidFile(toolCallId: string): string {
  * Wrap `innerCmd` so it runs as its own session leader (setsid), records the session id to
  * `pgidFile`, and removes the pidfile on normal exit. Returns ONE remote-shell command string.
  * `echo $$` consumes no stdin, so a piped script body flows through to `innerCmd` unchanged.
+ *
+ * The wrapper is `setsid sh -c '<launch>'; exit $?` (NOT `setsid -w`): the trailing `exit $?` is a
+ * second command, so the launching shell can't exec-optimize the single `setsid` invocation and
+ * must run it as a forked CHILD. That child is never a process-group leader, so setsid exec's
+ * `sh -c '<launch>'` in place (no fork) on EVERY setsid version — incl. CentOS 7 / RHEL 7's
+ * util-linux 2.23.2 and busybox, neither of which support `setsid -w`. Because there's no fork,
+ * the launching shell `wait`s for the real command and `exit $?` propagates its true exit status.
+ * It runs synchronously (no `&`), so a script body piped on stdin still reaches `innerCmd` (an `&`
+ * async list would have its stdin redirected to /dev/null when job control is off).
+ *
+ * The inner `sh -c` records its own pid via `echo $$`; setsid has already made that pid the new
+ * session id, so `pkill -s <sid>` still reaps the whole tree (incl. timeout's own process group).
  */
 export function wrapBackgroundSession(innerCmd: string, pgidFile: string): string {
   const launch = `echo $$ > ${pgidFile}; ${innerCmd}; rc=$?; rm -f ${pgidFile}; exit $rc`;
-  return `setsid -w sh -c ${shellEscape(launch)}`;
+  return `setsid sh -c ${shellEscape(launch)}; exit $?`;
 }
 
 /**

--- a/src/tools/infra/bg-session.ts
+++ b/src/tools/infra/bg-session.ts
@@ -45,6 +45,16 @@ export function backgroundPgidFile(toolCallId: string): string {
  *
  * The inner `sh -c` records its own pid via `echo $$`; setsid has already made that pid the new
  * session id, so `pkill -s <sid>` still reaps the whole tree (incl. timeout's own process group).
+ *
+ * LOAD-BEARING CONTRACT — two assumptions this correctness depends on:
+ *   1. The launching shell must NOT exec-optimize a multi-command sequence. POSIX shells
+ *      (bash/dash/ash/busybox sh) run `<cmd>; exit $?` as a forked child, which is exactly what
+ *      keeps setsid a non-leader so it exec's in place. A shell that tail-call-optimized the
+ *      sequence would let setsid inherit leader status, fork internally, and — with no `-w` —
+ *      the parent would exit 0 immediately, silently dropping the real exit code.
+ *   2. Do NOT "simplify" this to `exec setsid …`. `exec` makes setsid inherit the launching
+ *      shell's process-group-leader status, which triggers the same internal fork + lost exit
+ *      code regression. The forked-child path (no `exec`) is required, not incidental.
  */
 export function wrapBackgroundSession(innerCmd: string, pgidFile: string): string {
   const launch = `echo $$ > ${pgidFile}; ${innerCmd}; rc=$?; rm -f ${pgidFile}; exit $rc`;

--- a/src/tools/script-exec/host-script.test.ts
+++ b/src/tools/script-exec/host-script.test.ts
@@ -112,7 +112,8 @@ describe("host_script — one-step pod netns", () => {
     // Foreground now runs as a killable, timeout-bounded setsid session; the netns'd interpreter
     // command lives inside that wrapper (so the abort reap can kill the whole remote group).
     const remoteCmd = vi.mocked(sshExec).mock.calls[0][1] as string;
-    expect(remoteCmd).toContain("setsid -w sh -c");
+    expect(remoteCmd).toContain("setsid sh -c");
+    expect(remoteCmd).not.toContain("setsid -w");   // portable: no util-linux >= 2.24 dependency
     expect(remoteCmd).toContain("timeout ");
     expect(remoteCmd).toContain("ip netns exec cni-x ");
     expect(remoteCmd).toContain("bash -s");


### PR DESCRIPTION
## Summary

`host_exec`/`host_script` wrap every SSH command in a killable session via `setsid -w`, but the `-w`/`--wait` flag only exists in util-linux >= 2.24. On CentOS 7 / RHEL 7 (util-linux 2.23.2) and BusyBox, `setsid` aborts with `invalid option -- 'w'` and the command never runs. This PR removes the `-w` dependency while preserving the wait + real-exit-status and `pkill -s <sid>` reap semantics. Implements option #2 (pure-POSIX session wrapper) from the issue.

### Problem

Every command dispatched over SSH goes through `wrapBackgroundSession()` in `src/tools/infra/bg-session.ts`, which emitted `setsid -w sh -c '...'`. The `-w` flag (added in util-linux 2.24, 2013) is absent on older targets and BusyBox, so the wrapper fails immediately:

```
setsid: invalid option -- 'w'
```

Both the foreground and background paths of `host_exec`/`host_script` are affected, so basic operations (e.g. reading a file on a CentOS 7 node) fail. A stale code comment also claimed this dependency was "present on any normal SSH target incl. BusyBox", which is inaccurate.

### Solution

Drop `-w` and instead run `setsid sh -c '<launch>'; exit $?`. The trailing `exit $?` is a second command, so the launching shell cannot exec-optimize the lone `setsid` and must run it as a forked, non-process-group-leader child. In that case `setsid` exec's the program in place (no fork) on **every** setsid version, so the launching shell's `wait` still observes the real exit status, and `exit $?` propagates it. Session creation is unchanged, so `pkill -s <sid>` still reaps timeout's whole subtree on `job_stop`.

The fix is centralized in `bg-session.ts` and shared by `host_exec` / `host_script` / `node_exec`, with the rationale documented inline.

## Test Plan

- [x] `npx vitest run` for the affected suites — 32 tests pass (`bg-session`, `host-exec`, `host-exec-background`, `node-exec-foreground`, `host-script`)
- [x] Tests updated to assert `setsid sh -c` is emitted and `setsid -w` is absent
- [x] Manual: run a `host_exec` command against a CentOS 7 (util-linux 2.23.2) SSH target and confirm it executes and that `job_stop` still reaps the process tree

## Architecture Checklist

- [x] **Security model**: No new shell execution path; the change is confined to the existing `bg-session.ts` session wrapper shared by the cmd/script tools. No bypass of `command-sets.ts`.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included

Closes #356