### PR TITLE
feat(runtime): advertise KB-compile capability to the consumer on connect

### DIFF
--- a/src/gateway/agentbox/box-profile.ts
+++ b/src/gateway/agentbox/box-profile.ts
@@ -48,6 +48,19 @@ export const AGENT_PROFILE: BoxProfile = {
 };
 
 /**
+ * Whether this Runtime can host KB compile/test boxes — i.e. it was given an
+ * explicit compile-box image (helm `agentbox.compileBoxEnabled` ⇒ the
+ * SICLAW_COMPILE_BOX_IMAGE env). This is the single source of truth the Runtime
+ * advertises to its consumer on connect so the consumer can route compile runs
+ * here WITHOUT any consumer-side config. The bare `kbc-compile-box:latest`
+ * fallback in the profiles above is deliberately NOT treated as capable: an
+ * unset env means KB stays dark (fail-closed), so we must not claim capability.
+ */
+export function isCompileCapable(): boolean {
+  return !!process.env.SICLAW_COMPILE_BOX_IMAGE?.trim();
+}
+
+/**
  * kb-compile — a KB compile box. Reproduces the pre-refactor compile special-case
  * DECLARATIVELY: dedicated image, Anthropic-compatible LLM env (the lean box does
  * not phone home for settings), a writable /work with HOME pointed at it.

--- a/src/gateway/frontend-ws-client.test.ts
+++ b/src/gateway/frontend-ws-client.test.ts
@@ -391,4 +391,75 @@ describe("FrontendWsClient", () => {
     await expect(p1).rejects.toThrow("closed");
     await expect(p2).rejects.toThrow("closed");
   });
+
+  // ── capability advertisement (runtime.register on open) ──────
+
+  it("advertises capabilities via runtime.register on open", async () => {
+    const client = await createClient({ capabilities: { compile: true } });
+    const connectPromise = client.connect();
+    const ws = openLatestWs();
+    await connectPromise;
+
+    expect(ws._sent).toHaveLength(1);
+    const frame = JSON.parse(ws._sent[0]);
+    expect(frame.type).toBe("req");
+    expect(frame.method).toBe("runtime.register");
+    expect(frame.params).toEqual({ capabilities: { compile: true } });
+
+    client.close();
+  });
+
+  it("does not advertise when capabilities are empty", async () => {
+    const client = await createClient(); // defaultOpts has no capabilities
+    const connectPromise = client.connect();
+    const ws = openLatestWs();
+    await connectPromise;
+
+    expect(ws._sent).toHaveLength(0);
+    client.close();
+  });
+
+  it("re-advertises on every reconnect", async () => {
+    const client = await createClient({ capabilities: { compile: true } });
+    const connectPromise = client.connect();
+    const ws1 = openLatestWs();
+    await connectPromise;
+    expect(JSON.parse(ws1._sent[0]).method).toBe("runtime.register");
+
+    // Drop the connection and let the backoff timer fire a reconnect.
+    // First reconnect delay = base(1000) * 2^0 + jitter(0..2000) ≤ 3000ms.
+    ws1.emit("close");
+    await vi.advanceTimersByTimeAsync(3100);
+    const ws2 = openLatestWs();
+    expect(ws2).not.toBe(ws1);
+    expect(ws2._sent).toHaveLength(1);
+    expect(JSON.parse(ws2._sent[0]).method).toBe("runtime.register");
+
+    client.close();
+  });
+
+  it("survives an 'unknown method' ack from an older consumer (best-effort)", async () => {
+    const client = await createClient({ capabilities: { compile: true } });
+    const connectPromise = client.connect();
+    const ws = openLatestWs();
+    await connectPromise;
+
+    // Older consumer replies with an error for the unknown method.
+    const frame = JSON.parse(ws._sent[0]);
+    ws.emit("message", JSON.stringify({
+      type: "res",
+      id: frame.id,
+      ok: false,
+      error: "unknown method: runtime.register",
+    }));
+
+    // Connection stays up; a normal RPC still works afterwards.
+    expect(client.connected).toBe(true);
+    const p = client.request("config.getSettings");
+    const req = JSON.parse(ws._sent[ws._sent.length - 1]);
+    ws.emit("message", JSON.stringify({ type: "res", id: req.id, ok: true, payload: { ok: 1 } }));
+    await expect(p).resolves.toEqual({ ok: 1 });
+
+    client.close();
+  });
 });

--- a/src/gateway/frontend-ws-client.ts
+++ b/src/gateway/frontend-ws-client.ts
@@ -23,6 +23,14 @@ export interface FrontendWsClientOptions {
   agentId: string;
   /** RPC timeout in ms (default 30000) */
   timeoutMs?: number;
+  /**
+   * Runtime capabilities advertised to the consumer on every (re)connect via a
+   * best-effort `runtime.register` RPC (e.g. `{ compile: true }`). Lets the
+   * consumer route capability work here without any consumer-side config. Empty
+   * ⇒ nothing advertised. A consumer that predates `runtime.register` replies
+   * "unknown method"; that is ignored (advisory, non-fatal).
+   */
+  capabilities?: Record<string, boolean>;
 }
 
 // ── Internal types ───────────────────────────────────────────
@@ -63,6 +71,7 @@ export class FrontendWsClient {
       portalSecret: options.portalSecret,
       agentId: options.agentId,
       timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      capabilities: options.capabilities ?? {},
     };
   }
 
@@ -159,6 +168,21 @@ export class FrontendWsClient {
 
   // ── Private ──────────────────────────────────────────────────
 
+  /**
+   * Best-effort advertise of this Runtime's capabilities to the consumer.
+   * Fire-and-forget: a consumer that predates `runtime.register` replies
+   * "unknown method" and keeps the connection — capabilities are advisory, so a
+   * failed ack must not break the connection or the initial connect().
+   */
+  private advertiseCapabilities(): void {
+    const caps = this.opts.capabilities;
+    if (!caps || Object.keys(caps).length === 0) return;
+    this.request("runtime.register", { capabilities: caps }).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[frontend-ws] capability advertise not acked (ok on older consumer): ${message}`);
+    });
+  }
+
   private buildWsUrl(): string {
     let url = this.opts.serverUrl;
     // Convert http(s):// to ws(s)://
@@ -189,6 +213,10 @@ export class FrontendWsClient {
         this.connectResolve = null;
         this.connectReject = null;
       }
+
+      // Advertise capabilities on every (re)connect so the consumer's routing
+      // reflects the current connection, not a stale record.
+      this.advertiseCapabilities();
     });
 
     ws.on("message", (raw: WebSocket.Data) => {

--- a/src/lib/bootstrap-runtime.ts
+++ b/src/lib/bootstrap-runtime.ts
@@ -17,6 +17,7 @@ import { ChannelManager } from "../gateway/channel-manager.js";
 import { TaskCoordinator } from "../gateway/task-coordinator.js";
 import { createCredentialService } from "../gateway/credential-service.js";
 import { FrontendWsClient } from "../gateway/frontend-ws-client.js";
+import { isCompileCapable } from "../gateway/agentbox/box-profile.js";
 import { initChatRepo } from "../gateway/chat-repo.js";
 import { CertificateManager } from "../gateway/security/cert-manager.js";
 
@@ -50,6 +51,10 @@ export async function bootstrapRuntime(opts: BootstrapRuntimeOptions): Promise<R
     serverUrl: config.serverUrl,
     portalSecret: config.portalSecret,
     agentId: process.env.SICLAW_AGENT_ID || "runtime",
+    // Advertise KB-compile capability so the consumer can route compile runs to
+    // this Runtime with no consumer-side config. True iff a compile-box image
+    // was configured (helm agentbox.compileBoxEnabled ⇒ SICLAW_COMPILE_BOX_IMAGE).
+    capabilities: { compile: isCompileCapable() },
   });
   if (config.serverUrl) {
     try {


### PR DESCRIPTION
## What

The Runtime now advertises its capabilities (currently `{ compile }`) to the consumer over the existing `/ws/runtime` connection, via a best-effort `runtime.register` RPC sent on every (re)connect.

`compile` is `true` iff a compile-box image was configured for this Runtime — i.e. helm `agentbox.compileBoxEnabled` set `SICLAW_COMPILE_BOX_IMAGE`. This is exposed as `isCompileCapable()` (single source of truth, next to where the compile-box profiles resolve that image).

## Why

Lets the consumer route KB-compile runs to a compile-capable Runtime **from the Runtime's own config**, with zero consumer-side routing configuration.

Every connected Runtime sends `runtime.register`, but only one with `compileBoxEnabled` advertises `compile: true` (the rest send `compile: false`) — so in a multi-Runtime deployment the consumer picks the capable one with no per-Runtime env/values on its side. A non-capable Runtime explicitly reporting `compile: false` is intentional: the consumer learns "not me" rather than inferring it from silence. Enabling/moving compile becomes a one-line change on the Runtime's helm.

## Compatibility

Advertisement is advisory and non-fatal. A consumer that predates `runtime.register` replies `unknown method` and keeps the connection; the Runtime ignores the failed ack (verified: the consumer's WS dispatch returns an error response for unknown methods without dropping the connection). New-Runtime ↔ old-consumer therefore stays safe — normal chat is unaffected.

## Tests

`frontend-ws-client.test.ts`: advertises on open, does not advertise when capabilities are empty (the generic-client guard; the production caller always passes `{ compile }`), re-advertises on every reconnect, survives an `unknown method` ack. `tsc` clean, 20/20 pass.

Pairs with the consumer-side change that stores the advertisement and resolves the compile Runtime from it.
