### PR TITLE
Harden knowledge compiler runtime sync

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -264,6 +264,12 @@ class CompileRun:
         self._stall_interrupted_at = 0.0
         self._batch_active = False
         self._batch_notes: list[str] = []
+        # Full compile provenance is an explicit commit, never inferred from a
+        # replayed or rehydrated candidate/index.md.
+        self._full_compile_pending = False
+        # Keep the last full-compile commit replayable across relay restarts.
+        # The consumer dedupes it by immutable input revision.
+        self._commit_input_replay = False
         # Scoped incremental (真增量): armed at kickoff with {before: page_hashes,
         # changeset}; the post-turn seam runs the byte-integrity guard against it,
         # then clears it. None = this turn is not a scoped incremental.
@@ -357,6 +363,7 @@ MAX_SYNC_FILE_BYTES = int(os.environ.get("KBC_MAX_SYNC_FILE_BYTES", str(1024 * 1
 # result (a Read of a big source file) kills the whole session with a fatal
 # "exceeded maximum buffer size" — seen live on a 139-source compile (2026-07-06).
 SDK_MAX_BUFFER_BYTES = int(os.environ.get("KBC_SDK_MAX_BUFFER_BYTES", str(16 * 1024 * 1024)))
+_SYNC_TOMBSTONE = "__deleted__"
 
 
 def _collect_workspace_artifacts(workdir: str) -> list[dict]:
@@ -382,19 +389,31 @@ def _collect_workspace_artifacts(workdir: str) -> list[dict]:
     return out
 
 
-async def _sync_workspace(run: CompileRun, sent: dict) -> int:
+def _workspace_sync_cursor(workdir: str) -> dict[str, str]:
+    """Hash the workspace state already installed by the consumer."""
+    return {
+        art["path"]: hashlib.sha256(art["content"].encode("utf-8")).hexdigest()
+        for art in _collect_workspace_artifacts(workdir)
+    }
+
+
+async def _sync_workspace(run: CompileRun, sent: dict, *, commit_input: bool = False) -> int:
     """Emit a syncArtifacts event for workspace files changed since `sent`
     (path → content sha), plus TOMBSTONES ({path, deleted: true}) for
-    previously-synced files that no longer exist on disk. Updates `sent`;
+    previously-synced files that no longer exist on disk. Updates `sent` after
+    enqueue and retains tombstone markers for reconnect replay;
     returns the number of changed entries."""
+    if commit_input and not (Path(run.workdir) / "candidate" / "index.md").is_file():
+        raise FileNotFoundError("cannot commit compile input without candidate/index.md")
     changed = []
+    next_sent = dict(sent)
     collected = set()
     for art in _collect_workspace_artifacts(run.workdir):
         collected.add(art["path"])
         sha = hashlib.sha256(art["content"].encode("utf-8")).hexdigest()
         if sent.get(art["path"]) == sha:
             continue
-        sent[art["path"]] = sha
+        next_sent[art["path"]] = sha
         changed.append(art)
     # Tombstones: a previously-synced file the agent deleted (page merge, rename,
     # restructure) must be deleted from the consumer's store too — otherwise the
@@ -408,11 +427,37 @@ async def _sync_workspace(run: CompileRun, sent: dict) -> int:
     for path in [p for p in sent if p not in collected]:
         if (wd / path).is_file():
             continue  # still on disk, just not collectable — keep the row
-        del sent[path]
-        changed.append({"path": path, "deleted": True})
-    if changed:
-        await run.emit({"type": "syncArtifacts", "artifacts": changed})
+        if sent.get(path) != _SYNC_TOMBSTONE:
+            next_sent[path] = _SYNC_TOMBSTONE
+            changed.append({"path": path, "deleted": True})
+    if changed or commit_input:
+        event = {"type": "syncArtifacts", "artifacts": changed}
+        if commit_input:
+            event["commit_input"] = True
+        await run.emit(event)
+        # Advance the dedup cursor only after the event is queued. Tombstone
+        # markers are retained so an SSE re-attach can replay deletions too.
+        if changed:
+            sent.clear()
+            sent.update(next_sent)
+        if commit_input:
+            run._commit_input_replay = True
     return len(changed)
+
+
+def _workspace_replay_artifacts(run: CompileRun, sent: dict) -> list[dict]:
+    """Authoritative workspace replay for a newly attached SSE relay.
+
+    A runtime can crash after dequeuing syncArtifacts but before the consumer
+    acknowledges it. Re-send every current file and every remembered tombstone
+    on attach; consumer upserts/deletes are idempotent.
+    """
+    artifacts = _collect_workspace_artifacts(run.workdir)
+    current = {item["path"] for item in artifacts}
+    for path, value in sorted(sent.items()):
+        if value == _SYNC_TOMBSTONE and path not in current:
+            artifacts.append({"path": path, "deleted": True})
+    return artifacts
 
 
 async def _sync_loop(run: CompileRun, sent: dict):
@@ -1594,10 +1639,18 @@ async def _emit_message(run: CompileRun, msg) -> None:
         # alone can land seconds later and lose that race.
         sent = getattr(run, "_sync_sent", None)
         if sent is not None:
-            try:
-                await _sync_workspace(run, sent)
-            except Exception:
-                pass  # periodic loop retries; a sync hiccup must not kill the turn
+            if getattr(run, "_full_compile_pending", False) and repair_msg is None:
+                # Provenance commit is ordered in the same atomic consumer batch
+                # as the final content. Unlike ordinary sync, it fails closed:
+                # announcing turn_done before this is durable would lie about the
+                # input the draft was compiled from.
+                await _sync_workspace(run, sent, commit_input=True)
+                run._full_compile_pending = False
+            else:
+                try:
+                    await _sync_workspace(run, sent)
+                except Exception:
+                    pass  # periodic loop retries; a sync hiccup must not kill the turn
         await run.emit({"type": "turn_done", "text": reply})
         # Bounded auto-repair AFTER turn_done (async-post-check design, §4.3-c):
         # the turn ends normally; the repair is an ordinary next turn. When no
@@ -1614,6 +1667,7 @@ async def _emit_message(run: CompileRun, msg) -> None:
                 # would judge the next unrelated turn against this round's
                 # snapshot and restore over the owner's edits (review finding).
                 run._incr_pending = None
+                run._full_compile_pending = False
                 msg = (f"Self-check repair injection failed: {e!r}"
                        if selfcheck._is_en(getattr(run, "locale", None))
                        else f"自检回修注入失败: {e!r}")
@@ -1634,7 +1688,7 @@ async def _emit_message(run: CompileRun, msg) -> None:
 # declares no allowed_tools (profile.allowedTools = null → box default). A profile
 # that DOES declare a list (e.g. kb-test) overrides this.
 DEFAULT_COMPILE_ALLOWED_TOOLS = [
-    "Read", "Write", "Edit", "Glob", "Grep", "Bash",
+    "Read", "Write", "Edit", "Glob", "Grep",
     "mcp__compile__report_summary",
     "mcp__compile__propose_plan",
     "mcp__compile__resolve_ticket",
@@ -1663,6 +1717,7 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=session_id,
         session_store=InMemorySessionStore(),
+        hooks={"PreToolUse": [HookMatcher(hooks=[_make_compile_path_guard(Path(wd), run.locale)])]},
         # Stream partial deltas so the stall watchdog sees fine-grained model
         # liveness: a live-but-slow generation keeps emitting StreamEvents (idle
         # clock stays fresh), while a black-holed request emits nothing at all.
@@ -1744,8 +1799,13 @@ async def _start_incremental(run: "CompileRun", text: str) -> None:
         # so clear any stale CHANGESET here too (review): the turn is NOT
         # incremental and the model must not self-restrict to an old scope.
         (Path(run.workdir) / incremental.CHANGESET_PATH).unlink(missing_ok=True)
+        run._full_compile_pending = True
         run._begin_turn(text)
-        await run.client.query(text)
+        try:
+            await run.client.query(text)
+        except BaseException:
+            run._full_compile_pending = False
+            raise
         return
     # ADDED_TARGETS is a PER-ROUND declaration (pages the model merges added
     # sources into). Nothing box-side cleared it, so declarations from earlier
@@ -2190,10 +2250,9 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
             await _run_ledger_repairs(run, replies)  # the digest may have touched pages
         sent = getattr(run, "_sync_sent", None)
         if sent is not None:
-            try:
-                await _sync_workspace(run, sent)
-            except Exception:
-                pass
+            # Successful batch completion is one full-compile provenance commit.
+            # Content and input revision must land atomically before turn_done.
+            await _sync_workspace(run, sent, commit_input=True)
         await run.emit({"type": "turn_done", "text": "\n\n".join(replies).strip()
                         or _loc(run, "Batch compile complete.", "分批编译完成。")})
     except Exception as e:
@@ -2404,7 +2463,10 @@ async def _run_wrapper(run: CompileRun):
     eventually mislabeled by the idle watchdog. Cancellation (CancelledError)
     bypasses both the except and the `clean` flag, so a cancelled run still
     closes with just `end`."""
-    sent: dict = {}
+    # The consumer just rehydrated these files into a fresh box. Prime the diff
+    # cursor from that installed state so the first periodic tick cannot echo an
+    # unchanged candidate/index.md and impersonate a completed compile.
+    sent: dict = _workspace_sync_cursor(run.workdir)
     clean = False
     run._sync_sent = sent  # shared with _emit_message's pre-turn_done sync
     syncer = asyncio.create_task(_sync_loop(run, sent))
@@ -2481,14 +2543,19 @@ def _test_path_escape(root: Path, tool_name: str, tool_input: dict) -> str | Non
             target.resolve().relative_to(root)
         except ValueError:
             return f"{key}={v}"
-    # Glob's pattern is itself a path expression; an absolute pattern escapes even
-    # with `path` unset. (Grep's pattern is regex CONTENT — not a path; skip it.)
+    # Glob's pattern is itself a path expression even with `path` unset. Reject
+    # lexical parent traversal for relative patterns and resolve absolute bases.
+    # (Grep's pattern is regex CONTENT — not a path; skip it.)
     if tool_name == "Glob":
         pattern = tool_input.get("pattern")
-        if isinstance(pattern, str) and pattern.startswith("/"):
-            base = pattern.split("*", 1)[0]
+        if isinstance(pattern, str) and pattern.strip():
+            if ".." in PurePosixPath(pattern).parts:
+                return f"pattern={pattern}"
+            wildcard_positions = [pattern.find(ch) for ch in ("*", "?", "[") if ch in pattern]
+            base = pattern[:min(wildcard_positions)] if wildcard_positions else pattern
+            target = Path(base) if pattern.startswith("/") else root / base
             try:
-                Path(base).resolve().relative_to(root)
+                target.resolve().relative_to(root)
             except ValueError:
                 return f"pattern={pattern}"
     return None
@@ -2502,6 +2569,29 @@ def _make_test_path_guard(root: Path, locale: str | None = None):
 
     async def guard(input_data, tool_use_id, context):
         offender = _test_path_escape(root, str(input_data.get("tool_name", "")), input_data.get("tool_input") or {})
+        if offender:
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": deny_template.format(root=root, offender=offender),
+                }
+            }
+        return {}
+
+    return guard
+
+
+def _make_compile_path_guard(root: Path, locale: str | None = None):
+    """Constrain compiler file tools to /work and deny Bash even if a future
+    runtime profile accidentally adds it back to allowed_tools."""
+    deny_template = _prompt("guard_deny", locale).strip()
+
+    async def guard(input_data, tool_use_id, context):
+        tool_name = str(input_data.get("tool_name", ""))
+        offender = "tool=Bash" if tool_name == "Bash" else _test_path_escape(
+            root, tool_name, input_data.get("tool_input") or {}
+        )
         if offender:
             return {
                 "hookSpecificOutput": {
@@ -2765,8 +2855,16 @@ async def handle_message(request: web.Request):
                 "Noted — it will be passed along to the remaining batches.",
                 "已收到,会带给后续批次一并考虑。")})
         return web.json_response({"ok": True, "queued": True})
+    full_compile = _is_compile_trigger(text)
+    if full_compile:
+        run._full_compile_pending = True
     run._begin_turn(text)  # arm the stall watchdog — every model turn, incl. the owner's
-    await run.client.query(text)
+    try:
+        await run.client.query(text)
+    except BaseException:
+        if full_compile:
+            run._full_compile_pending = False
+        raise
     return web.json_response({"ok": True})
 
 
@@ -2782,6 +2880,18 @@ async def handle_events(request: web.Request):
     await resp.prepare(request)
     run._relays = getattr(run, "_relays", 0) + 1
     try:
+        # Replay BEFORE consuming the queue. This closes the crash window where
+        # a previous runtime dequeued a sync event but died before persisting it;
+        # it also works when the run already queued its terminal `end` frame.
+        wants_replay = request.query.get("replay") == "1"
+        replay = (_workspace_replay_artifacts(run, getattr(run, "_sync_sent", {}))
+                  if wants_replay else [])
+        replay_commit = wants_replay and getattr(run, "_commit_input_replay", False)
+        if replay or replay_commit:
+            ev = {"type": "syncArtifacts", "artifacts": replay}
+            if replay_commit:
+                ev["commit_input"] = True
+            await resp.write(("data: " + json.dumps(ev, ensure_ascii=False) + "\n\n").encode())
         while True:
             try:
                 ev = await asyncio.wait_for(run.events.get(), timeout=25)

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1752,11 +1752,11 @@ def _compile_system_prompt(run: "CompileRun") -> str:
 # "直接开始编译"). Natural-language phrasings deliberately do NOT trigger — a human
 # saying "继续编译前我想先改个要求" must not launch the train.
 _BATCH_TRIGGER_PREFIXES = ("直接开始编译", "批准,按此计划执行")
-_BATCH_TRIGGER_SUBSTR = "请增量重编"
+_INCREMENTAL_TRIGGER_PREFIXES = ("原料已更新,请增量重编", "请增量重编")
 
 
 def _is_compile_trigger(text: str) -> bool:
-    return text.startswith(_BATCH_TRIGGER_PREFIXES) or _BATCH_TRIGGER_SUBSTR in text
+    return text.startswith(_BATCH_TRIGGER_PREFIXES + _INCREMENTAL_TRIGGER_PREFIXES)
 
 
 def _batch_mode_enabled() -> bool:
@@ -2033,6 +2033,7 @@ async def _plan_batches(run: "CompileRun", inventory: list) -> dict:
             system_prompt={"type": "preset", "preset": "claude_code", "append": _planner_role(getattr(run, "locale", None))},
             allowed_tools=["Read", "Write", "Glob"],
             permission_mode="bypassPermissions",
+            hooks={"PreToolUse": [HookMatcher(hooks=[_make_compile_path_guard(Path(wd), run.locale)])]},
             setting_sources=[],
             model=os.environ.get("KBC_COMPILE_MODEL", "claude-opus-4-6"),
             max_turns=8,
@@ -2561,35 +2562,15 @@ def _test_path_escape(root: Path, tool_name: str, tool_input: dict) -> str | Non
     return None
 
 
-def _make_test_path_guard(root: Path, locale: str | None = None):
-    """PreToolUse hook confining a test session to its snapshot. A hook (not a
-    can_use_tool callback) because hooks fire under bypassPermissions too. The
-    steering message comes from the locale's prompt pack — it is model-facing."""
-    deny_template = _prompt("guard_deny", locale).strip()
-
-    async def guard(input_data, tool_use_id, context):
-        offender = _test_path_escape(root, str(input_data.get("tool_name", "")), input_data.get("tool_input") or {})
-        if offender:
-            return {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": deny_template.format(root=root, offender=offender),
-                }
-            }
-        return {}
-
-    return guard
-
-
-def _make_compile_path_guard(root: Path, locale: str | None = None):
-    """Constrain compiler file tools to /work and deny Bash even if a future
-    runtime profile accidentally adds it back to allowed_tools."""
+def _make_path_guard(root: Path, locale: str | None = None, *, deny_bash: bool = False):
+    """PreToolUse hook confining one SDK session to its workspace. Hooks fire
+    under bypassPermissions; compiler sessions also deny Bash as defense in
+    depth if a future profile accidentally adds it back."""
     deny_template = _prompt("guard_deny", locale).strip()
 
     async def guard(input_data, tool_use_id, context):
         tool_name = str(input_data.get("tool_name", ""))
-        offender = "tool=Bash" if tool_name == "Bash" else _test_path_escape(
+        offender = "tool=Bash" if deny_bash and tool_name == "Bash" else _test_path_escape(
             root, tool_name, input_data.get("tool_input") or {}
         )
         if offender:
@@ -2603,6 +2584,16 @@ def _make_compile_path_guard(root: Path, locale: str | None = None):
         return {}
 
     return guard
+
+
+def _make_test_path_guard(root: Path, locale: str | None = None):
+    """Constrain a read-only test consumer to its pinned snapshot."""
+    return _make_path_guard(root, locale)
+
+
+def _make_compile_path_guard(root: Path, locale: str | None = None):
+    """Constrain compiler and planner sessions to their /work workspace."""
+    return _make_path_guard(root, locale, deny_bash=True)
 
 
 async def test_session_driver(run: "TestRun"):

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -84,6 +84,13 @@ async def test_workspace_sync():
         paths = sorted(a["path"] for a in compile_box._collect_workspace_artifacts(str(wd)))
         assert paths == ["candidate/01.md", "eval/TESTS.md"], paths
 
+        # A fresh box starts from consumer-rehydrated files. Priming the cursor
+        # must prevent that unchanged index/workspace from being echoed as new.
+        primed = compile_box._workspace_sync_cursor(str(wd))
+        primed_run = compile_box.CompileRun("primed-run", str(wd), 1)
+        assert await compile_box._sync_workspace(primed_run, primed) == 0
+        assert primed_run.events.empty()
+
         run = compile_box.CompileRun("sync-run", str(wd), 1)
         sent: dict = {}
         assert await compile_box._sync_workspace(run, sent) == 2
@@ -101,9 +108,24 @@ async def test_workspace_sync():
         assert await compile_box._sync_workspace(run, sent) == 1
         ev = run.events.get_nowait()
         assert ev["artifacts"] == [{"path": "candidate/01.md", "deleted": True}], ev
-        assert "candidate/01.md" not in sent
+        assert sent["candidate/01.md"] == compile_box._SYNC_TOMBSTONE
         # steady state after the tombstone → no re-emit
         assert await compile_box._sync_workspace(run, sent) == 0 and run.events.empty()
+        replay = compile_box._workspace_replay_artifacts(run, sent)
+        assert {"path": "candidate/01.md", "deleted": True} in replay
+        # A full-compile commit is explicit and replayable even if its final
+        # content was already caught by a periodic sync.
+        try:
+            await compile_box._sync_workspace(run, sent, commit_input=True)
+            assert False, "compile commit without candidate/index.md must fail"
+        except FileNotFoundError:
+            pass
+        (wd / "candidate" / "index.md").write_text("# Index\n")
+        assert await compile_box._sync_workspace(run, sent, commit_input=True) == 1
+        ev = run.events.get_nowait()
+        assert ev["type"] == "syncArtifacts" and ev["commit_input"] is True, ev
+        assert [a["path"] for a in ev["artifacts"]] == ["candidate/index.md"], ev
+        assert run._commit_input_replay is True
         # a file that becomes UNCOLLECTABLE (oversized) but still exists on disk
         # must NOT be tombstoned — deletion is judged by is_file(), not by
         # absence from the collection.
@@ -334,12 +356,26 @@ async def test_test_path_escape_guard():
         assert ok(root, "Read", {"file_path": "../../work/raw/src.md"}) is not None
         assert ok(root, "Grep", {"path": "/work"}) == "path=/work"
         assert ok(root, "Glob", {"pattern": "/work/**/*.md"}) == "pattern=/work/**/*.md"
+        assert ok(root, "Glob", {"pattern": "../../etc/*.conf"}) == "pattern=../../etc/*.conf"
 
         # the PreToolUse hook wraps the predicate into a deny decision
         guard = compile_box._make_test_path_guard(root)
         deny = await guard({"tool_name": "Read", "tool_input": {"file_path": "/work/raw/x.md"}}, "t1", None)
         assert deny["hookSpecificOutput"]["permissionDecision"] == "deny", deny
         allow = await guard({"tool_name": "Read", "tool_input": {"file_path": "index.md"}}, "t2", None)
+        assert allow == {}, allow
+
+        # Compile sessions use the same confinement over /work and do not expose
+        # Bash. The hook denies it too as defense-in-depth against profile drift.
+        assert "Bash" not in compile_box.DEFAULT_COMPILE_ALLOWED_TOOLS
+        compile_guard = compile_box._make_compile_path_guard(root)
+        deny = await compile_guard({"tool_name": "Read", "tool_input": {"file_path": "/etc/passwd"}}, "c1", None)
+        assert deny["hookSpecificOutput"]["permissionDecision"] == "deny", deny
+        deny = await compile_guard({"tool_name": "Bash", "tool_input": {"command": "env"}}, "c2", None)
+        assert deny["hookSpecificOutput"]["permissionDecision"] == "deny", deny
+        deny = await compile_guard({"tool_name": "Glob", "tool_input": {"pattern": "../outside/*"}}, "c2b", None)
+        assert deny["hookSpecificOutput"]["permissionDecision"] == "deny", deny
+        allow = await compile_guard({"tool_name": "Write", "tool_input": {"file_path": "candidate/a.md"}}, "c3", None)
         assert allow == {}, allow
     print("✓ test-session path guard (C4): snapshot-confined, live /work denied")
 
@@ -393,7 +429,7 @@ def test_pack_candidates_to_wiki():
 
 
 def test_pack_candidates_symlink_confinement():
-    """Security: the compile session has Write+Bash, so it could ln -s a host file
+    """Security: a compromised workspace can still contain a symlink, so a host file
     into candidate/. The pinner must NOT copy content whose real path escapes
     candidate/ — neither a file symlink nor a symlinked directory."""
     with tempfile.TemporaryDirectory() as wd, tempfile.TemporaryDirectory() as dest_root, tempfile.TemporaryDirectory() as outside:

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -380,6 +380,30 @@ async def test_test_path_escape_guard():
     print("✓ test-session path guard (C4): snapshot-confined, live /work denied")
 
 
+async def test_batch_planner_uses_compile_path_guard():
+    """The model planner can Write under bypassPermissions, so it must carry the
+    same workspace confinement hook as every other compiler session."""
+    orig = compile_box.ClaudeSDKClient
+    previous_mode = os.environ.get("KBC_BATCH_PLANNER")
+    compile_box.ClaudeSDKClient = _FakeSDKClient
+    os.environ["KBC_BATCH_PLANNER"] = "model"
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            run = compile_box.CompileRun("planner-guard", td, 1)
+            inventory = [{"path": "a.md", "bytes": 10, "effective": 10}]
+            await compile_box._plan_batches(run, inventory)
+            opts = _FakeSDKClient.last.options
+            assert opts.allowed_tools == ["Read", "Write", "Glob"], opts.allowed_tools
+            assert opts.hooks and opts.hooks.get("PreToolUse"), opts.hooks
+    finally:
+        compile_box.ClaudeSDKClient = orig
+        if previous_mode is None:
+            os.environ.pop("KBC_BATCH_PLANNER", None)
+        else:
+            os.environ["KBC_BATCH_PLANNER"] = previous_mode
+    print("✓ batch planner uses compile workspace path guard")
+
+
 
 def test_pack_candidates_to_wiki():
     """_pack_candidates_to_wiki mirrors buildPublishBundleFromCandidates: candidate/
@@ -1362,6 +1386,7 @@ async def test_batch_orchestrator_routing_and_resume():
         assert compile_box._should_route_to_batch(run, "直接开始编译")
         assert compile_box._should_route_to_batch(run, "原料已更新,请增量重编: xx")
         assert not compile_box._should_route_to_batch(run, "你好")
+        assert not compile_box._should_route_to_batch(run, "请解释一下“请增量重编”是什么意思")
 
         # stub the session driver: record directives, pretend each session works
         driven: list[str] = []
@@ -2014,6 +2039,7 @@ async def main():
     test_pack_candidates_to_wiki()
     test_pack_candidates_symlink_confinement()
     await test_test_path_escape_guard()
+    await test_batch_planner_uses_compile_path_guard()
     await test_prompt_packs_locale()
     await test_test_session_driver_readonly()
     await test_open_close_test_session_http()

--- a/src/gateway/agentbox/box-profile.test.ts
+++ b/src/gateway/agentbox/box-profile.test.ts
@@ -22,7 +22,7 @@ describe("getBoxProfile", () => {
     expect(p.allowedTools).toBeUndefined();
   });
 
-  it("kb-compile → dedicated image + LLM env + writable /work + HOME, all tools", () => {
+  it("kb-compile → dedicated image + LLM env + writable /work + box-owned restricted tools", () => {
     process.env.SICLAW_COMPILE_BOX_IMAGE = "kbc-compile-box:test-tag";
     const p = getBoxProfile("kb-compile");
     expect(p.image).toBe("kbc-compile-box:test-tag");

--- a/src/gateway/capability/contract.ts
+++ b/src/gateway/capability/contract.ts
@@ -46,6 +46,7 @@ export const CAPABILITY_TEST_CLOSE = "capability.testClose" as const;
 /** siclaw → consumer: live stream + content sink + input fetch. */
 export const CAPABILITY_EVENT = "capability.event" as const;
 export const CAPABILITY_PERSIST_ARTIFACT = "capability.persistArtifact" as const;
+export const CAPABILITY_PERSIST_ARTIFACTS = "capability.persistArtifacts" as const;
 export const CAPABILITY_FETCH_INPUT = "capability.fetchInput" as const;
 
 /**
@@ -193,7 +194,7 @@ export interface CapabilityRunState {
   correlation_id: string;
   profile: string;
   status: CapabilityLifecycleStatus;
-  /** Opaque resume blob (JSON-serializable). Reserved — no writer yet. */
+  /** Opaque resume blob; KB runs currently checkpoint their installed input revision here. */
   checkpoint?: unknown;
   /**
    * Box session id, reserved for a future where the box persists its session and
@@ -254,12 +255,23 @@ export interface CapabilityPersistTurnRequest {
  */
 export interface CapabilityPersistArtifactRequest {
   run_id: string;
+  /** Immutable input revision materialized into this run. */
+  input_revision?: string;
   /** Logical path within the capability workspace, e.g. "candidate/00-intro.md". */
   path: string;
   /** Present on add/update; absent when `deleted` is set. */
   content?: CapabilityContentRef;
   /** Tombstone: delete the row for `path` from the consumer's store. */
   deleted?: boolean;
+}
+
+/** Atomic content batch. One box sync event is committed all-or-nothing. */
+export interface CapabilityPersistArtifactsRequest {
+  run_id: string;
+  input_revision?: string;
+  /** Explicit full-compile commit; replay/content presence alone never advances provenance. */
+  commit_input?: boolean;
+  artifacts: Array<Omit<CapabilityPersistArtifactRequest, "run_id" | "input_revision">>;
 }
 
 export interface CapabilityContentRef {
@@ -283,11 +295,15 @@ export interface CapabilityFetchInputRequest {
   run_id: string;
   /** Input kind: "" = frozen raw sources; CAPABILITY_INPUT_WORKSPACE_REF = durable workspace. */
   ref?: string;
+  /** Recovery pin: return this exact immutable source manifest instead of freezing current raw. */
+  input_revision?: string;
 }
 
 export interface CapabilityFetchInputResponse {
   bundle_base64?: string;
   bundle_sha256?: string;
+  /** Immutable consumer input revision represented by the source bundle. */
+  input_revision?: string;
   /**
    * Consumer-declared prompt/output locale for the run's box (e.g. "zh").
    * Locale is DOMAIN config — the tenant/KB's language — so it rides this

--- a/src/gateway/capability/contract.ts
+++ b/src/gateway/capability/contract.ts
@@ -45,7 +45,6 @@ export const CAPABILITY_TEST_CLOSE = "capability.testClose" as const;
 
 /** siclaw → consumer: live stream + content sink + input fetch. */
 export const CAPABILITY_EVENT = "capability.event" as const;
-export const CAPABILITY_PERSIST_ARTIFACT = "capability.persistArtifact" as const;
 export const CAPABILITY_PERSIST_ARTIFACTS = "capability.persistArtifacts" as const;
 export const CAPABILITY_FETCH_INPUT = "capability.fetchInput" as const;
 

--- a/src/gateway/capability/materialize.test.ts
+++ b/src/gateway/capability/materialize.test.ts
@@ -3,7 +3,7 @@ import { materializeCapabilityInputs } from "./materialize.js";
 import { CAPABILITY_FETCH_INPUT, CAPABILITY_INPUT_WORKSPACE_REF } from "./contract.js";
 
 function fakes(opts: {
-  raw?: { bundle_base64?: string; bundle_sha256?: string; locale?: string };
+  raw?: { bundle_base64?: string; bundle_sha256?: string; locale?: string; input_revision?: string };
   workspace?: { bundle_base64?: string; bundle_sha256?: string };
   workspaceError?: Error;
   sourcesError?: Error;
@@ -37,7 +37,7 @@ beforeEach(() => {
 describe("materializeCapabilityInputs", () => {
   it("fresh box: posts raw sources, then rehydrates the authoring workspace (locale rides along)", async () => {
     const { client, backend, posts } = fakes({
-      raw: { bundle_base64: "UkFX", bundle_sha256: "aa", locale: "zh" },
+      raw: { bundle_base64: "UkFX", bundle_sha256: "aa", locale: "zh", input_revision: "manifest-1" },
       workspace: { bundle_base64: "V1M=", bundle_sha256: "bb" },
     });
     const result = await materializeCapabilityInputs({ client, backend, runId: "r1" });
@@ -45,6 +45,7 @@ describe("materializeCapabilityInputs", () => {
     // The consumer-declared locale is surfaced to the caller (→ /session body)
     // and forwarded on both installs (they seed the constitution).
     expect(result.locale).toBe("zh");
+    expect(result.inputRevision).toBe("manifest-1");
     expect(posts.map((p) => p.path)).toEqual(["/sources", "/authoring"]);
     expect(posts[0].body).toMatchObject({ locale: "zh" });
     expect(posts[1].body).toEqual({ run_id: "r1", bundle_base64: "V1M=", bundle_sha256: "bb", locale: "zh" });
@@ -53,16 +54,34 @@ describe("materializeCapabilityInputs", () => {
     expect(backend.request).toHaveBeenNthCalledWith(2, CAPABILITY_FETCH_INPUT, { run_id: "r1", ref: CAPABILITY_INPUT_WORKSPACE_REF });
   });
 
+  it("dead-box recovery requests the exact checkpointed input revision", async () => {
+    const { client, backend } = fakes({
+      raw: { bundle_base64: "UkFX", input_revision: "manifest-1" },
+    });
+    const result = await materializeCapabilityInputs({
+      client,
+      backend,
+      runId: "r1",
+      inputRevision: "manifest-1",
+    });
+    expect(backend.request).toHaveBeenNthCalledWith(1, CAPABILITY_FETCH_INPUT, {
+      run_id: "r1",
+      input_revision: "manifest-1",
+    });
+    expect(result.inputRevision).toBe("manifest-1");
+  });
+
   it("live box (409 on /sources): never touches the workspace", async () => {
     const { client, backend, posts } = fakes({
-      raw: { bundle_base64: "UkFX" },
+      raw: { bundle_base64: "UkFX", input_revision: "current-but-not-installed" },
       workspace: { bundle_base64: "V1M=" },
       sourcesError: new Error("AgentBox request failed: 409 run r1 already exists"),
     });
-    await materializeCapabilityInputs({ client, backend, runId: "r1" });
+    const result = await materializeCapabilityInputs({ client, backend, runId: "r1" });
 
     expect(posts).toEqual([]); // no /authoring — live on-disk state wins
     expect(backend.request).toHaveBeenCalledTimes(1); // workspace never fetched
+    expect(result.inputRevision).toBeUndefined(); // keep the run's recovered checkpoint
   });
 
   it("live box detected via structured err.status (message wording independent)", async () => {

--- a/src/gateway/capability/materialize.ts
+++ b/src/gateway/capability/materialize.ts
@@ -32,6 +32,10 @@ export interface MaterializeBackend {
 }
 
 export interface MaterializeResult {
+  /** Immutable input revision actually installed into a fresh box. */
+  inputRevision?: string;
+  /** /sources reported an already-live run; the event relay must request replay. */
+  reattached?: boolean;
   /** Consumer-declared locale for the run's box (fetchInput), if any. */
   locale?: string;
   /** Consumer-managed LLM endpoint for the box (opaque passthrough; never logged). */
@@ -44,13 +48,18 @@ export async function materializeCapabilityInputs(opts: {
   client: MaterializeBoxClient;
   backend: MaterializeBackend;
   runId: string;
+  /** Existing checkpoint recovered for this run; fresh boxes must reinstall it exactly. */
+  inputRevision?: string;
 }): Promise<MaterializeResult> {
-  const { client, backend, runId } = opts;
+  const { client, backend, runId, inputRevision } = opts;
 
   const result: MaterializeResult = {};
   let freshBox = false;
   try {
-    const req: CapabilityFetchInputRequest = { run_id: runId };
+    const req: CapabilityFetchInputRequest = {
+      run_id: runId,
+      ...(inputRevision ? { input_revision: inputRevision } : {}),
+    };
     const src = (await backend.request(CAPABILITY_FETCH_INPUT, req)) as CapabilityFetchInputResponse;
     if (src?.locale) result.locale = src.locale;
     if (src?.llm && typeof src.llm === "object") result.llm = src.llm;
@@ -63,6 +72,7 @@ export async function materializeCapabilityInputs(opts: {
         locale: src.locale,
       });
       freshBox = true;
+      if (src.input_revision) result.inputRevision = src.input_revision;
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -75,6 +85,7 @@ export async function materializeCapabilityInputs(opts: {
       // The box already holds this run (live on-disk state) — reattach without
       // touching its workspace.
       console.log(`[capability] session ${runId}: box already live; skipping materialization`);
+      result.reattached = true;
     } else {
       console.warn(`[capability] session ${runId}: source materialize skipped:`, msg);
     }

--- a/src/gateway/capability/run-manager.test.ts
+++ b/src/gateway/capability/run-manager.test.ts
@@ -69,6 +69,38 @@ describe("CapabilityRunManager", () => {
     expect(be.persists().at(-1)?.params).toMatchObject({ status: "idle" });
   });
 
+  it("checkpoints the installed input revision and restores it after restart", async () => {
+    const be = new FakeBackend();
+    const mgr = new CapabilityRunManager(be);
+    const { runId } = await mgr.startRun({ profile: "kb-compile", orgId: "o1" });
+
+    await mgr.setInputRevision(runId, "manifest-1");
+    expect(mgr.get(runId)?.inputRevision).toBe("manifest-1");
+    expect(be.persists().at(-1)?.params).toMatchObject({
+      checkpoint: { input_revision: "manifest-1" },
+    });
+
+    const recoveredBackend = new FakeBackend();
+    recoveredBackend.activeRuns = [{
+      id: runId,
+      profile: "kb-compile",
+      org_id: "o1",
+      status: "running",
+      checkpoint: JSON.stringify({ input_revision: "manifest-1" }),
+    }];
+    const recovered = new CapabilityRunManager(recoveredBackend);
+    await recovered.recover();
+    expect(recovered.get(runId)?.inputRevision).toBe("manifest-1");
+  });
+
+  it("fails closed when the installed input revision cannot be checkpointed", async () => {
+    const be = new FakeBackend();
+    const mgr = new CapabilityRunManager(be);
+    const { runId } = await mgr.startRun({ profile: "kb-compile", orgId: "o1" });
+    be.failPersist = true;
+    await expect(mgr.setInputRevision(runId, "manifest-1")).rejects.toThrow("ws down");
+  });
+
   it("endRun persists the terminal state then drops the run from the live map", async () => {
     const be = new FakeBackend();
     const mgr = new CapabilityRunManager(be);

--- a/src/gateway/capability/run-manager.test.ts
+++ b/src/gateway/capability/run-manager.test.ts
@@ -8,9 +8,14 @@ class FakeBackend implements RunStateBackend {
   activeRuns: any[] = [];
   getRunRow: any = null;
   failPersist = false;
+  failPersistCount = 0;
   async request(method: string, params?: unknown): Promise<any> {
     this.calls.push({ method, params });
     if (method === CAPABILITY_PERSIST_RUN_STATE && this.failPersist) throw new Error("ws down");
+    if (method === CAPABILITY_PERSIST_RUN_STATE && this.failPersistCount > 0) {
+      if (this.failPersistCount > 0) this.failPersistCount -= 1;
+      throw new Error("FrontendWsClient disconnected");
+    }
     if (method === CAPABILITY_LIST_ACTIVE_RUNS) return { runs: this.activeRuns };
     if (method === CAPABILITY_GET_RUN) return this.getRunRow;
     return { ok: true };
@@ -97,8 +102,38 @@ describe("CapabilityRunManager", () => {
     const be = new FakeBackend();
     const mgr = new CapabilityRunManager(be);
     const { runId } = await mgr.startRun({ profile: "kb-compile", orgId: "o1" });
-    be.failPersist = true;
-    await expect(mgr.setInputRevision(runId, "manifest-1")).rejects.toThrow("ws down");
+    be.failPersistCount = 10;
+    vi.useFakeTimers();
+    try {
+      const checkpoint = mgr.setInputRevision(runId, "manifest-1");
+      const rejected = expect(checkpoint).rejects.toThrow("FrontendWsClient disconnected");
+      await vi.runAllTimersAsync();
+      await rejected;
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(mgr.get(runId)?.inputRevision).toBeUndefined();
+    expect(be.persists()).toHaveLength(5); // start + four bounded checkpoint attempts
+  });
+
+  it("retries a transient input checkpoint failure before allowing the box to run", async () => {
+    const be = new FakeBackend();
+    const mgr = new CapabilityRunManager(be);
+    const { runId } = await mgr.startRun({ profile: "kb-compile", orgId: "o1" });
+    be.failPersistCount = 2;
+    vi.useFakeTimers();
+    try {
+      const checkpoint = mgr.setInputRevision(runId, "manifest-1");
+      await vi.runAllTimersAsync();
+      await checkpoint;
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(mgr.get(runId)?.inputRevision).toBe("manifest-1");
+    expect(be.persists()).toHaveLength(4); // start + two failures + one ack
+    expect(be.persists().at(-1)?.params).toMatchObject({
+      checkpoint: { input_revision: "manifest-1" },
+    });
   });
 
   it("endRun persists the terminal state then drops the run from the live map", async () => {

--- a/src/gateway/capability/run-manager.ts
+++ b/src/gateway/capability/run-manager.ts
@@ -97,6 +97,8 @@ export interface CapabilityRunManagerOptions {
 // defer forever and pin its box. After this many consecutive failed re-checks we
 // stop deferring and reap the run anyway.
 const MAX_REAP_DEFERRALS = 5;
+const INPUT_REVISION_PERSIST_ATTEMPTS = 4;
+const INPUT_REVISION_RETRY_BASE_MS = 250;
 
 export class CapabilityRunManager {
   private runs = new Map<string, CapabilityRunRecord>();
@@ -218,8 +220,31 @@ export class CapabilityRunManager {
     const rec = this.runs.get(runId);
     const revision = inputRevision.trim();
     if (!rec || !revision || rec.inputRevision === revision) return;
+    const previousRevision = rec.inputRevision;
     rec.inputRevision = revision;
-    await this.persist(rec, { failFast: true });
+    try {
+      for (let attempt = 1; attempt <= INPUT_REVISION_PERSIST_ATTEMPTS; attempt += 1) {
+        try {
+          await this.persist(rec, { failFast: true });
+          return;
+        } catch (err) {
+          if (attempt === INPUT_REVISION_PERSIST_ATTEMPTS) throw err;
+          const delayMs = INPUT_REVISION_RETRY_BASE_MS * 2 ** (attempt - 1);
+          console.warn(
+            `[capability] checkpoint input revision for ${runId} failed ` +
+            `(attempt ${attempt}/${INPUT_REVISION_PERSIST_ATTEMPTS}); retrying in ${delayMs}ms: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+      }
+    } catch (err) {
+      // Never retain an in-memory checkpoint the consumer did not durably ack.
+      // A later session setup must retry instead of returning early on a value
+      // that exists only in this process.
+      rec.inputRevision = previousRevision;
+      throw err;
+    }
   }
 
   /** Bump last-DATA activity so the watchdog doesn't reap an actively-used run. */

--- a/src/gateway/capability/run-manager.ts
+++ b/src/gateway/capability/run-manager.ts
@@ -41,6 +41,8 @@ export interface CapabilityRunRecord {
   correlationId?: string;
   status: CapabilityLifecycleStatus;
   runtimeId?: string;
+  /** Frozen consumer input installed into this run's box. */
+  inputRevision?: string;
   /** Wall-clock ms of the last DATA event; drives the stale-run watchdog. */
   lastActivityMs: number;
   /**
@@ -196,6 +198,7 @@ export class CapabilityRunManager {
         orgId: row.org_id ?? "",
         correlationId: row.correlation_id || undefined,
         runtimeId: row.runtime_id || undefined,
+        inputRevision: inputRevisionFromCheckpoint(row.checkpoint),
         status,
         lastActivityMs: this.now(),
         lastHeartbeatMs: this.now(),
@@ -208,6 +211,15 @@ export class CapabilityRunManager {
       console.warn(`[capability] adopt(${runId}) failed: ${err instanceof Error ? err.message : String(err)}`);
       return undefined;
     }
+  }
+
+  /** Checkpoint the exact input before the box session is allowed to run. */
+  async setInputRevision(runId: string, inputRevision: string): Promise<void> {
+    const rec = this.runs.get(runId);
+    const revision = inputRevision.trim();
+    if (!rec || !revision || rec.inputRevision === revision) return;
+    rec.inputRevision = revision;
+    await this.persist(rec, { failFast: true });
   }
 
   /** Bump last-DATA activity so the watchdog doesn't reap an actively-used run. */
@@ -303,6 +315,7 @@ export class CapabilityRunManager {
           orgId: r.org_id ?? "",
           correlationId: r.correlation_id || undefined,
           runtimeId: r.runtime_id || undefined,
+          inputRevision: inputRevisionFromCheckpoint(r.checkpoint),
           status: r.status || "running",
           lastActivityMs: this.now(),
           lastHeartbeatMs: this.now(),
@@ -478,6 +491,7 @@ export class CapabilityRunManager {
       correlation_id: rec.correlationId ?? "",
       profile: rec.profile,
       status: rec.status,
+      ...(rec.inputRevision ? { checkpoint: { input_revision: rec.inputRevision } } : {}),
       // Reserved wire field, always "" — the runtime does not track a box session
       // id (see the note above adopt()); a future persistent-session design would
       // re-introduce the mirror + carry-through.
@@ -493,4 +507,18 @@ export class CapabilityRunManager {
       );
     }
   }
+}
+
+function inputRevisionFromCheckpoint(checkpoint: unknown): string | undefined {
+  let value = checkpoint;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!value || typeof value !== "object") return undefined;
+  const revision = (value as { input_revision?: unknown }).input_revision;
+  return typeof revision === "string" && revision.trim() ? revision.trim() : undefined;
 }

--- a/src/gateway/capability/session-driver.test.ts
+++ b/src/gateway/capability/session-driver.test.ts
@@ -115,6 +115,64 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     });
   });
 
+  it("downgrades a commit without an input revision while preserving artifact content", async () => {
+    const fe = fakeFrontend();
+    const mgr = fakeManager();
+    mgr.get.mockReturnValue({ status: "running" });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await driveCapabilitySession({
+        client: fakeClient([
+          {
+            type: "syncArtifacts",
+            artifacts: [{ path: "candidate/index.md", content: "# Index" }],
+            commit_input: true,
+          },
+          { type: "end" },
+        ]),
+        runId: "r1", frontendClient: fe, manager: mgr,
+      });
+    } finally {
+      errSpy.mockRestore();
+    }
+    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACTS, {
+      run_id: "r1",
+      artifacts: [{
+        path: "candidate/index.md",
+        content: { inline_base64: Buffer.from("# Index", "utf8").toString("base64") },
+      }],
+    });
+    expect(emits(fe)).toContainEqual({
+      run_id: "r1",
+      type: "summary",
+      payload: { text: expect.stringContaining("provenance was not advanced") },
+    });
+  });
+
+  it("does not send an empty commit when the run has no input revision", async () => {
+    const fe = fakeFrontend();
+    const mgr = fakeManager();
+    mgr.get.mockReturnValue({ status: "running" });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await driveCapabilitySession({
+        client: fakeClient([
+          { type: "syncArtifacts", artifacts: [], commit_input: true },
+          { type: "end" },
+        ]),
+        runId: "r1", frontendClient: fe, manager: mgr,
+      });
+    } finally {
+      errSpy.mockRestore();
+    }
+    expect(fe.request).not.toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACTS, expect.anything());
+    expect(emits(fe)).toContainEqual({
+      run_id: "r1",
+      type: "summary",
+      payload: { text: expect.stringContaining("provenance was not advanced") },
+    });
+  });
+
   it("done → lifecycle done + endRun(done)", async () => {
     const fe = fakeFrontend();
     const mgr = fakeManager();

--- a/src/gateway/capability/session-driver.test.ts
+++ b/src/gateway/capability/session-driver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { driveCapabilitySession } from "./session-driver.js";
-import { CAPABILITY_EVENT, CAPABILITY_PERSIST_ARTIFACT } from "./contract.js";
+import { CAPABILITY_EVENT, CAPABILITY_PERSIST_ARTIFACTS } from "./contract.js";
 
 // Fake box client that yields a fixed sequence of box events over streamPath.
 function fakeClient(events: any[]) {
@@ -32,6 +32,23 @@ function fakeManager() {
 const emits = (fe: any) => fe.emitEvent.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_EVENT).map((c: any[]) => c[1]);
 
 describe("driveCapabilitySession — box event → capability wire mapping", () => {
+  it("requests workspace replay only when re-attaching to a live box", async () => {
+    const paths: string[] = [];
+    const client = {
+      async *streamPath(path: string) {
+        paths.push(path);
+      },
+    } as any;
+    await driveCapabilitySession({
+      client,
+      runId: "r1",
+      frontendClient: fakeFrontend(),
+      manager: fakeManager(),
+      replayWorkspace: true,
+    });
+    expect(paths).toEqual(["/events/r1?replay=1"]);
+  });
+
   it("log/summary/turn_done map to capability.event and drive manager state", async () => {
     const fe = fakeFrontend();
     const mgr = fakeManager();
@@ -58,9 +75,10 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     expect(mgr.setStatus).toHaveBeenCalledWith("r1", "idle"); // turn ended → idle
   });
 
-  it("syncArtifacts persists each file as base64 via capability.persistArtifact", async () => {
+  it("syncArtifacts persists one atomic batch with the run input revision", async () => {
     const fe = fakeFrontend();
     const mgr = fakeManager();
+    mgr.get.mockReturnValue({ inputRevision: "manifest-1", status: "running" });
     await driveCapabilitySession({
       client: fakeClient([
         { type: "syncArtifacts", artifacts: [{ path: "candidate/a.md", content: "# A" }] },
@@ -68,10 +86,32 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
       ]),
       runId: "r1", frontendClient: fe, manager: mgr,
     });
-    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACT, {
+    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACTS, {
       run_id: "r1",
-      path: "candidate/a.md",
-      content: { inline_base64: Buffer.from("# A", "utf8").toString("base64") },
+      input_revision: "manifest-1",
+      artifacts: [{
+        path: "candidate/a.md",
+        content: { inline_base64: Buffer.from("# A", "utf8").toString("base64") },
+      }],
+    });
+  });
+
+  it("persists an explicit input commit even when no files changed", async () => {
+    const fe = fakeFrontend();
+    const mgr = fakeManager();
+    mgr.get.mockReturnValue({ inputRevision: "manifest-1", status: "running" });
+    await driveCapabilitySession({
+      client: fakeClient([
+        { type: "syncArtifacts", artifacts: [], commit_input: true },
+        { type: "end" },
+      ]),
+      runId: "r1", frontendClient: fe, manager: mgr,
+    });
+    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACTS, {
+      run_id: "r1",
+      input_revision: "manifest-1",
+      commit_input: true,
+      artifacts: [],
     });
   });
 
@@ -97,13 +137,15 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     expect(mgr.endRun).toHaveBeenCalledWith("r1", "failed");
   });
 
-  it("a persistArtifact outage never kills the relay — later events still flow", async () => {
+  it("a persistArtifacts outage retries until acknowledged before later events flow", async () => {
     const fe = fakeFrontend();
+    let attempts = 0;
     fe.request = vi.fn().mockImplementation(async (method: string) => {
-      if (method === CAPABILITY_PERSIST_ARTIFACT) throw new Error("ws blip");
+      if (method === CAPABILITY_PERSIST_ARTIFACTS && ++attempts < 3) throw new Error("ws blip");
       return { ok: true };
     });
     const mgr = fakeManager();
+    mgr.get.mockReturnValue({ runId: "r1", status: "running" });
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       await driveCapabilitySession({
@@ -123,10 +165,36 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     expect(emits(fe)).toContainEqual({ run_id: "r1", type: "turn", payload: { text: "still here" } });
     expect(mgr.setStatus).toHaveBeenCalledWith("r1", "idle");
     expect(mgr.endRun).not.toHaveBeenCalledWith("r1", "failed");
-    // It retried once before giving up on the artifact.
-    const artifactCalls = fe.request.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_PERSIST_ARTIFACT);
-    expect(artifactCalls).toHaveLength(2);
+    const artifactCalls = fe.request.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_PERSIST_ARTIFACTS);
+    expect(artifactCalls).toHaveLength(3);
+    expect(artifactCalls[0][1]).toEqual(artifactCalls[2][1]);
   }, 10_000);
+
+  it("stops retrying when the run is cancelled or reaped", async () => {
+    const fe = fakeFrontend();
+    let attempts = 0;
+    fe.request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === CAPABILITY_PERSIST_ARTIFACTS) {
+        attempts += 1;
+        throw new Error("consumer unavailable");
+      }
+      return { ok: true };
+    });
+    const mgr = fakeManager();
+    mgr.get.mockImplementation(() => attempts < 2 ? { runId: "r1", status: "running" } : undefined);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(driveCapabilitySession({
+        client: fakeClient([
+          { type: "syncArtifacts", artifacts: [{ path: "candidate/a.md", content: "# A" }] },
+        ]),
+        runId: "r1", frontendClient: fe, manager: mgr,
+      })).rejects.toThrow("no longer active");
+    } finally {
+      errSpy.mockRestore();
+    }
+    expect(attempts).toBe(2);
+  });
 
   it("a malformed artifact entry is skipped loudly — the relay and later artifacts survive", async () => {
     // Live 07-09: a runtime predating the tombstone branch threw in artifact
@@ -156,9 +224,12 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     } finally {
       errSpy.mockRestore();
     }
-    const artifactCalls = fe.request.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_PERSIST_ARTIFACT);
+    const artifactCalls = fe.request.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_PERSIST_ARTIFACTS);
     expect(artifactCalls).toHaveLength(1); // the good one after the bad one still landed
-    expect(artifactCalls[0][1]).toMatchObject({ run_id: "r1", path: "authoring/SELFCHECK.json" });
+    expect(artifactCalls[0][1]).toMatchObject({
+      run_id: "r1",
+      artifacts: [{ path: "authoring/SELFCHECK.json" }],
+    });
     expect(mgr.endRun).not.toHaveBeenCalledWith("r1", "failed");
   });
 
@@ -172,10 +243,10 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
       ]),
       runId: "r1", frontendClient: fe, manager: mgr,
     });
-    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACT, {
+    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACTS, {
       run_id: "r1",
-      path: "candidate/gone.md",
-      deleted: true,
+      input_revision: undefined,
+      artifacts: [{ path: "candidate/gone.md", deleted: true }],
     });
   });
 
@@ -232,10 +303,10 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
       ]),
       runId: "r1", frontendClient: fe, manager: mgr,
     });
-    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACT, {
+    expect(fe.request).toHaveBeenCalledWith(CAPABILITY_PERSIST_ARTIFACTS, {
       run_id: "r1",
-      path: "candidate/dup.md",
-      deleted: true,
+      input_revision: undefined,
+      artifacts: [{ path: "candidate/dup.md", deleted: true }],
     });
   });
 });

--- a/src/gateway/capability/session-driver.ts
+++ b/src/gateway/capability/session-driver.ts
@@ -19,12 +19,12 @@ import type {
   CapabilityEventFrame,
   CapabilityEventPayload,
   CapabilityEventType,
-  CapabilityPersistArtifactRequest,
+  CapabilityPersistArtifactsRequest,
   CapabilityPersistTurnRequest,
 } from "./contract.js";
 import {
   CAPABILITY_EVENT,
-  CAPABILITY_PERSIST_ARTIFACT,
+  CAPABILITY_PERSIST_ARTIFACTS,
   CAPABILITY_PERSIST_TURN,
   isTerminalCapabilityStatus,
 } from "./contract.js";
@@ -37,6 +37,8 @@ interface BoxEvent {
   error?: string;
   /** `deleted` entries are tombstones — the box removed a previously-synced file. */
   artifacts?: Array<{ path: string; content?: string; deleted?: boolean }>;
+  /** Explicit full-compile commit. Replayed file presence alone is not a commit. */
+  commit_input?: boolean;
 }
 
 export interface DriveCapabilitySessionOptions {
@@ -44,6 +46,8 @@ export interface DriveCapabilitySessionOptions {
   runId: string;
   frontendClient: FrontendWsClient;
   manager: CapabilityRunManager;
+  /** Re-attaching to a live box after relay/runtime loss: request full replay. */
+  replayWorkspace?: boolean;
 }
 
 /**
@@ -63,7 +67,8 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
   // must count as liveness (touchHeartbeat, the separate clock) or the watchdog
   // reaps a healthy run and kills its box. It is deliberately NOT touch(): a box
   // that ONLY heartbeats (a wedged turn) must still be reaped at dataStaleMs.
-  for await (const raw of client.streamPath(`/events/${runId}`, { onComment: () => manager.touchHeartbeat(runId) })) {
+  const eventPath = `/events/${runId}${opts.replayWorkspace ? "?replay=1" : ""}`;
+  for await (const raw of client.streamPath(eventPath, { onComment: () => manager.touchHeartbeat(runId) })) {
     const evt = raw as BoxEvent;
     // ANY box event means the box is alive → bump activity so the watchdog never
     // reaps an actively-working run (e.g. a long compile emitting only `log`).
@@ -92,49 +97,52 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
         await manager.setStatus(runId, "idle");
         break;
       case "syncArtifacts":
-        // Knowledge content the box produced → the consumer's store, one artifact
-        // at a time. Content is inline base64 (opaque to the transport). A failed
-        // persist must not fail the run (a transient WS blip would kill a healthy
-        // compile), but it IS real potential loss — the box's sync dedups by
-        // content hash, so this exact version is only re-sent if the file changes
-        // again. Hence one retry, then a loud log.
-        for (const a of evt.artifacts ?? []) {
-          let artifact: CapabilityPersistArtifactRequest;
-          try {
-            artifact = a.deleted
-              ? // Tombstone: the box deleted this file (page merge/rename/restructure).
-                // Without propagating it, the consumer's row outlives the file —
-                // publish ships the deleted page and the next respawn's workspace
-                // rehydration resurrects it onto the box's disk.
-                { run_id: runId, path: a.path, deleted: true }
+        // One box sync event is one consumer transaction. Keep retrying the
+        // SAME batch until acknowledged; consuming later turn_done/done frames
+        // before its workspace is durable would expose a torn draft.
+        {
+          const artifacts = (evt.artifacts ?? []).flatMap((a) => {
+            if (!a || typeof a.path !== "string" || !a.path) {
+              console.error(`[capability] run=${runId} malformed artifact entry skipped`);
+              return [];
+            }
+            if (!a.deleted && a.content !== undefined && typeof a.content !== "string") {
+              console.error(`[capability] run=${runId} malformed artifact entry (${a.path}) skipped`);
+              return [];
+            }
+            return [a.deleted
+              ? { path: a.path, deleted: true }
               : {
-                  run_id: runId,
                   path: a.path,
                   content: { inline_base64: Buffer.from(a.content ?? "", "utf8").toString("base64") },
-                };
-          } catch (err) {
-            // One malformed entry must not kill the relay: everything after it —
-            // later artifacts, the final SELFCHECK sync, settled, end — would be
-            // lost and the run stranded mid-state (seen live 07-09: a runtime
-            // predating the tombstone branch threw here on {deleted:true} and
-            // every incremental round wedged DIRTY with a leaked box).
-            console.error(
-              `[capability] run=${runId} malformed artifact entry (${String(a?.path ?? "?")}) skipped:`,
-              err instanceof Error ? err.message : String(err),
-            );
-            continue;
-          }
-          try {
-            await frontendClient.request(CAPABILITY_PERSIST_ARTIFACT, artifact);
-          } catch {
+                }];
+          });
+          if (artifacts.length === 0 && !evt.commit_input) break;
+          const request: CapabilityPersistArtifactsRequest = {
+            run_id: runId,
+            input_revision: manager.get(runId)?.inputRevision,
+            ...(evt.commit_input ? { commit_input: true } : {}),
+            artifacts,
+          };
+          let delayMs = 250;
+          for (;;) {
             try {
-              await new Promise((r) => setTimeout(r, 1000));
-              await frontendClient.request(CAPABILITY_PERSIST_ARTIFACT, artifact);
+              await frontendClient.request(CAPABILITY_PERSIST_ARTIFACTS, request);
+              break;
             } catch (err) {
+              const rec = manager.get(runId);
+              if (!rec || isTerminalCapabilityStatus(rec.status)) {
+                throw new Error(
+                  `persistArtifacts retry aborted because run ${runId} is no longer active: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
               console.error(
-                `[capability] run=${runId} persistArtifact(${a.path}) DROPPED after retry (box only re-sends on content change):`,
+                `[capability] run=${runId} persistArtifacts failed; retrying in ${delayMs}ms:`,
                 err instanceof Error ? err.message : String(err),
               );
+              manager.touchHeartbeat(runId);
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+              delayMs = Math.min(delayMs * 2, 5000);
             }
           }
         }

--- a/src/gateway/capability/session-driver.ts
+++ b/src/gateway/capability/session-driver.ts
@@ -3,7 +3,7 @@
  *
  * Consumes a box's `/events/:runId` SSE and speaks the GENERIC capability wire:
  *   - live frames  → capability.event {runId, type: log|turn|summary|lifecycle}
- *   - knowledge    → capability.persistArtifact (content → the consumer's store)
+ *   - knowledge    → capability.persistArtifacts (one all-or-nothing consumer batch)
  *   - lifecycle    → writes back to the CapabilityRunManager (idle/done/failed)
  *
  * This is the capability-native replacement for compile-driver's relayBoxEvents
@@ -117,11 +117,19 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
                   content: { inline_base64: Buffer.from(a.content ?? "", "utf8").toString("base64") },
                 }];
           });
-          if (artifacts.length === 0 && !evt.commit_input) break;
+          const inputRevision = manager.get(runId)?.inputRevision?.trim();
+          const commitInput = evt.commit_input === true && Boolean(inputRevision);
+          if (evt.commit_input && !commitInput) {
+            const warning =
+              "Source provenance was not advanced because this run has no pinned input revision. Any artifact changes will be saved without committing the input baseline; start a new compile run after source materialization recovers.";
+            console.error(`[capability] run=${runId} commit_input downgraded to content-only persistence: missing input revision`);
+            emit("summary", { text: warning });
+          }
+          if (artifacts.length === 0 && !commitInput) break;
           const request: CapabilityPersistArtifactsRequest = {
             run_id: runId,
-            input_revision: manager.get(runId)?.inputRevision,
-            ...(evt.commit_input ? { commit_input: true } : {}),
+            ...(inputRevision ? { input_revision: inputRevision } : {}),
+            ...(commitInput ? { commit_input: true } : {}),
             artifacts,
           };
           let delayMs = 250;

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -438,12 +438,22 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     if (!pending) {
       pending = (async () => {
         const client = await capabilityBoxClient(runId, profile, orgId);
+        let replayWorkspace = false;
         try {
           // Raw sources + (fresh box only) the durable authoring workspace, both
           // from the consumer's store. Best-effort — see materializeCapabilityInputs.
           // The consumer also declares the run's LOCALE through the same channel;
           // the box selects its prompt pack with it (absent ⇒ English default).
-          const materialized = await materializeCapabilityInputs({ client, backend: frontendClient, runId });
+          const materialized = await materializeCapabilityInputs({
+            client,
+            backend: frontendClient,
+            runId,
+            inputRevision: capabilityRunManager.get(runId)?.inputRevision,
+          });
+          replayWorkspace = materialized.reattached === true;
+          if (materialized.inputRevision) {
+            await capabilityRunManager.setInputRevision(runId, materialized.inputRevision);
+          }
           const allowedTools = getBoxProfile(profile).allowedTools ?? null;
           await client.postJson(`/session/${runId}`, {
             instruction: instruction ?? "",
@@ -469,7 +479,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           );
           throw err;
         }
-        driveCapabilitySession({ client, runId, frontendClient, manager: capabilityRunManager })
+        driveCapabilitySession({ client, runId, frontendClient, manager: capabilityRunManager, replayWorkspace })
           .catch(async (err) => {
             console.error(`[capability] session relay failed run=${runId}:`, err);
             await capabilityRunManager.endRun(runId, "failed").catch(() => {});


### PR DESCRIPTION
## Summary

- checkpoint and restore the exact frozen consumer input revision across dead-box recovery
- persist workspace changes as retryable atomic batches and replay content/tombstones after relay recovery
- advance compile provenance only through an explicit, idempotent `commit_input` signal; replayed or rehydrated files never imply a completed compile
- downgrade a legacy/missing-revision commit to content-only persistence instead of retrying a deterministic rejection
- remove Bash from the KB compiler and confine compiler, batch-planner, and test-session file tools to their workspaces with `PreToolUse` guards

## Why

The previous relay could permanently drop artifacts, a recovered box could silently switch to current raw instead of its pinned input, and replaying an unchanged `candidate/index.md` could be mistaken for a completed compile. The compiler also exposed shell and unrestricted file paths while its model credential lived in the process environment.

## Rollout gate

This is a **hard runtime/consumer cutover**, not a backward-compatible runtime fallback. The runtime starts calling `capability.persistArtifacts`; an older Sicore consumer does not implement that method.

1. Merge and deploy paired Sicore MR !618 first.
2. Confirm the new consumer handles `capability.persistArtifacts`, `input_revision`, and `commit_input`.
3. Only then deploy this Siclaw PR.

Roll back in reverse order. Sicore !618 retains the singular artifact handler for older runtimes during the rolling window, but this runtime intentionally does not fall back to singular writes because that would lose atomic batch, tombstone, and provenance semantics.

## Validation

- `npm test -- --run` — 4,344 passed, 2 skipped
- `npx tsc --noEmit`
- `npm run build`
- focused capability tests — 56 passed
- `python test_compile_box.py` protocol smoke with fake SDK session
- `python test_batching.py`
- `python test_incremental.py`
- `python -m py_compile ...`
- `git diff --check`
