### PR TITLE
feat(api-keys): owner-scoped visibility — admins see all, users see own

### DIFF
--- a/src/portal/agent-api.test.ts
+++ b/src/portal/agent-api.test.ts
@@ -704,16 +704,7 @@ describe("registerAgentRoutes", () => {
   // ── API Keys ─────────────────────────────────────────────
   describe("API keys", () => {
     describe("GET /api/v1/siclaw/agents/:id/api-keys", () => {
-      it("requires admin", async () => {
-        const { status } = await runRoute(router, fakeReq({
-          url: "/api/v1/siclaw/agents/a1/api-keys",
-          method: "GET",
-          headers: { authorization: `Bearer ${USER_TOKEN}` },
-        }));
-        expect(status).toBe(403);
-      });
-
-      it("lists keys for admin", async () => {
+      it("admin lists all keys for the agent (no owner filter)", async () => {
         query.mockResolvedValueOnce([[{ id: "k1", name: "test" }], []]);
         const { status, body } = await runRoute(router, fakeReq({
           url: "/api/v1/siclaw/agents/a1/api-keys",
@@ -721,6 +712,23 @@ describe("registerAgentRoutes", () => {
         }));
         expect(status).toBe(200);
         expect(body.data).toHaveLength(1);
+        // admin → filter on agent only
+        expect(query.mock.calls[0][1]).toEqual(["a1"]);
+        expect(query.mock.calls[0][0]).not.toMatch(/created_by = \?/);
+      });
+
+      it("regular user lists only their own keys (created_by filter)", async () => {
+        query.mockResolvedValueOnce([[{ id: "k1", created_by: "u1" }], []]);
+        const { status, body } = await runRoute(router, fakeReq({
+          url: "/api/v1/siclaw/agents/a1/api-keys",
+          method: "GET",
+          headers: { authorization: `Bearer ${USER_TOKEN}` },
+        }));
+        expect(status).toBe(200);
+        expect(body.data).toHaveLength(1);
+        // user → scoped to (agent, self)
+        expect(query.mock.calls[0][0]).toMatch(/created_by = \?/);
+        expect(query.mock.calls[0][1]).toEqual(["a1", "u1"]);
       });
     });
 
@@ -739,6 +747,23 @@ describe("registerAgentRoutes", () => {
         expect(status).toBe(201);
         expect(body.key).toMatch(/^sk-[a-f0-9]+$/);
       });
+
+      it("a regular user may create a key, stamped created_by = caller", async () => {
+        query
+          .mockResolvedValueOnce([undefined, []])
+          .mockResolvedValueOnce([[{ id: "k1", agent_id: "a1", name: "mine" }], []]);
+
+        const { status } = await runRoute(router, fakeReq({
+          url: "/api/v1/siclaw/agents/a1/api-keys",
+          method: "POST",
+          body: { name: "mine" },
+          headers: { authorization: `Bearer ${USER_TOKEN}` },
+        }));
+
+        expect(status).toBe(201);
+        // INSERT args: [id, agentId, name, keyHash, plaintext, keyPrefix, expires, created_by]
+        expect(query.mock.calls[0][1][7]).toBe("u1");
+      });
     });
 
     describe("DELETE /api/v1/siclaw/agents/:id/api-keys/:kid", () => {
@@ -751,9 +776,9 @@ describe("registerAgentRoutes", () => {
         expect(status).toBe(404);
       });
 
-      it("deletes key and its service accounts", async () => {
+      it("admin deletes any key and its service accounts", async () => {
         query
-          .mockResolvedValueOnce([[{ id: "k1" }], []])
+          .mockResolvedValueOnce([[{ id: "k1", created_by: "someone-else" }], []])
           .mockResolvedValueOnce([undefined, []])  // service accounts delete
           .mockResolvedValueOnce([undefined, []]); // key delete
 
@@ -763,6 +788,33 @@ describe("registerAgentRoutes", () => {
         }));
         expect(status).toBe(200);
         expect(body).toEqual({ ok: true });
+      });
+
+      it("a regular user may delete their own key", async () => {
+        query
+          .mockResolvedValueOnce([[{ id: "k1", created_by: "u1" }], []])
+          .mockResolvedValueOnce([undefined, []])
+          .mockResolvedValueOnce([undefined, []]);
+
+        const { status } = await runRoute(router, fakeReq({
+          url: "/api/v1/siclaw/agents/a1/api-keys/k1",
+          method: "DELETE",
+          headers: { authorization: `Bearer ${USER_TOKEN}` },
+        }));
+        expect(status).toBe(200);
+      });
+
+      it("a regular user cannot delete someone else's key (403, no delete issued)", async () => {
+        query.mockResolvedValueOnce([[{ id: "k1", created_by: "admin-1" }], []]);
+
+        const { status } = await runRoute(router, fakeReq({
+          url: "/api/v1/siclaw/agents/a1/api-keys/k1",
+          method: "DELETE",
+          headers: { authorization: `Bearer ${USER_TOKEN}` },
+        }));
+        expect(status).toBe(403);
+        // only the SELECT ran — no DELETE statements
+        expect(query.mock.calls).toHaveLength(1);
       });
     });
   });

--- a/src/portal/agent-api.ts
+++ b/src/portal/agent-api.ts
@@ -573,24 +573,29 @@ export function registerAgentRoutes(
   // API Keys (Portal-owned)
   // ================================================================
 
-  // List API keys
+  // List API keys. Admins see every key for the agent; a regular user sees only
+  // the keys they created (so each user manages their own without seeing others').
   router.get("/api/v1/siclaw/agents/:id/api-keys", async (req, res, params) => {
-    const auth = requireAdmin(req, res, jwtSecret);
-    if (!auth) return;
+    const auth = requireAuth(req, jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Authentication required" }); return; }
 
     const db = getDb();
+    const ownerOnly = auth.role !== "admin";
     const [rows] = await db.query(
       `SELECT id, agent_id, name, key_plain, key_prefix, last_used_at, expires_at, created_by, created_at
-       FROM agent_api_keys WHERE agent_id = ? ORDER BY created_at DESC, id DESC`,
-      [params.id],
+       FROM agent_api_keys WHERE agent_id = ?${ownerOnly ? " AND created_by = ?" : ""}
+       ORDER BY created_at DESC, id DESC`,
+      ownerOnly ? [params.id, auth.userId] : [params.id],
     ) as any;
     sendJson(res, 200, { data: rows });
   });
 
-  // Create API key
+  // Create API key. Any authenticated user may create a key for themselves
+  // (stamped created_by = caller); admins included. Ownership is what scopes
+  // list/delete below.
   router.post("/api/v1/siclaw/agents/:id/api-keys", async (req, res, params) => {
-    const auth = requireAdmin(req, res, jwtSecret);
-    if (!auth) return;
+    const auth = requireAuth(req, jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Authentication required" }); return; }
 
     const body = await parseBody<Record<string, unknown>>(req);
     const id = crypto.randomUUID();
@@ -613,17 +618,22 @@ export function registerAgentRoutes(
     sendJson(res, 201, { ...rows[0], key: plaintext });
   });
 
-  // Delete API key
+  // Delete API key. Admins may delete any key for the agent; a regular user may
+  // delete only keys they created.
   router.delete("/api/v1/siclaw/agents/:id/api-keys/:kid", async (req, res, params) => {
-    const auth = requireAdmin(req, res, jwtSecret);
-    if (!auth) return;
+    const auth = requireAuth(req, jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Authentication required" }); return; }
 
     const db = getDb();
     const [existing] = await db.query(
-      "SELECT id FROM agent_api_keys WHERE id = ? AND agent_id = ?",
+      "SELECT id, created_by FROM agent_api_keys WHERE id = ? AND agent_id = ?",
       [params.kid, params.id],
     ) as any;
     if (existing.length === 0) { sendJson(res, 404, { error: "API key not found" }); return; }
+    if (auth.role !== "admin" && existing[0].created_by !== auth.userId) {
+      sendJson(res, 403, { error: "You can only delete your own API keys" });
+      return;
+    }
 
     await db.query("DELETE FROM api_key_service_accounts WHERE api_key_id = ?", [params.kid]);
     await db.query("DELETE FROM agent_api_keys WHERE id = ?", [params.kid]);


### PR DESCRIPTION
## Summary

API key management was admin-only. This makes it **self-service** while keeping
admin oversight: a regular user can create and manage their own keys; an admin
still sees and controls every key.

## Changes (backend only — `src/portal/agent-api.ts`)

| Endpoint | Before | After |
|---|---|---|
| `GET .../api-keys` | `requireAdmin` → all keys | `requireAuth`; **admin → all** keys for the agent, **regular user → only their own** (`created_by = self`) |
| `POST .../api-keys` | `requireAdmin` | `requireAuth`; key stamped `created_by = caller` |
| `DELETE .../api-keys/:kid` | `requireAdmin` → any | `requireAuth`; **admin → any**, **regular user → only their own** (else `403`, before any DELETE is issued) |

Follows the existing "admin-or-self" pattern (see the password-reset route in
`auth.ts`).

## Not changed

- Auth verification is unaffected — it uses `key_hash`, never `key_plain`.
- `key_plain` stays viewable to its owner (and to admins). **No show-once** in
  this change (deliberate — discussed and deferred).
- No schema / migration / dependency changes.
- No frontend change needed: the API Keys tab is not admin-gated and `/agents`
  is reachable by regular users, so the panel works once the backend allows them.

## Testing

- `npx tsc --noEmit` clean. `agent-api.test.ts` green (47 tests), with new cases:
  admin lists all (no owner filter) / user lists only own (created_by filter) /
  user can create (created_by = caller) / user deletes own (200) / user cannot
  delete another's key (403, no DELETE issued).

🤖 Generated with [Claude Code](https://claude.com/claude-code)