### PR TITLE
fix(agentbox): strip injected language directive from user-message events (live + synced)

### DIFF
--- a/src/agentbox/__tests__/strip-user-directive-event.test.ts
+++ b/src/agentbox/__tests__/strip-user-directive-event.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { stripUserDirectiveFromEvent } from "../http-server.js";
+
+// The injected `[System: respond in X]` directive must not surface in the user
+// message rendered/streamed to consumers. These cover the live brain-event shapes
+// the agentbox forwards via writeEvent.
+
+describe("stripUserDirectiveFromEvent", () => {
+  it("strips the directive from a user message with array content", () => {
+    const out = stripUserDirectiveFromEvent({
+      type: "message_end",
+      message: { role: "user", content: [{ type: "text", text: "[System: respond in Chinese]\n你好" }] },
+    }) as any;
+    expect(out.message.content[0].text).toBe("你好");
+    expect(out.type).toBe("message_end");
+  });
+
+  it("strips the directive from a user message with string content", () => {
+    const out = stripUserDirectiveFromEvent({
+      type: "message_start",
+      message: { role: "user", content: "[System: respond in Chinese]\n你好" },
+    }) as any;
+    expect(out.message.content).toBe("你好");
+  });
+
+  it("preserves a leading Deep-Investigation marker, stripping only the directive", () => {
+    const out = stripUserDirectiveFromEvent({
+      message: { role: "user", content: [{ type: "text", text: "[Deep Investigation]\n[System: respond in Chinese]\n你好" }] },
+    }) as any;
+    expect(out.message.content[0].text).toBe("[Deep Investigation]\n你好");
+  });
+
+  it("leaves assistant / non-user message events untouched", () => {
+    const assistant = { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } };
+    expect(stripUserDirectiveFromEvent(assistant)).toBe(assistant);
+  });
+
+  it("leaves directive-free user messages and non-message events untouched (same reference)", () => {
+    const clean = { message: { role: "user", content: "你好" } };
+    expect(stripUserDirectiveFromEvent(clean)).toBe(clean);
+    const tool = { type: "tool_execution_start", toolName: "bash" };
+    expect(stripUserDirectiveFromEvent(tool)).toBe(tool);
+  });
+});

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -115,7 +115,7 @@ const DP_EXIT_MARKER = "[DP_EXIT]";
 // the gateway is the original text, so this only affects the live render. Strip the
 // directive from the first text block of any user-role message event before it leaves
 // the agentbox; the model already saw it, and consumers see the clean text.
-function stripUserDirectiveFromEvent(event: unknown): unknown {
+export function stripUserDirectiveFromEvent(event: unknown): unknown {
   const e = event as { message?: { role?: string; content?: unknown } } | null;
   const msg = e?.message;
   if (!msg || msg.role !== "user") return event;

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -21,6 +21,7 @@ import { HttpTransport } from "./credential-transport.js";
 import { getSyncHandler, createClusterHandler, createHostHandler, createToolsHandler } from "./sync-handlers.js";
 import { GATEWAY_SYNC_DESCRIPTORS, type AgentBoxSyncHandler, type GatewaySyncType } from "../shared/gateway-sync.js";
 import { detectLanguage } from "../shared/detect-language.js";
+import { stripLanguageDirective } from "../shared/strip-language-directive.js";
 import {
   candidateSupportsPromptMedia,
   clearModelRouteUserSelectionIfDifferent,
@@ -105,6 +106,37 @@ const MAX_BODY_SIZE = MAX_PROMPT_MEDIA_ITEMS * MAX_PROMPT_MEDIA_BASE64_CHARS + 5
 const BODY_TIMEOUT_MS = 30_000; // 30s
 const DP_ACTIVATION_MARKER = "[Deep Investigation]\n";
 const DP_EXIT_MARKER = "[DP_EXIT]";
+
+// We prepend a `[System: respond in X]` language directive to the user's prompt so
+// the model follows the input language. pi-agent records that as the user turn and
+// re-emits it as a `message_start`/`message_end` brain event, which is streamed LIVE
+// to the frontend (and forwarded to portals like sicore as chat.event) — leaking the
+// internal directive into the displayed user bubble. The user message persisted by
+// the gateway is the original text, so this only affects the live render. Strip the
+// directive from the first text block of any user-role message event before it leaves
+// the agentbox; the model already saw it, and consumers see the clean text.
+function stripUserDirectiveFromEvent(event: unknown): unknown {
+  const e = event as { message?: { role?: string; content?: unknown } } | null;
+  const msg = e?.message;
+  if (!msg || msg.role !== "user") return event;
+  const content = msg.content;
+  if (typeof content === "string") {
+    const stripped = stripLanguageDirective(content);
+    return stripped === content ? event : { ...e, message: { ...msg, content: stripped } };
+  }
+  if (Array.isArray(content)) {
+    const idx = content.findIndex((b) => (b as { type?: string })?.type === "text");
+    if (idx < 0) return event;
+    const block = content[idx] as { type: string; text?: unknown };
+    if (typeof block.text !== "string") return event;
+    const stripped = stripLanguageDirective(block.text);
+    if (stripped === block.text) return event;
+    const newContent = content.slice();
+    newContent[idx] = { ...block, text: stripped };
+    return { ...e, message: { ...msg, content: newContent } };
+  }
+  return event;
+}
 const MAX_PROMPT_IMAGES = MAX_PROMPT_MEDIA_ITEMS;
 const MAX_PROMPT_IMAGE_BASE64_CHARS = MAX_PROMPT_MEDIA_BASE64_CHARS;
 const SUPPORTED_PROMPT_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/webp"]);
@@ -992,7 +1024,7 @@ export function createHttpServer(
       if (closed || res.writableEnded) return;
       try {
         sseEventCount++;
-        const data = JSON.stringify(event);
+        const data = JSON.stringify(stripUserDirectiveFromEvent(event));
         res.write(`data: ${data}\n\n`);
       } catch (err) {
         console.warn(`[agentbox-http] SSE write error for session ${sessionId}:`, err);

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -46,6 +46,7 @@ import { loadConfig, getEmbeddingConfig, isMemoryEnabled } from "../core/config.
 import { emitDiagnostic } from "../shared/diagnostic-events.js";
 import { buildRedactionConfigForModelConfig, redactText, type RedactionConfig } from "../shared/output-redactor.js";
 import { detectLanguage } from "../shared/detect-language.js";
+import { stripLanguageDirective } from "../shared/strip-language-directive.js";
 import type {
   DelegationAppendMessagePayload,
   DelegationEventPayload,
@@ -1104,6 +1105,13 @@ export class AgentBoxSessionManager {
   }
 
   private async persistAppendMessage(message: DelegationAppendMessagePayload): Promise<string> {
+    // The brain records the user turn with the agentbox's injected
+    // `[System: respond in X]` language directive. Strip it before syncing the user
+    // message to the portal so it never surfaces in any consumer's chat UI (the
+    // directive already did its job at the model; it's not part of the user's text).
+    if (message.role === "user" && typeof message.content === "string") {
+      message = { ...message, content: stripLanguageDirective(message.content) };
+    }
     const result = await this.persistDelegationEvent({ type: "delegation.append_message", message });
     return result.id ?? "";
   }

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -7,6 +7,7 @@
 
 import type { FrontendWsClient } from "./frontend-ws-client.js";
 import { normalizeChatSessionTitle } from "./chat-session-fields.js";
+import { stripLanguageDirective } from "../shared/strip-language-directive.js";
 
 export interface ChatSessionLineageInput {
   /** Parent chat session for delegated child sessions. Null/undefined for normal top-level chat. */
@@ -137,10 +138,15 @@ export async function ensureChatSession(
  * path in `getMessages` below reverses the transformation.
  */
 export async function appendMessage(msg: AppendMessageInput): Promise<string> {
+  // Defence in depth: never persist the agentbox's injected `[System: respond in X]`
+  // language directive as a user message (it's a model-only control token). The
+  // gateway path already stores the original text, so this is a no-op there, but it
+  // guards any caller that hands us a brain-recorded user turn.
+  const content = msg.role === "user" ? stripLanguageDirective(msg.content) : msg.content;
   const result = await getClient().request("chat.appendMessage", {
     session_id: msg.sessionId,
     role: msg.role,
-    content: msg.content,
+    content,
     tool_name: msg.toolName ?? null,
     tool_input: msg.toolInput ?? null,
     metadata: msg.metadata != null ? JSON.stringify(msg.metadata) : null,

--- a/src/shared/__tests__/strip-language-directive.test.ts
+++ b/src/shared/__tests__/strip-language-directive.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { stripLanguageDirective } from "../strip-language-directive.js";
+
+describe("stripLanguageDirective", () => {
+  it("strips a leading injected directive", () => {
+    expect(stripLanguageDirective("[System: respond in Chinese]\n你好")).toBe("你好");
+    expect(stripLanguageDirective("[System: respond in Japanese]\nこんにちは")).toBe("こんにちは");
+  });
+
+  it("keeps a leading Deep-Investigation marker but strips the directive after it", () => {
+    expect(stripLanguageDirective("[Deep Investigation]\n[System: respond in Chinese]\n你好")).toBe(
+      "[Deep Investigation]\n你好",
+    );
+    expect(stripLanguageDirective("[DP_EXIT]\n[System: respond in Chinese]\n继续")).toBe("[DP_EXIT]\n继续");
+  });
+
+  it("leaves clean / English / directive-free messages untouched", () => {
+    expect(stripLanguageDirective("你好")).toBe("你好");
+    expect(stripLanguageDirective("hello there")).toBe("hello there");
+    expect(stripLanguageDirective("")).toBe("");
+  });
+
+  it("only strips at the start, not a mid-message occurrence the user typed", () => {
+    const typed = "what does [System: respond in Chinese] mean?";
+    expect(stripLanguageDirective(typed)).toBe(typed);
+  });
+
+  it("strips only the directive line, preserving the rest of a multi-line message", () => {
+    expect(stripLanguageDirective("[System: respond in Chinese]\n第一行\n第二行")).toBe("第一行\n第二行");
+  });
+});

--- a/src/shared/strip-language-directive.ts
+++ b/src/shared/strip-language-directive.ts
@@ -1,0 +1,26 @@
+/**
+ * The agentbox prepends a `[System: respond in <Language>]` directive to the user's
+ * prompt text (see agentbox/http-server.ts) so the model follows the user's input
+ * language. That directive is an internal model-control token: it must reach the
+ * model, but it must NEVER be shown or persisted as the user's message.
+ *
+ * The runtime's own gateway persists the original (pre-injection) text, so siclaw's
+ * Web UI is clean. But other portals on the runtime↔portal protocol (e.g. sicore)
+ * receive the user turn via the agentbox→portal append channel, where the brain's
+ * recorded turn carries the injected directive — leaking it into their chat UI.
+ * This strips it at the persistence boundary so every consumer sees the clean text.
+ *
+ * The directive is injected either at the very start of the text, or immediately
+ * after a single leading Deep-Investigation marker line (e.g. `[Deep Investigation]\n`).
+ * We only strip it in those positions so a user who literally types the phrase mid
+ * message isn't mangled.
+ */
+const LEADING_DIRECTIVE_RE = /^(\[[^\]\n]*\]\n)?\[System: respond in [^\]\n]+\]\n/;
+
+export function stripLanguageDirective(text: string): string {
+  if (!text) return text;
+  const m = text.match(LEADING_DIRECTIVE_RE);
+  if (!m) return text;
+  const keep = m[1] ?? ""; // preserve a leading DP marker line if present
+  return keep + text.slice(m[0].length);
+}


### PR DESCRIPTION
## Problem

The agentbox prepends `[System: respond in <Lang>]` to the user's prompt so the model follows the input language (made unconditional in #374). pi-agent records that as the user turn — so the directive surfaces in the displayed **user** message bubble on portals that render the live event stream (observed on sicore: a user bubble showing `[System: respond in Chinese] 你好`).

## Root cause (corrected after live debugging)

This is a **live-render** leak, not a persistence one. Verified against the live sicore DB: every persisted user row is the clean original text — the directive is **never** stored (the gateway persists the pre-injection text). The leak path is:

- pi-agent re-emits the user turn (with the injected directive) as a `message_start`/`message_end` brain event;
- the agentbox forwards every brain event to the frontend via `writeEvent` (and to portals like sicore as `chat.event`);
- the frontend renders that event as the user's message → the directive shows. A page reload clears it, because the DB is clean.

## Fix

- **Primary (`http-server.ts`):** strip the directive from the first text block of any user-role message event in `writeEvent`, before it leaves the agentbox. The model already received the directive; consumers (live + persisted) now see only the clean user text.
- **Defence-in-depth:** also strip user-role content at the two outbound append chokepoints — `session.ts` `persistAppendMessage` (delegation sync) and `gateway/chat-repo.ts` `appendMessage` (chat.appendMessage). These are no-ops on the already-clean persisted path but guard any future code that hands a brain-recorded user turn to persistence.

Shared `stripLanguageDirective` only strips a leading directive (optionally after a single Deep-Investigation marker line), so a user typing the phrase mid-message is untouched. The model still receives the directive — unchanged, covered by the existing `http-server.test.ts` cases.

## Tests / verification

- [x] Unit tests for `stripLanguageDirective`.
- [x] `npx tsc --noEmit`; full `npm test` (4040 passed) on the persistence-strip commit.
- [x] Live DB inspection on `sendong-sicore-test` proving the directive is never persisted (DB clean) — which is what redirected the fix to the live event path.
- [x] Live re-test on `sendong-sicore-test` with the agentbox rebuilt from this branch — confirmed: the injected directive no longer appears in the user bubble.