### PR TITLE
feat(channels): cache and display the bound group's chat title

### DIFF
--- a/portal-web/src/components/AgentSettings.tsx
+++ b/portal-web/src/components/AgentSettings.tsx
@@ -773,7 +773,7 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
   agentId: string; selectedChannelIds: Set<string>; setSelectedChannelIds: (v: Set<string>) => void
 }) {
   const toast = useToast()
-  const [bindings, setBindings] = useState<{ id: string; channel_id: string; channel_name: string; channel_type: string; route_key: string; route_type: string }[]>([])
+  const [bindings, setBindings] = useState<{ id: string; channel_id: string; channel_name: string; channel_type: string; route_key: string; route_type: string; display_name?: string | null }[]>([])
   const [allChannels, setAllChannels] = useState<{ id: string; name: string; type: string }[]>([])
   const [loading, setLoading] = useState(true)
   const [pairingCode, setPairingCode] = useState<string | null>(null)
@@ -875,8 +875,8 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
             {bindings.map(b => (
               <div key={b.id} className="flex items-center justify-between px-3 py-2 rounded-md border border-border/50">
                 <div>
-                  <p className="text-[12px] font-mono">{b.channel_name || b.channel_id}</p>
-                  <p className="text-[10px] text-muted-foreground">{b.route_type}: {b.route_key}</p>
+                  <p className="text-[12px]">{b.display_name || <span className="font-mono">{b.route_key}</span>}</p>
+                  <p className="text-[10px] text-muted-foreground font-mono">{b.channel_name || b.channel_id} · {b.route_type}: {b.route_key}</p>
                 </div>
                 <button onClick={() => handleUnbind(b.id)} title="Unbind" className="p-1 rounded-md hover:bg-destructive/20 text-muted-foreground hover:text-red-400">
                   <Trash2 className="h-3.5 w-3.5" />

--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -37,6 +37,8 @@ export interface ResolvedChannelBinding {
   sessionKey?: string | null;
   createdBy: string | null;
   routeType: "group" | "user";
+  /** Cached chat title from the platform; null/absent until backfilled. */
+  displayName?: string | null;
 }
 
 /**
@@ -88,12 +90,31 @@ export async function handlePairingCode(
   routeKey: string,
   routeType: "group" | "user",
   frontendClient: FrontendWsClient,
+  routeDisplayName?: string,
 ): Promise<{ success: boolean; agentName?: string; error?: string }> {
   return frontendClient.request("channel.pair", {
     code,
     channel_id: channelId,
     route_key: routeKey,
     route_type: routeType,
+    ...(routeDisplayName ? { route_display_name: routeDisplayName } : {}),
+  });
+}
+
+/**
+ * Push a freshly observed chat title onto the binding (display-only cache).
+ * Best-effort: callers fire-and-forget; a failure just leaves the old name.
+ */
+export async function updateBindingMeta(
+  channelId: string,
+  routeKey: string,
+  displayName: string,
+  frontendClient: FrontendWsClient,
+): Promise<{ success: boolean; error?: string }> {
+  return frontendClient.request("channel.updateBindingMeta", {
+    channel_id: channelId,
+    route_key: routeKey,
+    display_name: displayName,
   });
 }
 

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -38,6 +38,7 @@ const resetBindingSessionMock = vi.fn();
 const resolvePersonalBindingMock = vi.fn();
 const handlePersonalPairingCodeMock = vi.fn();
 const resetPersonalSessionMock = vi.fn();
+const updateBindingMetaMock = vi.fn();
 
 vi.mock("../channel-manager.js", () => ({
   resolveBinding: (...args: unknown[]) => resolveBindingMock(...args),
@@ -46,6 +47,7 @@ vi.mock("../channel-manager.js", () => ({
   resolvePersonalBinding: (...args: unknown[]) => resolvePersonalBindingMock(...args),
   handlePersonalPairingCode: (...args: unknown[]) => handlePersonalPairingCodeMock(...args),
   resetPersonalSession: (...args: unknown[]) => resetPersonalSessionMock(...args),
+  updateBindingMeta: (...args: unknown[]) => updateBindingMetaMock(...args),
   isChannelAccessDenied: (v: unknown) =>
     v !== null && typeof v === "object" && (v as { walled?: unknown }).walled === true,
 }));
@@ -261,7 +263,7 @@ describe("handleLarkMessage — PAIR command", () => {
 
     await handleLarkMessage(data, larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
 
-    expect(handlePairingCodeMock).toHaveBeenCalledWith("ABC123", "lark", "oc_abc123", "group", expect.anything());
+    expect(handlePairingCodeMock).toHaveBeenCalledWith("ABC123", "lark", "oc_abc123", "group", expect.anything(), undefined);
     expect(larkClient.im.message.reply).toHaveBeenCalledWith(expect.objectContaining({
       path: { message_id: "mid-1" },
       data: expect.objectContaining({
@@ -312,8 +314,21 @@ describe("handleLarkMessage — PAIR command", () => {
       },
     );
 
-    expect(handlePairingCodeMock).toHaveBeenCalledWith("ABC123", "lark", "oc_abc123", "group", expect.anything());
+    expect(handlePairingCodeMock).toHaveBeenCalledWith("ABC123", "lark", "oc_abc123", "group", expect.anything(), undefined);
     expect(handlePersonalPairingCodeMock).not.toHaveBeenCalled();
+  });
+
+  it("seeds the binding display name from the fetched group title", async () => {
+    handlePairingCodeMock.mockResolvedValue({ success: true, agentName: "SRE Bot" });
+    const larkClient = makeLarkClient() as any;
+    larkClient.request = vi.fn().mockResolvedValue({ data: { name: " 运维告警群 " } });
+
+    await handleLarkMessage(makeTextEvent("PAIR ABC123"), larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
+
+    expect(larkClient.request).toHaveBeenCalledWith(expect.objectContaining({
+      url: expect.stringContaining("/open-apis/im/v1/chats/oc_abc123"),
+    }));
+    expect(handlePairingCodeMock).toHaveBeenCalledWith("ABC123", "lark", "oc_abc123", "group", expect.anything(), "运维告警群");
   });
 
   it("PAIR success reply is Chinese for zh-CN (feishu domain)", async () => {
@@ -590,6 +605,71 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     expect(text).toContain("https://sicore.example/auth");
     expect(mgr.getOrCreate).not.toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("backfills the binding display name once when the platform reports a new title", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ bindingId: "b-name-1", displayName: null }));
+    promptMock.mockResolvedValue({ sessionId: "remote-1" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    updateBindingMetaMock.mockResolvedValue({ success: true });
+    const larkClient = makeLarkClient() as any;
+    larkClient.request = vi.fn().mockResolvedValue({ data: { name: "新群名" } });
+
+    await handleLarkMessage(makeTextEvent("hello"), larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
+    await new Promise((r) => setImmediate(r)); // detached backfill settles
+    expect(updateBindingMetaMock).toHaveBeenCalledWith("lark", "oc_abc123", "新群名", expect.anything());
+
+    // Once-per-process guard: a second message must not re-hit the platform API.
+    larkClient.request.mockClear();
+    updateBindingMetaMock.mockClear();
+    await handleLarkMessage(makeTextEvent("again"), larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
+    await new Promise((r) => setImmediate(r));
+    expect(larkClient.request).not.toHaveBeenCalled();
+    expect(updateBindingMetaMock).not.toHaveBeenCalled();
+  });
+
+  it("a transient name-fetch failure is retried on a later message (bounded)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ bindingId: "b-name-retry", displayName: null }));
+    promptMock.mockResolvedValue({ sessionId: "remote-1" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    updateBindingMetaMock.mockResolvedValue({ success: true });
+    const larkClient = makeLarkClient() as any;
+    larkClient.request = vi.fn().mockRejectedValueOnce(new Error("rate limited"))
+      .mockResolvedValue({ data: { name: "新群名" } });
+
+    // First message: fetch fails transiently — no update, but the guard must
+    // NOT be poisoned for the rest of the process lifetime.
+    await handleLarkMessage(makeTextEvent("hello"), larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
+    await new Promise((r) => setImmediate(r));
+    expect(updateBindingMetaMock).not.toHaveBeenCalled();
+
+    // Second message: retried and succeeds.
+    await handleLarkMessage(makeTextEvent("again"), larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
+    await new Promise((r) => setImmediate(r));
+    expect(updateBindingMetaMock).toHaveBeenCalledWith("lark", "oc_abc123", "新群名", expect.anything());
+
+    // Third message: success pinned the guard — no further API traffic.
+    larkClient.request.mockClear();
+    await handleLarkMessage(makeTextEvent("third"), larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
+    await new Promise((r) => setImmediate(r));
+    expect(larkClient.request).not.toHaveBeenCalled();
+  });
+
+  it("persistent name-fetch failures stop after the attempt cap", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ bindingId: "b-name-cap", displayName: null }));
+    promptMock.mockResolvedValue({ sessionId: "remote-1" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    updateBindingMetaMock.mockClear(); // mocks persist across tests in this file
+    const larkClient = makeLarkClient() as any;
+    larkClient.request = vi.fn().mockRejectedValue(new Error("down"));
+
+    for (let i = 0; i < 5; i++) {
+      await handleLarkMessage(makeTextEvent(`msg-${i}`), larkClient, "lark", makeAgentBoxManager() as any, undefined, {} as any);
+      await new Promise((r) => setImmediate(r));
+    }
+    // 3 attempts max, not one per message.
+    expect(larkClient.request).toHaveBeenCalledTimes(3);
+    expect(updateBindingMetaMock).not.toHaveBeenCalled();
   });
 
   it("with binding → getOrCreate uses agentId alone, and registers the durable channel session owner", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -16,6 +16,7 @@ import {
   resolvePersonalBinding,
   handlePersonalPairingCode,
   resetPersonalSession,
+  updateBindingMeta,
   isChannelAccessDenied,
   type ResolvedChannelBinding,
   type ChannelAccessDenied,
@@ -265,6 +266,63 @@ function buildLarkSessionKey(senderOpenId: string | null, chatId: string): strin
 }
 
 /**
+ * Fetch the group chat title, best-effort. Only requires the bot to be a
+ * member of the chat (scope im:chat:readonly) — no contacts permission.
+ * Returns null on any failure (missing scope, bot kicked, SDK mock in tests).
+ */
+async function fetchLarkChatName(larkClient: any, chatId: string): Promise<string | null> {
+  try {
+    const resp: any = await larkClient.request({
+      method: "GET",
+      url: `/open-apis/im/v1/chats/${encodeURIComponent(chatId)}`,
+    });
+    const name = resp?.data?.name ?? resp?.name;
+    return typeof name === "string" && name.trim() ? name.trim() : null;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[lark] Could not fetch chat name for chat=${chatId}: ${msg}`);
+    return null;
+  }
+}
+
+// Per-binding refresh attempts this process. A successful refresh pins the
+// counter to the cap (done for this gateway lifetime — renames are picked up
+// after a restart); a transient fetch failure leaves room to retry on later
+// messages, bounded so a persistently-failing API isn't hammered.
+const bindingNameRefreshAttempts = new Map<string, number>();
+const BINDING_NAME_REFRESH_MAX_ATTEMPTS = 3;
+
+/**
+ * Fire-and-forget: refresh the binding's cached chat title when the platform
+ * reports a different (or first) name. Display-only — failures are logged and
+ * never affect message handling.
+ */
+function backfillBindingDisplayName(
+  larkClient: any,
+  channelId: string,
+  chatId: string,
+  binding: ResolvedChannelBinding,
+  frontendClient: FrontendWsClient,
+): void {
+  const attempts = bindingNameRefreshAttempts.get(binding.bindingId) ?? 0;
+  if (attempts >= BINDING_NAME_REFRESH_MAX_ATTEMPTS) return;
+  // Count the attempt up front so concurrent messages can't stampede the API.
+  bindingNameRefreshAttempts.set(binding.bindingId, attempts + 1);
+  void (async () => {
+    const name = await fetchLarkChatName(larkClient, chatId);
+    if (!name) return; // transient failure — later messages may retry up to the cap
+    bindingNameRefreshAttempts.set(binding.bindingId, BINDING_NAME_REFRESH_MAX_ATTEMPTS);
+    if (name === binding.displayName) return;
+    try {
+      await updateBindingMeta(channelId, chatId, name, frontendClient);
+      console.log(`[lark] Binding name refreshed channel=${channelId} chat=${chatId} name="${name}"`);
+    } catch (err) {
+      console.warn(`[lark] Failed to update binding name for chat=${chatId}:`, err);
+    }
+  })();
+}
+
+/**
  * Whether a group message is actually directed at THIS bot.
  *
  * Feishu delivers a group message to an app scoped to "receive @bot messages"
@@ -496,7 +554,9 @@ export async function handleLarkMessage(
   const pairMatch = text.match(/^PAIR\s+([A-Z0-9]{6})$/i);
   if (pairMatch) {
     const code = pairMatch[1].toUpperCase();
-    const result = await handlePairingCode(code, groupChannelId, chatId, "group", frontendClient!);
+    // Seed the binding's display name with the group title (best-effort).
+    const chatName = await fetchLarkChatName(larkClient, chatId);
+    const result = await handlePairingCode(code, groupChannelId, chatId, "group", frontendClient!, chatName ?? undefined);
 
     const replyText = formatPairReply(result, locale);
     await replyToLark(larkClient, messageId, replyText);
@@ -531,6 +591,9 @@ export async function handleLarkMessage(
     // Only reply if the message looks like it's directed at the bot (@mention).
     return;
   }
+
+  // Keep the binding's cached group title fresh (display-only, detached).
+  backfillBindingDisplayName(larkClient, groupChannelId, chatId, binding, frontendClient!);
 
   // Use the SERVER-authoritative session key (not the local open_id default) for
   // both the queue and the queued context, so the two-path contract holds:

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1391,7 +1391,7 @@ describe("channel.resolveBinding", () => {
     const result = await getHandler("channel.resolveBinding")(
       { channel_id: "ch1", route_key: "group-123" }, "a1",
     );
-    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s1", createdBy: "u1", routeType: "group" });
+    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s1", createdBy: "u1", routeType: "group", displayName: null });
   });
 
   it("lazily creates a session for legacy bindings", async () => {
@@ -1406,7 +1406,7 @@ describe("channel.resolveBinding", () => {
     );
 
     expect(query.mock.calls[1][0]).toContain("UPDATE channel_bindings SET session_id");
-    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s-new", createdBy: "u1", routeType: "group" });
+    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s-new", createdBy: "u1", routeType: "group", displayName: null });
   });
 
   it("lazily creates a participant session when session_key is provided", async () => {
@@ -1436,6 +1436,7 @@ describe("channel.resolveBinding", () => {
       sessionKey: "open_id:ou_1",
       createdBy: "u1",
       routeType: "group",
+      displayName: null,
     });
   });
 
@@ -1510,9 +1511,51 @@ describe("channel.pair", () => {
       expect.any(String),
       "group-1",
       "group",
+      null,
       "u1",
     ]);
     expect(query.mock.calls[4][0]).toContain("DELETE FROM channel_binding_sessions");
+  });
+
+  it("seeds display_name from route_display_name", async () => {
+    const query = mockQuery(
+      [{ agent_id: "a1", created_by: "u1" }],
+      [],
+      [],
+      [{ id: "b-new", agent_id: "a1", session_id: "binding-session", route_type: "group", created_by: "u1" }],
+      [],
+      [],
+      [{ name: "My Agent" }],
+    );
+
+    const result = await getHandler("channel.pair")(
+      { code: "ABC123", channel_id: "ch1", route_key: "group-1", route_type: "group", route_display_name: "  运维告警群  " }, "a1",
+    );
+    expect(result.success).toBe(true);
+    expect(query.mock.calls[2][0]).toContain("display_name");
+    expect(query.mock.calls[2][1]).toContain("运维告警群");
+  });
+
+  it("re-pair without a name keeps the existing display_name (not in update set)", async () => {
+    const query = mockQuery(
+      [{ agent_id: "a2", created_by: "u1" }],
+      [{ id: "b-old", agent_id: "a1", session_id: "s-old", route_type: "group", display_name: "运维告警群", created_by: "u1" }],
+      [],
+      [{ id: "b-old", agent_id: "a2", session_id: "s-new", route_type: "group", display_name: "运维告警群", created_by: "u1" }],
+      [],
+      [],
+      [{ name: "Other Agent" }],
+    );
+
+    const result = await getHandler("channel.pair")(
+      { code: "ABC123", channel_id: "ch1", route_key: "group-1", route_type: "group" }, "a1",
+    );
+    expect(result.success).toBe(true);
+    // Upsert SQL: display_name appears in the INSERT column list but must NOT
+    // appear in the ON-conflict UPDATE clause when no name was provided.
+    const upsertSql: string = query.mock.calls[2][0];
+    const updateClause = upsertSql.slice(upsertSql.search(/on (duplicate key update|conflict)/i));
+    expect(updateClause).not.toContain("display_name");
   });
 
   it("returns error for invalid pairing code", async () => {
@@ -1537,6 +1580,53 @@ describe("channel.pair", () => {
     );
     expect(result.success).toBe(false);
     expect(result.error).toContain("Failed to create binding");
+  });
+});
+
+describe("channel.updateBindingMeta", () => {
+  it("updates the cached display name", async () => {
+    const query = mockQuery({ affectedRows: 1 } as any);
+
+    const result = await getHandler("channel.updateBindingMeta")(
+      { channel_id: "ch1", route_key: "group-1", display_name: "运维告警群" }, "a1",
+    );
+    expect(result).toEqual({ success: true });
+    expect(query.mock.calls[0][0]).toContain("UPDATE channel_bindings SET display_name");
+    expect(query.mock.calls[0][1]).toEqual(["运维告警群", "ch1", "group-1"]);
+  });
+
+  it("returns an error when the binding is missing", async () => {
+    mockQuery({ affectedRows: 0 } as any);
+
+    const result = await getHandler("channel.updateBindingMeta")(
+      { channel_id: "ch1", route_key: "group-404", display_name: "x" }, "a1",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
+  });
+
+  it("rejects an empty name without touching the DB", async () => {
+    const query = mockQuery();
+
+    const result = await getHandler("channel.updateBindingMeta")(
+      { channel_id: "ch1", route_key: "group-1", display_name: "   " }, "a1",
+    );
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("truncates at 255 code points without splitting surrogate pairs", async () => {
+    const query = mockQuery({ affectedRows: 1 } as any);
+
+    const result = await getHandler("channel.updateBindingMeta")(
+      { channel_id: "ch1", route_key: "group-1", display_name: "😀".repeat(300) }, "a1",
+    );
+    expect(result).toEqual({ success: true });
+    const stored: string = query.mock.calls[0][1][0];
+    // 255 code points (matches MySQL VARCHAR(255) char semantics),
+    // i.e. 510 UTF-16 units — and the last char is a whole emoji.
+    expect([...stored]).toHaveLength(255);
+    expect(stored.endsWith("😀")).toBe(true);
   });
 });
 
@@ -1741,9 +1831,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 48 handlers", () => {
+  it("registers exactly 49 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(48);
+    expect(handlers.size).toBe(49);
   });
 
   it("all expected handler names are registered", () => {
@@ -1759,6 +1849,7 @@ describe("buildAdapterRpcHandlers", () => {
       "task.update", "task.delete", "task.runRecord", "task.runStart",
       "task.runFinalize", "task.updateMeta", "task.fireNow", "task.notify", "task.prune",
       "channel.list", "channel.resolveBinding", "channel.pair", "channel.resetSession",
+      "channel.updateBindingMeta",
       "channel.resolvePersonalBinding", "channel.pairPersonal", "channel.resetPersonalSession",
       "agent.listForSkill", "agent.listForMcp", "agent.listForCluster", "agent.listForHost",
       "metrics.summary", "metrics.audit", "metrics.auditDetail",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -36,6 +36,7 @@ interface ChannelBindingRow {
   agent_id: string;
   session_id?: string | null;
   route_type?: "group" | "user" | string | null;
+  display_name?: string | null;
   created_by?: string | null;
   channel_created_by?: string | null;
 }
@@ -47,6 +48,8 @@ interface ResolvedChannelBinding {
   sessionKey?: string | null;
   createdBy: string | null;
   routeType: "group" | "user";
+  /** Cached chat title (group name); null until the gateway backfills it. */
+  displayName?: string | null;
 }
 
 function normalizeRouteType(value: unknown): "group" | "user" {
@@ -59,7 +62,7 @@ async function selectChannelBinding(
   routeKey: string,
 ): Promise<ChannelBindingRow | null> {
   const [rows] = await db.query(
-    `SELECT cb.id, cb.agent_id, cb.session_id, cb.route_type, cb.created_by,
+    `SELECT cb.id, cb.agent_id, cb.session_id, cb.route_type, cb.display_name, cb.created_by,
             c.created_by AS channel_created_by
      FROM channel_bindings cb
      LEFT JOIN channels c ON cb.channel_id = c.id
@@ -93,6 +96,7 @@ async function resolveChannelBinding(
     ...(session.sessionKey ? { sessionKey: session.sessionKey } : {}),
     createdBy: row.created_by ?? row.channel_created_by ?? null,
     routeType: normalizeRouteType(row.route_type),
+    displayName: row.display_name ?? null,
   };
 }
 
@@ -161,9 +165,19 @@ function normalizeChannelSessionKey(value: string): string {
   return trimmed;
 }
 
+/** Display-only cache of the chat title; identity stays route_key. Empty → null. */
+function normalizeBindingDisplayName(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  // Cap at 255 code points (not UTF-16 units) — matches MySQL VARCHAR(255)
+  // char semantics; never splits a surrogate pair.
+  return [...trimmed].slice(0, 255).join("");
+}
+
 async function pairChannelBinding(
   db: Db,
-  params: { code: string; channel_id: string; route_key: string; route_type: "group" | "user" },
+  params: { code: string; channel_id: string; route_key: string; route_type: "group" | "user"; route_display_name?: string | null },
 ): Promise<{ success: boolean; agentName?: string; error?: string }> {
   const now = toSqlTimestamp(new Date());
   const [codeRows] = await db.query(
@@ -178,14 +192,19 @@ async function pairChannelBinding(
   const existingBinding = await selectChannelBinding(db, params.channel_id, params.route_key);
   const bindingId = existingBinding?.id ?? crypto.randomUUID();
   const sessionId = crypto.randomUUID();
+  const displayName = normalizeBindingDisplayName(params.route_display_name);
   try {
     const upsert = buildUpsert(
       db,
       "channel_bindings",
-      ["id", "channel_id", "agent_id", "session_id", "route_key", "route_type", "created_by"],
-      [bindingId, params.channel_id, pairingCode.agent_id, sessionId, params.route_key, params.route_type, pairingCode.created_by],
+      ["id", "channel_id", "agent_id", "session_id", "route_key", "route_type", "display_name", "created_by"],
+      [bindingId, params.channel_id, pairingCode.agent_id, sessionId, params.route_key, params.route_type, displayName, pairingCode.created_by],
       ["channel_id", "route_key"],
-      ["agent_id", "session_id", "route_type", "created_by"],
+      // Keep an existing name when a re-pair couldn't fetch one (null) — the
+      // gateway's lazy backfill owns refreshes, PAIR only seeds.
+      displayName
+        ? ["agent_id", "session_id", "route_type", "display_name", "created_by"]
+        : ["agent_id", "session_id", "route_type", "created_by"],
     );
     await db.query(upsert.sql, upsert.params);
     const row = await selectChannelBinding(db, params.channel_id, params.route_key);
@@ -248,6 +267,26 @@ async function resetChannelBindingSession(
     oldSessionId: row.session_id ?? null,
     sessionId,
   };
+}
+
+/**
+ * Update display-only metadata on a binding (currently just the chat title).
+ * Called by the gateway when it observes a fresh name from the platform API.
+ */
+async function updateChannelBindingMeta(
+  db: Db,
+  channelId: string,
+  routeKey: string,
+  displayName: string | null,
+): Promise<{ success: boolean; error?: string }> {
+  const normalized = normalizeBindingDisplayName(displayName);
+  if (!normalized) return { success: false, error: "display_name must not be empty" };
+  const [result] = await db.query(
+    "UPDATE channel_bindings SET display_name = ? WHERE channel_id = ? AND route_key = ?",
+    [normalized, channelId, routeKey],
+  ) as any;
+  if (!result?.affectedRows) return { success: false, error: "Binding not found" };
+  return { success: true };
 }
 
 interface PersonalChannelConfig {
@@ -1530,6 +1569,17 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     sendJson(res, 200, await pairChannelBinding(db, body));
   });
 
+  // POST /api/internal/siclaw/channel/update-binding-meta
+  router.post("/api/internal/siclaw/channel/update-binding-meta", async (req, res) => {
+    if (!requireInternalAuth(req, internalSecret)) {
+      sendJson(res, 401, { error: "Invalid internal token" });
+      return;
+    }
+    const body = await parseBody<{ channel_id: string; route_key: string; display_name: string }>(req);
+    const db = getDb();
+    sendJson(res, 200, await updateChannelBindingMeta(db, body.channel_id, body.route_key, body.display_name));
+  });
+
   // POST /api/internal/siclaw/channel/reset-session
   router.post("/api/internal/siclaw/channel/reset-session", async (req, res) => {
     if (!requireInternalAuth(req, internalSecret)) {
@@ -2663,6 +2713,11 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
   handlers.set("channel.resetSession", async (params) => {
     const db = getDb();
     return resetChannelBindingSession(db, params.channel_id, params.route_key, params.session_key);
+  });
+
+  handlers.set("channel.updateBindingMeta", async (params) => {
+    const db = getDb();
+    return updateChannelBindingMeta(db, params.channel_id, params.route_key, params.display_name);
   });
 
   handlers.set("channel.resolvePersonalBinding", async (params) => {

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -388,6 +388,7 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     session_id CHAR(36) DEFAULT NULL,
     route_key VARCHAR(255) NOT NULL,
     route_type VARCHAR(20) NOT NULL DEFAULT 'group',
+    display_name VARCHAR(255) DEFAULT NULL,
     created_by CHAR(36),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (channel_id, route_key)
@@ -577,6 +578,10 @@ export async function runPortalMigrations(): Promise<void> {
   await safeAlterTable(db, "chat_sessions", "delegation_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "target_agent_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "channel_bindings", "session_id", "CHAR(36) DEFAULT NULL");
+  // Human-readable name of the bound chat (group title / user name), fetched
+  // from the channel platform at PAIR time and lazily refreshed by the gateway.
+  // Display-only cache — identity is always route_key, never this name.
+  await safeAlterTable(db, "channel_bindings", "display_name", "VARCHAR(255) DEFAULT NULL");
   await safeAlterTable(db, "chat_messages", "from_agent_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_messages", "parent_session_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "chat_messages", "delegation_id", "CHAR(36) DEFAULT NULL");


### PR DESCRIPTION
## Summary

Channel bindings currently show only the raw route key (`oc_xxx` chat id), so the Portal bindings list can't tell which Feishu group is which. This PR caches the group's chat title on the binding and shows it in the UI.

- `channel_bindings` gains a **`display_name`** column (display-only cache; identity stays `route_key`, never the name)
- **PAIR seeds the name**: the Lark gateway fetches `GET /im/v1/chats/:chat_id` (only needs `im:chat:readonly`, bot must be in the group) and passes it as `route_display_name` on `channel.pair`; a re-pair that fails to fetch keeps the existing name
- **Lazy backfill for existing bindings**: on a group message, the gateway refreshes the cached title at most once per process per binding via the new `channel.updateBindingMeta` RPC (WS handler + internal HTTP mirror) — also picks up group renames after a gateway restart
- Everything is best-effort: name fetch/update failures are logged and never affect message handling
- Portal Web bindings list shows the group title as the primary line, with channel name + route key as the secondary line

## Compatibility

No deploy-ordering constraint: an old frontend without `channel.updateBindingMeta` just makes the backfill log a warning; an old gateway leaves `display_name` NULL and the UI falls back to `route_key`.

## Tests

- `adapter-rpc.test.ts`: pair seeds/keeps `display_name`, `channel.updateBindingMeta` success/not-found/empty-name, handler count 48→49
- `lark.test.ts`: PAIR passes the fetched title; backfill fires once and honors the once-per-process guard
- `npm test` + `tsc --noEmit` clean (one pre-existing flake in `restricted-bash.test.ts` caused by stale `.claude/worktrees/` copies being collected by vitest — unrelated, fails on clean main too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

