### PR TITLE
fix(channels): show open-bot groups + the real Feishu bot name in the Portal

### DIFF
--- a/portal-web/src/components/AgentSettings.tsx
+++ b/portal-web/src/components/AgentSettings.tsx
@@ -772,6 +772,7 @@ function ResourcesTab({ allClusters, allHosts, selectedClusterIds, setSelectedCl
 interface PersonalBotInfo {
   id: string
   agent_id: string
+  name?: string | null
   domain: "feishu" | "lark"
   app_id: string
   access_mode: string
@@ -896,7 +897,7 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
           <div className="flex min-w-0 items-center gap-2">
             <ChevronRight className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${botExpanded ? "rotate-90" : ""}`} />
             <div className="min-w-0">
-              <h4 className="text-[13px] font-medium text-foreground">This agent's Feishu bot</h4>
+              <h4 className="text-[13px] font-medium text-foreground">{bot?.name || "This agent's Feishu bot"}</h4>
               {botExpanded || !bot ? (
                 <p className="mt-0.5 text-[11px] text-muted-foreground/70">A dedicated Feishu app — serves direct messages and every group it joins. Open access; admin-configured.</p>
               ) : (

--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -118,6 +118,21 @@ export async function updateBindingMeta(
   });
 }
 
+/**
+ * Persist a channel's display name (used to store a Feishu bot's real
+ * `app_name` so the Portal shows the actual bot name, not a placeholder).
+ */
+export async function updateChannelName(
+  channelId: string,
+  name: string,
+  frontendClient: FrontendWsClient,
+): Promise<{ success: boolean; error?: string }> {
+  return frontendClient.request("channel.updateName", {
+    channel_id: channelId,
+    name,
+  });
+}
+
 /** Reset the durable session attached to a channel binding. */
 export async function resetBindingSession(
   channelId: string,

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -17,6 +17,7 @@ import {
   handlePersonalPairingCode,
   resetPersonalSession,
   updateBindingMeta,
+  updateChannelName,
   isChannelAccessDenied,
   type ResolvedChannelBinding,
   type ChannelAccessDenied,
@@ -172,8 +173,20 @@ export function createLarkHandler(
           method: "GET",
           url: "/open-apis/bot/v3/info",
         });
-        botOpenId = botInfo?.bot?.open_id ?? botInfo?.data?.bot?.open_id;
+        const bot = botInfo?.bot ?? botInfo?.data?.bot;
+        botOpenId = bot?.open_id;
         console.log(`[lark] Channel ${channelId} bot open_id=${botOpenId ?? "(unknown)"}`);
+        // Persist the bot's real Feishu name so the Portal shows it instead of
+        // the synthetic "${agent} Bot" placeholder. ONLY for per-agent personal
+        // bots — a shared-app channel's name is admin-curated in the Channels
+        // UI and must not be clobbered by the raw Feishu app_name on restart.
+        // Best-effort + detached — a name write must never delay/fail startup.
+        const appName: string | undefined = typeof bot?.app_name === "string" ? bot.app_name.trim() : undefined;
+        if (appName && frontendClient && config.personal_bot) {
+          updateChannelName(channelId, appName, frontendClient).catch((err) => {
+            console.warn(`[lark] Could not persist bot name for channel ${channelId}: ${err instanceof Error ? err.message : String(err)}`);
+          });
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`[lark] Could not fetch bot info for channel ${channelId}; group @-mention gating falls back to @_all-exclusion: ${msg}`);

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1597,10 +1597,12 @@ describe("channel.resolveBinding", () => {
     expect(result).toEqual({ binding: null });
   });
 
-  it("open personal-bot auto-binds a group with a shared per-chat session", async () => {
-    mockQuery(
+  it("open personal-bot materializes a binding row + shared per-chat session on first service", async () => {
+    const query = mockQuery(
       [],                                                                  // selectChannelBinding → none
       [{ id: "ch1", created_by: "owner-1", config: JSON.stringify({ personal_bot: { agent_id: "a1", access_mode: "open" } }) }], // selectPersonalChannel
+      {},                                                                  // INSERT IGNORE channel_bindings (row materialized)
+      [{ id: "b-open", agent_id: "a1", route_type: "group", created_by: "owner-1" }], // reselect → the new row
       [],                                                                  // participant session lookup → none
       [],                                                                  // insert participant session
       [{ session_id: "chat-session" }],                                    // participant session reload
@@ -1609,9 +1611,20 @@ describe("channel.resolveBinding", () => {
     const result = await getHandler("channel.resolveBinding")(
       { channel_id: "ch1", route_key: "group-123", session_key: "open_id:ou_1", sender_open_id: "ou_1" }, "a1",
     );
+
+    // A channel_bindings row is inserted so the group is Portal-visible.
+    expect(query.mock.calls[2][0]).toContain("INTO channel_bindings");
+    expect(query.mock.calls[2][1]).toEqual([
+      expect.any(String), "ch1", "a1", "group-123", "owner-1",
+    ]);
+    // The session is keyed under the materialized row id, and that id is the
+    // binding id returned (not the channel id).
+    expect(query.mock.calls[5][1]).toEqual([
+      expect.any(String), "b-open", "chat:group-123", expect.any(String),
+    ]);
     expect(result.binding).toEqual({
       agentId: "a1",
-      bindingId: "ch1",
+      bindingId: "b-open",
       sessionId: "chat-session",
       sessionKey: "chat:group-123",
       createdBy: "owner-1",
@@ -1773,6 +1786,27 @@ describe("channel.updateBindingMeta", () => {
     // i.e. 510 UTF-16 units — and the last char is a whole emoji.
     expect([...stored]).toHaveLength(255);
     expect(stored.endsWith("😀")).toBe(true);
+  });
+});
+
+describe("channel.updateName", () => {
+  it("updates the channel name only when it differs", async () => {
+    const query = mockQuery({ affectedRows: 1 } as any);
+    const result = await getHandler("channel.updateName")(
+      { channel_id: "ch1", name: "寒彻的飞书 CLI" }, "a1",
+    );
+    expect(result).toEqual({ success: true });
+    expect(query.mock.calls[0][0]).toContain("UPDATE channels SET name");
+    // Guarded by `name != ?` so a restart with an unchanged name is a no-op write.
+    expect(query.mock.calls[0][0]).toContain("name != ?");
+    expect(query.mock.calls[0][1]).toEqual(["寒彻的飞书 CLI", "ch1", "寒彻的飞书 CLI"]);
+  });
+
+  it("rejects an empty name without touching the DB", async () => {
+    const query = mockQuery();
+    const result = await getHandler("channel.updateName")({ channel_id: "ch1", name: "   " }, "a1");
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
   });
 });
 
@@ -1977,9 +2011,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 51 handlers", () => {
+  it("registers exactly 52 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(51);
+    expect(handlers.size).toBe(52);
   });
 
   it("all expected handler names are registered", () => {
@@ -1995,7 +2029,7 @@ describe("buildAdapterRpcHandlers", () => {
       "task.update", "task.delete", "task.runRecord", "task.runStart",
       "task.runFinalize", "task.updateMeta", "task.fireNow", "task.notify", "task.prune",
       "channel.list", "channel.resolveBinding", "channel.pair", "channel.resetSession",
-      "channel.updateBindingMeta",
+      "channel.updateBindingMeta", "channel.updateName",
       "channel.resolvePersonalBinding", "channel.pairPersonal", "channel.resetPersonalSession",
       "agent.listForSkill", "agent.listForMcp", "agent.listForCluster", "agent.listForHost",
       "metrics.summary", "metrics.audit", "metrics.auditDetail",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -336,6 +336,26 @@ async function updateChannelBindingMeta(
   return { success: true };
 }
 
+/**
+ * Set a channel's display name. Used by the runtime to persist a Feishu bot's
+ * real `app_name` (from bot/v3/info) so the Portal shows the actual bot name
+ * instead of the synthetic `${agent} Bot` placeholder. Only updates when the
+ * name actually differs, so a runtime restart isn't a needless write.
+ */
+async function updateChannelName(
+  db: Db,
+  channelId: string,
+  name: string,
+): Promise<{ success: boolean; error?: string }> {
+  const normalized = normalizeBindingDisplayName(name);
+  if (!normalized) return { success: false, error: "name must not be empty" };
+  const [result] = await db.query(
+    "UPDATE channels SET name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND type = 'lark' AND name != ?",
+    [normalized, channelId, normalized],
+  ) as any;
+  return { success: !!result };
+}
+
 interface PersonalChannelConfig {
   personal_bot?: {
     agent_id?: string;
@@ -388,6 +408,31 @@ async function resolvePersonalChannelBinding(
 }
 
 /**
+ * Materialize a channel_bindings row for a group an open bot auto-serves, so
+ * the group is visible in the Portal's Active-groups list and its title can be
+ * backfilled (the list + name backfill both key off channel_bindings). Without
+ * this, an open bot's groups only ever get a channel_binding_sessions row and
+ * are invisible in the Portal. Idempotent on the (channel_id, route_key) unique
+ * key; a concurrent first-message loses the INSERT race and re-selects the
+ * winner's row. Returns the binding row id. Mirrors sicore's ensureAutoGroupBinding.
+ */
+async function ensureOpenGroupBindingRow(
+  db: Db,
+  channelId: string,
+  routeKey: string,
+  agentId: string,
+  createdBy: string | null,
+): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.query(
+    `${insertIgnorePrefix(db)} INTO channel_bindings (id, channel_id, agent_id, route_key, route_type, created_by) VALUES (?, ?, ?, ?, 'group', ?)`,
+    [id, channelId, agentId, routeKey, createdBy],
+  );
+  const row = await selectChannelBinding(db, channelId, routeKey);
+  return row?.id ?? id;
+}
+
+/**
  * Open-mode group fallback: a per-agent open bot answers in any group it joins
  * without a PAIR. All senders in one group share a single session (keyed by
  * chat id, distinct from the DM `open_id:` keys), and every turn runs as the
@@ -403,14 +448,22 @@ async function resolveOpenGroupBinding(
   if (!channel || !personalBot?.agent_id) return null;
   if (personalBot.access_mode !== "open") return null;
   if (personalBot.group_auto_bind === false) return null;
+
+  const createdBy = personalBot.owner_user_id ?? channel.created_by;
+  // Persist a binding row on first service so the group shows up in the Portal
+  // (and can carry a title/mode). Subsequent messages find it via
+  // selectChannelBinding and never re-enter this path. The session is keyed
+  // under the binding row id (not the channel id) so it stays consistent with
+  // the row that now owns the group.
+  const bindingId = await ensureOpenGroupBindingRow(db, channel.id, routeKey, personalBot.agent_id, createdBy);
   const sessionKey = `chat:${routeKey}`;
-  const session = await resolveChannelBindingParticipantSession(db, channel.id, sessionKey);
+  const session = await resolveChannelBindingParticipantSession(db, bindingId, sessionKey);
   return {
     agentId: personalBot.agent_id,
-    bindingId: channel.id,
+    bindingId,
     sessionId: session.sessionId,
     sessionKey: session.sessionKey,
-    createdBy: personalBot.owner_user_id ?? channel.created_by,
+    createdBy,
     routeType: "group",
   };
 }
@@ -2861,6 +2914,11 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
   handlers.set("channel.updateBindingMeta", async (params) => {
     const db = getDb();
     return updateChannelBindingMeta(db, params.channel_id, params.route_key, params.display_name);
+  });
+
+  handlers.set("channel.updateName", async (params) => {
+    const db = getDb();
+    return updateChannelName(db, params.channel_id, params.name);
   });
 
   handlers.set("channel.resolvePersonalBinding", async (params) => {

--- a/src/portal/siclaw-api.personal-bot.test.ts
+++ b/src/portal/siclaw-api.personal-bot.test.ts
@@ -121,6 +121,7 @@ describe("agent personal-bot routes", () => {
       expect(body.data).toEqual({
         id: "ch-bot-1",
         agent_id: "agent-1",
+        name: "cks Bot",
         domain: "feishu",
         app_id: "cli_xxx",
         access_mode: "open",

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2714,6 +2714,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       data: {
         id: row.id,
         agent_id: params.id,
+        name: row.name ?? null,
         domain: row.config.domain === "lark" ? "lark" : "feishu",
         app_id: row.config.app_id ?? "",
         access_mode: "open",


### PR DESCRIPTION
Two related Portal display gaps for an agent's **open personal Feishu bot**, so it matches what sicore's console shows.

## 1. Open-bot groups were invisible in the Portal

`resolveOpenGroupBinding` served an open bot's groups but only created a `channel_binding_sessions` row — never a `channel_bindings` row. The Portal's **Active groups** list and the group-title backfill both key off `channel_bindings`, so an open bot's groups showed as "Active groups (0)" with no names, even after auto-connect.

Fix: materialize a `channel_bindings` row on first service (idempotent on the `(channel_id, route_key)` unique key; concurrent first-message re-selects the winner). The group session is keyed under that row id, so subsequent messages resolve through the normal binding path. Mirrors sicore's `ensureAutoGroupBinding`.

- One-time effect: existing open-bot groups get a fresh session on upgrade (old channel-id-keyed session orphaned).

## 2. The bot's real name wasn't shown

The personal-bot card hardcoded "This agent's Feishu bot" and the channel was named `${agent} Bot`; the bot's real Feishu name (`bot/v3/info` `app_name`, e.g. "寒彻的飞书 CLI") was never captured.

Fix: the runtime reads `app_name` from the bot info it already fetches at channel start and persists it via a new `channel.updateName` RPC (best-effort, detached, only writes on change); `GET /personal-bot` returns the channel name; the card shows it (fallback to the old label when absent).

## Notes
- Independent of the per-group context-mode work.
- `contextMode`-free (targets main).

## Test
- `adapter-rpc.test.ts`: open-bot resolve now asserts the `channel_bindings` INSERT (correct column order) + the session keyed under the materialized row id; new `channel.updateName` cases (updates only on change; rejects empty).
- `siclaw-api.personal-bot.test.ts`: GET returns `name`.
- Full suite green (4393 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)