### PR TITLE
Improve context preflight error messages

### DIFF
--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -296,6 +296,42 @@ describe("PiAgentBrain", () => {
     expect(session.compact).not.toHaveBeenCalled();
   });
 
+  it("context preflight explains a missing or invalid model window", async () => {
+    const session = makeFakeSession();
+    const brain = new PiAgentBrain(session);
+
+    const result = await brain.ensureContextForModelPrompt(
+      { id: "gpt-5.5", name: "GPT-5.5", provider: "sicore-custom-model", contextWindow: 0, maxTokens: 100, reasoning: false },
+      "hello",
+    );
+
+    expect(result).toMatchObject({ ok: false, compacted: false, contextWindow: 0 });
+    expect(result.errorMessage).toBe(
+      "Context preflight failed for sicore-custom-model/gpt-5.5: context window must be greater than 0 tokens (received 0). Configure a positive context window for this model.",
+    );
+    expect(session.compact).not.toHaveBeenCalled();
+  });
+
+  it("context preflight reports the window and reserve when no token budget remains", async () => {
+    const session = makeFakeSession({
+      settingsManager: {
+        getCompactionSettings: vi.fn(() => ({ enabled: true, reserveTokens: 16_384, keepRecentTokens: 20_000 })),
+      },
+    });
+    const brain = new PiAgentBrain(session);
+
+    const result = await brain.ensureContextForModelPrompt(
+      { id: "DeepSeek-V4-Pro", name: "DeepSeek V4 Pro", provider: "sicore-custom-model", contextWindow: 10_000, maxTokens: 8172, reasoning: true },
+      "hello",
+    );
+
+    expect(result).toMatchObject({ ok: false, compacted: false, contextWindow: 10_000 });
+    expect(result.errorMessage).toBe(
+      "Context preflight failed for sicore-custom-model/DeepSeek-V4-Pro: context window 10000 tokens must exceed compaction reserve 16384 tokens. Increase the model context window or lower compaction.reserveTokens.",
+    );
+    expect(session.compact).not.toHaveBeenCalled();
+  });
+
   it("context preflight does not compact when fallback target has a larger window", async () => {
     const session = makeFakeSession({
       getContextUsage: vi.fn(() => ({ tokens: 1_000_000, contextWindow: 1_000_000, percent: 100 })),

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -303,12 +303,20 @@ export class PiAgentBrain implements BrainSession {
       Math.max(0, Math.floor(contextWindow * 0.02)),
     );
     const budget = contextWindow - reserveTokens;
-    if (contextWindow <= 0 || budget <= 0) {
+    if (contextWindow <= 0) {
       return {
         ok: false,
         compacted: false,
         contextWindow,
-        errorMessage: `Context preflight failed: invalid context window for ${model.provider}/${model.id}`,
+        errorMessage: `Context preflight failed for ${model.provider}/${model.id}: context window must be greater than 0 tokens (received ${contextWindow}). Configure a positive context window for this model.`,
+      };
+    }
+    if (budget <= 0) {
+      return {
+        ok: false,
+        compacted: false,
+        contextWindow,
+        errorMessage: `Context preflight failed for ${model.provider}/${model.id}: context window ${contextWindow} tokens must exceed compaction reserve ${reserveTokens} tokens. Increase the model context window or lower compaction.reserveTokens.`,
       };
     }
 


### PR DESCRIPTION
## Summary

- distinguish missing or non-positive context windows from windows that are too small for the configured compaction reserve
- include the actual context-window and reserve-token values in the error
- provide an actionable recommendation to increase the window or lower `compaction.reserveTokens`
- add regression coverage for both invalid-window cases

## Root cause

The preflight check previously collapsed `contextWindow <= 0` and `contextWindow - reserveTokens <= 0` into the same generic `invalid context window` message. A model configured with a 10,000-token window therefore gave no indication that Siclaw's default 16,384-token compaction reserve was the conflicting value.

## User impact

Users now see the exact configured values and a concrete remediation instead of a generic model error.

## Validation

- `npm test` — 4,337 passed, 2 skipped
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
