### PR TITLE
feat(portal): add per-model vision capability for image input

### DIFF
--- a/portal-web/src/pages/Models.tsx
+++ b/portal-web/src/pages/Models.tsx
@@ -10,6 +10,7 @@ interface ModelEntry {
   model_id: string
   name: string
   reasoning: boolean
+  vision: boolean
   context_window: number
   max_tokens: number
   is_default: boolean
@@ -43,12 +44,12 @@ export function Models() {
 
   // Add model
   const [showAddModel, setShowAddModel] = useState<string | null>(null)
-  const [modelForm, setModelForm] = useState({ model_id: "", name: "", context_window: "128000", max_tokens: "65536", reasoning: false, is_default: false })
+  const [modelForm, setModelForm] = useState({ model_id: "", name: "", context_window: "128000", max_tokens: "65536", reasoning: false, vision: false, is_default: false })
   const [addingModel, setAddingModel] = useState(false)
 
   // Edit model
   const [editingModelId, setEditingModelId] = useState<string | null>(null)
-  const [editModelForm, setEditModelForm] = useState({ model_id: "", name: "", context_window: "", max_tokens: "", reasoning: false, is_default: false })
+  const [editModelForm, setEditModelForm] = useState({ model_id: "", name: "", context_window: "", max_tokens: "", reasoning: false, vision: false, is_default: false })
   const [savingModel, setSavingModel] = useState(false)
 
   const fetchProviders = async () => {
@@ -114,7 +115,7 @@ export function Models() {
         body: { ...modelForm, context_window: parseInt(modelForm.context_window), max_tokens: parseInt(modelForm.max_tokens) },
       })
       setShowAddModel(null)
-      setModelForm({ model_id: "", name: "", context_window: "128000", max_tokens: "65536", reasoning: false, is_default: false })
+      setModelForm({ model_id: "", name: "", context_window: "128000", max_tokens: "65536", reasoning: false, vision: false, is_default: false })
       await fetchProviders()
       toast.success("Model added")
     } catch (err: any) { toast.error(err.message) } finally { setAddingModel(false) }
@@ -133,6 +134,7 @@ export function Models() {
       context_window: String(model.context_window),
       max_tokens: String(model.max_tokens),
       reasoning: !!model.reasoning,
+      vision: !!model.vision,
       is_default: !!model.is_default,
     })
   }
@@ -149,6 +151,7 @@ export function Models() {
           context_window: parseInt(editModelForm.context_window),
           max_tokens: parseInt(editModelForm.max_tokens),
           reasoning: editModelForm.reasoning,
+          vision: editModelForm.vision,
           is_default: editModelForm.is_default,
         },
       })
@@ -265,7 +268,7 @@ export function Models() {
                               <div>
                                 <p className="text-sm font-mono">{model.model_id}</p>
                                 <p className="text-xs text-muted-foreground">
-                                  {model.name || model.model_id}{model.reasoning ? " · reasoning" : ""} · {(model.context_window / 1000).toFixed(0)}K
+                                  {model.name || model.model_id}{model.reasoning ? " · reasoning" : ""}{model.vision ? " · vision" : ""} · {(model.context_window / 1000).toFixed(0)}K
                                   {!!model.is_default && <span className="ml-2 px-1.5 py-0.5 rounded text-[10px] bg-primary/20 text-primary">default</span>}
                                 </p>
                               </div>
@@ -286,6 +289,10 @@ export function Models() {
                                   <div className="flex items-center gap-2">
                                     <button type="button" role="switch" aria-checked={editModelForm.reasoning} onClick={() => setEditModelForm({ ...editModelForm, reasoning: !editModelForm.reasoning })} className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${editModelForm.reasoning ? "bg-primary" : "bg-muted"}`}><span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${editModelForm.reasoning ? "translate-x-3" : "translate-x-0"}`} /></button>
                                     <span className="text-xs text-muted-foreground">Reasoning model</span>
+                                  </div>
+                                  <div className="flex items-center gap-2">
+                                    <button type="button" role="switch" aria-checked={editModelForm.vision} onClick={() => setEditModelForm({ ...editModelForm, vision: !editModelForm.vision })} className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${editModelForm.vision ? "bg-primary" : "bg-muted"}`}><span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${editModelForm.vision ? "translate-x-3" : "translate-x-0"}`} /></button>
+                                    <span className="text-xs text-muted-foreground">Vision model</span>
                                   </div>
                                   <div className="flex items-center gap-2">
                                     <button type="button" role="switch" aria-checked={editModelForm.is_default} onClick={() => setEditModelForm({ ...editModelForm, is_default: !editModelForm.is_default })} className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${editModelForm.is_default ? "bg-primary" : "bg-muted"}`}><span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${editModelForm.is_default ? "translate-x-3" : "translate-x-0"}`} /></button>
@@ -316,6 +323,10 @@ export function Models() {
                           <div className="flex items-center gap-2">
                             <button type="button" role="switch" aria-checked={modelForm.reasoning} onClick={() => setModelForm({ ...modelForm, reasoning: !modelForm.reasoning })} className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${modelForm.reasoning ? "bg-primary" : "bg-muted"}`}><span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${modelForm.reasoning ? "translate-x-3" : "translate-x-0"}`} /></button>
                             <span className="text-xs text-muted-foreground">Reasoning model</span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <button type="button" role="switch" aria-checked={modelForm.vision} onClick={() => setModelForm({ ...modelForm, vision: !modelForm.vision })} className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${modelForm.vision ? "bg-primary" : "bg-muted"}`}><span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${modelForm.vision ? "translate-x-3" : "translate-x-0"}`} /></button>
+                            <span className="text-xs text-muted-foreground">Vision model</span>
                           </div>
                           <div className="flex items-center gap-2">
                             <button type="button" role="switch" aria-checked={modelForm.is_default} onClick={() => setModelForm({ ...modelForm, is_default: !modelForm.is_default })} className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${modelForm.is_default ? "bg-primary" : "bg-muted"}`}><span className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${modelForm.is_default ? "translate-x-3" : "translate-x-0"}`} /></button>

--- a/src/core/model-compat.test.ts
+++ b/src/core/model-compat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defaultProviderModelCompat } from "./model-compat.js";
+import { buildProviderModelDescriptor, defaultProviderModelCompat } from "./model-compat.js";
 
 describe("defaultProviderModelCompat", () => {
   it("keeps developer-role messages for the official OpenAI API", () => {
@@ -21,5 +21,41 @@ describe("defaultProviderModelCompat", () => {
       api: "anthropic",
       baseUrl: "https://api.anthropic.com/v1",
     }).supportsDeveloperRole).toBe(false);
+  });
+});
+
+describe("buildProviderModelDescriptor", () => {
+  const provider = { api: "anthropic", baseUrl: "https://api.anthropic.com/v1" };
+
+  it("maps vision=1 to text+image input capability", () => {
+    const d = buildProviderModelDescriptor(
+      { model_id: "claude-vision", name: "Claude Vision", reasoning: 1, vision: 1, context_window: 200000, max_tokens: 8192 },
+      provider,
+    );
+    expect(d.input).toEqual(["text", "image"]);
+    expect(d.id).toBe("claude-vision");
+    expect(d.name).toBe("Claude Vision");
+    expect(d.reasoning).toBe(true);
+    expect(d.contextWindow).toBe(200000);
+    expect(d.maxTokens).toBe(8192);
+  });
+
+  it("maps vision=0 to text-only input capability", () => {
+    const d = buildProviderModelDescriptor(
+      { model_id: "gpt-text", reasoning: 0, vision: 0, context_window: 128000, max_tokens: 4096 },
+      provider,
+    );
+    expect(d.input).toEqual(["text"]);
+    expect(d.reasoning).toBe(false);
+    // name falls back to model_id when absent
+    expect(d.name).toBe("gpt-text");
+  });
+
+  it("treats missing/falsy vision as text-only", () => {
+    const d = buildProviderModelDescriptor(
+      { model_id: "m", context_window: 1000, max_tokens: 100 },
+      provider,
+    );
+    expect(d.input).toEqual(["text"]);
   });
 });

--- a/src/core/model-compat.ts
+++ b/src/core/model-compat.ts
@@ -5,6 +5,16 @@ export interface ProviderCompatInput {
   baseUrl?: string | null;
 }
 
+/** Raw `model_entries` row shape needed to build a model descriptor. */
+export interface ProviderModelRow {
+  model_id: string;
+  name?: string | null;
+  reasoning?: unknown;
+  vision?: unknown;
+  context_window: number;
+  max_tokens: number;
+}
+
 function isOfficialOpenAIBaseUrl(baseUrl?: string | null): boolean {
   if (!baseUrl) return false;
   try {
@@ -24,5 +34,31 @@ export function defaultProviderModelCompat(provider: ProviderCompatInput): Requi
     supportsDeveloperRole: usesChatCompletions && isOfficialOpenAIBaseUrl(provider.baseUrl),
     supportsUsageInStreaming: true,
     maxTokensField: "max_tokens",
+  };
+}
+
+/**
+ * Build a single `ProviderModelConfig` descriptor from a `model_entries` row.
+ *
+ * This is the SINGLE place that translates the persisted `vision` boolean into
+ * the runtime `input` capability list. Keeping it centralized prevents the
+ * descriptor-construction drift that hardcoded `input: ["text"]` causes across
+ * the (6+) production paths that hydrate model bindings — a vision model whose
+ * `input` was missed would have its image request silently filtered by
+ * model-routing's `filterCandidatesForPromptMedia`.
+ */
+export function buildProviderModelDescriptor(
+  row: ProviderModelRow,
+  provider: ProviderCompatInput,
+) {
+  return {
+    id: row.model_id,
+    name: row.name ?? row.model_id,
+    reasoning: !!row.reasoning,
+    input: (row.vision ? ["text", "image"] : ["text"]) as string[],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: row.context_window,
+    maxTokens: row.max_tokens,
+    compat: defaultProviderModelCompat({ api: provider.api, baseUrl: provider.baseUrl }),
   };
 }

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -125,6 +125,8 @@ describe("config.getSettings", () => {
         id: "gpt-4",
         name: "GPT-4",
         reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 128000,
         maxTokens: 4096,
         compat: { supportsDeveloperRole: true, supportsUsageInStreaming: true, maxTokensField: "max_tokens" },

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -15,7 +15,7 @@ import {
   parseBody,
   type RestRouter,
 } from "../gateway/rest-router.js";
-import { defaultProviderModelCompat } from "../core/model-compat.js";
+import { buildProviderModelDescriptor } from "../core/model-compat.js";
 import { normalizeChatSessionPreview, normalizeChatSessionTitle } from "./chat-session-fields.js";
 import { safeParseSkillFiles } from "../shared/skill-package.js";
 import { walkJumpChainRows, chainHopFromRow } from "./host-api.js";
@@ -878,7 +878,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
 
     const p = providerRows[0];
     const [modelRows] = await db.query(
-      `SELECT model_id, name, reasoning, context_window, max_tokens
+      `SELECT model_id, name, reasoning, vision, context_window, max_tokens
        FROM model_entries WHERE provider_id = ? ORDER BY sort_order, created_at`,
       [p.id],
     ) as any;
@@ -893,14 +893,9 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
           baseUrl: p.base_url,
           apiKey: p.api_key || "",
           api: p.api_type,
-          models: (modelRows as any[]).map((m: any) => ({
-            id: m.model_id,
-            name: m.name || m.model_id,
-            reasoning: !!m.reasoning,
-            contextWindow: m.context_window,
-            maxTokens: m.max_tokens,
-            compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
-          })),
+          models: (modelRows as any[]).map((m: any) =>
+            buildProviderModelDescriptor(m, { api: p.api_type, baseUrl: p.base_url }),
+          ),
         },
       },
       default: { provider: agent.model_provider, modelId: agent.model_id },
@@ -1476,19 +1471,12 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     }
     const p = providerRows[0];
     const [entryRows] = await db.query(
-      "SELECT model_id, name, reasoning, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
+      "SELECT model_id, name, reasoning, vision, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
       [p.id],
     ) as any;
-    const models = (entryRows as any[]).map((m: any) => ({
-      id: m.model_id,
-      name: m.name ?? m.model_id,
-      reasoning: !!m.reasoning,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: m.context_window,
-      maxTokens: m.max_tokens,
-      compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
-    }));
+    const models = (entryRows as any[]).map((m: any) =>
+      buildProviderModelDescriptor(m, { api: p.api_type, baseUrl: p.base_url }),
+    );
     const modelRouting = await resolveAgentModelRouting(agent.model_routing, {
       provider: agent.model_provider,
       modelId: agent.model_id,
@@ -1864,7 +1852,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     }
     const p = providerRows[0];
     const [modelRows] = await db.query(
-      `SELECT model_id, name, reasoning, context_window, max_tokens
+      `SELECT model_id, name, reasoning, vision, context_window, max_tokens
        FROM model_entries WHERE provider_id = ? ORDER BY sort_order, created_at`,
       [p.id],
     ) as any;
@@ -1878,14 +1866,9 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
           baseUrl: p.base_url,
           apiKey: p.api_key || "",
           api: p.api_type,
-          models: (modelRows as any[]).map((m: any) => ({
-            id: m.model_id,
-            name: m.name || m.model_id,
-            reasoning: !!m.reasoning,
-            contextWindow: m.context_window,
-            maxTokens: m.max_tokens,
-            compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
-          })),
+          models: (modelRows as any[]).map((m: any) =>
+            buildProviderModelDescriptor(m, { api: p.api_type, baseUrl: p.base_url }),
+          ),
         },
       },
       default: { provider: agent.model_provider, modelId: agent.model_id },
@@ -1912,19 +1895,12 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     }
     const p = providerRows[0];
     const [entryRows] = await db.query(
-      "SELECT model_id, name, reasoning, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
+      "SELECT model_id, name, reasoning, vision, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
       [p.id],
     ) as any;
-    const models = (entryRows as any[]).map((m: any) => ({
-      id: m.model_id,
-      name: m.name ?? m.model_id,
-      reasoning: !!m.reasoning,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: m.context_window,
-      maxTokens: m.max_tokens,
-      compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
-    }));
+    const models = (entryRows as any[]).map((m: any) =>
+      buildProviderModelDescriptor(m, { api: p.api_type, baseUrl: p.base_url }),
+    );
     const modelRouting = await resolveAgentModelRouting(agent.model_routing, {
       provider: agent.model_provider,
       modelId: agent.model_id,

--- a/src/portal/chat-gateway.test.ts
+++ b/src/portal/chat-gateway.test.ts
@@ -521,6 +521,107 @@ describe("chat-gateway routes", () => {
         maxTokensField: "max_tokens",
       });
     });
+
+    it("forwards raw images (not OCR) when the bound model supports vision", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4v" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4v", name: "GPT-4V", reasoning: 0, vision: 1, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "what's in this image",
+          session_id: "s1",
+          attachments: [{ kind: "image", filename: "shot.png", mimeType: "image/png", data: "aGVsbG8=" }],
+        },
+      });
+
+      router.handle(req, res);
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      // Vision model: image goes through raw, never to OCR.
+      expect(fetchMock).not.toHaveBeenCalled();
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      expect(command.images).toEqual([{ mimeType: "image/png", data: "aGVsbG8=" }]);
+      expect(command.text).toBe("what's in this image");
+      expect(command.text).not.toContain("OCR");
+      // Model descriptor exposes the image input capability.
+      expect(command.modelConfig.models[0].input).toEqual(["text", "image"]);
+    });
+
+    it("uses a default prompt for an image-only vision message", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4v" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4v", name: "GPT-4V", reasoning: 0, vision: 1, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "",
+          session_id: "s1",
+          attachments: [{ kind: "image", filename: "shot.png", mimeType: "image/png", data: "aGVsbG8=" }],
+        },
+      });
+
+      router.handle(req, res);
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      expect(command.text).toBe("Please analyze the attached file(s).");
+      expect(command.images).toHaveLength(1);
+    });
+
+    it("keeps OCR and sends no raw images when the bound model lacks vision", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      query
+        .mockResolvedValueOnce([[{ model_provider: "openai", model_id: "gpt-4" }], []])
+        .mockResolvedValueOnce([[{ id: "p1", name: "openai", base_url: "u", api_key: "k", api_type: "openai" }], []])
+        .mockResolvedValueOnce([[{ model_id: "gpt-4", name: "GPT-4", reasoning: 0, vision: 0, context_window: 128000, max_tokens: 4096 }], []]);
+
+      const res = fakeRes();
+      const req = fakeReq({
+        url: "/api/v1/siclaw/agents/a1/chat/send",
+        method: "POST",
+        headers: { authorization: `Bearer ${USER_TOKEN}` },
+        body: {
+          text: "what's wrong here",
+          session_id: "s1",
+          attachments: [{ kind: "image", filename: "shot.png", mimeType: "image/png", data: "aGVsbG8=" }],
+        },
+      });
+
+      router.handle(req, res);
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+      await new Promise(r => setImmediate(r));
+
+      const command = (connMap.sendCommand as any).mock.calls[0][2];
+      // Non-vision model: no raw images, image still flows through the OCR path.
+      expect(command.images).toBeUndefined();
+      expect(command.text).toContain("OCR");
+      expect(command.modelConfig.models[0].input).toEqual(["text"]);
+    });
   });
 
   // ── chat.steer ───────────────────────────────────────────

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -17,6 +17,7 @@ import {
 } from "../gateway/rest-router.js";
 import { verifyJwt } from "../gateway/jwt.js";
 import type { ResolvedModelBinding } from "../gateway/agent-model-binding.js";
+import { modelOptionsSupportImageInput } from "../core/model-routing.js";
 import { getDb } from "../gateway/db.js";
 import {
   ErrorCodes,
@@ -24,7 +25,7 @@ import {
   isErrorDetail,
   type ErrorDetail,
 } from "../lib/error-envelope.js";
-import { defaultProviderModelCompat } from "../core/model-compat.js";
+import { buildProviderModelDescriptor } from "../core/model-compat.js";
 import { resolveAgentModelRouting } from "./model-routing-config.js";
 import { authenticateApiKey } from "./api-key-auth.js";
 
@@ -297,19 +298,12 @@ export async function resolveAgentModelBinding(agentId: string): Promise<Resolve
   if (!provider) return null;
 
   const [entryRows] = await db.query(
-    "SELECT model_id, name, reasoning, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
+    "SELECT model_id, name, reasoning, vision, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
     [provider.id],
   ) as any;
-  const models = (entryRows as any[]).map((m: any) => ({
-    id: m.model_id,
-    name: m.name ?? m.model_id,
-    reasoning: !!m.reasoning,
-    input: ["text"] as string[],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: m.context_window,
-    maxTokens: m.max_tokens,
-    compat: defaultProviderModelCompat({ api: provider.api_type, baseUrl: provider.base_url }),
-  }));
+  const models = (entryRows as any[]).map((m: any) =>
+    buildProviderModelDescriptor(m, { api: provider.api_type, baseUrl: provider.base_url }),
+  );
 
   const modelRouting = await resolveAgentModelRouting(agent.model_routing, {
     provider: agent.model_provider,
@@ -468,13 +462,48 @@ export function registerChatRoutes(
       }
     });
 
-    const promptText = await appendOcrEvidence(body.text ?? "", body.attachments);
+    // When the bound model can natively read images, forward image attachments
+    // as raw `images` (true multimodal) instead of OCR-ing them to text. PDFs
+    // (and all attachments for non-vision models) keep the existing OCR path.
+    // Uses the same routing-aware gate as the shared AgentBoxClient image-URL
+    // resolution (model-routing.ts), so a turn with a text-primary + vision
+    // fallback treats uploaded attachments and pasted image URLs identically —
+    // routing sends the turn to the vision candidate either way.
+    let promptText: string;
+    let images: Array<{ mimeType: string; data: string }> | undefined;
+    if (modelOptionsSupportImageInput({
+      modelProvider: modelBinding.modelProvider,
+      modelId: modelBinding.modelId,
+      modelConfig: modelBinding.modelConfig,
+      modelRouting: modelBinding.modelRouting,
+    })) {
+      const normalized = normalizeChatAttachments(body.attachments);
+      images = normalized
+        .filter((a): a is ChatAttachment & { data: string } => a.kind === "image" && typeof a.data === "string")
+        .map((a) => ({
+          mimeType: normalizeMimeType(a.mimeType ?? a.mime_type, a.filename),
+          data: a.data,
+        }));
+      // Non-image attachments (PDFs) still go through OCR; images are excluded
+      // from the OCR input so they are never double-processed.
+      promptText = await appendOcrEvidence(body.text ?? "", normalized.filter((a) => a.kind !== "image"));
+      // Image-only message with no text and no OCR evidence: a bare images
+      // payload with empty text leaves runtime prompt behavior undefined, so
+      // fall back to a default instruction (aligns with sicore).
+      if (promptText.trim() === "" && images.length > 0) {
+        promptText = ATTACHMENT_ONLY_PROMPT;
+      }
+      if (images.length === 0) images = undefined;
+    } else {
+      promptText = await appendOcrEvidence(body.text ?? "", body.attachments);
+    }
 
     // Send chat.send command
     const result = await connectionMap.sendCommand(agentId, "chat.send", {
       agentId,
       userId: auth.userId,
       text: promptText,
+      ...(images ? { images } : {}),
       sessionId,
       modelProvider: modelBinding.modelProvider,
       modelId: modelBinding.modelId,

--- a/src/portal/cli-snapshot-api.ts
+++ b/src/portal/cli-snapshot-api.ts
@@ -31,7 +31,7 @@ import type { RestRouter } from "../gateway/rest-router.js";
 import { sendJson } from "../gateway/rest-router.js";
 import { getDb, type Db } from "../gateway/db.js";
 import { safeParseJson } from "../gateway/dialect-helpers.js";
-import { defaultProviderModelCompat } from "../core/model-compat.js";
+import { buildProviderModelDescriptor } from "../core/model-compat.js";
 import { resolveCapabilities } from "../core/tool-capabilities.js";
 import type {
   CliSnapshotKnowledgeRepo,
@@ -99,6 +99,7 @@ interface ModelRow {
   model_id: string;
   name: string | null;
   reasoning: number;
+  vision: number;
   context_window: number;
   max_tokens: number;
   is_default: number;
@@ -294,7 +295,7 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
       "SELECT id, name, base_url, api_key, api_type FROM model_providers WHERE api_key IS NOT NULL AND api_key != '' ORDER BY sort_order, name",
     );
     const [models] = await db.query<ModelRow[]>(
-      "SELECT provider_id, model_id, name, reasoning, context_window, max_tokens, is_default FROM model_entries ORDER BY provider_id, sort_order, model_id",
+      "SELECT provider_id, model_id, name, reasoning, vision, context_window, max_tokens, is_default FROM model_entries ORDER BY provider_id, sort_order, model_id",
     );
     // MCP: scoped to agent via agent_mcp_servers when active, else all enabled.
     const [mcps] = activeAgentId
@@ -408,16 +409,9 @@ export function registerCliSnapshotRoute(router: RestRouter, cliSnapshotSecret: 
         apiKey: p.api_key ?? "",
         api: p.api_type,
         authHeader: true,
-        models: entries.map((m) => ({
-          id: m.model_id,
-          name: m.name ?? m.model_id,
-          reasoning: Boolean(m.reasoning),
-          input: ["text"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: m.context_window,
-          maxTokens: m.max_tokens,
-          compat: defaultProviderModelCompat({ api: p.api_type, baseUrl: p.base_url }),
-        })),
+        models: entries.map((m) =>
+          buildProviderModelDescriptor(m, { api: p.api_type, baseUrl: p.base_url }),
+        ),
       };
       // First model flagged is_default wins. If none, first provider's first model is a fallback.
       const defaultEntry = entries.find((m) => m.is_default === 1);

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -353,6 +353,7 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     model_id VARCHAR(255) NOT NULL,
     name VARCHAR(255),
     reasoning TINYINT(1) NOT NULL DEFAULT 0,
+    vision TINYINT(1) NOT NULL DEFAULT 0,
     context_window INT NOT NULL DEFAULT 128000,
     max_tokens INT NOT NULL DEFAULT 65536,
     is_default TINYINT(1) NOT NULL DEFAULT 0,
@@ -553,6 +554,7 @@ export async function runPortalMigrations(): Promise<void> {
   await safeAlterTable(db, "agents", "tool_capabilities", "TEXT DEFAULT NULL");
   await safeAlterTable(db, "agent_task_runs", "session_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "agent_tasks", "last_manual_run_at", "TIMESTAMP NULL DEFAULT NULL");
+  await safeAlterTable(db, "model_entries", "vision", "TINYINT(1) NOT NULL DEFAULT 0");
   await safeAlterTable(db, "skills", "is_builtin", "TINYINT(1) NOT NULL DEFAULT 0");
   await safeAlterTable(db, "skills", "overlay_of", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "skills", "files", "MEDIUMTEXT DEFAULT NULL");

--- a/src/portal/model-routing-config.ts
+++ b/src/portal/model-routing-config.ts
@@ -1,6 +1,6 @@
 import { getDb } from "../gateway/db.js";
 import { safeParseJson } from "../gateway/dialect-helpers.js";
-import { defaultProviderModelCompat } from "../core/model-compat.js";
+import { buildProviderModelDescriptor } from "../core/model-compat.js";
 import {
   normalizeCandidates,
   normalizeModelRoutePolicy,
@@ -25,6 +25,7 @@ interface ModelRow {
   model_id: string;
   name: string | null;
   reasoning: number | boolean;
+  vision: number | boolean;
   context_window: number;
   max_tokens: number;
 }
@@ -96,7 +97,7 @@ async function loadProviderConfigs(providerNames: string[]): Promise<Map<string,
     if (!provider) continue;
 
     const [modelRows] = await db.query<ModelRow[]>(
-      "SELECT model_id, name, reasoning, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
+      "SELECT model_id, name, reasoning, vision, context_window, max_tokens FROM model_entries WHERE provider_id = ?",
       [provider.id],
     );
     out.set(provider.name, {
@@ -105,16 +106,9 @@ async function loadProviderConfigs(providerNames: string[]): Promise<Map<string,
       apiKey: provider.api_key ?? "",
       api: provider.api_type,
       authHeader: true,
-      models: modelRows.map((model) => ({
-        id: model.model_id,
-        name: model.name ?? model.model_id,
-        reasoning: !!model.reasoning,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: model.context_window,
-        maxTokens: model.max_tokens,
-        compat: defaultProviderModelCompat({ api: provider.api_type, baseUrl: provider.base_url }),
-      })),
+      models: modelRows.map((model) =>
+        buildProviderModelDescriptor(model, { api: provider.api_type, baseUrl: provider.base_url }),
+      ),
     });
   }
   return out;

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2633,11 +2633,11 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const trim = (v: unknown): string | null => (typeof v === "string" ? v.trim() : null);
     const modelId = trim(body.model_id);
     await db.query(
-      `INSERT INTO model_entries (id, provider_id, model_id, name, reasoning, context_window, max_tokens, is_default, sort_order)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO model_entries (id, provider_id, model_id, name, reasoning, vision, context_window, max_tokens, is_default, sort_order)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id, params.id, modelId, trim(body.name) || modelId,
-        body.reasoning ? 1 : 0, body.context_window ?? null,
+        body.reasoning ? 1 : 0, body.vision ? 1 : 0, body.context_window ?? null,
         body.max_tokens ?? null, body.is_default ? 1 : 0,
         body.sort_order ?? 0,
       ],
@@ -2665,7 +2665,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     }
 
     const body = await parseBody<Record<string, unknown>>(req);
-    const fields = ["model_id", "name", "reasoning", "context_window", "max_tokens", "is_default", "sort_order"];
+    const fields = ["model_id", "name", "reasoning", "vision", "context_window", "max_tokens", "is_default", "sort_order"];
     const sets: string[] = [];
     const values: unknown[] = [];
     for (const f of fields) {


### PR DESCRIPTION
- add `vision` column to model_entries (TINYINT, safeAlterTable for legacy DBs)
- accept `vision` in model CRUD API (POST insert + PUT field whitelist)
- extract shared buildProviderModelDescriptor in model-compat that maps vision -> input ["text","image"]; replace 6 hardcoded input:["text"] sites (chat-gateway, model-routing-config, adapter x4, cli-snapshot) so every binding path advertises image capability consistently
- chat/send: forward image attachments as raw `images` to vision models instead of OCR; non-image (PDF) and non-vision models keep the OCR path; fall back to ATTACHMENT_ONLY_PROMPT for image-only messages
- gate attachment forwarding with the routing-aware modelOptionsSupportImageInput (shared with the AgentBoxClient image-URL resolution) so uploaded attachments and pasted image URLs are treated identically under model routing
- Models.tsx: add Vision toggle to add/edit forms and a list badge
- tests for descriptor builder and chat/send split

## Summary

<!-- 1-3 sentences: what problem does this solve and how. -->

### Problem

<!-- What broke or was missing? What symptom/impact did it cause? -->

### Solution

<!-- What changed and why this approach over alternatives? -->

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes
- [ ] Manual verification (describe below if applicable)

## Architecture Checklist

<!-- Skip items that clearly don't apply. -->

- [ ] **Deployment mode**: If touching resource sync, skills, or filesystem writes — verified behaviour in both local (LocalSpawner) and K8s (K8sSpawner) modes. See [`docs/design/invariants.md §1-2`](../docs/design/invariants.md).
- [ ] **Security model**: No new shell execution paths bypassing `command-sets.ts`. Skill scripts go through the review gate.
- [ ] **DB parity**: Schema changes keep `src/portal/migrate.ts` compatible with both MySQL and SQLite (see [`docs/design/invariants.md §5`](../docs/design/invariants.md)).
- [ ] **Tool protocol**: New tools register through `src/core/tool-registry.ts` and use the TypeBox `ToolDefinition` protocol.

## General Checklist

- [ ] Changes are focused on a single logical change
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No unrelated changes included
