### PR TITLE
feat(channels): per-group context mode for Lark groups (shared vs per-user)

### DIFF
--- a/docs/design/2026-07-11-lark-group-context-mode.md
+++ b/docs/design/2026-07-11-lark-group-context-mode.md
@@ -1,0 +1,223 @@
+# Lark Group Context Mode: Shared vs Per-User
+
+**Date**: 2026-07-11
+**Status**: Design approved, implementation pending
+**Branch**: `investigate/lark-group-context-mode`
+
+## Problem
+
+A group-chat agent serves two contradictory scenarios:
+
+- **Incident / war-room groups**: the whole group works one problem. The agent
+  must see the ENTIRE group discussion — including messages that never @-mention
+  it — so that when someone @s it, it answers from full context.
+- **Customer-support groups**: members ask unrelated questions. Each sender
+  needs an isolated conversation — no context bleed, no queueing behind other
+  people's turns, `/new` resets only yourself.
+
+Today the scoping is fixed per binding path (PAIR groups → per-sender
+`open_id:` sessions; open personal bots → group-shared `chat:` sessions) with
+no user-facing choice, and non-@ group messages are dropped unconditionally
+(`lark.ts` mention gate), so even a "shared" session only contains @-turns.
+
+## Decisions
+
+1. **Mode is per group, stored server-side on the binding row** — a
+   `context_mode` field (`shared` | `per_user`) on the group's binding record
+   (`channel_bindings` in the built-in Portal; the equivalent record in any
+   external portal adapter). NOT runtime config, NOT per agent (one agent
+   serves many groups).
+2. **A NEW group defaults to `shared`** — written explicitly at pair/auto-bind
+   time. But a NULL/legacy row resolves to `per_user` (grandfathering; see
+   Migration below), interpreted in ONE place server-side — do NOT read this as
+   "NULL means shared". Rationale: the primary use is support/incident groups; a
+   user who wants isolation creates their own group with the bot and manually
+   switches it to `per_user`.
+3. **The decision point stays `channel.resolveBinding`.** The server picks the
+   session-key formula from the mode — `shared` → `chat:{route_key}`,
+   `per_user` → a per-sender key (`open_id:{sender}`, or whatever per-user
+   identity the portal adapter maintains — the runtime treats the key as
+   opaque) — and additionally returns `context_mode` on
+   `ResolvedChannelBinding`. The runtime keeps using the returned `sessionKey`
+   verbatim for both session identity and the serialization queue (unchanged
+   contract); it must NOT infer mode from the key shape.
+4. **Full-context ingestion (shared mode only)** — *buffer-and-inject*:
+   - A non-@ group message in a `shared` group is appended to a per-session
+     **discussion buffer** (sender + text + time). It runs no agent turn and
+     MUST NOT touch the AgentBox (no wake-up of idle-destructed pods).
+   - When the bot is @-mentioned, the un-consumed buffer is rendered as an
+     attributed transcript block (`[name]: text` lines) and prepended to that
+     turn's prompt. Snapshot+clear happens inside the queued task (atomic
+     w.r.t. the binding queue). The discussion thus enters the agent's pi
+     session organically and accumulates turn over turn.
+   - Rationale for this shape: agent context is the AgentBox-side pi session
+     (JSONL), NOT rebuilt from `chat_messages` — writing passive rows to the DB
+     alone would be invisible to the model. Per-message injection into the
+     AgentBox was rejected (wakes/keeps pods alive on every group chatter).
+   - Bounds: the per-turn injected transcript is capped (newest-first retention,
+     e.g. ~100 messages / ~8k chars, with an explicit truncation note). The
+     buffer itself is bounded the same way.
+5. **Privacy discipline (hard rule)**: a non-@ message in a `per_user` group is
+   discarded immediately — never buffered, never persisted, never entered into
+   any context. The receive-all-group-messages permission is app-level, so the
+   bot receives chatter from ALL groups; only `shared` groups may consume it.
+6. **Sender attribution**: in `shared` mode every injected line and every
+   @-turn is prefixed with the sender (display name via contact API + cache
+   when the permission exists; open_id tail as fallback; a portal adapter that
+   maintains its own user identities may supply better display names).
+   Without attribution a multi-user shared context is ambiguous
+   ("check MY cluster").
+7. **Graceful degradation**: without the Feishu receive-all permission, non-@
+   messages never arrive; `shared` degrades to "shared @-turns only" (multiple
+   senders share one session but the agent doesn't hear the chatter). This is
+   functional, not an error.
+
+## Feishu permission matrix
+
+| Permission | per_user | shared (full context) |
+|---|---|---|
+| Receive @bot group messages (default bot capability) | required | required |
+| `im:message.group_any_msg:readonly` (receive ALL group messages) | not needed | **required for full context**; sensitive, tenant-admin approved, app-level |
+| `contact:user.base:readonly` (open_id → name) | not needed | recommended (attribution) |
+| `im:message:readonly` (fetch history — optional cold-start backfill) | not needed | optional |
+
+The privacy discipline in Decision 5 is the standing answer to the security
+review that the sensitive scope will trigger.
+
+## Message-flow contract (runtime)
+
+```
+group message arrives
+ ├─ @bot        → resolveBinding (existing path) → enqueue agent turn on the
+ │                returned sessionKey; in shared mode, prepend the drained
+ │                discussion buffer to the prompt
+ └─ no mention  → look up the group's context_mode (short-TTL cache, no RPC
+                  per message)
+                   ├─ shared   → append {sender, text, ts} to the session's
+                   │             discussion buffer; no agent run
+                   └─ per_user → drop immediately (today's behavior)
+```
+
+- The mode cache is invalidated by the existing channel-reload notification
+  (also the propagation path for console edits) and by TTL expiry. A switch
+  originating from the group's own card additionally busts the local cache
+  immediately (no notify round-trip).
+- `/new` in a shared group is REJECTED, not honored: the group shares one
+  session, so one member's reset would wipe everyone's context. The runtime
+  replies a short notice pointing at `/mode` (switch to per_user) or a new
+  group; a confirmation-gated "reset the whole room" is deferred. per_user
+  groups and personal chats reset the caller's own session as before.
+- Serialization: shared groups keep the single per-session queue (desirable
+  for incident coherence); per_user groups keep per-sender concurrent queues.
+- Mode switch mid-life = subsequent messages resolve to the OTHER key formula
+  (a different session), it does NOT reset a session. So a per_user→shared
+  switch-back reuses the group's prior `chat:` session and its history
+  resurfaces — the announcement therefore states the behavior change ("messages
+  are now handled as one shared conversation" / "each person talks separately"),
+  NOT a "fresh start" it can't guarantee. The runtime does drop its buffered
+  non-@ chatter on a detected mode change so stale chatter can't cross a switch.
+- The discussion buffer is runtime-process memory, keyed by session. A channel
+  app holds ONE long connection from one runtime process, so the buffer is
+  local by construction; a runtime restart drops un-consumed chatter (bounded,
+  documented loss). Persistence is a follow-up if it matters.
+
+## Product surfaces
+
+1. **In-group switch card** (MVP, channels-only): a command summons an
+   interactive card showing the current mode with switch buttons. The
+   *capability* is channel-generic (see below); the card UI is per-channel,
+   **Feishu first**.
+   - Summon: `/mode` in the group (command-word, recognized like `/new` /
+     `PAIR` — exact match, works with or without @bot).
+   - Card: current mode + two buttons (Team / Personal), reusing the
+     `card.action.trigger` callback chain (same infra as the 👍/👎 feedback
+     buttons; `action.value` is SELF-CONTAINED — binding/channel/chat ids +
+     locale embedded, no server-side card-id mapping).
+   - On switch: update `context_mode` via the generic RPC, invalidate the
+     runtime mode cache + drop the buffered chatter, update the card in place,
+     and post a visible group announcement stating the new behavior — audit
+     trail + everyone learns the change. The copy states the behavior change,
+     not a guaranteed reset.
+   - Permission: MVP allows any group member to switch, with the visible
+     announcement as the social control (groups are self-governed — the
+     "user creates their own group and flips it" flow must not require a
+     console admin). Tightening (binding creator / chat admin via
+     `im:chat:readonly` role query) is a follow-up knob, not MVP.
+2. **Bind-time notice** (MVP): the PAIR-success / auto-bind greeting states the
+   current mode in scenario language and embeds the same switch buttons. Copy
+   avoids "session/context" jargon (shared = "Team mode: the bot follows the
+   whole group's discussion"; per_user = "Personal mode: each person talks to
+   the bot privately"). The localized strings live in the channel's locale maps.
+3. **Management-plane switch**: the Portal channel-binding list gets a per-row
+   mode selector (admin-scoped; same RPC underneath). External portal
+   implementations expose the same selector in their own management UI.
+
+## Channel-generic switch contract
+
+The mode switch is a **channels-layer capability**, not a Feishu feature:
+
+- One generic server RPC — `channel.setContextMode(channel_id, route_key,
+  mode)` — updates the binding row and fires the existing channel-reload
+  notification. Management UIs and every channel's in-group card call the
+  SAME RPC.
+- The command word (`/mode`), the mode vocabulary (`shared` | `per_user`), the
+  self-governance rule, and the announcement requirement are channel-agnostic
+  contract; only the presentation (interactive card vs. text menu) is
+  per-channel.
+- Applies to channel-origin group bindings only (web/TUI sessions have no
+  binding row and no mode concept).
+- Rollout: Feishu implements the full surface now; DingTalk (once its groups
+  gain persistent sessions) and future channels implement the same contract
+  with their native UI affordance.
+
+## Portal-adapter wire contract
+
+The runtime works against ANY portal that implements the channel RPC
+vocabulary. For this feature a portal MUST provide:
+
+1. **Vocabulary**: `context_mode ∈ {"shared","per_user"}`; a NEW group is
+   written `"shared"`, while NULL/legacy rows resolve to `"per_user"`
+   (grandfathering), interpreted server-side in one place. (Do not read NULL
+   as shared.)
+2. **`channel.resolveBinding`**: honors the group's stored mode when choosing
+   the session key (`shared` → `chat:{route_key}`; `per_user` → a stable
+   per-sender key) and returns `context_mode` on the binding object. Any
+   per-sender access control the portal enforces is orthogonal: in `shared`
+   mode the access check still runs per sender, and the shared key is returned
+   only AFTER the sender passes.
+3. **`channel.setContextMode(channel_id, route_key, mode)`**: updates the
+   binding row, answers `{success}`, and triggers the channel-reload
+   notification so every serving runtime drops its mode cache.
+
+## Migration & compatibility
+
+- **Grandfathering (built-in Portal)**: existing PAIR groups behave per-sender
+  today, so a blind NULL → `shared` would regress them (merge separate contexts
+  into one). Instead:
+  1. `normalizeContextMode` resolves **NULL → `per_user`** (the one place the
+     default is interpreted), so any legacy row keeps its per-sender behavior.
+  2. `pairChannelBinding` **writes `context_mode="shared"` on INSERT** (not on a
+     re-pair conflict), so a freshly-bound group gets the product default
+     (shared) while a group already switched to per_user keeps its choice.
+  This needs no run-once data backfill (which siclaw's idempotent-DDL migration
+  couldn't express safely) — NULL only ever means "pre-upgrade row", and those
+  are exactly the ones to grandfather. The runtime mirrors the same NULL-safety:
+  an absent `contextMode` on the wire is treated as per_user (never buffer
+  chatter for an unconfirmed-shared group).
+- **Open-bot groups**: `resolveOpenGroupBinding` materializes a
+  `channel_bindings` row on first service (see the open-bot group fix that
+  landed alongside this) and stamps it `context_mode='shared'` — the fresh-group
+  default, matching open bots' historical shared behavior. It reports
+  `contextMode:"shared"` on that first turn; every subsequent message resolves
+  the same row via `selectChannelBinding` (same `chat:{route_key}` session), so
+  open-bot groups are first-class: listed in the Portal, mode-switchable via
+  `/mode` and the selector, exactly like PAIR groups. The runtime never infers
+  the mode from the key shape — it reads the returned `contextMode`.
+
+## Non-goals
+
+- Thread-level scoping (Lark group events carry no thread/root id).
+- Migrating existing session history across a mode switch.
+- Cross-group or cross-channel shared contexts.
+- DingTalk (groups are ephemeral-per-message by design; adopts the contract
+  when its groups gain persistent sessions).

--- a/portal-web/src/components/AgentSettings.tsx
+++ b/portal-web/src/components/AgentSettings.tsx
@@ -784,7 +784,7 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
   agentId: string; selectedChannelIds: Set<string>; setSelectedChannelIds: (v: Set<string>) => void
 }) {
   const toast = useToast()
-  const [bindings, setBindings] = useState<{ id: string; channel_id: string; channel_name: string; channel_type: string; route_key: string; route_type: string; display_name?: string | null }[]>([])
+  const [bindings, setBindings] = useState<{ id: string; channel_id: string; channel_name: string; channel_type: string; route_key: string; route_type: string; display_name?: string | null; context_mode?: string | null }[]>([])
   const [allChannels, setAllChannels] = useState<{ id: string; name: string; type: string; is_personal_bot?: boolean }[]>([])
   const [loading, setLoading] = useState(true)
   const [pairingCode, setPairingCode] = useState<string | null>(null)
@@ -875,6 +875,16 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
       await api(`/siclaw/agents/${agentId}/channel-bindings/${bindingId}`, { method: "DELETE" })
       setBindings(prev => prev.filter(b => b.id !== bindingId))
       toast.success("Binding removed")
+    } catch (err: any) { toast.error(err.message) }
+  }
+
+  const handleSetContextMode = async (bindingId: string, mode: "shared" | "per_user") => {
+    try {
+      await api(`/siclaw/agents/${agentId}/channel-bindings/${bindingId}/context-mode`, {
+        method: "PUT", body: { mode },
+      })
+      setBindings(prev => prev.map(b => (b.id === bindingId ? { ...b, context_mode: mode } : b)))
+      toast.success(mode === "shared" ? "Switched to Team (shared) mode" : "Switched to Personal (per-user) mode")
     } catch (err: any) { toast.error(err.message) }
   }
 
@@ -979,9 +989,22 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
                     <p className="truncate text-[10px] text-muted-foreground font-mono">{b.channel_name || b.channel_id} · {b.route_type}: {b.route_key}</p>
                   </div>
                 </div>
-                <button onClick={() => handleUnbind(b.id)} title="Unbind" className="p-1 rounded-md hover:bg-destructive/20 text-muted-foreground hover:text-red-400">
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  {b.route_type === "group" && (
+                    <select
+                      value={b.context_mode === "shared" ? "shared" : "per_user"}
+                      onChange={e => handleSetContextMode(b.id, e.target.value as "shared" | "per_user")}
+                      title="Context mode: Team shares one conversation; Personal gives each member their own"
+                      className="rounded-md border border-border/50 bg-secondary/30 px-1.5 py-1 text-[10px] text-muted-foreground hover:bg-secondary/50 focus:outline-none"
+                    >
+                      <option value="shared">Team (shared)</option>
+                      <option value="per_user">Personal (per-user)</option>
+                    </select>
+                  )}
+                  <button onClick={() => handleUnbind(b.id)} title="Unbind" className="p-1 rounded-md hover:bg-destructive/20 text-muted-foreground hover:text-red-400">
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
               </div>
             ))}
           </div>

--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -39,6 +39,19 @@ export interface ResolvedChannelBinding {
   routeType: "group" | "user";
   /** Cached chat title from the platform; null/absent until backfilled. */
   displayName?: string | null;
+  /**
+   * Group context sharing mode, chosen server-side from the binding row.
+   * `"shared"` → the whole group shares one session and non-@ chatter is
+   * buffered into it. `"per_user"` → each sender gets an isolated session and
+   * non-@ chatter is dropped. A NEW group defaults to `"shared"` (written at
+   * pair/auto-bind time), but the server resolves NULL/legacy rows to
+   * `"per_user"` (grandfathering — never merges an existing group's contexts),
+   * so an ABSENT field here is treated as `"per_user"` by the runtime: never
+   * buffer chatter for a group we can't confirm is shared. The runtime treats
+   * `sessionKey` as opaque; this field is the explicit signal for the non-@
+   * ingestion gate — never infer the mode from the key shape.
+   */
+  contextMode?: "shared" | "per_user";
 }
 
 /**
@@ -81,6 +94,26 @@ export async function resolveBinding(
     ...(senderOpenId ? { sender_open_id: senderOpenId } : {}),
   });
   return data.binding ?? null;
+}
+
+/**
+ * Set a group binding's context mode (shared|per_user) via the generic
+ * `channel.setContextMode` RPC. Backs the in-group /mode switch card; the
+ * console selector calls the same RPC. Best-effort — returns the portal's
+ * `{success}` shape, or a failure object if there is no frontend client.
+ */
+export async function setChannelContextMode(
+  channelId: string,
+  routeKey: string,
+  mode: "shared" | "per_user",
+  frontendClient?: FrontendWsClient,
+): Promise<{ success: boolean; mode?: string; error?: string }> {
+  if (!frontendClient) return { success: false, error: "No frontend client for setContextMode" };
+  return frontendClient.request("channel.setContextMode", {
+    channel_id: channelId,
+    route_key: routeKey,
+    mode,
+  });
 }
 
 /** Handle a PAIR code — validates and creates binding via RPC. */

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -13,6 +13,8 @@ import {
   PLACEHOLDER_BY_LOCALE,
   EMPTY_RESULT_NOTICE_BY_LOCALE,
   localeForDomain,
+  buildModeCard,
+  MODE_ACTION_KIND,
 } from "./lark-card.js";
 
 // ── sanitizeMarkdownForFeishu ──────────────────────────────────
@@ -447,5 +449,34 @@ describe("buildMilestoneCardMarkdown", () => {
     expect(lines).toHaveLength(11); // overflow line + 10 shown
     expect(md).toContain("step 14"); // newest kept
     expect(md).not.toContain("✅ step 1\n"); // oldest dropped
+  });
+});
+
+describe("buildModeCard", () => {
+  function buttons(card: any): any[] {
+    const cols = card.body.elements.find((e: any) => e.tag === "column_set").columns;
+    return cols.map((c: any) => c.elements[0]);
+  }
+
+  it("renders two self-contained mode buttons and marks the current one primary", () => {
+    const card = buildModeCard("shared", "ch1", "oc_group1", "zh-CN") as any;
+    const [sharedBtn, perUserBtn] = buttons(card);
+
+    expect(sharedBtn.behaviors[0].value).toEqual({
+      kind: MODE_ACTION_KIND, channel_id: "ch1", route_key: "oc_group1", mode: "shared", locale: "zh-CN",
+    });
+    expect(perUserBtn.behaviors[0].value).toEqual({
+      kind: MODE_ACTION_KIND, channel_id: "ch1", route_key: "oc_group1", mode: "per_user", locale: "zh-CN",
+    });
+    // Current mode (shared) is highlighted; the other is default.
+    expect(sharedBtn.type).toBe("primary");
+    expect(perUserBtn.type).toBe("default");
+    expect(sharedBtn.text.content).toContain("✓");
+  });
+
+  it("highlights per_user when that is the current mode", () => {
+    const [sharedBtn, perUserBtn] = buttons(buildModeCard("per_user", "ch1", "g", "en-US") as any);
+    expect(perUserBtn.type).toBe("primary");
+    expect(sharedBtn.type).toBe("default");
   });
 });

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -204,6 +204,113 @@ export function resetFeedbackEchoForTest(): void {
   feedbackEchoSessions.clear();
 }
 
+// ── Group context-mode switch card ───────────────────────────────
+
+export type GroupContextMode = "shared" | "per_user";
+
+export const MODE_ACTION_KIND = "siclaw_ctx_mode";
+
+/** Self-contained payload on each mode button (comes back verbatim in the
+ *  callback, mirroring the feedback buttons — no server-side card mapping). */
+export interface ModeActionValue {
+  kind: typeof MODE_ACTION_KIND;
+  channel_id: string;
+  route_key: string;
+  mode: GroupContextMode;
+  locale: LarkLocale;
+}
+
+const MODE_CARD_COPY: Record<LarkLocale, {
+  title: (m: GroupContextMode) => string;
+  hint: string;
+  shared: string;
+  perUser: string;
+}> = {
+  "zh-CN": {
+    title: (m) => `**本群上下文模式:当前为「${m === "shared" ? "团队模式" : "个人模式"}」**`,
+    hint: "团队模式:全群共用一个对话,机器人跟进全群讨论(故障/支持群)。\n个人模式:每个人各自独立对话,互不影响(大群/混合群)。\n切换后是一段新对话。",
+    shared: "团队模式",
+    perUser: "个人模式",
+  },
+  "en-US": {
+    title: (m) => `**Group context mode: currently ${m === "shared" ? "Team (shared)" : "Personal (per-user)"}**`,
+    hint: "Team: everyone shares one conversation; the bot follows the whole group (incident / support rooms).\nPersonal: each person talks to the bot privately (large / mixed groups).\nSwitching starts a fresh conversation.",
+    shared: "Team (shared)",
+    perUser: "Personal (per-user)",
+  },
+};
+
+/** Schema-2.0 card: current mode + two callback buttons (current one primary). */
+export function buildModeCard(
+  currentMode: GroupContextMode,
+  channelId: string,
+  routeKey: string,
+  locale: LarkLocale,
+): Record<string, unknown> {
+  const copy = MODE_CARD_COPY[locale];
+  const button = (mode: GroupContextMode, label: string) => {
+    const value: ModeActionValue = { kind: MODE_ACTION_KIND, channel_id: channelId, route_key: routeKey, mode, locale };
+    const isCurrent = mode === currentMode;
+    return {
+      tag: "button",
+      element_id: `mode_${mode}`,
+      text: { tag: "plain_text", content: isCurrent ? `✓ ${label}` : label },
+      type: isCurrent ? "primary" : "default",
+      behaviors: [{ type: "callback", value }],
+    };
+  };
+  return {
+    schema: "2.0",
+    body: {
+      elements: [
+        { tag: "markdown", content: copy.title(currentMode) },
+        { tag: "markdown", content: copy.hint },
+        {
+          tag: "column_set",
+          columns: [
+            { tag: "column", width: "auto", elements: [button("shared", copy.shared)] },
+            { tag: "column", width: "auto", elements: [button("per_user", copy.perUser)] },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+/** Post the mode-switch card as a reply. Returns false on any failure so the
+ *  caller can fall back to a plain-text mode notice. */
+export async function sendModeCard(
+  larkClient: any,
+  messageId: string,
+  currentMode: GroupContextMode,
+  channelId: string,
+  routeKey: string,
+  locale: LarkLocale,
+): Promise<boolean> {
+  try {
+    const createRes = await larkClient.cardkit.v1.card.create({
+      data: { type: "card_json", data: JSON.stringify(buildModeCard(currentMode, channelId, routeKey, locale)) },
+    });
+    const cardId: string | undefined = createRes?.data?.card_id;
+    if (!cardId) {
+      console.warn("[lark-card] mode card create returned no card_id");
+      return false;
+    }
+    const replyRes = await larkClient.im.message.reply({
+      path: { message_id: messageId },
+      data: { msg_type: "interactive", content: JSON.stringify({ type: "card", data: { card_id: cardId } }) },
+    });
+    if (replyRes && typeof replyRes.code === "number" && replyRes.code !== 0) {
+      console.error(`[lark-card] posting mode card failed: code=${replyRes.code} msg=${replyRes.msg}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("[lark-card] sendModeCard failed:", err);
+    return false;
+  }
+}
+
 /** The Lark SDK does NOT throw on a non-zero API code — check explicitly. */
 function cardApiFailed(res: unknown): boolean {
   const code = (res as { code?: unknown } | undefined)?.code;

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -40,6 +40,7 @@ const resolvePersonalBindingMock = vi.fn();
 const handlePersonalPairingCodeMock = vi.fn();
 const resetPersonalSessionMock = vi.fn();
 const updateBindingMetaMock = vi.fn();
+const setChannelContextModeMock = vi.fn();
 
 vi.mock("../channel-manager.js", () => ({
   resolveBinding: (...args: unknown[]) => resolveBindingMock(...args),
@@ -49,6 +50,7 @@ vi.mock("../channel-manager.js", () => ({
   handlePersonalPairingCode: (...args: unknown[]) => handlePersonalPairingCodeMock(...args),
   resetPersonalSession: (...args: unknown[]) => resetPersonalSessionMock(...args),
   updateBindingMeta: (...args: unknown[]) => updateBindingMetaMock(...args),
+  setChannelContextMode: (...args: unknown[]) => setChannelContextModeMock(...args),
   isChannelAccessDenied: (v: unknown) =>
     v !== null && typeof v === "object" && (v as { walled?: unknown }).walled === true,
 }));
@@ -960,6 +962,24 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     expect(resetBindingSessionMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "sicore_user:u42");
   });
 
+  it("/new in a SHARED group is rejected, not reset (one member can't wipe the group)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ sessionId: "grp", sessionKey: "chat:oc_abc123", contextMode: "shared" }));
+    const lark = makeLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("/new"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(resetBindingSessionMock).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(lark.im.message.reply.mock.calls[0][0].data.content).toContain("不支持单人重置");
+  });
+
   it("queues concurrent messages for the same sender instead of starting a second prompt", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ sessionId: "queued-session" }));
     let releaseFirst!: () => void;
@@ -1141,6 +1161,51 @@ describe("handleLarkCardAction — 👍/👎 feedback", () => {
   });
 });
 
+describe("handleLarkCardAction — /mode context switch", () => {
+  function modeClient() {
+    return { im: { message: { create: vi.fn().mockResolvedValue({}) } } };
+  }
+  function modeAction(mode: string, overrides: Record<string, unknown> = {}) {
+    return {
+      operator: { open_id: "ou_switcher" },
+      action: {
+        tag: "button",
+        value: { kind: "siclaw_ctx_mode", channel_id: "ch1", route_key: "oc_group1", mode, locale: "zh-CN" },
+      },
+      ...overrides,
+    };
+  }
+  const flush = () => new Promise((r) => setImmediate(r));
+
+  it("returns a success toast synchronously and persists + announces detached", async () => {
+    setChannelContextModeMock.mockResolvedValue({ success: true, mode: "per_user" });
+    const client = modeClient();
+    const result = handleLarkCardAction(modeAction("per_user"), client, { request: vi.fn() } as any);
+    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("个人模式") } });
+
+    await flush();
+    expect(setChannelContextModeMock).toHaveBeenCalledWith("ch1", "oc_group1", "per_user", expect.anything());
+    expect(client.im.message.create).toHaveBeenCalledWith(expect.objectContaining({
+      params: { receive_id_type: "chat_id" },
+      data: expect.objectContaining({ receive_id: "oc_group1", msg_type: "text" }),
+    }));
+  });
+
+  it("rejects an unknown mode with an error toast and no persist", async () => {
+    setChannelContextModeMock.mockClear();
+    const result = handleLarkCardAction(modeAction("bogus"), modeClient(), { request: vi.fn() } as any);
+    expect(result).toEqual({ toast: { type: "error", content: expect.any(String) } });
+    await flush();
+    expect(setChannelContextModeMock).not.toHaveBeenCalled();
+  });
+
+  it("a slow persist does NOT block the callback toast (200671 discipline)", () => {
+    setChannelContextModeMock.mockImplementation(() => new Promise(() => { /* never settles */ }));
+    const result = handleLarkCardAction(modeAction("shared"), modeClient(), { request: vi.fn() } as any);
+    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("团队模式") } });
+  });
+});
+
 describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => {
   const BOT = "ou_bot_self";
 
@@ -1215,6 +1280,47 @@ describe("buildChannelTurnPrompt", () => {
     expect(prompt).toContain("current user request");
     expect(prompt).toContain("Do not force the previous case");
     expect(prompt).toContain("画一个新集群的报告");
+  });
+
+  it("no shared context: no group-discussion block or asker attribution", () => {
+    const prompt = buildChannelTurnPrompt("hello");
+    expect(prompt).not.toContain("<group-discussion");
+    expect(prompt).not.toContain("is now asking");
+    expect(prompt).not.toContain("SHARED group");
+  });
+
+  it("shared: injects an attributed discussion transcript before the asker's request", () => {
+    const prompt = buildChannelTurnPrompt("what's the root cause?", {
+      discussion: [
+        { sender: "…abc123", text: "node-5 is NotReady" },
+        { sender: "…def456", text: "kubelet keeps crashing" },
+      ],
+      truncated: false,
+      asker: "…ghi789",
+    });
+    expect(prompt).toContain("SHARED group");
+    expect(prompt).toContain("<group-discussion>");
+    expect(prompt).toContain("[…abc123] node-5 is NotReady");
+    expect(prompt).toContain("[…def456] kubelet keeps crashing");
+    expect(prompt).toContain("[…ghi789] is now asking:");
+    // The discussion block precedes the current request.
+    expect(prompt.indexOf("<group-discussion>")).toBeLessThan(prompt.indexOf("is now asking"));
+    expect(prompt.indexOf("kubelet keeps crashing")).toBeLessThan(prompt.indexOf("what's the root cause?"));
+  });
+
+  it("shared with no buffered chatter: attributes the asker, no discussion block", () => {
+    const prompt = buildChannelTurnPrompt("hi", { discussion: [], truncated: false, asker: "…xyz" });
+    expect(prompt).not.toContain("<group-discussion");
+    expect(prompt).toContain("[…xyz] is now asking:");
+  });
+
+  it("shared truncated: notes older messages were dropped", () => {
+    const prompt = buildChannelTurnPrompt("go", {
+      discussion: [{ sender: "…a", text: "m" }],
+      truncated: true,
+      asker: "…b",
+    });
+    expect(prompt).toContain("older messages were dropped");
   });
 });
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -11,6 +11,7 @@ import { AgentBoxClient, type PromptOptions } from "../agentbox/client.js";
 import type { ChannelHandler } from "../channel-manager.js";
 import {
   resolveBinding,
+  setChannelContextMode,
   handlePairingCode,
   resetBindingSession,
   resolvePersonalBinding,
@@ -34,10 +35,14 @@ import {
   buildMilestoneCardMarkdown,
   applyFeedbackSelection,
   FEEDBACK_ACTION_KIND,
+  sendModeCard,
+  MODE_ACTION_KIND,
   PLACEHOLDER_BY_LOCALE,
   EMPTY_RESULT_NOTICE_BY_LOCALE,
   localeForDomain,
   type FeedbackActionValue,
+  type ModeActionValue,
+  type GroupContextMode,
   type LarkLocale,
 } from "./lark-card.js";
 import { collectImageAttachments, stripVisualBlocks, type RenderedReplyImage } from "./visual-image.js";
@@ -220,7 +225,7 @@ export function createLarkHandler(
         // handleLarkCardAction doc comment / the 200671 fix).
         "card.action.trigger": (data: any) => {
           try {
-            return handleLarkCardAction(data, larkClient);
+            return handleLarkCardAction(data, larkClient, frontendClient);
           } catch (err) {
             console.error(`[lark] Error handling card action for channel=${channelId}:`, err);
             return undefined;
@@ -365,6 +370,46 @@ function backfillBindingDisplayName(
   })();
 }
 
+const MODE_LABEL_BY_LOCALE: Record<LarkLocale, Record<GroupContextMode, string>> = {
+  "zh-CN": { shared: "团队模式(全群共享上下文)", per_user: "个人模式(各自独立上下文)" },
+  "en-US": { shared: "Team mode (shared context)", per_user: "Personal mode (per-user context)" },
+};
+
+const MODE_TOAST_BY_LOCALE: Record<LarkLocale, { ok: (m: GroupContextMode) => string; fail: string }> = {
+  "zh-CN": {
+    ok: (m) => `已切换为${m === "shared" ? "团队模式" : "个人模式"}`,
+    fail: "切换失败,请重试。",
+  },
+  "en-US": {
+    ok: (m) => `Switched to ${m === "shared" ? "Team" : "Personal"} mode`,
+    fail: "Couldn't switch mode. Please try again.",
+  },
+};
+
+const MODE_ANNOUNCE_BY_LOCALE: Record<LarkLocale, (m: GroupContextMode) => string> = {
+  "zh-CN": (m) =>
+    m === "shared"
+      ? `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].shared};之后大家的消息按全群共享处理。`
+      : `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].per_user};之后每个人各自独立对话。`,
+  "en-US": (m) =>
+    m === "shared"
+      ? `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].shared}; messages are handled as one shared conversation.`
+      : `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].per_user}; each person now talks to the bot separately.`,
+};
+
+const MODE_UNBOUND_NOTICE_BY_LOCALE: Record<LarkLocale, string> = {
+  "zh-CN": "❌ 本群还没绑定助手,无法设置上下文模式。请先用 PAIR 绑定。",
+  "en-US": "❌ This group isn't bound to an assistant yet, so there's no context mode to set. Pair it first.",
+};
+
+// Shared groups use one group-level session, so a single member's /new would
+// wipe everyone's context — disallowed. A confirmed "reset the whole room" is a
+// future, confirmation-gated action; for now, point the user at their options.
+const SHARED_NEW_REJECTED_NOTICE_BY_LOCALE: Record<LarkLocale, string> = {
+  "zh-CN": "团队模式(全群共享上下文)不支持单人重置——一个人 /new 会清空整群的上下文。如需独立对话,请用 /mode 切换为个人模式,或另建一个群。",
+  "en-US": "Team mode (shared group context) doesn't support a per-person /new — one reset would wipe the whole group's context. For a private thread, switch to Personal mode with /mode, or start a separate group.",
+};
+
 const FEEDBACK_TOAST_BY_LOCALE: Record<LarkLocale, { ok: string; fail: string }> = {
   "zh-CN": { ok: "已收到你的反馈，谢谢！", fail: "反馈记录失败，请稍后再试。" },
   "en-US": { ok: "Feedback recorded — thanks!", fail: "Could not record feedback. Please try again." },
@@ -390,29 +435,39 @@ const FEEDBACK_TOAST_BY_LOCALE: Record<LarkLocale, { ok: string; fail: string }>
 export function handleLarkCardAction(
   data: any,
   larkClient: any,
+  frontendClient?: FrontendWsClient,
 ): { toast: { type: string; content: string } } | undefined {
   // EventDispatcher flattens `event.*` onto the top level (same as messages).
   // Some Feishu/CardKit versions deliver `action.value` as a JSON string
-  // rather than a parsed object — accept both so feedback doesn't silently
+  // rather than a parsed object — accept both so a click doesn't silently
   // no-op on those clients.
   const rawValue = data?.action?.value;
-  let value: Partial<FeedbackActionValue> | undefined;
+  let value: { kind?: string; [k: string]: unknown } | undefined;
   if (typeof rawValue === "string") {
     try { value = JSON.parse(rawValue); } catch { value = undefined; }
   } else {
-    value = rawValue as Partial<FeedbackActionValue> | undefined;
+    value = rawValue as { kind?: string } | undefined;
   }
-  if (!value || value.kind !== FEEDBACK_ACTION_KIND) return undefined;
+  if (!value) return undefined;
 
-  const locale: LarkLocale = value.locale === "en-US" ? "en-US" : "zh-CN";
+  // Context-mode switch buttons take the same self-contained-value + optimistic
+  // toast + detached side-effect shape as feedback (200671 discipline).
+  if (value.kind === MODE_ACTION_KIND) {
+    return handleModeSwitchAction(value as Partial<ModeActionValue>, data, larkClient, frontendClient);
+  }
+
+  if (value.kind !== FEEDBACK_ACTION_KIND) return undefined;
+  const fb = value as Partial<FeedbackActionValue>;
+
+  const locale: LarkLocale = fb.locale === "en-US" ? "en-US" : "zh-CN";
   const toasts = FEEDBACK_TOAST_BY_LOCALE[locale];
-  const rating = value.rating === "up" || value.rating === "down" ? value.rating : null;
+  const rating = fb.rating === "up" || fb.rating === "down" ? fb.rating : null;
   const operatorOpenId: string | undefined = data?.operator?.open_id;
-  if (!rating || !value.session_id || !value.card_id || !operatorOpenId) {
-    console.warn(`[lark] Dropping malformed feedback action card=${value.card_id ?? "?"} rating=${value.rating ?? "?"} operator=${operatorOpenId ?? "?"}`);
+  if (!rating || !fb.session_id || !fb.card_id || !operatorOpenId) {
+    console.warn(`[lark] Dropping malformed feedback action card=${fb.card_id ?? "?"} rating=${fb.rating ?? "?"} operator=${operatorOpenId ?? "?"}`);
     return { toast: { type: "error", content: toasts.fail } };
   }
-  const { session_id: sessionId, card_id: cardId, channel_id: channelId } = value;
+  const { session_id: sessionId, card_id: cardId, channel_id: channelId } = fb;
 
   // Detached: persist the vote, then echo the button highlight. Neither is on
   // the callback-response critical path (see the 3s-budget note above).
@@ -432,13 +487,68 @@ export function handleLarkCardAction(
       }
       console.log(`[lark] Feedback recorded card=${cardId} session=${sessionId} rating=${rating} sender=${operatorOpenId}`);
       // Cosmetic: highlight the chosen button. Never rejects (best-effort boolean).
-      void applyFeedbackSelection(larkClient, value as FeedbackActionValue, rating);
+      void applyFeedbackSelection(larkClient, fb as FeedbackActionValue, rating);
     } catch (err) {
       console.error(`[lark] Feedback persist failed card=${cardId}:`, err);
     }
   })();
 
   return { toast: { type: "success", content: toasts.ok } };
+}
+
+/**
+ * Handle a context-mode switch button. Responds with an optimistic toast and
+ * runs persistence + the group announcement fully detached (Feishu's ~3s
+ * callback budget — same reasoning as feedback). Any group member may switch;
+ * the visible announcement is the social control (design decision), and it also
+ * tells everyone the conversation just reset.
+ */
+function handleModeSwitchAction(
+  value: Partial<ModeActionValue>,
+  data: any,
+  larkClient: any,
+  frontendClient?: FrontendWsClient,
+): { toast: { type: string; content: string } } {
+  const locale: LarkLocale = value.locale === "en-US" ? "en-US" : "zh-CN";
+  const toasts = MODE_TOAST_BY_LOCALE[locale];
+  const mode: GroupContextMode | null =
+    value.mode === "shared" ? "shared" : value.mode === "per_user" ? "per_user" : null;
+  if (!mode || !value.channel_id || !value.route_key) {
+    console.warn(`[lark] Dropping malformed mode action channel=${value.channel_id ?? "?"} mode=${value.mode ?? "?"}`);
+    return { toast: { type: "error", content: toasts.fail } };
+  }
+  const channelId = value.channel_id;
+  const routeKey = value.route_key;
+
+  // Optimistically flip the runtime's own view now: drop the old buffer + cache
+  // and record the new mode, so THIS runtime stops/starts retaining chatter
+  // immediately (no wait on the persist round-trip).
+  forgetGroupState(channelId, routeKey);
+  rememberGroupMode(channelId, routeKey, mode);
+
+  void (async () => {
+    try {
+      const result = await setChannelContextMode(channelId, routeKey, mode, frontendClient);
+      if (!result?.success) {
+        console.warn(`[lark] Mode switch persist rejected chat=${routeKey}: ${result?.error ?? "unknown"}`);
+        return;
+      }
+      console.log(`[lark] Context mode set chat=${routeKey} mode=${mode}`);
+      // Announce in the group — audit trail + everyone learns the reset.
+      await larkClient.im.message.create({
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: routeKey,
+          msg_type: "text",
+          content: JSON.stringify({ text: MODE_ANNOUNCE_BY_LOCALE[locale](mode) }),
+        },
+      });
+    } catch (err) {
+      console.error(`[lark] Mode switch failed chat=${routeKey}:`, err);
+    }
+  })();
+
+  return { toast: { type: "success", content: toasts.ok(mode) } };
 }
 
 /**
@@ -545,18 +655,146 @@ function firstLocalePost(raw: any): any {
   return undefined;
 }
 
-export function buildChannelTurnPrompt(text: string): string {
-  return [
+// ── Group context mode (shared vs per_user) ──────────────────────
+//
+// The server (portal adapter) owns the shared-vs-isolated decision and encodes
+// it in the session key it returns; the runtime only needs the mode to decide
+// whether to RETAIN non-@ chatter. Two pieces of runtime-local state support
+// that, both keyed by `${channelId}:${chatId}` and both intentionally
+// process-memory only (a channel app holds one long connection from one
+// runtime, so there is no cross-process buffer to reconcile; a restart drops
+// un-drained chatter — a bounded, documented loss).
+
+// Cache of each group's mode, populated on every @-turn's resolveBinding so the
+// non-@ ingestion gate costs no RPC. Short TTL; an in-group /mode switch busts
+// the entry immediately.
+const GROUP_MODE_TTL_MS = 60_000;
+const groupModeCache = new Map<string, { mode: GroupContextMode; at: number }>();
+
+// Discussion buffer for shared groups: non-@ chatter accumulated per group and
+// drained into the next @-turn's prompt. Bounded by count AND chars so a busy
+// group can't blow up memory or the prompt; `truncated` records that older
+// lines were dropped so the agent can be told the transcript is partial.
+const DISCUSSION_BUFFER_MAX_MSGS = 100;
+const DISCUSSION_BUFFER_MAX_CHARS = 8000;
+interface DiscussionLine { sender: string; text: string; }
+const discussionBuffers = new Map<string, { lines: DiscussionLine[]; truncated: boolean }>();
+
+// Both maps are keyed by group and bounded per entry (mode = one small record;
+// buffer = the MAX_MSGS/MAX_CHARS caps). This bounds the NUMBER of groups too,
+// so a bot in very many groups can't grow either map without limit — evicting
+// the oldest (insertion-ordered) entry, same shape as the feedback echo cache.
+const GROUP_STATE_MAX = 2000;
+
+function evictOldestIfFull<K, V>(map: Map<K, V>, cap: number, incomingKey: K): void {
+  if (map.has(incomingKey) || map.size < cap) return;
+  const oldest = map.keys().next().value;
+  if (oldest !== undefined) map.delete(oldest);
+}
+
+function groupStateKey(channelId: string, chatId: string): string {
+  return `${channelId}:${chatId}`;
+}
+
+function rememberGroupMode(channelId: string, chatId: string, mode: GroupContextMode): void {
+  const key = groupStateKey(channelId, chatId);
+  evictOldestIfFull(groupModeCache, GROUP_STATE_MAX, key);
+  groupModeCache.set(key, { mode, at: Date.now() });
+}
+
+/** Fresh cached mode, or undefined on miss/expiry. Never guesses — an unknown
+ *  group is treated as "not confirmed shared", so its chatter is NOT retained. */
+function cachedGroupMode(channelId: string, chatId: string): GroupContextMode | undefined {
+  const key = groupStateKey(channelId, chatId);
+  const entry = groupModeCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.at > GROUP_MODE_TTL_MS) {
+    groupModeCache.delete(key);
+    return undefined;
+  }
+  return entry.mode;
+}
+
+/** Drop cached mode + any buffered chatter for a group (used on a /mode switch). */
+function forgetGroupState(channelId: string, chatId: string): void {
+  const key = groupStateKey(channelId, chatId);
+  groupModeCache.delete(key);
+  discussionBuffers.delete(key);
+}
+
+function appendDiscussion(channelId: string, chatId: string, sender: string, text: string): void {
+  const key = groupStateKey(channelId, chatId);
+  evictOldestIfFull(discussionBuffers, GROUP_STATE_MAX, key);
+  const buf = discussionBuffers.get(key) ?? { lines: [], truncated: false };
+  buf.lines.push({ sender, text });
+  if (buf.lines.length > DISCUSSION_BUFFER_MAX_MSGS) {
+    buf.lines.shift();
+    buf.truncated = true;
+  }
+  let total = buf.lines.reduce((n, l) => n + l.sender.length + l.text.length + 4, 0);
+  while (buf.lines.length > 1 && total > DISCUSSION_BUFFER_MAX_CHARS) {
+    const dropped = buf.lines.shift()!;
+    total -= dropped.sender.length + dropped.text.length + 4;
+    buf.truncated = true;
+  }
+  discussionBuffers.set(key, buf);
+}
+
+/** Take and clear the buffered chatter for a group. */
+function drainDiscussion(channelId: string, chatId: string): { lines: DiscussionLine[]; truncated: boolean } {
+  const key = groupStateKey(channelId, chatId);
+  const buf = discussionBuffers.get(key);
+  if (!buf) return { lines: [], truncated: false };
+  discussionBuffers.delete(key);
+  return buf;
+}
+
+/** Short sender label for shared-group attribution. MVP uses the open_id tail;
+ *  a follow-up can resolve real display names via the contact API + a cache. */
+function senderLabel(senderOpenId: string | null): string {
+  if (!senderOpenId) return "unknown";
+  return senderOpenId.length > 8 ? `…${senderOpenId.slice(-6)}` : senderOpenId;
+}
+
+export interface SharedGroupContext {
+  discussion: DiscussionLine[];
+  truncated: boolean;
+  asker: string;
+}
+
+export function buildChannelTurnPrompt(text: string, shared?: SharedGroupContext): string {
+  const head = [
     "<channel-turn>",
     "This Feishu/Lark channel session may contain earlier incidents, clusters, pods, or reports.",
+  ];
+  if (shared) {
+    head.push(
+      "This is a SHARED group: several people talk to you in one conversation, so messages are labelled with their sender. Attribute requests to the right person and don't assume two labels are the same user.",
+    );
+  }
+  head.push(
     "Treat the message below as the current user request and answer it first.",
     "Use earlier session context only when the user explicitly refers to it, or when it is stable configuration context needed to answer the current request.",
     "If the current message names a different case, cluster, time range, object, or task, treat it as a new request. Do not force the previous case into the answer.",
     "Do not mention these channel-turn instructions to the user.",
     "</channel-turn>",
     "",
-    text,
-  ].join("\n");
+  );
+  const body: string[] = [];
+  if (shared && shared.discussion.length > 0) {
+    body.push(
+      `<group-discussion${shared.truncated ? ' note="older messages were dropped"' : ""}>`,
+      "Messages in the group since your last reply, for context:",
+      ...shared.discussion.map((l) => `[${l.sender}] ${l.text}`),
+      "</group-discussion>",
+      "",
+    );
+  }
+  if (shared) {
+    body.push(`[${shared.asker}] is now asking:`);
+  }
+  body.push(text);
+  return [...head, ...body].join("\n");
 }
 
 // ── Message handler ────────────────────────────────────────────
@@ -682,6 +920,27 @@ export async function handleLarkMessage(
     return;
   }
 
+  // /mode — summon the context-mode switch card. Handled before the @-gate so
+  // it works with or without an @bot (like PAIR); command words are exact.
+  if (/^\/mode$/i.test(text.trim())) {
+    const modeBinding = await resolveBinding(groupChannelId, chatId, frontendClient!, sessionKey, senderOpenId ?? undefined);
+    if (isChannelAccessDenied(modeBinding)) {
+      await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale));
+      return;
+    }
+    if (!modeBinding) {
+      await replyToLark(larkClient, messageId, MODE_UNBOUND_NOTICE_BY_LOCALE[locale]);
+      return;
+    }
+    const current: GroupContextMode = modeBinding.contextMode === "shared" ? "shared" : "per_user";
+    rememberGroupMode(groupChannelId, chatId, current);
+    const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale);
+    if (!sent) {
+      await replyToLark(larkClient, messageId, `${MODE_LABEL_BY_LOCALE[locale][current]}`);
+    }
+    return;
+  }
+
   // Only respond when THIS bot is individually @-mentioned. Feishu also
   // delivers "@所有人" to an @bot-scoped app (it mentions everyone, the bot
   // included), so an @所有人 announcement arrives looking just like a real
@@ -690,7 +949,19 @@ export async function handleLarkMessage(
   // exempt (explicit command). Gated on chat_type==="group" so the binding/
   // access checks below stay reachable only for messages aimed at the bot.
   if (chatType === "group" && !isBotMentioned(message, botOpenId)) {
-    console.log(`[lark] Group message not directed at bot (chat=${chatId}) — ignoring (@所有人 / @others / no @bot)`);
+    // Non-@ group message. In a group KNOWN to be shared, retain it as passive
+    // discussion context for the next @-turn — WITHOUT running the agent or
+    // touching the AgentBox (idle pods must not be woken by group chatter).
+    // In a per_user group, or one whose mode we haven't confirmed shared,
+    // drop it immediately: privacy discipline — only a confirmed-shared group
+    // may retain chatter (the receive-all-messages scope is app-level, so the
+    // bot sees chatter from groups it must not buffer).
+    if (text.length > 0 && cachedGroupMode(groupChannelId, chatId) === "shared") {
+      appendDiscussion(groupChannelId, chatId, senderLabel(senderOpenId), text);
+      console.log(`[lark] Buffered non-@ discussion for shared group chat=${chatId}`);
+    } else {
+      console.log(`[lark] Group message not directed at bot (chat=${chatId}) — ignoring (@所有人 / @others / no @bot)`);
+    }
     return;
   }
 
@@ -720,6 +991,18 @@ export async function handleLarkMessage(
   //   - authorized group → sicore_user:<id> (per-user)
   //   - legacy single binding session → "" (binding-level queue + /new reset)
   // /new then resets the right session, and same-session senders serialize.
+  // Cache the group's mode so the non-@ ingestion gate can decide whether to
+  // retain chatter without an RPC per message. Only an explicit "shared" is
+  // shared; an absent field (e.g. an older portal) is treated as per_user so we
+  // never buffer chatter for a group we can't confirm is shared (privacy-safe).
+  const contextMode: GroupContextMode = binding.contextMode === "shared" ? "shared" : "per_user";
+  // If the mode changed out of band (a console switch, or another actor) since
+  // we last cached it, drop any buffered chatter — it belonged to the previous
+  // mode and must not resurface (e.g. after a per_user detour back to shared).
+  const cachedMode = cachedGroupMode(groupChannelId, chatId);
+  if (cachedMode && cachedMode !== contextMode) forgetGroupState(groupChannelId, chatId);
+  rememberGroupMode(groupChannelId, chatId, contextMode);
+
   const effectiveSessionKey = binding.sessionKey ?? "";
   const queueKey = `${binding.bindingId}:${binding.sessionKey ?? "__binding__"}`;
   const queued = enqueueBindingTask(queueKey, () => processQueuedLarkMessage({
@@ -731,6 +1014,7 @@ export async function handleLarkMessage(
     sessionKey: effectiveSessionKey,
     channelId: groupChannelId,
     route: "group",
+    contextMode,
     larkClient,
     agentBoxManager,
     tlsOptions,
@@ -753,6 +1037,9 @@ interface QueuedLarkMessageContext {
   sessionKey: string;
   channelId: string;
   route: "group" | "personal";
+  /** Group route only: "shared" drains the discussion buffer into the prompt
+   *  and attributes the asker; absent/"per_user" behaves as an isolated chat. */
+  contextMode?: GroupContextMode;
   larkClient: any;
   agentBoxManager: AgentBoxManager;
   tlsOptions?: { cert: string; key: string; ca: string };
@@ -770,6 +1057,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     sessionKey,
     channelId,
     route,
+    contextMode,
     larkClient,
     agentBoxManager,
     tlsOptions,
@@ -778,6 +1066,14 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   } = ctx;
 
   if (/^\/new$/i.test(text)) {
+    // A shared group has ONE group-level session, so a single member's /new
+    // would clear everyone's context — reject it instead of resetting. (A
+    // confirmation-gated "reset the whole room" is deferred.) per_user groups
+    // and personal chats reset the caller's own session as before.
+    if (contextMode === "shared") {
+      await replyToLark(larkClient, messageId, SHARED_NEW_REJECTED_NOTICE_BY_LOCALE[locale]);
+      return;
+    }
     await handleNewCommand(route, channelId, chatId, sessionKey, messageId, larkClient, agentBoxManager, tlsOptions, frontendClient, locale);
     return;
   }
@@ -939,8 +1235,14 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const promptText = !visionCapable && imageRefs.length > 0
     ? `${effectiveText}\n[Note: the user attached ${imageRefs.length} image(s), but the current model cannot read images.]`
     : effectiveText;
+  // Shared group: drain the chatter buffered since the last reply and attribute
+  // the asker, so the agent answers @-turns with the whole group's context.
+  const drained = contextMode === "shared" ? drainDiscussion(channelId, chatId) : undefined;
+  const sharedContext: SharedGroupContext | undefined = drained
+    ? { discussion: drained.lines, truncated: drained.truncated, asker: senderLabel(senderOpenId) }
+    : undefined;
   const promptOpts: PromptOptions = {
-    text: buildChannelTurnPrompt(promptText),
+    text: buildChannelTurnPrompt(promptText, sharedContext),
     agentId,
     mode: "channel",
     sessionId,

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1531,20 +1531,20 @@ describe("channel.list", () => {
 });
 
 describe("channel.resolveBinding", () => {
-  it("returns binding when found", async () => {
-    mockQuery([{ id: "b1", agent_id: "a1", session_id: "s1", route_type: "group", created_by: "u1" }]);
+  it("per_user binding with no session_key returns the legacy binding session", async () => {
+    mockQuery([{ id: "b1", agent_id: "a1", session_id: "s1", route_type: "group", context_mode: "per_user", created_by: "u1" }]);
 
     const result = await getHandler("channel.resolveBinding")(
       { channel_id: "ch1", route_key: "group-123" }, "a1",
     );
-    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s1", createdBy: "u1", routeType: "group", displayName: null });
+    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s1", createdBy: "u1", routeType: "group", displayName: null, contextMode: "per_user" });
   });
 
-  it("lazily creates a session for legacy bindings", async () => {
+  it("lazily creates a session for legacy per_user bindings", async () => {
     const query = mockQuery(
-      [{ id: "b1", agent_id: "a1", session_id: null, route_type: "group", created_by: "u1" }],
+      [{ id: "b1", agent_id: "a1", session_id: null, route_type: "group", context_mode: "per_user", created_by: "u1" }],
       [],
-      [{ id: "b1", agent_id: "a1", session_id: "s-new", route_type: "group", created_by: "u1" }],
+      [{ id: "b1", agent_id: "a1", session_id: "s-new", route_type: "group", context_mode: "per_user", created_by: "u1" }],
     );
 
     const result = await getHandler("channel.resolveBinding")(
@@ -1552,12 +1552,12 @@ describe("channel.resolveBinding", () => {
     );
 
     expect(query.mock.calls[1][0]).toContain("UPDATE channel_bindings SET session_id");
-    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s-new", createdBy: "u1", routeType: "group", displayName: null });
+    expect(result.binding).toEqual({ agentId: "a1", bindingId: "b1", sessionId: "s-new", createdBy: "u1", routeType: "group", displayName: null, contextMode: "per_user" });
   });
 
-  it("lazily creates a participant session when session_key is provided", async () => {
+  it("per_user: creates a participant session keyed by the passed per-sender key", async () => {
     const query = mockQuery(
-      [{ id: "b1", agent_id: "a1", session_id: "shared-session", route_type: "group", created_by: "u1" }],
+      [{ id: "b1", agent_id: "a1", session_id: "shared-session", route_type: "group", context_mode: "per_user", created_by: "u1" }],
       [],
       [],
       [{ session_id: "sender-session" }],
@@ -1583,6 +1583,69 @@ describe("channel.resolveBinding", () => {
       createdBy: "u1",
       routeType: "group",
       displayName: null,
+      contextMode: "per_user",
+    });
+  });
+
+  it("explicit shared overrides the passed key with a per-chat session", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy-ignored", route_type: "group", context_mode: "shared", created_by: "u1" }],
+      [],                            // participant lookup for chat:group-123 → none
+      [],                            // insert participant session
+      [{ session_id: "chat-session" }], // reload
+    );
+
+    // Runtime still passes its per-sender guess; shared mode must ignore it.
+    const result = await getHandler("channel.resolveBinding")(
+      { channel_id: "ch1", route_key: "group-123", session_key: "open_id:ou_1" }, "a1",
+    );
+
+    expect(query.mock.calls[2][1]).toEqual([
+      expect.any(String),
+      "b1",
+      "chat:group-123",
+      expect.any(String),
+    ]);
+    expect(result.binding).toEqual({
+      agentId: "a1",
+      bindingId: "b1",
+      sessionId: "chat-session",
+      sessionKey: "chat:group-123",
+      createdBy: "u1",
+      routeType: "group",
+      displayName: null,
+      contextMode: "shared",
+    });
+  });
+
+  it("NULL context_mode grandfathers to per_user (uses the passed per-sender key, not chat:)", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", created_by: "u1" }], // context_mode absent → NULL
+      [],
+      [],
+      [{ session_id: "sender-session" }],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      { channel_id: "ch1", route_key: "group-123", session_key: "open_id:ou_1" }, "a1",
+    );
+
+    // Grandfathered: the passed per-sender key is used, NOT chat:group-123.
+    expect(query.mock.calls[2][1]).toEqual([
+      expect.any(String),
+      "b1",
+      "open_id:ou_1",
+      expect.any(String),
+    ]);
+    expect(result.binding).toEqual({
+      agentId: "a1",
+      bindingId: "b1",
+      sessionId: "sender-session",
+      sessionKey: "open_id:ou_1",
+      createdBy: "u1",
+      routeType: "group",
+      displayName: null,
+      contextMode: "per_user",
     });
   });
 
@@ -1629,6 +1692,7 @@ describe("channel.resolveBinding", () => {
       sessionKey: "chat:group-123",
       createdBy: "owner-1",
       routeType: "group",
+      contextMode: "shared",
     });
   });
 
@@ -1672,6 +1736,7 @@ describe("channel.pair", () => {
       "group",
       null,
       "u1",
+      "shared",
     ]);
     expect(query.mock.calls[4][0]).toContain("DELETE FROM channel_binding_sessions");
   });
@@ -1772,6 +1837,39 @@ describe("channel.updateBindingMeta", () => {
     );
     expect(result.success).toBe(false);
     expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe("channel.setContextMode", () => {
+  it("updates the binding's context_mode", async () => {
+    const query = mockQuery({ affectedRows: 1 } as any);
+
+    const result = await getHandler("channel.setContextMode")(
+      { channel_id: "ch1", route_key: "group-1", mode: "per_user" }, "a1",
+    );
+    expect(result).toEqual({ success: true, mode: "per_user" });
+    expect(query.mock.calls[0][0]).toContain("UPDATE channel_bindings SET context_mode");
+    expect(query.mock.calls[0][1]).toEqual(["per_user", "ch1", "group-1"]);
+  });
+
+  it("rejects an unknown mode without touching the DB", async () => {
+    const query = mockQuery();
+
+    const result = await getHandler("channel.setContextMode")(
+      { channel_id: "ch1", route_key: "group-1", mode: "bogus" }, "a1",
+    );
+    expect(result.success).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the binding is missing", async () => {
+    mockQuery({ affectedRows: 0 } as any);
+
+    const result = await getHandler("channel.setContextMode")(
+      { channel_id: "ch1", route_key: "group-404", mode: "shared" }, "a1",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
   });
 
   it("truncates at 255 code points without splitting surrogate pairs", async () => {
@@ -2011,9 +2109,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 52 handlers", () => {
+  it("registers exactly 53 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(52);
+    expect(handlers.size).toBe(53);
   });
 
   it("all expected handler names are registered", () => {
@@ -2029,7 +2127,7 @@ describe("buildAdapterRpcHandlers", () => {
       "task.update", "task.delete", "task.runRecord", "task.runStart",
       "task.runFinalize", "task.updateMeta", "task.fireNow", "task.notify", "task.prune",
       "channel.list", "channel.resolveBinding", "channel.pair", "channel.resetSession",
-      "channel.updateBindingMeta", "channel.updateName",
+      "channel.updateBindingMeta", "channel.updateName", "channel.setContextMode",
       "channel.resolvePersonalBinding", "channel.pairPersonal", "channel.resetPersonalSession",
       "agent.listForSkill", "agent.listForMcp", "agent.listForCluster", "agent.listForHost",
       "metrics.summary", "metrics.audit", "metrics.auditDetail",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -39,8 +39,22 @@ interface ChannelBindingRow {
   session_id?: string | null;
   route_type?: "group" | "user" | string | null;
   display_name?: string | null;
+  context_mode?: string | null;
   created_by?: string | null;
   channel_created_by?: string | null;
+}
+
+type ContextMode = "shared" | "per_user";
+
+/**
+ * Only an explicit "shared" is shared; NULL / anything unrecognised
+ * grandfathers to "per_user". Existing group bindings pre-date this column and
+ * behaved per-sender, so a NULL must NOT silently merge their contexts on
+ * upgrade. New bindings are written "shared" at pair time (the product default
+ * for a fresh group), so the NULL branch only ever hits legacy rows.
+ */
+function normalizeContextMode(value: unknown): ContextMode {
+  return value === "shared" ? "shared" : "per_user";
 }
 
 interface ResolvedChannelBinding {
@@ -52,6 +66,9 @@ interface ResolvedChannelBinding {
   routeType: "group" | "user";
   /** Cached chat title (group name); null until the gateway backfills it. */
   displayName?: string | null;
+  /** Group context sharing mode (shared default). Set for group bindings; absent
+   *  for 1:1/personal bindings where the mode is meaningless. */
+  contextMode?: ContextMode;
 }
 
 function normalizeRouteType(value: unknown): "group" | "user" {
@@ -64,7 +81,7 @@ async function selectChannelBinding(
   routeKey: string,
 ): Promise<ChannelBindingRow | null> {
   const [rows] = await db.query(
-    `SELECT cb.id, cb.agent_id, cb.session_id, cb.route_type, cb.display_name, cb.created_by,
+    `SELECT cb.id, cb.agent_id, cb.session_id, cb.route_type, cb.display_name, cb.context_mode, cb.created_by,
             c.created_by AS channel_created_by
      FROM channel_bindings cb
      LEFT JOIN channels c ON cb.channel_id = c.id
@@ -87,9 +104,23 @@ async function resolveChannelBinding(
     return resolveOpenGroupBinding(db, channelId, routeKey);
   }
 
-  const session = sessionKey
-    ? await resolveChannelBindingParticipantSession(db, row.id, sessionKey)
-    : await resolveLegacyChannelBindingSession(db, row, channelId, routeKey);
+  const routeType = normalizeRouteType(row.route_type);
+  const contextMode = normalizeContextMode(row.context_mode);
+
+  // Group context mode selects the session-key formula (the runtime uses the
+  // returned key verbatim for both session identity and its serialization
+  // queue, so this one choice drives shared-vs-isolated end to end):
+  //   shared   → chat:{route_key}  — the whole group shares one session,
+  //              overriding whatever per-sender key the runtime guessed.
+  //   per_user → the per-sender key the runtime passed (open_id:{sender}).
+  // Non-group (1:1 user) routes ignore the mode — they are single-user by
+  // nature — and keep the legacy passed-key-or-binding-session behavior.
+  const session =
+    routeType === "group" && contextMode === "shared"
+      ? await resolveChannelBindingParticipantSession(db, row.id, `chat:${routeKey}`)
+      : sessionKey
+        ? await resolveChannelBindingParticipantSession(db, row.id, sessionKey)
+        : await resolveLegacyChannelBindingSession(db, row, channelId, routeKey);
 
   return {
     agentId: row.agent_id,
@@ -97,8 +128,9 @@ async function resolveChannelBinding(
     sessionId: session.sessionId,
     ...(session.sessionKey ? { sessionKey: session.sessionKey } : {}),
     createdBy: row.created_by ?? row.channel_created_by ?? null,
-    routeType: normalizeRouteType(row.route_type),
+    routeType,
     displayName: row.display_name ?? null,
+    contextMode,
   };
 }
 
@@ -199,11 +231,13 @@ async function pairChannelBinding(
     const upsert = buildUpsert(
       db,
       "channel_bindings",
-      ["id", "channel_id", "agent_id", "session_id", "route_key", "route_type", "display_name", "created_by"],
-      [bindingId, params.channel_id, pairingCode.agent_id, sessionId, params.route_key, params.route_type, displayName, pairingCode.created_by],
+      ["id", "channel_id", "agent_id", "session_id", "route_key", "route_type", "display_name", "created_by", "context_mode"],
+      [bindingId, params.channel_id, pairingCode.agent_id, sessionId, params.route_key, params.route_type, displayName, pairingCode.created_by, "shared"],
       ["channel_id", "route_key"],
       // Keep an existing name when a re-pair couldn't fetch one (null) — the
-      // gateway's lazy backfill owns refreshes, PAIR only seeds.
+      // gateway's lazy backfill owns refreshes, PAIR only seeds. context_mode is
+      // seeded on INSERT ("shared" = new-group default) but NOT overwritten on a
+      // re-pair, so a group that was switched to per_user keeps its choice.
       displayName
         ? ["agent_id", "session_id", "route_type", "display_name", "created_by"]
         : ["agent_id", "session_id", "route_type", "created_by"],
@@ -356,6 +390,29 @@ async function updateChannelName(
   return { success: !!result };
 }
 
+/**
+ * Set a group's context sharing mode. The generic switch endpoint behind both
+ * the console selector and the in-group /mode card. Rejects anything but the
+ * two known modes so a bad client can't write a value that NULL-defaults to
+ * shared silently.
+ */
+async function updateChannelBindingContextMode(
+  db: Db,
+  channelId: string,
+  routeKey: string,
+  mode: unknown,
+): Promise<{ success: boolean; mode?: ContextMode; error?: string }> {
+  if (mode !== "shared" && mode !== "per_user") {
+    return { success: false, error: "mode must be 'shared' or 'per_user'" };
+  }
+  const [result] = await db.query(
+    "UPDATE channel_bindings SET context_mode = ? WHERE channel_id = ? AND route_key = ?",
+    [mode, channelId, routeKey],
+  ) as any;
+  if (!result?.affectedRows) return { success: false, error: "Binding not found" };
+  return { success: true, mode };
+}
+
 interface PersonalChannelConfig {
   personal_bot?: {
     agent_id?: string;
@@ -414,7 +471,7 @@ async function resolvePersonalChannelBinding(
  * this, an open bot's groups only ever get a channel_binding_sessions row and
  * are invisible in the Portal. Idempotent on the (channel_id, route_key) unique
  * key; a concurrent first-message loses the INSERT race and re-selects the
- * winner's row. Returns the binding row id. Mirrors sicore's ensureAutoGroupBinding.
+ * winner's row. Returns the binding row id.
  */
 async function ensureOpenGroupBindingRow(
   db: Db,
@@ -424,8 +481,12 @@ async function ensureOpenGroupBindingRow(
   createdBy: string | null,
 ): Promise<string> {
   const id = crypto.randomUUID();
+  // context_mode = 'shared': an open bot's group is a fresh group → the product
+  // default (team mode), matching open bots' historical shared behavior. Written
+  // on INSERT so subsequent messages (which resolve via selectChannelBinding, not
+  // this path) see 'shared' rather than the NULL→per_user grandfather default.
   await db.query(
-    `${insertIgnorePrefix(db)} INTO channel_bindings (id, channel_id, agent_id, route_key, route_type, created_by) VALUES (?, ?, ?, ?, 'group', ?)`,
+    `${insertIgnorePrefix(db)} INTO channel_bindings (id, channel_id, agent_id, route_key, route_type, created_by, context_mode) VALUES (?, ?, ?, ?, 'group', ?, 'shared')`,
     [id, channelId, agentId, routeKey, createdBy],
   );
   const row = await selectChannelBinding(db, channelId, routeKey);
@@ -465,6 +526,10 @@ async function resolveOpenGroupBinding(
     sessionKey: session.sessionKey,
     createdBy,
     routeType: "group",
+    // The materialized row carries context_mode='shared' (see
+    // ensureOpenGroupBindingRow); report it here too so the first message —
+    // before any subsequent selectChannelBinding lookup — is already shared.
+    contextMode: "shared",
   };
 }
 
@@ -1694,6 +1759,17 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     sendJson(res, 200, await updateChannelBindingMeta(db, body.channel_id, body.route_key, body.display_name));
   });
 
+  // POST /api/internal/siclaw/channel/set-context-mode
+  router.post("/api/internal/siclaw/channel/set-context-mode", async (req, res) => {
+    if (!requireInternalAuth(req, internalSecret)) {
+      sendJson(res, 401, { error: "Invalid internal token" });
+      return;
+    }
+    const body = await parseBody<{ channel_id: string; route_key: string; mode: string }>(req);
+    const db = getDb();
+    sendJson(res, 200, await updateChannelBindingContextMode(db, body.channel_id, body.route_key, body.mode));
+  });
+
   // POST /api/internal/siclaw/channel/reset-session
   router.post("/api/internal/siclaw/channel/reset-session", async (req, res) => {
     if (!requireInternalAuth(req, internalSecret)) {
@@ -2919,6 +2995,11 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
   handlers.set("channel.updateName", async (params) => {
     const db = getDb();
     return updateChannelName(db, params.channel_id, params.name);
+  });
+
+  handlers.set("channel.setContextMode", async (params) => {
+    const db = getDb();
+    return updateChannelBindingContextMode(db, params.channel_id, params.route_key, params.mode);
   });
 
   handlers.set("channel.resolvePersonalBinding", async (params) => {

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -429,6 +429,7 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     route_key VARCHAR(255) NOT NULL,
     route_type VARCHAR(20) NOT NULL DEFAULT 'group',
     display_name VARCHAR(255) DEFAULT NULL,
+    context_mode VARCHAR(20) DEFAULT NULL,
     created_by CHAR(36),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (channel_id, route_key)
@@ -620,6 +621,7 @@ export async function runPortalMigrations(): Promise<void> {
   // "by user" axis (actorUserColumn). Nullable; only set for channel sessions.
   await safeAlterTable(db, "chat_sessions", "sender_external_id", "VARCHAR(128) DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "channel_id", "CHAR(36) DEFAULT NULL");
+  await safeAlterTable(db, "channel_bindings", "context_mode", "VARCHAR(20) DEFAULT NULL");
   await safeAlterTable(db, "skill_versions", "labels", "TEXT DEFAULT NULL");
   await safeAlterTable(db, "skill_versions", "files", "MEDIUMTEXT DEFAULT NULL");
   await safeAlterTable(db, "chat_sessions", "parent_session_id", "CHAR(36) DEFAULT NULL");

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2670,6 +2670,36 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     sendJson(res, 200, { ok: true });
   });
 
+  // Set a group binding's context mode (shared|per_user) — admin any, user own.
+  // The runtime picks up the change on its mode cache's TTL (or the next @-turn
+  // resolve); the in-group /mode card is the low-latency path.
+  router.put(`${P}/agents/:id/channel-bindings/:bindingId/context-mode`, async (req, res, params) => {
+    const auth = requireAuth(req, config.jwtSecret);
+    if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
+
+    const body = await parseBody<{ mode?: string }>(req);
+    if (body.mode !== "shared" && body.mode !== "per_user") {
+      sendJson(res, 400, { error: "mode must be 'shared' or 'per_user'" });
+      return;
+    }
+
+    const db = getDb();
+    const isAdmin = auth.role === "admin";
+    const sql = isAdmin
+      ? "SELECT id FROM channel_bindings WHERE id = ? AND agent_id = ?"
+      : "SELECT id FROM channel_bindings WHERE id = ? AND agent_id = ? AND created_by = ?";
+    const params2 = isAdmin ? [params.bindingId, params.id] : [params.bindingId, params.id, auth.userId];
+
+    const [existing] = await db.query(sql, params2) as any;
+    if (existing.length === 0) {
+      sendJson(res, 404, { error: "Binding not found" });
+      return;
+    }
+
+    await db.query("UPDATE channel_bindings SET context_mode = ? WHERE id = ?", [body.mode, params.bindingId]);
+    sendJson(res, 200, { ok: true, mode: body.mode });
+  });
+
   // ================================================================
   // Personal bot (Agent sub-resource) — the agent's dedicated Feishu app.
   //


### PR DESCRIPTION
Lets a Feishu group run in one of two context modes, so one agent serves both kinds of room well:

- **shared (Team mode)** — the whole group shares one conversation and the agent follows the group's discussion (incident / support rooms).
- **per_user (Personal mode)** — each member gets an isolated conversation, concurrent and non-interfering (large / mixed groups).

The mechanism is a single server-side choice; the runtime stays agnostic.

## Server (portal adapter)
- `channel_bindings.context_mode` column (idempotent ADD, MySQL+SQLite).
- `resolveChannelBinding` picks the session-key formula from the mode for group routes: `shared` → `chat:{route_key}` (one group session + queue), `per_user` → the per-sender key the runtime passed. It returns `contextMode` on the binding so the runtime never infers the mode from the key shape.
- **Grandfathering (no regression on upgrade):** a NULL/legacy row resolves to `per_user` (existing groups were per-sender); a NEW group is written `"shared"` at pair/auto-bind time (do not read NULL as shared). Open-bot groups (materialized by the open-bot group fix) are stamped `"shared"` on INSERT too. No data backfill needed.
- New generic `channel.setContextMode` RPC; rejects unknown modes.

## Runtime (lark.ts)
- Per-group mode cache (short TTL, oldest-evicted) populated on each @-turn.
- Non-@ group messages: in a confirmed-shared group they are appended to a bounded per-group discussion buffer (count + char caps) and run NO agent turn (idle AgentBox pods are never woken by chatter); in per_user / unconfirmed groups they are dropped immediately (privacy discipline — the receive-all scope is app-level). A detected out-of-band mode change drops stale chatter.
- On an @-turn in a shared group, the buffer is drained, rendered as an attributed transcript, and prepended to the prompt with the asker attributed.
- `/mode` summons an interactive switch card (before the @-gate, like PAIR); its buttons reuse the feedback callback shape — optimistic toast + detached persist + a group announcement. Any member may switch; the announcement is the social control.
- `/new` in a shared group is rejected (one member can't wipe the group's shared context); per_user and personal chats reset as before.

## Portal UI
Per-group Team/Personal selector on the Active-groups list (admin any / user own); NULL renders as Personal to match the resolve default. Open-bot groups are first-class (listed + switchable) now that they materialize a binding row.

## Notes
- Attribution uses the sender open_id tail for now (contact-API display names are a follow-up).
- The runtime works against any portal that implements the channel RPC vocabulary; an external portal adapter (a different deployment) implements the same contract. Standalone design + the portal-adapter contract are in `docs/design/2026-07-11-lark-group-context-mode.md`.

## Test
- adapter (mode branch, grandfather, setContextMode), lark (buffer inject, shared prompt, /mode card + switch, /new reject), lark-card (mode card). Full suite green (4415 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)