### PR TITLE
fix(kbc): pin read-only consumer sessions to the read tool set

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2781,6 +2781,15 @@ async def _run_wrapper(run: CompileRun):
 # Default tool whitelist for a read-only kb-test session, used when the runtime
 # profile declares none. Read-only by construction: cannot mutate the snapshot.
 DEFAULT_TEST_ALLOWED_TOOLS = ["Read", "Glob", "Grep"]
+# Tools removed from a read-only consumer session's context entirely (not merely
+# left un-approved). Under bypassPermissions the allowed_tools split is moot, so
+# the read-only contract must be enforced by pinning `tools` to the read set and
+# denying the rest — the path hook only confines path-bearing tools, so Bash (a
+# shell that reads outside the snapshot) and WebFetch/WebSearch (breaking the
+# closed-book property the test score depends on) would otherwise slip through.
+READONLY_CONSUMER_DISALLOWED_TOOLS = [
+    "Bash", "Write", "Edit", "NotebookEdit", "Agent", "Task", "WebFetch", "WebSearch",
+]
 
 # Tool-input keys that name a filesystem path (Read.file_path, Glob/Grep.path).
 _TEST_PATH_KEYS = ("file_path", "path", "notebook_path")
@@ -2975,8 +2984,12 @@ async def test_session_driver(run: "TestRun"):
     opts = ClaudeAgentOptions(
         cwd=run.cwd,
         system_prompt={"type": "preset", "preset": "claude_code", "append": _prompt("test_role", run.locale)},
+        tools=list(DEFAULT_TEST_ALLOWED_TOOLS),    # read-only base set; removes Bash/Write/Web from context
         allowed_tools=run.allowed_tools or DEFAULT_TEST_ALLOWED_TOOLS,
+        disallowed_tools=list(READONLY_CONSUMER_DISALLOWED_TOOLS),  # belt-and-suspenders under bypass
         mcp_servers={},                            # no compile signal tools
+        strict_mcp_config=True,                    # ignore project/user/plugin MCP configs
+        skills=[],                                 # no skills for a read-only consumer
         permission_mode="bypassPermissions",       # the pod itself is the sandbox
         # C4: path confinement — absolute/../ reads must not escape the snapshot
         # to the live /work draft. Hook, not can_use_tool: hooks fire under bypass.

--- a/kbc/platform/pod/engine.py
+++ b/kbc/platform/pod/engine.py
@@ -150,8 +150,14 @@ class ClaudeEngine:
         opts = ClaudeAgentOptions(
             cwd=cwd,
             system_prompt={"type": "preset", "preset": "claude_code", "append": system_prompt},
+            tools=["Read", "Glob", "Grep"],       # read-only base set; removes Bash/Write/Web from context
             allowed_tools=["Read", "Glob", "Grep"],
+            disallowed_tools=[                     # belt-and-suspenders under bypass; keeps the PK closed-book
+                "Bash", "Write", "Edit", "NotebookEdit", "Agent", "Task", "WebFetch", "WebSearch",
+            ],
             mcp_servers={},
+            strict_mcp_config=True,                # ignore project/user/plugin MCP configs
+            skills=[],                             # no skills for a read-only reviewer
             permission_mode="bypassPermissions",  # pod 本身即 sandbox;守卫走 hook
             hooks={"PreToolUse": [HookMatcher(hooks=[_make_multiroot_guard(roots)])]},
             setting_sources=[],                   # 多租户隔离

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -632,6 +632,15 @@ async def test_test_session_driver_readonly():
             opts = _FakeSDKClient.last.options
             assert opts.allowed_tools == ["Read", "Glob", "Grep"], opts.allowed_tools
             assert "Write" not in opts.allowed_tools and "Bash" not in opts.allowed_tools
+            # Read-only contract enforced at the tool-availability layer, not just the
+            # path hook: Bash/Write/WebFetch removed from context so a wandering
+            # consumer cannot shell out of the snapshot or break the closed-book test.
+            assert opts.tools == ["Read", "Glob", "Grep"], opts.tools
+            assert opts.strict_mcp_config is True
+            assert opts.skills == [], opts.skills
+            assert set(opts.disallowed_tools) >= {
+                "Bash", "Write", "Edit", "WebFetch", "WebSearch",
+            }, opts.disallowed_tools
             assert opts.cwd == snap, opts.cwd
             assert opts.mcp_servers == {}, opts.mcp_servers
             # persona comes from the locale pack (TestRun without locale → en default)


### PR DESCRIPTION
Follow-up to #404 (which hardened the recommendation session). Applies the same tool-isolation to the two other **read-only** box sessions.

## Problem

The **test-session** driver (`compile_box.py test_session_driver`) and the **red/blue reviewer** (`engine.py`) run under `permission_mode="bypassPermissions"` with `tools` unset — so the full Claude Code preset (Bash, Write, Edit, WebFetch, WebSearch, …) is in the model context — and only `allowed_tools=["Read","Glob","Grep"]`. Under bypass, the allowed-vs-approved split is moot, so the read-only contract rested **entirely on the PreToolUse path hook**, which only confines *path-bearing* tools:

- `Bash` — a shell that can read outside the pinned snapshot; `_test_path_escape` never inspects shell commands. The test-session guard is `_make_test_path_guard` (no `deny_bash`), unlike the compile guard.
- `WebFetch` / `WebSearch` — no path key, so the hook passes them; a consumer could answer from the web instead of the KB, breaking the closed-book property the test **pass/fail signal (which gates publishing)** depends on.
- `Write` to an in-snapshot path — passes the path check, letting the consumer mutate its own immutable test evidence.

## Change

Mirror the recommendation-session hardening from #404 on both read-only sessions:

- `tools = ["Read","Glob","Grep"]` — removes everything else from context
- `disallowed_tools = [Bash, Write, Edit, NotebookEdit, Agent, Task, WebFetch, WebSearch]` — belt-and-suspenders under bypass
- `strict_mcp_config = True`, `skills = []`

**Compile is intentionally not touched** — it already denies Bash via `_make_compile_path_guard`, its output is provenance-gated (web-sourced claims fail selfcheck), and it legitimately needs `Write` + the MCP signal tools.

## Scope of value (honest)

This is **defense-in-depth + eval integrity**, not closing an active breach — the pod is already a single-tenant, ephemeral sandbox with a NetworkPolicy (Runtime-ingress-only) and stripped credentials. The concrete wins: keep the publish-gating test signal snapshot-confined and closed-book, and stop a wandering consumer from burning its turn budget on tools it should not use.

## Tests

- Extended `test_test_session_driver_readonly` to assert `tools` / `strict_mcp_config` / `skills` / `disallowed_tools` on the constructed opts.
- Full kbc suite green: `test_compile_box`, `test_redblue`, `test_selfcheck`, `test_office_ingest`, `test_mtls_auth`, `test_batching`, `test_incremental`, `test_mediaverify`. `py_compile` clean.
- Engine change is symmetric to the asserted test-session one and exercised (construction) by `test_redblue`; the redblue harness abstracts above `ClaudeAgentOptions`, so it carries no dedicated opts assertion.

Box-only; no runtime/web/sicore changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)