### PR TITLE
fix(kb): make authoring message dispatch idempotent

### DIFF
--- a/docs/design/2026-07-kb-authoring-message-idempotency.md
+++ b/docs/design/2026-07-kb-authoring-message-idempotency.md
@@ -1,0 +1,38 @@
+# KB Authoring Message Idempotency
+
+## Contract
+
+`capability.message` accepts an optional consumer-minted `message_id`. When it
+is present, the runtime and capability box must acknowledge repeated delivery
+without injecting a second conversational turn. Calls without the field retain
+the original at-least-once behavior for rolling compatibility.
+
+The KB control plane uses its durable authoring-operation UUID as the kickoff
+message id. The original kickoff text is stored on the operation, so a retry
+cannot silently replace the payload associated with that id.
+
+## Crash ordering
+
+The runtime follows this order:
+
+1. forward `{message, message_id}` to the box;
+2. persist run status `running`;
+3. checkpoint the accepted id in the consumer-owned run store;
+4. acknowledge the caller.
+
+The box claims the id before invoking the model. If model dispatch itself
+throws, it releases the claim so the caller can retry. If the box accepted the
+turn but the runtime dies before step 3, the retry reaches the same box and is
+deduplicated there. If step 3 committed, a restarted runtime restores the recent
+id set from the run checkpoint and does not contact the box again.
+
+Ids are limited to 128 characters, and only the most recent 128 are checkpointed. Capability runs are bounded by
+their normal lifecycle/TTL, so this is enough for HTTP retry windows without
+turning the run checkpoint into an unbounded transcript.
+
+## Deployment
+
+The field is additive and optional, so Sicore, the runtime, and the compile-box
+image may roll independently. Full protection is active after all three pieces
+are deployed; changing `compile_box.py` requires rebuilding the
+`kbc-compile-box` image.

--- a/kbc/platform/pod/README.md
+++ b/kbc/platform/pod/README.md
@@ -11,7 +11,7 @@ Platform-agnostic (kbc base); the siclaw runtime reuses agentbox's K8sSpawner to
   - `POST /sources`  `{run_id?, workdir?, bundle_base64, bundle_sha256?}` → upload the frozen raw bundle, safely unpack into `workdir/raw/` (`drop/` kept as a compatibility alias); calling it after the run has started returns 409
   - `POST /authoring` `{run_id?, workdir?, bundle_base64, bundle_sha256?}` → upload authoring/candidate/eval/release assets, safely unpack into `workdir/`; also allowed on a live run (workspace re-hydration goes through here)
   - `POST /session/{run_id}` `{workdir?, instruction?, allowed_tools?}` → start this run's persistent conversation session (waits for the first /message); idempotent, on a live run it is a no-op attach
-  - `POST /message/{run_id}` `{message}` → inject one round of user message into the persistent session; prepare, compile, and adjudication-driven fix-up are all **ordinary turns**
+  - `POST /message/{run_id}` `{message, message_id?}` → inject one round of user message into the persistent session; a repeated consumer-minted `message_id` is acknowledged without injecting a second turn; prepare, compile, and adjudication-driven fix-up are all **ordinary turns**
   - `GET  /events/{run_id}` → SSE structured events: `session` / `log` / `summary` / `turn_done` / `syncArtifacts` / `plan_proposed` / `error` / `end`
   - `POST /test-session/{run_id}` → **start a test session**: pin the parent run's current draft (`candidate/`) into an immutable snapshot + start a read-only consumer session (reuses this pod, zero new infra); returns `test_session_id` + `snapshot_hash` + `pages`
   - `POST /test-message/{tid}` / `GET /test-events/{tid}` / `POST /test-session/{tid}/close` → the test session's inject / live-stream / teardown

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -270,6 +270,10 @@ class CompileRun:
         # Keep the last full-compile commit replayable across relay restarts.
         # The consumer dedupes it by immutable input revision.
         self._commit_input_replay = False
+        # Consumer-minted turn ids accepted by this live box. The runtime also
+        # checkpoints them; this local set closes the crash window where the box
+        # accepted a turn but the runtime died before persisting its ack.
+        self._message_ids: set[str] = set()
         # Scoped incremental (真增量): armed at kickoff with {before: page_hashes,
         # changeset}; the post-turn seam runs the byte-integrity guard against it,
         # then clears it. None = this turn is not a scoped incremental.
@@ -2798,6 +2802,13 @@ async def handle_message(request: web.Request):
     text = (body.get("message") or "").strip()
     if not text:
         return web.json_response({"error": "message is required"}, status=400)
+    message_id = (body.get("message_id") or "").strip()
+    if len(message_id) > 128:
+        return web.json_response({"error": "message_id must be at most 128 characters"}, status=400)
+    if message_id and message_id in run._message_ids:
+        return web.json_response({"ok": True, "duplicate": True})
+    if message_id:
+        run._message_ids.add(message_id)
     # v3 brief: if the wizard's 「开始生成知识库」message carries a 定调标签 block,
     # persist it deterministically to authoring/BRIEF.json BEFORE the turn so the
     # agent reads it this turn. Fail-open — a parse hiccup never blocks the turn.
@@ -2807,7 +2818,12 @@ async def handle_message(request: web.Request):
     # precedence over the batch/full route (which is the "recompile everything"
     # fallback when no changeset is present).
     if _should_route_to_incremental(run, text):
-        await _start_incremental(run, text)
+        try:
+            await _start_incremental(run, text)
+        except BaseException:
+            if message_id:
+                run._message_ids.discard(message_id)
+            raise
         return web.json_response({"ok": True, "incremental": True})
     if _is_compile_trigger(text):
         # A FULL recompile kickoff (compile trigger, no RAW_CHANGES) voids any
@@ -2855,6 +2871,8 @@ async def handle_message(request: web.Request):
     except BaseException:
         if full_compile:
             run._full_compile_pending = False
+        if message_id:
+            run._message_ids.discard(message_id)
         raise
     return web.json_response({"ok": True})
 

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -336,6 +336,55 @@ async def test_message_waits_for_connect():
     print("✓ message waits for connect (P2.2 race fix)")
 
 
+async def test_message_idempotency_key():
+    """A lost runtime ack may replay capability.message. The box must inject a
+    stable message_id once, while a dispatch error releases the id for retry."""
+    compile_box.RUNS.clear()
+    client = TestClient(TestServer(compile_box.build_app()))
+    await client.start_server()
+    try:
+        class _C:
+            def __init__(self):
+                self.queries = []
+
+            async def query(self, text, session_id="default"):
+                self.queries.append(text)
+
+        run = compile_box.CompileRun("idem-live", "/tmp", 1)
+        fake = _C()
+        run.client = fake
+        run.connected.set()
+        compile_box.RUNS[run.run_id] = run
+        first = await client.post(f"/message/{run.run_id}", json={"message_id": "op-1", "message": "compile once"})
+        second = await client.post(f"/message/{run.run_id}", json={"message_id": "op-1", "message": "compile twice"})
+        assert first.status == 200 and second.status == 200, (await first.text(), await second.text())
+        assert (await second.json()).get("duplicate") is True
+        assert fake.queries == ["compile once"], fake.queries
+
+        class _Flaky:
+            def __init__(self):
+                self.calls = 0
+
+            async def query(self, text, session_id="default"):
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("dispatch failed")
+
+        retry_run = compile_box.CompileRun("idem-retry", "/tmp", 1)
+        flaky = _Flaky()
+        retry_run.client = flaky
+        retry_run.connected.set()
+        compile_box.RUNS[retry_run.run_id] = retry_run
+        failed = await client.post(f"/message/{retry_run.run_id}", json={"message_id": "op-2", "message": "retry me"})
+        retried = await client.post(f"/message/{retry_run.run_id}", json={"message_id": "op-2", "message": "retry me"})
+        assert failed.status == 500 and retried.status == 200, (failed.status, retried.status)
+        assert flaky.calls == 2, flaky.calls
+    finally:
+        await client.close()
+        compile_box.RUNS.clear()
+    print("✓ /message message_id is once-only and releases on dispatch failure")
+
+
 # ── 起测试会话 (read-only test session) ──
 
 async def test_test_path_escape_guard():
@@ -2036,6 +2085,7 @@ async def main():
     await test_session_driver_conversational()
     await test_conversational_session()
     await test_message_waits_for_connect()
+    await test_message_idempotency_key()
     test_pack_candidates_to_wiki()
     test_pack_candidates_symlink_confinement()
     await test_test_path_escape_guard()

--- a/src/gateway/capability/contract.ts
+++ b/src/gateway/capability/contract.ts
@@ -103,6 +103,11 @@ export interface CapabilityStartResponse {
 export interface CapabilityMessageRequest {
   run_id: string;
   /**
+   * Consumer-minted idempotency key for this conversational turn. Optional for
+   * rolling compatibility; retries carrying the same id must be accepted once.
+   */
+  message_id?: string;
+  /**
    * A conversational turn injected into the live session — a compile instruction,
    * a plain chat turn, or "apply these rulings: ..." (contradiction writeback).
    * The run's profile/org come from the run record minted at start, not the frame.
@@ -193,7 +198,7 @@ export interface CapabilityRunState {
   correlation_id: string;
   profile: string;
   status: CapabilityLifecycleStatus;
-  /** Opaque resume blob; KB runs currently checkpoint their installed input revision here. */
+  /** Opaque resume blob; KB runs checkpoint input revision and accepted message ids here. */
   checkpoint?: unknown;
   /**
    * Box session id, reserved for a future where the box persists its session and

--- a/src/gateway/capability/run-manager.test.ts
+++ b/src/gateway/capability/run-manager.test.ts
@@ -98,6 +98,41 @@ describe("CapabilityRunManager", () => {
     expect(recovered.get(runId)?.inputRevision).toBe("manifest-1");
   });
 
+  it("checkpoints accepted message ids and restores dedupe after restart", async () => {
+    const be = new FakeBackend();
+    const mgr = new CapabilityRunManager(be);
+    const { runId } = await mgr.startRun({ profile: "kb-compile", orgId: "o1" });
+
+    await mgr.setInputRevision(runId, "manifest-1");
+    await mgr.rememberMessageId(runId, "op-1");
+    expect(mgr.hasMessageId(runId, "op-1")).toBe(true);
+    expect(be.persists().at(-1)?.params).toMatchObject({
+      checkpoint: { input_revision: "manifest-1", message_ids: ["op-1"] },
+    });
+
+    const recoveredBackend = new FakeBackend();
+    recoveredBackend.activeRuns = [{
+      id: runId,
+      profile: "kb-compile",
+      org_id: "o1",
+      status: "running",
+      checkpoint: JSON.stringify({ input_revision: "manifest-1", message_ids: ["op-1"] }),
+    }];
+    const recovered = new CapabilityRunManager(recoveredBackend);
+    await recovered.recover();
+    expect(recovered.hasMessageId(runId, "op-1")).toBe(true);
+  });
+
+  it("rolls back an unacknowledged message id so the caller can retry", async () => {
+    const be = new FakeBackend();
+    const mgr = new CapabilityRunManager(be);
+    const { runId } = await mgr.startRun({ profile: "kb-compile", orgId: "o1" });
+    be.failPersist = true;
+
+    await expect(mgr.rememberMessageId(runId, "op-1")).rejects.toThrow("ws down");
+    expect(mgr.hasMessageId(runId, "op-1")).toBe(false);
+  });
+
   it("fails closed when the installed input revision cannot be checkpointed", async () => {
     const be = new FakeBackend();
     const mgr = new CapabilityRunManager(be);

--- a/src/gateway/capability/run-manager.ts
+++ b/src/gateway/capability/run-manager.ts
@@ -43,6 +43,8 @@ export interface CapabilityRunRecord {
   runtimeId?: string;
   /** Frozen consumer input installed into this run's box. */
   inputRevision?: string;
+  /** Recent consumer turn ids durably accepted by this run (retry dedupe). */
+  messageIds: string[];
   /** Wall-clock ms of the last DATA event; drives the stale-run watchdog. */
   lastActivityMs: number;
   /**
@@ -99,6 +101,7 @@ export interface CapabilityRunManagerOptions {
 const MAX_REAP_DEFERRALS = 5;
 const INPUT_REVISION_PERSIST_ATTEMPTS = 4;
 const INPUT_REVISION_RETRY_BASE_MS = 250;
+const MAX_MESSAGE_IDS = 128;
 
 export class CapabilityRunManager {
   private runs = new Map<string, CapabilityRunRecord>();
@@ -164,6 +167,7 @@ export class CapabilityRunManager {
       correlationId: p.correlationId,
       runtimeId: p.runtimeId,
       status: p.initialStatus ?? "running",
+      messageIds: [],
       lastActivityMs: this.now(),
       lastHeartbeatMs: this.now(),
     };
@@ -201,6 +205,7 @@ export class CapabilityRunManager {
         correlationId: row.correlation_id || undefined,
         runtimeId: row.runtime_id || undefined,
         inputRevision: inputRevisionFromCheckpoint(row.checkpoint),
+        messageIds: messageIdsFromCheckpoint(row.checkpoint),
         status,
         lastActivityMs: this.now(),
         lastHeartbeatMs: this.now(),
@@ -247,6 +252,30 @@ export class CapabilityRunManager {
     }
   }
 
+  hasMessageId(runId: string, messageId: string): boolean {
+    const id = messageId.trim();
+    return id !== "" && (this.runs.get(runId)?.messageIds.includes(id) ?? false);
+  }
+
+  /**
+   * Persist a turn id only AFTER the box accepted it. If this checkpoint write
+   * fails, roll the in-memory mark back: the caller returns an error and retries
+   * the same id; the box-level dedupe then turns that retry into a harmless ack.
+   */
+  async rememberMessageId(runId: string, messageId: string): Promise<void> {
+    const rec = this.runs.get(runId);
+    const id = messageId.trim();
+    if (!rec || !id || rec.messageIds.includes(id)) return;
+    const previous = rec.messageIds;
+    rec.messageIds = [...previous, id].slice(-MAX_MESSAGE_IDS);
+    try {
+      await this.persist(rec, { failFast: true });
+    } catch (err) {
+      rec.messageIds = previous;
+      throw err;
+    }
+  }
+
   /** Bump last-DATA activity so the watchdog doesn't reap an actively-used run. */
   touch(runId: string): void {
     const rec = this.runs.get(runId);
@@ -280,11 +309,9 @@ export class CapabilityRunManager {
     const rec = this.runs.get(runId);
     if (!rec) return;
     // Terminal is sticky — mirror endRun. A record can sit here in a TERMINAL
-    // state while its final persist retries (flushTerminal). capability.message
-    // calls setStatus("running") after two awaits (ensure session + POST
-    // /message), so a done/error/cancel landing in that window must not be
-    // flipped back to non-terminal — that would hide the record from
-    // flushTerminal and degrade the true outcome to a watchdog "failed".
+    // state while its final persist retries (flushTerminal). A concurrent
+    // done/error/cancel must never be flipped back to non-terminal — that would
+    // hide the record from flushTerminal and degrade the true outcome.
     if (isTerminalCapabilityStatus(rec.status)) return;
     rec.status = status;
     rec.lastActivityMs = this.now();
@@ -341,6 +368,7 @@ export class CapabilityRunManager {
           correlationId: r.correlation_id || undefined,
           runtimeId: r.runtime_id || undefined,
           inputRevision: inputRevisionFromCheckpoint(r.checkpoint),
+          messageIds: messageIdsFromCheckpoint(r.checkpoint),
           status: r.status || "running",
           lastActivityMs: this.now(),
           lastHeartbeatMs: this.now(),
@@ -510,13 +538,17 @@ export class CapabilityRunManager {
    */
   private async persist(rec: CapabilityRunRecord, opts?: { failFast?: boolean }): Promise<void> {
     // The contract type IS the wire shape (snake_case) — see contract.ts WIRE RULE.
+    const checkpoint = {
+      ...(rec.inputRevision ? { input_revision: rec.inputRevision } : {}),
+      ...(rec.messageIds.length > 0 ? { message_ids: rec.messageIds } : {}),
+    };
     const state: CapabilityRunState = {
       run_id: rec.runId,
       org_id: rec.orgId ?? "",
       correlation_id: rec.correlationId ?? "",
       profile: rec.profile,
       status: rec.status,
-      ...(rec.inputRevision ? { checkpoint: { input_revision: rec.inputRevision } } : {}),
+      ...(Object.keys(checkpoint).length > 0 ? { checkpoint } : {}),
       // Reserved wire field, always "" — the runtime does not track a box session
       // id (see the note above adopt()); a future persistent-session design would
       // re-introduce the mirror + carry-through.
@@ -546,4 +578,22 @@ function inputRevisionFromCheckpoint(checkpoint: unknown): string | undefined {
   if (!value || typeof value !== "object") return undefined;
   const revision = (value as { input_revision?: unknown }).input_revision;
   return typeof revision === "string" && revision.trim() ? revision.trim() : undefined;
+}
+
+function messageIdsFromCheckpoint(checkpoint: unknown): string[] {
+  let value = checkpoint;
+  if (typeof value === "string") {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return [];
+    }
+  }
+  if (!value || typeof value !== "object") return [];
+  const ids = (value as { message_ids?: unknown }).message_ids;
+  if (!Array.isArray(ids)) return [];
+  return ids
+    .filter((id): id is string => typeof id === "string" && id.trim() !== "" && id.trim().length <= 128)
+    .map((id) => id.trim())
+    .slice(-MAX_MESSAGE_IDS);
 }

--- a/src/gateway/server-capability-message-id.test.ts
+++ b/src/gateway/server-capability-message-id.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const box = vi.hoisted(() => ({
+  posts: vi.fn(async () => ({})),
+}));
+
+vi.mock("./chat-repo.js", () => ({
+  ensureChatSession: vi.fn(async () => {}),
+  appendMessage: vi.fn(async () => "msg-id"),
+  incrementMessageCount: vi.fn(async () => {}),
+}));
+
+vi.mock("./output-redactor.js", () => ({
+  buildRedactionConfigForModelConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("./sse-consumer.js", () => ({
+  consumeAgentSse: vi.fn(async () => ({ resultText: "", taskReportText: "", errorMessage: "", eventCount: 0, durationMs: 0 })),
+}));
+
+vi.mock("./agentbox/client.js", () => ({
+  AgentBoxClient: class {
+    endpoint: string;
+    constructor(endpoint: string) { this.endpoint = endpoint; }
+    postJson = box.posts;
+    getJson = vi.fn(async () => ({}));
+    streamPath = async function* () {
+      await new Promise<never>(() => {});
+    };
+  },
+}));
+
+vi.mock("./capability/materialize.js", () => ({
+  materializeCapabilityInputs: vi.fn(async () => ({ locale: undefined, llm: undefined, settings: undefined })),
+}));
+
+const { startRuntime } = await import("./server.js");
+
+function fakeFrontendClient() {
+  return {
+    request: vi.fn(async () => ({ ok: true })),
+    onCommand: vi.fn(), emitEvent: vi.fn(), close: vi.fn(),
+  } as any;
+}
+
+function fakeAgentBoxManager() {
+  return {
+    setCertManager: vi.fn(), setSpawnEnvResolver: vi.fn(), setPersistenceResolver: vi.fn(),
+    getAsync: vi.fn(async () => null),
+    getOrCreate: vi.fn(async () => ({ boxId: "agentbox-x", endpoint: "https://10.0.0.9:3000", agentId: "x" })),
+    stop: vi.fn(async () => {}), list: vi.fn(() => []), cleanup: vi.fn(async () => {}),
+  } as any;
+}
+
+let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+  vi.clearAllMocks();
+});
+
+describe("capability.message idempotency", () => {
+  it("forwards message_id to the box once and acknowledges a retry", async () => {
+    const frontend = fakeFrontendClient();
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: fakeAgentBoxManager(),
+      frontendClient: frontend,
+      credentialService: {} as any,
+    });
+    const start = server.rpcMethods.get("capability.start")!;
+    const message = server.rpcMethods.get("capability.message")!;
+    const started = await start({ profile: "kb-compile" }) as { run_id: string };
+
+    const first = await message({ run_id: started.run_id, message_id: "op-1", message: "compile once" });
+    const retry = await message({ run_id: started.run_id, message_id: "op-1", message: "compile twice" });
+
+    expect(first).toMatchObject({ ok: true, run_id: started.run_id });
+    expect(retry).toMatchObject({ ok: true, run_id: started.run_id, duplicate: true });
+    const messagePosts = box.posts.mock.calls.filter(([path]) => path === `/message/${started.run_id}`);
+    expect(messagePosts).toHaveLength(1);
+    expect(messagePosts[0]?.[1]).toEqual({ message: "compile once", message_id: "op-1" });
+    const runningPersistIndex = frontend.request.mock.calls.findIndex(([, payload]: any[]) => payload?.status === "running");
+    const messagePostIndex = box.posts.mock.calls.findIndex(([path]) => path === `/message/${started.run_id}`);
+    expect(runningPersistIndex).toBeGreaterThanOrEqual(0);
+    expect(messagePostIndex).toBeGreaterThanOrEqual(0);
+    expect(frontend.request.mock.invocationCallOrder[runningPersistIndex]).toBeLessThan(box.posts.mock.invocationCallOrder[messagePostIndex]!);
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -574,8 +574,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const req = params as unknown as CapabilityMessageRequest;
     const runId = req.run_id;
     const message = req.message;
+    const messageId = req.message_id?.trim();
     if (!runId) throw new Error("run_id is required");
     if (!message) throw new Error("message is required");
+    if (messageId && messageId.length > 128) throw new Error("message_id must be at most 128 characters");
     // The run record is the authority for the box's profile/org. A run missing
     // from memory is first re-adopted from the consumer's store (heals a boot
     // recovery that raced the consumer); only a run the STORE doesn't know (or
@@ -586,13 +588,24 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // A terminal record can linger in memory while its final persist retries
     // (flushTerminal) — it is just as unaddressable as an unknown run.
     if (!rec || isTerminalCapabilityStatus(rec.status)) throw new Error(`unknown capability run: ${runId}`);
+    if (messageId && capabilityRunManager.hasMessageId(runId, messageId)) {
+      return { ok: true, run_id: runId, duplicate: true };
+    }
     capabilityRunManager.touch(runId); // keep the watchdog off an actively-used run
     const { client } = await ensureCapabilitySession(runId, rec.profile, rec.orgId || undefined, undefined);
-    await client.postJson(`/message/${runId}`, { message });
-    // The box is now working a turn: reflect it (turn_done flips back to idle).
-    // Keeps the consumer's view honest AND puts the run in the strict staleMs
-    // tier — a wedged turn must not enjoy the long idle TTL.
+    // Publish running BEFORE the box can emit turn_done. Posting first allowed a
+    // fast turn_done→idle to land and then be overwritten by this handler's late
+    // running write, leaving an already-finished turn permanently busy.
     await capabilityRunManager.setStatus(runId, "running");
+    try {
+      await client.postJson(`/message/${runId}`, { message, ...(messageId ? { message_id: messageId } : {}) });
+    } catch (err) {
+      // The box did not accept the turn. Restore the hosting run to idle; a
+      // terminal state that raced here remains sticky in setStatus().
+      await capabilityRunManager.setStatus(runId, "idle");
+      throw err;
+    }
+    if (messageId) await capabilityRunManager.rememberMessageId(runId, messageId);
     return { ok: true, run_id: runId };
   });
 


### PR DESCRIPTION
## Summary

- add consumer-minted message IDs to KB capability turns
- persist accepted message IDs in runtime checkpoints and deduplicate retries in the live compile box
- mark a run as running before dispatch so a fast turn completion cannot be overwritten by a late running update
- release message IDs when dispatch fails before acceptance

## Why

The authoring lifecycle now retries ambiguous dispatches instead of deleting the stable draft. Without end-to-end turn idempotency, a lost acknowledgement could execute the same regeneration or repair instruction twice.

## Dependency

This is a stacked PR on top of #396. Retarget it to `main` after #396 merges.

PR #395 also touches `compile_box.py`; whichever lands second should rebase and preserve both the consumer-meta settle ordering and this message-id fencing.

## Validation

- `npm test -- --run src/gateway/capability/run-manager.test.ts src/gateway/capability/session-driver.test.ts src/gateway/server-capability-message-id.test.ts` (52 tests passed)
- focused Python compiler sync, terminal-signal, and message-id retry checks passed
- `git diff --check`
