### PR TITLE
fix(capability): malformed artifact entry must not kill the relay; stop the box when it does die

### DIFF
--- a/src/gateway/capability/session-driver.test.ts
+++ b/src/gateway/capability/session-driver.test.ts
@@ -128,6 +128,57 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     expect(artifactCalls).toHaveLength(2);
   }, 10_000);
 
+  it("a malformed artifact entry is skipped loudly — the relay and later artifacts survive", async () => {
+    // Live 07-09: a runtime predating the tombstone branch threw in artifact
+    // construction (Buffer.from(undefined)) and the WHOLE relay died right after
+    // turn_done — the final SELFCHECK sync, settled, and end were lost, every
+    // incremental round wedged DIRTY, and the box pod leaked. Construction is
+    // still throwable today (a box bug sending a non-string content), so the
+    // guard is a boundary rule, not a legacy patch: skip the bad entry, keep
+    // the stream.
+    const fe = fakeFrontend();
+    const mgr = fakeManager();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await driveCapabilitySession({
+        client: fakeClient([
+          {
+            type: "syncArtifacts",
+            artifacts: [
+              { path: "authoring/BAD.json", content: 42 as any }, // non-string → Buffer.from throws
+              { path: "authoring/SELFCHECK.json", content: '{"state":"passed"}' },
+            ],
+          },
+          { type: "end" },
+        ]),
+        runId: "r1", frontendClient: fe, manager: mgr,
+      });
+    } finally {
+      errSpy.mockRestore();
+    }
+    const artifactCalls = fe.request.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_PERSIST_ARTIFACT);
+    expect(artifactCalls).toHaveLength(1); // the good one after the bad one still landed
+    expect(artifactCalls[0][1]).toMatchObject({ run_id: "r1", path: "authoring/SELFCHECK.json" });
+    expect(mgr.endRun).not.toHaveBeenCalledWith("r1", "failed");
+  });
+
+  it("a deletion tombstone persists as {deleted:true} with no content", async () => {
+    const fe = fakeFrontend();
+    const mgr = fakeManager();
+    await driveCapabilitySession({
+      client: fakeClient([
+        { type: "syncArtifacts", artifacts: [{ path: "candidate/gone.md", deleted: true }] },
+        { type: "end" },
+      ]),
+      runId: "r1", frontendClient: fe, manager: mgr,
+    });
+    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACT, {
+      run_id: "r1",
+      path: "candidate/gone.md",
+      deleted: true,
+    });
+  });
+
   it("an unhandled box event (e.g. the retired 'parked') is ignored, not fatal", async () => {
     // The box never emits 'parked' (the handler was removed as dead code); a stray
     // one must fall through harmlessly — no turn, no status change, no crash.

--- a/src/gateway/capability/session-driver.ts
+++ b/src/gateway/capability/session-driver.ts
@@ -99,17 +99,31 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
         // content hash, so this exact version is only re-sent if the file changes
         // again. Hence one retry, then a loud log.
         for (const a of evt.artifacts ?? []) {
-          const artifact: CapabilityPersistArtifactRequest = a.deleted
-            ? // Tombstone: the box deleted this file (page merge/rename/restructure).
-              // Without propagating it, the consumer's row outlives the file —
-              // publish ships the deleted page and the next respawn's workspace
-              // rehydration resurrects it onto the box's disk.
-              { run_id: runId, path: a.path, deleted: true }
-            : {
-                run_id: runId,
-                path: a.path,
-                content: { inline_base64: Buffer.from(a.content ?? "", "utf8").toString("base64") },
-              };
+          let artifact: CapabilityPersistArtifactRequest;
+          try {
+            artifact = a.deleted
+              ? // Tombstone: the box deleted this file (page merge/rename/restructure).
+                // Without propagating it, the consumer's row outlives the file —
+                // publish ships the deleted page and the next respawn's workspace
+                // rehydration resurrects it onto the box's disk.
+                { run_id: runId, path: a.path, deleted: true }
+              : {
+                  run_id: runId,
+                  path: a.path,
+                  content: { inline_base64: Buffer.from(a.content ?? "", "utf8").toString("base64") },
+                };
+          } catch (err) {
+            // One malformed entry must not kill the relay: everything after it —
+            // later artifacts, the final SELFCHECK sync, settled, end — would be
+            // lost and the run stranded mid-state (seen live 07-09: a runtime
+            // predating the tombstone branch threw here on {deleted:true} and
+            // every incremental round wedged DIRTY with a leaked box).
+            console.error(
+              `[capability] run=${runId} malformed artifact entry (${String(a?.path ?? "?")}) skipped:`,
+              err instanceof Error ? err.message : String(err),
+            );
+            continue;
+          }
           try {
             await frontendClient.request(CAPABILITY_PERSIST_ARTIFACT, artifact);
           } catch {

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -454,6 +454,15 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         driveCapabilitySession({ client, runId, frontendClient, manager: capabilityRunManager })
           .catch(async (err) => {
             console.error(`[capability] session relay failed run=${runId}:`, err);
+            // The run is terminal from here (endRun below) and can never be
+            // re-adopted, so its box is unreachable garbage — stop it, or every
+            // relay crash leaks a pod (4 live boxes for one repo, seen 07-09).
+            await agentBoxManager.stop(runId).catch((stopErr) =>
+              console.error(
+                `[capability] stop box after relay failure run=${runId}:`,
+                stopErr instanceof Error ? stopErr.message : String(stopErr),
+              ),
+            );
             await capabilityRunManager.endRun(runId, "failed").catch(() => {});
           })
           .finally(() => {
@@ -531,7 +540,14 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   rpcMethods.set("capability.cancel", async (params) => {
     const runId = (params as unknown as CapabilityCancelRequest).run_id;
     if (!runId) throw new Error("run_id is required");
-    await agentBoxManager.stop(runId).catch(() => {});
+    // Best-effort by design (the cancel must terminalize the run regardless),
+    // but a swallowed stop is how box pods leak — log it loudly.
+    await agentBoxManager.stop(runId).catch((err) =>
+      console.error(
+        `[capability] cancel: stop box run=${runId} failed (pod may leak):`,
+        err instanceof Error ? err.message : String(err),
+      ),
+    );
     await capabilityRunManager.endRun(runId, "done");
     return { ok: true, run_id: runId };
   });


### PR DESCRIPTION
## Problem (seen live on siflow-test, 2026-07-09)

A relay crash in `driveCapabilitySession` right after `turn_done` (a runtime predating the tombstone branch threw `ERR_INVALID_ARG_TYPE` in artifact construction) permanently killed the run's event pipe. Everything the box emitted afterwards was lost:

- the final SELFCHECK sync → the store kept a mid-repair state (a dangling-citation warning shown on the publish page forever),
- `converge_phase: settled` → the consumer's converge hook never fired, so the incremental baseline never advanced,
- deletion tombstones → deleted pages resurrected from the store on the next respawn,
- and the box pod leaked (the relay-failure path only `endRun(failed)`s — 4 live boxes observed for one repo).

## Fixes (three boundaries)

1. **session-driver**: artifact construction moved inside a per-entry guard. A malformed entry — still reachable today via a non-string `content` — is skipped with a loud log instead of killing the stream and everything after it.
2. **server relay catch**: stop the box before terminalizing the run. A failed run can never be re-adopted (`adopt` refuses terminal runs), so its box is unreachable garbage; without this every relay crash leaks a pod.
3. **capability.cancel**: the swallowed `stop` failure now logs loudly — it is exactly how pods leak silently.

## Tests

`session-driver.test.ts`: malformed entry skipped + later artifacts still land + run not failed; deletion tombstone persists as `{deleted:true}`. 11/11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)