### PR TITLE
feat(mcp): add Sicore A2A adapter for coding agents

### DIFF
--- a/mcp/sicore-a2a-adapter/README.md
+++ b/mcp/sicore-a2a-adapter/README.md
@@ -1,0 +1,115 @@
+# Sicore A2A MCP Adapter
+
+A minimal local stdio MCP server that lets Codex or Claude Code use one existing Siclaw agent through Sicore's A2A API.
+
+The adapter is intentionally thin:
+
+```text
+Codex / Claude Code --stdio MCP--> this adapter --HTTPS A2A--> Sicore --> Siclaw Runtime --> the agent's existing AgentBox
+```
+
+It does not hold cluster credentials, choose a Siclaw agent, or execute infrastructure tools. One adapter process is fixed to one `SICLAW_AGENT_ID` and one Sicore A2A key.
+
+## Tools
+
+- `siclaw_investigate`: create or continue an investigation and wait up to 50 seconds. Longer investigations continue server-side and are watched with `siclaw_wait_task`.
+- `siclaw_wait_task`: wait up to 50 seconds on an existing task without submitting another investigation. Use it repeatedly as the same-turn watchdog.
+- `siclaw_get_task`: get one immediate compact snapshot; terminal snapshots include the full result.
+- `siclaw_cancel_task`: cancel a non-terminal task.
+- `siclaw_list_tasks`: recover/list tasks scoped to the same agent and API key.
+
+## Build and test
+
+```bash
+npm install
+npm test
+npm run build
+```
+
+Requires Node.js 22.19 or newer.
+
+## Configuration
+
+Required:
+
+- `SICORE_URL`: Sicore base URL, for example `https://sicore.example.com`.
+- `SICLAW_AGENT_ID`: the agent UUID bound to the A2A key.
+- exactly one of:
+  - `SICLAW_A2A_KEY_FILE`: path to a file containing the key. On Unix it must have mode `0600` or stricter.
+  - `SICLAW_A2A_KEY`: direct environment fallback for ephemeral testing.
+
+Optional:
+
+- `SICLAW_A2A_TIMEOUT_MS`: per-request timeout, default `30000`.
+- `SICLAW_A2A_POLL_INTERVAL_MS`: task polling interval, default `3000`.
+
+The key must never be passed as a command-line argument or committed to a project MCP config. Prefer a private key file outside the repository:
+
+```bash
+mkdir -p ~/.config/siclaw
+umask 077
+read -s SICLAW_TEST_KEY
+printf '%s' "$SICLAW_TEST_KEY" > ~/.config/siclaw/test-a2a-key
+unset SICLAW_TEST_KEY
+chmod 600 ~/.config/siclaw/test-a2a-key
+```
+
+## Run directly
+
+```bash
+SICORE_URL=https://sicore.example.com \
+SICLAW_AGENT_ID=<agent-uuid> \
+SICLAW_A2A_KEY_FILE=~/.config/siclaw/test-a2a-key \
+node dist/index.js
+```
+
+The process speaks MCP over stdout. Diagnostic startup messages go only to stderr and never include the key.
+
+## Codex
+
+Use absolute paths so the MCP process does not depend on the current project directory:
+
+```bash
+codex mcp add \
+  --env SICORE_URL=https://sicore.example.com \
+  --env SICLAW_AGENT_ID=<agent-uuid> \
+  --env SICLAW_A2A_KEY_FILE=/absolute/path/to/test-a2a-key \
+  siclaw-test -- node /absolute/path/to/sicore-a2a-adapter/dist/index.js
+```
+
+## Claude Code
+
+```bash
+claude mcp add -s user \
+  -e SICORE_URL=https://sicore.example.com \
+  -e SICLAW_AGENT_ID=<agent-uuid> \
+  -e SICLAW_A2A_KEY_FILE=/absolute/path/to/test-a2a-key \
+  siclaw-test -- node /absolute/path/to/sicore-a2a-adapter/dist/index.js
+```
+
+Create one named MCP server per Siclaw agent/key pair. The model-visible tool schemas intentionally contain no `agent_id` parameter.
+
+## Watchdog behavior
+
+Sicore owns the durable background task. The local adapter stays stateless and
+does not run a persistent daemon. When `siclaw_investigate` returns a working
+task, the MCP client should keep the current turn open and call
+`siclaw_wait_task` with the same `task_id` until the task is terminal, the user
+asks it to stop, or an overall investigation deadline is exhausted.
+
+Working responses contain only the latest status, timestamp, and accumulated
+character count. The growing partial report is deliberately withheld so each
+watchdog call does not repeat many kilobytes into the model context. The full
+report is returned once on a terminal response. `siclaw_list_tasks` can recover
+task IDs after a client restart without returning stored reports.
+
+The same watchdog rule is advertised through MCP server instructions, so the
+client model does not have to infer or remember the polling protocol from a
+previous conversation.
+
+## Failure behavior
+
+- A2A `message:send` is never automatically retried, avoiding duplicate investigation tasks.
+- If a bounded wait expires, the tool returns a compact working task; call `siclaw_wait_task` again instead of resubmitting the question.
+- HTTP 401/403/429/503 and A2A error reasons are returned as MCP tool errors without request headers or key material.
+- Adapter restarts do not lose server-side tasks; recover them with `siclaw_list_tasks` using the same key.

--- a/mcp/sicore-a2a-adapter/README.md
+++ b/mcp/sicore-a2a-adapter/README.md
@@ -33,13 +33,13 @@ Requires Node.js 22.19 or newer.
 Required:
 
 - `SICORE_URL`: Sicore base URL, for example `https://sicore.example.com`.
-- `SICLAW_AGENT_ID`: the agent UUID bound to the A2A key.
 - exactly one of:
   - `SICLAW_A2A_KEY_FILE`: path to a file containing the key. On Unix it must have mode `0600` or stricter.
   - `SICLAW_A2A_KEY`: direct environment fallback for ephemeral testing.
 
 Optional:
 
+- `SICLAW_AGENT_ID`: the agent UUID bound to the A2A key. Keys are per-agent, so by default the adapter resolves the agent from the key at startup (`GET /api/v1/a2a/self`). Set it explicitly to pin the agent as a cross-check, or when talking to an older Sicore without the `/self` endpoint.
 - `SICLAW_A2A_TIMEOUT_MS`: network-operation timeout, default `30000`. Bounded GET retries share this same budget.
 - `SICLAW_A2A_POLL_INTERVAL_MS`: task polling interval, default `3000`.
 
@@ -58,7 +58,6 @@ chmod 600 ~/.config/siclaw/test-a2a-key
 
 ```bash
 SICORE_URL=https://sicore.example.com \
-SICLAW_AGENT_ID=<agent-uuid> \
 SICLAW_A2A_KEY_FILE=~/.config/siclaw/test-a2a-key \
 node dist/index.js
 ```
@@ -72,7 +71,6 @@ Use absolute paths so the MCP process does not depend on the current project dir
 ```bash
 codex mcp add \
   --env SICORE_URL=https://sicore.example.com \
-  --env SICLAW_AGENT_ID=<agent-uuid> \
   --env SICLAW_A2A_KEY_FILE=/absolute/path/to/test-a2a-key \
   siclaw-test -- node /absolute/path/to/sicore-a2a-adapter/dist/index.js
 ```
@@ -82,12 +80,11 @@ codex mcp add \
 ```bash
 claude mcp add -s user \
   -e SICORE_URL=https://sicore.example.com \
-  -e SICLAW_AGENT_ID=<agent-uuid> \
   -e SICLAW_A2A_KEY_FILE=/absolute/path/to/test-a2a-key \
   siclaw-test -- node /absolute/path/to/sicore-a2a-adapter/dist/index.js
 ```
 
-Create one named MCP server per Siclaw agent/key pair. The model-visible tool schemas intentionally contain no `agent_id` parameter.
+Create one named MCP server per Siclaw agent/key pair. The model-visible tool schemas intentionally contain no `agent_id` parameter, and the adapter derives the agent from the key itself (add `-e SICLAW_AGENT_ID=<agent-uuid>` to pin it explicitly or for an older Sicore).
 
 ## Watchdog behavior
 

--- a/mcp/sicore-a2a-adapter/README.md
+++ b/mcp/sicore-a2a-adapter/README.md
@@ -40,7 +40,7 @@ Required:
 
 Optional:
 
-- `SICLAW_A2A_TIMEOUT_MS`: per-request timeout, default `30000`.
+- `SICLAW_A2A_TIMEOUT_MS`: network-operation timeout, default `30000`. Bounded GET retries share this same budget.
 - `SICLAW_A2A_POLL_INTERVAL_MS`: task polling interval, default `3000`.
 
 The key must never be passed as a command-line argument or committed to a project MCP config. Prefer a private key file outside the repository:
@@ -110,6 +110,8 @@ previous conversation.
 ## Failure behavior
 
 - A2A `message:send` is never automatically retried, avoiding duplicate investigation tasks.
+- Idempotent task reads retry transient timeouts, connection failures, malformed responses, HTTP 408/429, and HTTP 500/502/503/504 at most twice with short backoff. Retries stay inside the read or watchdog deadline.
+- Task cancellation is never automatically retried.
 - If a bounded wait expires, the tool returns a compact working task; call `siclaw_wait_task` again instead of resubmitting the question.
 - HTTP 401/403/429/503 and A2A error reasons are returned as MCP tool errors without request headers or key material.
 - Adapter restarts do not lose server-side tasks; recover them with `siclaw_list_tasks` using the same key.

--- a/mcp/sicore-a2a-adapter/package-lock.json
+++ b/mcp/sicore-a2a-adapter/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.19.8",
+        "tsx": "^4.23.1",
         "typescript": "^5.9.0",
         "vitest": "^3.0.0"
       },
@@ -2465,6 +2466,26 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -2541,6 +2562,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",

--- a/mcp/sicore-a2a-adapter/package-lock.json
+++ b/mcp/sicore-a2a-adapter/package-lock.json
@@ -1,0 +1,2767 @@
+{
+  "name": "@scitix/sicore-a2a-mcp-adapter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scitix/sicore-a2a-mcp-adapter",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1"
+      },
+      "bin": {
+        "sicore-a2a-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.8",
+        "typescript": "^5.9.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/sicore-a2a-adapter/package.json
+++ b/mcp/sicore-a2a-adapter/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.8",
+    "tsx": "^4.23.1",
     "typescript": "^5.9.0",
     "vitest": "^3.0.0"
   },

--- a/mcp/sicore-a2a-adapter/package.json
+++ b/mcp/sicore-a2a-adapter/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@scitix/sicore-a2a-mcp-adapter",
+  "version": "0.1.0",
+  "description": "Local stdio MCP adapter for one Sicore-hosted Siclaw A2A agent",
+  "type": "module",
+  "private": true,
+  "bin": {
+    "sicore-a2a-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "npm run build && vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts"
+  },
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.8",
+    "typescript": "^5.9.0",
+    "vitest": "^3.0.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/mcp/sicore-a2a-adapter/src/a2a-client.test.ts
+++ b/mcp/sicore-a2a-adapter/src/a2a-client.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { A2aClientError, normalizeTask, SicoreA2aClient } from "./a2a-client.js";
-import type { AdapterConfig } from "./config.js";
+import { A2aClientError, normalizeTask, resolveAgentId, SicoreA2aClient } from "./a2a-client.js";
+import type { ResolvedAdapterConfig } from "./config.js";
 
-function config(extra: Partial<AdapterConfig> = {}): AdapterConfig {
+function config(extra: Partial<ResolvedAdapterConfig> = {}): ResolvedAdapterConfig {
   return {
     baseUrl: "https://sicore.example.com",
     agentId: "agent/one",
@@ -50,6 +50,34 @@ describe("normalizeTask", () => {
 
   it("uses the status message as the error for failed tasks", () => {
     expect(normalizeTask(task("TASK_STATE_FAILED")).error).toBe("investigation failed");
+  });
+});
+
+describe("resolveAgentId", () => {
+  it("resolves the bound agent from the key via /self", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ agentId: "agent-9" }));
+    await expect(resolveAgentId(config(), fetchImpl as typeof fetch)).resolves.toBe("agent-9");
+    expect(String(fetchImpl.mock.calls[0][0])).toBe("https://sicore.example.com/api/v1/a2a/self");
+  });
+
+  it("tells the operator to pin SICLAW_AGENT_ID on an older Sicore", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: { message: "A2A route not found" } }, 404));
+    await expect(resolveAgentId(config(), fetchImpl as typeof fetch))
+      .rejects.toThrow(/set SICLAW_AGENT_ID/);
+  });
+
+  it("propagates authentication failures without masking them", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      error: {
+        status: "UNAUTHENTICATED",
+        message: "A valid SiCore agent API key is required",
+        details: [{ reason: "AUTHENTICATION_REQUIRED" }],
+      },
+    }, 401));
+    const error = await resolveAgentId(config(), fetchImpl as typeof fetch).catch((value) => value as A2aClientError);
+    expect(error).toBeInstanceOf(A2aClientError);
+    expect(error.httpStatus).toBe(401);
+    expect(error.reason).toBe("AUTHENTICATION_REQUIRED");
   });
 });
 

--- a/mcp/sicore-a2a-adapter/src/a2a-client.test.ts
+++ b/mcp/sicore-a2a-adapter/src/a2a-client.test.ts
@@ -89,6 +89,37 @@ describe("SicoreA2aClient", () => {
     expect(error.message).not.toContain("super-secret-key");
   });
 
+  it("retries transient GET failures within one read timeout", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: { message: "temporary" } }, 500))
+      .mockResolvedValueOnce(new Response("not-json", { status: 200 }))
+      .mockResolvedValueOnce(jsonResponse({ task: task("TASK_STATE_COMPLETED", "recovered") }));
+    const client = new SicoreA2aClient(config(), fetchImpl as typeof fetch);
+
+    await expect(client.getTask("task-1")).resolves.toMatchObject({ state: "completed", result: "recovered" });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("bounds transient GET retries", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: { message: "temporary" } }, 503));
+    const client = new SicoreA2aClient(config(), fetchImpl as typeof fetch);
+
+    await expect(client.getTask("task-1")).rejects.toBeInstanceOf(A2aClientError);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("never retries task submission or cancellation", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: { message: "temporary" } }, 503));
+    const client = new SicoreA2aClient(config(), fetchImpl as typeof fetch);
+
+    await expect(client.sendMessage("check node")).rejects.toBeInstanceOf(A2aClientError);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    await expect(client.cancelTask("task-1")).rejects.toBeInstanceOf(A2aClientError);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it("polls until a task becomes terminal", async () => {
     const fetchImpl = vi
       .fn()
@@ -101,6 +132,27 @@ describe("SicoreA2aClient", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps read retries inside the wait deadline and returns the last snapshot", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ task: task() }))
+      .mockImplementationOnce(async (_url: string | URL | Request, init?: RequestInit) => (
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        })
+      ));
+    const client = new SicoreA2aClient(
+      config({ requestTimeoutMs: 5_000, pollIntervalMs: 10 }),
+      fetchImpl as typeof fetch,
+    );
+
+    const startedAt = Date.now();
+    await expect(client.waitForTask("task-1", 0.05)).resolves.toMatchObject({ state: "working" });
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it("maps list and cancel routes", async () => {
     const fetchImpl = vi
       .fn()
@@ -110,7 +162,7 @@ describe("SicoreA2aClient", () => {
 
     const list = await client.listTasks({ contextId: "context-1", status: "TASK_STATE_WORKING", pageSize: 10, pageToken: 0 });
     expect(list.total_size).toBe(1);
-    expect(list.next_page_token).toBe("10");
+    expect(list.next_page_token).toBe(10);
     expect(String(fetchImpl.mock.calls[0][0])).toContain("contextId=context-1");
     expect(String(fetchImpl.mock.calls[0][0])).toContain("status=TASK_STATE_WORKING");
 

--- a/mcp/sicore-a2a-adapter/src/a2a-client.test.ts
+++ b/mcp/sicore-a2a-adapter/src/a2a-client.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { A2aClientError, normalizeTask, SicoreA2aClient } from "./a2a-client.js";
+import type { AdapterConfig } from "./config.js";
+
+function config(extra: Partial<AdapterConfig> = {}): AdapterConfig {
+  return {
+    baseUrl: "https://sicore.example.com",
+    agentId: "agent/one",
+    apiKey: "super-secret-key",
+    requestTimeoutMs: 5_000,
+    pollIntervalMs: 100,
+    ...extra,
+  };
+}
+
+function task(state = "TASK_STATE_WORKING", artifact?: string) {
+  return {
+    id: "task-1",
+    contextId: "context-1",
+    status: {
+      state,
+      timestamp: "2026-07-18T00:00:00.000Z",
+      message: { parts: [{ text: state === "TASK_STATE_FAILED" ? "investigation failed" : "Siclaw is working" }] },
+    },
+    ...(artifact ? { artifacts: [{ parts: [{ text: artifact }] }] } : {}),
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/a2a+json" },
+  });
+}
+
+describe("normalizeTask", () => {
+  it("returns a stable completed task shape", () => {
+    expect(normalizeTask(task("TASK_STATE_COMPLETED", "root cause"))).toEqual({
+      task_id: "task-1",
+      context_id: "context-1",
+      state: "completed",
+      a2a_state: "TASK_STATE_COMPLETED",
+      is_terminal: true,
+      status_message: "Siclaw is working",
+      result: "root cause",
+      error: null,
+      updated_at: "2026-07-18T00:00:00.000Z",
+    });
+  });
+
+  it("uses the status message as the error for failed tasks", () => {
+    expect(normalizeTask(task("TASK_STATE_FAILED")).error).toBe("investigation failed");
+  });
+});
+
+describe("SicoreA2aClient", () => {
+  it("sends the canonical text message without exposing the agent as tool input", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) => jsonResponse({ task: task() }));
+    const client = new SicoreA2aClient(config(), fetchImpl as typeof fetch);
+    await client.sendMessage("check node", "context-1");
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(String(url)).toBe("https://sicore.example.com/api/v1/a2a/agents/agent%2Fone/message:send");
+    expect(init?.headers).toMatchObject({ authorization: "Bearer super-secret-key" });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      message: {
+        role: "ROLE_USER",
+        parts: [{ text: "check node" }],
+        contextId: "context-1",
+      },
+    });
+  });
+
+  it("maps A2A errors without including the bearer key", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      error: {
+        status: "UNAUTHENTICATED",
+        message: "A valid SiCore agent API key is required",
+        details: [{ reason: "AUTHENTICATION_REQUIRED" }],
+      },
+    }, 401));
+    const client = new SicoreA2aClient(config(), fetchImpl as typeof fetch);
+
+    const error = await client.getTask("task-1").catch((value) => value as A2aClientError);
+    expect(error).toBeInstanceOf(A2aClientError);
+    expect(error.httpStatus).toBe(401);
+    expect(error.reason).toBe("AUTHENTICATION_REQUIRED");
+    expect(error.message).not.toContain("super-secret-key");
+  });
+
+  it("polls until a task becomes terminal", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ task: task() }))
+      .mockResolvedValueOnce(jsonResponse({ task: task("TASK_STATE_COMPLETED", "done") }));
+    const client = new SicoreA2aClient(config(), fetchImpl as typeof fetch);
+    const result = await client.waitForTask("task-1", 1);
+    expect(result.state).toBe("completed");
+    expect(result.result).toBe("done");
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps list and cancel routes", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ tasks: [task()], totalSize: 1, pageSize: 10, nextPageToken: "10" }))
+      .mockResolvedValueOnce(jsonResponse({ task: task("TASK_STATE_CANCELED") }));
+    const client = new SicoreA2aClient(config(), fetchImpl as typeof fetch);
+
+    const list = await client.listTasks({ contextId: "context-1", status: "TASK_STATE_WORKING", pageSize: 10, pageToken: 0 });
+    expect(list.total_size).toBe(1);
+    expect(list.next_page_token).toBe("10");
+    expect(String(fetchImpl.mock.calls[0][0])).toContain("contextId=context-1");
+    expect(String(fetchImpl.mock.calls[0][0])).toContain("status=TASK_STATE_WORKING");
+
+    expect((await client.cancelTask("task-1")).state).toBe("canceled");
+    expect(String(fetchImpl.mock.calls[1][0])).toContain("/tasks/task-1:cancel");
+  });
+});

--- a/mcp/sicore-a2a-adapter/src/a2a-client.ts
+++ b/mcp/sicore-a2a-adapter/src/a2a-client.ts
@@ -1,5 +1,5 @@
 import { setTimeout as delay } from "node:timers/promises";
-import type { AdapterConfig } from "./config.js";
+import type { AdapterConfig, ResolvedAdapterConfig } from "./config.js";
 
 export const TERMINAL_A2A_STATES = new Set([
   "TASK_STATE_COMPLETED",
@@ -171,11 +171,141 @@ function normalizeNextPageToken(value: unknown): number | null {
   return token;
 }
 
+async function a2aRequest<T>(
+  fetchImpl: typeof fetch,
+  apiKey: string,
+  url: string,
+  method: string,
+  body: unknown,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  timer.unref();
+  try {
+    let response: Response;
+    try {
+      response = await fetchImpl(url, {
+        method,
+        headers: {
+          accept: "application/a2a+json, application/json",
+          authorization: `Bearer ${apiKey}`,
+          ...(body === undefined ? {} : { "content-type": "application/json" }),
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new A2aClientError("Sicore A2A request timed out", {
+          reason: "A2A_TIMEOUT",
+          retriable: true,
+        });
+      }
+      throw new A2aClientError(
+        `Could not reach Sicore A2A endpoint: ${error instanceof Error ? error.message : String(error)}`,
+        { reason: "A2A_UNREACHABLE", retriable: true },
+      );
+    }
+
+    let raw: string;
+    try {
+      raw = await response.text();
+    } catch (error) {
+      throw new A2aClientError(
+        `Could not read Sicore A2A response: ${error instanceof Error ? error.message : String(error)}`,
+        {
+          httpStatus: response.status,
+          reason: "A2A_RESPONSE_READ_FAILED",
+          retriable: method === "GET",
+        },
+      );
+    }
+    let payload: unknown = null;
+    if (raw) {
+      try {
+        payload = JSON.parse(raw);
+      } catch {
+        throw new A2aClientError("Sicore returned a non-JSON A2A response", {
+          httpStatus: response.status,
+          reason: "INVALID_A2A_RESPONSE",
+          retriable: method === "GET" && (response.ok || isRetriableHttpStatus(response.status)),
+        });
+      }
+    }
+    if (!response.ok) throw errorFromResponse(response.status, payload);
+    return payload as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function retryIdempotentRead<T>(
+  requestTimeoutMs: number,
+  operation: (timeoutMs: number) => Promise<T>,
+  overallDeadline?: number,
+): Promise<T> {
+  const operationDeadline = Math.min(
+    overallDeadline ?? Number.POSITIVE_INFINITY,
+    Date.now() + requestTimeoutMs,
+  );
+  let lastError: A2aClientError | null = null;
+
+  for (let attempt = 0; attempt <= READ_RETRY_DELAYS_MS.length; attempt += 1) {
+    const remaining = operationDeadline - Date.now();
+    if (remaining <= 0) {
+      throw lastError ?? new A2aClientError("Sicore A2A request timed out", {
+        reason: "A2A_TIMEOUT",
+        retriable: true,
+      });
+    }
+    try {
+      return await operation(remaining);
+    } catch (error) {
+      if (!(error instanceof A2aClientError) || !error.retriable) throw error;
+      lastError = error;
+      const retryDelayMs = READ_RETRY_DELAYS_MS[attempt];
+      if (retryDelayMs === undefined || Date.now() + retryDelayMs >= operationDeadline) throw error;
+      await delay(retryDelayMs);
+    }
+  }
+
+  throw lastError ?? new A2aClientError("Sicore A2A read failed");
+}
+
+// resolveAgentId asks Sicore which agent the configured key is bound to
+// (GET /api/v1/a2a/self). Keys are per-agent, so this spares the operator
+// from copying the agent UUID into client config. Older Sicore deployments
+// without the endpoint require SICLAW_AGENT_ID to be set explicitly.
+export async function resolveAgentId(
+  config: AdapterConfig,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<string> {
+  let payload: { agentId?: unknown } | null;
+  try {
+    payload = await retryIdempotentRead(config.requestTimeoutMs, (timeoutMs) =>
+      a2aRequest(fetchImpl, config.apiKey, `${config.baseUrl}/api/v1/a2a/self`, "GET", undefined, timeoutMs));
+  } catch (error) {
+    if (error instanceof A2aClientError && error.httpStatus === 404) {
+      throw new A2aClientError(
+        "This Sicore does not support key self-resolution (GET /api/v1/a2a/self); set SICLAW_AGENT_ID explicitly",
+        { httpStatus: 404, reason: "SELF_RESOLUTION_UNSUPPORTED" },
+      );
+    }
+    throw error;
+  }
+  const agentId = typeof payload?.agentId === "string" ? payload.agentId.trim() : "";
+  if (!agentId) {
+    throw new A2aClientError("Sicore /self returned no agentId", { reason: "INVALID_A2A_RESPONSE" });
+  }
+  return agentId;
+}
+
 export class SicoreA2aClient implements SiclawA2aApi {
   private readonly agentBaseUrl: string;
 
   constructor(
-    private readonly config: AdapterConfig,
+    private readonly config: ResolvedAdapterConfig,
     private readonly fetchImpl: typeof fetch = globalThis.fetch,
   ) {
     this.agentBaseUrl = `${config.baseUrl}/api/v1/a2a/agents/${encodeURIComponent(config.agentId)}`;
@@ -187,97 +317,14 @@ export class SicoreA2aClient implements SiclawA2aApi {
     body?: unknown,
     timeoutMs = this.config.requestTimeoutMs,
   ): Promise<T> {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
-    timer.unref();
-    try {
-      let response: Response;
-      try {
-        response = await this.fetchImpl(`${this.agentBaseUrl}${path}`, {
-          method,
-          headers: {
-            accept: "application/a2a+json, application/json",
-            authorization: `Bearer ${this.config.apiKey}`,
-            ...(body === undefined ? {} : { "content-type": "application/json" }),
-          },
-          body: body === undefined ? undefined : JSON.stringify(body),
-          signal: controller.signal,
-        });
-      } catch (error) {
-        if (controller.signal.aborted) {
-          throw new A2aClientError("Sicore A2A request timed out", {
-            reason: "A2A_TIMEOUT",
-            retriable: true,
-          });
-        }
-        throw new A2aClientError(
-          `Could not reach Sicore A2A endpoint: ${error instanceof Error ? error.message : String(error)}`,
-          { reason: "A2A_UNREACHABLE", retriable: true },
-        );
-      }
-
-      let raw: string;
-      try {
-        raw = await response.text();
-      } catch (error) {
-        throw new A2aClientError(
-          `Could not read Sicore A2A response: ${error instanceof Error ? error.message : String(error)}`,
-          {
-            httpStatus: response.status,
-            reason: "A2A_RESPONSE_READ_FAILED",
-            retriable: method === "GET",
-          },
-        );
-      }
-      let payload: unknown = null;
-      if (raw) {
-        try {
-          payload = JSON.parse(raw);
-        } catch {
-          throw new A2aClientError("Sicore returned a non-JSON A2A response", {
-            httpStatus: response.status,
-            reason: "INVALID_A2A_RESPONSE",
-            retriable: method === "GET" && (response.ok || isRetriableHttpStatus(response.status)),
-          });
-        }
-      }
-      if (!response.ok) throw errorFromResponse(response.status, payload);
-      return payload as T;
-    } finally {
-      clearTimeout(timer);
-    }
+    return a2aRequest(this.fetchImpl, this.config.apiKey, `${this.agentBaseUrl}${path}`, method, body, timeoutMs);
   }
 
   private async readWithRetry<T>(
     operation: (timeoutMs: number) => Promise<T>,
     overallDeadline?: number,
   ): Promise<T> {
-    const operationDeadline = Math.min(
-      overallDeadline ?? Number.POSITIVE_INFINITY,
-      Date.now() + this.config.requestTimeoutMs,
-    );
-    let lastError: A2aClientError | null = null;
-
-    for (let attempt = 0; attempt <= READ_RETRY_DELAYS_MS.length; attempt += 1) {
-      const remaining = operationDeadline - Date.now();
-      if (remaining <= 0) {
-        throw lastError ?? new A2aClientError("Sicore A2A request timed out", {
-          reason: "A2A_TIMEOUT",
-          retriable: true,
-        });
-      }
-      try {
-        return await operation(remaining);
-      } catch (error) {
-        if (!(error instanceof A2aClientError) || !error.retriable) throw error;
-        lastError = error;
-        const retryDelayMs = READ_RETRY_DELAYS_MS[attempt];
-        if (retryDelayMs === undefined || Date.now() + retryDelayMs >= operationDeadline) throw error;
-        await delay(retryDelayMs);
-      }
-    }
-
-    throw lastError ?? new A2aClientError("Sicore A2A read failed");
+    return retryIdempotentRead(this.config.requestTimeoutMs, operation, overallDeadline);
   }
 
   private async loadTask(taskId: string, overallDeadline?: number): Promise<SiclawTask> {

--- a/mcp/sicore-a2a-adapter/src/a2a-client.ts
+++ b/mcp/sicore-a2a-adapter/src/a2a-client.ts
@@ -1,0 +1,268 @@
+import { setTimeout as delay } from "node:timers/promises";
+import type { AdapterConfig } from "./config.js";
+
+export const TERMINAL_A2A_STATES = new Set([
+  "TASK_STATE_COMPLETED",
+  "TASK_STATE_FAILED",
+  "TASK_STATE_CANCELED",
+  "TASK_STATE_REJECTED",
+]);
+
+const SIMPLE_STATE: Record<string, SiclawTaskState> = {
+  TASK_STATE_SUBMITTED: "submitted",
+  TASK_STATE_WORKING: "working",
+  TASK_STATE_COMPLETED: "completed",
+  TASK_STATE_FAILED: "failed",
+  TASK_STATE_CANCELED: "canceled",
+  TASK_STATE_REJECTED: "rejected",
+};
+
+export type SiclawTaskState =
+  | "submitted"
+  | "working"
+  | "completed"
+  | "failed"
+  | "canceled"
+  | "rejected"
+  | "unknown";
+
+export interface SiclawTask {
+  task_id: string;
+  context_id: string;
+  state: SiclawTaskState;
+  a2a_state: string;
+  is_terminal: boolean;
+  status_message: string | null;
+  result: string | null;
+  error: string | null;
+  updated_at: string | null;
+}
+
+export interface SiclawTaskList {
+  tasks: SiclawTask[];
+  total_size: number;
+  page_size: number;
+  next_page_token: string | null;
+}
+
+export interface ListTaskOptions {
+  contextId?: string;
+  status?: string;
+  pageSize?: number;
+  pageToken?: number;
+}
+
+export interface SiclawA2aApi {
+  sendMessage(question: string, contextId?: string): Promise<SiclawTask>;
+  getTask(taskId: string): Promise<SiclawTask>;
+  cancelTask(taskId: string): Promise<SiclawTask>;
+  listTasks(options?: ListTaskOptions): Promise<SiclawTaskList>;
+  waitForTask(taskId: string, waitSeconds: number): Promise<SiclawTask>;
+}
+
+interface A2aErrorEnvelope {
+  error?: {
+    code?: number;
+    status?: string;
+    message?: string;
+    details?: Array<{ reason?: string }>;
+  };
+}
+
+export class A2aClientError extends Error {
+  readonly httpStatus: number | null;
+  readonly reason: string;
+  readonly retriable: boolean;
+
+  constructor(message: string, options: { httpStatus?: number; reason?: string; retriable?: boolean } = {}) {
+    super(message);
+    this.name = "A2aClientError";
+    this.httpStatus = options.httpStatus ?? null;
+    this.reason = options.reason ?? "A2A_REQUEST_FAILED";
+    this.retriable = options.retriable ?? false;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function textParts(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const item of value) {
+    const record = asRecord(item);
+    if (record && typeof record.text === "string" && record.text.trim()) out.push(record.text);
+  }
+  return out;
+}
+
+function statusMessage(task: Record<string, unknown>): string | null {
+  const status = asRecord(task.status);
+  const message = asRecord(status?.message);
+  const text = textParts(message?.parts).join("\n\n").trim();
+  return text || null;
+}
+
+function artifactText(task: Record<string, unknown>): string | null {
+  if (!Array.isArray(task.artifacts)) return null;
+  const parts: string[] = [];
+  for (const artifactValue of task.artifacts) {
+    const artifact = asRecord(artifactValue);
+    parts.push(...textParts(artifact?.parts));
+  }
+  const text = parts.join("\n\n").trim();
+  return text || null;
+}
+
+export function normalizeTask(value: unknown): SiclawTask {
+  const task = asRecord(value);
+  if (!task || typeof task.id !== "string" || !task.id) {
+    throw new A2aClientError("Sicore returned an invalid A2A task", { reason: "INVALID_A2A_RESPONSE" });
+  }
+  const status = asRecord(task.status);
+  const rawState = typeof status?.state === "string" ? status.state : "TASK_STATE_UNSPECIFIED";
+  const message = statusMessage(task);
+  const state = SIMPLE_STATE[rawState] ?? "unknown";
+  const failed = state === "failed" || state === "rejected";
+  return {
+    task_id: task.id,
+    context_id: typeof task.contextId === "string" ? task.contextId : "",
+    state,
+    a2a_state: rawState,
+    is_terminal: TERMINAL_A2A_STATES.has(rawState),
+    status_message: message,
+    result: artifactText(task),
+    error: failed ? message ?? "Siclaw task failed" : null,
+    updated_at: typeof status?.timestamp === "string" ? status.timestamp : null,
+  };
+}
+
+function errorFromResponse(status: number, payload: unknown): A2aClientError {
+  const envelope = payload as A2aErrorEnvelope;
+  const message = envelope?.error?.message || `Sicore A2A request failed with HTTP ${status}`;
+  const reason = envelope?.error?.details?.[0]?.reason || envelope?.error?.status || "A2A_REQUEST_FAILED";
+  return new A2aClientError(message, {
+    httpStatus: status,
+    reason,
+    retriable: status === 429 || status === 502 || status === 503 || status === 504,
+  });
+}
+
+export class SicoreA2aClient implements SiclawA2aApi {
+  private readonly agentBaseUrl: string;
+
+  constructor(
+    private readonly config: AdapterConfig,
+    private readonly fetchImpl: typeof fetch = globalThis.fetch,
+  ) {
+    this.agentBaseUrl = `${config.baseUrl}/api/v1/a2a/agents/${encodeURIComponent(config.agentId)}`;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.config.requestTimeoutMs);
+    timer.unref();
+    try {
+      let response: Response;
+      try {
+        response = await this.fetchImpl(`${this.agentBaseUrl}${path}`, {
+          method,
+          headers: {
+            accept: "application/a2a+json, application/json",
+            authorization: `Bearer ${this.config.apiKey}`,
+            ...(body === undefined ? {} : { "content-type": "application/json" }),
+          },
+          body: body === undefined ? undefined : JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw new A2aClientError("Sicore A2A request timed out", {
+            reason: "A2A_TIMEOUT",
+            retriable: true,
+          });
+        }
+        throw new A2aClientError(
+          `Could not reach Sicore A2A endpoint: ${error instanceof Error ? error.message : String(error)}`,
+          { reason: "A2A_UNREACHABLE", retriable: true },
+        );
+      }
+
+      const raw = await response.text();
+      let payload: unknown = null;
+      if (raw) {
+        try {
+          payload = JSON.parse(raw);
+        } catch {
+          throw new A2aClientError("Sicore returned a non-JSON A2A response", {
+            httpStatus: response.status,
+            reason: "INVALID_A2A_RESPONSE",
+            retriable: response.status >= 500,
+          });
+        }
+      }
+      if (!response.ok) throw errorFromResponse(response.status, payload);
+      return payload as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async sendMessage(question: string, contextId?: string): Promise<SiclawTask> {
+    const payload = await this.request<{ task?: unknown }>("POST", "/message:send", {
+      message: {
+        role: "ROLE_USER",
+        parts: [{ text: question }],
+        ...(contextId ? { contextId } : {}),
+      },
+    });
+    return normalizeTask(payload.task);
+  }
+
+  async getTask(taskId: string): Promise<SiclawTask> {
+    const payload = await this.request<{ task?: unknown }>("GET", `/tasks/${encodeURIComponent(taskId)}`);
+    return normalizeTask(payload.task);
+  }
+
+  async cancelTask(taskId: string): Promise<SiclawTask> {
+    const payload = await this.request<{ task?: unknown }>("POST", `/tasks/${encodeURIComponent(taskId)}:cancel`);
+    return normalizeTask(payload.task);
+  }
+
+  async listTasks(options: ListTaskOptions = {}): Promise<SiclawTaskList> {
+    const query = new URLSearchParams();
+    if (options.contextId) query.set("contextId", options.contextId);
+    if (options.status) query.set("status", options.status);
+    if (options.pageSize !== undefined) query.set("pageSize", String(options.pageSize));
+    if (options.pageToken !== undefined) query.set("pageToken", String(options.pageToken));
+    const suffix = query.size > 0 ? `?${query}` : "";
+    const payload = await this.request<{
+      tasks?: unknown[];
+      totalSize?: number;
+      pageSize?: number;
+      nextPageToken?: string;
+    }>("GET", `/tasks${suffix}`);
+    return {
+      tasks: Array.isArray(payload.tasks) ? payload.tasks.map(normalizeTask) : [],
+      total_size: typeof payload.totalSize === "number" ? payload.totalSize : 0,
+      page_size: typeof payload.pageSize === "number" ? payload.pageSize : 0,
+      next_page_token: payload.nextPageToken ? payload.nextPageToken : null,
+    };
+  }
+
+  async waitForTask(taskId: string, waitSeconds: number): Promise<SiclawTask> {
+    let current = await this.getTask(taskId);
+    if (current.is_terminal || waitSeconds <= 0) return current;
+    const deadline = Date.now() + waitSeconds * 1_000;
+    while (Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      await delay(Math.min(this.config.pollIntervalMs, Math.max(remaining, 0)));
+      current = await this.getTask(taskId);
+      if (current.is_terminal) return current;
+    }
+    return current;
+  }
+}

--- a/mcp/sicore-a2a-adapter/src/a2a-client.ts
+++ b/mcp/sicore-a2a-adapter/src/a2a-client.ts
@@ -8,6 +8,8 @@ export const TERMINAL_A2A_STATES = new Set([
   "TASK_STATE_REJECTED",
 ]);
 
+const READ_RETRY_DELAYS_MS = [100, 300] as const;
+
 const SIMPLE_STATE: Record<string, SiclawTaskState> = {
   TASK_STATE_SUBMITTED: "submitted",
   TASK_STATE_WORKING: "working",
@@ -42,7 +44,7 @@ export interface SiclawTaskList {
   tasks: SiclawTask[];
   total_size: number;
   page_size: number;
-  next_page_token: string | null;
+  next_page_token: number | null;
 }
 
 export interface ListTaskOptions {
@@ -147,8 +149,26 @@ function errorFromResponse(status: number, payload: unknown): A2aClientError {
   return new A2aClientError(message, {
     httpStatus: status,
     reason,
-    retriable: status === 429 || status === 502 || status === 503 || status === 504,
+    retriable: isRetriableHttpStatus(status),
   });
+}
+
+function isRetriableHttpStatus(status: number): boolean {
+  return status === 408 || status === 429 || status === 500
+    || status === 502 || status === 503 || status === 504;
+}
+
+function normalizeNextPageToken(value: unknown): number | null {
+  if (value === undefined || value === null || value === "") return null;
+  const token = typeof value === "number"
+    ? value
+    : typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isSafeInteger(token) || token < 0) {
+    throw new A2aClientError("Sicore returned an invalid A2A page token", {
+      reason: "INVALID_A2A_RESPONSE",
+    });
+  }
+  return token;
 }
 
 export class SicoreA2aClient implements SiclawA2aApi {
@@ -161,9 +181,14 @@ export class SicoreA2aClient implements SiclawA2aApi {
     this.agentBaseUrl = `${config.baseUrl}/api/v1/a2a/agents/${encodeURIComponent(config.agentId)}`;
   }
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    timeoutMs = this.config.requestTimeoutMs,
+  ): Promise<T> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.config.requestTimeoutMs);
+    const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
     timer.unref();
     try {
       let response: Response;
@@ -191,7 +216,19 @@ export class SicoreA2aClient implements SiclawA2aApi {
         );
       }
 
-      const raw = await response.text();
+      let raw: string;
+      try {
+        raw = await response.text();
+      } catch (error) {
+        throw new A2aClientError(
+          `Could not read Sicore A2A response: ${error instanceof Error ? error.message : String(error)}`,
+          {
+            httpStatus: response.status,
+            reason: "A2A_RESPONSE_READ_FAILED",
+            retriable: method === "GET",
+          },
+        );
+      }
       let payload: unknown = null;
       if (raw) {
         try {
@@ -200,7 +237,7 @@ export class SicoreA2aClient implements SiclawA2aApi {
           throw new A2aClientError("Sicore returned a non-JSON A2A response", {
             httpStatus: response.status,
             reason: "INVALID_A2A_RESPONSE",
-            retriable: response.status >= 500,
+            retriable: method === "GET" && (response.ok || isRetriableHttpStatus(response.status)),
           });
         }
       }
@@ -209,6 +246,50 @@ export class SicoreA2aClient implements SiclawA2aApi {
     } finally {
       clearTimeout(timer);
     }
+  }
+
+  private async readWithRetry<T>(
+    operation: (timeoutMs: number) => Promise<T>,
+    overallDeadline?: number,
+  ): Promise<T> {
+    const operationDeadline = Math.min(
+      overallDeadline ?? Number.POSITIVE_INFINITY,
+      Date.now() + this.config.requestTimeoutMs,
+    );
+    let lastError: A2aClientError | null = null;
+
+    for (let attempt = 0; attempt <= READ_RETRY_DELAYS_MS.length; attempt += 1) {
+      const remaining = operationDeadline - Date.now();
+      if (remaining <= 0) {
+        throw lastError ?? new A2aClientError("Sicore A2A request timed out", {
+          reason: "A2A_TIMEOUT",
+          retriable: true,
+        });
+      }
+      try {
+        return await operation(remaining);
+      } catch (error) {
+        if (!(error instanceof A2aClientError) || !error.retriable) throw error;
+        lastError = error;
+        const retryDelayMs = READ_RETRY_DELAYS_MS[attempt];
+        if (retryDelayMs === undefined || Date.now() + retryDelayMs >= operationDeadline) throw error;
+        await delay(retryDelayMs);
+      }
+    }
+
+    throw lastError ?? new A2aClientError("Sicore A2A read failed");
+  }
+
+  private async loadTask(taskId: string, overallDeadline?: number): Promise<SiclawTask> {
+    return this.readWithRetry(async (timeoutMs) => {
+      const payload = await this.request<{ task?: unknown }>(
+        "GET",
+        `/tasks/${encodeURIComponent(taskId)}`,
+        undefined,
+        timeoutMs,
+      );
+      return normalizeTask(payload.task);
+    }, overallDeadline);
   }
 
   async sendMessage(question: string, contextId?: string): Promise<SiclawTask> {
@@ -223,8 +304,7 @@ export class SicoreA2aClient implements SiclawA2aApi {
   }
 
   async getTask(taskId: string): Promise<SiclawTask> {
-    const payload = await this.request<{ task?: unknown }>("GET", `/tasks/${encodeURIComponent(taskId)}`);
-    return normalizeTask(payload.task);
+    return this.loadTask(taskId);
   }
 
   async cancelTask(taskId: string): Promise<SiclawTask> {
@@ -239,30 +319,46 @@ export class SicoreA2aClient implements SiclawA2aApi {
     if (options.pageSize !== undefined) query.set("pageSize", String(options.pageSize));
     if (options.pageToken !== undefined) query.set("pageToken", String(options.pageToken));
     const suffix = query.size > 0 ? `?${query}` : "";
-    const payload = await this.request<{
-      tasks?: unknown[];
-      totalSize?: number;
-      pageSize?: number;
-      nextPageToken?: string;
-    }>("GET", `/tasks${suffix}`);
-    return {
-      tasks: Array.isArray(payload.tasks) ? payload.tasks.map(normalizeTask) : [],
-      total_size: typeof payload.totalSize === "number" ? payload.totalSize : 0,
-      page_size: typeof payload.pageSize === "number" ? payload.pageSize : 0,
-      next_page_token: payload.nextPageToken ? payload.nextPageToken : null,
-    };
+    return this.readWithRetry(async (timeoutMs) => {
+      const payload = await this.request<{
+        tasks?: unknown[];
+        totalSize?: number;
+        pageSize?: number;
+        nextPageToken?: unknown;
+      }>("GET", `/tasks${suffix}`, undefined, timeoutMs);
+      return {
+        tasks: Array.isArray(payload.tasks) ? payload.tasks.map(normalizeTask) : [],
+        total_size: typeof payload.totalSize === "number" ? payload.totalSize : 0,
+        page_size: typeof payload.pageSize === "number" ? payload.pageSize : 0,
+        next_page_token: normalizeNextPageToken(payload.nextPageToken),
+      };
+    });
   }
 
   async waitForTask(taskId: string, waitSeconds: number): Promise<SiclawTask> {
-    let current = await this.getTask(taskId);
-    if (current.is_terminal || waitSeconds <= 0) return current;
+    if (waitSeconds <= 0) return this.getTask(taskId);
     const deadline = Date.now() + waitSeconds * 1_000;
+    let current: SiclawTask | null = null;
+    let lastError: A2aClientError | null = null;
+
     while (Date.now() < deadline) {
+      try {
+        current = await this.loadTask(taskId, deadline);
+        lastError = null;
+      } catch (error) {
+        if (!(error instanceof A2aClientError) || !error.retriable) throw error;
+        lastError = error;
+      }
+      if (current?.is_terminal) return current;
+
       const remaining = deadline - Date.now();
-      await delay(Math.min(this.config.pollIntervalMs, Math.max(remaining, 0)));
-      current = await this.getTask(taskId);
-      if (current.is_terminal) return current;
+      if (remaining <= 0) break;
+      await delay(Math.min(this.config.pollIntervalMs, remaining));
     }
-    return current;
+    if (current) return current;
+    throw lastError ?? new A2aClientError("Sicore A2A wait timed out before receiving a task snapshot", {
+      reason: "A2A_TIMEOUT",
+      retriable: true,
+    });
   }
 }

--- a/mcp/sicore-a2a-adapter/src/config.test.ts
+++ b/mcp/sicore-a2a-adapter/src/config.test.ts
@@ -30,6 +30,10 @@ describe("loadConfig", () => {
     });
   });
 
+  it("treats SICLAW_AGENT_ID as optional for key self-resolution", () => {
+    expect(loadConfig(baseEnv({ SICLAW_AGENT_ID: undefined })).agentId).toBeUndefined();
+  });
+
   it("allows HTTP only for loopback testing", () => {
     expect(loadConfig(baseEnv({ SICORE_URL: "http://127.0.0.1:3000" })).baseUrl)
       .toBe("http://127.0.0.1:3000");

--- a/mcp/sicore-a2a-adapter/src/config.test.ts
+++ b/mcp/sicore-a2a-adapter/src/config.test.ts
@@ -1,0 +1,64 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ConfigError, loadConfig } from "./config.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function baseEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    SICORE_URL: "https://sicore.example.com/",
+    SICLAW_AGENT_ID: "agent-1",
+    SICLAW_A2A_KEY: "test-key",
+    ...extra,
+  };
+}
+
+describe("loadConfig", () => {
+  it("loads and normalizes environment configuration", () => {
+    expect(loadConfig(baseEnv())).toEqual({
+      baseUrl: "https://sicore.example.com",
+      agentId: "agent-1",
+      apiKey: "test-key",
+      requestTimeoutMs: 30_000,
+      pollIntervalMs: 3_000,
+    });
+  });
+
+  it("allows HTTP only for loopback testing", () => {
+    expect(loadConfig(baseEnv({ SICORE_URL: "http://127.0.0.1:3000" })).baseUrl)
+      .toBe("http://127.0.0.1:3000");
+    expect(() => loadConfig(baseEnv({ SICORE_URL: "http://sicore.example.com" })))
+      .toThrow(/must use HTTPS/);
+  });
+
+  it("reads a private key file without persisting it in config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sicore-a2a-config-"));
+    tempDirs.push(dir);
+    const keyFile = join(dir, "key");
+    writeFileSync(keyFile, "file-key\n", { mode: 0o600 });
+    chmodSync(keyFile, 0o600);
+    const env = baseEnv({ SICLAW_A2A_KEY: undefined, SICLAW_A2A_KEY_FILE: keyFile });
+    expect(loadConfig(env).apiKey).toBe("file-key");
+  });
+
+  it.runIf(process.platform !== "win32")("rejects a group-readable key file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sicore-a2a-config-"));
+    tempDirs.push(dir);
+    const keyFile = join(dir, "key");
+    writeFileSync(keyFile, "file-key\n", { mode: 0o644 });
+    chmodSync(keyFile, 0o644);
+    expect(() => loadConfig(baseEnv({ SICLAW_A2A_KEY: undefined, SICLAW_A2A_KEY_FILE: keyFile })))
+      .toThrow(/chmod 600/);
+  });
+
+  it("rejects ambiguous key sources", () => {
+    expect(() => loadConfig(baseEnv({ SICLAW_A2A_KEY_FILE: "/tmp/key" })))
+      .toThrow(ConfigError);
+  });
+});

--- a/mcp/sicore-a2a-adapter/src/config.ts
+++ b/mcp/sicore-a2a-adapter/src/config.ts
@@ -1,0 +1,107 @@
+import { readFileSync, statSync } from "node:fs";
+
+export interface AdapterConfig {
+  baseUrl: string;
+  agentId: string;
+  apiKey: string;
+  requestTimeoutMs: number;
+  pollIntervalMs: number;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+function required(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name]?.trim();
+  if (!value) throw new ConfigError(`${name} is required`);
+  return value;
+}
+
+function parseBoundedInteger(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const raw = env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new ConfigError(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return value;
+}
+
+function isLoopback(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function normalizeBaseUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new ConfigError("SICORE_URL must be an absolute URL");
+  }
+  if (url.username || url.password) {
+    throw new ConfigError("SICORE_URL must not contain credentials");
+  }
+  if (url.search || url.hash) {
+    throw new ConfigError("SICORE_URL must not contain a query string or fragment");
+  }
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopback(url.hostname))) {
+    throw new ConfigError("SICORE_URL must use HTTPS (HTTP is allowed only for loopback testing)");
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+function loadKeyFromFile(path: string): string {
+  let stat;
+  try {
+    stat = statSync(path);
+  } catch {
+    throw new ConfigError("SICLAW_A2A_KEY_FILE could not be read");
+  }
+  if (!stat.isFile()) throw new ConfigError("SICLAW_A2A_KEY_FILE must point to a regular file");
+  if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+    throw new ConfigError("SICLAW_A2A_KEY_FILE must not be readable or writable by group/others (use chmod 600)");
+  }
+  let key: string;
+  try {
+    key = readFileSync(path, "utf8").trim();
+  } catch {
+    throw new ConfigError("SICLAW_A2A_KEY_FILE could not be read");
+  }
+  if (!key) throw new ConfigError("SICLAW_A2A_KEY_FILE is empty");
+  return key;
+}
+
+function loadApiKey(env: NodeJS.ProcessEnv): string {
+  const direct = env.SICLAW_A2A_KEY?.trim();
+  const keyFile = env.SICLAW_A2A_KEY_FILE?.trim();
+  if (direct && keyFile) {
+    throw new ConfigError("Set only one of SICLAW_A2A_KEY or SICLAW_A2A_KEY_FILE");
+  }
+  if (keyFile) return loadKeyFromFile(keyFile);
+  if (direct) return direct;
+  throw new ConfigError("SICLAW_A2A_KEY or SICLAW_A2A_KEY_FILE is required");
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): AdapterConfig {
+  const agentId = required(env, "SICLAW_AGENT_ID");
+  if (Buffer.byteLength(agentId, "utf8") > 255) {
+    throw new ConfigError("SICLAW_AGENT_ID must be 255 bytes or less");
+  }
+  return {
+    baseUrl: normalizeBaseUrl(required(env, "SICORE_URL")),
+    agentId,
+    apiKey: loadApiKey(env),
+    requestTimeoutMs: parseBoundedInteger(env, "SICLAW_A2A_TIMEOUT_MS", 30_000, 1_000, 120_000),
+    pollIntervalMs: parseBoundedInteger(env, "SICLAW_A2A_POLL_INTERVAL_MS", 3_000, 500, 5_000),
+  };
+}

--- a/mcp/sicore-a2a-adapter/src/config.ts
+++ b/mcp/sicore-a2a-adapter/src/config.ts
@@ -2,11 +2,14 @@ import { readFileSync, statSync } from "node:fs";
 
 export interface AdapterConfig {
   baseUrl: string;
-  agentId: string;
+  /** Absent when the agent should be resolved from the key via GET /api/v1/a2a/self. */
+  agentId?: string;
   apiKey: string;
   requestTimeoutMs: number;
   pollIntervalMs: number;
 }
+
+export type ResolvedAdapterConfig = AdapterConfig & { agentId: string };
 
 export class ConfigError extends Error {
   constructor(message: string) {
@@ -93,8 +96,8 @@ function loadApiKey(env: NodeJS.ProcessEnv): string {
 }
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): AdapterConfig {
-  const agentId = required(env, "SICLAW_AGENT_ID");
-  if (Buffer.byteLength(agentId, "utf8") > 255) {
+  const agentId = env.SICLAW_AGENT_ID?.trim() || undefined;
+  if (agentId && Buffer.byteLength(agentId, "utf8") > 255) {
     throw new ConfigError("SICLAW_AGENT_ID must be 255 bytes or less");
   }
   return {

--- a/mcp/sicore-a2a-adapter/src/index.ts
+++ b/mcp/sicore-a2a-adapter/src/index.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { SicoreA2aClient } from "./a2a-client.js";
+import { loadConfig } from "./config.js";
+import { serveStdio } from "./server.js";
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const server = await serveStdio(new SicoreA2aClient(config));
+  process.stderr.write(
+    `[sicore-a2a-mcp] ready agent=${config.agentId} endpoint=${new URL(config.baseUrl).origin}\n`,
+  );
+
+  const shutdown = async (): Promise<void> => {
+    await server.close();
+    process.exit(0);
+  };
+  process.once("SIGINT", () => void shutdown());
+  process.once("SIGTERM", () => void shutdown());
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `[sicore-a2a-mcp] fatal: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/mcp/sicore-a2a-adapter/src/index.ts
+++ b/mcp/sicore-a2a-adapter/src/index.ts
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
-import { SicoreA2aClient } from "./a2a-client.js";
+import { resolveAgentId, SicoreA2aClient } from "./a2a-client.js";
 import { loadConfig } from "./config.js";
 import { serveStdio } from "./server.js";
 
 async function main(): Promise<void> {
   const config = loadConfig();
-  const server = await serveStdio(new SicoreA2aClient(config));
+  const agentId = config.agentId ?? await resolveAgentId(config);
+  const server = await serveStdio(new SicoreA2aClient({ ...config, agentId }));
   process.stderr.write(
-    `[sicore-a2a-mcp] ready agent=${config.agentId} endpoint=${new URL(config.baseUrl).origin}\n`,
+    `[sicore-a2a-mcp] ready agent=${agentId} endpoint=${new URL(config.baseUrl).origin}`
+    + `${config.agentId ? "" : " (agent resolved from key)"}\n`,
   );
 
   const shutdown = async (): Promise<void> => {

--- a/mcp/sicore-a2a-adapter/src/server.test.ts
+++ b/mcp/sicore-a2a-adapter/src/server.test.ts
@@ -1,0 +1,70 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SiclawA2aApi, SiclawTask } from "./a2a-client.js";
+import { createMcpServer } from "./server.js";
+
+const closeAfter: Array<{ close(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(closeAfter.splice(0).map((item) => item.close()));
+});
+
+function completedTask(): SiclawTask {
+  return {
+    task_id: "task-1",
+    context_id: "context-1",
+    state: "completed",
+    a2a_state: "TASK_STATE_COMPLETED",
+    is_terminal: true,
+    status_message: "completed",
+    result: "root cause",
+    error: null,
+    updated_at: "2026-07-18T00:00:00.000Z",
+  };
+}
+
+function fakeApi(): SiclawA2aApi {
+  return {
+    sendMessage: vi.fn(async () => completedTask()),
+    getTask: vi.fn(async () => completedTask()),
+    cancelTask: vi.fn(async () => completedTask()),
+    listTasks: vi.fn(async () => ({ tasks: [completedTask()], total_size: 1, page_size: 20, next_page_token: null })),
+    waitForTask: vi.fn(async () => completedTask()),
+  };
+}
+
+describe("MCP server", () => {
+  it("completes MCP initialization, lists tools, and calls Siclaw through the adapter", async () => {
+    const api = fakeApi();
+    const server = createMcpServer(api);
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    closeAfter.push(client, server);
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    expect(client.getInstructions()).toContain("call siclaw_wait_task");
+    expect(client.getInstructions()).toContain("Never resubmit the same question");
+
+    const listed = await client.listTools();
+    expect(listed.tools.map((tool) => tool.name)).toEqual([
+      "siclaw_investigate",
+      "siclaw_wait_task",
+      "siclaw_get_task",
+      "siclaw_cancel_task",
+      "siclaw_list_tasks",
+    ]);
+
+    const result = await client.callTool({
+      name: "siclaw_investigate",
+      arguments: { question: "check node", wait_seconds: 0 },
+    });
+    expect(api.sendMessage).toHaveBeenCalledWith("check node", undefined);
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      task_id: "task-1",
+      state: "completed",
+      result: "root cause",
+    });
+  });
+});

--- a/mcp/sicore-a2a-adapter/src/server.ts
+++ b/mcp/sicore-a2a-adapter/src/server.ts
@@ -1,0 +1,32 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { SiclawA2aApi } from "./a2a-client.js";
+import { createToolHandler, TOOL_DEFINITIONS } from "./tools.js";
+
+export const SERVER_INSTRUCTIONS = [
+  "Use siclaw_investigate for operational questions that require the configured Siclaw SRE agent.",
+  "When it returns a non-terminal task, keep the current turn open and call siclaw_wait_task with the same task_id until terminal, unless the user requests fire-and-forget, asks to stop, or the overall investigation deadline is exhausted.",
+  "Never resubmit the same question merely because a task is still working.",
+  "Use siclaw_list_tasks to recover server-side tasks after a client restart.",
+].join(" ");
+
+export function createMcpServer(api: SiclawA2aApi): Server {
+  const server = new Server(
+    { name: "sicore-a2a-mcp-adapter", version: "0.1.0" },
+    { capabilities: { tools: {} }, instructions: SERVER_INSTRUCTIONS },
+  );
+  const handleTool = createToolHandler(api);
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [...TOOL_DEFINITIONS] }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => (
+    await handleTool(request.params.name, request.params.arguments ?? {}) as any
+  ));
+  return server;
+}
+
+export async function serveStdio(api: SiclawA2aApi): Promise<Server> {
+  const server = createMcpServer(api);
+  await server.connect(new StdioServerTransport());
+  return server;
+}

--- a/mcp/sicore-a2a-adapter/src/stdio.e2e.test.ts
+++ b/mcp/sicore-a2a-adapter/src/stdio.e2e.test.ts
@@ -52,10 +52,10 @@ describe("stdio process", () => {
     httpServers.push(mock);
     const port = await listen(mock);
 
-    const adapterEntrypoint = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+    const adapterEntrypoint = fileURLToPath(new URL("./index.ts", import.meta.url));
     const transport = new StdioClientTransport({
       command: process.execPath,
-      args: [adapterEntrypoint],
+      args: ["--import", "tsx", adapterEntrypoint],
       env: {
         SICORE_URL: `http://127.0.0.1:${port}`,
         SICLAW_AGENT_ID: "agent-e2e",

--- a/mcp/sicore-a2a-adapter/src/stdio.e2e.test.ts
+++ b/mcp/sicore-a2a-adapter/src/stdio.e2e.test.ts
@@ -1,0 +1,86 @@
+import { createServer, type Server as HttpServer } from "node:http";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+const clients: Client[] = [];
+const httpServers: HttpServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(clients.splice(0).map((client) => client.close()));
+  await Promise.all(httpServers.splice(0).map((server) => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  })));
+});
+
+async function listen(server: HttpServer): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("mock server did not bind TCP");
+  return address.port;
+}
+
+function completedTask() {
+  return {
+    id: "task-e2e",
+    contextId: "context-e2e",
+    status: {
+      state: "TASK_STATE_COMPLETED",
+      timestamp: "2026-07-18T00:00:00.000Z",
+      message: { parts: [{ text: "completed" }] },
+    },
+    artifacts: [{ parts: [{ text: "e2e root cause" }] }],
+  };
+}
+
+describe("stdio process", () => {
+  it("bridges a real MCP subprocess call to the Sicore A2A HTTP contract", async () => {
+    let observedAuth = "";
+    let observedBody: unknown;
+    const mock = createServer(async (request, response) => {
+      observedAuth = request.headers.authorization ?? "";
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      observedBody = chunks.length > 0 ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : null;
+      response.writeHead(200, { "content-type": "application/a2a+json" });
+      response.end(JSON.stringify({ task: completedTask() }));
+    });
+    httpServers.push(mock);
+    const port = await listen(mock);
+
+    const adapterEntrypoint = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [adapterEntrypoint],
+      env: {
+        SICORE_URL: `http://127.0.0.1:${port}`,
+        SICLAW_AGENT_ID: "agent-e2e",
+        SICLAW_A2A_KEY: "e2e-key",
+      },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "stdio-e2e", version: "1.0.0" });
+    clients.push(client);
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: "siclaw_investigate",
+      arguments: { question: "check e2e", wait_seconds: 0 },
+    });
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      task_id: "task-e2e",
+      context_id: "context-e2e",
+      state: "completed",
+      result: "e2e root cause",
+    });
+    expect(observedAuth).toBe("Bearer e2e-key");
+    expect(observedBody).toEqual({
+      message: { role: "ROLE_USER", parts: [{ text: "check e2e" }] },
+    });
+  });
+});

--- a/mcp/sicore-a2a-adapter/src/stdio.e2e.test.ts
+++ b/mcp/sicore-a2a-adapter/src/stdio.e2e.test.ts
@@ -83,4 +83,42 @@ describe("stdio process", () => {
       message: { role: "ROLE_USER", parts: [{ text: "check e2e" }] },
     });
   });
+
+  it("self-resolves the agent from the key when SICLAW_AGENT_ID is absent", async () => {
+    const paths: string[] = [];
+    const mock = createServer(async (request, response) => {
+      paths.push(request.url ?? "");
+      for await (const _chunk of request) { /* drain */ }
+      response.writeHead(200, { "content-type": "application/a2a+json" });
+      if (request.url === "/api/v1/a2a/self") {
+        response.end(JSON.stringify({ agentId: "agent-resolved" }));
+        return;
+      }
+      response.end(JSON.stringify({ task: completedTask() }));
+    });
+    httpServers.push(mock);
+    const port = await listen(mock);
+
+    const adapterEntrypoint = fileURLToPath(new URL("./index.ts", import.meta.url));
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ["--import", "tsx", adapterEntrypoint],
+      env: {
+        SICORE_URL: `http://127.0.0.1:${port}`,
+        SICLAW_A2A_KEY: "e2e-key",
+      },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "stdio-e2e-self", version: "1.0.0" });
+    clients.push(client);
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: "siclaw_investigate",
+      arguments: { question: "check self-resolve", wait_seconds: 0 },
+    });
+    expect(result.isError).not.toBe(true);
+    expect(paths[0]).toBe("/api/v1/a2a/self");
+    expect(paths).toContain("/api/v1/a2a/agents/agent-resolved/message:send");
+  });
 });

--- a/mcp/sicore-a2a-adapter/src/tools.test.ts
+++ b/mcp/sicore-a2a-adapter/src/tools.test.ts
@@ -97,6 +97,23 @@ describe("tool contract", () => {
     expect(result.structuredContent).not.toHaveProperty("result");
   });
 
+  it("keeps the submitted task_id when the bounded wait fails after submission", async () => {
+    const api = fakeApi();
+    vi.mocked(api.waitForTask).mockRejectedValue(new Error("Sicore A2A request timed out"));
+    const result = await createToolHandler(api)("siclaw_investigate", { question: "check node" });
+
+    expect(api.sendMessage).toHaveBeenCalledOnce();
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toMatchObject({
+      task_id: "task-1",
+      state: "working",
+      wait_error: "Sicore A2A request timed out",
+    });
+    expect(result.content[0].text).toContain("task-1");
+    expect(result.content[0].text).toContain("wait_error: Sicore A2A request timed out");
+    expect(result.content[0].text).toContain("do not submit the same investigation again");
+  });
+
   it("returns MCP tool errors for invalid arguments", async () => {
     const result = await createToolHandler(fakeApi())("siclaw_get_task", {});
     expect(result.isError).toBe(true);

--- a/mcp/sicore-a2a-adapter/src/tools.test.ts
+++ b/mcp/sicore-a2a-adapter/src/tools.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SiclawA2aApi, SiclawTask } from "./a2a-client.js";
+import { createToolHandler, TOOL_DEFINITIONS } from "./tools.js";
+
+function task(state: SiclawTask["state"] = "working"): SiclawTask {
+  return {
+    task_id: "task-1",
+    context_id: "context-1",
+    state,
+    a2a_state: state === "completed" ? "TASK_STATE_COMPLETED" : "TASK_STATE_WORKING",
+    is_terminal: state === "completed",
+    status_message: state === "completed" ? "completed" : "working",
+    result: state === "completed" ? "root cause" : null,
+    error: null,
+    updated_at: null,
+  };
+}
+
+function fakeApi(): SiclawA2aApi {
+  return {
+    sendMessage: vi.fn(async () => task()),
+    getTask: vi.fn(async () => task("completed")),
+    cancelTask: vi.fn(async () => ({ ...task(), state: "canceled", a2a_state: "TASK_STATE_CANCELED", is_terminal: true })),
+    listTasks: vi.fn(async () => ({ tasks: [task()], total_size: 1, page_size: 20, next_page_token: null })),
+    waitForTask: vi.fn(async () => task("completed")),
+  };
+}
+
+describe("tool contract", () => {
+  it("keeps the configured agent out of every model-visible input schema", () => {
+    expect(TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual([
+      "siclaw_investigate",
+      "siclaw_wait_task",
+      "siclaw_get_task",
+      "siclaw_cancel_task",
+      "siclaw_list_tasks",
+    ]);
+    for (const tool of TOOL_DEFINITIONS) {
+      expect(tool.inputSchema.properties).not.toHaveProperty("agent_id");
+      expect(tool.inputSchema.additionalProperties).toBe(false);
+    }
+  });
+
+  it("submits and waits for a bounded investigation", async () => {
+    const api = fakeApi();
+    const handle = createToolHandler(api);
+    const result = await handle("siclaw_investigate", {
+      question: "check node",
+      context_id: "context-1",
+      wait_seconds: 5,
+    });
+    expect(api.sendMessage).toHaveBeenCalledWith("check node", "context-1");
+    expect(api.waitForTask).toHaveBeenCalledWith("task-1", 5);
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toMatchObject({ state: "completed", result: "root cause" });
+  });
+
+  it("maps simple list status to the A2A enum", async () => {
+    const api = fakeApi();
+    const handle = createToolHandler(api);
+    const result = await handle("siclaw_list_tasks", { status: "working", page_size: 10 });
+    expect(api.listTasks).toHaveBeenCalledWith({
+      contextId: undefined,
+      status: "TASK_STATE_WORKING",
+      pageSize: 10,
+      pageToken: 0,
+    });
+    expect(result.structuredContent).toMatchObject({ total_size: 1 });
+  });
+
+  it("waits on an existing task without submitting another investigation", async () => {
+    const api = fakeApi();
+    const handle = createToolHandler(api);
+    const result = await handle("siclaw_wait_task", {
+      task_id: "task-1",
+      wait_seconds: 45,
+    });
+    expect(api.waitForTask).toHaveBeenCalledWith("task-1", 45);
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(result.structuredContent).toMatchObject({ state: "completed", result: "root cause" });
+  });
+
+  it("keeps a working response compact until the terminal result", async () => {
+    const api = fakeApi();
+    vi.mocked(api.getTask).mockResolvedValue({
+      ...task(),
+      result: "partial evidence that should not be repeated",
+      updated_at: "2026-07-18T00:00:00.000Z",
+    });
+    const result = await createToolHandler(api)("siclaw_get_task", { task_id: "task-1" });
+    expect(result.content[0].text).not.toContain("partial evidence that should not be repeated");
+    expect(result.content[0].text).toContain("siclaw_wait_task");
+    expect(result.structuredContent).toMatchObject({
+      state: "working",
+      progress_chars: 44,
+    });
+    expect(result.structuredContent).not.toHaveProperty("result");
+  });
+
+  it("returns MCP tool errors for invalid arguments", async () => {
+    const result = await createToolHandler(fakeApi())("siclaw_get_task", {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/task_id/);
+  });
+
+  it("keeps waits below common MCP client request timeouts", async () => {
+    const result = await createToolHandler(fakeApi())("siclaw_investigate", {
+      question: "check node",
+      wait_seconds: 51,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/between 0 and 50/);
+
+    const waitResult = await createToolHandler(fakeApi())("siclaw_wait_task", {
+      task_id: "task-1",
+      wait_seconds: 51,
+    });
+    expect(waitResult.isError).toBe(true);
+    expect(waitResult.content[0].text).toMatch(/between 1 and 50/);
+  });
+});

--- a/mcp/sicore-a2a-adapter/src/tools.ts
+++ b/mcp/sicore-a2a-adapter/src/tools.ts
@@ -110,6 +110,7 @@ type ToolResult = {
 type TaskToolView = Omit<SiclawTask, "result"> & {
   result?: string | null;
   progress_chars: number;
+  wait_error?: string;
 };
 
 function taskView(task: SiclawTask, includeTerminalResult: boolean): TaskToolView {
@@ -154,13 +155,14 @@ function intArg(
   return value as number;
 }
 
-function taskText(task: SiclawTask): string {
+function taskText(task: SiclawTask, waitError?: string): string {
   const lines = [
     `Siclaw task ${task.task_id}: ${task.state}`,
     `context_id: ${task.context_id}`,
   ];
   if (task.updated_at) lines.push(`updated_at: ${task.updated_at}`);
   if (task.status_message) lines.push(`status: ${task.status_message}`);
+  if (waitError) lines.push(`wait_error: ${waitError} (status polling failed, but the task was already created)`);
   if (task.is_terminal && task.result) lines.push("", task.result);
   if (!task.is_terminal) {
     const progressChars = task.result?.length ?? 0;
@@ -170,10 +172,12 @@ function taskText(task: SiclawTask): string {
   return lines.join("\n");
 }
 
-function taskResult(task: SiclawTask): ToolResult {
+function taskResult(task: SiclawTask, waitError?: string): ToolResult {
+  const view = taskView(task, true);
+  if (waitError) view.wait_error = waitError;
   return {
-    content: [{ type: "text", text: taskText(task) }],
-    structuredContent: taskView(task, true) as unknown as Record<string, unknown>,
+    content: [{ type: "text", text: taskText(task, waitError) }],
+    structuredContent: view as unknown as Record<string, unknown>,
   };
 }
 
@@ -195,10 +199,14 @@ export function createToolHandler(api: SiclawA2aApi) {
         const contextId = stringArg(args, "context_id");
         const waitSeconds = intArg(args, "wait_seconds", 20, 0, 50);
         const submitted = await api.sendMessage(question, contextId);
-        const task = waitSeconds > 0 && !submitted.is_terminal
-          ? await api.waitForTask(submitted.task_id, waitSeconds)
-          : submitted;
-        return taskResult(task);
+        if (waitSeconds === 0 || submitted.is_terminal) return taskResult(submitted);
+        try {
+          return taskResult(await api.waitForTask(submitted.task_id, waitSeconds));
+        } catch (error) {
+          // The task exists server-side at this point; a plain error would drop the
+          // task_id and invite the client to resubmit a duplicate investigation.
+          return taskResult(submitted, error instanceof Error ? error.message : String(error));
+        }
       }
       if (name === "siclaw_get_task") {
         return taskResult(await api.getTask(stringArg(args, "task_id", true)!));

--- a/mcp/sicore-a2a-adapter/src/tools.ts
+++ b/mcp/sicore-a2a-adapter/src/tools.ts
@@ -1,0 +1,240 @@
+import type { SiclawA2aApi, SiclawTask, SiclawTaskList } from "./a2a-client.js";
+
+const STATUS_TO_A2A: Record<string, string> = {
+  submitted: "TASK_STATE_SUBMITTED",
+  working: "TASK_STATE_WORKING",
+  completed: "TASK_STATE_COMPLETED",
+  failed: "TASK_STATE_FAILED",
+  canceled: "TASK_STATE_CANCELED",
+  rejected: "TASK_STATE_REJECTED",
+};
+
+export const TOOL_DEFINITIONS = [
+  {
+    name: "siclaw_investigate",
+    description: "Ask the configured Siclaw SRE agent to investigate an operational question. This creates an asynchronous Sicore A2A task. Reuse context_id to continue the same investigation. If the returned task is not terminal, do not submit it again: call siclaw_wait_task until it finishes unless the user explicitly requested fire-and-forget. The configured A2A key fixes which Siclaw agent is used.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        question: {
+          type: "string",
+          minLength: 1,
+          description: "The concrete operational question for Siclaw, including relevant target names and time window when known.",
+        },
+        context_id: {
+          type: "string",
+          minLength: 1,
+          maxLength: 255,
+          description: "Optional context_id from a prior task to continue the same Siclaw investigation session.",
+        },
+        wait_seconds: {
+          type: "integer",
+          minimum: 0,
+          maximum: 50,
+          default: 20,
+          description: "How long to wait for a terminal result before returning the task as working. The 50-second ceiling stays below common MCP client request timeouts; use siclaw_wait_task later when it is still running.",
+        },
+      },
+      required: ["question"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "siclaw_wait_task",
+    description: "Wait for an existing Siclaw investigation without creating another task. Use this as the same-turn watchdog: call it repeatedly while the task is non-terminal, unless the user asks to stop or the overall investigation deadline is exhausted. Working responses are compact; the full report is returned once the task reaches a terminal state.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", minLength: 1, maxLength: 255 },
+        wait_seconds: {
+          type: "integer",
+          minimum: 1,
+          maximum: 50,
+          default: 45,
+          description: "Bounded watchdog wait. Keep this below the MCP client's request timeout.",
+        },
+      },
+      required: ["task_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "siclaw_get_task",
+    description: "Get one immediate snapshot of a Siclaw investigation task created with this same A2A key. Use siclaw_wait_task instead when actively waiting for completion.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", minLength: 1, maxLength: 255 },
+      },
+      required: ["task_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "siclaw_cancel_task",
+    description: "Cancel a non-terminal Siclaw investigation task created with this same A2A key.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        task_id: { type: "string", minLength: 1, maxLength: 255 },
+      },
+      required: ["task_id"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "siclaw_list_tasks",
+    description: "List Siclaw investigation tasks scoped to this configured agent and A2A key. Use this to recover task IDs after a local client restart.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        context_id: { type: "string", minLength: 1, maxLength: 255 },
+        status: {
+          type: "string",
+          enum: ["submitted", "working", "completed", "failed", "canceled", "rejected"],
+        },
+        page_size: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+        page_token: { type: "integer", minimum: 0, default: 0 },
+      },
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+type ToolResult = {
+  isError?: boolean;
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
+};
+
+type TaskToolView = Omit<SiclawTask, "result"> & {
+  result?: string | null;
+  progress_chars: number;
+};
+
+function taskView(task: SiclawTask, includeTerminalResult: boolean): TaskToolView {
+  const { result, ...summary } = task;
+  return {
+    ...summary,
+    progress_chars: result?.length ?? 0,
+    ...(includeTerminalResult && task.is_terminal ? { result } : {}),
+  };
+}
+
+function argsRecord(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Tool arguments must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringArg(args: Record<string, unknown>, name: string, required = false): string | undefined {
+  const value = args[name];
+  if (value === undefined && !required) return undefined;
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${name} must be a non-empty string`);
+  const trimmed = value.trim();
+  if (Buffer.byteLength(trimmed, "utf8") > 255 && name !== "question") {
+    throw new Error(`${name} must be 255 bytes or less`);
+  }
+  return trimmed;
+}
+
+function intArg(
+  args: Record<string, unknown>,
+  name: string,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const value = args[name];
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || (value as number) < min || (value as number) > max) {
+    throw new Error(`${name} must be an integer between ${min} and ${max}`);
+  }
+  return value as number;
+}
+
+function taskText(task: SiclawTask): string {
+  const lines = [
+    `Siclaw task ${task.task_id}: ${task.state}`,
+    `context_id: ${task.context_id}`,
+  ];
+  if (task.updated_at) lines.push(`updated_at: ${task.updated_at}`);
+  if (task.status_message) lines.push(`status: ${task.status_message}`);
+  if (task.is_terminal && task.result) lines.push("", task.result);
+  if (!task.is_terminal) {
+    const progressChars = task.result?.length ?? 0;
+    if (progressChars > 0) lines.push(`progress_chars: ${progressChars} (partial report withheld until terminal)`);
+    lines.push("", "The investigation is still running. Call siclaw_wait_task with the task_id; do not submit the same investigation again.");
+  }
+  return lines.join("\n");
+}
+
+function taskResult(task: SiclawTask): ToolResult {
+  return {
+    content: [{ type: "text", text: taskText(task) }],
+    structuredContent: taskView(task, true) as unknown as Record<string, unknown>,
+  };
+}
+
+function listText(list: SiclawTaskList): string {
+  if (list.tasks.length === 0) return "No Siclaw tasks matched this query.";
+  const rows = list.tasks.map((task) => `${task.task_id}\t${task.state}\tcontext=${task.context_id}`);
+  return [`Siclaw tasks (${list.tasks.length}/${list.total_size}):`, ...rows].join("\n");
+}
+
+export function createToolHandler(api: SiclawA2aApi) {
+  return async (name: string, rawArgs: unknown): Promise<ToolResult> => {
+    try {
+      const args = argsRecord(rawArgs ?? {});
+      if (name === "siclaw_investigate") {
+        const question = stringArg(args, "question", true)!;
+        if (Buffer.byteLength(question, "utf8") > 512 * 1024) {
+          throw new Error("question must be 512 KiB or less");
+        }
+        const contextId = stringArg(args, "context_id");
+        const waitSeconds = intArg(args, "wait_seconds", 20, 0, 50);
+        const submitted = await api.sendMessage(question, contextId);
+        const task = waitSeconds > 0 && !submitted.is_terminal
+          ? await api.waitForTask(submitted.task_id, waitSeconds)
+          : submitted;
+        return taskResult(task);
+      }
+      if (name === "siclaw_get_task") {
+        return taskResult(await api.getTask(stringArg(args, "task_id", true)!));
+      }
+      if (name === "siclaw_wait_task") {
+        const taskId = stringArg(args, "task_id", true)!;
+        const waitSeconds = intArg(args, "wait_seconds", 45, 1, 50);
+        return taskResult(await api.waitForTask(taskId, waitSeconds));
+      }
+      if (name === "siclaw_cancel_task") {
+        return taskResult(await api.cancelTask(stringArg(args, "task_id", true)!));
+      }
+      if (name === "siclaw_list_tasks") {
+        const status = stringArg(args, "status");
+        if (status && !STATUS_TO_A2A[status]) throw new Error("status is invalid");
+        const list = await api.listTasks({
+          contextId: stringArg(args, "context_id"),
+          status: status ? STATUS_TO_A2A[status] : undefined,
+          pageSize: intArg(args, "page_size", 20, 1, 100),
+          pageToken: intArg(args, "page_token", 0, 0, Number.MAX_SAFE_INTEGER),
+        });
+        return {
+          content: [{ type: "text", text: listText(list) }],
+          structuredContent: {
+            ...list,
+            tasks: list.tasks.map((task) => taskView(task, false)),
+          } as unknown as Record<string, unknown>,
+        };
+      }
+      throw new Error(`Unknown tool: ${name}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        isError: true,
+        content: [{ type: "text", text: message }],
+      };
+    }
+  };
+}

--- a/mcp/sicore-a2a-adapter/tsconfig.json
+++ b/mcp/sicore-a2a-adapter/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/mcp/sicore-a2a-adapter/vitest.config.ts
+++ b/mcp/sicore-a2a-adapter/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Add a minimal local stdio MCP adapter that lets Codex and Claude Code reuse one Sicore-hosted Siclaw agent through the existing A2A task API.

### Problem

Coding agents need a safe way to delegate production investigations without receiving cluster credentials or choosing a different Siclaw agent at runtime. Long investigations must survive client restarts without repeatedly injecting the growing partial report into model context.

### Solution

- fix each adapter process to one Sicore URL, agent ID, and private A2A key file
- expose investigate, bounded watchdog wait, snapshot, list/recovery, and cancel tools
- advertise same-turn watchdog instructions through MCP initialization
- keep working responses compact and return the full report only at terminal state
- validate key-file permissions and avoid retrying task submission

No Sicore backend change is required: the existing A2A API already owns durable task state, progress, recovery, and cancellation.

## Test Plan

- [x] `npm ci`
- [x] `npm test` (20 tests)
- [x] `npm audit --omit=dev` (0 vulnerabilities)
- [x] Real Sicore A2A smoke: working task returned no partial result, then `siclaw_wait_task` returned `WATCHDOG_READY` on the same task ID
