### PR TITLE
fix(runtime): harden capability box lifecycle boundaries

### DIFF
--- a/.github/workflows/kbc-ci.yml
+++ b/.github/workflows/kbc-ci.yml
@@ -33,3 +33,5 @@ jobs:
         working-directory: kbc/platform/pod
       - run: python test_redblue.py
         working-directory: kbc/platform/pod
+      - run: python test_mtls_auth.py
+        working-directory: kbc/platform/pod

--- a/docs/install/kubernetes.mdx
+++ b/docs/install/kubernetes.mdx
@@ -108,6 +108,14 @@ On first launch, open the Portal UI and register the first user — that account
 
 Runtime and Portal both expose Prometheus metrics at `/metrics`. The chart can create ServiceMonitor, PodMonitor, Grafana dashboard, and PrometheusRule resources under the `metrics.*` values block.
 
+The Runtime endpoint also exposes bounded KB capability lifecycle series such as
+`siclaw_gateway_capability_starts_total`,
+`siclaw_gateway_capability_start_duration_ms`,
+`siclaw_gateway_capability_active_runs`,
+`siclaw_gateway_capability_materialization_failures_total`, and
+`siclaw_gateway_capability_relay_failures_total`. They intentionally carry no
+run, repository, user, or operation identifiers; use logs/traces for drill-down.
+
 Common settings:
 
 ```yaml
@@ -144,4 +152,10 @@ runtime:
 - Kubernetes mode requires MySQL. SQLite is only for single-process local use.
 - AgentBox pods are created on demand by the Runtime.
 - Runtime ↔ AgentBox traffic is secured with mTLS automatically.
+- KB compile/test boxes additionally receive a default-on ingress NetworkPolicy;
+  the chart's Runtime pod is the only default caller on port 3000. Extend
+  `agentbox.networkPolicy.ingressFrom` only for an intentional extra caller.
+- A Runtime rolling restart preserves K8s AgentBox pods so the replacement can
+  re-adopt live capability runs. Cluster-wide box deletion remains an explicit
+  cleanup operation, not a process-shutdown side effect.
 - If you deploy monitoring resources from the chart, do not also apply duplicate monitor manifests manually.

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -147,9 +147,9 @@ spec:
                   key: tls.key
             {{- end }}
             {{- with .Values.runtime.llm }}
-            # LLM endpoint for lean capability boxes (kb-compile / kb-test) —
-            # forwarded into spawned kb boxes via BoxProfile envForward. The
-            # chat path does not read these (agent models come from the Portal).
+            # LLM fallback for lean capability boxes (kb-compile / kb-test).
+            # Runtime sends it through the mTLS /session payload only when the
+            # consumer omitted its own LLM block; the chat path does not read it.
             {{- if .baseUrl }}
             - name: ANTHROPIC_BASE_URL
               value: {{ .baseUrl | quote }}

--- a/helm/siclaw/templates/kb-box-networkpolicy.yaml
+++ b/helm/siclaw/templates/kb-box-networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- $agentbox := .Values.agentbox | default dict -}}
+{{- $networkPolicy := $agentbox.networkPolicy | default dict -}}
+{{- if and (eq (include "siclaw.runtime.enabled" .) "true") $networkPolicy.enabled }}
+{{- $extraIngressFrom := $networkPolicy.ingressFrom | default list -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "siclaw.fullname" . }}-kb-box
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "siclaw.labels" (dict "ctx" . "component" "kb-box") | nindent 4 }}
+spec:
+  # These labels are stamped by K8sSpawner on its runtime-created Pods. Keep
+  # this selector aligned with K8sSpawner's default labelPrefix (siclaw.io).
+  podSelector:
+    matchExpressions:
+      - key: siclaw.io/boxType
+        operator: In
+        values:
+          - kb-compile
+          - kb-test
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Runtime owns capability sessions and is the normal caller. Restrict
+        # by release-scoped pod labels; mTLS in compile_box verifies the caller
+        # certificate again before every non-health route.
+        - podSelector:
+            matchLabels:
+              {{- include "siclaw.selectorLabels" (dict "ctx" . "component" "runtime") | nindent 14 }}
+        {{- with $extraIngressFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 3000
+{{- end }}

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -202,6 +202,15 @@ agentbox:
   # nodes carrying all of these labels (e.g. { disktype: ssd, pool: agents }).
   # Empty ⇒ no constraint; the scheduler picks any eligible node.
   nodeSelector: {}
+  # Ingress isolation for dynamically spawned KB compile/test boxes. The
+  # Runtime is the only built-in caller; mTLS remains the identity boundary.
+  # KB pods use exec health probes, so kubelet/node CIDRs do not need a broad
+  # NetworkPolicy exception (behavior differs across CNIs for HTTP probes).
+  networkPolicy:
+    enabled: true
+    # Extra trusted callers, e.g. a separately deployed Gateway in the same or
+    # another namespace. Entries are appended to the Runtime podSelector.
+    ingressFrom: []
   persistence:
     # PVC persistence has two independent concepts:
     #   1. PVC availability (infrastructure) — is a shared RWX PVC present that

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -82,14 +82,15 @@ runtime:
   subagentConcurrency: 5
   # LLM endpoint for LEAN CAPABILITY BOXES (kb-compile / kb-test) ONLY. The chat
   # path does not read these — agent models come from the Portal/Upstream model
-  # descriptors. They exist so the runtime can forward ANTHROPIC_* into spawned
-  # kb boxes (BoxProfile envForward). Token rotation: update the Secret, then
-  # rollout-restart the runtime (env Secrets resolve at pod start); live kb
-  # boxes keep their spawn-time token until respawned — either keep the old
-  # token valid through a grace window, or delete agentbox pods after rotating.
+  # descriptors. On a fresh KB session Runtime sends these through the mTLS
+  # /session payload only when the consumer did not provide its own LLM block;
+  # credentials are never copied into the KB PodSpec. Token rotation: update the
+  # Secret, rollout-restart Runtime (env Secrets resolve at pod start), then keep
+  # the old token valid through a grace window or delete KB agentbox pods. A live
+  # box's already-connected SDK client keeps its session-start token until respawn.
   llm:
     baseUrl: ""            # e.g. https://api.scitix.ai/model-api (massapi proxy)
-    model: ""              # optional ANTHROPIC_MODEL default for the box CLI
+    model: ""              # optional model default (below KBC_COMPILE_MODEL)
     tokenSecret:
       name: ""             # existing Secret holding the massapi token
       key: "ANTHROPIC_AUTH_TOKEN"

--- a/kbc/platform/pod/README.md
+++ b/kbc/platform/pod/README.md
@@ -62,8 +62,8 @@ docker run --rm -p 3000:3000 \
 
 ## Auth / mTLS
 
-- **LLM**: locally reuses the `~/.claude` subscription (no key needed); container/production must use `ANTHROPIC_API_KEY` or `ANTHROPIC_BASE_URL`→massapi (credentials do not enter the sandbox).
-- **Transport**: if `tls.crt/tls.key/ca.crt` exist under `SICLAW_CERT_PATH` (default `/etc/siclaw/certs`) → serve HTTPS and require a client certificate (runtime/gateway); otherwise HTTP (local). Reuses agentbox's per-box mTLS shell.
+- **LLM**: locally reuses the `~/.claude` subscription (no key needed). In production the consumer sends the selected `base_url` and auth token in the authenticated `/session` body after input materialization; the Runtime token is not copied into the pod spec.
+- **Transport**: if `tls.crt/tls.key/ca.crt` exist under `SICLAW_CERT_PATH` (default `/etc/siclaw/certs`), the box serves HTTPS. `/health` remains certificate-optional for the in-container Kubernetes probe; every data/session/event route requires a verified client certificate whose OU is `Runtime` or `Gateway`. Partial TLS material fails startup. Without TLS material the server uses HTTP for explicit local development only.
 
 ## Layer-1 self-check: coverage ledger + lint (`selfcheck.py`)
 

--- a/kbc/platform/pod/README.md
+++ b/kbc/platform/pod/README.md
@@ -10,7 +10,7 @@ Platform-agnostic (kbc base); the siclaw runtime reuses agentbox's K8sSpawner to
 - **`compile_box.py` (served, production form)** — an aiohttp service, driven by the runtime over the **box's own HTTP+SSE contract**:
   - `POST /sources`  `{run_id?, workdir?, bundle_base64, bundle_sha256?}` → upload the frozen raw bundle, safely unpack into `workdir/raw/` (`drop/` kept as a compatibility alias); calling it after the run has started returns 409
   - `POST /authoring` `{run_id?, workdir?, bundle_base64, bundle_sha256?}` → upload authoring/candidate/eval/release assets, safely unpack into `workdir/`; also allowed on a live run (workspace re-hydration goes through here)
-  - `POST /session/{run_id}` `{workdir?, instruction?, allowed_tools?}` → start this run's persistent conversation session (waits for the first /message); idempotent, on a live run it is a no-op attach
+  - `POST /session/{run_id}` `{workdir?, instruction?, allowed_tools?, llm?, settings?}` → start this run's persistent conversation session (waits for the first /message); idempotent, on a live run it is a no-op attach and does not hot-rotate the connected SDK client
   - `POST /message/{run_id}` `{message}` → inject one round of user message into the persistent session; prepare, compile, and adjudication-driven fix-up are all **ordinary turns**
   - `GET  /events/{run_id}` → SSE structured events: `session` / `log` / `summary` / `turn_done` / `syncArtifacts` / `plan_proposed` / `error` / `end`
   - `POST /test-session/{run_id}` → **start a test session**: pin the parent run's current draft (`candidate/`) into an immutable snapshot + start a read-only consumer session (reuses this pod, zero new infra); returns `test_session_id` + `snapshot_hash` + `pages`
@@ -62,7 +62,7 @@ docker run --rm -p 3000:3000 \
 
 ## Auth / mTLS
 
-- **LLM**: locally reuses the `~/.claude` subscription (no key needed). In production the consumer sends the selected `base_url` and auth token in the authenticated `/session` body after input materialization; the Runtime token is not copied into the pod spec.
+- **LLM**: locally reuses the `~/.claude` subscription (no key needed). In production the consumer's whole `llm` block is authoritative; only when it is absent does Runtime send its Helm `ANTHROPIC_*` fallback in the authenticated `/session` body. Runtime credentials are never merged into a consumer block or copied into the KB PodSpec. A live SDK client keeps its session-start credential until the documented grace-window + box-respawn rotation.
 - **Transport**: if `tls.crt/tls.key/ca.crt` exist under `SICLAW_CERT_PATH` (default `/etc/siclaw/certs`), the box serves HTTPS. `/health` remains certificate-optional for the in-container Kubernetes probe; every data/session/event route requires a verified client certificate whose OU is `Runtime` or `Gateway`. Partial TLS material fails startup. Without TLS material the server uses HTTP for explicit local development only.
 
 ## Layer-1 self-check: coverage ledger + lint (`selfcheck.py`)

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1701,6 +1701,13 @@ DEFAULT_COMPILE_ALLOWED_TOOLS = [
 ]
 
 
+def _compile_model() -> str:
+    """Resolve the model shared by every compiler-owned SDK session."""
+    return (os.environ.get("KBC_COMPILE_MODEL")
+            or os.environ.get("ANTHROPIC_MODEL")
+            or "claude-opus-4-6")
+
+
 def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, session_id: str) -> "ClaudeAgentOptions":
     """One options builder for the persistent session AND every batch session —
     identical role/tools/model so a batch page is written under exactly the same
@@ -1717,9 +1724,7 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
         # Pin the compile model explicitly: the box talks to massapi (Bedrock),
         # which serves specific ids — the SDK default may not be one, and the KB
         # compile default is opus by product decision. Overridable per-deploy.
-        model=(os.environ.get("KBC_COMPILE_MODEL")
-               or os.environ.get("ANTHROPIC_MODEL")
-               or "claude-opus-4-6"),
+        model=_compile_model(),
         max_turns=int(os.environ.get("KBC_MAX_TURNS", "150")),
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=session_id,
@@ -2042,7 +2047,7 @@ async def _plan_batches(run: "CompileRun", inventory: list) -> dict:
             permission_mode="bypassPermissions",
             hooks={"PreToolUse": [HookMatcher(hooks=[_make_compile_path_guard(Path(wd), run.locale)])]},
             setting_sources=[],
-            model=os.environ.get("KBC_COMPILE_MODEL", "claude-opus-4-6"),
+            model=_compile_model(),
             max_turns=8,
             max_buffer_size=SDK_MAX_BUFFER_BYTES,
             session_id=str(uuid.uuid4()),

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -56,6 +56,10 @@ import batching
 import incremental
 import mediaverify
 import office_ingest
+from mtls_auth import (
+    client_certificate_error as _client_certificate_error,
+    server_ssl_context,
+)
 import redblue
 import selfcheck
 from engine import ClaudeEngine
@@ -3070,8 +3074,19 @@ async def _flush_on_shutdown(_app) -> None:
             pass
 
 
+@web.middleware
+async def _client_certificate_middleware(request: web.Request, handler):
+    error = _client_certificate_error(request)
+    if error is not None:
+        return web.json_response({"error": error}, status=403)
+    return await handler(request)
+
+
 def build_app() -> web.Application:
-    app = web.Application(client_max_size=_http_max_request_bytes())
+    app = web.Application(
+        client_max_size=_http_max_request_bytes(),
+        middlewares=[_client_certificate_middleware],
+    )
     app.on_shutdown.append(_flush_on_shutdown)
     app.add_routes([
         web.post("/sources", handle_sources),
@@ -3090,25 +3105,9 @@ def build_app() -> web.Application:
 
 
 def _ssl_context():
-    """Production mTLS: with certs, HTTPS + required client cert (only the
-    runtime/gateway can drive the box). No certs locally → plain HTTP."""
+    """Production mTLS, or intentional plain HTTP when no certs exist locally."""
     cert_dir = Path(os.environ.get("SICLAW_CERT_PATH", "/etc/siclaw/certs"))
-    crt, key, ca = cert_dir / "tls.crt", cert_dir / "tls.key", cert_dir / "ca.crt"
-    if not (crt.exists() and key.exists()):
-        return None
-    import ssl
-    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    ctx.load_cert_chain(str(crt), str(key))
-    if ca.exists():
-        ctx.load_verify_locations(str(ca))
-        # CERT_OPTIONAL, not CERT_REQUIRED: the k8s readiness/liveness probes hit
-        # /health over HTTPS WITHOUT a client cert; requiring one fails the TLS
-        # handshake so the probes never pass and kubelet kills the box. The box is
-        # only addressed by the runtime in-cluster, so requesting-but-not-requiring
-        # the client cert is acceptable for v1. (Production: exempt /health + check
-        # the cert per-route, like agentbox does.)
-        ctx.verify_mode = ssl.CERT_OPTIONAL
-    return ctx
+    return server_ssl_context(cert_dir)
 
 
 def main():

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -15,7 +15,7 @@ structured signals:
 Surface (driven by the runtime):
   POST /sources            {run_id?, workdir?, bundle_base64, bundle_sha256?, locale?} install the frozen raw bundle → workdir/raw
   POST /authoring          {run_id?, workdir?, bundle_base64, bundle_sha256?, locale?} install authoring/candidate/eval/release assets → workdir/
-  POST /session/{run_id}   {workdir?, instruction?, allowed_tools?, locale?} start the run's persistent conversational session (waits for the first /message); idempotent
+  POST /session/{run_id}   {workdir?, instruction?, allowed_tools?, locale?, llm?, settings?} start the run's persistent conversational session (waits for the first /message); idempotent
   POST /message/{run_id}   {message} inject one user turn into the persistent session (prepare/compile/patch are all ordinary turns)
   GET  /events/{run_id}    structured SSE stream (session/log/summary/turn_done/syncArtifacts/plan_proposed/error/end)
   POST /test-session/{run_id}  start a test session: pin the current draft as an immutable snapshot + a read-only consumer session (reuses this pod)
@@ -23,7 +23,8 @@ Surface (driven by the runtime):
   GET  /health
 
 LLM auth: local runs reuse the subscription (the SDK ships the claude binary);
-production pods set ANTHROPIC_BASE_URL → massapi (keys injected outside the container).
+production config arrives as one authoritative /session llm block (consumer, or
+Runtime Helm fallback when absent), keeping credentials out of the KB PodSpec.
 mTLS: with SICLAW_CERT_PATH certs present the box serves HTTPS and requires a
 client cert (runtime/gateway); otherwise plain HTTP (local).
 """
@@ -1716,7 +1717,9 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
         # Pin the compile model explicitly: the box talks to massapi (Bedrock),
         # which serves specific ids — the SDK default may not be one, and the KB
         # compile default is opus by product decision. Overridable per-deploy.
-        model=os.environ.get("KBC_COMPILE_MODEL", "claude-opus-4-6"),
+        model=(os.environ.get("KBC_COMPILE_MODEL")
+               or os.environ.get("ANTHROPIC_MODEL")
+               or "claude-opus-4-6"),
         max_turns=int(os.environ.get("KBC_MAX_TURNS", "150")),
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=session_id,
@@ -2672,9 +2675,10 @@ async def _teardown_test_session(run: "TestRun"):
 # The consumer owns the credential store and the KB capability policy; both arrive on
 # the /session body and apply IN-PROCESS (the box spawns before fetchInput runs,
 # so pod env is too early — and this keeps the token out of the pod spec).
-# Precedence: consumer config > runtime-env forward (helm fallback) > image
-# defaults. ONE exception: KBC_PK_MODE=off set at the runtime level is the ops
-# KILL SWITCH and must win over consumer config.
+# LLM authority is whole-block: consumer object, else Runtime's Helm fallback;
+# omitted fields in a present object never inherit another authority's token.
+# ONE settings exception: KBC_PK_MODE=off set at the runtime level is the ops
+# KILL SWITCH and must win over consumer settings.
 _PK_KILL_AT_BOOT = os.environ.get("KBC_PK_MODE") == "off"
 
 
@@ -2688,12 +2692,29 @@ def _apply_session_config(body: dict) -> None:
     per-run (SDK client env) instead of mutating the process environment."""
     llm = body.get("llm")
     if isinstance(llm, dict):
-        if llm.get("base_url"):
-            os.environ["ANTHROPIC_BASE_URL"] = str(llm["base_url"])
-        if llm.get("auth_token"):
-            os.environ["ANTHROPIC_AUTH_TOKEN"] = str(llm["auth_token"])
-            # The SDK accepts either; clear a stale forwarded API key so the
-            # consumer credential unambiguously wins.
+        # The LLM object is one authority block, not field-level overrides. If
+        # the consumer supplied it, omitted fields must not inherit a Runtime or
+        # image credential that belongs to another endpoint.
+        for field, env_name in (
+            ("base_url", "ANTHROPIC_BASE_URL"),
+            ("model", "ANTHROPIC_MODEL"),
+        ):
+            value = llm.get(field)
+            if value:
+                os.environ[env_name] = str(value)
+            else:
+                os.environ.pop(env_name, None)
+
+        auth_token = llm.get("auth_token")
+        api_key = llm.get("api_key")
+        if auth_token:
+            os.environ["ANTHROPIC_AUTH_TOKEN"] = str(auth_token)
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+        elif api_key:
+            os.environ["ANTHROPIC_API_KEY"] = str(api_key)
+            os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
+        else:
+            os.environ.pop("ANTHROPIC_AUTH_TOKEN", None)
             os.environ.pop("ANTHROPIC_API_KEY", None)
     settings = body.get("settings")
     if isinstance(settings, dict):
@@ -2710,7 +2731,10 @@ async def handle_session(request: web.Request):
     """Start (or no-op attach to) the run's persistent CONVERSATIONAL session —
     it connects and waits for the first /message (prepare chat; a compile is just
     a later turn). Idempotent: a second call for a live run is a no-op, so the
-    runtime can safely ensure-then-message."""
+    runtime can safely ensure-then-message. A live attach deliberately does not
+    hot-apply a new LLM block: its already-connected SDK child captured the
+    original environment. Rotate with the documented grace window + box respawn
+    until an idle-boundary client reconnect protocol exists."""
     run_id = request.match_info["run_id"]
     if run_id in RUNS:
         return web.json_response({"ok": True, "run_id": run_id, "already_live": True})

--- a/kbc/platform/pod/mtls_auth.py
+++ b/kbc/platform/pod/mtls_auth.py
@@ -1,0 +1,78 @@
+"""Application-layer authorization for compile-box's optional-client-cert TLS.
+
+The TLS handshake requests and verifies a certificate when one is presented,
+while allowing Kubernetes to reach ``/health`` without one. Protected routes
+therefore complete the policy here using the verified TLS transport state.
+"""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+
+
+TRUSTED_CLIENT_OUS = frozenset({"Runtime", "Gateway"})
+
+
+def server_ssl_context(cert_dir: Path):
+    """Build the production TLS context without allowing partial-cert downgrade.
+
+    A completely empty directory means intentional local HTTP mode. If any TLS
+    material is present, all three files are mandatory; otherwise falling back
+    to HTTP would silently remove the application-layer certificate gate.
+    """
+    crt, key, ca = cert_dir / "tls.crt", cert_dir / "tls.key", cert_dir / "ca.crt"
+    present = {path.name: path.exists() for path in (crt, key, ca)}
+    if not any(present.values()):
+        return None
+    missing = [name for name, exists in present.items() if not exists]
+    if missing:
+        raise RuntimeError(f"Incomplete compile-box TLS material; missing: {', '.join(missing)}")
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(str(crt), str(key))
+    ctx.load_verify_locations(str(ca))
+    # Kubelet/local exec probes reach /health without a client certificate.
+    # Any certificate that IS presented is verified against the CA here; the
+    # application middleware requires it and authorizes its OU on other routes.
+    ctx.verify_mode = ssl.CERT_OPTIONAL
+    return ctx
+
+
+def client_certificate_error(request) -> str | None:
+    """Return an authorization error, or ``None`` when the request is allowed.
+
+    A request with no TLS transport is the supported local-development HTTP
+    mode. HTTPS callers must present a CA-verified certificate whose OU is one
+    of the trusted runtime roles. ``/health`` is the only TLS exception.
+    """
+    if request.path == "/health":
+        return None
+
+    transport = request.transport
+    if transport is None:
+        return None
+    ssl_object = transport.get_extra_info("ssl_object")
+    if ssl_object is None:
+        return None
+
+    verify_mode = getattr(getattr(ssl_object, "context", None), "verify_mode", ssl.CERT_NONE)
+    if verify_mode not in (ssl.CERT_OPTIONAL, ssl.CERT_REQUIRED):
+        return "Client certificate was not verified by the TLS transport"
+
+    try:
+        peer_cert = ssl_object.getpeercert()
+    except (OSError, ValueError, ssl.SSLError):
+        peer_cert = None
+    if not peer_cert:
+        return "Client certificate required"
+
+    ous = {
+        str(value)
+        for rdn in peer_cert.get("subject", ())
+        for key, value in rdn
+        if key == "organizationalUnitName"
+    }
+    if not ous.intersection(TRUSTED_CLIENT_OUS):
+        return "Forbidden: only Runtime/Gateway client certificates may access this API"
+    return None

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -382,11 +382,15 @@ async def test_test_path_escape_guard():
 
 async def test_batch_planner_uses_compile_path_guard():
     """The model planner can Write under bypassPermissions, so it must carry the
-    same workspace confinement hook as every other compiler session."""
+    same workspace confinement hook and model policy as every other compiler session."""
     orig = compile_box.ClaudeSDKClient
     previous_mode = os.environ.get("KBC_BATCH_PLANNER")
+    previous_compile_model = os.environ.get("KBC_COMPILE_MODEL")
+    previous_anthropic_model = os.environ.get("ANTHROPIC_MODEL")
     compile_box.ClaudeSDKClient = _FakeSDKClient
     os.environ["KBC_BATCH_PLANNER"] = "model"
+    os.environ.pop("KBC_COMPILE_MODEL", None)
+    os.environ["ANTHROPIC_MODEL"] = "consumer-selected-model"
     try:
         with tempfile.TemporaryDirectory() as td:
             run = compile_box.CompileRun("planner-guard", td, 1)
@@ -395,13 +399,22 @@ async def test_batch_planner_uses_compile_path_guard():
             opts = _FakeSDKClient.last.options
             assert opts.allowed_tools == ["Read", "Write", "Glob"], opts.allowed_tools
             assert opts.hooks and opts.hooks.get("PreToolUse"), opts.hooks
+            assert opts.model == "consumer-selected-model", opts.model
     finally:
         compile_box.ClaudeSDKClient = orig
         if previous_mode is None:
             os.environ.pop("KBC_BATCH_PLANNER", None)
         else:
             os.environ["KBC_BATCH_PLANNER"] = previous_mode
-    print("✓ batch planner uses compile workspace path guard")
+        if previous_compile_model is None:
+            os.environ.pop("KBC_COMPILE_MODEL", None)
+        else:
+            os.environ["KBC_COMPILE_MODEL"] = previous_compile_model
+        if previous_anthropic_model is None:
+            os.environ.pop("ANTHROPIC_MODEL", None)
+        else:
+            os.environ["ANTHROPIC_MODEL"] = previous_anthropic_model
+    print("✓ batch planner uses compile workspace path guard and model policy")
 
 
 

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -775,7 +775,7 @@ def test_apply_session_config():
     """Consumer-managed llm/settings from /session body (DESIGN-kb-llm-binding-v2):
     llm applies + clears a stale forwarded API key; settings whitelisted to
     KBC_*; the boot-time KBC_PK_MODE=off kill switch outranks consumer config."""
-    keys = ("ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY",
+    keys = ("ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY",
             "KBC_COMPILE_MODEL", "KBC_PK_MODE")
     backup = {k: os.environ.get(k) for k in keys}
     kill_backup = compile_box._PK_KILL_AT_BOOT
@@ -785,17 +785,34 @@ def test_apply_session_config():
         os.environ.pop("KBC_COMPILE_MODEL", None)
         compile_box._PK_KILL_AT_BOOT = False
         compile_box._apply_session_config({
-            "llm": {"base_url": "https://massapi.example/model-api", "auth_token": "tok-1"},
+            "llm": {"base_url": "https://massapi.example/model-api",
+                    "auth_token": "tok-1", "model": "claude-sonnet-4-6"},
             "settings": {"KBC_COMPILE_MODEL": "claude-opus-4-8",
                          "KBC_PK_MODE": "auto",
                          "EVIL_KEY": "nope", "PATH": "/pwn"},
         })
         assert os.environ["ANTHROPIC_BASE_URL"] == "https://massapi.example/model-api"
+        assert os.environ["ANTHROPIC_MODEL"] == "claude-sonnet-4-6"
         assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "tok-1"
         assert "ANTHROPIC_API_KEY" not in os.environ           # stale key cleared
         assert os.environ["KBC_COMPILE_MODEL"] == "claude-opus-4-8"
         assert os.environ["KBC_PK_MODE"] == "auto"
         assert "EVIL_KEY" not in os.environ and os.environ.get("PATH") != "/pwn"
+
+        run = compile_box.CompileRun("config-test", "/tmp", 1, "")
+        opts = compile_box._compile_session_opts(run, "/tmp", "role", "session-1")
+        assert opts.model == "claude-opus-4-8"                 # explicit KBC setting wins
+        os.environ.pop("KBC_COMPILE_MODEL")
+        opts = compile_box._compile_session_opts(run, "/tmp", "role", "session-2")
+        assert opts.model == "claude-sonnet-4-6"               # Helm LLM model fallback
+
+        # A present consumer block is authoritative as a whole: absent fields
+        # clear the previous endpoint/token instead of mixing authorities.
+        compile_box._apply_session_config({"llm": {"api_key": "api-key-2"}})
+        assert "ANTHROPIC_BASE_URL" not in os.environ
+        assert "ANTHROPIC_MODEL" not in os.environ
+        assert "ANTHROPIC_AUTH_TOKEN" not in os.environ
+        assert os.environ["ANTHROPIC_API_KEY"] == "api-key-2"
 
         # ops kill switch: runtime-level off beats consumer "auto"
         os.environ["KBC_PK_MODE"] = "off"

--- a/kbc/platform/pod/test_mtls_auth.py
+++ b/kbc/platform/pod/test_mtls_auth.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import ssl
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from mtls_auth import client_certificate_error, server_ssl_context
+
+
+class FakeTlsTransport:
+    def __init__(self, cert=None, verify_mode=ssl.CERT_OPTIONAL):
+        self._ssl = SimpleNamespace(
+            context=SimpleNamespace(verify_mode=verify_mode),
+            getpeercert=lambda: cert,
+        )
+
+    def get_extra_info(self, name):
+        return self._ssl if name == "ssl_object" else None
+
+
+def request(path, transport):
+    return SimpleNamespace(path=path, transport=transport)
+
+
+def certificate(ou):
+    return {"subject": ((('commonName', 'caller'),), (('organizationalUnitName', ou),))}
+
+
+class ClientCertificateGateTest(unittest.TestCase):
+    def test_empty_cert_directory_is_explicit_local_http_mode(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(server_ssl_context(Path(tmp)))
+
+    def test_partial_tls_material_fails_closed_instead_of_downgrading_to_http(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "tls.crt").touch()
+            with self.assertRaisesRegex(RuntimeError, "tls.key, ca.crt"):
+                server_ssl_context(Path(tmp))
+
+    def test_health_allows_tls_without_client_certificate(self):
+        self.assertIsNone(client_certificate_error(request("/health", FakeTlsTransport())))
+
+    def test_plain_http_local_mode_remains_available(self):
+        self.assertIsNone(client_certificate_error(request("/sources", None)))
+
+    def test_tls_protected_route_requires_certificate(self):
+        self.assertIn(
+            "certificate required",
+            client_certificate_error(request("/sources", FakeTlsTransport())).lower(),
+        )
+
+    def test_tls_context_must_verify_the_peer(self):
+        error = client_certificate_error(request(
+            "/sources",
+            FakeTlsTransport(certificate("Runtime"), verify_mode=ssl.CERT_NONE),
+        ))
+        self.assertIn("verified", error.lower())
+
+    def test_rejects_untrusted_ou(self):
+        error = client_certificate_error(request(
+            "/sources",
+            FakeTlsTransport(certificate("AgentBox")),
+        ))
+        self.assertIn("runtime/gateway", error.lower())
+
+    def test_allows_runtime_and_gateway_ous(self):
+        for ou in ("Runtime", "Gateway"):
+            with self.subTest(ou=ou):
+                self.assertIsNone(client_certificate_error(request(
+                    "/sources",
+                    FakeTlsTransport(certificate(ou)),
+                )))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/gateway/agentbox/box-profile.test.ts
+++ b/src/gateway/agentbox/box-profile.test.ts
@@ -29,6 +29,8 @@ describe("getBoxProfile", () => {
     expect(p.home).toBe("/work");
     expect(p.volumes).toEqual([{ name: "work", mountPath: "/work", sizeLimit: "4Gi" }]);
     expect(p.envForward).toContain("ANTHROPIC_BASE_URL");
+    expect(p.envForward).not.toContain("ANTHROPIC_API_KEY");
+    expect(p.envForward).not.toContain("ANTHROPIC_AUTH_TOKEN");
     expect(p.allowedTools).toBeNull();
   });
 

--- a/src/gateway/agentbox/box-profile.ts
+++ b/src/gateway/agentbox/box-profile.ts
@@ -78,7 +78,11 @@ function kbCompileProfile(): BoxProfile {
   return {
     name: "kb-compile",
     image: process.env.SICLAW_COMPILE_BOX_IMAGE || "kbc-compile-box:latest",
-    envForward: ["ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "KBC_*"],
+    // LLM credentials arrive in the consumer-managed /session payload after
+    // fail-closed input materialization. Never duplicate a Runtime secret into
+    // the pod spec; only the non-secret endpoint and ops KBC_* kill switches
+    // are inherited as rolling-upgrade fallbacks.
+    envForward: ["ANTHROPIC_BASE_URL", "KBC_*"],
     home: "/work",
     volumes: [{ name: "work", mountPath: "/work", sizeLimit: "4Gi" }], // installer allows 2GB unpacked raw + candidate output — 1Gi evicted large-corpus pods
     // A compile box realistically runs 1-2Gi (Claude Code + candidate tree +
@@ -104,7 +108,7 @@ function kbTestProfile(): BoxProfile {
   return {
     name: "kb-test",
     image: process.env.SICLAW_COMPILE_BOX_IMAGE || "kbc-compile-box:latest",
-    envForward: ["ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "KBC_*"],
+    envForward: ["ANTHROPIC_BASE_URL", "KBC_*"],
     home: "/work",
     // Same cap as kb-compile — the profiles' documented invariant is "identical
     // box shape, trust differs only in allowedTools" (a sizeLimit is a ceiling,

--- a/src/gateway/agentbox/box-profile.ts
+++ b/src/gateway/agentbox/box-profile.ts
@@ -28,8 +28,9 @@ export interface BoxProfile {
    */
   image?: string;
   /**
-   * Extra runtime-process env names forwarded into the box, ON TOP of the base
-   * agentbox allowlist. The box does NOT inherit runtime env; only these pass.
+   * Profile-declared Runtime env names. The box never inherits arbitrary
+   * Runtime env: normal AgentBoxes also have a small built-in allowlist, while
+   * lean profiles receive only the names declared here.
    */
   envForward?: string[];
   /** HOME override (e.g. "/work" when rootfs is read-only and the image HOME isn't writable). */
@@ -78,10 +79,10 @@ function kbCompileProfile(): BoxProfile {
   return {
     name: "kb-compile",
     image: process.env.SICLAW_COMPILE_BOX_IMAGE || "kbc-compile-box:latest",
-    // LLM credentials arrive in the consumer-managed /session payload after
-    // fail-closed input materialization. Never duplicate a Runtime secret into
-    // the pod spec; only the non-secret endpoint and ops KBC_* kill switches
-    // are inherited as rolling-upgrade fallbacks.
+    // LLM credentials arrive in /session after fail-closed input materialization:
+    // consumer block first, Runtime Helm fallback only when that block is absent.
+    // Never duplicate a Runtime secret into the pod spec; only the non-secret
+    // endpoint and ops KBC_* kill switches remain as rolling-version fallbacks.
     envForward: ["ANTHROPIC_BASE_URL", "KBC_*"],
     home: "/work",
     volumes: [{ name: "work", mountPath: "/work", sizeLimit: "4Gi" }], // installer allows 2GB unpacked raw + candidate output — 1Gi evicted large-corpus pods

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -339,6 +339,8 @@ describe("K8sSpawner — spawn branches", () => {
     expect(container.livenessProbe.httpGet).toBeUndefined();
     expect(container.readinessProbe.exec.command.join(" ")).toContain("/health");
     expect(container.livenessProbe.exec.command).toEqual(container.readinessProbe.exec.command);
+    expect(container.readinessProbe.timeoutSeconds).toBe(3);
+    expect(container.livenessProbe.timeoutSeconds).toBe(3);
   });
 
   it("refuses to forward secret-shaped names through the prefix glob (ops knobs only)", async () => {

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -286,6 +286,26 @@ describe("K8sSpawner — spawn branches", () => {
     }
   });
 
+  it("uses in-container exec probes for KB boxes so NetworkPolicy need not admit kubelet traffic", async () => {
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "10.0.0.23", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    await s.spawn({ agentId: "kb-probe", profile: "kb-compile" });
+    const container = calls.createNamespacedPod[0].body.spec.containers[0];
+    expect(container.readinessProbe.httpGet).toBeUndefined();
+    expect(container.livenessProbe.httpGet).toBeUndefined();
+    expect(container.readinessProbe.exec.command.join(" ")).toContain("/health");
+    expect(container.livenessProbe.exec.command).toEqual(container.readinessProbe.exec.command);
+  });
+
   it("refuses to forward secret-shaped names through the prefix glob (ops knobs only)", async () => {
     process.env.KBC_PK_MODE = "off";                       // knob → forwarded
     process.env.KBC_MASSAPI_TOKEN = "sk-parked";           // secret-shaped → refused

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -286,6 +286,41 @@ describe("K8sSpawner — spawn branches", () => {
     }
   });
 
+  it("keeps agent-only embedding credentials out of lean KB PodSpecs", async () => {
+    process.env.SICLAW_EMBEDDING_BASE_URL = "https://embedding.example/v1";
+    process.env.SICLAW_EMBEDDING_API_KEY = "embedding-secret";
+
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads % 2 === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "10.0.0.24", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    try {
+      await s.spawn({ agentId: "normal-agent" });
+      await s.spawn({ agentId: "kb-compile-run", profile: "kb-compile" });
+      await s.spawn({ agentId: "kb-test-run", profile: "kb-test" });
+      const agentEnv = calls.createNamespacedPod[0].body.spec.containers[0].env;
+      const capabilityEnvs = calls.createNamespacedPod
+        .slice(1)
+        .map((call: any) => call.body.spec.containers[0].env);
+
+      expect(agentEnv).toContainEqual({ name: "SICLAW_EMBEDDING_BASE_URL", value: "https://embedding.example/v1" });
+      expect(agentEnv).toContainEqual({ name: "SICLAW_EMBEDDING_API_KEY", value: "embedding-secret" });
+      for (const env of capabilityEnvs) {
+        expect(env.some((entry: any) => entry.name.startsWith("SICLAW_EMBEDDING_"))).toBe(false);
+      }
+    } finally {
+      delete process.env.SICLAW_EMBEDDING_BASE_URL;
+      delete process.env.SICLAW_EMBEDDING_API_KEY;
+    }
+  });
+
   it("uses in-container exec probes for KB boxes so NetworkPolicy need not admit kubelet traffic", async () => {
     const cm = new FakeCertManager();
     const s = new K8sSpawner({ namespace: "siclaw-debug" });

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -253,34 +253,32 @@ export class K8sSpawner implements BoxSpawner {
       { name: "SICLAW_GATEWAY_URL", value: this.gatewayUrl(namespace) },
       { name: "SICLAW_AGENT_ID", value: agentId },
     ];
-    if (process.env.SICLAW_MEMORY_ENABLED !== undefined) {
-      env.push({ name: "SICLAW_MEMORY_ENABLED", value: process.env.SICLAW_MEMORY_ENABLED });
-    }
+    // Normal AgentBoxes need Runtime-level memory/embedding/sub-agent settings.
+    // Lean capability profiles do not use those features, and inheriting this
+    // base allowlist would copy SICLAW_EMBEDDING_API_KEY into an unrelated KB
+    // PodSpec. Capability boxes receive only their profile-declared env below.
+    if (profile.name === "agent") {
+      if (process.env.SICLAW_MEMORY_ENABLED !== undefined) {
+        env.push({ name: "SICLAW_MEMORY_ENABLED", value: process.env.SICLAW_MEMORY_ENABLED });
+      }
 
-    // Forward agentbox-relevant runtime knobs into the agentbox pod. The agentbox
-    // runs in its own pod and does NOT inherit the runtime process env, yet this
-    // flag is read inside the agentbox (sub-agent fan-out limiter, design §3).
-    // Curated allowlist only — never forward arbitrary env. Set the value on the
-    // runtime deployment to control every agentbox it spawns.
-    const AGENTBOX_FORWARDED_ENV = [
-      "SICLAW_SUBAGENT_CONCURRENCY",
-      // Embedding endpoint for the memory indexer. The agentbox reads these via
-      // loadConfig() env overrides (config.ts); set on the runtime deployment to
-      // configure every agentbox it spawns. API key is optional (TEI-style
-      // self-hosted endpoints are usually unauthenticated).
-      "SICLAW_EMBEDDING_BASE_URL",
-      "SICLAW_EMBEDDING_MODEL",
-      "SICLAW_EMBEDDING_DIMENSIONS",
-      "SICLAW_EMBEDDING_API_KEY",
-      // Trace deployment environment (Langfuse deployment.environment.name). The
-      // agentbox reads it via loadConfig() env override → config.tracing.environment.
-      // Per-runtime: set on the runtime deployment to tag every agentbox it spawns.
-      "SICLAW_TRACING_ENVIRONMENT",
-    ];
-    for (const name of AGENTBOX_FORWARDED_ENV) {
-      const value = process.env[name];
-      if (value !== undefined && value !== "") {
-        env.push({ name, value });
+      const AGENTBOX_FORWARDED_ENV = [
+        "SICLAW_SUBAGENT_CONCURRENCY",
+        // Embedding endpoint for the memory indexer. The agentbox reads these via
+        // loadConfig() env overrides (config.ts); set on the runtime deployment to
+        // configure every normal AgentBox it spawns.
+        "SICLAW_EMBEDDING_BASE_URL",
+        "SICLAW_EMBEDDING_MODEL",
+        "SICLAW_EMBEDDING_DIMENSIONS",
+        "SICLAW_EMBEDDING_API_KEY",
+        // Trace deployment environment (Langfuse deployment.environment.name).
+        "SICLAW_TRACING_ENVIRONMENT",
+      ];
+      for (const name of AGENTBOX_FORWARDED_ENV) {
+        const value = process.env[name];
+        if (value !== undefined && value !== "") {
+          env.push({ name, value });
+        }
       }
     }
 

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -516,6 +516,7 @@ export class K8sSpawner implements BoxSpawner {
                   ] },
                   initialDelaySeconds: 2,
                   periodSeconds: 2,
+                  timeoutSeconds: 3,
                 }
               : {
                   httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },
@@ -530,6 +531,7 @@ export class K8sSpawner implements BoxSpawner {
                   ] },
                   initialDelaySeconds: 10,
                   periodSeconds: 10,
+                  timeoutSeconds: 3,
                 }
               : {
                   httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -506,16 +506,38 @@ export class K8sSpawner implements BoxSpawner {
                 },
               };
             })(),
-            readinessProbe: {
-              httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },
-              initialDelaySeconds: 2,
-              periodSeconds: 2,
-            },
-            livenessProbe: {
-              httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },
-              initialDelaySeconds: 10,
-              periodSeconds: 10,
-            },
+            // NetworkPolicy for capability boxes admits only Runtime ingress.
+            // Kubelet HTTP probes originate outside that podSelector on several
+            // CNIs, so use an in-container HTTPS check for KB profiles. The
+            // endpoint is deliberately the sole route that needs no client cert.
+            readinessProbe: profile.name === "kb-compile" || profile.name === "kb-test"
+              ? {
+                  exec: { command: [
+                    "python", "-c",
+                    "import ssl,urllib.request; urllib.request.urlopen('https://127.0.0.1:3000/health', context=ssl._create_unverified_context(), timeout=2).read()",
+                  ] },
+                  initialDelaySeconds: 2,
+                  periodSeconds: 2,
+                }
+              : {
+                  httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },
+                  initialDelaySeconds: 2,
+                  periodSeconds: 2,
+                },
+            livenessProbe: profile.name === "kb-compile" || profile.name === "kb-test"
+              ? {
+                  exec: { command: [
+                    "python", "-c",
+                    "import ssl,urllib.request; urllib.request.urlopen('https://127.0.0.1:3000/health', context=ssl._create_unverified_context(), timeout=2).read()",
+                  ] },
+                  initialDelaySeconds: 10,
+                  periodSeconds: 10,
+                }
+              : {
+                  httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },
+                  initialDelaySeconds: 10,
+                  periodSeconds: 10,
+                },
           },
         ],
       },

--- a/src/gateway/agentbox/manager.test.ts
+++ b/src/gateway/agentbox/manager.test.ts
@@ -430,6 +430,23 @@ describe("AgentBoxManager — cleanup", () => {
     expect(spawner.cleanupCalls).toBe(1);
     expect(mgr.stats().total).toBe(0);
   });
+
+  it("shutdown preserves K8s boxes for another Runtime replica to adopt", async () => {
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+    await mgr.shutdown();
+    expect(spawner.stopCalls).toEqual([]);
+    expect(spawner.cleanupCalls).toBe(0);
+  });
+
+  it("shutdown still cleans up process-local boxes", async () => {
+    const spawner = new FakeSpawner("local");
+    const mgr = new AgentBoxManager(spawner);
+    await mgr.getOrCreate("agent-a");
+    await mgr.shutdown();
+    expect(spawner.stopCalls).toEqual(["box-agent-a"]);
+    expect(spawner.cleanupCalls).toBe(1);
+  });
 });
 
 describe("AgentBoxManager — K8s CA-fingerprint self-heal", () => {

--- a/src/gateway/agentbox/manager.test.ts
+++ b/src/gateway/agentbox/manager.test.ts
@@ -68,6 +68,20 @@ describe("AgentBoxManager — Local mode", () => {
     expect(mgr.stats()).toEqual({ total: 1, agentIds: ["agent-a"] });
   });
 
+  it("reports whether local setup created or reused the box", async () => {
+    const spawner = new FakeSpawner("local");
+    const mgr = new AgentBoxManager(spawner);
+    const first = await mgr.getOrCreateWithDisposition("agent-a");
+    expect(first.created).toBe(true);
+
+    spawner.getReturns.set("box-agent-a", {
+      boxId: "box-agent-a", agentId: "agent-a", status: "running",
+      endpoint: "x", createdAt: new Date(), lastActiveAt: new Date(),
+    });
+    const second = await mgr.getOrCreateWithDisposition("agent-a");
+    expect(second).toMatchObject({ created: false, handle: { boxId: "box-agent-a" } });
+  });
+
   it("reuses the cached box on second call for the same agent", async () => {
     const spawner = new FakeSpawner("local");
     const mgr = new AgentBoxManager(spawner);
@@ -156,6 +170,24 @@ describe("AgentBoxManager — K8s mode", () => {
     expect(handle.boxId).toBe("agentbox-agent-a");
     expect(handle.endpoint).toBe("https://10.0.0.1:3000");
     expect(spawner.spawnCalls).toHaveLength(0);
+  });
+
+  it("reports whether K8s setup created or adopted the pod", async () => {
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+    const created = await mgr.getOrCreateWithDisposition("new-run", { profile: "kb-compile" });
+    expect(created.created).toBe(true);
+
+    spawner.getReturns.set("agentbox-live-run", {
+      boxId: "agentbox-live-run", agentId: "live-run", status: "running",
+      endpoint: "https://10.0.0.9:3000", createdAt: new Date(), lastActiveAt: new Date(),
+      profile: "kb-compile",
+    });
+    const adopted = await mgr.getOrCreateWithDisposition("live-run", { profile: "kb-compile" });
+    expect(adopted).toMatchObject({
+      created: false,
+      handle: { boxId: "agentbox-live-run", endpoint: "https://10.0.0.9:3000" },
+    });
   });
 
   it("creates a new pod when none exists", async () => {

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -33,6 +33,12 @@ interface ManagedBox {
   createdAt: Date;
 }
 
+export interface AgentBoxAcquisition {
+  handle: AgentBoxHandle;
+  /** True only when this call created/recreated the underlying box. */
+  created: boolean;
+}
+
 export class AgentBoxManager {
   private spawner: BoxSpawner;
   private config: Required<AgentBoxManagerConfig>;
@@ -156,6 +162,20 @@ export class AgentBoxManager {
    * (after restart/idle-release), not immediately on a warm pod.
    */
   async getOrCreate(agentId: string, config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
+    return (await this.getOrCreateWithDisposition(agentId, config)).handle;
+  }
+
+  /**
+   * Get or create a box and report ownership of the resulting resource.
+   *
+   * Callers that perform multi-step setup need this distinction: a failed setup
+   * may clean up a box it just created, but must never delete a live box reused
+   * during Runtime adoption or a warm request.
+   */
+  async getOrCreateWithDisposition(
+    agentId: string,
+    config?: Partial<AgentBoxConfig>,
+  ): Promise<AgentBoxAcquisition> {
     if (!agentId) throw new Error("AgentBoxManager.getOrCreate requires an agentId");
     if (this.isK8s) {
       return this.getOrCreateK8s(agentId, config);
@@ -163,7 +183,10 @@ export class AgentBoxManager {
     return this.getOrCreateLocal(agentId, config);
   }
 
-  private async getOrCreateK8s(agentId: string, config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
+  private async getOrCreateK8s(
+    agentId: string,
+    config?: Partial<AgentBoxConfig>,
+  ): Promise<AgentBoxAcquisition> {
     const name = this.podName(agentId);
     const wantProfile = config?.profile ?? "agent";
 
@@ -174,7 +197,7 @@ export class AgentBoxManager {
         // Warm reuse: return the running pod without spawning. Per-agent config
         // (env/persistence) is NOT re-resolved here — the pod's volume mount is
         // already fixed, so a changed mode applies on the next cold spawn.
-        return { boxId: name, endpoint: info.endpoint, agentId };
+        return { handle: { boxId: name, endpoint: info.endpoint, agentId }, created: false };
       }
       // Profile changed under the same identity — reusing the old-shaped pod would
       // silently run the wrong image/tools/volumes (the historic stale-box gap).
@@ -199,10 +222,13 @@ export class AgentBoxManager {
     });
 
     handle.agentId = agentId;
-    return handle;
+    return { handle, created: true };
   }
 
-  private async getOrCreateLocal(agentId: string, config?: Partial<AgentBoxConfig>): Promise<AgentBoxHandle> {
+  private async getOrCreateLocal(
+    agentId: string,
+    config?: Partial<AgentBoxConfig>,
+  ): Promise<AgentBoxAcquisition> {
     const existing = this.boxes.get(agentId);
     if (existing) {
       existing.lastActiveAt = new Date();
@@ -210,7 +236,7 @@ export class AgentBoxManager {
       if (info && info.status === "running") {
         // Warm reuse: cached running box returned without spawning. Per-agent
         // config (env/persistence) is NOT re-resolved — applies on next cold spawn.
-        return existing.handle;
+        return { handle: existing.handle, created: false };
       }
       this.boxes.delete(agentId);
     }
@@ -226,7 +252,7 @@ export class AgentBoxManager {
     });
 
     this.boxes.set(agentId, { handle, lastActiveAt: new Date(), createdAt: new Date() });
-    return handle;
+    return { handle, created: true };
   }
 
   /**

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -38,6 +38,7 @@ export class AgentBoxManager {
   private config: Required<AgentBoxManagerConfig>;
   private boxes = new Map<string, ManagedBox>();
   private healthCheckTimer?: ReturnType<typeof setInterval>;
+  private orphanSweepInitialTimer?: ReturnType<typeof setTimeout>;
   private orphanSweepTimer?: ReturnType<typeof setInterval>;
   private readonly isK8s: boolean;
   private spawnEnvResolver?: (agentId: string) => Promise<Record<string, string> | undefined>;
@@ -72,7 +73,8 @@ export class AgentBoxManager {
         console.warn("[agentbox-manager] orphan sweep failed:", err?.message ?? err));
     // unref'd + stored (review finding): the sweep must never pin the event
     // loop or outlive cleanup() — same discipline as the run watchdog.
-    (setTimeout(tick, 60_000) as any).unref?.();
+    this.orphanSweepInitialTimer = setTimeout(tick, 60_000);
+    (this.orphanSweepInitialTimer as any).unref?.();
     this.orphanSweepTimer = setInterval(tick, intervalMs);
     (this.orphanSweepTimer as any).unref?.();
   }
@@ -321,18 +323,41 @@ export class AgentBoxManager {
   }
 
   async cleanup(): Promise<void> {
-    this.stopHealthCheck();
-    // The orphan-sweep interval dies with the manager (review: the clear had
-    // landed in setSpawnEnvResolver, which both left it running post-cleanup
-    // and silently disabled GC if a resolver was ever re-set after boot).
-    if (this.orphanSweepTimer) {
-      clearInterval(this.orphanSweepTimer);
-      this.orphanSweepTimer = undefined;
-    }
+    this.stopBackgroundLoops();
     for (const [, managed] of this.boxes) {
       await this.spawner.stop(managed.handle.boxId);
     }
     this.boxes.clear();
     await this.spawner.cleanup();
+  }
+
+  /**
+   * Process shutdown is not cluster teardown. In K8s mode boxes and their
+   * durable run rows outlive a Runtime pod and are adopted by the replacement;
+   * deleting every labelled pod here destroys that hand-off window. Local and
+   * child-process spawners still own their children, so they use full cleanup.
+   */
+  async shutdown(): Promise<void> {
+    if (!this.isK8s) {
+      await this.cleanup();
+      return;
+    }
+    this.stopBackgroundLoops();
+    this.boxes.clear();
+  }
+
+  private stopBackgroundLoops(): void {
+    this.stopHealthCheck();
+    // The orphan-sweep interval dies with the manager (review: the clear had
+    // landed in setSpawnEnvResolver, which both left it running post-cleanup
+    // and silently disabled GC if a resolver was ever re-set after boot).
+    if (this.orphanSweepInitialTimer) {
+      clearTimeout(this.orphanSweepInitialTimer);
+      this.orphanSweepInitialTimer = undefined;
+    }
+    if (this.orphanSweepTimer) {
+      clearInterval(this.orphanSweepTimer);
+      this.orphanSweepTimer = undefined;
+    }
   }
 }

--- a/src/gateway/capability/capability-metrics.test.ts
+++ b/src/gateway/capability/capability-metrics.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { federationSelfRegistry } from "../federation-self-metrics.js";
+import {
+  capabilityActiveRuns,
+  capabilityMaterializationFailuresTotal,
+  capabilityRelayFailuresTotal,
+  capabilityStartDurationMs,
+  capabilityStartsTotal,
+} from "./capability-metrics.js";
+
+describe("capability lifecycle metrics", () => {
+  beforeEach(() => federationSelfRegistry.resetMetrics());
+
+  it("exports only bounded lifecycle labels", async () => {
+    capabilityStartsTotal.inc({ outcome: "success" });
+    capabilityStartDurationMs.observe({ outcome: "success" }, 123);
+    capabilityMaterializationFailuresTotal.inc({ stage: "workspace-fetch" });
+    capabilityRelayFailuresTotal.inc();
+    capabilityActiveRuns.set(2);
+
+    const output = await federationSelfRegistry.metrics();
+    expect(output).toContain('siclaw_gateway_capability_starts_total{outcome="success"} 1');
+    expect(output).toContain('siclaw_gateway_capability_materialization_failures_total{stage="workspace-fetch"} 1');
+    expect(output).toContain("siclaw_gateway_capability_relay_failures_total 1");
+    expect(output).toContain("siclaw_gateway_capability_active_runs 2");
+    expect(output).not.toContain("run_id=");
+    expect(output).not.toContain("repo_id=");
+  });
+});

--- a/src/gateway/capability/capability-metrics.ts
+++ b/src/gateway/capability/capability-metrics.ts
@@ -1,0 +1,39 @@
+import { Counter, Gauge, Histogram } from "prom-client";
+
+import { federationSelfRegistry } from "../federation-self-metrics.js";
+
+// Gateway-native capability lifecycle metrics. Labels are deliberately bounded:
+// repo/run/operation identifiers belong in traces and logs, never Prometheus.
+export const capabilityStartsTotal = new Counter({
+  name: "siclaw_gateway_capability_starts_total",
+  help: "Capability start attempts by outcome",
+  labelNames: ["outcome"] as const,
+  registers: [federationSelfRegistry],
+});
+
+export const capabilityStartDurationMs = new Histogram({
+  name: "siclaw_gateway_capability_start_duration_ms",
+  help: "End-to-end capability start and box setup duration in milliseconds",
+  labelNames: ["outcome"] as const,
+  buckets: [100, 500, 1_000, 3_000, 10_000, 30_000, 60_000, 120_000],
+  registers: [federationSelfRegistry],
+});
+
+export const capabilityActiveRuns = new Gauge({
+  name: "siclaw_gateway_capability_active_runs",
+  help: "Non-terminal capability runs currently tracked by this Runtime",
+  registers: [federationSelfRegistry],
+});
+
+export const capabilityMaterializationFailuresTotal = new Counter({
+  name: "siclaw_gateway_capability_materialization_failures_total",
+  help: "Fail-closed capability input materialization failures by stable stage",
+  labelNames: ["stage"] as const,
+  registers: [federationSelfRegistry],
+});
+
+export const capabilityRelayFailuresTotal = new Counter({
+  name: "siclaw_gateway_capability_relay_failures_total",
+  help: "Capability box event relays that ended with an error",
+  registers: [federationSelfRegistry],
+});

--- a/src/gateway/capability/contract.ts
+++ b/src/gateway/capability/contract.ts
@@ -298,6 +298,21 @@ export interface CapabilityFetchInputRequest {
   input_revision?: string;
 }
 
+/**
+ * LLM connection settings installed into one capability box at session setup.
+ *
+ * The object is an authority boundary, not a bag of field-level overrides:
+ * when the consumer supplies it, Runtime must forward that object as-is and
+ * must not fill missing fields with Runtime credentials. Only an entirely
+ * absent consumer object may fall back to Runtime's Helm-provided environment.
+ */
+export interface CapabilityLlmConfig {
+  base_url?: string;
+  auth_token?: string;
+  api_key?: string;
+  model?: string;
+}
+
 export interface CapabilityFetchInputResponse {
   bundle_base64?: string;
   bundle_sha256?: string;
@@ -312,12 +327,13 @@ export interface CapabilityFetchInputResponse {
   locale?: string;
   /**
    * Consumer-managed LLM endpoint for the run's box (DESIGN-kb-llm-binding-v2).
-   * The consumer owns the credential store; the runtime passes
-   * this through OPAQUELY into the box /session body and MUST NOT log it.
-   * Absent ⇒ the box falls back to the runtime-env-forwarded ANTHROPIC_* vars
-   * (the helm Secret path).
+   * The consumer owns the credential store; Runtime passes this whole object
+   * OPAQUELY into the box /session body and MUST NOT log it or merge a Runtime
+   * credential into missing fields. Only an absent object uses Runtime's
+   * Helm-provided ANTHROPIC_* values, also delivered through /session so
+   * credentials never enter the KB PodSpec.
    */
-  llm?: { base_url?: string; auth_token?: string };
+  llm?: CapabilityLlmConfig;
   /**
    * Consumer-managed box behavior knobs, keyed by the box's OWN env vocabulary
    * (KBC_* — model tiers, PK/media-verify switches, budgets). Same wire shape

--- a/src/gateway/capability/materialize.test.ts
+++ b/src/gateway/capability/materialize.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { materializeCapabilityInputs } from "./materialize.js";
+import { CapabilityMaterializationError, materializeCapabilityInputs } from "./materialize.js";
 import { CAPABILITY_FETCH_INPUT, CAPABILITY_INPUT_WORKSPACE_REF } from "./contract.js";
 
 function fakes(opts: {
   raw?: { bundle_base64?: string; bundle_sha256?: string; locale?: string; input_revision?: string };
   workspace?: { bundle_base64?: string; bundle_sha256?: string };
+  rawError?: Error;
   workspaceError?: Error;
   sourcesError?: Error;
+  authoringError?: Error;
 }) {
   const posts: Array<{ path: string; body: any }> = [];
   const client = {
     postJson: vi.fn(async (path: string, body: any) => {
       if (path === "/sources" && opts.sourcesError) throw opts.sourcesError;
+      if (path === "/authoring" && opts.authoringError) throw opts.authoringError;
       posts.push({ path, body });
       return { ok: true };
     }),
@@ -23,6 +26,7 @@ function fakes(opts: {
         if (opts.workspaceError) throw opts.workspaceError;
         return opts.workspace ?? {};
       }
+      if (opts.rawError) throw opts.rawError;
       return opts.raw ?? {};
     }),
   };
@@ -106,12 +110,53 @@ describe("materializeCapabilityInputs", () => {
     expect(backend.request).toHaveBeenCalledTimes(1);
   });
 
-  it("workspace fetch failure degrades to raw-only (no throw)", async () => {
+  it("raw fetch transport failure is typed and fails closed", async () => {
+    const { client, backend, posts } = fakes({ rawError: new Error("consumer RPC timed out") });
+    const error = await materializeCapabilityInputs({ client, backend, runId: "r1" }).catch((err) => err);
+
+    expect(error).toMatchObject({
+      name: "CapabilityMaterializationError",
+      stage: "source-fetch",
+      cause: expect.objectContaining({ message: "consumer RPC timed out" }),
+    });
+    expect(error).toBeInstanceOf(CapabilityMaterializationError);
+    expect(posts).toEqual([]);
+  });
+
+  it("raw source install failure is typed and fails closed", async () => {
+    const { client, backend, posts } = fakes({
+      raw: { bundle_base64: "UkFX" },
+      sourcesError: new Error("box install failed: 500"),
+    });
+    await expect(materializeCapabilityInputs({ client, backend, runId: "r1" })).rejects.toMatchObject({
+      name: "CapabilityMaterializationError",
+      stage: "source-install",
+    });
+    expect(posts).toEqual([]);
+  });
+
+  it("workspace fetch failure is typed and fails closed", async () => {
     const { client, backend, posts } = fakes({
       raw: { bundle_base64: "UkFX" },
       workspaceError: new Error("store hiccup"),
     });
-    await expect(materializeCapabilityInputs({ client, backend, runId: "r1" })).resolves.toEqual({});
+    await expect(materializeCapabilityInputs({ client, backend, runId: "r1" })).rejects.toMatchObject({
+      name: "CapabilityMaterializationError",
+      stage: "workspace-fetch",
+    });
+    expect(posts.map((p) => p.path)).toEqual(["/sources"]);
+  });
+
+  it("workspace install failure is typed and fails closed", async () => {
+    const { client, backend, posts } = fakes({
+      raw: { bundle_base64: "UkFX" },
+      workspace: { bundle_base64: "V1M=" },
+      authoringError: new Error("box authoring install failed: 500"),
+    });
+    await expect(materializeCapabilityInputs({ client, backend, runId: "r1" })).rejects.toMatchObject({
+      name: "CapabilityMaterializationError",
+      stage: "workspace-install",
+    });
     expect(posts.map((p) => p.path)).toEqual(["/sources"]);
   });
 

--- a/src/gateway/capability/materialize.ts
+++ b/src/gateway/capability/materialize.ts
@@ -22,7 +22,11 @@
  */
 
 import { CAPABILITY_FETCH_INPUT, CAPABILITY_INPUT_WORKSPACE_REF } from "./contract.js";
-import type { CapabilityFetchInputRequest, CapabilityFetchInputResponse } from "./contract.js";
+import type {
+  CapabilityFetchInputRequest,
+  CapabilityFetchInputResponse,
+  CapabilityLlmConfig,
+} from "./contract.js";
 
 /** Just the surfaces this needs (so tests can pass fakes). */
 export interface MaterializeBoxClient {
@@ -39,8 +43,8 @@ export interface MaterializeResult {
   reattached?: boolean;
   /** Consumer-declared locale for the run's box (fetchInput), if any. */
   locale?: string;
-  /** Consumer-managed LLM endpoint for the box (opaque passthrough; never logged). */
-  llm?: { base_url?: string; auth_token?: string };
+  /** Consumer-managed LLM block for the box (opaque whole-block passthrough; never logged). */
+  llm?: CapabilityLlmConfig;
   /** Consumer-managed KBC_* behavior knobs for the box (opaque passthrough). */
   settings?: Record<string, string>;
 }

--- a/src/gateway/capability/materialize.ts
+++ b/src/gateway/capability/materialize.ts
@@ -8,9 +8,10 @@
  * The workspace step ONLY runs when /sources succeeded, because that is the
  * fresh-box signal: a box that already holds this run 409s /sources ("run
  * already exists"), and pushing the store's workspace onto a LIVE box could
- * roll back up to a sync interval of newer on-disk work. Everything here is
- * best-effort — an empty KB or a store hiccup must not block the conversation;
- * the box then simply starts from whatever did materialize.
+ * roll back up to a sync interval of newer on-disk work. A successful fetch
+ * with no bundle is the consumer's typed absence (an empty KB / brand-new
+ * workspace). Transport and install failures fail setup closed: continuing
+ * from a partial or unknown input could overwrite a durable draft.
  *
  * Known bounded gap: a box CONTAINER restart clears its in-process run table
  * but keeps /work (emptyDir survives container restarts), so /sources then
@@ -44,6 +45,31 @@ export interface MaterializeResult {
   settings?: Record<string, string>;
 }
 
+export type CapabilityMaterializationStage =
+  | "source-fetch"
+  | "source-install"
+  | "workspace-fetch"
+  | "workspace-install";
+
+/** Setup error with a stable stage for lifecycle reporting and metrics. */
+export class CapabilityMaterializationError extends Error {
+  readonly stage: CapabilityMaterializationStage;
+
+  constructor(stage: CapabilityMaterializationStage, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`capability input materialization failed at ${stage}: ${detail}`, { cause });
+    this.name = "CapabilityMaterializationError";
+    this.stage = stage;
+  }
+}
+
+function isBoxAlreadyLive(err: unknown): boolean {
+  const status = (err as { status?: unknown } | null)?.status;
+  if (status === 409) return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return typeof status !== "number" && message.includes("failed: 409");
+}
+
 export async function materializeCapabilityInputs(opts: {
   client: MaterializeBoxClient;
   backend: MaterializeBackend;
@@ -54,63 +80,67 @@ export async function materializeCapabilityInputs(opts: {
   const { client, backend, runId, inputRevision } = opts;
 
   const result: MaterializeResult = {};
-  let freshBox = false;
+  const req: CapabilityFetchInputRequest = {
+    run_id: runId,
+    ...(inputRevision ? { input_revision: inputRevision } : {}),
+  };
+  let src: CapabilityFetchInputResponse;
   try {
-    const req: CapabilityFetchInputRequest = {
-      run_id: runId,
-      ...(inputRevision ? { input_revision: inputRevision } : {}),
-    };
-    const src = (await backend.request(CAPABILITY_FETCH_INPUT, req)) as CapabilityFetchInputResponse;
-    if (src?.locale) result.locale = src.locale;
-    if (src?.llm && typeof src.llm === "object") result.llm = src.llm;
-    if (src?.settings && typeof src.settings === "object") result.settings = src.settings;
-    if (src?.bundle_base64) {
-      await client.postJson("/sources", {
-        run_id: runId,
-        bundle_base64: src.bundle_base64,
-        bundle_sha256: src.bundle_sha256,
-        locale: src.locale,
-      });
-      freshBox = true;
-      if (src.input_revision) result.inputRevision = src.input_revision;
-    }
+    src = (await backend.request(CAPABILITY_FETCH_INPUT, req)) as CapabilityFetchInputResponse;
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    // Prefer the structured HTTP status (client attaches err.status); fall back to
-    // the message only when it's absent (finding E — a client message reword must
-    // not silently turn a 409 into a hard error).
-    const status = (err as { status?: unknown } | null)?.status;
-    const boxAlreadyLive = status === 409 || (typeof status !== "number" && msg.includes("failed: 409"));
-    if (boxAlreadyLive) {
+    throw new CapabilityMaterializationError("source-fetch", err);
+  }
+
+  if (src?.locale) result.locale = src.locale;
+  if (src?.llm && typeof src.llm === "object") result.llm = src.llm;
+  if (src?.settings && typeof src.settings === "object") result.settings = src.settings;
+
+  // RPC success + no bundle is the explicit empty-source result. It is not a
+  // fresh-box signal, so never guess and push workspace state onto a live box.
+  if (!src?.bundle_base64) return result;
+
+  try {
+    await client.postJson("/sources", {
+      run_id: runId,
+      bundle_base64: src.bundle_base64,
+      bundle_sha256: src.bundle_sha256,
+      locale: src.locale,
+    });
+  } catch (err) {
+    // Prefer the structured HTTP status; message parsing is only a rolling-
+    // upgrade fallback for older clients that did not attach err.status.
+    if (isBoxAlreadyLive(err)) {
       // The box already holds this run (live on-disk state) — reattach without
       // touching its workspace.
       console.log(`[capability] session ${runId}: box already live; skipping materialization`);
       result.reattached = true;
-    } else {
-      console.warn(`[capability] session ${runId}: source materialize skipped:`, msg);
+      return result;
     }
-    return result;
+    throw new CapabilityMaterializationError("source-install", err);
   }
-  if (!freshBox) return result; // empty KB — nothing told us the box is fresh, don't guess
+  if (src.input_revision) result.inputRevision = src.input_revision;
+
+  let ws: CapabilityFetchInputResponse;
+  try {
+    const workspaceReq: CapabilityFetchInputRequest = { run_id: runId, ref: CAPABILITY_INPUT_WORKSPACE_REF };
+    ws = (await backend.request(CAPABILITY_FETCH_INPUT, workspaceReq)) as CapabilityFetchInputResponse;
+  } catch (err) {
+    throw new CapabilityMaterializationError("workspace-fetch", err);
+  }
+
+  // Successful absence is a brand-new attempt with no durable workspace yet.
+  if (!ws?.bundle_base64) return result;
 
   try {
-    const req: CapabilityFetchInputRequest = { run_id: runId, ref: CAPABILITY_INPUT_WORKSPACE_REF };
-    const ws = (await backend.request(CAPABILITY_FETCH_INPUT, req)) as CapabilityFetchInputResponse;
-    if (ws?.bundle_base64) {
-      await client.postJson("/authoring", {
-        run_id: runId,
-        bundle_base64: ws.bundle_base64,
-        bundle_sha256: ws.bundle_sha256,
-        locale: result.locale,
-      });
-      console.log(`[capability] session ${runId}: rehydrated authoring workspace into fresh box`);
-    }
+    await client.postJson("/authoring", {
+      run_id: runId,
+      bundle_base64: ws.bundle_base64,
+      bundle_sha256: ws.bundle_sha256,
+      locale: result.locale,
+    });
   } catch (err) {
-    // The box still has raw/ — the agent can work; it just lost draft continuity.
-    console.warn(
-      `[capability] session ${runId}: workspace rehydrate skipped:`,
-      err instanceof Error ? err.message : String(err),
-    );
+    throw new CapabilityMaterializationError("workspace-install", err);
   }
+  console.log(`[capability] session ${runId}: rehydrated authoring workspace into fresh box`);
   return result;
 }

--- a/src/gateway/capability/run-manager.ts
+++ b/src/gateway/capability/run-manager.ts
@@ -178,6 +178,15 @@ export class CapabilityRunManager {
     return this.runs.get(runId);
   }
 
+  /** Current non-terminal runs, sampled by the gateway Prometheus endpoint. */
+  activeCount(): number {
+    let count = 0;
+    for (const rec of this.runs.values()) {
+      if (!isTerminalCapabilityStatus(rec.status)) count++;
+    }
+    return count;
+  }
+
   /**
    * Adopt a run this runtime doesn't hold in memory by reading it back from the
    * consumer's store — heals the drift where boot-time recovery missed it (e.g.

--- a/src/gateway/capability/session-config.test.ts
+++ b/src/gateway/capability/session-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCapabilitySessionLlm } from "./session-config.js";
+
+describe("resolveCapabilitySessionLlm", () => {
+  it("treats the consumer LLM object as authoritative without field-level Runtime fallback", () => {
+    const consumer = { base_url: "https://tenant.example/v1" };
+    const resolved = resolveCapabilitySessionLlm(consumer, {
+      ANTHROPIC_BASE_URL: "https://runtime.example/v1",
+      ANTHROPIC_AUTH_TOKEN: "runtime-secret",
+      ANTHROPIC_MODEL: "runtime-model",
+    });
+
+    expect(resolved).toBe(consumer);
+    expect(resolved).toEqual({ base_url: "https://tenant.example/v1" });
+  });
+
+  it("uses the complete Runtime Helm fallback only when the consumer object is absent", () => {
+    expect(resolveCapabilitySessionLlm(undefined, {
+      ANTHROPIC_BASE_URL: "https://runtime.example/v1",
+      ANTHROPIC_AUTH_TOKEN: "runtime-secret",
+      ANTHROPIC_API_KEY: "lower-precedence-key",
+      ANTHROPIC_MODEL: "runtime-model",
+    })).toEqual({
+      base_url: "https://runtime.example/v1",
+      auth_token: "runtime-secret",
+      api_key: undefined,
+      model: "runtime-model",
+    });
+  });
+
+  it("preserves API-key-only Runtime deployments without duplicating credential modes", () => {
+    expect(resolveCapabilitySessionLlm(undefined, {
+      ANTHROPIC_API_KEY: "runtime-api-key",
+    })).toEqual({
+      base_url: undefined,
+      auth_token: undefined,
+      api_key: "runtime-api-key",
+      model: undefined,
+    });
+  });
+
+  it("returns undefined when neither authority configured an LLM block", () => {
+    expect(resolveCapabilitySessionLlm(undefined, {})).toBeUndefined();
+  });
+});

--- a/src/gateway/capability/session-config.ts
+++ b/src/gateway/capability/session-config.ts
@@ -1,0 +1,33 @@
+import type { CapabilityLlmConfig } from "./contract.js";
+
+type RuntimeEnv = Readonly<Record<string, string | undefined>>;
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value?.trim() ? value : undefined;
+}
+
+/**
+ * Resolve the LLM block sent to a capability box's /session endpoint.
+ *
+ * Consumer ownership is whole-block: even an empty consumer object is
+ * authoritative. Runtime's Helm credentials are consulted only when the
+ * consumer omitted the object entirely, which prevents a tenant-selected URL
+ * from accidentally receiving a Runtime-owned token.
+ */
+export function resolveCapabilitySessionLlm(
+  consumer: CapabilityLlmConfig | undefined,
+  env: RuntimeEnv = process.env,
+): CapabilityLlmConfig | undefined {
+  if (consumer !== undefined) return consumer;
+
+  const authToken = nonEmpty(env.ANTHROPIC_AUTH_TOKEN);
+  const apiKey = authToken ? undefined : nonEmpty(env.ANTHROPIC_API_KEY);
+  const fallback: CapabilityLlmConfig = {
+    base_url: nonEmpty(env.ANTHROPIC_BASE_URL),
+    auth_token: authToken,
+    api_key: apiKey,
+    model: nonEmpty(env.ANTHROPIC_MODEL),
+  };
+
+  return Object.values(fallback).some((value) => value !== undefined) ? fallback : undefined;
+}

--- a/src/gateway/federation-self-metrics.ts
+++ b/src/gateway/federation-self-metrics.ts
@@ -1,11 +1,11 @@
 /**
- * Gateway-side self-monitoring registry for the Prometheus federation (K8s mode).
+ * Gateway-native monitoring registry exposed beside federated box metrics.
  *
  * 🔴 DEDUP CONTRACT (metrics-federation-DESIGN.md module 3): this registry is the
- * ONLY local-registry content the gateway exposes on /metrics in K8s mode. It must
- * contain ONLY gateway-native / federation self-monitoring metrics (all
- * `siclaw_federation_*`), which have ZERO name overlap with the federated business
- * metrics (`siclaw_tokens_total`, …) emitted by PromFederationAggregator.
+ * ONLY local-registry content the gateway exposes on /metrics in K8s mode. It
+ * contains gateway-native federation (`siclaw_federation_*`) and capability
+ * lifecycle (`siclaw_gateway_*`) metrics, which have ZERO name overlap with the
+ * federated box business metrics (`siclaw_tokens_total`, …).
  *
  * The 13 business-metric definitions registered in shared/metrics.js
  * (`metricsRegistry`) are deliberately NOT exposed in K8s mode — the gateway process
@@ -19,7 +19,7 @@
 
 import { Counter, Gauge, Histogram, Registry } from "prom-client";
 
-/** Dedicated registry for federation self-monitoring metrics (K8s mode). */
+/** Dedicated registry for gateway-native metrics (K8s mode). */
 export const federationSelfRegistry = new Registry();
 
 /**

--- a/src/gateway/server-capability-setup-failure.test.ts
+++ b/src/gateway/server-capability-setup-failure.test.ts
@@ -1,12 +1,12 @@
 /**
- * capability.start — a pod spawned but whose session SETUP fails (materialize /
- * POST /session throwing) must be stopped right there (review): the relay's
- * finally — the normal stop owner — never attaches on that path, so without
- * the setup-failure stop the pod + cert Secret leak until the orphan sweep.
+ * Capability session setup boundaries: clean up a newly-created box on failure,
+ * preserve a reused/adopted live box, count typed materialization stages, and
+ * deliver Runtime's standalone Helm LLM fallback through /session.
  */
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 const materializeMock = vi.hoisted(() => vi.fn());
+const postJsonMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
@@ -27,24 +27,28 @@ vi.mock("./agentbox/client.js", () => ({
   AgentBoxClient: class {
     endpoint: string;
     constructor(endpoint: string) { this.endpoint = endpoint; }
-    postJson = vi.fn(async () => { throw new Error("box unreachable during setup"); });
+    postJson = postJsonMock;
     getJson = vi.fn(async () => ({}));
     streamEvents = async function* () {};
+    streamPath = async function* () {};
   },
 }));
 
-vi.mock("./capability/materialize.js", () => ({
+vi.mock("./capability/materialize.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./capability/materialize.js")>()),
   materializeCapabilityInputs: materializeMock,
 }));
 
 const { startRuntime } = await import("./server.js");
+const { CapabilityMaterializationError } = await import("./capability/materialize.js");
+const { federationSelfRegistry } = await import("./federation-self-metrics.js");
 
 function fakeFrontendClient() {
   return { request: vi.fn(async () => ({})), onCommand: vi.fn(), emitEvent: vi.fn(), close: vi.fn() } as any;
 }
 
-function fakeAgentBoxManager() {
-  return {
+function fakeAgentBoxManager(created = true) {
+  const manager = {
     setCertManager: vi.fn(),
     setSpawnEnvResolver: vi.fn(),
     setPersistenceResolver: vi.fn(),
@@ -54,18 +58,30 @@ function fakeAgentBoxManager() {
     list: vi.fn(() => []),
     cleanup: vi.fn(async () => {}),
   } as any;
+  manager.getOrCreateWithDisposition = vi.fn(async (...args: any[]) => ({
+    handle: await manager.getOrCreate(...args),
+    created,
+  }));
+  return manager;
 }
 
 let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
+beforeEach(() => {
+  federationSelfRegistry.resetMetrics();
+  materializeMock.mockReset();
+  postJsonMock.mockReset().mockResolvedValue({ ok: true });
+});
 afterEach(async () => {
   if (server) await server.close();
   server = undefined;
+  federationSelfRegistry.resetMetrics();
   vi.clearAllMocks();
 });
 
-describe("startRuntime — capability.start setup failure", () => {
+describe("startRuntime — capability session setup", () => {
   it("stops the just-spawned box when session setup fails (no leak until the sweep)", async () => {
     materializeMock.mockResolvedValueOnce({ locale: undefined, llm: undefined, settings: undefined });
+    postJsonMock.mockRejectedValueOnce(new Error("box unreachable during setup"));
     const manager = fakeAgentBoxManager();
     server = await startRuntime({
       config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
@@ -80,10 +96,15 @@ describe("startRuntime — capability.start setup failure", () => {
     // …and the setup-failure path stopped it with the SAME runId it spawned under.
     expect(manager.stop).toHaveBeenCalledTimes(1);
     expect(manager.stop.mock.calls[0][0]).toBe(manager.getOrCreate.mock.calls[0][0]);
+    expect(await federationSelfRegistry.metrics()).not.toContain(
+      "siclaw_gateway_capability_materialization_failures_total{stage=",
+    );
   });
 
   it("stops the just-spawned box when fail-closed materialization rejects", async () => {
-    materializeMock.mockRejectedValueOnce(new Error("capability input materialization failed at workspace-fetch"));
+    materializeMock.mockRejectedValueOnce(
+      new CapabilityMaterializationError("workspace-fetch", new Error("store unavailable")),
+    );
     const manager = fakeAgentBoxManager();
     server = await startRuntime({
       config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
@@ -97,5 +118,75 @@ describe("startRuntime — capability.start setup failure", () => {
     expect(manager.getOrCreate).toHaveBeenCalledTimes(1);
     expect(manager.stop).toHaveBeenCalledTimes(1);
     expect(manager.stop.mock.calls[0][0]).toBe(manager.getOrCreate.mock.calls[0][0]);
+    expect(await federationSelfRegistry.metrics()).toContain(
+      'siclaw_gateway_capability_materialization_failures_total{stage="workspace-fetch"} 1',
+    );
+  });
+
+  it("preserves a reused live box when reattachment materialization fails", async () => {
+    materializeMock.mockRejectedValueOnce(
+      new CapabilityMaterializationError("source-fetch", new Error("consumer reconnecting")),
+    );
+    const manager = fakeAgentBoxManager(false);
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: manager,
+      frontendClient: fakeFrontendClient(),
+      credentialService: {} as any,
+    });
+
+    const start = server.rpcMethods.get("capability.start")!;
+    await expect(start({ profile: "kb-compile", input: { instruction: "go" } })).rejects.toThrow(/source-fetch/);
+    expect(manager.getOrCreateWithDisposition).toHaveBeenCalledTimes(1);
+    expect(manager.stop).not.toHaveBeenCalled();
+    expect(await federationSelfRegistry.metrics()).toContain(
+      'siclaw_gateway_capability_materialization_failures_total{stage="source-fetch"} 1',
+    );
+  });
+
+  it("delivers the Runtime Helm LLM fallback through /session without mixing credential modes", async () => {
+    materializeMock.mockResolvedValueOnce({ locale: "en", llm: undefined, settings: undefined });
+    const previous = {
+      baseUrl: process.env.ANTHROPIC_BASE_URL,
+      authToken: process.env.ANTHROPIC_AUTH_TOKEN,
+      apiKey: process.env.ANTHROPIC_API_KEY,
+      model: process.env.ANTHROPIC_MODEL,
+    };
+    process.env.ANTHROPIC_BASE_URL = "https://runtime.example/v1";
+    process.env.ANTHROPIC_AUTH_TOKEN = "runtime-secret";
+    process.env.ANTHROPIC_API_KEY = "lower-precedence-key";
+    process.env.ANTHROPIC_MODEL = "runtime-model";
+    try {
+      const manager = fakeAgentBoxManager(true);
+      server = await startRuntime({
+        config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+        agentBoxManager: manager,
+        frontendClient: fakeFrontendClient(),
+        credentialService: {} as any,
+      });
+
+      const start = server.rpcMethods.get("capability.start")!;
+      await expect(start({ profile: "kb-compile", input: { instruction: "go" } })).resolves.toHaveProperty("run_id");
+      const sessionPost = postJsonMock.mock.calls.find(([path]) => String(path).startsWith("/session/"));
+      expect(sessionPost?.[1]).toMatchObject({
+        locale: "en",
+        llm: {
+          base_url: "https://runtime.example/v1",
+          auth_token: "runtime-secret",
+          model: "runtime-model",
+        },
+      });
+      expect(sessionPost?.[1].llm.api_key).toBeUndefined();
+    } finally {
+      for (const [name, value] of Object.entries({
+        ANTHROPIC_BASE_URL: previous.baseUrl,
+        ANTHROPIC_AUTH_TOKEN: previous.authToken,
+        ANTHROPIC_API_KEY: previous.apiKey,
+        ANTHROPIC_MODEL: previous.model,
+      })) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
   });
 });

--- a/src/gateway/server-capability-setup-failure.test.ts
+++ b/src/gateway/server-capability-setup-failure.test.ts
@@ -6,6 +6,8 @@
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
 
+const materializeMock = vi.hoisted(() => vi.fn());
+
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
@@ -31,10 +33,8 @@ vi.mock("./agentbox/client.js", () => ({
   },
 }));
 
-// Materialize is best-effort by contract; keep it inert so the failure under
-// test is the /session POST.
 vi.mock("./capability/materialize.js", () => ({
-  materializeCapabilityInputs: vi.fn(async () => ({ locale: undefined, llm: undefined, settings: undefined })),
+  materializeCapabilityInputs: materializeMock,
 }));
 
 const { startRuntime } = await import("./server.js");
@@ -65,6 +65,7 @@ afterEach(async () => {
 
 describe("startRuntime — capability.start setup failure", () => {
   it("stops the just-spawned box when session setup fails (no leak until the sweep)", async () => {
+    materializeMock.mockResolvedValueOnce({ locale: undefined, llm: undefined, settings: undefined });
     const manager = fakeAgentBoxManager();
     server = await startRuntime({
       config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
@@ -77,6 +78,23 @@ describe("startRuntime — capability.start setup failure", () => {
     // The pod WAS spawned…
     expect(manager.getOrCreate).toHaveBeenCalledTimes(1);
     // …and the setup-failure path stopped it with the SAME runId it spawned under.
+    expect(manager.stop).toHaveBeenCalledTimes(1);
+    expect(manager.stop.mock.calls[0][0]).toBe(manager.getOrCreate.mock.calls[0][0]);
+  });
+
+  it("stops the just-spawned box when fail-closed materialization rejects", async () => {
+    materializeMock.mockRejectedValueOnce(new Error("capability input materialization failed at workspace-fetch"));
+    const manager = fakeAgentBoxManager();
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: manager,
+      frontendClient: fakeFrontendClient(),
+      credentialService: {} as any,
+    });
+
+    const start = server.rpcMethods.get("capability.start")!;
+    await expect(start({ profile: "kb-compile", input: { instruction: "go" } })).rejects.toThrow(/workspace-fetch/);
+    expect(manager.getOrCreate).toHaveBeenCalledTimes(1);
     expect(manager.stop).toHaveBeenCalledTimes(1);
     expect(manager.stop.mock.calls[0][0]).toBe(manager.getOrCreate.mock.calls[0][0]);
   });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -41,6 +41,7 @@ import type {
   CapabilityTestStartResponse,
 } from "./capability/contract.js";
 import { CapabilityMaterializationError, materializeCapabilityInputs } from "./capability/materialize.js";
+import { resolveCapabilitySessionLlm } from "./capability/session-config.js";
 import {
   capabilityActiveRuns,
   capabilityMaterializationFailuresTotal,
@@ -299,9 +300,6 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         try {
           promptResult = await client.prompt(promptOpts);
         } catch (err) {
-          if (err instanceof CapabilityMaterializationError) {
-            capabilityMaterializationFailuresTotal.inc({ stage: err.stage });
-          }
           // Concurrent send: agentbox returns 409 "Session is already
           // running. Use the steer endpoint to add input to the active
           // prompt." when the user double-taps send before the previous
@@ -390,12 +388,31 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   // manually started kbc box (usually http://127.0.0.1:3000) to reuse a local
   // Claude Code/OAuth session while testing the consumer↔runtime protocol.
   const localCapabilityBoxEndpoint = process.env.SICLAW_COMPILE_BOX_ENDPOINT?.trim();
-  const capabilityBoxClient = async (runId: string, profile: string, orgId?: string): Promise<AgentBoxClient> => {
+  const capabilityBoxClient = async (
+    runId: string,
+    profile: string,
+    orgId?: string,
+  ): Promise<{ client: AgentBoxClient; created: boolean }> => {
     if (localCapabilityBoxEndpoint) {
-      return new AgentBoxClient(localCapabilityBoxEndpoint, 30000, agentBoxTlsOptions);
+      return {
+        client: new AgentBoxClient(localCapabilityBoxEndpoint, 30000, agentBoxTlsOptions),
+        created: false,
+      };
     }
-    const handle = await agentBoxManager.getOrCreate(runId, { profile, orgId });
-    return new AgentBoxClient(handle.endpoint, 30000, agentBoxTlsOptions);
+    // Compatibility for embedded managers/test doubles built before acquisition
+    // disposition existed. The concrete manager always reports it; an older
+    // implementation is conservatively treated as the creator so failed setup
+    // retains the historical cleanup behavior.
+    const manager = agentBoxManager as AgentBoxManager & {
+      getOrCreateWithDisposition?: AgentBoxManager["getOrCreateWithDisposition"];
+    };
+    const acquired = typeof manager.getOrCreateWithDisposition === "function"
+      ? await manager.getOrCreateWithDisposition(runId, { profile, orgId })
+      : { handle: await manager.getOrCreate(runId, { profile, orgId }), created: true };
+    return {
+      client: new AgentBoxClient(acquired.handle.endpoint, 30000, agentBoxTlsOptions),
+      created: acquired.created,
+    };
   };
 
   // ── Capability protocol (option B): siclaw owns the run lifecycle ──────────
@@ -447,7 +464,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     let pending = capabilitySessions.get(runId);
     if (!pending) {
       pending = (async () => {
-        const client = await capabilityBoxClient(runId, profile, orgId);
+        const { client, created } = await capabilityBoxClient(runId, profile, orgId);
         let replayWorkspace = false;
         try {
           // Raw sources + (fresh box only) the durable authoring workspace, both
@@ -469,24 +486,32 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             instruction: instruction ?? "",
             allowed_tools: allowedTools,
             locale: materialized.locale,
-            // Consumer-managed LLM endpoint + KBC_* knobs (DESIGN-kb-llm-binding-v2):
-            // opaque passthrough — the box applies them in-process before its SDK
-            // connects. Never logged here; token stays out of the pod spec.
-            llm: materialized.llm,
+            // Whole-block authority: consumer LLM config wins as-is; only an
+            // absent block uses Runtime's Helm env. The box applies it before
+            // its SDK connects. Never logged here; token stays out of PodSpec.
+            llm: resolveCapabilitySessionLlm(materialized.llm),
             settings: materialized.settings,
           });
         } catch (err) {
-          // Setup failed AFTER the pod was spawned (review): the relay's
-          // finally below — the normal stop owner — never attaches on this
-          // path, so without this stop a spawn-succeeded-but-setup-failed run
-          // leaks its pod + cert Secret until the orphan sweep. stop() is
-          // 404-tolerant (local escape-hatch boxes aren't spawner-managed).
-          void agentBoxManager.stop(runId).catch((stopErr) =>
-            console.error(
-              `[capability] stop box after setup failure run=${runId}:`,
-              stopErr instanceof Error ? stopErr.message : String(stopErr),
-            ),
-          );
+          if (err instanceof CapabilityMaterializationError) {
+            capabilityMaterializationFailuresTotal.inc({ stage: err.stage });
+          }
+          // Only a box created by THIS setup attempt is disposable. A Runtime
+          // replacement can be reattaching to an adopted live box; deleting it
+          // because the consumer had a transient fetch failure would destroy the
+          // in-flight turn that shutdown()/adopt are specifically preserving.
+          if (created) {
+            void agentBoxManager.stop(runId).catch((stopErr) =>
+              console.error(
+                `[capability] stop new box after setup failure run=${runId}:`,
+                stopErr instanceof Error ? stopErr.message : String(stopErr),
+              ),
+            );
+          } else {
+            console.warn(
+              `[capability] setup failed while reattaching existing box run=${runId}; preserving it for retry`,
+            );
+          }
           throw err;
         }
         driveCapabilitySession({ client, runId, frontendClient, manager: capabilityRunManager, replayWorkspace })

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -40,7 +40,14 @@ import type {
   CapabilityTestStartRequest,
   CapabilityTestStartResponse,
 } from "./capability/contract.js";
-import { materializeCapabilityInputs } from "./capability/materialize.js";
+import { CapabilityMaterializationError, materializeCapabilityInputs } from "./capability/materialize.js";
+import {
+  capabilityActiveRuns,
+  capabilityMaterializationFailuresTotal,
+  capabilityRelayFailuresTotal,
+  capabilityStartDurationMs,
+  capabilityStartsTotal,
+} from "./capability/capability-metrics.js";
 import {
   type RpcHandler,
   type RpcContext,
@@ -292,6 +299,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         try {
           promptResult = await client.prompt(promptOpts);
         } catch (err) {
+          if (err instanceof CapabilityMaterializationError) {
+            capabilityMaterializationFailuresTotal.inc({ stage: err.stage });
+          }
           // Concurrent send: agentbox returns 409 "Session is already
           // running. Use the steer endpoint to add input to the active
           // prompt." when the user double-taps send before the previous
@@ -481,6 +491,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         }
         driveCapabilitySession({ client, runId, frontendClient, manager: capabilityRunManager, replayWorkspace })
           .catch(async (err) => {
+            capabilityRelayFailuresTotal.inc();
             console.error(`[capability] session relay failed run=${runId}:`, err);
             await capabilityRunManager.endRun(runId, "failed").catch(() => {});
           })
@@ -540,6 +551,8 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   });
 
   rpcMethods.set("capability.start", async (params) => {
+    const startedAt = Date.now();
+    let startedRunId = "";
     const req = params as unknown as CapabilityStartRequest;
     const profile = req.profile?.trim();
     if (!profile) throw new Error("profile is required");
@@ -554,20 +567,25 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // an instruction-less start (chat arrives via capability.message right
     // after, or the run only hosts test sessions) starts at rest (idle) — the
     // first capability.message flips it running.
-    const rec = await capabilityRunManager.startRun({
-      profile,
-      orgId: orgId ?? "",
-      correlationId: req.correlation_id,
-      initialStatus: instruction && instruction.trim() ? "running" : "idle",
-    });
     try {
+      const rec = await capabilityRunManager.startRun({
+        profile,
+        orgId: orgId ?? "",
+        correlationId: req.correlation_id,
+        initialStatus: instruction && instruction.trim() ? "running" : "idle",
+      });
+      startedRunId = rec.runId;
       await ensureCapabilitySession(rec.runId, rec.profile, orgId, instruction);
+      capabilityStartsTotal.inc({ outcome: "success" });
+      capabilityStartDurationMs.observe({ outcome: "success" }, Date.now() - startedAt);
+      const res: CapabilityStartResponse = { run_id: rec.runId };
+      return res;
     } catch (err) {
-      await capabilityRunManager.endRun(rec.runId, "failed");
+      capabilityStartsTotal.inc({ outcome: "failure" });
+      capabilityStartDurationMs.observe({ outcome: "failure" }, Date.now() - startedAt);
+      if (startedRunId) await capabilityRunManager.endRun(startedRunId, "failed");
       throw err;
     }
-    const res: CapabilityStartResponse = { run_id: rec.runId };
-    return res;
   });
 
   rpcMethods.set("capability.message", async (params) => {
@@ -984,6 +1002,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       (async () => {
         try {
           const { metricsRegistry } = await import("../shared/metrics.js");
+          capabilityActiveRuns.set(capabilityRunManager.activeCount());
           if (promFederation && federationSelfMetrics) {
             // K8s mode: business metrics come from federation. The gateway's own
             // metricsRegistry holds the same metric *names* with empty values, so we
@@ -1189,7 +1208,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     async close() {
       metricsAggregator?.destroy();
       frontendClient.close();
-      await agentBoxManager.cleanup();
+      // Older embedded test/adapter managers may only implement cleanup(); the
+      // concrete manager's shutdown() preserves K8s boxes across Runtime rolls.
+      const manager = agentBoxManager as AgentBoxManager & { shutdown?: () => Promise<void> };
+      if (typeof manager.shutdown === "function") await manager.shutdown();
+      else await manager.cleanup();
       httpServer.close();
       httpsServer?.close();
     },


### PR DESCRIPTION
## Summary

- fail capability setup closed with stage-specific materialization errors and metrics
- authenticate compile-box data routes with client certificates and isolate KB boxes with the Runtime-only NetworkPolicy
- preserve K8s boxes across Runtime rolling restarts; setup failure only cleans up a box created by that setup attempt
- treat consumer LLM config as one authority block and use Runtime Helm fallback only when the block is absent
- deliver LLM credentials through the mTLS `/session` payload and keep LLM/embedding secrets out of KB PodSpecs
- add bounded Prometheus metrics for capability start, materialization, relay failures, and active runs
- run the mTLS route suite in KBC CI

## Verification

- `npm test` (4361 passed, 2 skipped)
- `npm run build`
- 111 focused capability/manager/spawner tests
- full `kbc/platform/pod/test_compile_box.py` protocol suite
- `test_mtls_auth.py` (8 passed)
- Helm lint and Runtime/compile-box templates
- local merge simulation against current `main`
- `git diff --check`

## Operational note

A live box's already-connected SDK child keeps its session-start credential. Token rotation therefore still requires a grace window plus KB box respawn; this PR deliberately does not claim hot rotation.

## Dependency

Targets `main` directly.