### PR TITLE
feat(capability): consumer-managed LLM credential + KBC settings for kb boxes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ RUNTIME_IMAGE  = $(REGISTRY)/siclaw-runtime:$(TAG)
 AGENTBOX_IMAGE = $(REGISTRY)/siclaw-agentbox:$(TAG)
 PORTAL_IMAGE   = $(REGISTRY)/siclaw-portal:$(TAG)
 OCR_IMAGE      = $(REGISTRY)/siclaw-ocr:$(TAG)
+KBC_IMAGE      = $(REGISTRY)/kbc-compile-box:$(TAG)
 
 # ── OCI labels injected into every image ──
 DOCKER_LABELS = \
@@ -72,7 +73,7 @@ build-portal-web: ## Compile Portal frontend (Vite)
 # ==================== Docker ====================
 ##@ Docker
 
-docker: docker-runtime docker-agentbox docker-portal docker-ocr ## Build all Docker images
+docker: docker-runtime docker-agentbox docker-portal docker-ocr docker-kbc ## Build all Docker images
 
 docker-runtime: ## Build runtime image
 	docker build -f Dockerfile.runtime $(DOCKER_LABELS) -t $(RUNTIME_IMAGE) .
@@ -86,7 +87,10 @@ docker-portal: ## Build portal image
 docker-ocr: ## Build OCR backend image
 	docker build -f Dockerfile.ocr $(DOCKER_LABELS) -t $(OCR_IMAGE) .
 
-push: push-runtime push-agentbox push-portal push-ocr ## Push all images to registry
+docker-kbc: ## Build KB compile-box image (spawned per compile run; helm agentbox.compileBoxEnabled derives this tag)
+	cd kbc && docker build -f platform/pod/Dockerfile $(DOCKER_LABELS) -t $(KBC_IMAGE) .
+
+push: push-runtime push-agentbox push-portal push-ocr push-kbc ## Push all images to registry
 
 push-runtime: ## Push runtime image
 	docker push $(RUNTIME_IMAGE)
@@ -99,6 +103,9 @@ push-portal: ## Push portal image
 
 push-ocr: ## Push OCR backend image
 	docker push $(OCR_IMAGE)
+
+push-kbc: ## Push KB compile-box image
+	docker push $(KBC_IMAGE)
 
 # ==================== Test ====================
 ##@ Test
@@ -124,6 +131,7 @@ info: ## Print build variables
 	@echo "AGENTBOX:    $(AGENTBOX_IMAGE)"
 	@echo "PORTAL:      $(PORTAL_IMAGE)"
 	@echo "OCR:         $(OCR_IMAGE)"
+	@echo "KBC:         $(KBC_IMAGE)"
 
 logs: ## View recent logs (all components)
 	@echo "=== Runtime ===" && \

--- a/helm/siclaw/templates/_helpers.tpl
+++ b/helm/siclaw/templates/_helpers.tpl
@@ -80,6 +80,27 @@ Build agentbox image string — same registry/tag as gateway, different componen
 {{- end }}
 
 {{/*
+KB compile-box image (spawned per compile run by the runtime; NOT a helm-managed
+pod). Release-coupled by default: agentbox.compileBoxEnabled=true derives
+{registry}/kbc-compile-box:{image.tag} — the image ships with every release
+(`make docker` builds it). agentbox.compileBoxImage overrides the full string
+(hot-fix the compile brain independently of a release) and implies enabled.
+Empty result ⇒ KB stays dark (fail-closed).
+*/}}
+{{- define "siclaw.compileBoxImage" -}}
+{{- $ab := .Values.agentbox | default dict -}}
+{{- if $ab.compileBoxImage -}}
+{{- $ab.compileBoxImage -}}
+{{- else if $ab.compileBoxEnabled -}}
+{{- if .Values.image.registry -}}
+{{- printf "%s/kbc-compile-box:%s" .Values.image.registry .Values.image.tag -}}
+{{- else -}}
+{{- printf "kbc-compile-box:%s" .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Build OCR image string. Allows the independently deployed OCR service to move
 faster than the main Portal/Runtime images when desired.
 */}}

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -102,11 +102,14 @@ spec:
             - name: SICLAW_DEBUG_IMAGE
               value: {{ .Values.agentbox.debugImage | quote }}
             {{- end }}
-            {{- if .Values.agentbox.compileBoxImage }}
+            {{- $compileBoxImage := include "siclaw.compileBoxImage" . }}
+            {{- if $compileBoxImage }}
             # KB-compile box image (kbc/ in this repo) — consumed by the
             # BoxProfile registry for kb-compile / kb-test capability boxes.
+            # Derived from image.registry/tag via compileBoxEnabled, or pinned
+            # explicitly via compileBoxImage. Absent ⇒ KB dark (fail-closed).
             - name: SICLAW_COMPILE_BOX_IMAGE
-              value: {{ .Values.agentbox.compileBoxImage | quote }}
+              value: {{ $compileBoxImage | quote }}
             {{- end }}
             {{- if .Values.agentbox.nodeSelector }}
             # Node scheduling constraint forwarded by the runtime spawner onto

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -183,10 +183,15 @@ ocr:
 # -- AgentBox (spawned at runtime by K8s spawner)
 agentbox:
   debugImage: ""
-  # KB-compile box image (built from this repo's kbc/ — see kbc/platform/pod/
-  # Dockerfile). Consumed by the BoxProfile registry for kb-compile / kb-test
-  # capability boxes. Empty ⇒ the runtime's built-in default tag; pin a
-  # commit-sha tag here for releases, e.g. "registry/.../kbc-compile-box:main-<sha>".
+  # KB compile capability (kb-compile / kb-test boxes; built from this repo's
+  # kbc/, ships with every release via `make docker`). The RELEASE-COUPLED
+  # switch: true ⇒ the runtime spawns {image.registry}/kbc-compile-box:{image.tag}
+  # — same registry/tag convention as every other component. false + no
+  # override ⇒ KB stays dark (fail-closed; compile attempts error, chat
+  # unaffected).
+  compileBoxEnabled: false
+  # Full-image override (implies enabled): hot-fix the compile brain
+  # independently of a release, e.g. "registry/.../kbc-compile-box:main-<sha>".
   compileBoxImage: ""
   # Node selector applied to every spawned AgentBox pod. Constrains pods to
   # nodes carrying all of these labels (e.g. { disktype: ssd, pool: agents }).

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1717,6 +1717,39 @@ async def _teardown_test_session(run: "TestRun"):
 
 # ── HTTP ──
 
+# ── consumer-managed box config (DESIGN-kb-llm-binding-v2-2026-07-07) ────────
+# sicore owns the credential store and the KB capability policy; both arrive on
+# the /session body and apply IN-PROCESS (the box spawns before fetchInput runs,
+# so pod env is too early — and this keeps the token out of the pod spec).
+# Precedence: consumer config > runtime-env forward (helm fallback) > image
+# defaults. ONE exception: KBC_PK_MODE=off set at the runtime level is the ops
+# KILL SWITCH and must win over consumer config.
+_PK_KILL_AT_BOOT = os.environ.get("KBC_PK_MODE") == "off"
+
+
+def _apply_session_config(body: dict) -> None:
+    """Apply consumer-managed llm/settings from the /session body to os.environ.
+    Never log the token; whitelist settings keys to the box's own vocabulary."""
+    llm = body.get("llm")
+    if isinstance(llm, dict):
+        if llm.get("base_url"):
+            os.environ["ANTHROPIC_BASE_URL"] = str(llm["base_url"])
+        if llm.get("auth_token"):
+            os.environ["ANTHROPIC_AUTH_TOKEN"] = str(llm["auth_token"])
+            # The SDK accepts either; clear a stale forwarded API key so the
+            # consumer credential unambiguously wins.
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+    settings = body.get("settings")
+    if isinstance(settings, dict):
+        for key, value in settings.items():
+            k = str(key)
+            if not k.startswith("KBC_") or value is None:
+                continue  # whitelist: only the box's own knob vocabulary
+            if k == "KBC_PK_MODE" and _PK_KILL_AT_BOOT:
+                continue  # ops kill switch outranks consumer config
+            os.environ[k] = str(value)
+
+
 async def handle_session(request: web.Request):
     """Start (or no-op attach to) the run's persistent CONVERSATIONAL session —
     it connects and waits for the first /message (prepare chat; a compile is just
@@ -1726,6 +1759,10 @@ async def handle_session(request: web.Request):
     if run_id in RUNS:
         return web.json_response({"ok": True, "run_id": run_id, "already_live": True})
     body = await request.json() if request.body_exists else {}
+    # Consumer-managed LLM endpoint + KBC_* knobs (DESIGN-kb-llm-binding-v2):
+    # applied to os.environ BEFORE any SDK/engine session exists, so the
+    # persistent session, batch sessions, PK and media-verify all inherit them.
+    _apply_session_config(body)
     run = CompileRun(run_id, body.get("workdir", "/work"), int(body.get("round", 1)), body.get("instruction", ""))
     # Tool whitelist from the runtime BoxProfile (None/absent → driver default).
     run.allowed_tools = body.get("allowed_tools")

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -569,6 +569,51 @@ async def test_propose_plan_never_bounces():
 
 # ── Protocol v3: brief consumption + append-only proposed questions ──
 
+def test_apply_session_config():
+    """Consumer-managed llm/settings from /session body (DESIGN-kb-llm-binding-v2):
+    llm applies + clears a stale forwarded API key; settings whitelisted to
+    KBC_*; the boot-time KBC_PK_MODE=off kill switch outranks consumer config."""
+    keys = ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY",
+            "KBC_COMPILE_MODEL", "KBC_PK_MODE")
+    backup = {k: os.environ.get(k) for k in keys}
+    kill_backup = compile_box._PK_KILL_AT_BOOT
+    try:
+        os.environ["ANTHROPIC_API_KEY"] = "stale-forwarded-key"
+        os.environ.pop("KBC_PK_MODE", None)
+        os.environ.pop("KBC_COMPILE_MODEL", None)
+        compile_box._PK_KILL_AT_BOOT = False
+        compile_box._apply_session_config({
+            "llm": {"base_url": "https://massapi.example/model-api", "auth_token": "tok-1"},
+            "settings": {"KBC_COMPILE_MODEL": "claude-opus-4-8",
+                         "KBC_PK_MODE": "auto",
+                         "EVIL_KEY": "nope", "PATH": "/pwn"},
+        })
+        assert os.environ["ANTHROPIC_BASE_URL"] == "https://massapi.example/model-api"
+        assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "tok-1"
+        assert "ANTHROPIC_API_KEY" not in os.environ           # stale key cleared
+        assert os.environ["KBC_COMPILE_MODEL"] == "claude-opus-4-8"
+        assert os.environ["KBC_PK_MODE"] == "auto"
+        assert "EVIL_KEY" not in os.environ and os.environ.get("PATH") != "/pwn"
+
+        # ops kill switch: runtime-level off beats consumer "auto"
+        os.environ["KBC_PK_MODE"] = "off"
+        compile_box._PK_KILL_AT_BOOT = True
+        compile_box._apply_session_config({"settings": {"KBC_PK_MODE": "auto"}})
+        assert os.environ["KBC_PK_MODE"] == "off"
+
+        # absent/None fields are a clean no-op
+        compile_box._apply_session_config({})
+        compile_box._apply_session_config({"llm": None, "settings": None})
+    finally:
+        for k, v in backup.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        compile_box._PK_KILL_AT_BOOT = kill_backup
+    print("\u2713 _apply_session_config: llm + whitelist + kill-switch precedence")
+
+
 def test_parse_brief_block():
     """The wizard's 定调标签 block parses into the BRIEF.json record (tags split on
     Chinese separators, raw kept from the marker); an ordinary message → None."""
@@ -826,6 +871,7 @@ async def main():
     await test_open_close_test_session_http()
     await test_test_message_path()
     await test_propose_plan_never_bounces()
+    test_apply_session_config()
     test_parse_brief_block()
     test_merge_proposed_questions()
     await test_propose_questions_appends_dedup()

--- a/src/gateway/capability/contract.ts
+++ b/src/gateway/capability/contract.ts
@@ -278,4 +278,18 @@ export interface CapabilityFetchInputResponse {
    * (English prompt packs).
    */
   locale?: string;
+  /**
+   * Consumer-managed LLM endpoint for the run's box (DESIGN-kb-llm-binding-v2).
+   * The consumer (e.g. sicore) owns the credential store; the runtime passes
+   * this through OPAQUELY into the box /session body and MUST NOT log it.
+   * Absent ⇒ the box falls back to the runtime-env-forwarded ANTHROPIC_* vars
+   * (the helm Secret path).
+   */
+  llm?: { base_url?: string; auth_token?: string };
+  /**
+   * Consumer-managed box behavior knobs, keyed by the box's OWN env vocabulary
+   * (KBC_* — model tiers, PK/media-verify switches, budgets). Same wire shape
+   * as the env fallback so v1/v2 share one semantics; the box whitelists keys.
+   */
+  settings?: Record<string, string>;
 }

--- a/src/gateway/capability/materialize.ts
+++ b/src/gateway/capability/materialize.ts
@@ -34,6 +34,10 @@ export interface MaterializeBackend {
 export interface MaterializeResult {
   /** Consumer-declared locale for the run's box (fetchInput), if any. */
   locale?: string;
+  /** Consumer-managed LLM endpoint for the box (opaque passthrough; never logged). */
+  llm?: { base_url?: string; auth_token?: string };
+  /** Consumer-managed KBC_* behavior knobs for the box (opaque passthrough). */
+  settings?: Record<string, string>;
 }
 
 export async function materializeCapabilityInputs(opts: {
@@ -49,6 +53,8 @@ export async function materializeCapabilityInputs(opts: {
     const req: CapabilityFetchInputRequest = { run_id: runId };
     const src = (await backend.request(CAPABILITY_FETCH_INPUT, req)) as CapabilityFetchInputResponse;
     if (src?.locale) result.locale = src.locale;
+    if (src?.llm && typeof src.llm === "object") result.llm = src.llm;
+    if (src?.settings && typeof src.settings === "object") result.settings = src.settings;
     if (src?.bundle_base64) {
       await client.postJson("/sources", {
         run_id: runId,

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -445,6 +445,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           instruction: instruction ?? "",
           allowed_tools: allowedTools,
           locale: materialized.locale,
+          // Consumer-managed LLM endpoint + KBC_* knobs (DESIGN-kb-llm-binding-v2):
+          // opaque passthrough — the box applies them in-process before its SDK
+          // connects. Never logged here; token stays out of the pod spec.
+          llm: materialized.llm,
+          settings: materialized.settings,
         });
         driveCapabilitySession({ client, runId, frontendClient, manager: capabilityRunManager })
           .catch(async (err) => {


### PR DESCRIPTION
Stacked on #384 (DESIGN-kb-llm-binding-v2). The consumer (sicore) becomes the single source of truth for the KB boxes' LLM endpoint/token and behavior knobs; helm stays minimal (cluster fallback + ops kill switch only).

- `contract.ts`: `CapabilityFetchInputResponse` gains optional `llm{base_url, auth_token}` + `settings{KBC_*}` — same channel and shape as the `locale` precedent. Absent fields ⇒ the runtime-env (helm Secret) fallback.
- `materialize.ts` / `server.ts`: opaque passthrough into the box `/session` body; never logged; token never lands in the pod spec (the box spawns before fetchInput, so this is in-process config by construction).
- `compile_box`: `_apply_session_config()` applies `llm` + whitelisted `KBC_*` keys to `os.environ` before any SDK/engine session exists. Precedence: consumer config > runtime env forward > image defaults — with ONE exception: a runtime-level `KBC_PK_MODE=off` is the ops kill switch and outranks consumer config. A stale forwarded `ANTHROPIC_API_KEY` is cleared when a consumer token arrives.
- Compatible both ways: old sicore → env fallback; new sicore against an old box → unknown body fields ignored.

sicore counterpart: `feat/kb-llm-binding` on GitLab (maintainer config table + resolve + maintainer dialog).

Tests: `_apply_session_config` unit (llm/whitelist/kill-switch), capability vitest 39, five kbc pod suites, tsc clean.
