### PR TITLE
fix(lark): respond to card 👍/👎 callback immediately to avoid Feishu 200671

### DIFF
--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1061,10 +1061,16 @@ describe("handleLarkCardAction — 👍/👎 feedback", () => {
     };
   }
 
-  it("persists the vote keyed by the clicker's open_id and returns a success toast", async () => {
-    recordChannelFeedbackMock.mockResolvedValue({ success: true });
-    const result = await handleLarkCardAction(makeCardAction(), makeLarkClient());
+  // Flush the detached persist/echo IIFE queued by the (synchronous) handler.
+  const flush = () => new Promise((r) => setImmediate(r));
 
+  it("returns the success toast synchronously and persists the vote detached", async () => {
+    recordChannelFeedbackMock.mockResolvedValue({ success: true });
+    // Synchronous return — the callback response must not await persistence.
+    const result = handleLarkCardAction(makeCardAction(), makeLarkClient());
+    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("反馈") } });
+
+    await flush();
     expect(recordChannelFeedbackMock).toHaveBeenCalledWith({
       sessionId: "sess-1",
       messageRef: "CARD-1",
@@ -1073,14 +1079,14 @@ describe("handleLarkCardAction — 👍/👎 feedback", () => {
       channelId: "lark",
       source: "lark",
     });
-    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("反馈") } });
   });
 
   it("ignores card actions that are not feedback buttons", async () => {
     recordChannelFeedbackMock.mockClear();
     const data = makeCardAction({ action: { tag: "button", value: { kind: "something_else" } } });
-    const result = await handleLarkCardAction(data, makeLarkClient());
+    const result = handleLarkCardAction(data, makeLarkClient());
     expect(result).toBeUndefined();
+    await flush();
     expect(recordChannelFeedbackMock).not.toHaveBeenCalled();
   });
 
@@ -1089,23 +1095,38 @@ describe("handleLarkCardAction — 👍/👎 feedback", () => {
     recordChannelFeedbackMock.mockResolvedValue({ success: true });
     const data = makeCardAction();
     (data.action as any).value = JSON.stringify((data.action as any).value);
-    const result = await handleLarkCardAction(data, makeLarkClient());
-    expect(recordChannelFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({ rating: "up", messageRef: "CARD-1" }));
+    const result = handleLarkCardAction(data, makeLarkClient());
     expect(result).toEqual({ toast: { type: "success", content: expect.any(String) } });
+    await flush();
+    expect(recordChannelFeedbackMock).toHaveBeenCalledWith(expect.objectContaining({ rating: "up", messageRef: "CARD-1" }));
   });
 
   it("missing operator open_id → error toast, nothing persisted", async () => {
     recordChannelFeedbackMock.mockClear();
     const data = makeCardAction({ operator: {} });
-    const result = await handleLarkCardAction(data, makeLarkClient());
+    const result = handleLarkCardAction(data, makeLarkClient());
     expect(result).toEqual({ toast: { type: "error", content: expect.any(String) } });
+    await flush();
     expect(recordChannelFeedbackMock).not.toHaveBeenCalled();
   });
 
-  it("a persist failure surfaces as an error toast", async () => {
+  it("a slow persist does NOT block the callback response (200671 fix)", async () => {
+    // Persistence hangs; the handler must still return its toast synchronously
+    // so Feishu gets a response well inside its ~3s budget.
+    recordChannelFeedbackMock.mockImplementation(() => new Promise(() => { /* never settles */ }));
+    const result = handleLarkCardAction(makeCardAction(), makeLarkClient());
+    expect(result).toEqual({ toast: { type: "success", content: expect.any(String) } });
+  });
+
+  it("a persist failure is swallowed (optimistic toast already returned)", async () => {
     recordChannelFeedbackMock.mockRejectedValueOnce(new Error("db down"));
-    const result = await handleLarkCardAction(makeCardAction(), makeLarkClient());
-    expect(result).toEqual({ toast: { type: "error", content: expect.any(String) } });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Still an optimistic success toast — the click did reach us; a rare
+    // persist failure is logged, never shown as 200671 on a saved vote.
+    const result = handleLarkCardAction(makeCardAction(), makeLarkClient());
+    expect(result).toEqual({ toast: { type: "success", content: expect.any(String) } });
+    await flush();
+    expect(console.error).toHaveBeenCalled();
   });
 
   it("down votes and en-US locale flow through", async () => {
@@ -1113,22 +1134,10 @@ describe("handleLarkCardAction — 👍/👎 feedback", () => {
     const data = makeCardAction();
     (data.action as any).value.rating = "down";
     (data.action as any).value.locale = "en-US";
-    const result = await handleLarkCardAction(data, makeLarkClient());
-    expect(recordChannelFeedbackMock).toHaveBeenLastCalledWith(expect.objectContaining({ rating: "down" }));
+    const result = handleLarkCardAction(data, makeLarkClient());
     expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("thanks") } });
-  });
-
-  it("a hung persist RPC is deadline-raced into an error toast instead of blocking the callback", async () => {
-    vi.useFakeTimers();
-    try {
-      recordChannelFeedbackMock.mockImplementation(() => new Promise(() => { /* never settles */ }));
-      const pending = handleLarkCardAction(makeCardAction(), makeLarkClient());
-      await vi.advanceTimersByTimeAsync(2600);
-      const result = await pending;
-      expect(result).toEqual({ toast: { type: "error", content: expect.any(String) } });
-    } finally {
-      vi.useRealTimers();
-    }
+    await flush();
+    expect(recordChannelFeedbackMock).toHaveBeenLastCalledWith(expect.objectContaining({ rating: "down" }));
   });
 });
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -187,15 +187,19 @@ export function createLarkHandler(
           });
           return Promise.resolve();
         },
-        // Card button clicks (👍/👎 feedback). Unlike messages, the handler's
-        // return value IS the callback response (toast shown to the clicker),
-        // so this one is awaited — persistence is deadline-raced inside the
-        // handler to stay within Feishu's callback window.
-        "card.action.trigger": (data: any) =>
-          handleLarkCardAction(data, larkClient).catch((err) => {
+        // Card button clicks (👍/👎 feedback). The handler's return value IS
+        // the callback response (toast shown to the clicker), so it resolves
+        // synchronously and immediately — persistence runs detached inside the
+        // handler to stay well within Feishu's ~3s callback window (see the
+        // handleLarkCardAction doc comment / the 200671 fix).
+        "card.action.trigger": (data: any) => {
+          try {
+            return handleLarkCardAction(data, larkClient);
+          } catch (err) {
             console.error(`[lark] Error handling card action for channel=${channelId}:`, err);
             return undefined;
-          }),
+          }
+        },
       });
 
       const ws = new lark.WSClient({
@@ -340,28 +344,27 @@ const FEEDBACK_TOAST_BY_LOCALE: Record<LarkLocale, { ok: string; fail: string }>
   "en-US": { ok: "Feedback recorded — thanks!", fail: "Could not record feedback. Please try again." },
 };
 
-// Feishu expects the card-callback response within a few seconds; the WS RPC's
-// own timeout is 30s. Race the persist so a degraded Portal degrades to a
-// quick error toast instead of a hung click + Feishu redelivery storm. A
-// persist that lands after the deadline is absorbed by the upsert when the
-// user retries.
-const FEEDBACK_PERSIST_DEADLINE_MS = 2500;
-
 /**
  * Handle a `card.action.trigger` callback. Only feedback buttons (our
  * FEEDBACK_ACTION_KIND discriminator) are processed; anything else returns
  * undefined so future card actions can add their own handling.
  *
- * The return value is sent back to Feishu as the callback response — a toast
- * shown to the clicker. Persistence goes through chat-repo's module-global
- * RPC client (same path as message persistence); the button-state echo on the
- * card itself is best-effort (needs this process to still know the card's
- * sequence).
+ * The return value is the card-callback response Feishu shows as a toast.
+ * Feishu enforces a hard ~3s budget on that response measured END-TO-END
+ * (its edge → this pod → back). We MUST NOT block it on the persist RPC:
+ * persistence hops to Portal/sicore over WS, and that latency plus the two
+ * network legs intermittently blew the 3s budget — Feishu then rejected an
+ * otherwise-valid response with business error 200671, even though the vote
+ * had already been written. So respond OPTIMISTICALLY and immediately, and
+ * run persistence + the button-state echo fully detached. Feedback is
+ * best-effort (and confirmed reliable in practice); a rare persist failure is
+ * logged rather than surfaced, which is strictly better than showing 200671
+ * on a click that did save.
  */
-export async function handleLarkCardAction(
+export function handleLarkCardAction(
   data: any,
   larkClient: any,
-): Promise<{ toast: { type: string; content: string } } | undefined> {
+): { toast: { type: string; content: string } } | undefined {
   // EventDispatcher flattens `event.*` onto the top level (same as messages).
   // Some Feishu/CardKit versions deliver `action.value` as a JSON string
   // rather than a parsed object — accept both so feedback doesn't silently
@@ -383,44 +386,32 @@ export async function handleLarkCardAction(
     console.warn(`[lark] Dropping malformed feedback action card=${value.card_id ?? "?"} rating=${value.rating ?? "?"} operator=${operatorOpenId ?? "?"}`);
     return { toast: { type: "error", content: toasts.fail } };
   }
+  const { session_id: sessionId, card_id: cardId, channel_id: channelId } = value;
 
-  // Never rejects — failures collapse to {success:false} so a late settle
-  // after the deadline below can't surface as an unhandled rejection.
-  const persist = recordChannelFeedback({
-    sessionId: value.session_id,
-    messageRef: value.card_id,
-    rating,
-    senderExternalId: operatorOpenId,
-    channelId: value.channel_id ?? null,
-    source: "lark",
-  }).catch((err): { success: boolean; error?: string } => {
-    console.error(`[lark] Feedback persist failed card=${value.card_id}:`, err);
-    return { success: false, error: err instanceof Error ? err.message : String(err) };
-  });
-  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-  const result = await Promise.race([
-    persist,
-    new Promise<null>((resolve) => {
-      deadlineTimer = setTimeout(() => resolve(null), FEEDBACK_PERSIST_DEADLINE_MS);
-      (deadlineTimer as { unref?: () => void }).unref?.();
-    }),
-  ]);
-  // Clear the timer once the race settles — on the common fast-persist path it
-  // would otherwise stay armed (harmlessly, thanks to unref) for the full deadline.
-  if (deadlineTimer) clearTimeout(deadlineTimer);
-  if (!result?.success) {
-    if (result == null) {
-      console.warn(`[lark] Feedback persist timed out (${FEEDBACK_PERSIST_DEADLINE_MS}ms) card=${value.card_id}`);
-    } else if (result.error) {
-      console.warn(`[lark] Feedback persist rejected card=${value.card_id}: ${result.error}`);
+  // Detached: persist the vote, then echo the button highlight. Neither is on
+  // the callback-response critical path (see the 3s-budget note above).
+  void (async () => {
+    try {
+      const result = await recordChannelFeedback({
+        sessionId,
+        messageRef: cardId,
+        rating,
+        senderExternalId: operatorOpenId,
+        channelId: channelId ?? null,
+        source: "lark",
+      });
+      if (!result?.success) {
+        console.warn(`[lark] Feedback persist rejected card=${cardId}: ${result?.error ?? "unknown"}`);
+        return;
+      }
+      console.log(`[lark] Feedback recorded card=${cardId} session=${sessionId} rating=${rating} sender=${operatorOpenId}`);
+      // Cosmetic: highlight the chosen button. Never rejects (best-effort boolean).
+      void applyFeedbackSelection(larkClient, value as FeedbackActionValue, rating);
+    } catch (err) {
+      console.error(`[lark] Feedback persist failed card=${cardId}:`, err);
     }
-    return { toast: { type: "error", content: toasts.fail } };
-  }
+  })();
 
-  console.log(`[lark] Feedback recorded card=${value.card_id} session=${value.session_id} rating=${rating} sender=${operatorOpenId}`);
-  // Detached: highlighting the chosen button is cosmetic; the toast below is
-  // the authoritative confirmation. Never rejects (best-effort boolean).
-  void applyFeedbackSelection(larkClient, value as FeedbackActionValue, rating);
   return { toast: { type: "success", content: toasts.ok } };
 }
 


### PR DESCRIPTION
## Problem

Clicking a Feishu answer-card 👍/👎 button intermittently pops **`code: 200671`** in the Feishu client — but the vote **is** recorded (Runtime logs `[lark] Feedback recorded …`, and the `message_feedback` row exists). `200671` is a Feishu **business error** meaning it did not receive a valid card-callback response in time.

## Root cause — timing, not the callback mechanism

Feishu enforces a hard **~3s budget on the callback response, measured end-to-end** (its edge → runtime pod → back). `handleLarkCardAction` **awaited the persist** before returning the toast, and persistence hops to Portal/sicore over the WS RPC. That latency + the two network legs intermittently exceeded 3s → Feishu rejected an otherwise-valid response with 200671, **after** the row had already been written. This is exactly why it's intermittent/load-correlated and why the data always lands.

The registration is **correct** and unchanged: the official Feishu Node SDK wires `card.action.trigger` through `EventDispatcher` + `WSClient.start({eventDispatcher})` and returns `{toast}` — identical to ours; SDK 1.24.0+ supports this over the long connection ([official docs](https://open.feishu.cn/document/feishu-cards/card-callback-communication?lang=zh-CN)). The SDK does base64 the handler's return value back as the callback response (verified in the 1.58.0 bundle). So the earlier hypothesis that we "must use a separate card handler / HTTP callback" is **not** the cause.

## Fix

Respond **optimistically and synchronously**: return the success toast the moment the click is validated, and run persistence + the button-highlight echo **fully detached**. The response now leaves in microseconds regardless of Portal/sicore latency, well inside the 3s budget. Feedback is best-effort (and reliable in practice); a rare persist failure is logged rather than surfaced — strictly better than showing 200671 on a click that did save. The 2.5s deadline-race is removed (too close to 3s once RTT is counted, and it still returned an error toast on the slow path).

## Verification

- Per the original report: after deploy, click 👍 once — Feishu should show the success toast (「已收到你的反馈，谢谢！」) and **no** 200671. Persistence was already fine and isn't the indicator.
- If any residual 200671 remains, pull the exact `msg` by Log ID on the open platform (200671 is Log-ID-diagnosable).

## Tests

`lark.test.ts` (97) + `lark-card.test.ts` (31) pass. Card-action suite rewritten for the synchronous optimistic-response contract: sync toast return, detached persist, slow-persist-does-not-block, persist-failure-swallowed, JSON-string `action.value`, locale/rating paths.

> Note: 8 unrelated suites fail locally on a missing `@arizeai/openinference-semantic-conventions` (tracing dep merged to main today, not resolvable in this env) — fails identically on clean `main`; CI/build-host with a fresh install is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)