### PR TITLE
fix(channels): run sub-agents foreground in channel (Feishu/DingTalk) sessions + graceful 409

### DIFF
--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -403,6 +403,12 @@ export async function createSiclawSession(
       memoryDir: memoryEnabled ? memoryDir : undefined,
       sessionEventEmitter: opts?.sessionEventEmitter,
       spawnSubagentExecutor: opts?.spawnSubagentExecutor,
+      // Channel (Feishu/DingTalk) is the one entry that BOTH exposes spawn_subagent (see its
+      // registration `modes`) AND has no persistent client to receive a detached conclusion —
+      // so a detached batch would strand its result. Force sub-agents foreground there. web/cli
+      // also have spawn_subagent but are persistent (keep background); a2a/api/task don't expose
+      // spawn_subagent at all, so they're unaffected either way. run_in_background exec untouched.
+      foregroundSubagentOnly: mode === "channel",
       jobStopExecutor: opts?.jobStopExecutor,
       backgroundExecExecutor: opts?.backgroundExecExecutor,
       taskOutputReader: opts?.taskOutputReader,

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -365,6 +365,16 @@ export interface ToolRefs {
    * never sees a non-working tool (children get no executor → no recursion).
    */
   spawnSubagentExecutor?: SpawnSubagentExecutor;
+  /**
+   * Force spawn_subagent to run FOREGROUND (block, return results inline) — hides the
+   * `run_in_background` param and flips a multi-item batch's default from background to
+   * foreground. Set only for the `channel` session mode: it exposes spawn_subagent (see the
+   * tool's registration `modes`) yet has no persistent client to receive a detached conclusion,
+   * so a background batch would strand its result. web/cli also expose spawn_subagent but are
+   * persistent (leave this false → keep background); a2a/api/task don't expose spawn_subagent at
+   * all. Does NOT affect `run_in_background` exec (node/pod/bash), a within-turn primitive.
+   */
+  foregroundSubagentOnly?: boolean;
   /** Cancels a running background job (sub-agent or bash). Enables the job_stop tool. */
   jobStopExecutor?: JobStopExecutor;
   /**

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1336,6 +1336,37 @@ describe("handleLarkMessage — streaming card flow", () => {
     clearBackgroundChannelDelivery(sessionId);
   });
 
+  it("surfaces foreground sub-agent progress (tool_execution_update) as a live card step", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-fg-progress" });
+    streamEventsMock.mockImplementation(async function* () {
+      // Group progress carries structured details.items; the card localizes it (tool text is
+      // hard-coded English, so we render N/M from items in the channel locale).
+      yield {
+        type: "tool_execution_update",
+        toolCallId: "t1",
+        partialResult: {
+          content: [{ type: "text", text: "Running sub-agents… 2/3 done" }],
+          details: { phase: "map", items: [{ status: "done" }, { status: "done" }, { status: "running" }] },
+        },
+      };
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "统一结论：GPFS 抖动。" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("排查"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const contentCalls = lark.cardkit.v1.cardElement.content.mock.calls.map((c: any) => c[0].data.content as string);
+    // Localized (zh-CN default) progress step, computed from items (2 done / 3 total).
+    expect(contentCalls.some((c) => c.includes("子任务执行中") && c.includes("2/3") && c.includes("⏳"))).toBe(true);
+    // Not the raw English activity text.
+    expect(contentCalls.some((c) => c.includes("Running sub-agents"))).toBe(false);
+    expect(contentCalls.at(-1)).toContain("统一结论");
+  });
+
   it("shows only the latest step on the card and replaces it with the conclusion on finalize", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-explicit-channel" });
@@ -1929,9 +1960,9 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(JSON.parse(replyArg.data.content).text).toBe("答复");
   });
 
-  it("shows an error message in the card when the agent throws", async () => {
+  it("shows a sanitized error notice (never the raw error) when the agent throws", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
-    promptMock.mockRejectedValue(new Error("AgentBox unreachable"));
+    promptMock.mockRejectedValue(new Error("AgentBox unreachable https://agentbox-internal:8443"));
     const lark = makeCardAwareLarkClient();
 
     await handleLarkMessage(
@@ -1945,8 +1976,80 @@ describe("handleLarkMessage — streaming card flow", () => {
 
     expect(lark.cardkit.v1.cardElement.content).toHaveBeenCalledTimes(1);
     const contentText = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
-    expect(contentText).toContain("\u274C");
-    expect(contentText).toContain("AgentBox unreachable");
+    expect(contentText).toContain("\u5904\u7406\u65F6\u51FA\u9519\u4E86");
+    // Raw error / internal endpoint must NOT leak to the chat.
+    expect(contentText).not.toContain("AgentBox unreachable");
+    expect(contentText).not.toContain("agentbox-internal");
+  });
+
+  it("retries a 409 then succeeds \u2014 never surfaces the raw 409", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    const busy = Object.assign(new Error('AgentBox request failed: 409 {"error":"Session is already running."}'), { status: 409 });
+    promptMock.mockRejectedValueOnce(busy).mockResolvedValueOnce({ sessionId: "s-retry" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "\u7ED3\u8BBA\u597D\u4E86" }] } };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("\u7ED3\u8BBA\u662F\u5565"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    expect(promptMock).toHaveBeenCalledTimes(2); // one 409, one success
+    const last = lark.cardkit.v1.cardElement.content.mock.calls.at(-1)?.[0].data.content ?? "";
+    expect(last).toContain("\u7ED3\u8BBA\u597D\u4E86");
+    expect(last).not.toContain("409");
+  });
+
+  it("shows a friendly busy notice when 409 persists past the retry window", async () => {
+    vi.useFakeTimers();
+    try {
+      resolveBindingMock.mockResolvedValue(makeBinding());
+      const busy = Object.assign(new Error('AgentBox request failed: 409 {"error":"Session is already running."}'), { status: 409 });
+      promptMock.mockRejectedValue(busy); // always busy \u2192 retry window elapses
+      const lark = makeCardAwareLarkClient();
+
+      const p = handleLarkMessage(makeTextEvent("\u7ED3\u8BBA\u662F\u5565"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+      await vi.runAllTimersAsync(); // fast-forward the backoff until the retry cap is hit
+      await p;
+
+      const contentText = lark.cardkit.v1.cardElement.content.mock.calls.at(-1)?.[0].data.content ?? "";
+      expect(contentText).toContain("\u8FD8\u5728\u5904\u7406\u4E0A\u4E00\u6761");
+      expect(contentText).not.toContain("409");
+      expect(contentText).not.toContain("already running");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still sends the busy notice via text reply when CardKit creation fails + 409 persists", async () => {
+    vi.useFakeTimers();
+    try {
+      resolveBindingMock.mockResolvedValue(makeBinding());
+      const busy = Object.assign(new Error('AgentBox request failed: 409 {"error":"Session is already running."}'), { status: 409 });
+      promptMock.mockRejectedValue(busy);
+      // CardKit create returns no card_id \u2192 openTypingCard yields null cardSession \u2192 the reply
+      // must fall through to a plain-text busy notice (regression: sessionBusy was missing from
+      // the fallback condition, so nothing was sent).
+      const lark = {
+        im: { image: { create: vi.fn() }, message: { reply: vi.fn().mockResolvedValue({}) } },
+        cardkit: {
+          v1: {
+            card: { create: vi.fn().mockResolvedValue({ data: {} }), settings: vi.fn().mockResolvedValue({ code: 0 }) },
+            cardElement: { content: vi.fn().mockResolvedValue({ code: 0 }) },
+          },
+        },
+      };
+
+      const p = handleLarkMessage(makeTextEvent("\u7ED3\u8BBA\u662F\u5565"), lark as any, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+      await vi.runAllTimersAsync();
+      await p;
+
+      expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
+      const replyText = JSON.parse(lark.im.message.reply.mock.calls[0][0].data.content).text as string;
+      expect(replyText).toContain("\u8FD8\u5728\u5904\u7406\u4E0A\u4E00\u6761");
+      expect(replyText).not.toContain("409");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders English placeholder when the channel domain is 'lark' (global)", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -54,6 +54,19 @@ const QUEUE_FULL_NOTICE_BY_LOCALE = {
   "zh-CN": "⏳ 当前会话还有较多消息排队处理中，请稍后再发。",
   "en-US": "⏳ This channel session already has several messages queued. Please try again later.",
 } as const;
+// Session is single-threaded in AgentBox: after waiting out the busy window (queue-until-idle)
+// the session is still occupied (e.g. a long run_in_background exec job). Ask the user to retry
+// rather than clobbering the in-flight work or dumping the raw 409.
+const SESSION_BUSY_NOTICE_BY_LOCALE = {
+  "zh-CN": "⏳ 还在处理上一条，请稍候再发。",
+  "en-US": "⏳ Still working on the previous message — please try again shortly.",
+} as const;
+// Generic failure notice. The raw error can leak internal endpoints / infra to everyone in the
+// chat, so we log the real error and show this instead.
+const AGENT_ERROR_NOTICE_BY_LOCALE = {
+  "zh-CN": "❌ 处理时出错了，请稍后重试。",
+  "en-US": "❌ Something went wrong while processing this. Please try again later.",
+} as const;
 const NEW_SESSION_NOTICE_BY_LOCALE = {
   "zh-CN": "✅ 已开启新会话，此入口中的历史上下文已清空。",
   "en-US": "✅ Started a new session. Previous context for this channel entry has been cleared.",
@@ -928,11 +941,14 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   let resultText = "";
   let replyImages: RenderedReplyImage[] = [];
   let agentError: Error | null = null;
+  let sessionBusy = false;
   try {
-    const promptResult = await client.prompt(promptOpts);
+    // queue-until-idle: wait out a busy session instead of dumping a raw 409.
+    const promptResult = await promptWithBusyRetry(client, promptOpts);
     const collected = await collectChannelResponse(client, promptResult.sessionId, "lark", {
       includeImages: true,
       onMilestone: addMilestone,
+      locale,
       // Audit: persist assistant + tool rows so the channel transcript matches
       // web/api/a2a (origin="channel" set on the session above). Tool output on
       // this stream is already sanitized at the agentbox boundary.
@@ -941,16 +957,24 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     resultText = collected.text;
     replyImages = collected.images;
   } catch (err) {
-    agentError = err instanceof Error ? err : new Error(String(err));
-    console.error(`[lark] Agent execution failed for session=${sessionId}:`, agentError);
+    if (isSessionBusyError(err)) {
+      // Still busy after the retry window — surface a friendly notice, don't clobber.
+      sessionBusy = true;
+      console.warn(`[lark] Session still busy after retry for session=${sessionId}`);
+    } else {
+      agentError = err instanceof Error ? err : new Error(String(err));
+      console.error(`[lark] Agent execution failed for session=${sessionId}:`, agentError);
+    }
   }
 
-  // Materialize the final reply body. Preserve the agent-like-API-key UX:
-  // a single message to the user — no intermediate tool-call spam.
-  const finalBody = agentError
-    ? `\u274C ${agentError.message.slice(0, 500)}`
-    : (resultText || EMPTY_RESULT_NOTICE_BY_LOCALE[locale]);
-  if (agentError) replyImages = [];
+  // Session-busy and other errors both get a sanitized notice \u2014 the raw error (internal
+  // endpoints, 409 JSON) must never reach the chat; it was logged above.
+  const finalBody = sessionBusy
+    ? SESSION_BUSY_NOTICE_BY_LOCALE[locale]
+    : agentError
+      ? AGENT_ERROR_NOTICE_BY_LOCALE[locale]
+      : (resultText || EMPTY_RESULT_NOTICE_BY_LOCALE[locale]);
+  if (agentError || sessionBusy) replyImages = [];
   const displayBody = stripVisualBlocks(finalBody, { stripSourceBlocks: replyImages.length > 0 })
     || VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
   // The final card is JUST the conclusion — the live step indicator is replaced
@@ -977,9 +1001,10 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       // duplicate messages in the group.
       console.warn(`[lark] Card finalize incomplete for cardId=${cardSession.cardId}; user may see stuck placeholder`);
     }
-  } else if (resultText || agentError) {
-    // Card could not be opened; fall back to a plain text reply with
-    // whatever we have (final answer or error) + any accumulated milestones.
+  } else if (resultText || agentError || sessionBusy) {
+    // Card could not be opened; fall back to a plain text reply with whatever we have —
+    // a real answer, an error notice, OR the session-busy notice (sessionBusy carries no
+    // resultText/agentError, so it must be listed explicitly or the busy notice is dropped).
     await replyToLark(larkClient, messageId, finalCardBody);
     deliveredTextChars = finalCardBody.length;
   }
@@ -1121,6 +1146,43 @@ function shouldDeliverBackgroundReply(text: string, previousChars: number): bool
   return !(previousChars > 80 && chars < 120 && chars < previousChars * 0.75);
 }
 
+/**
+ * True when an AgentBox prompt failed with HTTP 409 ("Session is already running") — the session
+ * is single-threaded and something (previous turn / lingering background exec / synthetic delivery)
+ * still holds the brain. The client wraps non-2xx as `AgentBox request failed: <status> <body>`
+ * with a `.status` field.
+ */
+function isSessionBusyError(err: unknown): boolean {
+  if (err && typeof err === "object" && (err as { status?: number }).status === 409) return true;
+  const m = err instanceof Error ? err.message : String(err);
+  return /request failed: 409\b/i.test(m) || /already running/i.test(m);
+}
+
+/**
+ * queue-until-idle: the per-binding queue already serialises a sender's messages, but a turn can
+ * end while a run_in_background exec job (or the synthetic delivery turn) still holds the session —
+ * so the next dequeued message can still hit 409. Retry with backoff until the session frees; give
+ * up after maxWaitMs so a genuinely stuck/long job doesn't pin the handler forever (caller then
+ * shows the friendly busy notice). Never surfaces the raw 409.
+ */
+async function promptWithBusyRetry(
+  client: AgentBoxClient,
+  opts: PromptOptions,
+  maxWaitMs = 45_000,
+): Promise<Awaited<ReturnType<AgentBoxClient["prompt"]>>> {
+  const started = Date.now();
+  let delay = 500;
+  for (;;) {
+    try {
+      return await client.prompt(opts);
+    } catch (err) {
+      if (!isSessionBusyError(err) || Date.now() - started >= maxWaitMs) throw err;
+      await new Promise((r) => setTimeout(r, delay));
+      delay = Math.min(delay * 2, 3000);
+    }
+  }
+}
+
 async function deliverVisibleChannelText(
   larkClient: any,
   messageId: string,
@@ -1181,7 +1243,7 @@ export async function collectChannelResponse(
   client: AgentBoxClient,
   sessionId: string,
   logPrefix = "lark",
-  options: { includeImages?: boolean; onMilestone?: (text: string) => void; persist?: ChannelPersistContext } = {},
+  options: { includeImages?: boolean; onMilestone?: (text: string) => void; persist?: ChannelPersistContext; locale?: LarkLocale } = {},
 ): Promise<CollectedChannelResponse> {
   const parts: string[] = [];
   const images: RenderedReplyImage[] = [];
@@ -1215,6 +1277,36 @@ export async function collectChannelResponse(
   try {
     for await (const event of client.streamEvents(sessionId)) {
       const ev = event as Record<string, any>;
+
+      // Live tool progress → milestone. A FOREGROUND sub-agent batch blocks the parent inside one
+      // tool call, so no intermediate assistant turn fires while it runs — without this the card
+      // sits frozen at the last line for the whole (multi-minute) batch. spawn_subagent streams
+      // group progress via tool_execution_update; surface it as the current ⏳ step. (Background
+      // groups instead report via group_progress, not this SSE.)
+      if (ev.type === "tool_execution_update" && options.onMilestone) {
+        const items = Array.isArray(ev.partialResult?.details?.items) ? ev.partialResult.details.items : null;
+        let milestone = "";
+        if (items) {
+          // Structured group progress → render in the channel locale (the tool's own activity
+          // text is hard-coded English; localize here where we know the locale).
+          const total = items.length;
+          const done = items.filter((i: any) => i?.status !== "queued" && i?.status !== "running").length;
+          milestone = (options.locale === "en-US")
+            ? `Running sub-agents… ${done}/${total} done`
+            : `子任务执行中… ${done}/${total} 完成`;
+        } else {
+          // Non-group progress (single-agent step activity): fall back to the raw activity text.
+          const blocks = Array.isArray(ev.partialResult?.content) ? ev.partialResult.content : [];
+          const activity = blocks
+            .filter((b: any) => b?.type === "text")
+            .map((b: any) => (b.text ?? "") as string)
+            .join(" ")
+            .trim();
+          milestone = activity ? (condenseMilestone(activity) || activity) : "";
+        }
+        if (milestone) options.onMilestone(milestone);
+      }
+
       if (ev.type === "content_block_delta" && ev.delta?.text) parts.push(ev.delta.text);
       if (ev.type === "text" && typeof ev.text === "string") parts.push(ev.text);
 

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -627,6 +627,10 @@ export async function runPortalMigrations(): Promise<void> {
   await safeAlterTable(db, "chat_sessions", "delegation_id", "VARCHAR(64) DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "target_agent_id", "CHAR(36) DEFAULT NULL");
   await safeAlterTable(db, "channel_bindings", "session_id", "CHAR(36) DEFAULT NULL");
+  // Binding owner (the user who PAIRed this chat). Present in the CREATE TABLE above, but older
+  // installs predate it — adapter.ts / siclaw-api.ts SELECT cb.created_by, so existing DBs need
+  // this backfill ALTER or every channel message errors ("Unknown column 'cb.created_by'").
+  await safeAlterTable(db, "channel_bindings", "created_by", "CHAR(36) DEFAULT NULL");
   // Human-readable name of the bound chat (group title / user name), fetched
   // from the channel platform at PAIR time and lazily refreshed by the gateway.
   // Display-only cache — identity is always route_key, never this name.

--- a/src/tools/workflow/spawn-subagent.test.ts
+++ b/src/tools/workflow/spawn-subagent.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { createSpawnSubagentTool, registration } from "./spawn-subagent.js";
 import { RUN_IN_BACKGROUND_ENABLED } from "../../core/subagent-registry.js";
+import { ToolRegistry } from "../../core/tool-registry.js";
 import type {
   ToolRefs,
   SpawnSubagentGroupRequest,
@@ -99,6 +100,61 @@ describe("spawn_subagent tool — single-task collapse path", () => {
     } else {
       expect(captured?.runInBackground).toBe(false);
     }
+  });
+});
+
+describe("spawn_subagent tool — availability by session mode (real ToolRegistry.resolve)", () => {
+  // The tool's registration limits it to modes ["web","channel","cli"]. Resolve the REAL tool
+  // list per entry path (not a hand-built tool) so we assert what each session actually gets:
+  // only `channel` (of the modes that have the tool) needs the foreground gate; a2a/api/task
+  // don't expose spawn_subagent at all, so foregrounding them would be a no-op.
+  const reg = new ToolRegistry();
+  reg.register(registration);
+  const names = (mode: string): string[] =>
+    reg.resolve({ mode: mode as any, refs: makeRefs(vi.fn() as any) }).map((t) => t.name);
+
+  it("exposes spawn_subagent in web/channel/cli, and NOT in task/api/a2a", () => {
+    expect(names("channel")).toContain("spawn_subagent");
+    expect(names("web")).toContain("spawn_subagent");
+    expect(names("cli")).toContain("spawn_subagent");
+    expect(names("task")).not.toContain("spawn_subagent");
+    expect(names("api")).not.toContain("spawn_subagent");
+    expect(names("a2a")).not.toContain("spawn_subagent");
+  });
+});
+
+describe("spawn_subagent tool — foregroundSubagentOnly (channel)", () => {
+  it("hides run_in_background and forces a multi-item batch to foreground", async () => {
+    let captured: SpawnSubagentGroupRequest | undefined;
+    const executor = vi.fn(async (req: SpawnSubagentGroupRequest): Promise<SpawnSubagentResult> => {
+      captured = req;
+      return { status: "done", summary: "all checked", childSessionId: "c", toolCalls: 1, durationMs: 5 };
+    });
+    const tool = createSpawnSubagentTool({ ...makeRefs(executor), foregroundSubagentOnly: true });
+
+    expect((tool.parameters as any).properties.run_in_background).toBeUndefined();
+
+    await tool.execute("call-fg", {
+      description: "triage 3 nodes",
+      items: ["check node-a", "check node-b", "check node-c"],
+    });
+    expect(captured?.runInBackground).toBe(false);
+  });
+
+  it("leaves the multi-item background default intact when NOT foregroundSubagentOnly (web/cli)", async () => {
+    let captured: SpawnSubagentGroupRequest | undefined;
+    const executor = vi.fn(async (req: SpawnSubagentGroupRequest): Promise<SpawnSubagentResult> => {
+      captured = req;
+      return req.runInBackground
+        ? { status: "launched", childSessionId: "c", jobId: "j" }
+        : { status: "done", summary: "x", childSessionId: "c", toolCalls: 1, durationMs: 5 };
+    });
+    const tool = createSpawnSubagentTool(makeRefs(executor)); // foregroundSubagentOnly unset
+    await tool.execute("call-web", {
+      description: "triage 3 nodes",
+      items: ["check node-a", "check node-b", "check node-c"],
+    });
+    expect(captured?.runInBackground).toBe(RUN_IN_BACKGROUND_ENABLED);
   });
 });
 

--- a/src/tools/workflow/spawn-subagent.ts
+++ b/src/tools/workflow/spawn-subagent.ts
@@ -62,7 +62,7 @@ function itemToText(item: string | Record<string, string>): string {
   return typeof item === "string" ? item : JSON.stringify(item);
 }
 
-function buildDescription(groupEnabled: boolean): string {
+function buildDescription(groupEnabled: boolean, backgroundAllowed: boolean): string {
   const lines = listSubagentTypes().map((t) => `- ${t.agentType}: ${t.whenToUse}`);
   // Rollback (SICLAW_SUBAGENT_GROUP_ENABLED=false): the tool is single-task only, so DON'T teach the
   // batch pattern the tool would then reject — describe the single spawn and point at N separate calls.
@@ -107,17 +107,19 @@ function buildDescription(groupEnabled: boolean): string {
     "{{item}}; omit task_template only when each string item is already a complete prompt. Items must be " +
     "homogeneous — all strings or all objects. Never delegate understanding — give concrete targets, paths, " +
     "and what to check, not 'based on your findings, decide X'.\n\n" +
-    "Foreground vs background: a SINGLE item runs FOREGROUND by default (blocks and returns the result " +
-    "inline so you can keep reasoning); a MULTI-item batch runs in the BACKGROUND by default (it can take " +
-    "10+ minutes, so it launches detached and a completion notification carrying the result arrives on its " +
-    "own)." +
-    (RUN_IN_BACKGROUND_ENABLED
-      ? " Override with run_in_background: set true to detach a single task, or false to block on a small " +
+    (backgroundAllowed
+      ? "Foreground vs background: a SINGLE item runs FOREGROUND by default (blocks and returns the result " +
+        "inline so you can keep reasoning); a MULTI-item batch runs in the BACKGROUND by default (it can take " +
+        "10+ minutes, so it launches detached and a completion notification carrying the result arrives on its " +
+        "own). Override with run_in_background: set true to detach a single task, or false to block on a small " +
         "batch whose result you need inline right now. After a BACKGROUND launch, just END YOUR TURN (or do " +
         "other independent work) — never poll it, never spawn another sub-agent to 'wait for' it, and never " +
         "fabricate its result; report to the user only when the notification arrives. Returns a job_id you " +
         "can pass to job_stop to cancel."
-      : "") +
+      : "Every launch runs FOREGROUND: the call BLOCKS until all items (and the reduce, if any) finish, then " +
+        "returns the results inline. This surface has no detached delivery, so you MUST fold the findings into " +
+        "your reply THIS turn — never tell the user you'll 'report back later'. A large batch can take minutes; " +
+        "that is expected — keep the turn open until it returns.") +
     "\n\nAvailable subagent_type values (shared by every map + reduce child):\n" +
     lines.join("\n")
   );
@@ -127,12 +129,16 @@ export function createSpawnSubagentTool(
   refs: ToolRefs,
   executor = refs.spawnSubagentExecutor,
 ): ToolDefinition {
+  // Background (detached) delegation is allowed only when the global switch is on AND this entry
+  // point can receive an async conclusion. On channel/a2a/api/cron (foregroundSubagentOnly) every
+  // launch runs foreground so the turn carries the real answer. run_in_background exec is separate.
+  const backgroundAllowed = RUN_IN_BACKGROUND_ENABLED && !refs.foregroundSubagentOnly;
   return {
     name: "spawn_subagent",
     label: "Spawn Sub-agent",
     renderCall: (_a, theme) => new Text(theme.fg("toolTitle", theme.bold("spawn_subagent")), 0, 0),
     renderResult: renderTextResult,
-    description: buildDescription(isSubagentGroupEnabled()),
+    description: buildDescription(isSubagentGroupEnabled(), backgroundAllowed),
     parameters: Type.Object({
       description: Type.String({ description: "Short (3-5 word) label for the task or batch." }),
       task_template: Type.Optional(
@@ -169,7 +175,7 @@ export function createSpawnSubagentTool(
       // (see the runInBackground resolution below), so every launch runs FOREGROUND — this overrides
       // the conditional default rather than preserving it. Foreground batches still work; only
       // detached/background launches are unavailable until the notification chain lands.
-      ...(RUN_IN_BACKGROUND_ENABLED
+      ...(backgroundAllowed
         ? {
             run_in_background: Type.Optional(
               Type.Boolean({
@@ -225,7 +231,7 @@ export function createSpawnSubagentTool(
       // Conditional default (design §"Tool layer (single entry)"): a single item runs foreground (grab the result and
       // keep reasoning), a multi-item batch runs background (asymmetric harm — each side fits its own
       // failure mode). An explicit run_in_background always wins; the flag is force-false while gated.
-      const runInBackground = RUN_IN_BACKGROUND_ENABLED
+      const runInBackground = backgroundAllowed
         ? (p.run_in_background ?? plan.tasks.length > 1)
         : false;
 


### PR DESCRIPTION
## Problem (channel only)

In a **channel** session (Feishu/DingTalk), when the agent fans out a multi-item `spawn_subagent` batch it defaults to **background/detached**: the turn returns a "已开始…稍后汇总" ack and the real conclusion is delivered later via a best-effort, gateway-in-memory, no-retry path. A channel has no persistent client to receive that async conclusion, so the card shows the ack (not the answer), a follow-up while busy dumped a raw `409`, and feedback buttons landed on the interim card.

Scope note (thanks @LikiosSedo): `spawn_subagent`'s registration is `modes: ["web","channel","cli"]`, so `ToolRegistry.resolve` filters it out of `task`/`api`/`a2a` sessions entirely — those paths never expose the tool, so only **channel** (of the modes that *have* it and *lack* a persistent client) needs this. `web`/`cli` also have it but are persistent (keep background). Long-running API work streams via a2a (`message/stream`), which has no such issue.

## What changed

- **Foreground sub-agents in channel** (`agent-factory.ts`, `tool-registry.ts`, `spawn-subagent.ts`): `foregroundSubagentOnly = mode === "channel"`. `spawn_subagent` hides `run_in_background` and a multi-item batch blocks + runs in parallel + returns the real conclusion. `run_in_background` exec (within-turn perftest server→client) untouched.
- **Live progress on the card** (`lark.ts`): a foreground batch blocks the parent in one tool call, so surface `tool_execution_update` group progress as a ⏳ step, rendered from `details.items` in the channel locale (`子任务执行中… N/M 完成`).
- **Graceful 409** (`lark.ts`): `409 "session busy"` → queue-until-idle retry with backoff, friendly notice on timeout; sanitize all errors; the busy notice is also sent when CardKit creation failed (`sessionBusy` in the text fallback).

## Separate bug fixed here (needed to deploy)

**`fix(migrate)`**: `channel_bindings.created_by` was only in the CREATE TABLE — existing installs errored `Unknown column 'cb.created_by'` on every channel message. Added the missing `safeAlterTable` backfill.

## Testing

- Unit: `ToolRegistry.resolve` per session mode (spawn_subagent present in web/channel/cli, absent in task/api/a2a); foreground flag behavior; lark progress/409/sanitize/card-fallback; migrate. Full suite green, `tsc` clean.
- E2E on siclaw-inner (Feishu): "后台并发三个 subagent, sleep 10/15/20" → ran foreground in parallel (~20s), live "子任务执行中… N/M 完成", conclusion + 👍/👎 on the final card, no 409.

## Deployment

Touches **agentbox** (gate) + **runtime** (channel) + **portal** (migrate). Deploy all three; portal runs the migration on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)