### PR TITLE
feat(kbc): compile-box robustness — model-stall watchdog, rate-limit backoff, graceful shutdown

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -170,6 +170,32 @@ _MODEL_TOOL_IDLE_TIMEOUT_S = float(os.environ.get("KBC_MODEL_TOOL_IDLE_TIMEOUT_S
 _MODEL_MAX_RETRIES = int(os.environ.get("KBC_MODEL_MAX_RETRIES", "3"))
 _MODEL_WATCHDOG_POLL_S = float(os.environ.get("KBC_MODEL_WATCHDOG_POLL_S", "10"))
 
+# ── Rate-limit resilience (C2) ───────────────────────────────────────────────
+# massapi under concurrency (5-10 boxes × the red-blue PK) can return 429/503/529.
+# The bundled CLI retries internally a few times; past that the turn ends with
+# is_error=True and api_error_status set (CLI >= 2.1.110). We back off and re-issue
+# rather than failing the run — massapi's limits are not ours to fix (out of
+# scope), so this is graceful handling, not a fix. Exhaustion ends the turn with a
+# clear owner-facing note instead of a crash.
+_MODEL_RATE_STATUSES = frozenset({429, 503, 529})
+_MODEL_RATE_MAX_RETRIES = int(os.environ.get("KBC_MODEL_RATE_MAX_RETRIES", "5"))
+_MODEL_RATE_BACKOFF_BASE_S = float(os.environ.get("KBC_MODEL_RATE_BACKOFF_BASE_S", "2"))
+_MODEL_RATE_BACKOFF_CAP_S = float(os.environ.get("KBC_MODEL_RATE_BACKOFF_CAP_S", "30"))
+
+# ── Graceful-shutdown flush (F3) ─────────────────────────────────────────────
+# SIGTERM stops the box (pod delete / eviction / OOM after the runtime reap).
+# /work is an emptyDir destroyed with the pod, and work reaches the store only via
+# the periodic sync — so without a shutdown flush the last ≤SYNC_INTERVAL_SECS is
+# lost. on_shutdown final-syncs each active run and gives the relay a bounded
+# window to drain. Best-effort within the grace period (F1 is the durable fix).
+_SHUTDOWN_DRAIN_S = float(os.environ.get("KBC_SHUTDOWN_DRAIN_S", "0.5"))
+_SHUTDOWN_DRAIN_MAX_S = float(os.environ.get("KBC_SHUTDOWN_DRAIN_MAX_S", "8"))
+
+
+def _rate_backoff_delay(attempt: int) -> float:
+    """Exponential backoff (attempt is 1-based), capped."""
+    return min(_MODEL_RATE_BACKOFF_BASE_S * (2 ** (attempt - 1)), _MODEL_RATE_BACKOFF_CAP_S)
+
 
 class ModelStallError(Exception):
     """A turn's model request stalled past the idle bound and exhausted retries.
@@ -231,9 +257,10 @@ class CompileRun:
         self._tool_pending = False          # last assistant msg asked for a tool
         self._last_model_activity = 0.0     # monotonic ts of the last inbound SDK msg / query
         self._last_directive = ""           # the in-flight turn's text, for retry
-        self._model_retries = 0             # retries used on the in-flight turn
+        self._model_retries = 0             # stall retries used on the in-flight turn
         self._stall_retrying = False        # watchdog interrupted; awaiting the interrupted result
-        self._stall_fatal = False           # retries exhausted → fail this turn
+        self._stall_fatal = False           # stall retries exhausted → fail this turn
+        self._rate_retries = 0              # rate-limit (429/503/529) retries on the in-flight turn
 
     async def emit(self, ev: dict):
         await self.events.put(ev)
@@ -247,6 +274,7 @@ class CompileRun:
         self._model_retries = 0
         self._stall_retrying = False
         self._stall_fatal = False
+        self._rate_retries = 0
         self._last_model_activity = time.monotonic()
 
     async def inject_user_message(self, text: str):
@@ -1537,6 +1565,31 @@ async def _consume_turn_stream(run: CompileRun, client, *, stop_on_result: bool)
                 run._last_model_activity = time.monotonic()
                 await client.query(run._last_directive)   # retry on a fresh request
                 continue
+            # C2: a rate-limited / overloaded model call ends the turn with
+            # is_error + api_error_status. Back off and re-issue rather than
+            # surfacing it as a finished turn.
+            status = getattr(msg, "api_error_status", None)
+            if getattr(msg, "is_error", False) and status in _MODEL_RATE_STATUSES:
+                if run._rate_retries < _MODEL_RATE_MAX_RETRIES:
+                    run._rate_retries += 1
+                    delay = _rate_backoff_delay(run._rate_retries)
+                    run._turn_text = []
+                    await run.emit({
+                        "type": "rate_limited",
+                        "status": status,
+                        "attempt": run._rate_retries,
+                        "backoff_s": round(delay, 1),
+                    })
+                    run._last_model_activity = time.monotonic()  # backoff isn't a stall
+                    await asyncio.sleep(delay)
+                    run._last_model_activity = time.monotonic()
+                    await client.query(run._last_directive)
+                    continue
+                await run.emit({
+                    "type": "summary",
+                    "text": f"模型限流(HTTP {status}),退避重试 {run._rate_retries} 次仍未通过,本轮先停,请稍后再开编。",
+                })
+                # fall through: end the turn (run goes idle), do not crash
             run._turn_active = False
             await _emit_message(run, msg)
             if stop_on_result:
@@ -2047,8 +2100,30 @@ async def handle_close_test(request: web.Request):
     return web.json_response({"ok": True})
 
 
+async def _flush_on_shutdown(_app) -> None:
+    """aiohttp on_shutdown (F3): SIGTERM is stopping the box. Emit a final
+    workspace sync for every active run so the last unsynced work reaches the
+    store instead of dying with the emptyDir /work, then give the SSE relay a
+    bounded window to drain the queued events before connections close.
+    Best-effort — a store that never acks still loses it; F1 is the durable fix."""
+    runs = [r for r in RUNS.values() if getattr(r, "_sync_sent", None) is not None]
+    for run in runs:
+        try:
+            n = await _sync_workspace(run, run._sync_sent)
+            if n:
+                await run.emit({"type": "summary", "text": f"[shutdown] 落盘 {n} 个改动文件"})
+        except Exception:
+            pass
+    deadline = time.monotonic() + _SHUTDOWN_DRAIN_MAX_S
+    while runs and time.monotonic() < deadline:
+        if all(run.events.empty() for run in runs):
+            break
+        await asyncio.sleep(_SHUTDOWN_DRAIN_S)
+
+
 def build_app() -> web.Application:
     app = web.Application(client_max_size=_http_max_request_bytes())
+    app.on_shutdown.append(_flush_on_shutdown)
     app.add_routes([
         web.post("/sources", handle_sources),
         web.post("/authoring", handle_authoring),

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -37,6 +37,7 @@ import re
 import shutil
 import tarfile
 import tempfile
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -154,6 +155,28 @@ _COMPILE_IMPL = None  # set at bottom to run_session
 _TEST_SESSION_IMPL = None
 
 
+# ── Model-stall watchdog (L1) ────────────────────────────────────────────────
+# A compile turn can wedge on a black-holed model request (massapi/upstream
+# accepts the connection but never responds). The bundled `claude` CLI's own
+# request timeout is ~60min and not tunable from here, so a routine upstream
+# hiccup froze a run for an hour. We own the recovery: a turn-scoped watchdog
+# reaps a wedged model request in seconds and re-issues the turn.
+#
+# Idle is measured as MODEL-response latency — a pending tool (Read/Bash run in
+# the CLI, not the model) relaxes the bound so a long tool never looks like a
+# stall (invariant I4: never false-kill a live turn).
+_MODEL_IDLE_TIMEOUT_S = float(os.environ.get("KBC_MODEL_IDLE_TIMEOUT_S", "90"))
+_MODEL_TOOL_IDLE_TIMEOUT_S = float(os.environ.get("KBC_MODEL_TOOL_IDLE_TIMEOUT_S", "660"))
+_MODEL_MAX_RETRIES = int(os.environ.get("KBC_MODEL_MAX_RETRIES", "3"))
+_MODEL_WATCHDOG_POLL_S = float(os.environ.get("KBC_MODEL_WATCHDOG_POLL_S", "10"))
+
+
+class ModelStallError(Exception):
+    """A turn's model request stalled past the idle bound and exhausted retries.
+    Raised out of the consume loop so _run_wrapper fails the run with a clear
+    reason instead of the box sitting silently."""
+
+
 class CompileRun:
     def __init__(self, run_id: str, workdir: str, round_: int, instruction: str = ""):
         self.run_id = run_id
@@ -200,15 +223,38 @@ class CompileRun:
         # Layer-2 red-blue PK (S2): the in-flight background task, if any.
         # Single-flight per run; durable state lives in SELFCHECK.json `pk`.
         self._pk_task: asyncio.Task | None = None
+        # Model-stall watchdog (L1) — turn-scoped state, updated by the receive
+        # loop (_consume_turn_stream) and the watchdog task. A turn is "active"
+        # from query() until its real ResultMessage; the watchdog only judges an
+        # active turn, and only against model latency (see _MODEL_* above).
+        self._turn_active = False
+        self._tool_pending = False          # last assistant msg asked for a tool
+        self._last_model_activity = 0.0     # monotonic ts of the last inbound SDK msg / query
+        self._last_directive = ""           # the in-flight turn's text, for retry
+        self._model_retries = 0             # retries used on the in-flight turn
+        self._stall_retrying = False        # watchdog interrupted; awaiting the interrupted result
+        self._stall_fatal = False           # retries exhausted → fail this turn
 
     async def emit(self, ev: dict):
         await self.events.put(ev)
+
+    def _begin_turn(self, directive: str):
+        """Arm the stall watchdog for a new model turn. Called for every turn —
+        the owner's /message AND internal self-check/verify/batch injections."""
+        self._last_directive = directive
+        self._turn_active = True
+        self._tool_pending = False
+        self._model_retries = 0
+        self._stall_retrying = False
+        self._stall_fatal = False
+        self._last_model_activity = time.monotonic()
 
     async def inject_user_message(self, text: str):
         """Engine seam: push a user turn into the live session. The Claude SDK
         driver is one line; a future engine driver (e.g. Codex) reimplements
         just this method — self-check orchestration stays engine-neutral."""
         if self.client:
+            self._begin_turn(text)
             await self.client.query(text)
 
 
@@ -1141,6 +1187,12 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=session_id,
         session_store=InMemorySessionStore(),
+        # Stream partial deltas so the stall watchdog sees fine-grained model
+        # liveness: a live-but-slow generation keeps emitting StreamEvents (idle
+        # clock stays fresh), while a black-holed request emits nothing at all.
+        # _emit_message ignores StreamEvent by name, so the log/turn stream and
+        # the batch driver's ResultMessage detection are unchanged.
+        include_partial_messages=True,
     )
 
 
@@ -1228,11 +1280,9 @@ async def _drive_batch_session(run: "CompileRun", directive: str, label: str) ->
         await client.connect()
         run.client = client
         await run.emit({"type": "log", "text": f"—— {label} 开始 ——"})
+        run._begin_turn(directive)
         await client.query(directive)
-        async for msg in client.receive_messages():
-            await _emit_message(run, msg)
-            if type(msg).__name__ == "ResultMessage":
-                break
+        await _consume_turn_stream(run, client, stop_on_result=True)
         return run._last_turn_reply
     finally:
         run._suppress_turn_done = False
@@ -1331,14 +1381,13 @@ async def _plan_batches(run: "CompileRun", inventory: list) -> dict:
         try:
             await client.connect()
             run.client = client
-            await client.query(
+            directive = (
                 f"预算:每批 effective 总量不超过 {budget}(只按 effective 字段装箱,不看 bytes)。"
                 "读 authoring/SOURCES_INVENTORY.json,写 authoring/BATCH_PLAN.json。"
             )
-            async for msg in client.receive_messages():
-                await _emit_message(run, msg)
-                if type(msg).__name__ == "ResultMessage":
-                    break
+            run._begin_turn(directive)  # planner is a model call too — arm the stall watchdog
+            await client.query(directive)
+            await _consume_turn_stream(run, client, stop_on_result=True)
         finally:
             run._suppress_turn_done = False
             run.client = prev
@@ -1454,6 +1503,82 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
     _maybe_start_pk(run)
 
 
+def _note_model_activity(run: CompileRun, msg) -> None:
+    """Every inbound SDK message (StreamEvent delta, assistant/user turn, result)
+    proves the model link is alive → reset the idle clock. An assistant message
+    that asks for a tool flips tool_pending so the watchdog uses the longer bound
+    while the CLI runs Read/Bash (that gap is not a model stall)."""
+    run._last_model_activity = time.monotonic()
+    if type(msg).__name__ == "AssistantMessage":
+        blocks = getattr(msg, "content", None) or []
+        run._tool_pending = any(type(b).__name__ == "ToolUseBlock" for b in blocks)
+    else:
+        run._tool_pending = False
+
+
+async def _consume_turn_stream(run: CompileRun, client, *, stop_on_result: bool) -> None:
+    """Relay a session's message stream through _emit_message, owning the
+    stall-retry seam. A ResultMessage that the watchdog provoked (via interrupt())
+    is NOT a real turn end: discard it and re-issue the directive (bounded), or
+    raise ModelStallError when retries are spent. A REAL ResultMessage ends the
+    turn — cleared BEFORE _emit_message, which may inject a follow-up turn that
+    re-arms the watchdog. stop_on_result mirrors the batch driver's break."""
+    async for msg in client.receive_messages():
+        _note_model_activity(run, msg)
+        if type(msg).__name__ == "ResultMessage":
+            if run._stall_retrying:
+                run._turn_text = []           # the wedged attempt produced nothing usable
+                run._stall_retrying = False
+                if run._stall_fatal:
+                    run._turn_active = False
+                    raise ModelStallError(
+                        f"model request stalled; exhausted {run._model_retries} attempt(s)"
+                    )
+                run._last_model_activity = time.monotonic()
+                await client.query(run._last_directive)   # retry on a fresh request
+                continue
+            run._turn_active = False
+            await _emit_message(run, msg)
+            if stop_on_result:
+                return
+            continue
+        await _emit_message(run, msg)
+
+
+async def _model_stall_watchdog(run: CompileRun) -> None:
+    """Reap a turn wedged on a black-holed model request. Interrupt the attempt;
+    _consume_turn_stream then re-issues it (or fails). Only judges an ACTIVE turn,
+    and relaxes to the tool bound while a tool is pending — never false-kills a
+    live turn or a long tool (I4)."""
+    while not run.done:
+        await asyncio.sleep(_MODEL_WATCHDOG_POLL_S)
+        if not run._turn_active or run._stall_retrying:
+            continue
+        client = run.client
+        if client is None:
+            continue
+        bound = _MODEL_TOOL_IDLE_TIMEOUT_S if run._tool_pending else _MODEL_IDLE_TIMEOUT_S
+        idle = time.monotonic() - run._last_model_activity
+        if idle <= bound:
+            continue
+        run._stall_fatal = run._model_retries >= _MODEL_MAX_RETRIES
+        run._model_retries += 1
+        run._stall_retrying = True
+        run._last_model_activity = time.monotonic()   # bridge the interrupt→result gap
+        await run.emit({
+            "type": "turn_stalled",
+            "attempt": run._model_retries,
+            "fatal": run._stall_fatal,
+            "idle_s": round(idle, 1),
+        })
+        try:
+            await client.interrupt()
+        except Exception as e:
+            # No interrupted-result will come → don't leave the loop waiting on it.
+            run._stall_retrying = False
+            await run.emit({"type": "summary", "text": f"模型停滞:中断失败,下一轮重试 {e!r}"})
+
+
 async def run_session(run: CompileRun):
     """Persistent driver: host ONE long-lived Claude Code session (ClaudeSDKClient)
     for this KB. BOX_ROLE (+ the playbook + the attempt instruction) is the standing
@@ -1486,8 +1611,7 @@ async def run_session(run: CompileRun):
         # current draft; the owner reviews and publishes separately (deterministic
         # publish, no submit gate). A finished turn is simply finished — no
         # nudging — so a live session can never get stuck "compiling".
-        async for msg in client.receive_messages():
-            await _emit_message(run, msg)
+        await _consume_turn_stream(run, client, stop_on_result=False)
     finally:
         run.connected.set()  # unblock any /message waiters even if connect failed
         run.client = None
@@ -1500,16 +1624,19 @@ async def _run_wrapper(run: CompileRun):
     sent: dict = {}
     run._sync_sent = sent  # shared with _emit_message's pre-turn_done sync
     syncer = asyncio.create_task(_sync_loop(run, sent))
+    watchdog = asyncio.create_task(_model_stall_watchdog(run))
     try:
         await _COMPILE_IMPL(run)
     except Exception as e:  # top-level boundary: surface crashes as an error event, never swallow
         await run.emit({"type": "error", "error": repr(e)})
     finally:
         syncer.cancel()
-        try:
-            await syncer
-        except asyncio.CancelledError:
-            pass
+        watchdog.cancel()
+        for _t in (syncer, watchdog):
+            try:
+                await _t
+            except asyncio.CancelledError:
+                pass
         # Final sync so the last writes are durable even if no tick caught them —
         # especially on the crash path where no bundle was submitted.
         try:

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -948,7 +948,8 @@ class _ToolGapFake:
         pass
 
 
-async def _run_stall_scenario(fake, *, idle, poll, max_retries, tool_idle=660.0):
+async def _run_stall_scenario(fake, *, idle, poll, max_retries, tool_idle=660.0,
+                              rate_base=None, rate_cap=None, rate_max=None):
     """Drive one turn through _consume_turn_stream with the watchdog running, at
     test-tuned knobs (restored after). Returns (run, drained events, raised)."""
     saved = (
@@ -956,11 +957,20 @@ async def _run_stall_scenario(fake, *, idle, poll, max_retries, tool_idle=660.0)
         compile_box._MODEL_TOOL_IDLE_TIMEOUT_S,
         compile_box._MODEL_MAX_RETRIES,
         compile_box._MODEL_WATCHDOG_POLL_S,
+        compile_box._MODEL_RATE_BACKOFF_BASE_S,
+        compile_box._MODEL_RATE_BACKOFF_CAP_S,
+        compile_box._MODEL_RATE_MAX_RETRIES,
     )
     compile_box._MODEL_IDLE_TIMEOUT_S = idle
     compile_box._MODEL_TOOL_IDLE_TIMEOUT_S = tool_idle
     compile_box._MODEL_MAX_RETRIES = max_retries
     compile_box._MODEL_WATCHDOG_POLL_S = poll
+    if rate_base is not None:
+        compile_box._MODEL_RATE_BACKOFF_BASE_S = rate_base
+    if rate_cap is not None:
+        compile_box._MODEL_RATE_BACKOFF_CAP_S = rate_cap
+    if rate_max is not None:
+        compile_box._MODEL_RATE_MAX_RETRIES = rate_max
     raised = None
     with tempfile.TemporaryDirectory() as td:
         run = compile_box.CompileRun("wd", td, 1)
@@ -984,6 +994,9 @@ async def _run_stall_scenario(fake, *, idle, poll, max_retries, tool_idle=660.0)
                 compile_box._MODEL_TOOL_IDLE_TIMEOUT_S,
                 compile_box._MODEL_MAX_RETRIES,
                 compile_box._MODEL_WATCHDOG_POLL_S,
+                compile_box._MODEL_RATE_BACKOFF_BASE_S,
+                compile_box._MODEL_RATE_BACKOFF_CAP_S,
+                compile_box._MODEL_RATE_MAX_RETRIES,
             ) = saved
     return run, _drain(run), raised
 
@@ -1036,6 +1049,108 @@ async def test_model_stall_exhausts_to_error():
     print("✓ model stall: retries exhausted → ModelStallError (fails fast, no hang)")
 
 
+# ── Rate-limit resilience (C2) ───────────────────────────────────────────────
+
+
+class _RateLimitedFakeClient:
+    """Ends each turn with a rate-limit error result until the Nth query, which
+    produces a normal completion. `is_error` + `api_error_status` mirror the CLI's
+    ResultMessage on a 429/503/529 (CLI >= 2.1.110)."""
+
+    def __init__(self, options=None, succeed_on_query=2, status=429):
+        self.options = options
+        self.queries = []
+        self.interrupts = 0
+        self._succeed_on = succeed_on_query
+        self._status = status
+        self._gate = asyncio.Event()
+        self._closed = False
+
+    async def connect(self, prompt=None):
+        pass
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+        self._gate.set()
+
+    async def interrupt(self):
+        self.interrupts += 1
+
+    async def receive_messages(self):
+        while not self._closed:
+            await self._gate.wait()
+            self._gate.clear()
+            if len(self.queries) >= self._succeed_on:
+                yield AssistantMessage("compiled ok")
+                yield ResultMessage()
+                self._closed = True
+                return
+            r = ResultMessage()
+            r.is_error = True
+            r.api_error_status = self._status
+            yield r
+            # loop back and wait for the retry query
+
+    async def disconnect(self):
+        self._closed = True
+
+
+async def test_model_rate_limit_backoff_then_completes():
+    """C2: a 429 error result backs off + re-issues; the retry completes."""
+    fake = _RateLimitedFakeClient(succeed_on_query=2, status=429)
+    run, evs, raised = await _run_stall_scenario(
+        fake, idle=90, poll=0.03, max_retries=3, rate_base=0.01, rate_cap=0.02, rate_max=5)
+    types = [e["type"] for e in evs]
+    assert raised is None, raised
+    assert fake.queries == ["批 1/10", "批 1/10"], fake.queries
+    assert "rate_limited" in types, types
+    assert next(e for e in evs if e["type"] == "rate_limited")["status"] == 429
+    assert run._last_turn_reply == "compiled ok", run._last_turn_reply
+    print("✓ rate limit: 429 backs off + re-issues, then completes (C2)")
+
+
+async def test_model_rate_limit_exhausts_gracefully():
+    """C2: persistent 529 → after the retry budget the turn ends with a clear note
+    (run idle), not a crash."""
+    fake = _RateLimitedFakeClient(succeed_on_query=999, status=529)
+    run, evs, raised = await _run_stall_scenario(
+        fake, idle=90, poll=0.03, max_retries=3, rate_base=0.01, rate_cap=0.02, rate_max=2)
+    types = [e["type"] for e in evs]
+    assert raised is None, raised                       # graceful, not a crash
+    assert types.count("rate_limited") == 2, types      # rate_max retries
+    assert any(e["type"] == "summary" and "限流" in e.get("text", "") for e in evs), evs
+    print("✓ rate limit: exhausted budget ends gracefully with a note, no crash (C2)")
+
+
+# ── Graceful-shutdown flush (F3) ─────────────────────────────────────────────
+
+
+async def test_shutdown_flush_syncs_active_runs():
+    """F3: on_shutdown final-syncs each active run's unsynced workspace so a pod
+    kill (SIGTERM) doesn't lose the last window of on-disk work."""
+    saved = compile_box._SHUTDOWN_DRAIN_MAX_S
+    compile_box._SHUTDOWN_DRAIN_MAX_S = 0.1
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            wd = Path(td)
+            (wd / "candidate").mkdir(parents=True)
+            (wd / "candidate" / "01.md").write_text("# page one\n", "utf-8")
+            run = compile_box.CompileRun("shut1", td, 1)
+            run._sync_sent = {}
+            compile_box.RUNS["shut1"] = run
+            try:
+                await compile_box._flush_on_shutdown(None)
+            finally:
+                compile_box.RUNS.pop("shut1", None)
+            evs = _drain(run)
+            sync = [e for e in evs if e["type"] == "syncArtifacts"]
+            assert sync, evs
+            assert "candidate/01.md" in [a["path"] for a in sync[0]["artifacts"]], sync
+    finally:
+        compile_box._SHUTDOWN_DRAIN_MAX_S = saved
+    print("✓ shutdown flush: final-syncs active runs' unsynced workspace (F3)")
+
+
 async def main():
     # PK never fires in these wiring tests — a qualifying fixture must not spawn
     # a real ClaudeEngine in the background (test_selfcheck covers PK wiring).
@@ -1060,6 +1175,9 @@ async def main():
     await test_model_stall_live_stream_not_reaped()
     await test_model_stall_tool_gap_not_reaped()
     await test_model_stall_exhausts_to_error()
+    await test_model_rate_limit_backoff_then_completes()
+    await test_model_rate_limit_exhausts_gracefully()
+    await test_shutdown_flush_syncs_active_runs()
 
     compile_box._COMPILE_IMPL = fake_driver
     compile_box.RUNS.clear()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -115,6 +115,20 @@ class ResultMessage:
     pass
 
 
+# Stand-ins for the SDK's other message/block types — only the class NAME matters
+# to the watchdog (_note_model_activity dispatches on type(msg).__name__).
+class StreamEvent:  # partial-delta liveness (include_partial_messages)
+    pass
+
+
+class UserMessage:  # tool_result carrier
+    pass
+
+
+class ToolUseBlock:  # a content block that requests a tool
+    pass
+
+
 class _FakeSDKClient:
     """Stands in for ClaudeSDKClient: records connect/query, yields preloaded
     messages then stops (the real client blocks for the next turn)."""
@@ -811,6 +825,217 @@ async def test_batch_orchestrator_routing_and_resume():
     print("\u2713 batch orchestrator: gate/stamps/single turn_done/resume/notes")
 
 
+# ── Model-stall watchdog (L1) ────────────────────────────────────────────────
+
+
+def _drain(run):
+    evs = []
+    while not run.events.empty():
+        evs.append(run.events.get_nowait())
+    return evs
+
+
+class _StallingFakeClient:
+    """Black-holes each attempt (receive blocks on a gate) until the Nth query;
+    interrupt() unblocks with a bare ResultMessage (the interrupted attempt). The
+    Nth query produces a real reply + ResultMessage. `produce_on_query=999` never
+    recovers (exhaustion path)."""
+
+    def __init__(self, options=None, produce_on_query=2):
+        self.options = options
+        self.queries = []
+        self.interrupts = 0
+        self._produce_on = produce_on_query
+        self._gate = asyncio.Event()
+        self._mode = "blackhole"
+        self._closed = False
+
+    async def connect(self, prompt=None):
+        pass
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+        if len(self.queries) >= self._produce_on:
+            self._mode = "produce"
+        else:
+            self._mode = "blackhole"          # no gate → receive blocks (the wedge)
+        if self._mode == "produce":
+            self._gate.set()
+
+    async def interrupt(self):
+        self.interrupts += 1
+        self._mode = "interrupted"
+        self._gate.set()
+
+    async def receive_messages(self):
+        while not self._closed:
+            await self._gate.wait()
+            self._gate.clear()
+            if self._mode == "interrupted":
+                yield ResultMessage()          # the interrupted attempt ends
+            elif self._mode == "produce":
+                yield AssistantMessage("批 1/10 完成")
+                yield ResultMessage()
+                self._closed = True
+                return
+            # blackhole → loop back and block on the gate again
+
+    async def disconnect(self):
+        self._closed = True
+
+
+class _LiveStreamFake:
+    """A live-but-slow generation: emits StreamEvent liveness faster than the idle
+    bound, so the watchdog must never reap it."""
+
+    def __init__(self, options=None, ticks=6, dt=0.05):
+        self.options = options
+        self.queries = []
+        self.interrupts = 0
+        self._ticks = ticks
+        self._dt = dt
+
+    async def connect(self, prompt=None):
+        pass
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def interrupt(self):
+        self.interrupts += 1
+
+    async def receive_messages(self):
+        for _ in range(self._ticks):
+            await asyncio.sleep(self._dt)
+            yield StreamEvent()
+        yield AssistantMessage("done streaming")
+        yield ResultMessage()
+
+    async def disconnect(self):
+        pass
+
+
+class _ToolGapFake:
+    """A tool the CLI runs for a while: after the assistant asks for a tool
+    (tool_pending), there is a model-silent gap longer than the idle bound but
+    shorter than the tool bound — must NOT be reaped."""
+
+    def __init__(self, options=None, gap=0.3):
+        self.options = options
+        self.queries = []
+        self.interrupts = 0
+        self._gap = gap
+
+    async def connect(self, prompt=None):
+        pass
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def interrupt(self):
+        self.interrupts += 1
+
+    async def receive_messages(self):
+        am = AssistantMessage("calling read")
+        am.content = [TextBlock("calling read"), ToolUseBlock()]
+        yield am                                # tool_pending = True
+        await asyncio.sleep(self._gap)          # model-silent while the CLI runs the tool
+        yield UserMessage()                     # tool_result → tool_pending = False
+        yield AssistantMessage("read done")
+        yield ResultMessage()
+
+    async def disconnect(self):
+        pass
+
+
+async def _run_stall_scenario(fake, *, idle, poll, max_retries, tool_idle=660.0):
+    """Drive one turn through _consume_turn_stream with the watchdog running, at
+    test-tuned knobs (restored after). Returns (run, drained events, raised)."""
+    saved = (
+        compile_box._MODEL_IDLE_TIMEOUT_S,
+        compile_box._MODEL_TOOL_IDLE_TIMEOUT_S,
+        compile_box._MODEL_MAX_RETRIES,
+        compile_box._MODEL_WATCHDOG_POLL_S,
+    )
+    compile_box._MODEL_IDLE_TIMEOUT_S = idle
+    compile_box._MODEL_TOOL_IDLE_TIMEOUT_S = tool_idle
+    compile_box._MODEL_MAX_RETRIES = max_retries
+    compile_box._MODEL_WATCHDOG_POLL_S = poll
+    raised = None
+    with tempfile.TemporaryDirectory() as td:
+        run = compile_box.CompileRun("wd", td, 1)
+        run._suppress_turn_done = True          # isolate the watchdog from post-turn machinery
+        run.client = fake
+        wdog = asyncio.create_task(compile_box._model_stall_watchdog(run))
+        try:
+            await run.inject_user_message("批 1/10")
+            await compile_box._consume_turn_stream(run, fake, stop_on_result=True)
+        except compile_box.ModelStallError as e:
+            raised = e
+        finally:
+            run.done = True
+            wdog.cancel()
+            try:
+                await wdog
+            except asyncio.CancelledError:
+                pass
+            (
+                compile_box._MODEL_IDLE_TIMEOUT_S,
+                compile_box._MODEL_TOOL_IDLE_TIMEOUT_S,
+                compile_box._MODEL_MAX_RETRIES,
+                compile_box._MODEL_WATCHDOG_POLL_S,
+            ) = saved
+    return run, _drain(run), raised
+
+
+async def test_model_stall_retries_then_completes():
+    """A black-holed model request is interrupted and re-issued on a fresh query;
+    the retry produces output and the turn finishes (turn_stalled then completes)."""
+    fake = _StallingFakeClient(produce_on_query=2)
+    run, evs, raised = await _run_stall_scenario(fake, idle=0.15, poll=0.03, max_retries=3)
+    types = [e["type"] for e in evs]
+    assert raised is None, raised
+    assert fake.interrupts == 1, fake.interrupts
+    assert fake.queries == ["批 1/10", "批 1/10"], fake.queries
+    assert "turn_stalled" in types, types
+    assert run._last_turn_reply == "批 1/10 完成", run._last_turn_reply
+    print("✓ model stall: interrupt + retry recovers a black-holed request")
+
+
+async def test_model_stall_live_stream_not_reaped():
+    """A live-but-slow generation (StreamEvents flowing) is never reaped (I4)."""
+    fake = _LiveStreamFake(ticks=6, dt=0.05)
+    run, evs, raised = await _run_stall_scenario(fake, idle=0.15, poll=0.03, max_retries=3)
+    assert raised is None, raised
+    assert fake.interrupts == 0, fake.interrupts
+    assert "turn_stalled" not in [e["type"] for e in evs]
+    print("✓ model stall: a live-but-slow stream is never reaped")
+
+
+async def test_model_stall_tool_gap_not_reaped():
+    """A model-silent gap while the CLI runs a tool (tool_pending) uses the longer
+    tool bound — not mistaken for a model stall (I4)."""
+    fake = _ToolGapFake(gap=0.3)
+    run, evs, raised = await _run_stall_scenario(fake, idle=0.15, poll=0.03, max_retries=3, tool_idle=1.0)
+    assert raised is None, raised
+    assert fake.interrupts == 0, fake.interrupts
+    assert "turn_stalled" not in [e["type"] for e in evs]
+    print("✓ model stall: a long tool (tool_pending) is not mistaken for a stall")
+
+
+async def test_model_stall_exhausts_to_error():
+    """A request that never recovers is retried up to the bound, then fails the
+    turn with ModelStallError (the run fails fast instead of hanging for ~1h)."""
+    fake = _StallingFakeClient(produce_on_query=999)
+    run, evs, raised = await _run_stall_scenario(fake, idle=0.1, poll=0.03, max_retries=2)
+    types = [e["type"] for e in evs]
+    assert isinstance(raised, compile_box.ModelStallError), raised
+    assert fake.interrupts == 3, fake.interrupts          # 2 retries + the fatal attempt
+    assert types.count("turn_stalled") == 3, types
+    assert any(e["type"] == "turn_stalled" and e.get("fatal") for e in evs), evs
+    print("✓ model stall: retries exhausted → ModelStallError (fails fast, no hang)")
+
+
 async def main():
     # PK never fires in these wiring tests — a qualifying fixture must not spawn
     # a real ClaudeEngine in the background (test_selfcheck covers PK wiring).
@@ -831,6 +1056,10 @@ async def main():
     await test_propose_questions_appends_dedup()
     await test_message_captures_brief()
     await test_batch_orchestrator_routing_and_resume()
+    await test_model_stall_retries_then_completes()
+    await test_model_stall_live_stream_not_reaped()
+    await test_model_stall_tool_gap_not_reaped()
+    await test_model_stall_exhausts_to_error()
 
     compile_box._COMPILE_IMPL = fake_driver
     compile_box.RUNS.clear()


### PR DESCRIPTION
## What

Three box-side robustness fixes for the KB compile pod (`kbc/platform/pod/compile_box.py`), **stacked on #384 (batch compile)** because they harden its batch / persistent / planner drivers. No runtime or contract changes.

**L1 — model-stall watchdog.** A compile turn can wedge on a black-holed model request (massapi/upstream accepts the connection but never streams a response). The bundled `claude` CLI's own request timeout is ~60min and not tunable from the box, so a routine upstream hiccup froze a live run for an hour (observed: a batch-1 first request sat silent 63 min before the CLI timed out and recovered on its own). A turn-scoped watchdog reaps the wedged request and re-issues the turn in seconds. Idle is measured as model-response latency — a pending tool relaxes the bound, and `include_partial_messages` gives fine-grained liveness — so a live-but-slow generation is never false-killed. Exhausted retries fail the run with a clear reason instead of hanging.

**C2 — rate-limit resilience.** Under 5-10 concurrent boxes (× the red-blue PK) massapi can 429 / 503 / 529. Past the CLI's internal retries the turn ends with `is_error` + `api_error_status` (CLI ≥ 2.1.110). We back off (exponential, capped) and re-issue rather than failing the run; exhaustion ends the turn with an owner-facing note (run idle), not a crash. massapi's limits are not ours to fix — this is graceful handling.

**F3 — graceful shutdown flush.** The box had no SIGTERM handling: on a pod kill (delete / eviction / OOM after a reap) the last ≤`SYNC_INTERVAL_SECS` of compiled work — living only on the emptyDir `/work` — was lost, because `_run_wrapper`'s final sync never runs on signal death. An aiohttp `on_shutdown` handler final-syncs every active run's workspace and gives the SSE relay a bounded window to drain. Best-effort within the grace period.

## Coverage

The watchdog runs for the whole run (`_run_wrapper`) and monitors shared `CompileRun` state, so it covers every model call — the persistent driver, each batch session, and the batch planner. The stall/rate retry seams live in a shared `_consume_turn_stream`; `_emit_message` is unchanged. New events (`turn_stalled`, `rate_limited`, `[shutdown]` summary) are forward-compatible — the runtime default-ignores them.

## Tests

Box suite green (protocol smoke + all unit tests), including 7 new: black-hole → interrupt+retry recovers; live-but-slow stream not reaped; long tool not reaped; stall exhaustion → error; 429 backoff → completes; 429 exhaustion → graceful; shutdown flush. Env knobs: `KBC_MODEL_IDLE_TIMEOUT_S` (90), `KBC_MODEL_TOOL_IDLE_TIMEOUT_S` (660), `KBC_MODEL_MAX_RETRIES` (3), `KBC_MODEL_RATE_MAX_RETRIES` (5), `KBC_MODEL_RATE_BACKOFF_BASE_S`/`_CAP_S` (2/30), `KBC_SHUTDOWN_DRAIN_S`/`_MAX_S` (0.5/8).

## Deploy

Box behavior change → needs a `kbc-compile-box` image rebuild (runtime env `SICLAW_COMPILE_BOX_IMAGE`); the runtime is unchanged and default-ignores the new events. Runbook: `RUNBOOK-kb-compile-deploy-2026-07-06.md`.

## Scope (deliberately out of this PR)

Assessed against an explicit "basic usability, skip low-probability" bar: **F1** (artifact-persistence ack/reconcile) and **C1** (concurrency memory tuning) were analyzed and intentionally not done (F1 is self-mitigating via periodic re-sync + coverage ledger + recovery self-heal; C1 is low-probability on the large GPU nodes and the per-box 4Gi limit is empirically adequate). **L4** (turn-delivery durability) and the **two-clock-watchdog deploy** remain, coupled to the run-manager review on #378. Full analysis: `REVIEW-kb-compile-robustness-audit-2026-07-06.md`.

> Stacked on #384 — GitHub retargets the base to `main` automatically when #384 merges.
