### PR TITLE
fix(gateway): make capability cancellation confirmed and race-safe

### DIFF
--- a/src/gateway/capability/contract.ts
+++ b/src/gateway/capability/contract.ts
@@ -163,6 +163,17 @@ export interface CapabilityCancelRequest {
   run_id: string;
 }
 
+export interface CapabilityCancelResponse {
+  ok: true;
+  run_id: string;
+  /**
+   * True only after the AgentBox termination request was accepted (or the box
+   * was already absent). Runtime lifecycle terminalization is initiated first;
+   * domain consumers must still fence their own writers before cancellation.
+   */
+  stop_confirmed: true;
+}
+
 // ---- Test session (read-only consumer probe over a pinned draft snapshot) ----
 
 export interface CapabilityTestStartRequest {

--- a/src/gateway/capability/run-manager.ts
+++ b/src/gateway/capability/run-manager.ts
@@ -219,7 +219,10 @@ export class CapabilityRunManager {
    * undefined when the store doesn't know the run or it already ended, so the
    * caller can refuse instead of spawning an unmanaged box.
    */
-  async adopt(runId: string): Promise<CapabilityRunRecord | undefined> {
+  async adopt(
+    runId: string,
+    opts: { notifyOnAdopt?: boolean } = {},
+  ): Promise<CapabilityRunRecord | undefined> {
     const existing = this.runs.get(runId);
     if (existing) return existing;
     try {
@@ -244,7 +247,10 @@ export class CapabilityRunManager {
       };
       this.runs.set(rec.runId, rec);
       console.log(`[capability] adopted run ${runId} from the consumer store (missed by boot recovery)`);
-      this.onAdopt?.(rec);
+      // Destructive control paths may adopt only to terminalize a run. They
+      // must not trigger relay reattachment, which could race cancellation and
+      // recreate execution for a run that is being stopped.
+      if (opts.notifyOnAdopt !== false) this.onAdopt?.(rec);
       return rec;
     } catch (err) {
       console.warn(`[capability] adopt(${runId}) failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/gateway/server-capability-cancel.test.ts
+++ b/src/gateway/server-capability-cancel.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const box = vi.hoisted(() => ({
+  posts: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("./chat-repo.js", () => ({
+  ensureChatSession: vi.fn(async () => {}),
+  appendMessage: vi.fn(async () => "msg-id"),
+  incrementMessageCount: vi.fn(async () => {}),
+}));
+vi.mock("./output-redactor.js", () => ({ buildRedactionConfigForModelConfig: vi.fn(() => ({})) }));
+vi.mock("./sse-consumer.js", () => ({
+  consumeAgentSse: vi.fn(async () => ({ resultText: "", taskReportText: "", errorMessage: "", eventCount: 0, durationMs: 0 })),
+}));
+vi.mock("./agentbox/client.js", () => ({
+  AgentBoxClient: class {
+    postJson = box.posts;
+    async getJson() { return {}; }
+    async *streamPath() { await new Promise(() => {}); }
+  },
+}));
+vi.mock("./capability/materialize.js", () => ({
+  materializeCapabilityInputs: vi.fn(async () => ({ locale: undefined, llm: undefined, settings: undefined })),
+}));
+
+const { startRuntime } = await import("./server.js");
+
+function fakeFrontendClient(options: {
+  rows?: Array<Record<string, unknown>>;
+  listActive?: boolean;
+} = {}) {
+  const rows = new Map(
+    (options.rows ?? []).map((row) => [String(row.id), { ...row }]),
+  );
+  const request = vi.fn(async (method: string, params: any) => {
+    if (method === "capability.persistRunState") {
+      rows.set(params.run_id, { id: params.run_id, ...params });
+      return { ok: true };
+    }
+    if (method === "capability.getRun") return rows.get(params.run_id) ?? null;
+    if (method === "capability.listActiveRuns") {
+      if (options.listActive === false) return { runs: [] };
+      return {
+        runs: [...rows.values()].filter((row) => row.status !== "done" && row.status !== "failed"),
+      };
+    }
+    return { ok: true };
+  });
+  return {
+    request,
+    rows,
+    onCommand: vi.fn(),
+    emitEvent: vi.fn(),
+    close: vi.fn(),
+  } as any;
+}
+
+function fakeAgentBoxManager(stop = vi.fn(async () => {})) {
+  return {
+    setCertManager: vi.fn(),
+    setSpawnEnvResolver: vi.fn(),
+    setPersistenceResolver: vi.fn(),
+    getAsync: vi.fn(async () => null),
+    getOrCreate: vi.fn(async (runId: string) => ({
+      boxId: `agentbox-${runId}`,
+      endpoint: "https://10.0.0.9:3000",
+      agentId: runId,
+    })),
+    stop,
+    list: vi.fn(() => []),
+    cleanup: vi.fn(async () => {}),
+  } as any;
+}
+
+let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
+
+beforeEach(() => {
+  box.posts.mockReset().mockResolvedValue({ ok: true });
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("capability.cancel", () => {
+  it("terminalizes the run before stopping its box and rejects later messages", async () => {
+    let releaseStop!: () => void;
+    let markStopStarted!: () => void;
+    const stopStarted = new Promise<void>((resolve) => { markStopStarted = resolve; });
+    const stopReleased = new Promise<void>((resolve) => { releaseStop = resolve; });
+    const stop = vi.fn(async () => {
+      markStopStarted();
+      await stopReleased;
+    });
+    const frontend = fakeFrontendClient();
+    const manager = fakeAgentBoxManager(stop);
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: manager,
+      frontendClient: frontend,
+      credentialService: {} as any,
+    });
+    const start = server.rpcMethods.get("capability.start")!;
+    const cancel = server.rpcMethods.get("capability.cancel")!;
+    const message = server.rpcMethods.get("capability.message")!;
+    const started = await start({ profile: "kb-compile" }) as { run_id: string };
+
+    const cancelling = cancel({ run_id: `  ${started.run_id}  ` });
+    await stopStarted;
+
+    const terminalPersistIndex = frontend.request.mock.calls.findIndex(
+      ([method, params]: any[]) => method === "capability.persistRunState" && params.status === "done",
+    );
+    expect(terminalPersistIndex).toBeGreaterThanOrEqual(0);
+    expect(frontend.request.mock.invocationCallOrder[terminalPersistIndex]).toBeLessThan(
+      stop.mock.invocationCallOrder[0]!,
+    );
+    await expect(message({ run_id: started.run_id, message: "compile again" })).rejects.toThrow(
+      `unknown capability run: ${started.run_id}`,
+    );
+
+    releaseStop();
+    await expect(cancelling).resolves.toEqual({
+      ok: true,
+      run_id: started.run_id,
+      stop_confirmed: true,
+    });
+    expect(stop).toHaveBeenCalledWith(started.run_id);
+  });
+
+  it("surfaces uncertain cleanup and lets an idempotent retry confirm the stop", async () => {
+    const stop = vi.fn()
+      .mockRejectedValueOnce(new Error("pod deletion timed out"))
+      .mockResolvedValueOnce(undefined);
+    const frontend = fakeFrontendClient();
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: fakeAgentBoxManager(stop),
+      frontendClient: frontend,
+      credentialService: {} as any,
+    });
+    const start = server.rpcMethods.get("capability.start")!;
+    const cancel = server.rpcMethods.get("capability.cancel")!;
+    const started = await start({ profile: "kb-compile" }) as { run_id: string };
+
+    await expect(cancel({ run_id: started.run_id })).rejects.toThrow("pod deletion timed out");
+    expect(frontend.rows.get(started.run_id)).toMatchObject({ status: "done" });
+    await expect(cancel({ run_id: started.run_id })).resolves.toMatchObject({
+      ok: true,
+      stop_confirmed: true,
+    });
+    expect(stop).toHaveBeenCalledTimes(2);
+    const terminalPersists = frontend.request.mock.calls.filter(
+      ([method, params]: any[]) => method === "capability.persistRunState" && params.status === "done",
+    );
+    expect(terminalPersists).toHaveLength(1);
+  });
+
+  it("terminalizes a store-only run without reattaching or respawning its box", async () => {
+    const frontend = fakeFrontendClient({
+      rows: [{ id: "run-after-restart", profile: "kb-compile", org_id: "org-1", status: "running" }],
+      listActive: false,
+    });
+    const manager = fakeAgentBoxManager();
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: manager,
+      frontendClient: frontend,
+      credentialService: {} as any,
+    });
+    const cancel = server.rpcMethods.get("capability.cancel")!;
+
+    await expect(cancel({ run_id: "run-after-restart" })).resolves.toMatchObject({
+      ok: true,
+      stop_confirmed: true,
+    });
+    expect(frontend.rows.get("run-after-restart")).toMatchObject({ status: "done" });
+    expect(manager.getAsync).not.toHaveBeenCalled();
+    expect(manager.getOrCreate).not.toHaveBeenCalled();
+    expect(manager.stop).toHaveBeenCalledWith("run-after-restart");
+  });
+
+  it("rejects a blank run id before touching the run store or box", async () => {
+    const frontend = fakeFrontendClient();
+    const manager = fakeAgentBoxManager();
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: manager,
+      frontendClient: frontend,
+      credentialService: {} as any,
+    });
+    const cancel = server.rpcMethods.get("capability.cancel")!;
+
+    await expect(cancel({ run_id: "   " })).rejects.toThrow("run_id is required");
+    expect(manager.stop).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -32,6 +32,7 @@ import { driveTestSession } from "./capability/test-relay.js";
 import { CAPABILITY_GET_RUN, isTerminalCapabilityStatus } from "./capability/contract.js";
 import type {
   CapabilityCancelRequest,
+  CapabilityCancelResponse,
   CapabilityCommandRequest,
   CapabilityMessageRequest,
   CapabilityStartRequest,
@@ -746,18 +747,36 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   });
 
   rpcMethods.set("capability.cancel", async (params) => {
-    const runId = (params as unknown as CapabilityCancelRequest).run_id;
+    const requestedRunId = (params as unknown as CapabilityCancelRequest).run_id;
+    const runId = typeof requestedRunId === "string" ? requestedRunId.trim() : "";
     if (!runId) throw new Error("run_id is required");
-    // Best-effort by design (the cancel must terminalize the run regardless),
-    // but a swallowed stop is how box pods leak — log it loudly.
-    await agentBoxManager.stop(runId).catch((err) =>
+
+    // Fence Runtime traffic before asking the box to stop. The consumer owns
+    // domain rollback and must fence its writers before calling cancel; this
+    // terminal mark additionally prevents a concurrent message/command from
+    // entering while K8s processes the pod deletion.
+    const rec = capabilityRunManager.get(runId) ??
+      (await capabilityRunManager.adopt(runId, { notifyOnAdopt: false }));
+    if (rec) await capabilityRunManager.endRun(runId, "done");
+
+    // stop() is idempotent and treats an already-absent K8s pod as success. Any
+    // other failure is uncertain cleanup and must reach the consumer; claiming
+    // success here would let callers mistake a live box for a completed stop.
+    try {
+      await agentBoxManager.stop(runId);
+    } catch (err) {
       console.error(
-        `[capability] cancel: stop box run=${runId} failed (pod may leak):`,
+        `[capability] cancel: stop box run=${runId} failed:`,
         err instanceof Error ? err.message : String(err),
-      ),
-    );
-    await capabilityRunManager.endRun(runId, "done");
-    return { ok: true, run_id: runId };
+      );
+      throw err;
+    }
+    const response: CapabilityCancelResponse = {
+      ok: true,
+      run_id: runId,
+      stop_confirmed: true,
+    };
+    return response;
   });
 
   // ── Read-only test sessions (start-a-test-session) — reuse the run's live box ──


### PR DESCRIPTION
## Summary

Make `capability.cancel` a confirmed, idempotent execution stop that fences the Runtime run before requesting AgentBox termination. This is the Siclaw half of the knowledge-compilation Stop flow; the paired Sicore change will own writer fencing, draft rollback, and cleanup-pending state.

### Problem

The existing handler stopped the AgentBox before terminalizing its run, swallowed non-404 stop failures, and could not terminalize a run that only existed in the consumer store after a Runtime restart. Callers therefore received success even when execution cleanup was uncertain, while destructive adoption could reattach a relay during cancellation.

### Solution

- terminalize known or store-adopted runs before stopping the AgentBox
- suppress the normal relay-reattach callback when adoption is only for cancellation
- propagate uncertain stop failures so Sicore can record cleanup as pending and retry
- return `stop_confirmed: true` only after the idempotent AgentBox stop succeeds
- keep the existing `done` Runtime terminal state and leave domain-level `cancelled` semantics to Sicore

This PR is independent of #409 and does not change the compile-box image or protocol.

## Test Plan

- [x] `npx vitest run src/gateway/server-capability-cancel.test.ts src/gateway/capability/run-manager.test.ts`
- [x] `npx tsc --noEmit`
- [x] `npm test` (220 files; 4423 passed, 2 skipped)
