### PR TITLE
fix(gateway): pair tool results by toolCallId, not per-name FIFO

### DIFF
--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -677,7 +677,7 @@ describe("consumeAgentSse — tool execution", () => {
     expect(result.resultText).toBe("Investigation complete.");
   });
 
-  it("supports parallel tool calls by keying pending state per toolName", async () => {
+  it("supports parallel tool calls via the per-toolName FIFO fallback when events lack a toolCallId", async () => {
     const events = [
       { type: "tool_execution_start", toolName: "a", args: { x: 1 } },
       { type: "tool_execution_start", toolName: "b", args: { y: 2 } },
@@ -692,6 +692,45 @@ describe("consumeAgentSse — tool execution", () => {
     const b = toolRows.find((r) => r.toolName === "b");
     expect(a.toolInput).toContain("\"x\":1");
     expect(b.toolInput).toContain("\"y\":2");
+  });
+
+  it("pairs same-name parallel calls by toolCallId when ends arrive out of start order", async () => {
+    // pi-agent executes a same-turn tool batch in parallel: all starts fire in
+    // call order, each end fires on ITS OWN completion. Name-FIFO pairing wrote
+    // the first-completed result into the first-STARTED row — the audit/live
+    // card then showed one command with another call's output.
+    const events = [
+      { type: "tool_execution_start", toolCallId: "c1", toolName: "navix", args: { cmd: "nodes" } },
+      { type: "tool_execution_start", toolCallId: "c2", toolName: "navix", args: { cmd: "workloads" } },
+      { type: "tool_execution_start", toolCallId: "c3", toolName: "navix", args: { cmd: "diagnoses" } },
+      // Completion order ≠ start order.
+      { type: "tool_execution_end", toolCallId: "c3", toolName: "navix",
+        result: { content: [{ type: "text", text: "diagnoses output" }] } },
+      { type: "tool_execution_end", toolCallId: "c1", toolName: "navix",
+        result: { content: [{ type: "text", text: "nodes output" }] } },
+      { type: "tool_execution_end", toolCallId: "c2", toolName: "navix",
+        result: { content: [{ type: "text", text: "workloads output" }] } },
+    ];
+    const relayedEndRowIds: Array<string | undefined> = [];
+    await consumeAgentSse({
+      client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true,
+      onEvent: (_evt, eventType, extra) => {
+        if (eventType === "tool_execution_end") relayedEndRowIds.push(extra?.dbMessageId);
+      },
+    });
+    // Placeholder rows were appended in start order: msg-1=c1, msg-2=c2, msg-3=c3.
+    // Each result must land in its own row.
+    expect(updateCalls).toHaveLength(3);
+    const byRow = Object.fromEntries(updateCalls.map((u) => [u.messageId, u]));
+    expect(byRow["msg-1"].toolInput).toContain("nodes");
+    expect(byRow["msg-1"].content).toBe("nodes output");
+    expect(byRow["msg-2"].toolInput).toContain("workloads");
+    expect(byRow["msg-2"].content).toBe("workloads output");
+    expect(byRow["msg-3"].toolInput).toContain("diagnoses");
+    expect(byRow["msg-3"].content).toBe("diagnoses output");
+    // The relayed live event must carry the row its result was written to, so the
+    // frontend (which prefers dbMessageId) attaches it to the right card.
+    expect(relayedEndRowIds).toEqual(["msg-3", "msg-1", "msg-2"]);
   });
 });
 

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -290,6 +290,25 @@ function shiftPending<T>(map: Map<string, T[]>, key: string): T | undefined {
   return value;
 }
 
+/** Everything captured at tool_execution_start that its tool_execution_end
+ *  (and the abort finalizer) needs to complete the row. */
+interface PendingToolCall {
+  toolName: string;
+  /** Raw JSON of the call args (unredacted — redacted at write time). */
+  input: string;
+  startMs: number;
+  /** DB row id of the eagerly-persisted "running" placeholder (persist mode only). */
+  messageId?: string;
+  preThinkingMs?: number;
+}
+
+/** Pairing key for a tool_execution_start/end pair: the invocation-unique
+ *  toolCallId when the event carries one, else the tool name (FIFO fallback). */
+function toolCallKey(evt: Record<string, unknown>, toolName: string): string {
+  const id = evt.toolCallId;
+  return typeof id === "string" && id ? id : toolName;
+}
+
 export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<SseConsumptionResult> {
   const { client, sessionId, userId, onEvent, signal } = opts;
   const persist = opts.persistMessages === true;
@@ -354,17 +373,13 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   };
   let lastToolName = "";
 
-  // Queued by toolName. pi-agent events do not always expose a stable call id,
-  // so this preserves multiple same-name starts across refresh persistence in
-  // the order the runtime emits them.
-  const pendingToolInputs = new Map<string, string[]>();
-  const pendingToolStartTimes = new Map<string, number[]>();
-  const pendingToolMessageIds = new Map<string, string[]>();
-  // Per-tool pre-tool-call thinking time captured at tool_execution_start, to
-  // be merged into the row's metadata at tool_execution_end (so the persisted
-  // metadata survives the round-trip without being clobbered by the
-  // extractPersistableDetails extraction from result.details).
-  const pendingPreThinkingMs = new Map<string, number[]>();
+  // In-flight tool calls awaiting their tool_execution_end. Keyed by the
+  // event's toolCallId (stable per invocation): pi-agent runs a same-turn tool
+  // batch in PARALLEL, so ends arrive in completion order, not start order —
+  // name-FIFO pairing writes call A's result into call B's row (and stamps the
+  // wrong dbMessageId on the relayed event, so the live card cross-attaches
+  // too). Events lacking a toolCallId fall back to a per-toolName FIFO queue.
+  const pendingToolCalls = new Map<string, PendingToolCall[]>();
 
   let eventCount = 0;
   const startTime = Date.now();
@@ -536,9 +551,9 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       if (toolResult?.details?.blocked) outcome = "blocked";
       else if (toolResult?.details?.error) outcome = "error";
 
-      const toolStartTime = shiftPending(pendingToolStartTimes, toolName);
-      const durationMs = toolStartTime != null ? Date.now() - toolStartTime : undefined;
-      const preThinkingMs = shiftPending(pendingPreThinkingMs, toolName);
+      const pendingCall = shiftPending(pendingToolCalls, toolCallKey(evt, toolName));
+      const durationMs = pendingCall ? Date.now() - pendingCall.startMs : undefined;
+      const preThinkingMs = pendingCall?.preThinkingMs;
       // Surface duration + pre-thinking on the live event for frontend.
       if (durationMs != null) {
         (evt as Record<string, unknown>).durationMs = durationMs;
@@ -546,8 +561,8 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       if (preThinkingMs != null) {
         (evt as Record<string, unknown>).preThinkingMs = preThinkingMs;
       }
-      const toolInput = shiftPending(pendingToolInputs, toolName) || "";
-      const existingMessageId = shiftPending(pendingToolMessageIds, toolName);
+      const toolInput = pendingCall?.input || "";
+      const existingMessageId = pendingCall?.messageId;
       const detailsMeta = extractPersistableDetails(toolResult?.details, redactionConfig);
       // Merge pre-thinking back in — extractPersistableDetails only looks at
       // the tool *result*, so we'd otherwise lose what we recorded at
@@ -646,11 +661,13 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       // nonNegative() drops cross-pod clock-drift artefacts; absence
       // downstream means "unknown", which is the correct semantics.
       const preThinkingMs = nonNegative(nowAtStart - lastBoundaryTime);
-      pushPending(pendingToolInputs, startToolName, rawToolInput);
-      pushPending(pendingToolStartTimes, startToolName, nowAtStart);
-      if (preThinkingMs !== undefined) {
-        pushPending(pendingPreThinkingMs, startToolName, preThinkingMs);
-      }
+      const pendingCall: PendingToolCall = {
+        toolName: startToolName,
+        input: rawToolInput,
+        startMs: nowAtStart,
+      };
+      if (preThinkingMs !== undefined) pendingCall.preThinkingMs = preThinkingMs;
+      pushPending(pendingToolCalls, toolCallKey(evt, startToolName), pendingCall);
       lastToolName = startToolName;
       // Surface on the live event so frontend can render 💭 immediately.
       if (preThinkingMs !== undefined) {
@@ -682,7 +699,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           durationMs: null,
           metadata: startMetadataWithRoute,
         });
-        pushPending(pendingToolMessageIds, startToolName, dbMessageId);
+        pendingCall.messageId = dbMessageId;
         await incrementMessageCount(sessionId);
       }
     }
@@ -894,28 +911,27 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   // null, metadata.status="stopped"), and persist any partial assistant text so the words the
   // model already streamed don't vanish on the next refetch.
   if (persist && signal?.aborted) {
-    for (const [toolName, ids] of pendingToolMessageIds) {
-      // startTimes/inputs are pushed in lockstep with the message ids on tool_execution_start
-      // and shifted together on tool_execution_end, so the surviving entries stay index-aligned.
-      const startTimes = pendingToolStartTimes.get(toolName) ?? [];
-      const inputs = pendingToolInputs.get(toolName) ?? [];
-      for (let i = 0; i < ids.length; i++) {
-        const stoppedMeta: Record<string, unknown> = { status: "stopped" };
-        if (startTimes[i] != null) stoppedMeta.started_at = new Date(startTimes[i]).toISOString();
+    for (const queue of pendingToolCalls.values()) {
+      for (const pendingCall of queue) {
+        if (!pendingCall.messageId) continue;
+        const stoppedMeta: Record<string, unknown> = {
+          status: "stopped",
+          started_at: new Date(pendingCall.startMs).toISOString(),
+        };
         try {
           // updateMessage REPLACES columns (it is not a partial patch), so we must re-send
           // toolName + toolInput or they'd be NULLed — leaving the stopped card with no identity.
           await updateMessage({
-            messageId: ids[i],
+            messageId: pendingCall.messageId,
             sessionId,
             content: "",
-            toolName,
-            toolInput: inputs[i] ? redactText(inputs[i], redactionConfig) : null,
+            toolName: pendingCall.toolName,
+            toolInput: pendingCall.input ? redactText(pendingCall.input, redactionConfig) : null,
             outcome: null,
             metadata: stoppedMeta,
           });
         } catch (err) {
-          console.warn(`[sse-consumer] ${userId}: failed to finalize aborted tool row ${ids[i]}:`, err);
+          console.warn(`[sse-consumer] ${userId}: failed to finalize aborted tool row ${pendingCall.messageId}:`, err);
         }
       }
     }


### PR DESCRIPTION
## Problem

In the maintainer session audit view (and the live chat), parallel same-name tool calls showed **one command with another call's output** — e.g. a `navix … nodes` card displaying the `schedule-diagnoses` result. `duration_ms` and `pre_thinking_ms` were cross-attached the same way.

## Root cause

pi-agent executes a same-turn tool batch **in parallel** (`executeToolCallsParallel`): all `tool_execution_start` events fire in call order, but each `tool_execution_end` fires on its own completion — so end order ≠ start order.

The gateway SSE consumer paired starts and ends through **per-toolName FIFO queues** (`pendingToolInputs` / `pendingToolStartTimes` / `pendingToolMessageIds` / `pendingPreThinkingMs`). With several same-name calls completing out of start order, the Nth-completed result was written into the Nth-**started** row. The wrong row id was also stamped as `dbMessageId` on the relayed live event, and the frontend prefers `dbMessageId` over its own `toolCallId` fallback — so the live card cross-attached identically.

The comment justifying name-keying ("pi-agent events do not always expose a stable call id") is stale: both tool events carry a required, invocation-unique `toolCallId` (pi-agent-core 0.80.7), agentbox forwards events verbatim, and every other consumer in the codebase (subagent persistence, delegation stream, tool metrics, portal-web live handler) already pairs by it.

## Fix

- Key the consumer's pending state by `toolCallId`, collapsing the four lockstep queues into one `PendingToolCall` record queue; events lacking an id keep the per-toolName FIFO as fallback.
- The abort finalizer walks the same records (behavior unchanged: persisted-but-unfinished rows finalize as `stopped` with identity re-sent).

Gateway-only change — agentbox and frontend untouched.

## Testing

- New regression test: 3 same-name parallel calls completing out of start order — each result must land in its own row, and the relayed `tool_execution_end` must carry the row it was written to.
- Renamed the existing parallel test to document it now covers the no-`toolCallId` fallback path.
- `npx tsc --noEmit` clean; full `npm test` green at repo root (only pre-existing failures in stale `.claude/worktrees/` copies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)