### PR TITLE
feat(channels,metrics): attribute & filter channel audit by sender

### DIFF
--- a/docs/design/2026-06-29-channel-sender-audit-filter.md
+++ b/docs/design/2026-06-29-channel-sender-audit-filter.md
@@ -1,0 +1,172 @@
+# Channel sender audit attribution & filtering
+
+> Date: 2026-06-29 · Status: approved design, pre-implementation
+> Scope: siclaw standalone only. See "Dependency direction" below.
+
+## Problem
+
+A siclaw `channel` agent (Lark / DingTalk) can be used directly by **anyone**
+in a group or DM under *open* mode. Every such interaction is persisted to the
+audit tables (`chat_sessions` / `chat_messages`) and surfaced in the admin
+Metrics UI (Sessions / Tools tabs).
+
+Today the audit cannot tell the senders apart. Ten people taking turns in one
+group all collapse into the binding owner — there is no way to isolate "the
+sessions and tool calls that came from this one person." Operators need to
+**group and filter channel audit by the actual sender**.
+
+## Dependency direction (the rule that shapes this design)
+
+**SiCore depends on siclaw; siclaw must never depend on SiCore.**
+
+Therefore siclaw has **no concept of a "SiCore user."** Mapping a Lark/DingTalk
+account to a SiCore identity is solved entirely inside SiCore's own layer and is
+out of scope here. Any field that exists only to carry a SiCore identity through
+siclaw (`sicore_user_id`, `ResolvedChannelBinding.senderUserId`) is a reverse
+dependency and is **removed** by this design.
+
+We attribute channel audit using only identifiers siclaw already owns natively.
+
+## Identity model
+
+For a `channel`-origin session, the actor is the **channel sender**, identified
+by:
+
+- **`sender_external_id`** — Lark `open_id` / DingTalk `senderStaffId`. siclaw
+  already keys per-sender sessions on this (`open_id:<sender>` session key), so
+  it is the stable "same person" key.
+- **`channel_id`** — which channel / IM app the sender belongs to. `open_id` is
+  scoped per Lark app, so the same human has a different `open_id` per app;
+  **`(channel_id, sender_external_id)` is the unique pair**. `channel_id` comes
+  from siclaw's own `channels` table.
+
+### Value rules (invariant)
+
+- The channel actor is **the end user, never the binding owner**. We never fall
+  back to `created_by`.
+- When the sender id cannot be obtained (some open-mode cases), the column is
+  `NULL`. We do not substitute the owner to "fill" the row.
+- siclaw does **not** resolve the sender's display name. The audit presents the
+  raw `sender_external_id`. (See "Future" for the one cheap, dependency-free
+  enhancement we deliberately defer.)
+
+`web` / `api` / `a2a` origins are unchanged: their actor remains the owning
+`user_id` (logged-in user / API-key owner).
+
+## Data model
+
+`chat_sessions` carries the channel actor:
+
+| column | meaning |
+|---|---|
+| `sender_external_id` | open_id / staffId of the sender (NULL for non-channel or when absent) |
+| `channel_id` | the channel / IM app (NULL for non-channel) |
+
+A channel session is per-sender by construction (session key `open_id:<sender>`),
+so **one session = one sender**; the session row alone fully attributes it.
+
+`chat_messages.sender_external_id` is **removed.** It was dead weight: every
+audit/tools query already joins `chat_sessions` and filters on
+`s.sender_external_id`, never the message-level copy. Removing it eliminates
+redundancy and a drift risk (a message's sender disagreeing with its session's).
+Tool-level attribution is obtained by joining a message back to its session.
+
+### Removed (SiCore coupling)
+
+- `chat_sessions.sicore_user_id`, `chat_messages.sicore_user_id` — schema,
+  `adapter.ts` (`chat.ensureSession` / `chat.appendMessage`), `chat-repo.ts`.
+- `ResolvedChannelBinding.senderUserId` — `channel-manager.ts`.
+- `actorSicoreUserId` pass-through — `channels/lark.ts`, `channels/dingtalk.ts`.
+- The `sicore_user_id` arm of the Metrics user axis and the `sicoreUserId`
+  pairing returned by the channel-senders endpoint — `metrics-entry.ts`,
+  `siclaw-api.ts`, `portal-web` hooks/components.
+
+## Metrics behavior
+
+The "by user" axis is origin-aware and contains no SiCore concept:
+
+```
+actorUserColumn ≡ CASE WHEN origin = 'channel'
+                       THEN <alias>.sender_external_id
+                       ELSE <alias>.user_id END
+```
+
+The "who" axis is **origin-aware in the UI**, not just in SQL. The Sessions /
+Tools tabs show exactly one identity filter, chosen by entry:
+
+- **off-channel** (web / api / a2a / all): the **portal-user** dropdown
+  ("All Users"), filtering on `user_id`.
+- **channel**: the portal-user dropdown is **hidden** (channel actors are
+  open_ids, never portal users — applying a portal-user filter would match no
+  channel rows), replaced by the two channel filters below. The portal-user
+  filter is also not *applied* on the channel entry even if a stale value lingers.
+
+For the `channel` entry, the Sessions and Tools tabs expose two clean filters:
+
+1. **Channel** — pick which channel / IM app (`channel_id`).
+2. **Sender** — pick or type a `sender_external_id`; once set, Sessions and
+   Tools show only that person's rows.
+
+The sender picker is fed by the channel-senders endpoint, which returns the
+**distinct senders seen in the window with an occurrence count and last-seen
+timestamp, ordered by recency**. Raw `open_id`s are opaque; the count and
+last-seen are what make the list usable ("the one active 5 minutes ago with 30
+messages"). The endpoint returns sender ids only — no SiCore pairing, no name.
+
+In the Sessions / Tools tables, a channel row's actor column shows the
+`sender_external_id` (truncated, full value on hover), so an operator can spot
+the same person across multiple sessions at a glance.
+
+### Response shape: owner and sender are separate fields
+
+Audit row payloads (`audit/sessions`, `metrics/audit`, the session snapshot)
+return **`userId` = the owner `user_id` (always a portal user)** and a separate
+**`senderId` = `sender_external_id` (channel sender, null off-channel)**. The
+actor is NOT overloaded onto a single `userId` field whose meaning flips by
+`origin` — a consumer that joins `siclaw_users` on `userId` stays correct for
+every row, and the UI simply renders `senderId` for channel rows, `userId`
+otherwise. `actorUserColumn` (the origin-aware CASE) is used only for the
+actor-based *filter* and the *distinct-actor count*, never as a projected field.
+
+### Metric semantics: NULL senders and the distinct-actor count
+
+`distinctUsers` counts `COUNT(DISTINCT actorUserColumn)` — owners for off-channel
+rows, senders for channel rows. Two consequences, both intentional:
+
+- A channel session whose sender is NULL (event omitted it) is **excluded** from
+  `distinctUsers` and from any sender-grouped view, while still counting in
+  `totalSessions`. So "distinct senders" ≤ "channel sessions"; the two tiles can
+  legitimately differ.
+- For the `all` entry the distinct set mixes portal UUIDs and channel sender ids.
+  They never collide (disjoint formats), so the count is meaningful as "distinct
+  actors across all entries".
+
+## Migration
+
+`migrate.ts` is additive (CREATE TABLE IF NOT EXISTS + idempotent
+`safeAlterTable`); it does not drop columns. The removed columns
+(`sicore_user_id`, message-level `sender_external_id`) were introduced on the
+current unmerged branch, so removing them from the branch means fresh databases
+never receive them. The only database that already has them is a manually-migrated
+test deployment (siclaw-inner), which is disposable and can be recreated. **No
+destructive migration is written**; the mainline schema is simply clean.
+
+## Testing
+
+- `chat-repo`: `sender_external_id` write mapping on sessions; no owner fallback;
+  removal of `sicore_user_id` / message-level `sender_external_id` reflected in
+  assertions.
+- `lark` / `dingtalk`: open mode → `sender_external_id` set (NULL when absent),
+  never owner; `channel_id` stamped on the session.
+- Metrics: filtering sessions and tools by `sender_external_id` + `channel_id`;
+  `actorUserColumn` no longer references any SiCore column; channel-senders
+  endpoint returns count + last-seen ordered by recency.
+
+## Future (deferred, not in this change)
+
+If `open_id` proves too hard to recognize in practice, capture the sender's
+display name **only if it already arrives in the Lark/DingTalk event payload**
+(no extra contact-API call, no external dependency) and denormalize it as
+`chat_sessions.sender_display_name` — a single point-in-time column, no join
+table. This is native channel data, not a SiCore concept, so it does not violate
+the dependency-direction rule. Deferred to keep this change minimal.

--- a/portal-web/src/components/metrics/AuditTable.tsx
+++ b/portal-web/src/components/metrics/AuditTable.tsx
@@ -127,8 +127,8 @@ export function AuditTable({ userFilterId, channelFilterId, senderFilterId, user
               <AuditRow
                 key={log.id}
                 log={log}
-                username={log.origin === "channel"
-                  ? (log.senderId ?? "—")
+                username={log.senderId
+                  ? log.senderId
                   : (log.userId ? (userMap.get(log.userId) ?? log.userId) : "—")}
                 expanded={expandedId === log.id}
                 onToggle={() => toggleExpand(log.id)}

--- a/portal-web/src/components/metrics/AuditTable.tsx
+++ b/portal-web/src/components/metrics/AuditTable.tsx
@@ -47,7 +47,7 @@ function OutcomeIcon({ outcome }: { outcome: string | null }) {
   }
 }
 
-export function AuditTable({ userFilterId, usernameHint, entry, timeRange }: { userFilterId: string | null; usernameHint: string | null; entry: EntryMode; timeRange: TimeRange }) {
+export function AuditTable({ userFilterId, channelFilterId, senderFilterId, usernameHint, entry, timeRange }: { userFilterId: string | null; channelFilterId: string | null; senderFilterId: string | null; usernameHint: string | null; entry: EntryMode; timeRange: TimeRange }) {
   const [tool, setTool] = useState("All")
   const [status, setStatus] = useState("All")
   const [expandedId, setExpandedId] = useState<string | null>(null)
@@ -67,11 +67,13 @@ export function AuditTable({ userFilterId, usernameHint, entry, timeRange }: { u
       userId: userFilterId ?? undefined,
       toolName: tool === "All" ? undefined : tool,
       outcome: status === "All" ? undefined : status,
+      channelId: channelFilterId ?? undefined,
+      senderExternalId: senderFilterId ?? undefined,
       entry,
       from: String(fromMs),
       to: String(toMs),
     }
-  }, [tool, status, entry, timeRange.from, timeRange.to, userFilterId])
+  }, [tool, status, entry, timeRange.from, timeRange.to, userFilterId, channelFilterId, senderFilterId])
 
   const { logs, hasMore, loading, loadMore } = useAudit(params)
 
@@ -125,7 +127,9 @@ export function AuditTable({ userFilterId, usernameHint, entry, timeRange }: { u
               <AuditRow
                 key={log.id}
                 log={log}
-                username={log.userId ? (userMap.get(log.userId) ?? log.userId) : "—"}
+                username={log.origin === "channel"
+                  ? (log.senderId ?? "—")
+                  : (log.userId ? (userMap.get(log.userId) ?? log.userId) : "—")}
                 expanded={expandedId === log.id}
                 onToggle={() => toggleExpand(log.id)}
               />

--- a/portal-web/src/components/metrics/SenderCombobox.tsx
+++ b/portal-web/src/components/metrics/SenderCombobox.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { ChevronDown } from "lucide-react"
+import type { ChannelSender } from "../../hooks/useMetrics"
+
+/** Compact "last seen" — relative for recent, short date beyond a day. */
+function relTime(iso: string): string {
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t)) return ""
+  const s = Math.max(0, Math.floor((Date.now() - t) / 1000))
+  if (s < 60) return "just now"
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return new Date(iso).toLocaleDateString([], { month: "short", day: "numeric" })
+}
+
+/**
+ * Channel sender picker — a combobox that is BOTH a dropdown and a free input:
+ * click the caret (or focus) to see every sender seen in the window (open_id /
+ * staffId, ordered by recency, with message/session counts + last-seen), type
+ * to filter, or paste an id directly. Raw ids are opaque, so the counts +
+ * last-seen are what make the list recognizable.
+ */
+export function SenderCombobox({
+  value,
+  onChange,
+  senders,
+}: {
+  value: string
+  onChange: (v: string) => void
+  senders: ChannelSender[]
+}) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("mousedown", onDoc)
+    return () => document.removeEventListener("mousedown", onDoc)
+  }, [open])
+
+  const q = value.trim().toLowerCase()
+  const filtered = useMemo(
+    () => (q ? senders.filter((s) => s.senderId.toLowerCase().includes(q)) : senders),
+    [senders, q],
+  )
+
+  return (
+    <div ref={ref} className="relative">
+      <div className="flex items-center h-8 w-56 rounded-md bg-secondary border border-border focus-within:border-blue-500">
+        <input
+          value={value}
+          onChange={(e) => { onChange(e.target.value); setOpen(true) }}
+          onFocus={() => setOpen(true)}
+          placeholder="open_id / staff id"
+          className="flex-1 min-w-0 h-full px-2 text-[12px] bg-transparent text-foreground font-mono placeholder:font-sans focus:outline-none"
+        />
+        {value && (
+          <button
+            onClick={() => { onChange(""); setOpen(false) }}
+            title="Clear"
+            className="px-1 text-muted-foreground hover:text-foreground text-[13px] leading-none"
+          >×</button>
+        )}
+        <button
+          onClick={() => setOpen((o) => !o)}
+          title="Toggle sender list"
+          className="px-1.5 h-full text-muted-foreground hover:text-foreground"
+        >
+          <ChevronDown className={`h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`} />
+        </button>
+      </div>
+      {open && (
+        <div className="absolute z-20 mt-1 w-72 max-h-72 overflow-y-auto rounded-md border border-border bg-card shadow-lg">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-2 text-[12px] text-muted-foreground">No senders in this window</div>
+          ) : (
+            filtered.map((s) => (
+              <button
+                key={s.senderId}
+                onClick={() => { onChange(s.senderId); setOpen(false) }}
+                className={`block w-full text-left px-3 py-1.5 hover:bg-secondary ${s.senderId === value ? "bg-secondary/60" : ""}`}
+              >
+                <div className="font-mono text-[12px] text-foreground truncate">{s.senderId}</div>
+                <div className="text-[11px] text-muted-foreground">
+                  {s.messageCount} msgs · {s.sessionCount} sessions · {relTime(s.lastSeen)}
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/portal-web/src/components/metrics/SessionTable.tsx
+++ b/portal-web/src/components/metrics/SessionTable.tsx
@@ -28,11 +28,15 @@ const DEFAULT_VISIBLE_SESSIONS = 5
 
 export function SessionTable({
   userFilterId,
+  channelFilterId,
+  senderFilterId,
   usernameHint,
   entry,
   timeRange,
 }: {
   userFilterId: string | null
+  channelFilterId: string | null
+  senderFilterId: string | null
   usernameHint: string | null
   entry: EntryMode
   timeRange: TimeRange
@@ -66,11 +70,13 @@ export function SessionTable({
     return {
       userId: userFilterId ?? undefined,
       agentId: agentId || undefined,
+      channelId: channelFilterId ?? undefined,
+      senderExternalId: senderFilterId ?? undefined,
       from: String(fromMs),
       to: String(toMs),
       entry,
     }
-  }, [agentId, timeRange.from, timeRange.to, userFilterId, entry])
+  }, [agentId, timeRange.from, timeRange.to, userFilterId, channelFilterId, senderFilterId, entry])
 
   const { sessions, hasMore, loading, loadMore } = useSessions(params)
 
@@ -125,7 +131,9 @@ export function SessionTable({
     })
 
   const openSession = (s: SessionListItem) => setSnapshotId(s.sessionId)
-  const usernameFor = (s: SessionListItem) => (s.userId ? userMap.get(s.userId) ?? s.userId : "—")
+  // Channel rows: the actor is the sender (open_id); other origins: the owner.
+  const usernameFor = (s: SessionListItem) =>
+    s.origin === "channel" ? (s.senderId ?? "—") : (s.userId ? userMap.get(s.userId) ?? s.userId : "—")
 
   return (
     <section className="px-6 py-6 space-y-4">

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -64,6 +64,9 @@ export interface AuditLog {
   id: string
   sessionId: string
   userId: string | null
+  // Channel (Lark/DingTalk) sender id (open_id / staffId); null for web/api/a2a.
+  // The actor to display is senderId for channel rows, else userId.
+  senderId: string | null
   agentId: string | null
   agentName: string | null
   toolName: string | null
@@ -102,6 +105,11 @@ export interface TimingStats {
 export interface SessionListItem {
   sessionId: string
   userId: string | null
+  /** Channel (Lark/DingTalk) sender id (open_id / staffId); null for web/api/a2a.
+   *  Display the sender for channel rows, the owner userId otherwise. */
+  senderId: string | null
+  /** For channel sessions: which channel the session belongs to (else null). */
+  channelId: string | null
   agentId: string
   agentName: string | null
   agentGroupName: string | null  // siclaw has no agent groups → always null
@@ -300,6 +308,10 @@ interface AuditParams {
   userId?: string
   toolName?: string
   outcome?: string
+  /** Channel sub-filter (only meaningful when entry === "channel"). */
+  channelId?: string
+  /** Exact channel sender id (Lark open_id / DingTalk staffId), channel entry only. */
+  senderExternalId?: string
   /** Entry-form axis (overview / web / api / a2a / channel / scheduled). */
   entry?: EntryMode
   /** Absolute window bounds (unix ms as strings), already resolved + frozen by
@@ -331,6 +343,8 @@ export function useAudit(params: AuditParams): {
     if (p.userId) q.set("userId", p.userId)
     if (p.toolName) q.set("toolName", p.toolName)
     if (p.outcome) q.set("outcome", p.outcome)
+    if (p.channelId) q.set("channelId", p.channelId)
+    if (p.senderExternalId) q.set("senderExternalId", p.senderExternalId)
     if (p.entry) q.set("entry", p.entry)
     if (p.from) q.set("from", p.from)
     if (p.to) q.set("to", p.to)
@@ -359,7 +373,7 @@ export function useAudit(params: AuditParams): {
     setLogs([])
     doFetch(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params.userId, params.toolName, params.outcome, params.entry, params.from, params.to])
+  }, [params.userId, params.toolName, params.outcome, params.channelId, params.senderExternalId, params.entry, params.from, params.to])
 
   return { logs, hasMore, loading, loadMore: () => doFetch(true), refresh: () => doFetch(false) }
 }
@@ -369,6 +383,10 @@ export function useAudit(params: AuditParams): {
 export interface SessionParams {
   userId?: string
   agentId?: string
+  /** Channel sub-filter (only meaningful when entry === "channel"). */
+  channelId?: string
+  /** Exact channel sender id (Lark open_id / DingTalk staffId), channel entry only. */
+  senderExternalId?: string
   entry?: EntryMode
   /** Resolved epoch-ms (as string), frozen by the caller for cursor pagination. */
   from?: string
@@ -396,6 +414,8 @@ export function useSessions(params: SessionParams): {
     const p = paramsRef.current
     if (p.userId) q.set("userId", p.userId)
     if (p.agentId) q.set("agentId", p.agentId)
+    if (p.channelId) q.set("channelId", p.channelId)
+    if (p.senderExternalId) q.set("senderExternalId", p.senderExternalId)
     if (p.entry) q.set("entry", p.entry)
     if (p.from) q.set("from", p.from)
     if (p.to) q.set("to", p.to)
@@ -422,7 +442,7 @@ export function useSessions(params: SessionParams): {
     setSessions([])
     doFetch(false)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params.userId, params.agentId, params.entry, params.from, params.to])
+  }, [params.userId, params.agentId, params.channelId, params.senderExternalId, params.entry, params.from, params.to])
 
   return { sessions, hasMore, loading, loadMore: () => doFetch(true), refresh: () => doFetch(false) }
 }
@@ -511,4 +531,59 @@ export function useUsers(): { users: UserListEntry[]; loading: boolean } {
   }, [])
 
   return { users, loading }
+}
+
+// ── Channels list (reuses the existing /channels admin endpoint) ──
+// Populates the Metrics channel sub-filter (shown for the "channel" entry).
+
+export interface ChannelListEntry { id: string; name: string }
+
+export function useChannels(): { channels: ChannelListEntry[]; loading: boolean } {
+  const [channels, setChannels] = useState<ChannelListEntry[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    api<{ data: Array<{ id: string; name?: string }> }>("/channels")
+      .then((r) => {
+        if (cancelled) return
+        const list = Array.isArray(r.data) ? r.data : []
+        setChannels(list.map((c) => ({ id: c.id, name: c.name || c.id })))
+        setLoading(false)
+      })
+      .catch(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  return { channels, loading }
+}
+
+// ── Channel senders (distinct open_ids / staffIds seen in a window) ──
+// Feeds the Metrics open_id filter combobox so an admin can pin one sender even
+// when they are not linked to a SiCore account.
+
+export interface ChannelSender { senderId: string; sessionCount: number; messageCount: number; lastSeen: string }
+
+export function useChannelSenders(
+  range: TimeRange,
+  channelId: string | null,
+  enabled: boolean,
+): { senders: ChannelSender[]; loading: boolean } {
+  const [senders, setSenders] = useState<ChannelSender[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!enabled) { setSenders([]); return }
+    let cancelled = false
+    setLoading(true)
+    const { fromMs, toMs } = resolveRange(range)
+    const q = new URLSearchParams({ from: String(fromMs), to: String(toMs) })
+    if (channelId) q.set("channelId", channelId)
+    api<{ senders: ChannelSender[] }>(`/siclaw/audit/channel-senders?${q.toString()}`)
+      .then((r) => { if (!cancelled) { setSenders(Array.isArray(r.senders) ? r.senders : []); setLoading(false) } })
+      .catch(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [enabled, channelId, range.from, range.to])
+
+  return { senders, loading }
 }

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react"
 import { Loader2, RefreshCw } from "lucide-react"
-import { useSummary, useTiming, useUsers, rangeLabel, ENTRY_LABELS, DEFAULT_RANGE, type EntryMode, type TimeRange } from "../hooks/useMetrics"
+import { useSummary, useTiming, useUsers, useChannels, useChannelSenders, rangeLabel, ENTRY_LABELS, DEFAULT_RANGE, type EntryMode, type TimeRange } from "../hooks/useMetrics"
 import { KpiCards } from "../components/metrics/KpiCards"
 import { TrendChart } from "../components/metrics/TrendChart"
 import { TimingStatsCard } from "../components/metrics/TimingStatsCard"
@@ -9,6 +9,7 @@ import { SessionTable } from "../components/metrics/SessionTable"
 import { GrafanaFrame } from "../components/metrics/GrafanaFrame"
 import { TimeRangePicker } from "../components/metrics/TimeRangePicker"
 import { EntrySelector } from "../components/metrics/EntrySelector"
+import { SenderCombobox } from "../components/metrics/SenderCombobox"
 
 type TabKey = "dashboard" | "sessions" | "tools" | "grafana"
 
@@ -18,15 +19,27 @@ const TAB_LABEL: Record<TabKey, string> = { dashboard: "Dashboard", sessions: "S
 export function Metrics() {
   const [tab, setTab] = useState<TabKey>("dashboard")
   const [userId, setUserId] = useState<string>("")         // "" = All Users (Sessions/Tools filter only)
+  const [channelId, setChannelId] = useState<string>("")   // "" = All Channels (channel entry only)
+  const [senderId, setSenderId] = useState<string>("")     // exact channel sender open_id/staffId (channel entry only)
   const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_RANGE)
   const [entry, setEntry] = useState<EntryMode>("all")     // entry-form axis, shared across tabs
 
-  const filterUserId = userId || null
+  // The "who" axis is origin-aware. Channel actors are open_ids, NOT portal
+  // users, so the portal-user filter does not apply on the channel entry (it
+  // would match no channel rows) — channel uses the sender (open_id) filter
+  // instead. Only apply the portal-user filter off-channel.
+  const filterUserId = entry === "channel" ? null : (userId || null)
+  // Channel sub-filters only apply to the channel entry; ignored otherwise.
+  const filterChannelId = entry === "channel" ? (channelId || null) : null
+  const filterSenderId = entry === "channel" ? (senderId.trim() || null) : null
   const rLabel = rangeLabel(timeRange)
   const isAudit = tab === "sessions" || tab === "tools"
   const showControls = tab !== "grafana"
 
   const { users } = useUsers()
+  const { channels } = useChannels()
+  // Distinct channel senders seen in the window — feeds the open_id combobox.
+  const { senders } = useChannelSenders(timeRange, filterChannelId, isAudit && entry === "channel")
   // Dashboard is an external-facing showcase: aggregate only, never scoped to
   // an individual — so summary/timing are fetched without a user filter.
   const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(timeRange, null, entry)
@@ -65,9 +78,11 @@ export function Metrics() {
                   <RefreshCw className={`h-3.5 w-3.5 transition-transform duration-500 ${spinning ? "animate-spin" : ""}`} />
                 </button>
               )}
-              {/* User filter — audit tabs only (the Dashboard is an outward-facing
-                  board and does not drill down by user). */}
-              {isAudit && (
+              {/* Portal-user filter — audit tabs, and NOT the channel entry
+                  (channel actors are open_ids, not portal users; channel uses the
+                  sender filter below). The Dashboard is outward-facing and never
+                  drills down by user. */}
+              {isAudit && entry !== "channel" && (
                 <select
                   value={userId}
                   onChange={(e) => setUserId(e.target.value)}
@@ -78,6 +93,26 @@ export function Metrics() {
                     <option key={u.id} value={u.id}>{u.username}</option>
                   ))}
                 </select>
+              )}
+              {/* Channel sub-filter — audit tabs, only when the channel entry is
+                  selected (channelId is meaningless for web/api/a2a). */}
+              {isAudit && entry === "channel" && (
+                <select
+                  value={channelId}
+                  onChange={(e) => setChannelId(e.target.value)}
+                  className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
+                >
+                  <option value="">All Channels</option>
+                  {channels.map((c) => (
+                    <option key={c.id} value={c.id}>{c.name}</option>
+                  ))}
+                </select>
+              )}
+              {/* Channel sender (open_id / staffId) — dropdown + free input:
+                  pick from senders seen in the window (with counts + last-seen)
+                  or type/paste an id. Audit tabs, channel entry only. */}
+              {isAudit && entry === "channel" && (
+                <SenderCombobox value={senderId} onChange={setSenderId} senders={senders} />
               )}
               {/* Entry-form axis + time window — shared by Dashboard/Sessions/Tools. */}
               {showControls && <EntrySelector value={entry} onChange={setEntry} />}
@@ -157,11 +192,11 @@ export function Metrics() {
         )}
 
         {tab === "sessions" && (
-          <SessionTable userFilterId={filterUserId} usernameHint={selectedUsername} entry={entry} timeRange={timeRange} />
+          <SessionTable userFilterId={filterUserId} channelFilterId={filterChannelId} senderFilterId={filterSenderId} usernameHint={entry === "channel" ? null : selectedUsername} entry={entry} timeRange={timeRange} />
         )}
 
         {tab === "tools" && (
-          <AuditTable userFilterId={filterUserId} usernameHint={selectedUsername} entry={entry} timeRange={timeRange} />
+          <AuditTable userFilterId={filterUserId} channelFilterId={filterChannelId} senderFilterId={filterSenderId} usernameHint={entry === "channel" ? null : selectedUsername} entry={entry} timeRange={timeRange} />
         )}
 
         {tab === "grafana" && <GrafanaFrame />}

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -99,7 +99,10 @@ export function Metrics() {
               {isAudit && entry === "channel" && (
                 <select
                   value={channelId}
-                  onChange={(e) => setChannelId(e.target.value)}
+                  // Clear the sender when the channel changes — a sender id is
+                  // scoped to its channel, so a stale pick would filter the new
+                  // channel to an empty set with no visible reason.
+                  onChange={(e) => { setChannelId(e.target.value); setSenderId("") }}
                   className="h-8 px-2 pr-6 text-[12px] rounded-md bg-secondary border border-border text-foreground focus:outline-none focus:border-blue-500"
                 >
                   <option value="">All Channels</option>

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -309,14 +309,17 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
       yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "done." }] } };
     });
 
-    await handleDingTalkMessage(makeDownstream("查一下 pod"), "ch", makeAgentBoxManager("agent-7") as any, undefined, {} as any);
+    await handleDingTalkMessage(makeDownstream("查一下 pod", { senderStaffId: "staff-1" }), "ch", makeAgentBoxManager("agent-7") as any, undefined, {} as any);
 
     // Session row created with origin="channel" (6th arg), owner as user_id.
     expect(ensureChatSessionMock).toHaveBeenCalledTimes(1);
     const ecArgs = ensureChatSessionMock.mock.calls[0];
     expect(ecArgs[1]).toBe("agent-7");     // agentId
-    expect(ecArgs[2]).toBe("owner-1");     // user_id = binding owner
+    expect(ecArgs[2]).toBe("owner-1");     // user_id = binding owner (ownership)
     expect(ecArgs[5]).toBe("channel");     // origin
+    // The channel sender is the raw staff id, the channel is "ch", stamped on the
+    // session. NEVER the owner. siclaw has no SiCore-user concept.
+    expect(ecArgs[7]).toMatchObject({ senderExternalId: "staff-1", channelId: "ch" });
 
     const rows = appendMessageMock.mock.calls.map((c) => c[0] as any);
     expect(rows.find((m) => m.role === "user")?.content).toBe("查一下 pod");

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -325,9 +325,13 @@ export async function handleDingTalkMessage(
   // the binding owner (a real user UUID), mirroring lark. Best-effort: a persist
   // failure must NOT break the reply (DingTalk worked without persistence before).
   const auditable = !!binding.createdBy;
+  // Channel audit actor (NOT runtime identity). The sender's raw DingTalk staff
+  // id is the "same person" key for channel audit; it is stamped on the SESSION
+  // (chat_sessions), never falls back to the binding owner. NULL when absent.
+  const senderExternalId = message.senderStaffId ?? null;
   if (auditable) {
     try {
-      await ensureChatSession(sessionId, agentId, binding.createdBy!, text, text, "channel");
+      await ensureChatSession(sessionId, agentId, binding.createdBy!, text, text, "channel", undefined, { senderExternalId, channelId });
       await appendMessage({
         sessionId,
         role: "user",

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -426,6 +426,8 @@ describe("handleLarkMessage — personal bot p2p", () => {
       "hello personal",
       "hello personal",
       "channel",
+      undefined,
+      expect.objectContaining({ senderExternalId: "ou_user_1" }),
     );
     expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: "session-open-ou1",
@@ -717,6 +719,9 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       {} as any,
     );
 
+    // Record the raw open_id as the channel sender on the SESSION, NEVER the
+    // binding owner. Session row user_id stays the owner ("user-1") for
+    // ownership, but the channel audit actor is the sender_external_id.
     expect(ensureChatSessionMock).toHaveBeenCalledWith(
       "session-fixed",
       "a1",
@@ -724,6 +729,8 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       "检查当前集群",
       "检查当前集群",
       "channel",
+      undefined,
+      expect.objectContaining({ senderExternalId: "ou_user_1", channelId: "lark" }),
     );
     expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: "session-fixed",
@@ -746,6 +753,32 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     });
     expect(promptMock.mock.calls[0][0].text).toContain("<channel-turn>");
     expect(promptMock.mock.calls[0][0].text).toContain("检查当前集群");
+  });
+
+  it("records the raw open_id as the channel sender even for a sicore_user session key", async () => {
+    // siclaw has no SiCore-user concept: regardless of the server-issued session
+    // key, the audit sender is always the raw open_id, stamped on the session.
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionKey: "sicore_user:sender-99",
+      createdBy: "owner-1",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+
+    await handleLarkMessage(
+      makeTextEvent("查一下"),
+      makeLarkClient(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    // Session row still owned by createdBy; the channel sender is the open_id.
+    expect(ensureChatSessionMock).toHaveBeenCalledWith(
+      "session-fixed", "a1", "owner-1", "查一下", "查一下", "channel",
+      undefined, expect.objectContaining({ senderExternalId: "ou_user_1" }),
+    );
   });
 
   it("reuses the same durable session for multiple messages from the same sender in the same group", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -621,6 +621,11 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const agentId = binding.agentId;
   const sessionId = binding.sessionId;
   sessionRegistry.remember(sessionId, binding.createdBy, agentId);
+  // Channel audit actor (NOT runtime identity — that stays `createdBy` via
+  // remember() above). The sender's raw open_id is the "same person" key for
+  // channel audit; it is stamped on the SESSION (chat_sessions), never falls
+  // back to the binding owner. open_id is NULL when the event omits it.
+  const senderExternalId = senderOpenId ?? null;
 
   console.log(`[lark] Message channel=${channelId} chat=${chatId} sender=${senderOpenId ?? "unknown"} → agent=${agentId} session=${sessionId}: "${effectiveText.slice(0, 80)}" images=${imageRefs.length}`);
 
@@ -629,7 +634,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   // session title free of plaintext Signature/AccessKeyId.
   const persistedText = redactImageUrlsInText(effectiveText);
   try {
-    await ensureChatSession(sessionId, agentId, binding.createdBy, persistedText, persistedText, "channel");
+    await ensureChatSession(sessionId, agentId, binding.createdBy, persistedText, persistedText, "channel", undefined, { senderExternalId, channelId });
     await appendMessage({
       sessionId,
       role: "user",

--- a/src/gateway/chat-repo.test.ts
+++ b/src/gateway/chat-repo.test.ts
@@ -95,6 +95,18 @@ describe("ensureChatSession", () => {
 
     expect(fake.calls[0].params.title).toHaveLength(255);
   });
+
+  it("stamps sender_external_id + channel_id when the channel-audit opts provide them", async () => {
+    await ensureChatSession("sid", "agent", "user", "Title", "Preview", "channel", undefined, { senderExternalId: "ou_x", channelId: "lark" });
+    expect(fake.calls[0].params.sender_external_id).toBe("ou_x");
+    expect(fake.calls[0].params.channel_id).toBe("lark");
+  });
+
+  it("omits channel-audit columns when no opts are passed (web/api callers unchanged)", async () => {
+    await ensureChatSession("sid", "agent", "user", "Title", "Preview", "web");
+    expect(fake.calls[0].params.sender_external_id).toBeUndefined();
+    expect(fake.calls[0].params.channel_id).toBeUndefined();
+  });
 });
 
 describe("appendMessage", () => {

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -115,6 +115,7 @@ export async function ensureChatSession(
   sessionId: string, agentId: string, userId: string,
   title?: string, preview?: string, origin?: string,
   lineage?: ChatSessionLineageInput,
+  opts?: { senderExternalId?: string | null; channelId?: string | null },
 ): Promise<void> {
   const payload: Record<string, unknown> = {
     session_id: sessionId, agent_id: agentId, user_id: userId,
@@ -126,6 +127,11 @@ export async function ensureChatSession(
     payload.delegation_id = lineage.delegationId ?? null;
     payload.target_agent_id = lineage.targetAgentId ?? null;
   }
+  // Channel (Lark/DingTalk) audit dimensions: the raw sender id (open_id /
+  // staffId — the "same person" key, never the binding owner) and which channel.
+  // Each gated on != null so web/api/a2a callers leave the payload unchanged.
+  if (opts?.senderExternalId != null) payload.sender_external_id = opts.senderExternalId;
+  if (opts?.channelId != null) payload.channel_id = opts.channelId;
   await getClient().request("chat.ensureSession", payload);
 }
 

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -1006,6 +1006,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
       title?: string; preview?: string; origin?: string;
       parent_session_id?: string | null; parent_agent_id?: string | null;
       delegation_id?: string | null; target_agent_id?: string | null;
+      sender_external_id?: string | null; channel_id?: string | null;
     }>(req);
     const db = getDb();
     // last_active_at omitted: relies on schema DEFAULT CURRENT_TIMESTAMP for
@@ -1014,11 +1015,12 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     const upsert = buildUpsert(
       db,
       "chat_sessions",
-      ["id", "agent_id", "user_id", "title", "preview", "message_count", "origin", "parent_session_id", "parent_agent_id", "delegation_id", "target_agent_id"],
+      ["id", "agent_id", "user_id", "title", "preview", "message_count", "origin", "parent_session_id", "parent_agent_id", "delegation_id", "target_agent_id", "sender_external_id", "channel_id"],
       [body.session_id, body.agent_id, body.user_id,
        normalizeChatSessionTitle(body.title), normalizeChatSessionPreview(body.preview), 0, body.origin || null,
        body.parent_session_id ?? null, body.parent_agent_id ?? null,
-       body.delegation_id ?? null, body.target_agent_id ?? null],
+       body.delegation_id ?? null, body.target_agent_id ?? null,
+       body.sender_external_id ?? null, body.channel_id ?? null],
       ["id"],
       [{ col: "last_active_at", expr: "CURRENT_TIMESTAMP" }],
     );

--- a/src/portal/metrics-entry.test.ts
+++ b/src/portal/metrics-entry.test.ts
@@ -2,10 +2,25 @@ import { describe, it, expect } from "vitest";
 import {
   ENTRY_MODES,
   normalizeEntry,
+  actorUserColumn,
   entrySessionPredicate,
   entryMessagePredicate,
   type EntryMode,
 } from "./metrics-entry.js";
+
+describe("actorUserColumn", () => {
+  it("attributes channel rows to the sender (sender_external_id), else user_id", () => {
+    const expr = actorUserColumn("s");
+    expect(expr).toBe(
+      "CASE WHEN s.origin = 'channel' THEN s.sender_external_id ELSE s.user_id END",
+    );
+  });
+  it("supports an unaliased chat_sessions table", () => {
+    expect(actorUserColumn("")).toBe(
+      "CASE WHEN origin = 'channel' THEN sender_external_id ELSE user_id END",
+    );
+  });
+});
 
 describe("normalizeEntry", () => {
   it("passes through the known entry modes", () => {

--- a/src/portal/metrics-entry.test.ts
+++ b/src/portal/metrics-entry.test.ts
@@ -3,6 +3,7 @@ import {
   ENTRY_MODES,
   normalizeEntry,
   actorUserColumn,
+  channelColExpr,
   entrySessionPredicate,
   entryMessagePredicate,
   type EntryMode,
@@ -18,6 +19,21 @@ describe("actorUserColumn", () => {
   it("supports an unaliased chat_sessions table", () => {
     expect(actorUserColumn("")).toBe(
       "CASE WHEN origin = 'channel' THEN sender_external_id ELSE user_id END",
+    );
+  });
+});
+
+describe("channelColExpr", () => {
+  it("session-level (no parent) → bare aliased column", () => {
+    expect(channelColExpr("channel_id", "s")).toBe("s.channel_id");
+    expect(channelColExpr("sender_external_id", "")).toBe("sender_external_id");
+  });
+  it("message-level (parent alias) → COALESCE child→parent so delegation children inherit", () => {
+    expect(channelColExpr("channel_id", "s", "parent_s")).toBe(
+      "COALESCE(s.channel_id, parent_s.channel_id)",
+    );
+    expect(channelColExpr("sender_external_id", "s", "parent_s")).toBe(
+      "COALESCE(s.sender_external_id, parent_s.sender_external_id)",
     );
   });
 });

--- a/src/portal/metrics-entry.ts
+++ b/src/portal/metrics-entry.ts
@@ -24,6 +24,34 @@
 
 export type EntryMode = "all" | "web" | "api" | "a2a" | "channel" | "scheduled";
 
+/**
+ * SQL expression for the "user" a row is attributed to in the Metrics axis.
+ *
+ * For **channel** sessions the audit actor is the channel sender (the raw
+ * sender id — Lark open_id / DingTalk staffId — which is the "same person" key),
+ * NOT the binding owner. For every other origin it is the session's `user_id`
+ * (web=logged-in, api/a2a=API-key owner). siclaw has no SiCore-user concept, so
+ * no SiCore identity appears here.
+ *
+ * Use this ONLY for the actor-based FILTER and the distinct-actor COUNT — it is
+ * the canonical "who acted" expression. Do NOT project it as the response
+ * `userId` field: row payloads expose `user_id` (always the owner) and
+ * `sender_external_id` separately, so a consumer never has to disambiguate one
+ * overloaded field by `origin`.
+ *
+ * The channel dimension is intentionally NOT scoped here: Lark `open_id` is
+ * per-app unique and DingTalk `staffId` has a distinct shape, so senders never
+ * collide across origins/channels — narrowing to one channel is left to the
+ * explicit `channel_id` filter, not folded into this expression.
+ *
+ * `alias` is the chat_sessions table alias (default "s"); pass "" for an
+ * unaliased `FROM chat_sessions`.
+ */
+export function actorUserColumn(alias = "s"): string {
+  const p = alias ? `${alias}.` : "";
+  return `CASE WHEN ${p}origin = 'channel' THEN ${p}sender_external_id ELSE ${p}user_id END`;
+}
+
 /** The user-selectable entry buckets (excludes the internal "delegation"). */
 export const ENTRY_MODES: readonly EntryMode[] = ["all", "web", "api", "a2a", "channel", "scheduled"];
 

--- a/src/portal/metrics-entry.ts
+++ b/src/portal/metrics-entry.ts
@@ -52,6 +52,26 @@ export function actorUserColumn(alias = "s"): string {
   return `CASE WHEN ${p}origin = 'channel' THEN ${p}sender_external_id ELSE ${p}user_id END`;
 }
 
+/**
+ * SQL column expression for a channel_id / sender_external_id filter, parent-aware.
+ *
+ * `channel_id` and `sender_external_id` are stamped on the PARENT channel
+ * session only. A MESSAGE-LEVEL query that uses {@link entryMessagePredicate}'s
+ * parent join counts a delegation child's rows (origin='delegation', these
+ * columns NULL) under the parent's channel entry — so it MUST filter/project via
+ * `COALESCE(child, parent)`, or those rows vanish the moment a channel/sender
+ * filter is applied. Pass `parentAlias` for such queries. Omit it for
+ * SESSION-LEVEL queries (no parent join; a delegation child is never a channel
+ * session there) — passing it would reference an unjoined alias.
+ *
+ * Centralized so every filter site inherits the same parent-aware form and the
+ * three query endpoints (audit / summary / timing) cannot silently diverge.
+ */
+export function channelColExpr(col: "channel_id" | "sender_external_id", alias = "s", parentAlias?: string): string {
+  const a = alias ? `${alias}.` : "";
+  return parentAlias ? `COALESCE(${a}${col}, ${parentAlias}.${col})` : `${a}${col}`;
+}
+
 /** The user-selectable entry buckets (excludes the internal "delegation"). */
 export const ENTRY_MODES: readonly EntryMode[] = ["all", "web", "api", "a2a", "channel", "scheduled"];
 

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -291,6 +291,8 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     parent_agent_id CHAR(36) DEFAULT NULL,
     delegation_id CHAR(36) DEFAULT NULL,
     target_agent_id CHAR(36) DEFAULT NULL,
+    sender_external_id VARCHAR(128) DEFAULT NULL,
+    channel_id CHAR(36) DEFAULT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     last_active_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL DEFAULT NULL
@@ -563,6 +565,11 @@ export async function runPortalMigrations(): Promise<void> {
   // enforced in app code (validateJumpChain) and acquire-time tolerates dangling refs.
   await safeAlterTable(db, "hosts", "jump_host_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "hosts", "passphrase", "VARCHAR(500) DEFAULT NULL");
+  // Channel (Lark/DingTalk) audit attribution: the actual end-user actor and the
+  // channel, distinct from the binding-owner user_id. Read by the Metrics
+  // "by user" axis (actorUserColumn). Nullable; only set for channel sessions.
+  await safeAlterTable(db, "chat_sessions", "sender_external_id", "VARCHAR(128) DEFAULT NULL");
+  await safeAlterTable(db, "chat_sessions", "channel_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "skill_versions", "labels", "TEXT DEFAULT NULL");
   await safeAlterTable(db, "skill_versions", "files", "MEDIUMTEXT DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "parent_session_id", "CHAR(36) DEFAULT NULL");

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -495,6 +495,23 @@ describe("siclaw-api misc routes", () => {
       expect(sql).toContain("s.origin = 'delegation' AND parent_s.origin = 'api'"); // inheritance
       expect(sql).toContain("LEFT JOIN agents a ON s.agent_id = a.id");             // agentName
     });
+
+    it("channel + sender filters inherit from the parent session (delegation children not dropped)", async () => {
+      query.mockResolvedValueOnce([[], []]);
+      await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/metrics/audit?from=1000&to=2000&entry=channel&channelId=chan-1&senderExternalId=ou_a",
+        method: "GET",
+        headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
+      }));
+      const sql: string = query.mock.calls[0][0];
+      // channel_id / sender_external_id are NULL on a delegation child, so the
+      // filters COALESCE to the parent channel session — else sub-agent tool
+      // rows silently vanish from a channel/sender-filtered view.
+      expect(sql).toContain("COALESCE(s.channel_id, parent_s.channel_id) = ?");
+      expect(sql).toContain("COALESCE(s.sender_external_id, parent_s.sender_external_id) = ?");
+      // projected senderId is parent-aware too, so kept delegation rows show the sender
+      expect(sql).toContain("COALESCE(s.sender_external_id, parent_s.sender_external_id) AS senderId");
+    });
   });
 
   describe("GET /api/v1/siclaw/metrics/timing", () => {

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -535,7 +535,8 @@ describe("siclaw-api misc routes", () => {
     it("returns per-session rows with tool/error counts + agentName, entry-filtered", async () => {
       query.mockResolvedValueOnce([[
         {
-          sessionId: "s1", userId: "u1", agentId: "a1", agentName: "Ops Agent",
+          sessionId: "s1", userId: "owner-1", senderId: "ou_alice", channelId: "chan-1",
+          agentId: "a1", agentName: "Ops Agent",
           title: "t", preview: "p", origin: "channel", messageCount: 8,
           createdAt: new Date(1000), lastActiveAt: new Date(2000),
           toolCallCount: 5, errorToolCallCount: 2,
@@ -553,6 +554,8 @@ describe("siclaw-api misc routes", () => {
       expect(body.sessions[0]).toMatchObject({
         sessionId: "s1", agentName: "Ops Agent", agentGroupName: null,
         origin: "channel", messageCount: 8, toolCallCount: 5, errorToolCallCount: 2,
+        // owner and channel sender are separate fields (not overloaded on userId)
+        userId: "owner-1", senderId: "ou_alice", channelId: "chan-1",
       });
     });
 

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -3044,9 +3044,14 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const conds: string[] = ["m.role = 'tool'", "m.created_at BETWEEN ? AND ?", msg.predicate];
     const params: unknown[] = [from, to];
     // Origin-aware actor: channel rows filter by the actual sender, never owner.
+    // channel_id / sender_external_id live on the PARENT channel session; a
+    // delegation child inherits them via parent_s (COALESCE) so its tool rows —
+    // which the entry predicate already counts under the parent's channel entry —
+    // don't vanish the moment a channel/sender filter is applied. (user_id IS set
+    // on the child, so the actor filter needs no parent fallback.)
     if (query.userId) { conds.push(`${actorUserColumn("s")} = ?`); params.push(query.userId); }
-    if (channelId) { conds.push("s.channel_id = ?"); params.push(channelId); }
-    if (query.senderExternalId) { conds.push("s.sender_external_id = ?"); params.push(query.senderExternalId); }
+    if (channelId) { conds.push("COALESCE(s.channel_id, parent_s.channel_id) = ?"); params.push(channelId); }
+    if (query.senderExternalId) { conds.push("COALESCE(s.sender_external_id, parent_s.sender_external_id) = ?"); params.push(query.senderExternalId); }
     if (query.toolName) { conds.push("m.tool_name = ?"); params.push(query.toolName); }
     if (query.outcome) { conds.push("m.outcome = ?"); params.push(query.outcome); }
     if (query.cursorTs && query.cursorId) {
@@ -3061,7 +3066,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       `SELECT m.id, m.session_id AS sessionId, m.tool_name AS toolName,
               SUBSTR(m.tool_input, 1, 500) AS toolInput,
               m.outcome, m.duration_ms AS durationMs, m.created_at AS timestamp,
-              s.user_id AS userId, s.sender_external_id AS senderId, s.agent_id AS agentId, s.origin AS origin,
+              s.user_id AS userId, COALESCE(s.sender_external_id, parent_s.sender_external_id) AS senderId, s.agent_id AS agentId, s.origin AS origin,
               a.name AS agentName
        FROM chat_messages m
        LEFT JOIN chat_sessions s ON m.session_id = s.id

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -54,7 +54,7 @@ import {
   normalizeChatSessionTitle,
   truncateChatSessionTitle,
 } from "./chat-session-fields.js";
-import { normalizeEntry, entrySessionPredicate, entryMessagePredicate } from "./metrics-entry.js";
+import { normalizeEntry, entrySessionPredicate, entryMessagePredicate, actorUserColumn } from "./metrics-entry.js";
 import { summariseLatency, extractTimingMs } from "./metrics-timing.js";
 
 /** Trace viewer message limit — matches siclaw_main.cron-limits.MAX_TRACE_MESSAGES */
@@ -2853,12 +2853,23 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // Message/tool-level: count a delegation child's rows under its PARENT's
     // entry so sub-agent tool calls stay auditable. msg.join adds the parent LEFT JOIN.
     const msg = entryMessagePredicate(entry);
+    // Channel sub-axis: narrow to one channel (only meaningful for entry=channel).
+    const channelId = entry === "channel" ? (query.channelId || null) : null;
+    // User filter is origin-aware: channel sessions group by the actual sender
+    // (sender_external_id), never the binding owner. The channelId filter is
+    // session-level. Appends to `params` in order.
+    const userChanCond = (alias: string, params: unknown[]): string => {
+      let s = "";
+      if (userFilter) { s += ` AND ${actorUserColumn(alias)} = ?`; params.push(userFilter); }
+      if (channelId) { s += ` AND ${alias ? alias + "." : ""}channel_id = ?`; params.push(channelId); }
+      return s;
+    };
 
     const db = getDb();
 
     const sessionParams: unknown[] = [from, to];
     let totalSessionsSql = `SELECT COUNT(*) AS c FROM chat_sessions WHERE created_at >= ? AND created_at <= ? AND ${tablePred}`;
-    if (userFilter) { totalSessionsSql += " AND user_id = ?"; sessionParams.push(userFilter); }
+    totalSessionsSql += userChanCond("", sessionParams);
     const [sRows] = await db.query(totalSessionsSql, sessionParams) as [Array<{ c: number }>, unknown];
     const totalSessions = Number(sRows[0]?.c ?? 0);
 
@@ -2869,15 +2880,15 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}
         AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
-    if (userFilter) { totalPromptsSql += " AND s.user_id = ?"; pParams.push(userFilter); }
+    totalPromptsSql += userChanCond("s", pParams);
     const [pRows] = await db.query(totalPromptsSql, pParams) as [Array<{ c: number }>, unknown];
     const totalPrompts = Number(pRows[0]?.c ?? 0);
 
     // ── distinctUsers (window) ──
     const duParams: unknown[] = [from, to];
-    let distinctUsersSql = `SELECT COUNT(DISTINCT user_id) AS c FROM chat_sessions
+    let distinctUsersSql = `SELECT COUNT(DISTINCT ${actorUserColumn("")}) AS c FROM chat_sessions
       WHERE created_at >= ? AND created_at <= ? AND ${tablePred}`;
-    if (userFilter) { distinctUsersSql += " AND user_id = ?"; duParams.push(userFilter); }
+    distinctUsersSql += userChanCond("", duParams);
     const [duRows] = await db.query(distinctUsersSql, duParams) as [Array<{ c: number }>, unknown];
     const distinctUsers = Number(duRows[0]?.c ?? 0);
 
@@ -2888,7 +2899,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       ${msg.join}
       WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}`;
-    if (userFilter) { toolCallsSql += " AND s.user_id = ?"; tcParams.push(userFilter); }
+    toolCallsSql += userChanCond("s", tcParams);
     const [tcRows] = await db.query(toolCallsSql, tcParams) as [Array<{ c: number }>, unknown];
     const toolCalls = Number(tcRows[0]?.c ?? 0);
 
@@ -2905,7 +2916,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
         AND m.tool_name IN ('local_script', 'host_script', 'pod_script', 'node_script')
         AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}`;
-    if (userFilter) { skillsSql += " AND s.user_id = ?"; suParams.push(userFilter); }
+    skillsSql += userChanCond("s", suParams);
     skillsSql += " ORDER BY m.created_at DESC LIMIT ?";
     suParams.push(SKILL_ROW_LIMIT + 1);
     const [suRows] = await db.query(skillsSql, suParams) as [Array<{ toolInput: string | null }>, unknown];
@@ -2958,7 +2969,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}
         AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
-    if (userFilter) { dailyPromptsSql += " AND s.user_id = ?"; dpParams.push(userFilter); }
+    dailyPromptsSql += userChanCond("s", dpParams);
     dailyPromptsSql += " GROUP BY DATE(m.created_at)";
 
     const dtParams: unknown[] = [from, to];
@@ -2967,7 +2978,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       ${msg.join}
       WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}`;
-    if (userFilter) { dailyToolsSql += " AND s.user_id = ?"; dtParams.push(userFilter); }
+    dailyToolsSql += userChanCond("s", dtParams);
     dailyToolsSql += " GROUP BY DATE(m.created_at)";
 
     const [dpRes, dtRes] = await Promise.all([
@@ -3029,9 +3040,13 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // entry. `msg.join` adds the parent-session LEFT JOIN.
     const entry = normalizeEntry(query.entry ?? query.source ?? query.origin);
     const msg = entryMessagePredicate(entry);
+    const channelId = entry === "channel" ? (query.channelId || null) : null;
     const conds: string[] = ["m.role = 'tool'", "m.created_at BETWEEN ? AND ?", msg.predicate];
     const params: unknown[] = [from, to];
-    if (query.userId) { conds.push("s.user_id = ?"); params.push(query.userId); }
+    // Origin-aware actor: channel rows filter by the actual sender, never owner.
+    if (query.userId) { conds.push(`${actorUserColumn("s")} = ?`); params.push(query.userId); }
+    if (channelId) { conds.push("s.channel_id = ?"); params.push(channelId); }
+    if (query.senderExternalId) { conds.push("s.sender_external_id = ?"); params.push(query.senderExternalId); }
     if (query.toolName) { conds.push("m.tool_name = ?"); params.push(query.toolName); }
     if (query.outcome) { conds.push("m.outcome = ?"); params.push(query.outcome); }
     if (query.cursorTs && query.cursorId) {
@@ -3046,7 +3061,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       `SELECT m.id, m.session_id AS sessionId, m.tool_name AS toolName,
               SUBSTR(m.tool_input, 1, 500) AS toolInput,
               m.outcome, m.duration_ms AS durationMs, m.created_at AS timestamp,
-              s.user_id AS userId, s.agent_id AS agentId, s.origin AS origin,
+              s.user_id AS userId, s.sender_external_id AS senderId, s.agent_id AS agentId, s.origin AS origin,
               a.name AS agentName
        FROM chat_messages m
        LEFT JOIN chat_sessions s ON m.session_id = s.id
@@ -3060,7 +3075,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
 
     const hasMore = rows.length > limit;
     const logs = rows.slice(0, limit).map((r: any) => ({
-      id: r.id, sessionId: r.sessionId, userId: r.userId, agentId: r.agentId,
+      id: r.id, sessionId: r.sessionId, userId: r.userId, senderId: r.senderId ?? null, agentId: r.agentId,
       agentName: r.agentName ?? null,
       toolName: r.toolName, toolInput: r.toolInput, outcome: r.outcome,
       durationMs: r.durationMs, origin: r.origin ?? null,
@@ -3107,6 +3122,13 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const userFilter = query.userId || null;
     const entry = normalizeEntry(query.entry ?? query.source);
     const msg = entryMessagePredicate(entry); // delegation-inherited (sub-agent tool latency counts)
+    const channelId = entry === "channel" ? (query.channelId || null) : null;
+    const userChanCond = (alias: string, params: unknown[]): string => {
+      let s = "";
+      if (userFilter) { s += ` AND ${actorUserColumn(alias)} = ?`; params.push(userFilter); }
+      if (channelId) { s += ` AND ${alias ? alias + "." : ""}channel_id = ?`; params.push(channelId); }
+      return s;
+    };
     const TIMING_ROW_LIMIT = 50_000;
     const db = getDb();
 
@@ -3117,7 +3139,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       ${msg.join}
       WHERE m.role = 'assistant' AND m.created_at >= ? AND m.created_at <= ?
         AND m.metadata IS NOT NULL AND ${msg.predicate}`;
-    if (userFilter) { aSql += " AND s.user_id = ?"; aParams.push(userFilter); }
+    aSql += userChanCond("s", aParams);
     aSql += " ORDER BY m.created_at DESC LIMIT ?";
     aParams.push(TIMING_ROW_LIMIT + 1);
     const [aRows] = await db.query(aSql, aParams) as [Array<{ metadata: string | null }>, unknown];
@@ -3137,7 +3159,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       ${msg.join}
       WHERE m.role = 'tool' AND m.tool_name IS NOT NULL AND m.duration_ms IS NOT NULL
         AND m.created_at >= ? AND m.created_at <= ? AND ${msg.predicate}`;
-    if (userFilter) { tSql += " AND s.user_id = ?"; tParams.push(userFilter); }
+    tSql += userChanCond("s", tParams);
     tSql += " ORDER BY m.created_at DESC LIMIT ?";
     tParams.push(TIMING_ROW_LIMIT + 1);
     const [tRows] = await db.query(tSql, tParams) as [Array<{ toolName: string; durationMs: number }>, unknown];
@@ -3174,9 +3196,15 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const sPred = entrySessionPredicate(entry, "s");
 
     // Window + ordering by activity (last_active_at, falling back to created_at).
+    const channelId = entry === "channel" ? (query.channelId || null) : null;
     const conds: string[] = ["COALESCE(s.last_active_at, s.created_at) BETWEEN ? AND ?", sPred, "s.deleted_at IS NULL"];
     const params: unknown[] = [from, to];
-    if (query.userId) { conds.push("s.user_id = ?"); params.push(query.userId); }
+    // Origin-aware actor: channel sessions filter by the actual sender, never owner.
+    if (query.userId) { conds.push(`${actorUserColumn("s")} = ?`); params.push(query.userId); }
+    if (channelId) { conds.push("s.channel_id = ?"); params.push(channelId); }
+    // Exact channel sender id (Lark open_id / DingTalk staffId) — lets an admin
+    // pin one sender even when they are NOT linked to a SiCore account.
+    if (query.senderExternalId) { conds.push("s.sender_external_id = ?"); params.push(query.senderExternalId); }
     if (query.agentId) { conds.push("s.agent_id = ?"); params.push(query.agentId); }
     if (query.cursorTs && query.cursorId) {
       const cursorDate = new Date(parseInt(query.cursorTs, 10));
@@ -3187,7 +3215,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
 
     const db = getDb();
     const [rows] = await db.query(
-      `SELECT s.id AS sessionId, s.user_id AS userId, s.agent_id AS agentId, a.name AS agentName,
+      `SELECT s.id AS sessionId, s.user_id AS userId, s.sender_external_id AS senderId, s.channel_id AS channelId, s.agent_id AS agentId, a.name AS agentName,
               s.title AS title, s.preview AS preview, s.origin AS origin, s.message_count AS messageCount,
               s.created_at AS createdAt, s.last_active_at AS lastActiveAt,
               (SELECT COUNT(*) FROM chat_messages cm WHERE cm.session_id = s.id AND cm.role = 'tool') AS toolCallCount,
@@ -3203,7 +3231,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const hasMore = rows.length > limit;
     const toIso = (v: unknown) => (v instanceof Date ? v.toISOString() : (v as string | null));
     const sessions = rows.slice(0, limit).map((r: any) => ({
-      sessionId: r.sessionId, userId: r.userId, agentId: r.agentId, agentName: r.agentName ?? null,
+      sessionId: r.sessionId, userId: r.userId, senderId: r.senderId ?? null, channelId: r.channelId ?? null, agentId: r.agentId, agentName: r.agentName ?? null,
       agentGroupName: null, // siclaw has no agent groups
       title: r.title ?? null, preview: r.preview ?? null,
       origin: r.origin ?? null,
@@ -3217,6 +3245,39 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     }));
 
     sendJson(res, 200, { sessions, hasMore });
+  });
+
+  // GET /api/v1/siclaw/audit/channel-senders — distinct channel sender ids
+  // (Lark open_id / DingTalk staffId) seen in the window, to populate the
+  // Metrics sender filter. Raw ids are opaque, so each carries an occurrence
+  // count + last-seen and the list is ordered by recency — that is what makes
+  // it usable ("the one active 5 min ago with 30 messages"). Admin-only.
+  router.get("/api/v1/siclaw/audit/channel-senders", async (req, res) => {
+    const admin = requireAdmin(req, config.jwtSecret);
+    if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
+    const query = parseQuery(req.url ?? "");
+    const from = parseTs(query.from) ?? new Date(Date.now() - 7 * 86_400_000);
+    const to = parseTs(query.to) ?? new Date();
+    const conds: string[] = ["origin = 'channel'", "sender_external_id IS NOT NULL", "created_at BETWEEN ? AND ?"];
+    const params: unknown[] = [from, to];
+    if (query.channelId) { conds.push("channel_id = ?"); params.push(query.channelId); }
+    const db = getDb();
+    const [rows] = await db.query(
+      `SELECT sender_external_id AS senderId, COUNT(*) AS sessionCount,
+              SUM(message_count) AS messageCount, MAX(last_active_at) AS lastSeen
+       FROM chat_sessions WHERE ${conds.join(" AND ")}
+       GROUP BY sender_external_id
+       ORDER BY lastSeen DESC LIMIT 500`,
+      params,
+    ) as [Array<{ senderId: string; sessionCount: number; messageCount: number | null; lastSeen: string }>, unknown];
+    sendJson(res, 200, {
+      senders: rows.map((r) => ({
+        senderId: r.senderId,
+        sessionCount: Number(r.sessionCount) || 0,
+        messageCount: Number(r.messageCount) || 0,
+        lastSeen: r.lastSeen,
+      })),
+    });
   });
 
   // GET /api/v1/siclaw/audit/sessions/:id/messages — admin-only, READ-ONLY
@@ -3233,7 +3294,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const db = getDb();
 
     const [sRows] = await db.query(
-      `SELECT s.id AS sessionId, s.user_id AS userId, s.agent_id AS agentId, a.name AS agentName,
+      `SELECT s.id AS sessionId, s.user_id AS userId, s.sender_external_id AS senderId, s.channel_id AS channelId, s.agent_id AS agentId, a.name AS agentName,
               s.title AS title, s.preview AS preview, s.origin AS origin, s.message_count AS messageCount,
               s.created_at AS createdAt, s.last_active_at AS lastActiveAt
        FROM chat_sessions s LEFT JOIN agents a ON s.agent_id = a.id
@@ -3265,7 +3326,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
 
     sendJson(res, 200, {
       session: {
-        sessionId: s.sessionId, userId: s.userId, agentId: s.agentId, agentName: s.agentName ?? null,
+        sessionId: s.sessionId, userId: s.userId, senderId: s.senderId ?? null, agentId: s.agentId, agentName: s.agentName ?? null,
         title: s.title ?? null, preview: s.preview ?? null, origin: s.origin ?? null,
         messageCount: Number(s.messageCount ?? 0),
         createdAt: toIso(s.createdAt), lastActiveAt: toIso(s.lastActiveAt),

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -54,7 +54,7 @@ import {
   normalizeChatSessionTitle,
   truncateChatSessionTitle,
 } from "./chat-session-fields.js";
-import { normalizeEntry, entrySessionPredicate, entryMessagePredicate, actorUserColumn } from "./metrics-entry.js";
+import { normalizeEntry, entrySessionPredicate, entryMessagePredicate, actorUserColumn, channelColExpr } from "./metrics-entry.js";
 import { summariseLatency, extractTimingMs } from "./metrics-timing.js";
 
 /** Trace viewer message limit — matches siclaw_main.cron-limits.MAX_TRACE_MESSAGES */
@@ -2856,12 +2856,15 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // Channel sub-axis: narrow to one channel (only meaningful for entry=channel).
     const channelId = entry === "channel" ? (query.channelId || null) : null;
     // User filter is origin-aware: channel sessions group by the actual sender
-    // (sender_external_id), never the binding owner. The channelId filter is
-    // session-level. Appends to `params` in order.
-    const userChanCond = (alias: string, params: unknown[]): string => {
+    // (sender_external_id), never the binding owner. `parentAlias` is passed for
+    // MESSAGE-level queries (which join parent_s and count delegation children
+    // under the parent's channel entry) so the channel filter COALESCEs to the
+    // parent — else those child rows drop; session-level queries omit it.
+    // Appends to `params` in order.
+    const userChanCond = (alias: string, params: unknown[], parentAlias?: string): string => {
       let s = "";
       if (userFilter) { s += ` AND ${actorUserColumn(alias)} = ?`; params.push(userFilter); }
-      if (channelId) { s += ` AND ${alias ? alias + "." : ""}channel_id = ?`; params.push(channelId); }
+      if (channelId) { s += ` AND ${channelColExpr("channel_id", alias, parentAlias)} = ?`; params.push(channelId); }
       return s;
     };
 
@@ -2880,7 +2883,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}
         AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
-    totalPromptsSql += userChanCond("s", pParams);
+    totalPromptsSql += userChanCond("s", pParams, "parent_s");
     const [pRows] = await db.query(totalPromptsSql, pParams) as [Array<{ c: number }>, unknown];
     const totalPrompts = Number(pRows[0]?.c ?? 0);
 
@@ -2899,7 +2902,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       ${msg.join}
       WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}`;
-    toolCallsSql += userChanCond("s", tcParams);
+    toolCallsSql += userChanCond("s", tcParams, "parent_s");
     const [tcRows] = await db.query(toolCallsSql, tcParams) as [Array<{ c: number }>, unknown];
     const toolCalls = Number(tcRows[0]?.c ?? 0);
 
@@ -2916,7 +2919,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
         AND m.tool_name IN ('local_script', 'host_script', 'pod_script', 'node_script')
         AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}`;
-    skillsSql += userChanCond("s", suParams);
+    skillsSql += userChanCond("s", suParams, "parent_s");
     skillsSql += " ORDER BY m.created_at DESC LIMIT ?";
     suParams.push(SKILL_ROW_LIMIT + 1);
     const [suRows] = await db.query(skillsSql, suParams) as [Array<{ toolInput: string | null }>, unknown];
@@ -2969,7 +2972,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       WHERE m.role = 'user' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}
         AND (m.metadata IS NULL OR m.metadata NOT LIKE '%"kind":"delegation_event"%')`;
-    dailyPromptsSql += userChanCond("s", dpParams);
+    dailyPromptsSql += userChanCond("s", dpParams, "parent_s");
     dailyPromptsSql += " GROUP BY DATE(m.created_at)";
 
     const dtParams: unknown[] = [from, to];
@@ -2978,7 +2981,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       ${msg.join}
       WHERE m.role = 'tool' AND m.created_at >= ? AND m.created_at <= ?
         AND ${msg.predicate}`;
-    dailyToolsSql += userChanCond("s", dtParams);
+    dailyToolsSql += userChanCond("s", dtParams, "parent_s");
     dailyToolsSql += " GROUP BY DATE(m.created_at)";
 
     const [dpRes, dtRes] = await Promise.all([
@@ -3050,8 +3053,8 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // don't vanish the moment a channel/sender filter is applied. (user_id IS set
     // on the child, so the actor filter needs no parent fallback.)
     if (query.userId) { conds.push(`${actorUserColumn("s")} = ?`); params.push(query.userId); }
-    if (channelId) { conds.push("COALESCE(s.channel_id, parent_s.channel_id) = ?"); params.push(channelId); }
-    if (query.senderExternalId) { conds.push("COALESCE(s.sender_external_id, parent_s.sender_external_id) = ?"); params.push(query.senderExternalId); }
+    if (channelId) { conds.push(`${channelColExpr("channel_id", "s", "parent_s")} = ?`); params.push(channelId); }
+    if (query.senderExternalId) { conds.push(`${channelColExpr("sender_external_id", "s", "parent_s")} = ?`); params.push(query.senderExternalId); }
     if (query.toolName) { conds.push("m.tool_name = ?"); params.push(query.toolName); }
     if (query.outcome) { conds.push("m.outcome = ?"); params.push(query.outcome); }
     if (query.cursorTs && query.cursorId) {
@@ -3066,7 +3069,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       `SELECT m.id, m.session_id AS sessionId, m.tool_name AS toolName,
               SUBSTR(m.tool_input, 1, 500) AS toolInput,
               m.outcome, m.duration_ms AS durationMs, m.created_at AS timestamp,
-              s.user_id AS userId, COALESCE(s.sender_external_id, parent_s.sender_external_id) AS senderId, s.agent_id AS agentId, s.origin AS origin,
+              s.user_id AS userId, ${channelColExpr("sender_external_id", "s", "parent_s")} AS senderId, s.agent_id AS agentId, s.origin AS origin,
               a.name AS agentName
        FROM chat_messages m
        LEFT JOIN chat_sessions s ON m.session_id = s.id
@@ -3128,10 +3131,13 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const entry = normalizeEntry(query.entry ?? query.source);
     const msg = entryMessagePredicate(entry); // delegation-inherited (sub-agent tool latency counts)
     const channelId = entry === "channel" ? (query.channelId || null) : null;
+    // Both timing queries are MESSAGE-level (parent_s joined, delegation children
+    // counted under the parent's entry), so the channel filter COALESCEs to the
+    // parent — else sub-agent latency rows drop when a channel filter is applied.
     const userChanCond = (alias: string, params: unknown[]): string => {
       let s = "";
       if (userFilter) { s += ` AND ${actorUserColumn(alias)} = ?`; params.push(userFilter); }
-      if (channelId) { s += ` AND ${alias ? alias + "." : ""}channel_id = ?`; params.push(channelId); }
+      if (channelId) { s += ` AND ${channelColExpr("channel_id", alias, "parent_s")} = ?`; params.push(channelId); }
       return s;
     };
     const TIMING_ROW_LIMIT = 50_000;


### PR DESCRIPTION
## Summary

Channel (Lark/DingTalk) sessions are now audited by the **actual sender** —
the siclaw-native `sender_external_id` (Lark `open_id` / DingTalk `staffId`)
scoped to its `channel_id` — never the binding owner. The Metrics admin UI can
filter and group channel Sessions/Tools by **sender + channel**, so an operator
can isolate one person's activity in a shared group bot.

## Why

A channel agent can be used by anyone in a group (open/PAIR-bound), and today
the audit collapses every sender into the binding owner — there was no way to
tell the senders apart. The sender's `open_id` is the stable "same person" key
siclaw already has (it keys per-sender sessions on `open_id:<sender>`).

**Dependency direction (the rule that shaped this):** SiCore depends on siclaw,
never the reverse. So siclaw has **no SiCore-user concept** — an earlier draft of
this branch added `sicore_user_id` / `ResolvedChannelBinding.senderUserId`; those
are all removed here (a reverse dependency). Mapping a Lark account to a SiCore
identity is solved separately on the SiCore side, out of scope for siclaw.

## What changed

- **Schema** (`migrate.ts`): `chat_sessions` carries `sender_external_id` +
  `channel_id`. `chat_messages` carries neither (redundant with its session;
  a channel session is per-sender). No `sicore_user_id` anywhere.
- **Channels** (`lark.ts`, `dingtalk.ts`, `chat-repo.ts`, `adapter.ts`): stamp
  the sender id + channel on the session; never fall back to the owner; NULL when
  the event omits the sender.
- **Metrics** (`metrics-entry.ts`, `siclaw-api.ts`): `actorUserColumn` =
  `CASE channel THEN sender_external_id ELSE user_id`. The channel-senders
  endpoint returns each sender with an occurrence count + last-seen, ordered by
  recency, so the opaque ids are recognizable.
- **Metrics UI** (`Metrics.tsx`, hooks, tables): the "who" axis is origin-aware —
  the portal-user ("All Users") filter shows/applies **only off-channel**; the
  channel entry hides it and uses the **sender (open_id)** filter + a channel
  picker. `web`/`api`/`a2a` attribution is unchanged.

Design doc: `docs/design/2026-06-29-channel-sender-audit-filter.md`.

## Not in scope

- No SiCore identity / account linking (SiCore's own layer).
- No sender display-name resolution (deferred; only worth it if the event already
  carries the name — no extra API/dependency).
- API-key "show-once" hardening is tracked separately.

## Testing

- `npx tsc --noEmit` clean (backend + portal-web).
- Full backend `npm test` green (7648 passed; the only failures are in a stale
  `.claude/worktrees/` copy, unrelated). portal-web vitest green.

## Deploy

Verified on siclaw-inner: `siclaw-portal:v0.2.3-chanuser4` +
`siclaw-runtime:v0.2.3-chanuser3` (runtime code byte-identical to this head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)