### PR TITLE
feat(kbc): add resumable Source Snapshot v2 delivery

### DIFF
--- a/kbc/platform/pod/README.md
+++ b/kbc/platform/pod/README.md
@@ -9,6 +9,7 @@ Platform-agnostic (kbc base); the siclaw runtime reuses agentbox's K8sSpawner to
 
 - **`compile_box.py` (served, production form)** — an aiohttp service, driven by the runtime over the **box's own HTTP+SSE contract**:
   - `POST /sources`  `{run_id?, workdir?, bundle_base64, bundle_sha256?}` → upload the frozen raw bundle, safely unpack into `workdir/raw/` (`drop/` kept as a compatibility alias); calling it after the run has started returns 409
+  - Source Snapshot v2 (large/resumable raw input): `POST /sources/begin` with the immutable descriptor → upload only returned `missing_parts` through `POST /sources/part` → `POST /sources/commit`; `POST /sources/state` can recover progress after a container restart. Every compressed part and declared file is SHA-256 verified, and `raw/` changes only after a complete atomic commit. The v1 `/sources` route remains supported for rolling upgrades and small bundles.
   - `POST /authoring` `{run_id?, workdir?, bundle_base64, bundle_sha256?}` → upload authoring/candidate/eval/release assets, safely unpack into `workdir/`; also allowed on a live run (workspace re-hydration goes through here)
   - `POST /session/{run_id}` `{workdir?, instruction?, allowed_tools?, llm?, settings?}` → start this run's persistent conversation session (waits for the first /message); idempotent, on a live run it is a no-op attach and does not hot-rotate the connected SDK client
   - `POST /message/{run_id}` `{message, message_id?}` → inject one genuine conversational turn; a repeated consumer-minted `message_id` is acknowledged without injecting a second turn; legacy control-prefix recognition remains only for rolling upgrades
@@ -54,6 +55,10 @@ docker run --rm -p 3000:3000 \
   kbc-compile-box
 # then:
 #   POST :3000/sources {"run_id":"r1","bundle_base64":"...","bundle_sha256":"..."}
+# or for Source Snapshot v2:
+#   POST :3000/sources/begin  {"run_id":"r1","input_revision":"...","snapshot":{...}}
+#   POST :3000/sources/part   {"run_id":"r1","input_revision":"...","part_id":"part-000001","bundle_base64":"..."}
+#   POST :3000/sources/commit {"run_id":"r1","input_revision":"..."}
 #   POST :3000/authoring {"run_id":"r1","bundle_base64":"...","bundle_sha256":"..."}
 #   POST :3000/session/r1 {"instruction":"..."}
 #   POST :3000/message/r1 {"message":"compile raw/ into candidate pages"} → GET :3000/events/r1 (SSE)

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -670,11 +670,14 @@ def _install_source_bundle(bundle: bytes, workdir: str, expected_sha256: str | N
     }
 
 
-def _safe_authoring_path(name: str) -> Path:
+def _safe_authoring_path(name: str, *, is_dir: bool = False) -> Path:
     rel = _safe_tar_path(name)
+    allowed_roots = {"authoring", "candidate", "eval", "release"}
+    if len(rel.parts) == 1 and is_dir and rel.parts[0] in allowed_roots:
+        return rel
     if len(rel.parts) < 2:
         raise ValueError(f"unsafe authoring path {name!r}: must include a file path under a workspace directory")
-    if rel.parts[0] not in {"authoring", "candidate", "eval", "release"}:
+    if rel.parts[0] not in allowed_roots:
         raise ValueError(f"unsafe authoring path {name!r}: must be under authoring/, candidate/, eval/, or release/")
     return rel
 
@@ -703,7 +706,7 @@ def _install_authoring_bundle(bundle: bytes, workdir: str, expected_sha256: str 
             raise ValueError(f"invalid authoring bundle: {e}") from e
         with tf:
             for member in tf.getmembers():
-                rel = _safe_authoring_path(member.name)
+                rel = _safe_authoring_path(member.name, is_dir=member.isdir())
                 target = staging / Path(*rel.parts)
                 resolved = target.resolve(strict=False)
                 try:

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -3837,16 +3837,15 @@ async def handle_session(request: web.Request):
 
 
 async def handle_sources(request: web.Request):
-    body = await request.json()
-    run_id = body.get("run_id")
-    if run_id and run_id in RUNS:
-        return web.json_response({"error": "run already exists; upload sources before /session", "run_id": run_id}, status=409)
-
-    encoded = body.get("bundle_base64") or body.get("bundle_b64")
-    if not encoded:
-        return web.json_response({"error": "bundle_base64 is required"}, status=400)
-
     try:
+        body = await _source_request_body(request)
+        run_id = body.get("run_id")
+        conflict = _source_live_conflict(run_id)
+        if conflict is not None:
+            return conflict
+        encoded = body.get("bundle_base64") or body.get("bundle_b64")
+        if not encoded:
+            return web.json_response({"error": "bundle_base64 is required"}, status=400)
         bundle = base64.b64decode(encoded, validate=True)
         result = _install_source_bundle(bundle, body.get("workdir", "/work"), body.get("bundle_sha256"), locale=body.get("locale"))
     except (ValueError, TypeError) as e:
@@ -3861,19 +3860,36 @@ def _snapshot_request_identity(body: dict) -> tuple[str, str, str]:
     return body.get("workdir", "/work"), body.get("run_id"), body.get("input_revision")
 
 
-def _snapshot_live_conflict(run_id: str | None):
+async def _source_request_body(request: web.Request) -> dict:
+    try:
+        body = await request.json() if request.body_exists else {}
+    except (ValueError, UnicodeDecodeError, TypeError) as error:
+        raise ValueError("request body must be valid JSON") from error
+    if not isinstance(body, dict):
+        raise TypeError("request body must be a JSON object")
+    return body
+
+
+def _source_live_conflict(run_id: str | None):
     if run_id and run_id in RUNS:
-        return web.json_response({"error": "run already exists; upload sources before /session", "run_id": run_id}, status=409)
+        return web.json_response({
+            "error": {
+                "code": "KBC_RUN_ALREADY_LIVE",
+                "message": "run already exists; upload sources before /session",
+                "retriable": False,
+                "details": {"run_id": run_id},
+            },
+        }, status=409)
     return None
 
 
 async def handle_sources_begin(request: web.Request):
-    body = await request.json()
-    workdir, run_id, input_revision = _snapshot_request_identity(body)
-    conflict = _snapshot_live_conflict(run_id)
-    if conflict is not None:
-        return conflict
     try:
+        body = await _source_request_body(request)
+        workdir, run_id, input_revision = _snapshot_request_identity(body)
+        conflict = _source_live_conflict(run_id)
+        if conflict is not None:
+            return conflict
         result = source_snapshot.begin_snapshot(workdir, run_id, input_revision, body.get("snapshot"))
     except source_snapshot.SnapshotConflict as error:
         return web.json_response({"error": str(error)}, status=409)
@@ -3883,9 +3899,9 @@ async def handle_sources_begin(request: web.Request):
 
 
 async def handle_sources_state(request: web.Request):
-    body = await request.json()
-    workdir, run_id, input_revision = _snapshot_request_identity(body)
     try:
+        body = await _source_request_body(request)
+        workdir, run_id, input_revision = _snapshot_request_identity(body)
         result = source_snapshot.snapshot_state(workdir, run_id, input_revision)
     except source_snapshot.SnapshotConflict as error:
         return web.json_response({"error": str(error)}, status=409)
@@ -3895,15 +3911,15 @@ async def handle_sources_state(request: web.Request):
 
 
 async def handle_sources_part(request: web.Request):
-    body = await request.json()
-    workdir, run_id, input_revision = _snapshot_request_identity(body)
-    conflict = _snapshot_live_conflict(run_id)
-    if conflict is not None:
-        return conflict
-    encoded = body.get("bundle_base64") or body.get("bundle_b64")
-    if not encoded:
-        return web.json_response({"error": "bundle_base64 is required"}, status=400)
     try:
+        body = await _source_request_body(request)
+        workdir, run_id, input_revision = _snapshot_request_identity(body)
+        conflict = _source_live_conflict(run_id)
+        if conflict is not None:
+            return conflict
+        encoded = body.get("bundle_base64") or body.get("bundle_b64")
+        if not encoded:
+            return web.json_response({"error": "bundle_base64 is required"}, status=400)
         bundle = base64.b64decode(encoded, validate=True)
         result = source_snapshot.install_part(
             workdir,
@@ -3921,12 +3937,12 @@ async def handle_sources_part(request: web.Request):
 
 
 async def handle_sources_commit(request: web.Request):
-    body = await request.json()
-    workdir, run_id, input_revision = _snapshot_request_identity(body)
-    conflict = _snapshot_live_conflict(run_id)
-    if conflict is not None:
-        return conflict
     try:
+        body = await _source_request_body(request)
+        workdir, run_id, input_revision = _snapshot_request_identity(body)
+        conflict = _source_live_conflict(run_id)
+        if conflict is not None:
+            return conflict
         result = source_snapshot.commit_snapshot(
             workdir,
             run_id,

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -14,6 +14,10 @@ structured signals:
 
 Surface (driven by the runtime):
   POST /sources            {run_id?, workdir?, bundle_base64, bundle_sha256?, locale?} install the frozen raw bundle → workdir/raw
+  POST /sources/begin      {run_id, input_revision, snapshot} begin/resume a Source Snapshot v2 install
+  POST /sources/state      {run_id, input_revision} report missing Source Snapshot v2 parts
+  POST /sources/part       {run_id, input_revision, part_id, bundle_base64} verify and persist one part
+  POST /sources/commit     {run_id, input_revision} atomically install a complete v2 snapshot → workdir/raw
   POST /authoring          {run_id?, workdir?, bundle_base64, bundle_sha256?, locale?} install authoring/candidate/eval/release assets → workdir/
   POST /session/{run_id}   {workdir?, instruction?, allowed_tools?, locale?, llm?, settings?} start the run's persistent conversational session (waits for the first /message); idempotent
   POST /message/{run_id}   {message} inject one user turn into the persistent session (prepare/compile/patch are all ordinary turns)
@@ -68,6 +72,7 @@ import redblue
 import selfcheck
 from engine import selected_readonly_engine
 from codex_engine import CodexSDKClient, EngineTool, isolated_readonly_workspace
+import source_snapshot
 
 # massapi/Bedrock rejects the `context_management` field Claude Code attaches
 # (HTTP 400 "context_management: Extra inputs are not permitted").
@@ -3849,6 +3854,90 @@ async def handle_sources(request: web.Request):
     return web.json_response({"ok": True, **result})
 
 
+def _snapshot_request_identity(body: dict) -> tuple[str, str, str]:
+    return body.get("workdir", "/work"), body.get("run_id"), body.get("input_revision")
+
+
+def _snapshot_live_conflict(run_id: str | None):
+    if run_id and run_id in RUNS:
+        return web.json_response({"error": "run already exists; upload sources before /session", "run_id": run_id}, status=409)
+    return None
+
+
+async def handle_sources_begin(request: web.Request):
+    body = await request.json()
+    workdir, run_id, input_revision = _snapshot_request_identity(body)
+    conflict = _snapshot_live_conflict(run_id)
+    if conflict is not None:
+        return conflict
+    try:
+        result = source_snapshot.begin_snapshot(workdir, run_id, input_revision, body.get("snapshot"))
+    except source_snapshot.SnapshotConflict as error:
+        return web.json_response({"error": str(error)}, status=409)
+    except (ValueError, TypeError) as error:
+        return web.json_response({"error": str(error)}, status=400)
+    return web.json_response({"ok": True, **result})
+
+
+async def handle_sources_state(request: web.Request):
+    body = await request.json()
+    workdir, run_id, input_revision = _snapshot_request_identity(body)
+    try:
+        result = source_snapshot.snapshot_state(workdir, run_id, input_revision)
+    except source_snapshot.SnapshotConflict as error:
+        return web.json_response({"error": str(error)}, status=409)
+    except (ValueError, TypeError) as error:
+        return web.json_response({"error": str(error)}, status=400)
+    return web.json_response({"ok": True, **result})
+
+
+async def handle_sources_part(request: web.Request):
+    body = await request.json()
+    workdir, run_id, input_revision = _snapshot_request_identity(body)
+    conflict = _snapshot_live_conflict(run_id)
+    if conflict is not None:
+        return conflict
+    encoded = body.get("bundle_base64") or body.get("bundle_b64")
+    if not encoded:
+        return web.json_response({"error": "bundle_base64 is required"}, status=400)
+    try:
+        bundle = base64.b64decode(encoded, validate=True)
+        result = source_snapshot.install_part(
+            workdir,
+            run_id,
+            input_revision,
+            body.get("part_id"),
+            bundle,
+            body.get("bundle_sha256"),
+        )
+    except source_snapshot.SnapshotConflict as error:
+        return web.json_response({"error": str(error)}, status=409)
+    except (ValueError, TypeError) as error:
+        return web.json_response({"error": str(error)}, status=400)
+    return web.json_response({"ok": True, **result})
+
+
+async def handle_sources_commit(request: web.Request):
+    body = await request.json()
+    workdir, run_id, input_revision = _snapshot_request_identity(body)
+    conflict = _snapshot_live_conflict(run_id)
+    if conflict is not None:
+        return conflict
+    try:
+        result = source_snapshot.commit_snapshot(
+            workdir,
+            run_id,
+            input_revision,
+            convert_office=office_ingest.convert_tree,
+        )
+        _ensure_workdir_constitution(workdir, body.get("locale"))
+    except source_snapshot.SnapshotConflict as error:
+        return web.json_response({"error": str(error)}, status=409)
+    except (ValueError, TypeError) as error:
+        return web.json_response({"error": str(error)}, status=400)
+    return web.json_response({"ok": True, **result})
+
+
 async def handle_authoring(request: web.Request):
     # NOTE: authoring assets are just installed into the workspace (/work/authoring
     # etc.), independent of run state — so this is allowed on a LIVE session run
@@ -4365,6 +4454,10 @@ def build_app() -> web.Application:
     app.on_shutdown.append(_flush_on_shutdown)
     app.add_routes([
         web.post("/sources", handle_sources),
+        web.post("/sources/begin", handle_sources_begin),
+        web.post("/sources/state", handle_sources_state),
+        web.post("/sources/part", handle_sources_part),
+        web.post("/sources/commit", handle_sources_commit),
         web.post("/authoring", handle_authoring),
         web.post("/session/{run_id}", handle_session),
         web.post("/message/{run_id}", handle_message),

--- a/kbc/platform/pod/source_snapshot.py
+++ b/kbc/platform/pod/source_snapshot.py
@@ -69,7 +69,21 @@ def canonical_file_manifest(files: list[dict]) -> bytes:
         ({"path": item["path"], "sha256": item["sha256"], "size_bytes": item["size_bytes"]} for item in files),
         key=lambda item: item["path"],
     )
-    return json.dumps(normalized, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    # Sicore computes this digest with Go's encoding/json.  Its otherwise
+    # compact UTF-8 output escapes the HTML-sensitive code points and the two
+    # JavaScript line separators even inside filenames.  Mirror that wire
+    # contract explicitly; Python's json encoder leaves these characters raw
+    # when ensure_ascii=False, which would make a valid path such as R&D.md
+    # reject the whole snapshot with a manifest hash mismatch.
+    payload = json.dumps(normalized, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    payload = (
+        payload.replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+    return payload.encode("utf-8")
 
 
 def validate_snapshot(snapshot: object) -> dict:

--- a/kbc/platform/pod/source_snapshot.py
+++ b/kbc/platform/pod/source_snapshot.py
@@ -1,0 +1,449 @@
+"""Resumable, verified Source Snapshot v2 installation for the compile box.
+
+Each part is independently staged and survives a container restart. Only a
+complete snapshot is assembled and atomically swapped into ``workdir/raw``;
+partial or corrupt uploads never become compiler-visible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_PART_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class SnapshotConflict(ValueError):
+    """The requested operation conflicts with persisted snapshot state."""
+
+
+class SnapshotIncomplete(SnapshotConflict):
+    """Commit was requested before every declared part arrived."""
+
+
+def _positive_env(name: str, default: int) -> int:
+    value = int(os.environ.get(name, str(default)))
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _safe_path(name: str) -> PurePosixPath:
+    if not isinstance(name, str) or not name or "\\" in name:
+        raise ValueError(f"unsafe source path {name!r}")
+    path = PurePosixPath(name)
+    if path.is_absolute():
+        raise ValueError(f"unsafe source path {name!r}: path must be relative")
+    parts = [part for part in path.parts if part not in ("", ".")]
+    if not parts or any(part == ".." for part in parts):
+        raise ValueError(f"unsafe source path {name!r}: parent traversal is not allowed")
+    return PurePosixPath(*parts)
+
+
+def _require_sha256(value: object, field: str) -> str:
+    normalized = str(value or "").lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise ValueError(f"{field} must be a lowercase SHA-256 hex digest")
+    return normalized
+
+
+def _require_nonnegative_int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def canonical_file_manifest(files: list[dict]) -> bytes:
+    normalized = sorted(
+        ({"path": item["path"], "sha256": item["sha256"], "size_bytes": item["size_bytes"]} for item in files),
+        key=lambda item: item["path"],
+    )
+    return json.dumps(normalized, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def validate_snapshot(snapshot: object) -> dict:
+    if not isinstance(snapshot, dict) or snapshot.get("version") != 2:
+        raise ValueError("source snapshot version must be 2")
+    parts = snapshot.get("parts")
+    if not isinstance(parts, list) or not parts:
+        raise ValueError("source snapshot must contain at least one part")
+    max_parts = _positive_env("KBC_MAX_SOURCE_PARTS", 10_000)
+    max_files = _positive_env("KBC_MAX_SOURCE_FILES", 100_000)
+    max_part_bytes = _positive_env("KBC_MAX_SOURCE_PART_BYTES", 64 * 1024 * 1024)
+    max_part_unpacked = _positive_env("KBC_MAX_SOURCE_PART_UNPACKED_BYTES", 128 * 1024 * 1024)
+    max_total_unpacked = _positive_env("KBC_MAX_SOURCE_UNPACKED_BYTES", 2 * 1024 * 1024 * 1024)
+    if len(parts) > max_parts:
+        raise ValueError(f"source snapshot has too many parts: {len(parts)} > {max_parts}")
+
+    normalized_parts: list[dict] = []
+    all_files: list[dict] = []
+    seen_parts: set[str] = set()
+    seen_paths: set[str] = set()
+    for index, raw_part in enumerate(parts):
+        if not isinstance(raw_part, dict):
+            raise ValueError(f"source snapshot part {index} must be an object")
+        part_id = str(raw_part.get("part_id") or "")
+        if not _PART_ID_RE.fullmatch(part_id):
+            raise ValueError(f"invalid source snapshot part_id {part_id!r}")
+        if part_id in seen_parts:
+            raise ValueError(f"duplicate source snapshot part_id {part_id}")
+        seen_parts.add(part_id)
+        bundle_size = _require_nonnegative_int(raw_part.get("bundle_size_bytes"), f"part {part_id} bundle_size_bytes")
+        unpacked_size = _require_nonnegative_int(raw_part.get("unpacked_size_bytes"), f"part {part_id} unpacked_size_bytes")
+        file_count = _require_nonnegative_int(raw_part.get("file_count"), f"part {part_id} file_count")
+        if bundle_size == 0 or bundle_size > max_part_bytes:
+            raise ValueError(f"source part {part_id} compressed size is outside 1..{max_part_bytes}")
+        if unpacked_size > max_part_unpacked:
+            raise ValueError(f"source part {part_id} unpacks too large: {unpacked_size} > {max_part_unpacked}")
+        raw_files = raw_part.get("files")
+        if not isinstance(raw_files, list) or not raw_files:
+            raise ValueError(f"source part {part_id} must declare files")
+        normalized_files: list[dict] = []
+        for raw_file in raw_files:
+            if not isinstance(raw_file, dict):
+                raise ValueError(f"source part {part_id} contains an invalid file descriptor")
+            rel = _safe_path(raw_file.get("path"))
+            path = rel.as_posix()
+            if path in seen_paths:
+                raise ValueError(f"duplicate source snapshot path {path}")
+            seen_paths.add(path)
+            item = {
+                "path": path,
+                "size_bytes": _require_nonnegative_int(raw_file.get("size_bytes"), f"file {path} size_bytes"),
+                "sha256": _require_sha256(raw_file.get("sha256"), f"file {path} sha256"),
+            }
+            normalized_files.append(item)
+            all_files.append(item)
+        if file_count != len(normalized_files):
+            raise ValueError(f"source part {part_id} file_count does not match files")
+        actual_unpacked = sum(item["size_bytes"] for item in normalized_files)
+        if unpacked_size != actual_unpacked:
+            raise ValueError(f"source part {part_id} unpacked_size_bytes does not match files")
+        normalized_parts.append({
+            "part_id": part_id,
+            "sha256": _require_sha256(raw_part.get("sha256"), f"part {part_id} sha256"),
+            "bundle_size_bytes": bundle_size,
+            "unpacked_size_bytes": unpacked_size,
+            "file_count": file_count,
+            "files": normalized_files,
+        })
+
+    file_count = _require_nonnegative_int(snapshot.get("file_count"), "source snapshot file_count")
+    total_bytes = _require_nonnegative_int(snapshot.get("total_bytes"), "source snapshot total_bytes")
+    if file_count != len(all_files):
+        raise ValueError("source snapshot file_count does not match parts")
+    if file_count > max_files:
+        raise ValueError(f"source snapshot has too many files: {file_count} > {max_files}")
+    if total_bytes != sum(item["size_bytes"] for item in all_files):
+        raise ValueError("source snapshot total_bytes does not match files")
+    if total_bytes > max_total_unpacked:
+        raise ValueError(f"source snapshot unpacks too large: {total_bytes} > {max_total_unpacked}")
+    manifest_sha = _require_sha256(snapshot.get("manifest_sha256"), "source snapshot manifest_sha256")
+    actual_manifest_sha = hashlib.sha256(canonical_file_manifest(all_files)).hexdigest()
+    if manifest_sha != actual_manifest_sha:
+        raise ValueError(f"source snapshot manifest sha256 mismatch: expected {manifest_sha}, got {actual_manifest_sha}")
+    return {
+        "version": 2,
+        "manifest_sha256": manifest_sha,
+        "total_bytes": total_bytes,
+        "file_count": file_count,
+        "parts": normalized_parts,
+    }
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _identity(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:32]
+
+
+def _snapshot_root(workdir: str, run_id: str, input_revision: str) -> Path:
+    if not isinstance(run_id, str) or not run_id.strip():
+        raise ValueError("run_id is required")
+    if not isinstance(input_revision, str) or not input_revision.strip():
+        raise ValueError("input_revision is required")
+    return Path(workdir) / ".source-snapshots" / _identity(run_id) / _identity(input_revision)
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temp.write_bytes(payload)
+        os.replace(temp, path)
+    finally:
+        if temp.exists():
+            temp.unlink()
+
+
+def _load_descriptor(root: Path) -> dict:
+    path = root / "descriptor.json"
+    if not path.is_file():
+        raise SnapshotConflict("source snapshot has not been initialized")
+    try:
+        return validate_snapshot(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SnapshotConflict(f"persisted source snapshot descriptor is invalid: {exc}") from exc
+
+
+def _part_by_id(snapshot: dict, part_id: str) -> dict:
+    for part in snapshot["parts"]:
+        if part["part_id"] == part_id:
+            return part
+    raise ValueError(f"unknown source snapshot part {part_id}")
+
+
+def _part_dir(root: Path, part_id: str) -> Path:
+    if not _PART_ID_RE.fullmatch(part_id):
+        raise ValueError(f"invalid source snapshot part_id {part_id!r}")
+    return root / "parts" / part_id
+
+
+def _part_complete(root: Path, part: dict) -> bool:
+    marker = _part_dir(root, part["part_id"]) / ".complete.json"
+    try:
+        value = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return value == {"part_id": part["part_id"], "sha256": part["sha256"]}
+
+
+def snapshot_state(workdir: str, run_id: str, input_revision: str) -> dict:
+    root = _snapshot_root(workdir, run_id, input_revision)
+    snapshot = _load_descriptor(root)
+    committed = (root / "committed.json").is_file()
+    received = [part["part_id"] for part in snapshot["parts"] if _part_complete(root, part)]
+    received_set = set(received)
+    missing = [] if committed else [part["part_id"] for part in snapshot["parts"] if part["part_id"] not in received_set]
+    return {
+        "input_revision": input_revision,
+        "manifest_sha256": snapshot["manifest_sha256"],
+        "committed": committed,
+        "received_parts": received,
+        "missing_parts": missing,
+    }
+
+
+def begin_snapshot(workdir: str, run_id: str, input_revision: str, raw_snapshot: object) -> dict:
+    snapshot = validate_snapshot(raw_snapshot)
+    root = _snapshot_root(workdir, run_id, input_revision)
+    descriptor_path = root / "descriptor.json"
+    canonical = _canonical_json(snapshot)
+    if descriptor_path.exists():
+        if descriptor_path.read_bytes() != canonical:
+            raise SnapshotConflict("source snapshot descriptor changed for the same run and revision")
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+        _atomic_write(descriptor_path, canonical)
+    return snapshot_state(workdir, run_id, input_revision)
+
+
+def _extract_part(bundle: bytes, destination: Path, part: dict) -> None:
+    expected = {item["path"]: item for item in part["files"]}
+    seen: set[str] = set()
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(bundle), mode="r:gz")
+    except tarfile.TarError as exc:
+        raise ValueError(f"invalid source part {part['part_id']}: {exc}") from exc
+    with archive:
+        for member in archive.getmembers():
+            rel = _safe_path(member.name)
+            target = destination / Path(*rel.parts)
+            try:
+                target.resolve(strict=False).relative_to(destination.resolve())
+            except ValueError as exc:
+                raise ValueError(f"unsafe source path {member.name!r}: escapes part directory") from exc
+            if not member.isfile():
+                # The Sicore writer emits file entries only; parent directories
+                # are created from each declared path. Reject every extra tar
+                # member so a small descriptor cannot hide a directory-entry
+                # amplification payload.
+                raise ValueError(f"unsupported source entry {member.name!r}: only declared regular files are allowed")
+            path = rel.as_posix()
+            descriptor = expected.get(path)
+            if descriptor is None:
+                raise ValueError(f"source part {part['part_id']} contains undeclared file {path}")
+            if path in seen:
+                raise ValueError(f"source part {part['part_id']} contains duplicate file {path}")
+            if member.size != descriptor["size_bytes"]:
+                raise ValueError(f"source part {part['part_id']} size mismatch for {path}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = archive.extractfile(member)
+            if source is None:
+                raise ValueError(f"could not read source entry {path}")
+            digest = hashlib.sha256()
+            with source, target.open("wb") as output:
+                while True:
+                    chunk = source.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    output.write(chunk)
+            if digest.hexdigest() != descriptor["sha256"]:
+                raise ValueError(f"source part {part['part_id']} sha256 mismatch for {path}")
+            seen.add(path)
+    missing = sorted(set(expected) - seen)
+    if missing:
+        raise ValueError(f"source part {part['part_id']} is missing declared files: {', '.join(missing[:3])}")
+
+
+def install_part(
+    workdir: str,
+    run_id: str,
+    input_revision: str,
+    part_id: str,
+    bundle: bytes,
+    expected_sha256: str | None = None,
+) -> dict:
+    root = _snapshot_root(workdir, run_id, input_revision)
+    snapshot = _load_descriptor(root)
+    part = _part_by_id(snapshot, part_id)
+    if (root / "committed.json").exists():
+        return {**snapshot_state(workdir, run_id, input_revision), "duplicate": True}
+    if _part_complete(root, part):
+        return {**snapshot_state(workdir, run_id, input_revision), "duplicate": True}
+    if len(bundle) != part["bundle_size_bytes"]:
+        raise ValueError(f"source part {part_id} compressed size mismatch")
+    actual_sha = hashlib.sha256(bundle).hexdigest()
+    if expected_sha256 and expected_sha256.lower() != part["sha256"]:
+        raise ValueError(f"source part {part_id} request hash does not match descriptor")
+    if actual_sha != part["sha256"]:
+        raise ValueError(f"source part {part_id} sha256 mismatch: expected {part['sha256']}, got {actual_sha}")
+
+    parts_root = root / "parts"
+    parts_root.mkdir(parents=True, exist_ok=True)
+    temp = Path(tempfile.mkdtemp(prefix=f".{part_id}-", dir=parts_root))
+    destination = _part_dir(root, part_id)
+    try:
+        _extract_part(bundle, temp, part)
+        _atomic_write(temp / ".complete.json", _canonical_json({"part_id": part_id, "sha256": part["sha256"]}))
+        if destination.exists():
+            if _part_complete(root, part):
+                return {**snapshot_state(workdir, run_id, input_revision), "duplicate": True}
+            raise SnapshotConflict(f"source part {part_id} has conflicting persisted state")
+        temp.rename(destination)
+    finally:
+        if temp.exists():
+            shutil.rmtree(temp)
+    return snapshot_state(workdir, run_id, input_revision)
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    elif path.exists() or path.is_symlink():
+        path.unlink()
+
+
+def _swap_raw(workdir: Path, staging: Path, mark_committed: Callable[[], None]) -> None:
+    raw = workdir / "raw"
+    drop = workdir / "drop"
+    backup = workdir / f".raw-backup-{uuid.uuid4().hex}"
+    had_raw = raw.exists() or raw.is_symlink()
+    if had_raw:
+        raw.rename(backup)
+    try:
+        staging.rename(raw)
+        _remove_path(drop)
+        try:
+            drop.symlink_to(raw, target_is_directory=True)
+        except OSError:
+            shutil.copytree(raw, drop)
+        # Keep the old raw tree recoverable until the durable commit marker is
+        # installed. A marker-write failure therefore rolls the visible tree
+        # back instead of leaving an unrecorded half-commit.
+        mark_committed()
+    except Exception:
+        _remove_path(raw)
+        if had_raw and backup.exists():
+            backup.rename(raw)
+        _remove_path(drop)
+        if raw.exists():
+            try:
+                drop.symlink_to(raw, target_is_directory=True)
+            except OSError:
+                shutil.copytree(raw, drop)
+        raise
+    finally:
+        _remove_path(backup)
+
+
+def commit_snapshot(
+    workdir: str,
+    run_id: str,
+    input_revision: str,
+    convert_office: Callable[[str], tuple[list, list]] | None = None,
+) -> dict:
+    root = _snapshot_root(workdir, run_id, input_revision)
+    snapshot = _load_descriptor(root)
+    state = snapshot_state(workdir, run_id, input_revision)
+    if state["committed"]:
+        return {**state, "files": snapshot["file_count"], "bytes": snapshot["total_bytes"], "duplicate": True}
+    if state["missing_parts"]:
+        raise SnapshotIncomplete(f"source snapshot is incomplete; missing {len(state['missing_parts'])} part(s)")
+
+    wd = Path(workdir)
+    wd.mkdir(parents=True, exist_ok=True)
+    staging = wd / f".drop-snapshot-{uuid.uuid4().hex}"
+    office_converted: list = []
+    try:
+        staging.mkdir(mode=0o755)
+        for part in snapshot["parts"]:
+            source_root = _part_dir(root, part["part_id"])
+            for item in part["files"]:
+                rel = _safe_path(item["path"])
+                source = source_root / Path(*rel.parts)
+                if not source.is_file() or source.stat().st_size != item["size_bytes"]:
+                    raise SnapshotConflict(f"persisted source part is incomplete for {item['path']}")
+                if _hash_file(source) != item["sha256"]:
+                    raise SnapshotConflict(f"persisted source part is corrupt for {item['path']}")
+                target = staging / Path(*rel.parts)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target)
+        if convert_office:
+            office_converted, office_errors = convert_office(str(staging))
+            for rel, error in office_errors:
+                print(f"[office] {rel}: conversion skipped ({error})")
+        committed = {
+            "input_revision": input_revision,
+            "manifest_sha256": snapshot["manifest_sha256"],
+            "file_count": snapshot["file_count"],
+            "total_bytes": snapshot["total_bytes"],
+        }
+        _swap_raw(
+            wd,
+            staging,
+            lambda: _atomic_write(root / "committed.json", _canonical_json(committed)),
+        )
+        shutil.rmtree(root / "parts", ignore_errors=True)
+    except Exception:
+        _remove_path(staging)
+        raise
+    return {
+        **snapshot_state(workdir, run_id, input_revision),
+        "files": snapshot["file_count"],
+        "bytes": snapshot["total_bytes"],
+        "parts": len(snapshot["parts"]),
+        "office_converted": len(office_converted),
+    }

--- a/kbc/platform/pod/source_snapshot.py
+++ b/kbc/platform/pod/source_snapshot.py
@@ -371,6 +371,10 @@ def _remove_path(path: Path) -> None:
 
 
 def _swap_raw(workdir: Path, staging: Path, mark_committed: Callable[[], None]) -> None:
+    # Concurrency contract: commit_snapshot and this rename sequence run
+    # synchronously on the compile-box event loop, and the HTTP handler rejects
+    # commits after a run becomes live. Do not offload or make this path async
+    # without first adding a per-workdir lock around the complete swap/rollback.
     raw = workdir / "raw"
     drop = workdir / "drop"
     backup = workdir / f".raw-backup-{uuid.uuid4().hex}"

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3140,6 +3140,26 @@ async def main():
             assert (Path(td) / "authoring" / "CLAUDE.md").read_text() == "follow the workspace\n"
             assert (Path(td) / "eval" / "TESTS.md").read_text() == "# Tests\n"
 
+            # Standard tar tools emit explicit root directory entries before files.
+            # Those safe roots must be accepted without permitting root-level files.
+            directory_bundle_buffer = io.BytesIO()
+            with tarfile.open(fileobj=directory_bundle_buffer, mode="w:gz") as tf:
+                root = tarfile.TarInfo("candidate/")
+                root.type = tarfile.DIRTYPE
+                root.mode = 0o755
+                tf.addfile(root)
+                payload = b"# Restored candidate\n"
+                page = tarfile.TarInfo("candidate/index.md")
+                page.size = len(payload)
+                tf.addfile(page, io.BytesIO(payload))
+            r = await client.post("/authoring", json={
+                "run_id": "r1",
+                "workdir": td,
+                "bundle_base64": base64.b64encode(directory_bundle_buffer.getvalue()).decode(),
+            })
+            assert r.status == 200, await r.text()
+            assert (Path(td) / "candidate" / "index.md").read_text() == "# Restored candidate\n"
+
             bad_authoring_bundle = make_source_bundle({"raw/nope.md": "nope"})
             r = await client.post("/authoring", json={
                 "workdir": td,

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from aiohttp.test_utils import TestClient, TestServer
 
 import compile_box
+import source_snapshot
 
 
 async def fake_driver(run):
@@ -66,6 +67,39 @@ def deterministic_bytes(size):
         out.extend(hashlib.sha256(str(i).encode()).digest())
         i += 1
     return bytes(out[:size])
+
+
+def make_source_snapshot(groups):
+    parts = []
+    bundles = []
+    all_files = []
+    for index, files in enumerate(groups, start=1):
+        bundle = make_source_bundle(files)
+        descriptors = []
+        for path, data in files.items():
+            payload = data if isinstance(data, bytes) else data.encode()
+            descriptors.append({
+                "path": path,
+                "size_bytes": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            })
+        all_files.extend(descriptors)
+        parts.append({
+            "part_id": f"part-{index:06d}",
+            "sha256": hashlib.sha256(bundle).hexdigest(),
+            "bundle_size_bytes": len(bundle),
+            "unpacked_size_bytes": sum(item["size_bytes"] for item in descriptors),
+            "file_count": len(descriptors),
+            "files": descriptors,
+        })
+        bundles.append(bundle)
+    return {
+        "version": 2,
+        "manifest_sha256": hashlib.sha256(source_snapshot.canonical_file_manifest(all_files)).hexdigest(),
+        "total_bytes": sum(item["size_bytes"] for item in all_files),
+        "file_count": len(all_files),
+        "parts": parts,
+    }, bundles
 
 
 async def test_workspace_sync():
@@ -3016,6 +3050,51 @@ async def main():
     await client.start_server()
     try:
         assert (await (await client.get("/health")).json())["status"] == "ok"
+
+        with tempfile.TemporaryDirectory() as td:
+            workdir = Path(td)
+            (workdir / "raw").mkdir()
+            (workdir / "raw" / "old.md").write_text("old raw\n")
+            snapshot, part_bundles = make_source_snapshot([
+                {"docs/a.md": "alpha\n"},
+                {"docs/b.md": "beta\n"},
+            ])
+            identity = {"run_id": "snapshot-run", "input_revision": "manifest-v2", "workdir": td}
+            r = await client.post("/sources/begin", json={**identity, "snapshot": snapshot})
+            begin = await r.json()
+            assert r.status == 200 and begin["missing_parts"] == ["part-000001", "part-000002"], begin
+
+            r = await client.post("/sources/part", json={
+                **identity,
+                "part_id": "part-000001",
+                "bundle_base64": base64.b64encode(part_bundles[0]).decode(),
+                "bundle_sha256": snapshot["parts"][0]["sha256"],
+            })
+            assert r.status == 200, await r.text()
+            r = await client.post("/sources/state", json=identity)
+            state = await r.json()
+            assert state["missing_parts"] == ["part-000002"], state
+            r = await client.post("/sources/commit", json=identity)
+            assert r.status == 409, await r.text()
+            assert (workdir / "raw" / "old.md").read_text() == "old raw\n"
+
+            r = await client.post("/sources/part", json={
+                **identity,
+                "part_id": "part-000002",
+                "bundle_base64": base64.b64encode(part_bundles[1]).decode(),
+                "bundle_sha256": snapshot["parts"][1]["sha256"],
+            })
+            assert r.status == 200, await r.text()
+            r = await client.post("/sources/commit", json={**identity, "locale": "zh"})
+            committed = await r.json()
+            assert r.status == 200 and committed["committed"], committed
+            assert (workdir / "raw" / "docs" / "a.md").read_text() == "alpha\n"
+            assert (workdir / "drop" / "docs" / "b.md").read_text() == "beta\n"
+            r = await client.post("/sources/begin", json={**identity, "snapshot": snapshot})
+            replay = await r.json()
+            assert r.status == 200 and replay["committed"] and replay["missing_parts"] == [], replay
+
+            print("✓ Source Snapshot v2 HTTP resume + atomic commit + idempotent replay")
 
         with tempfile.TemporaryDirectory() as td:
             large_bundle = make_source_bundle({"large.bin": deterministic_bytes(2 * 1024 * 1024)})

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3060,6 +3060,11 @@ async def main():
                 {"docs/b.md": "beta\n"},
             ])
             identity = {"run_id": "snapshot-run", "input_revision": "manifest-v2", "workdir": td}
+            for route in ("/sources", "/sources/begin", "/sources/state", "/sources/part", "/sources/commit"):
+                for payload in (b"", b"{"):
+                    r = await client.post(route, data=payload, headers={"Content-Type": "application/json"})
+                    assert r.status == 400, (route, payload, r.status, await r.text())
+
             r = await client.post("/sources/begin", json={**identity, "snapshot": snapshot})
             begin = await r.json()
             assert r.status == 200 and begin["missing_parts"] == ["part-000001", "part-000002"], begin
@@ -3185,7 +3190,16 @@ async def main():
                 "workdir": td,
                 "bundle_base64": base64.b64encode(bundle).decode(),
             })
-            assert r.status == 409, r.status
+            live_conflict = await r.json()
+            assert r.status == 409 and live_conflict["error"]["code"] == "KBC_RUN_ALREADY_LIVE", live_conflict
+            r = await client.post("/sources/begin", json={
+                "run_id": "r1",
+                "input_revision": "manifest-v2",
+                "workdir": td,
+                "snapshot": snapshot,
+            })
+            live_conflict = await r.json()
+            assert r.status == 409 and live_conflict["error"]["code"] == "KBC_RUN_ALREADY_LIVE", live_conflict
             # /authoring IS allowed on a live run (200): the runtime rehydrates the
             # durable workspace / pushes assets into an existing session through it.
             r = await client.post("/authoring", json={

--- a/kbc/platform/pod/test_source_snapshot.py
+++ b/kbc/platform/pod/test_source_snapshot.py
@@ -86,6 +86,19 @@ class SourceSnapshotTest(unittest.TestCase):
             "03893ac5d1c473dd02f41eb12245120037acfa71357ac1fbf20b9ac82bc388b0",
         )
 
+    def test_canonical_manifest_matches_sicore_json_escaping(self):
+        files = [{
+            "path": "R&D<plan>\u2028.md",
+            "sha256": "a" * 64,
+            "size_bytes": 1,
+        }]
+        self.assertEqual(
+            source_snapshot.canonical_file_manifest(files).decode(),
+            '[{"path":"R\\u0026D\\u003cplan\\u003e\\u2028.md","sha256":"'
+            + "a" * 64
+            + '","size_bytes":1}]',
+        )
+
     def test_resumes_missing_parts_and_commits_atomically(self):
         snapshot, bundles = make_snapshot([
             {"docs/a.md": b"alpha\n"},

--- a/kbc/platform/pod/test_source_snapshot.py
+++ b/kbc/platform/pod/test_source_snapshot.py
@@ -1,0 +1,318 @@
+import gzip
+import hashlib
+import io
+import json
+import os
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import source_snapshot
+
+
+def make_bundle(files: dict[str, bytes]) -> bytes:
+    stream = io.BytesIO()
+    with tarfile.open(fileobj=stream, mode="w:gz") as archive:
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return stream.getvalue()
+
+
+def make_snapshot(groups: list[dict[str, bytes]]) -> tuple[dict, list[bytes]]:
+    parts = []
+    bundles = []
+    all_files = []
+    for index, files in enumerate(groups, start=1):
+        bundle = make_bundle(files)
+        bundles.append(bundle)
+        descriptors = [
+            {
+                "path": path,
+                "size_bytes": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            }
+            for path, payload in files.items()
+        ]
+        all_files.extend(descriptors)
+        parts.append({
+            "part_id": f"part-{index:06d}",
+            "sha256": hashlib.sha256(bundle).hexdigest(),
+            "bundle_size_bytes": len(bundle),
+            "unpacked_size_bytes": sum(item["size_bytes"] for item in descriptors),
+            "file_count": len(descriptors),
+            "files": descriptors,
+        })
+    return {
+        "version": 2,
+        "manifest_sha256": hashlib.sha256(source_snapshot.canonical_file_manifest(all_files)).hexdigest(),
+        "total_bytes": sum(item["size_bytes"] for item in all_files),
+        "file_count": len(all_files),
+        "parts": parts,
+    }, bundles
+
+
+def deterministic_directory_bundle(root: Path, files: list[dict]) -> bytes:
+    stream = io.BytesIO()
+    with gzip.GzipFile(fileobj=stream, mode="wb", mtime=0) as compressed:
+        with tarfile.open(fileobj=compressed, mode="w") as archive:
+            for file in files:
+                info = tarfile.TarInfo(file["path"])
+                info.size = file["size_bytes"]
+                info.mode = 0o644
+                info.mtime = 0
+                with (root / file["path"]).open("rb") as body:
+                    archive.addfile(info, body)
+    return stream.getvalue()
+
+
+class SourceSnapshotTest(unittest.TestCase):
+    def test_canonical_manifest_matches_sicore_contract(self):
+        files = [
+            {"path": "b.md", "sha256": "2" * 64, "size_bytes": 4},
+            {"path": "a.md", "sha256": "1" * 64, "size_bytes": 3},
+        ]
+        payload = source_snapshot.canonical_file_manifest(files)
+        self.assertEqual(
+            payload.decode(),
+            '[{"path":"a.md","sha256":"' + "1" * 64 + '","size_bytes":3},'
+            '{"path":"b.md","sha256":"' + "2" * 64 + '","size_bytes":4}]',
+        )
+        self.assertEqual(
+            hashlib.sha256(payload).hexdigest(),
+            "03893ac5d1c473dd02f41eb12245120037acfa71357ac1fbf20b9ac82bc388b0",
+        )
+
+    def test_resumes_missing_parts_and_commits_atomically(self):
+        snapshot, bundles = make_snapshot([
+            {"docs/a.md": b"alpha\n"},
+            {"docs/b.md": b"beta\n"},
+        ])
+        with tempfile.TemporaryDirectory() as directory:
+            workdir = Path(directory)
+            (workdir / "raw").mkdir()
+            (workdir / "raw" / "old.md").write_text("old\n", encoding="utf-8")
+
+            state = source_snapshot.begin_snapshot(directory, "run-1", "revision-1", snapshot)
+            self.assertEqual(state["missing_parts"], ["part-000001", "part-000002"])
+            source_snapshot.install_part(
+                directory,
+                "run-1",
+                "revision-1",
+                "part-000001",
+                bundles[0],
+                snapshot["parts"][0]["sha256"],
+            )
+
+            # State is filesystem-backed; no in-memory session is needed to resume.
+            state = source_snapshot.snapshot_state(directory, "run-1", "revision-1")
+            self.assertEqual(state["received_parts"], ["part-000001"])
+            self.assertEqual(state["missing_parts"], ["part-000002"])
+            with self.assertRaises(source_snapshot.SnapshotIncomplete):
+                source_snapshot.commit_snapshot(directory, "run-1", "revision-1")
+            self.assertEqual((workdir / "raw" / "old.md").read_text(encoding="utf-8"), "old\n")
+
+            source_snapshot.install_part(directory, "run-1", "revision-1", "part-000002", bundles[1])
+            result = source_snapshot.commit_snapshot(
+                directory,
+                "run-1",
+                "revision-1",
+                convert_office=lambda _path: ([], []),
+            )
+            self.assertTrue(result["committed"])
+            self.assertEqual((workdir / "raw" / "docs" / "a.md").read_bytes(), b"alpha\n")
+            self.assertEqual((workdir / "drop" / "docs" / "b.md").read_bytes(), b"beta\n")
+            self.assertFalse((workdir / "raw" / "old.md").exists())
+
+            # Replays after a lost response are idempotent even after staged parts are reclaimed.
+            replay = source_snapshot.install_part(directory, "run-1", "revision-1", "part-000001", bundles[0])
+            self.assertTrue(replay["duplicate"])
+            replay = source_snapshot.commit_snapshot(directory, "run-1", "revision-1")
+            self.assertTrue(replay["duplicate"])
+
+    def test_corrupt_part_never_changes_existing_raw(self):
+        snapshot, bundles = make_snapshot([{"new.md": b"new\n"}])
+        with tempfile.TemporaryDirectory() as directory:
+            workdir = Path(directory)
+            (workdir / "raw").mkdir()
+            (workdir / "raw" / "old.md").write_text("old\n", encoding="utf-8")
+            source_snapshot.begin_snapshot(directory, "run-1", "revision-1", snapshot)
+            with self.assertRaisesRegex(ValueError, "compressed size mismatch|sha256 mismatch"):
+                source_snapshot.install_part(directory, "run-1", "revision-1", "part-000001", bundles[0] + b"corrupt")
+            self.assertEqual((workdir / "raw" / "old.md").read_text(encoding="utf-8"), "old\n")
+            self.assertEqual(
+                source_snapshot.snapshot_state(directory, "run-1", "revision-1")["missing_parts"],
+                ["part-000001"],
+            )
+
+    def test_commit_marker_failure_rolls_visible_raw_back(self):
+        snapshot, bundles = make_snapshot([{"new.md": b"new\n"}])
+        with tempfile.TemporaryDirectory() as directory:
+            workdir = Path(directory)
+            (workdir / "raw").mkdir()
+            (workdir / "raw" / "old.md").write_text("old\n", encoding="utf-8")
+            source_snapshot.begin_snapshot(directory, "run-1", "revision-1", snapshot)
+            source_snapshot.install_part(directory, "run-1", "revision-1", "part-000001", bundles[0])
+
+            with mock.patch.object(source_snapshot, "_atomic_write", side_effect=OSError("disk full")):
+                with self.assertRaisesRegex(OSError, "disk full"):
+                    source_snapshot.commit_snapshot(directory, "run-1", "revision-1")
+
+            self.assertEqual((workdir / "raw" / "old.md").read_text(encoding="utf-8"), "old\n")
+            self.assertFalse((workdir / "raw" / "new.md").exists())
+            self.assertEqual((workdir / "drop" / "old.md").read_text(encoding="utf-8"), "old\n")
+
+    def test_part_cannot_smuggle_an_undeclared_file(self):
+        declared = b"declared\n"
+        malicious_bundle = make_bundle({"declared.md": declared, "extra.md": b"extra\n"})
+        files = [{
+            "path": "declared.md",
+            "size_bytes": len(declared),
+            "sha256": hashlib.sha256(declared).hexdigest(),
+        }]
+        snapshot = {
+            "version": 2,
+            "manifest_sha256": hashlib.sha256(source_snapshot.canonical_file_manifest(files)).hexdigest(),
+            "total_bytes": len(declared),
+            "file_count": 1,
+            "parts": [{
+                "part_id": "part-000001",
+                "sha256": hashlib.sha256(malicious_bundle).hexdigest(),
+                "bundle_size_bytes": len(malicious_bundle),
+                "unpacked_size_bytes": len(declared),
+                "file_count": 1,
+                "files": files,
+            }],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            source_snapshot.begin_snapshot(directory, "run-1", "revision-1", snapshot)
+            with self.assertRaisesRegex(ValueError, "undeclared file"):
+                source_snapshot.install_part(directory, "run-1", "revision-1", "part-000001", malicious_bundle)
+
+    def test_part_rejects_non_file_tar_members(self):
+        payload = b"declared\n"
+        stream = io.BytesIO()
+        with tarfile.open(fileobj=stream, mode="w:gz") as archive:
+            directory = tarfile.TarInfo("empty-dir")
+            directory.type = tarfile.DIRTYPE
+            archive.addfile(directory)
+            file_info = tarfile.TarInfo("declared.md")
+            file_info.size = len(payload)
+            archive.addfile(file_info, io.BytesIO(payload))
+        bundle = stream.getvalue()
+        files = [{
+            "path": "declared.md",
+            "size_bytes": len(payload),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }]
+        snapshot = {
+            "version": 2,
+            "manifest_sha256": hashlib.sha256(source_snapshot.canonical_file_manifest(files)).hexdigest(),
+            "total_bytes": len(payload),
+            "file_count": 1,
+            "parts": [{
+                "part_id": "part-000001",
+                "sha256": hashlib.sha256(bundle).hexdigest(),
+                "bundle_size_bytes": len(bundle),
+                "unpacked_size_bytes": len(payload),
+                "file_count": 1,
+                "files": files,
+            }],
+        }
+        with tempfile.TemporaryDirectory() as workdir:
+            source_snapshot.begin_snapshot(workdir, "run-1", "revision-1", snapshot)
+            with self.assertRaisesRegex(ValueError, "only declared regular files"):
+                source_snapshot.install_part(workdir, "run-1", "revision-1", "part-000001", bundle)
+
+    def test_same_revision_rejects_a_changed_descriptor(self):
+        snapshot, _ = make_snapshot([{"a.md": b"a"}])
+        changed, _ = make_snapshot([{"b.md": b"b"}])
+        with tempfile.TemporaryDirectory() as directory:
+            source_snapshot.begin_snapshot(directory, "run-1", "revision-1", snapshot)
+            with self.assertRaisesRegex(source_snapshot.SnapshotConflict, "descriptor changed"):
+                source_snapshot.begin_snapshot(directory, "run-1", "revision-1", changed)
+
+    def test_manifest_hash_and_path_are_validated_before_staging(self):
+        snapshot, _ = make_snapshot([{"a.md": b"a"}])
+        invalid_hash = json.loads(json.dumps(snapshot))
+        invalid_hash["manifest_sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "manifest sha256 mismatch"):
+            source_snapshot.validate_snapshot(invalid_hash)
+
+        invalid_path = json.loads(json.dumps(snapshot))
+        invalid_path["parts"][0]["files"][0]["path"] = "../a.md"
+        with self.assertRaisesRegex(ValueError, "parent traversal"):
+            source_snapshot.validate_snapshot(invalid_path)
+
+    @unittest.skipUnless(os.environ.get("KBC_GPU_RAW_DIR"), "KBC_GPU_RAW_DIR is not set")
+    def test_large_directory_installs_without_a_monolithic_request(self):
+        root = Path(os.environ["KBC_GPU_RAW_DIR"])
+        files = []
+        for path in sorted(item for item in root.rglob("*") if item.is_file()):
+            digest = hashlib.sha256()
+            with path.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+            files.append({
+                "path": path.relative_to(root).as_posix(),
+                "size_bytes": path.stat().st_size,
+                "sha256": digest.hexdigest(),
+            })
+
+        target = 32 * 1024 * 1024
+        groups = []
+        current = []
+        current_bytes = 0
+        for file in files:
+            if current and current_bytes + file["size_bytes"] > target:
+                groups.append(current)
+                current = []
+                current_bytes = 0
+            current.append(file)
+            current_bytes += file["size_bytes"]
+        if current:
+            groups.append(current)
+
+        parts = []
+        for index, group in enumerate(groups, start=1):
+            bundle = deterministic_directory_bundle(root, group)
+            parts.append({
+                "part_id": f"part-{index:06d}",
+                "sha256": hashlib.sha256(bundle).hexdigest(),
+                "bundle_size_bytes": len(bundle),
+                "unpacked_size_bytes": sum(file["size_bytes"] for file in group),
+                "file_count": len(group),
+                "files": group,
+            })
+        snapshot = {
+            "version": 2,
+            "manifest_sha256": hashlib.sha256(source_snapshot.canonical_file_manifest(files)).hexdigest(),
+            "total_bytes": sum(file["size_bytes"] for file in files),
+            "file_count": len(files),
+            "parts": parts,
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            source_snapshot.begin_snapshot(directory, "gpu-run", "gpu-revision", snapshot)
+            for part, group in zip(parts, groups):
+                source_snapshot.install_part(
+                    directory,
+                    "gpu-run",
+                    "gpu-revision",
+                    part["part_id"],
+                    deterministic_directory_bundle(root, group),
+                )
+            result = source_snapshot.commit_snapshot(directory, "gpu-run", "gpu-revision")
+            self.assertTrue(result["committed"])
+            self.assertEqual(result["files"], len(files))
+            self.assertEqual(result["bytes"], snapshot["total_bytes"])
+            self.assertGreater(len(parts), 1)
+            self.assertLessEqual(max(part["bundle_size_bytes"] for part in parts), 64 * 1024 * 1024)
+            self.assertTrue((Path(directory) / "raw" / files[0]["path"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/gateway/agentbox/client.test.ts
+++ b/src/gateway/agentbox/client.test.ts
@@ -351,6 +351,31 @@ describe("AgentBoxClient — error paths", () => {
     } finally { await srv.close(); }
   });
 
+  it("preserves an AgentBox-provided live-run code on conflict", async () => {
+    const srv = await startServer((_req, res) => {
+      res.writeHead(409, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        error: {
+          code: "KBC_RUN_ALREADY_LIVE",
+          message: "run already exists; upload sources before /session",
+          retriable: false,
+          details: { run_id: "r1" },
+        },
+      }));
+    });
+    try {
+      const client = new AgentBoxClient(`http://127.0.0.1:${srv.port}`);
+      const err = await client.postJson("/sources/begin", {}).catch((caught) => caught);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toMatchObject({
+        status: 409,
+        code: "KBC_RUN_ALREADY_LIVE",
+        retriable: false,
+        details: { run_id: "r1" },
+      });
+    } finally { await srv.close(); }
+  });
+
   it("preserves an AgentBox-provided code/retriable on non-conflict statuses", async () => {
     const srv = await startServer((_req, res) => {
       res.writeHead(503, { "Content-Type": "application/json" });

--- a/src/gateway/capability/contract.ts
+++ b/src/gateway/capability/contract.ts
@@ -410,6 +410,40 @@ export interface CapabilityContentRef {
  * raw-source bundle. Go mirror: capability.InputRefWorkspace.
  */
 export const CAPABILITY_INPUT_WORKSPACE_REF = "workspace" as const;
+/** Fetch one immutable Source Snapshot v2 part by `part_id`. */
+export const CAPABILITY_INPUT_SOURCE_PART_REF = "source-part" as const;
+
+export interface CapabilitySourceSnapshotFile {
+  /** Relative POSIX path under raw/. */
+  path: string;
+  size_bytes: number;
+  sha256: string;
+}
+
+export interface CapabilitySourceSnapshotPart {
+  part_id: string;
+  /** SHA-256 of this part's compressed tar.gz bytes. */
+  sha256: string;
+  bundle_size_bytes: number;
+  unpacked_size_bytes: number;
+  file_count: number;
+  files: CapabilitySourceSnapshotFile[];
+}
+
+/**
+ * Immutable, resumable raw-source delivery descriptor.
+ *
+ * `manifest_sha256` is the SHA-256 of the canonical flattened file manifest
+ * (path/size/sha256 sorted by path). The box independently recomputes it before
+ * accepting an install, while each compressed part is verified separately.
+ */
+export interface CapabilitySourceSnapshot {
+  version: 2;
+  manifest_sha256: string;
+  total_bytes: number;
+  file_count: number;
+  parts: CapabilitySourceSnapshotPart[];
+}
 
 /**
  * Input fetch. GENERALIZES compile.sourceBundle. siclaw asks the consumer for
@@ -418,10 +452,12 @@ export const CAPABILITY_INPUT_WORKSPACE_REF = "workspace" as const;
  */
 export interface CapabilityFetchInputRequest {
   run_id: string;
-  /** Input kind: "" = frozen raw sources; CAPABILITY_INPUT_WORKSPACE_REF = durable workspace. */
+  /** Input kind: raw sources, durable workspace, or one Source Snapshot v2 part. */
   ref?: string;
   /** Recovery pin: return this exact immutable source manifest instead of freezing current raw. */
   input_revision?: string;
+  /** Required when ref=CAPABILITY_INPUT_SOURCE_PART_REF. */
+  part_id?: string;
 }
 
 /**
@@ -446,6 +482,8 @@ export interface CapabilityLlmConfig {
 export interface CapabilityFetchInputResponse {
   bundle_base64?: string;
   bundle_sha256?: string;
+  /** Present instead of bundle_base64 for resumable Source Snapshot v2 delivery. */
+  source_snapshot?: CapabilitySourceSnapshot;
   /** Immutable consumer input revision represented by the source bundle. */
   input_revision?: string;
   /**

--- a/src/gateway/capability/materialize.test.ts
+++ b/src/gateway/capability/materialize.test.ts
@@ -236,7 +236,9 @@ describe("materializeCapabilityInputs", () => {
     const { client, backend, posts } = fakes({
       raw: { bundle_base64: "UkFX", input_revision: "current-but-not-installed" },
       workspace: { bundle_base64: "V1M=" },
-      sourcesError: new Error("AgentBox request failed: 409 run r1 already exists"),
+      sourcesError: new Error(
+        'AgentBox request failed: 409 {"error":"run already exists; upload sources before /session","run_id":"r1"}',
+      ),
     });
     const result = await materializeCapabilityInputs({ client, backend, runId: "r1" });
 
@@ -245,10 +247,11 @@ describe("materializeCapabilityInputs", () => {
     expect(result.inputRevision).toBeUndefined(); // keep the run's recovered checkpoint
   });
 
-  it("live box detected via structured err.status (message wording independent)", async () => {
-    // The client attaches err.status; a reworded message with no "failed: 409"
-    // substring must still be recognized as box-already-live (finding E).
-    const err = Object.assign(new Error("conflict: box already holds this run"), { status: 409 });
+  it("live box detected via stable conflict code (message wording independent)", async () => {
+    const err = Object.assign(new Error("conflict: box already holds this run"), {
+      status: 409,
+      code: "KBC_RUN_ALREADY_LIVE",
+    });
     const { client, backend, posts } = fakes({
       raw: { bundle_base64: "UkFX" },
       workspace: { bundle_base64: "V1M=" },
@@ -256,6 +259,39 @@ describe("materializeCapabilityInputs", () => {
     });
     await materializeCapabilityInputs({ client, backend, runId: "r1" });
 
+    expect(posts).toEqual([]);
+    expect(backend.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("Source Snapshot v2 treats an untagged 409 as an install conflict, not a live reattach", async () => {
+    const snapshot = {
+      version: 2 as const,
+      manifest_sha256: "f".repeat(64),
+      total_bytes: 3,
+      file_count: 1,
+      parts: [{
+        part_id: "part-000001",
+        sha256: "a".repeat(64),
+        bundle_size_bytes: 10,
+        unpacked_size_bytes: 3,
+        file_count: 1,
+        files: [{ path: "a.md", size_bytes: 3, sha256: "1".repeat(64) }],
+      }],
+    };
+    const conflict = Object.assign(
+      new Error("AgentBox request failed: 409 source snapshot descriptor changed for the same run and revision"),
+      { status: 409, code: "CONFLICT" },
+    );
+    const { client, backend, posts } = fakes({
+      raw: { source_snapshot: snapshot, input_revision: "manifest-2" },
+      sourcesError: conflict,
+    });
+
+    await expect(materializeCapabilityInputs({ client, backend, runId: "r2" })).rejects.toMatchObject({
+      name: "CapabilityMaterializationError",
+      stage: "source-install",
+      cause: expect.objectContaining({ status: 409, code: "CONFLICT" }),
+    });
     expect(posts).toEqual([]);
     expect(backend.request).toHaveBeenCalledTimes(1);
   });

--- a/src/gateway/capability/materialize.test.ts
+++ b/src/gateway/capability/materialize.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CapabilityMaterializationError, materializeCapabilityInputs } from "./materialize.js";
-import { CAPABILITY_FETCH_INPUT, CAPABILITY_INPUT_WORKSPACE_REF } from "./contract.js";
+import {
+  CAPABILITY_FETCH_INPUT,
+  CAPABILITY_INPUT_SOURCE_PART_REF,
+  CAPABILITY_INPUT_WORKSPACE_REF,
+} from "./contract.js";
+import type { CapabilityFetchInputResponse } from "./contract.js";
 
 function fakes(opts: {
-  raw?: { bundle_base64?: string; bundle_sha256?: string; locale?: string; input_revision?: string };
+  raw?: CapabilityFetchInputResponse;
+  parts?: Record<string, CapabilityFetchInputResponse>;
+  missingParts?: string[];
   workspace?: { bundle_base64?: string; bundle_sha256?: string };
   rawError?: Error;
   workspaceError?: Error;
@@ -14,8 +21,15 @@ function fakes(opts: {
   const client = {
     postJson: vi.fn(async (path: string, body: any) => {
       if (path === "/sources" && opts.sourcesError) throw opts.sourcesError;
+      if (path.startsWith("/sources/") && opts.sourcesError) throw opts.sourcesError;
       if (path === "/authoring" && opts.authoringError) throw opts.authoringError;
       posts.push({ path, body });
+      if (path === "/sources/begin") {
+        return {
+          ok: true,
+          missing_parts: opts.missingParts ?? body.snapshot.parts.map((part: { part_id: string }) => part.part_id),
+        };
+      }
       return { ok: true };
     }),
   };
@@ -25,6 +39,9 @@ function fakes(opts: {
       if (params?.ref === CAPABILITY_INPUT_WORKSPACE_REF) {
         if (opts.workspaceError) throw opts.workspaceError;
         return opts.workspace ?? {};
+      }
+      if (params?.ref === CAPABILITY_INPUT_SOURCE_PART_REF) {
+        return opts.parts?.[params.part_id] ?? {};
       }
       if (opts.rawError) throw opts.rawError;
       return opts.raw ?? {};
@@ -73,6 +90,110 @@ describe("materializeCapabilityInputs", () => {
       input_revision: "manifest-1",
     });
     expect(result.inputRevision).toBe("manifest-1");
+  });
+
+  it("Source Snapshot v2 uploads only box-reported missing parts and commits before workspace", async () => {
+    const snapshot = {
+      version: 2 as const,
+      manifest_sha256: "f".repeat(64),
+      total_bytes: 7,
+      file_count: 2,
+      parts: [
+        {
+          part_id: "part-000001",
+          sha256: "a".repeat(64),
+          bundle_size_bytes: 10,
+          unpacked_size_bytes: 3,
+          file_count: 1,
+          files: [{ path: "a.md", size_bytes: 3, sha256: "1".repeat(64) }],
+        },
+        {
+          part_id: "part-000002",
+          sha256: "b".repeat(64),
+          bundle_size_bytes: 11,
+          unpacked_size_bytes: 4,
+          file_count: 1,
+          files: [{ path: "b.md", size_bytes: 4, sha256: "2".repeat(64) }],
+        },
+      ],
+    };
+    const { client, backend, posts } = fakes({
+      raw: { source_snapshot: snapshot, input_revision: "manifest-2", locale: "zh" },
+      parts: {
+        "part-000002": {
+          bundle_base64: "UDI=",
+          bundle_sha256: "b".repeat(64),
+          input_revision: "manifest-2",
+        },
+      },
+      missingParts: ["part-000002"],
+      workspace: { bundle_base64: "V1M=" },
+    });
+
+    const result = await materializeCapabilityInputs({ client, backend, runId: "r2" });
+
+    expect(result).toMatchObject({ inputRevision: "manifest-2", locale: "zh" });
+    expect(posts.map((post) => post.path)).toEqual([
+      "/sources/begin",
+      "/sources/part",
+      "/sources/commit",
+      "/authoring",
+    ]);
+    expect(backend.request).toHaveBeenNthCalledWith(2, CAPABILITY_FETCH_INPUT, {
+      run_id: "r2",
+      input_revision: "manifest-2",
+      ref: CAPABILITY_INPUT_SOURCE_PART_REF,
+      part_id: "part-000002",
+    });
+  });
+
+  it("Source Snapshot v2 rejects a part from another revision before upload", async () => {
+    const snapshot = {
+      version: 2 as const,
+      manifest_sha256: "f".repeat(64),
+      total_bytes: 3,
+      file_count: 1,
+      parts: [{
+        part_id: "part-000001",
+        sha256: "a".repeat(64),
+        bundle_size_bytes: 10,
+        unpacked_size_bytes: 3,
+        file_count: 1,
+        files: [{ path: "a.md", size_bytes: 3, sha256: "1".repeat(64) }],
+      }],
+    };
+    const { client, backend, posts } = fakes({
+      raw: { source_snapshot: snapshot, input_revision: "manifest-2" },
+      parts: { "part-000001": { bundle_base64: "UDE=", input_revision: "manifest-other" } },
+    });
+
+    await expect(materializeCapabilityInputs({ client, backend, runId: "r2" })).rejects.toMatchObject({
+      name: "CapabilityMaterializationError",
+      stage: "source-install",
+      message: expect.stringContaining("revision mismatch"),
+    });
+    expect(posts.map((post) => post.path)).toEqual(["/sources/begin"]);
+  });
+
+  it("Source Snapshot v2 requires an immutable input revision", async () => {
+    const { client, backend, posts } = fakes({
+      raw: {
+        source_snapshot: {
+          version: 2,
+          manifest_sha256: "f".repeat(64),
+          total_bytes: 0,
+          file_count: 0,
+          parts: [],
+        },
+      },
+    });
+
+    await expect(materializeCapabilityInputs({ client, backend, runId: "r2" })).rejects.toMatchObject({
+      name: "CapabilityMaterializationError",
+      stage: "source-install",
+      message: expect.stringContaining("requires input_revision"),
+    });
+    expect(posts).toEqual([]);
   });
 
   it("rejects a consumer response for a different pinned revision before installing sources", async () => {

--- a/src/gateway/capability/materialize.ts
+++ b/src/gateway/capability/materialize.ts
@@ -21,11 +21,16 @@
  * workspace probe would be needed to close it.
  */
 
-import { CAPABILITY_FETCH_INPUT, CAPABILITY_INPUT_WORKSPACE_REF } from "./contract.js";
+import {
+  CAPABILITY_FETCH_INPUT,
+  CAPABILITY_INPUT_SOURCE_PART_REF,
+  CAPABILITY_INPUT_WORKSPACE_REF,
+} from "./contract.js";
 import type {
   CapabilityFetchInputRequest,
   CapabilityFetchInputResponse,
   CapabilityLlmConfig,
+  CapabilitySourceSnapshot,
 } from "./contract.js";
 
 /** Just the surfaces this needs (so tests can pass fakes). */
@@ -74,6 +79,71 @@ function isBoxAlreadyLive(err: unknown): boolean {
   return typeof status !== "number" && message.includes("failed: 409");
 }
 
+function hasSourceInput(src: CapabilityFetchInputResponse | null | undefined): boolean {
+  return Boolean(src?.bundle_base64 || src?.source_snapshot);
+}
+
+function requireV2Revision(src: CapabilityFetchInputResponse): string {
+  const revision = typeof src.input_revision === "string" ? src.input_revision.trim() : "";
+  if (!revision) throw new Error("Source Snapshot v2 requires input_revision");
+  return revision;
+}
+
+async function installSourceSnapshot(opts: {
+  client: MaterializeBoxClient;
+  backend: MaterializeBackend;
+  runId: string;
+  src: CapabilityFetchInputResponse;
+  snapshot: CapabilitySourceSnapshot;
+}): Promise<void> {
+  const { client, backend, runId, src, snapshot } = opts;
+  const revision = requireV2Revision(src);
+  const begin = await client.postJson<{ missing_parts?: string[] }>("/sources/begin", {
+    run_id: runId,
+    input_revision: revision,
+    snapshot,
+    locale: src.locale,
+  });
+  const missing = Array.isArray(begin?.missing_parts) ? begin.missing_parts : [];
+  const expected = new Map(snapshot.parts.map((part) => [part.part_id, part]));
+
+  for (const partId of missing) {
+    const descriptor = expected.get(partId);
+    if (!descriptor) throw new Error(`box requested unknown source part ${partId}`);
+
+    const req: CapabilityFetchInputRequest = {
+      run_id: runId,
+      input_revision: revision,
+      ref: CAPABILITY_INPUT_SOURCE_PART_REF,
+      part_id: partId,
+    };
+    const fetched = (await backend.request(CAPABILITY_FETCH_INPUT, req)) as CapabilityFetchInputResponse;
+    const returnedRevision = typeof fetched?.input_revision === "string" ? fetched.input_revision.trim() : "";
+    if (returnedRevision !== revision) {
+      throw new Error(
+        `source part ${partId} revision mismatch: requested ${revision}, received ${returnedRevision || "<missing>"}`,
+      );
+    }
+    if (!fetched.bundle_base64) throw new Error(`source part ${partId} returned no bundle`);
+    if (fetched.bundle_sha256 && fetched.bundle_sha256.toLowerCase() !== descriptor.sha256.toLowerCase()) {
+      throw new Error(`source part ${partId} descriptor hash mismatch`);
+    }
+    await client.postJson("/sources/part", {
+      run_id: runId,
+      input_revision: revision,
+      part_id: partId,
+      bundle_base64: fetched.bundle_base64,
+      bundle_sha256: descriptor.sha256,
+    });
+  }
+
+  await client.postJson("/sources/commit", {
+    run_id: runId,
+    input_revision: revision,
+    locale: src.locale,
+  });
+}
+
 export async function materializeCapabilityInputs(opts: {
   client: MaterializeBoxClient;
   backend: MaterializeBackend;
@@ -106,7 +176,7 @@ export async function materializeCapabilityInputs(opts: {
         ),
       );
     }
-    if (!src.bundle_base64) {
+    if (!hasSourceInput(src)) {
       throw new CapabilityMaterializationError(
         "source-fetch",
         new Error(`pinned input revision ${pinnedRevision} returned no source bundle`),
@@ -120,15 +190,20 @@ export async function materializeCapabilityInputs(opts: {
 
   // RPC success + no bundle is the explicit empty-source result. It is not a
   // fresh-box signal, so never guess and push workspace state onto a live box.
-  if (!src?.bundle_base64) return result;
+  if (!hasSourceInput(src)) return result;
 
   try {
-    await client.postJson("/sources", {
-      run_id: runId,
-      bundle_base64: src.bundle_base64,
-      bundle_sha256: src.bundle_sha256,
-      locale: src.locale,
-    });
+    if (src.source_snapshot) {
+      if (src.bundle_base64) throw new Error("source response cannot contain both bundle_base64 and source_snapshot");
+      await installSourceSnapshot({ client, backend, runId, src, snapshot: src.source_snapshot });
+    } else {
+      await client.postJson("/sources", {
+        run_id: runId,
+        bundle_base64: src.bundle_base64,
+        bundle_sha256: src.bundle_sha256,
+        locale: src.locale,
+      });
+    }
   } catch (err) {
     // Prefer the structured HTTP status; message parsing is only a rolling-
     // upgrade fallback for older clients that did not attach err.status.

--- a/src/gateway/capability/materialize.ts
+++ b/src/gateway/capability/materialize.ts
@@ -72,11 +72,19 @@ export class CapabilityMaterializationError extends Error {
   }
 }
 
+const BOX_RUN_ALREADY_LIVE = "KBC_RUN_ALREADY_LIVE";
+const LEGACY_BOX_RUN_ALREADY_LIVE = "run already exists; upload sources before /session";
+
 function isBoxAlreadyLive(err: unknown): boolean {
-  const status = (err as { status?: unknown } | null)?.status;
-  if (status === 409) return true;
+  const metadata = err as { status?: unknown; code?: unknown } | null;
+  const status = metadata?.status;
+  if (status === 409 && metadata?.code === BOX_RUN_ALREADY_LIVE) return true;
   const message = err instanceof Error ? err.message : String(err);
-  return typeof status !== "number" && message.includes("failed: 409");
+  // Rolling-upgrade compatibility for boxes that predate the stable conflict
+  // code. Match the exact legacy live-run text as well as the 409; Source
+  // Snapshot v2 deliberately uses 409 for persisted-state conflicts too.
+  return message.includes(LEGACY_BOX_RUN_ALREADY_LIVE)
+    && (status === 409 || (typeof status !== "number" && message.includes("failed: 409")));
 }
 
 function hasSourceInput(src: CapabilityFetchInputResponse | null | undefined): boolean {


### PR DESCRIPTION
## Summary

Add Source Snapshot v2 so the runtime can materialize large immutable KB Raw inputs as independently verified, resumable parts instead of one monolithic base64 request. The legacy `/sources` path remains unchanged for small inputs and rolling upgrades.

### Problem

The current capability input path serializes the entire frozen Raw workspace into one tar.gz/base64 payload. The real GPU workspace is 1,773 files and 628,153,605 raw bytes, which makes a single request memory-heavy and fragile to retry.

### Solution

- Add a versioned source descriptor and `source-part` capability fetch contract.
- Add `/sources/begin`, `/sources/state`, `/sources/part`, and `/sources/commit` to the compile box.
- Persist received parts on disk, request only missing parts after retries/restarts, and make every operation idempotent.
- Verify descriptor, compressed-part, and per-file SHA-256 values; reject undeclared paths and every non-regular tar entry.
- Assemble into staging and atomically replace `raw/` only after all parts validate; preserve the previous Raw on validation or commit-marker failure.
- Keep v1 delivery behavior intact.

The paired [Sicore MR !664](https://gitlab.scitix-inner.ai/k8s/sicore/-/merge_requests/664) sender change must be deployed only after this receiver is available.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (227 files, 4,485 passed, 2 skipped)
- [x] `npm run build` passes
- [x] Compile-box HTTP protocol smoke passes, including resume, incomplete-commit rejection, atomic commit, and idempotent replay
- [x] Python Source Snapshot unit tests pass
- [x] Manual verification: the real GPU Raw directory (1,773 files, 628,153,605 bytes) installs successfully in 20 parts without a monolithic request

## Architecture Checklist

- [ ] **Deployment mode**: Not deployed in this PR; local compile-box protocol and filesystem behavior are verified. K8s acceptance belongs to the paired rollout after both repositories merge.
- [x] **Security model**: No new shell execution path; archive input is size-bounded, manifest-bound, path-confined, and SHA-256 verified.
- [x] **DB parity**: Not applicable; Siclaw schema is unchanged.
- [x] **Tool protocol**: Not applicable; no agent tool was added.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No unrelated changes included
