### PR TITLE
fix(portal-web): stop auto-title writing to the wrong chat session

### DIFF
--- a/portal-web/src/components/AgentChat.tsx
+++ b/portal-web/src/components/AgentChat.tsx
@@ -266,6 +266,13 @@ export function AgentChat({ agentId, selectedSessionId, onSessionChange }: Agent
   useEffect(() => {
     if (!activeSessionId) return
     if (titledSessionRef.current === activeSessionId) return
+    // Guard against the stale-messages race: on a session switch `activeSessionId`
+    // updates synchronously, but `pilot.messages` still holds the PREVIOUS session's
+    // messages until usePilotChat's async history load resolves. Without this check we
+    // would derive a title from the previous session's first message and PUT it onto the
+    // newly-active (often empty) session — producing a session whose title belongs to a
+    // different conversation. Only proceed once the loaded messages match the active session.
+    if (pilot.messagesSessionId !== activeSessionId) return
     const userMsg = pilot.messages.find((m) => m.role === "user")
     const assistantMsg = pilot.messages.find((m) => m.role === "assistant")
     if (!userMsg || !assistantMsg) return
@@ -283,7 +290,7 @@ export function AgentChat({ agentId, selectedSessionId, onSessionChange }: Agent
     api(`/siclaw/agents/${agentId}/chat/sessions/${activeSessionId}`, {
       method: "PUT", body: { title },
     }).catch(() => {})
-  }, [activeSessionId, pilot.messages, sessions, agentId])
+  }, [activeSessionId, pilot.messages, pilot.messagesSessionId, sessions, agentId])
 
   // Close panels on session switch
   useEffect(() => {

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -88,6 +88,11 @@ interface UsePilotChatOptions {
 
 interface UsePilotChatReturn {
   messages: PilotMessage[]
+  /** The session id that `messages` currently belong to. Updated atomically with `messages`
+   *  on every session switch/load, so consumers can tell whether the loaded messages actually
+   *  correspond to the active session (they lag behind `sessionId` during the async history
+   *  load). Guards message-derived writes (e.g. auto-titling) against a stale-messages race. */
+  messagesSessionId: string | null
   streaming: boolean
   streamText: string
   dpActive: boolean
@@ -726,6 +731,11 @@ function hasActiveAsyncDelegationSurface(messages: PilotMessage[]): boolean {
 
 export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePilotChatReturn {
   const [messages, setMessages] = useState<PilotMessage[]>([])
+  // The session id that `messages` currently belong to. Kept in lockstep with every
+  // wholesale `setMessages` in the session-switch effect below so a stale-messages window
+  // (activeSessionId already switched, but the new session's history hasn't loaded yet) is
+  // observable to consumers. Live per-turn appends keep the same session, so they don't touch it.
+  const [messagesSessionId, setMessagesSessionId] = useState<string | null>(sessionId ?? null)
   const [streaming, setStreaming] = useState(false)
   const [streamText, setStreamText] = useState("")
   const [dpActive, setDpActive] = useState(false)
@@ -800,6 +810,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
 
     if (!sessionId) {
       setMessages([])
+      setMessagesSessionId(null)
       setStreaming(false)
       streamingRef.current = false
       recoveredStreamingRef.current = false
@@ -817,6 +828,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
     const cached = messagesCacheRef.current.get(sessionId)
     if (cached?.streaming) {
       setMessages(cached.messages)
+      setMessagesSessionId(sessionId)
       setStreaming(true)
       streamingRef.current = true
       recoveredStreamingRef.current = false
@@ -848,6 +860,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         const { items, pilotMsgs } = await fetchSessionPage1(agentId, sessionId!)
         if (cancelled) return
         setMessages(pilotMsgs)
+        setMessagesSessionId(sessionId!)
         // Restore the context meter from persisted history so it shows on open/
         // refresh — without it the meter stays blank until the next live
         // agent_end. Only set when a snapshot is found: never blank an existing
@@ -875,6 +888,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
         console.error("[usePilotChat] Failed to load messages:", err)
         if (!cancelled) {
           setMessages([])
+          setMessagesSessionId(sessionId!)
           setStreaming(false)
           streamingRef.current = false
           recoveredStreamingRef.current = false
@@ -1913,6 +1927,7 @@ export function usePilotChat({ agentId, sessionId }: UsePilotChatOptions): UsePi
 
   return {
     messages,
+    messagesSessionId,
     streaming,
     streamText,
     dpActive,


### PR DESCRIPTION
## Summary

Fixes a race in the web chat where a newly-created (empty) session gets titled with a *different* conversation's first message, so the Recent Sessions list shows titles that don't match their sessions.

### Problem

`GET /agents/:id/chat/sessions` returns rows like an empty session (`message_count: 0`) whose `title` actually belongs to another, real session. Tracing every backend title-write path shows this row can only be produced by the `PUT /chat/sessions/:sid { title }` rename endpoint (it's the sole path that sets a title without appending a message or bumping `last_active_at`). The only caller that renames using message-derived text is the frontend auto-title effect in `AgentChat.tsx`.

Root cause is a stale-messages race: on a session switch `activeSessionId` updates synchronously, but `pilot.messages` still holds the **previous** session's messages until `usePilotChat`'s async history load resolves. In that window the auto-title effect derives a title from the previous session's first message and `PUT`s it onto the newly-active empty session.

### Solution

Track `messagesSessionId` in lockstep with every wholesale `setMessages` in `usePilotChat` (clear / cache-restore / load success / load error), expose it, and guard the auto-title effect on `pilot.messagesSessionId === activeSessionId`. A title is now only derived once the loaded messages actually belong to the active session — no rendering/UX change, just closes the write-timing gap.

Note: pre-existing mis-titled rows in the DB are not touched by this code fix and need a separate data correction (empty sessions with a non-default title).

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` (portal-web `vitest run`) passes — 18 files, 172 tests
- [x] Manual: create a session with a conversation, then click New Session; the new session no longer inherits the previous session's title

---
_Supersedes #376, which was auto-closed after a force-push that rebased this branch onto `main` to drop unrelated commits._
