### PR TITLE
fix(agentbox): decouple language-following from memory

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -16,6 +16,7 @@ import type https from "node:https";
 
 const mockConfigState = vi.hoisted(() => ({
   modelRouting: undefined as unknown,
+  memoryEnabled: true,
 }));
 
 // Silence metrics auth side effects.
@@ -53,7 +54,7 @@ vi.mock("../core/config.js", () => ({
     },
     modelRouting: mockConfigState.modelRouting,
   }),
-  isMemoryEnabled: () => true,
+  isMemoryEnabled: () => mockConfigState.memoryEnabled,
 }));
 
 // Make sync-handlers a no-op registry.
@@ -236,6 +237,7 @@ const origEnv = { SICLAW_GATEWAY_URL: process.env.SICLAW_GATEWAY_URL, SICLAW_CER
 
 beforeEach(async () => {
   mockConfigState.modelRouting = undefined;
+  mockConfigState.memoryEnabled = true;
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -328,6 +330,37 @@ describe("http-server — prompt + session lifecycle", () => {
       "Please analyze the attached image.",
       { images: [{ mimeType: "image/png", data: "aW1n" }] },
     );
+  });
+
+  // Regression: language-following must NOT be gated on memory. A memory-off agent
+  // (e.g. the GPU-cloud sales-guide) still needs its reply to follow the user's
+  // language; the `[System: respond in X]` directive is injected regardless of memory.
+  it("POST /api/prompt injects the language directive even when memory is disabled", async () => {
+    mockConfigState.memoryEnabled = false;
+    const session = await sm.getOrCreate("lang-nomem");
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "你好",
+      sessionId: "lang-nomem",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      modelConfig: modelConfigWithInput(["text"]),
+    });
+    expect(r.status).toBe(200);
+    expect(session.brain.prompt.mock.calls[0][0]).toBe("[System: respond in Chinese]\n你好");
+  });
+
+  it("POST /api/prompt leaves English prompts untouched when memory is disabled", async () => {
+    mockConfigState.memoryEnabled = false;
+    const session = await sm.getOrCreate("lang-en-nomem");
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "hello there",
+      sessionId: "lang-en-nomem",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      modelConfig: modelConfigWithInput(["text"]),
+    });
+    expect(r.status).toBe(200);
+    expect(session.brain.prompt.mock.calls[0][0]).toBe("hello there");
   });
 
   it("POST /api/prompt forwards large valid images to brain.prompt", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -12,7 +12,7 @@ import type { TLSSocket } from "node:tls";
 import type { AgentBoxSessionManager } from "./session.js";
 import type { SessionMode } from "../core/types.js";
 import type { AgentMode } from "../core/tool-registry.js";
-import { isMemoryEnabled, loadConfig } from "../core/config.js";
+import { loadConfig } from "../core/config.js";
 import { emitDiagnostic } from "../shared/diagnostic-events.js";
 import { checkMetricsAuth } from "../shared/metrics.js"; // also registers metrics subscriber (side-effect)
 import { GatewayClient } from "./gateway-client.js";
@@ -755,8 +755,15 @@ export function createHttpServer(
     // IMPORTANT: append after DP markers, not prepend before them.
     // Prepending would break marker detection in pi-agent extension input handlers
     // (e.g., [System: respond in Chinese]\n[Deep Investigation]\n... fails startsWith check).
+    //
+    // The directive is injected UNCONDITIONALLY (not gated on memory): following the
+    // user's language is a baseline behaviour every agent needs, independent of whether
+    // it has long-term memory. Only the PROFILE.md persistence below is a memory concern.
+    // (Previously this was accidentally gated on isMemoryEnabled() as a side effect of
+    // "disable memory by default", which left memory-off agents — e.g. the GPU-cloud
+    // sales-guide — with no language enforcement, so they drifted to the model's bias.)
     const detectedLang = detectLanguage(promptText);
-    if (detectedLang !== "English" && isMemoryEnabled()) {
+    if (detectedLang !== "English") {
       // Only two DP markers remain after the refactor: activation and exit.
       const dpMarkers = [DP_ACTIVATION_MARKER, `${DP_EXIT_MARKER}\n`];
       const matchedMarker = dpMarkers.find(m => promptText.startsWith(m));


### PR DESCRIPTION
## Summary

Following the user's input language was accidentally gated on memory, so memory-off agents drifted to the model's default language. This drops the `&& isMemoryEnabled()` guard from the `[System: respond in X]` injection so every agent follows the user's language.

### Problem

The runtime injects its `[System: respond in X]` language directive only when memory is enabled, so **memory-off agents get no language enforcement** and drift to the model's default — e.g. a Chinese-biased model (DeepSeek) answers an English question in Chinese. Surfaced on the GPU-cloud product/sales agent, which is intentionally memory-off (no-PVC, ephemeral).

### Solution

`git blame` points at `5d9a3ed` ("fix(memory): disable siclaw memory by default"), which added `&& isMemoryEnabled()` to the **wrong** block:

```ts
-    if (detectedLang !== "English") {
+    if (detectedLang !== "English" && isMemoryEnabled()) {
```

Following the user's language is a baseline behaviour independent of long-term memory. The block that legitimately depends on memory is the `PROFILE.md` Language persistence below it — and that already no-ops via `fs.existsSync` when there's no memory dir.

- Inject the directive **unconditionally** (drop `&& isMemoryEnabled()`).
- Leave `PROFILE.md` persistence untouched (still effectively memory-scoped via `fs.existsSync`).
- Drop the now-unused `isMemoryEnabled` import in `http-server.ts`.

This is the root-cause fix; a portal-side workaround in `siclaw-gpu-cloud` (re-injecting the directive for memory-off agents) becomes redundant once a runtime image with this change ships.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (199 files, 4035 passed, 2 skipped)
- [x] New regression test: a **memory-off** agent still gets `[System: respond in Chinese]` prepended (guards against re-coupling); companion test asserts English input is left untouched with memory off.

## Architecture Checklist

- [x] **Deployment mode**: No resource sync / skills / filesystem-write changes. Pure in-memory prompt-text adjustment; identical in LocalSpawner and K8sSpawner.
- [x] **Security model**: No new shell execution paths.
- [x] **DB parity**: No schema changes.
- [x] **Tool protocol**: No tool changes.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included