### PR TITLE
feat(kbc): add hierarchical compilation for very large corpora

### DIFF
--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -20,6 +20,7 @@ Design invariants:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -30,7 +31,8 @@ DEFAULT_BATCH_THRESHOLD_BYTES = 400 * 1024
 DEFAULT_BATCH_BUDGET_BYTES = 200 * 1024
 DEFAULT_HIERARCHICAL_THRESHOLD_BYTES = 8 * 1024 * 1024
 DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES = 1024 * 1024
-DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 400 * 1024
+DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 128 * 1024
+DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES = 64 * 1024
 DEFAULT_REDUCTION_BUDGET_BYTES = 512 * 1024
 
 # ── effective-size weighting ─────────────────────────────────────────────────
@@ -62,6 +64,39 @@ def _hierarchical_context_anchor_max_bytes() -> int:
     over. Later chunks can use the Candidate produced by the first chunk."""
     return int(os.environ.get(
         "KBC_HIERARCHICAL_CONTEXT_ANCHOR_MAX_BYTES", str(96 * 1024)))
+
+
+def _hierarchical_text_slice_bytes() -> int:
+    return max(1, int(os.environ.get(
+        "KBC_HIERARCHICAL_TEXT_SLICE_BYTES",
+        str(DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES))))
+
+
+def _text_slices(path: Path, size: int) -> tuple[int, list[dict[str, int]]] | None:
+    """Line-bounded chunks for a Markdown source that cannot safely fit one
+    hierarchical model turn. The Raw file remains the provenance identity;
+    these ranges only bound what each internal map session may read."""
+    if path.suffix.lower() != ".md" or size <= hierarchical_text_budget_bytes():
+        return None
+    lines = path.read_bytes().splitlines(keepends=True)
+    if not lines:
+        return None
+    target = min(_hierarchical_text_slice_bytes(), hierarchical_text_budget_bytes())
+    slices: list[dict[str, int]] = []
+    start = 0
+    while start < len(lines):
+        end = start
+        total = 0
+        while end < len(lines) and (total + len(lines[end]) <= target or end == start):
+            total += len(lines[end])
+            end += 1
+        slices.append({
+            "start_line": start + 1,
+            "end_line": end,
+            "bytes": total,
+        })
+        start = end
+    return len(lines), slices
 
 
 def _pdf_page_cost() -> int:
@@ -159,11 +194,15 @@ def scan_sources(raw_dir: Path) -> list[dict[str, Any]]:
         size = p.stat().st_size
         if size == 0:
             continue
-        items.append({
+        item = {
             "path": str(p.relative_to(raw_dir)),
             "bytes": size,
             "effective": effective_bytes(p, size),
-        })
+        }
+        sliced = _text_slices(p, size)
+        if sliced is not None:
+            item["line_count"], item["text_slices"] = sliced
+        items.append(item)
     return items
 
 
@@ -325,6 +364,30 @@ def pack_hierarchical_batches(
             "status": "pending",
         })
 
+    def append_text_slices(item: dict[str, Any]) -> None:
+        slices = item.get("text_slices") or []
+        source = str(item["path"])
+        source_key = hashlib.sha256(source.encode("utf-8")).hexdigest()[:12]
+        count = len(slices)
+        for index, text_slice in enumerate(slices, start=1):
+            result.append({
+                "id": f"h{len(result) + 1:03d}",
+                "sources": [source],
+                "context_sources": [],
+                "source_ranges": {
+                    source: {
+                        **text_slice,
+                        "part": index,
+                        "parts": count,
+                        "slice_file": f".kbc-batch-slices/{source_key}-p{index:03d}.md",
+                    },
+                },
+                "defer_accounting": index < count,
+                "bytes": int(text_slice["bytes"]),
+                "text_bytes": int(text_slice["bytes"]),
+                "status": "pending",
+            })
+
     def flush() -> None:
         nonlocal current, current_bytes, current_text_bytes
         if current:
@@ -353,7 +416,11 @@ def pack_hierarchical_batches(
         flush()
         anchor = family[0] if str(family[0]["path"]).lower().endswith(".md") else None
         remaining = family[:]
-        if anchor is not None:
+        sliced_anchor = anchor if anchor is not None and anchor.get("text_slices") else None
+        if sliced_anchor is not None:
+            remaining.pop(0)
+            append_text_slices(sliced_anchor)
+        elif anchor is not None:
             # The anchor itself is accounted once, in the first chunk.
             first = [remaining.pop(0)]
             first_bytes = _hierarchical_eff(first[0])
@@ -372,7 +439,8 @@ def pack_hierarchical_batches(
         # Re-reading an oversized anchor on every chunk would itself overflow
         # the context. In that rare case the chunks remain independent.
         context = [anchor] if (
-            anchor is not None and _hierarchical_eff(anchor) < limit and _text_eff(anchor) < text_limit
+            sliced_anchor is None and anchor is not None
+            and _hierarchical_eff(anchor) < limit and _text_eff(anchor) < text_limit
             and _text_eff(anchor) <= _hierarchical_context_anchor_max_bytes()
         ) else []
         context_bytes = sum(_hierarchical_eff(i) for i in context)
@@ -415,8 +483,13 @@ def build_plan(
     text_budget: int | None = None,
 ) -> dict[str, Any]:
     mode = "hierarchical" if planner == "hierarchical-code" else "flat"
+    has_text_slices = any(batch.get("source_ranges") for batch in batches)
     return {
-        "version": 2 if mode == "hierarchical" else 1,
+        "version": (
+            3 if mode == "hierarchical" and has_text_slices
+            else 2 if mode == "hierarchical"
+            else 1
+        ),
         "planner": planner,
         "mode": mode,
         "phase": "map",
@@ -449,9 +522,11 @@ def validate_plan(
     b = budget if budget is not None else batch_budget_bytes()
     errors: list[str] = []
     effective = _hierarchical_eff if plan.get("mode") == "hierarchical" else _eff
-    sizes = {i["path"]: effective(i) for i in inventory}
-    text_sizes = {i["path"]: _text_eff(i) for i in inventory}
+    records = {i["path"]: i for i in inventory}
+    sizes = {path: effective(item) for path, item in records.items()}
+    text_sizes = {path: _text_eff(item) for path, item in records.items()}
     seen: dict[str, str] = {}
+    slice_appearances: dict[str, list[dict[str, Any]]] = {}
     seen_ids: set[str] = set()
     batches = plan.get("batches")
     if not isinstance(batches, list) or not batches:
@@ -474,17 +549,61 @@ def validate_plan(
         if not isinstance(context, list):
             errors.append(f"batch {bid}: context_sources must be a list")
             context = []
+        source_ranges = batch.get("source_ranges", {})
+        if not isinstance(source_ranges, dict):
+            errors.append(f"batch {bid}: source_ranges must be an object")
+            source_ranges = {}
+        unknown_range_sources = set(source_ranges) - set(sources)
+        if unknown_range_sources:
+            errors.append(
+                f"batch {bid}: source_ranges names unassigned source(s): "
+                + ", ".join(sorted(unknown_range_sources)[:3]))
+        if source_ranges and (len(sources) != 1 or context):
+            errors.append(f"batch {bid}: a text-slice batch must contain one source and no context")
         total = 0
         text_total = 0
         for path in sources:
             if path not in sizes:
                 errors.append(f"batch {bid}: unknown source {path}")
                 continue
+            source_range = source_ranges.get(path)
             if path in seen:
-                errors.append(f"source {path} appears in {seen[path]} and {bid}")
-            seen[path] = bid
-            total += sizes[path]
-            text_total += text_sizes[path]
+                if source_range is None or path not in slice_appearances:
+                    errors.append(f"source {path} appears in {seen[path]} and {bid}")
+            else:
+                seen[path] = bid
+            if source_range is None:
+                if path in slice_appearances:
+                    errors.append(f"source {path} mixes sliced and unsliced assignments")
+                total += sizes[path]
+                text_total += text_sizes[path]
+                continue
+            if not isinstance(source_range, dict):
+                errors.append(f"batch {bid}: invalid source range for {path}")
+                continue
+            try:
+                parsed_range = {
+                    "bid": bid,
+                    "start_line": int(source_range["start_line"]),
+                    "end_line": int(source_range["end_line"]),
+                    "bytes": int(source_range["bytes"]),
+                    "part": int(source_range["part"]),
+                    "parts": int(source_range["parts"]),
+                    "slice_file": str(source_range["slice_file"]),
+                    "defer_accounting": bool(batch.get("defer_accounting", False)),
+                }
+            except (KeyError, TypeError, ValueError):
+                errors.append(f"batch {bid}: malformed source range for {path}")
+                continue
+            if parsed_range["start_line"] < 1 or parsed_range["end_line"] < parsed_range["start_line"]:
+                errors.append(f"batch {bid}: invalid line range for {path}")
+            if parsed_range["bytes"] < 1:
+                errors.append(f"batch {bid}: empty text slice for {path}")
+            if not parsed_range["slice_file"].startswith(".kbc-batch-slices/"):
+                errors.append(f"batch {bid}: unsafe slice file for {path}")
+            slice_appearances.setdefault(path, []).append(parsed_range)
+            total += max(0, parsed_range["bytes"])
+            text_total += max(0, parsed_range["bytes"])
         for path in context:
             if path not in sizes:
                 errors.append(f"batch {bid}: unknown context source {path}")
@@ -503,6 +622,26 @@ def validate_plan(
         ):
             errors.append(
                 f"batch {bid}: {text_total} text bytes exceeds text budget {text_budget}")
+    for path, appearances in slice_appearances.items():
+        line_count = int(records.get(path, {}).get("line_count", 0))
+        ordered = sorted(appearances, key=lambda item: item["part"])
+        declared_parts = {item["parts"] for item in ordered}
+        if line_count < 1 or len(declared_parts) != 1 or next(iter(declared_parts), 0) != len(ordered):
+            errors.append(f"source {path} has incomplete text-slice metadata")
+            continue
+        if [item["part"] for item in ordered] != list(range(1, len(ordered) + 1)):
+            errors.append(f"source {path} has non-sequential text slices")
+        expected_start = 1
+        for index, item in enumerate(ordered):
+            if item["start_line"] != expected_start:
+                errors.append(f"source {path} text slices are not contiguous")
+                break
+            expected_start = item["end_line"] + 1
+            should_defer = index < len(ordered) - 1
+            if item["defer_accounting"] != should_defer:
+                errors.append(f"source {path} has invalid deferred-accounting boundary")
+        if expected_start != line_count + 1:
+            errors.append(f"source {path} text slices do not cover all {line_count} lines")
     missing = [p for p in sizes if p not in seen]
     if missing:
         errors.append(f"sources not covered: {', '.join(sorted(missing)[:5])}" + ("…" if len(missing) > 5 else ""))
@@ -617,6 +756,10 @@ def prune_missing_sources(plan: dict[str, Any], known: set[str]) -> list[str]:
         if gone:
             dropped.extend(gone)
             b["sources"] = sources
+            ranges = b.get("source_ranges")
+            if isinstance(ranges, dict):
+                for source in gone:
+                    ranges.pop(source, None)
             if not sources:
                 b["status"] = "done"
         context = [s for s in b.get("context_sources", []) if s in known]
@@ -624,7 +767,7 @@ def prune_missing_sources(plan: dict[str, Any], known: set[str]) -> list[str]:
         if context_gone:
             dropped.extend(context_gone)
             b["context_sources"] = context
-    return dropped
+    return sorted(set(dropped))
 
 
 def dump_json(value: Any) -> str:

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -53,7 +53,15 @@ def _hierarchical_image_cost() -> int:
     map session. Keep the established flat-planner estimate for medium corpora,
     but use a conservative cost in the very-large hierarchical path."""
     return int(os.environ.get(
-        "KBC_HIERARCHICAL_IMAGE_COST_BYTES", str(64 * 1024)))
+        "KBC_HIERARCHICAL_IMAGE_COST_BYTES", str(128 * 1024)))
+
+
+def _hierarchical_context_anchor_max_bytes() -> int:
+    """A large rendered document is useful in the first family chunk, but
+    replaying it beside every later image chunk burns the same context over and
+    over. Later chunks can use the Candidate produced by the first chunk."""
+    return int(os.environ.get(
+        "KBC_HIERARCHICAL_CONTEXT_ANCHOR_MAX_BYTES", str(96 * 1024)))
 
 
 def _pdf_page_cost() -> int:
@@ -365,6 +373,7 @@ def pack_hierarchical_batches(
         # the context. In that rare case the chunks remain independent.
         context = [anchor] if (
             anchor is not None and _hierarchical_eff(anchor) < limit and _text_eff(anchor) < text_limit
+            and _text_eff(anchor) <= _hierarchical_context_anchor_max_bytes()
         ) else []
         context_bytes = sum(_hierarchical_eff(i) for i in context)
         context_text_bytes = sum(_text_eff(i) for i in context)

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -48,6 +48,14 @@ def _image_cost() -> int:
     return int(os.environ.get("KBC_BATCH_IMAGE_COST_BYTES", str(30 * 1024)))
 
 
+def _hierarchical_image_cost() -> int:
+    """High-resolution page renders accumulate vision tokens across a long
+    map session. Keep the established flat-planner estimate for medium corpora,
+    but use a conservative cost in the very-large hierarchical path."""
+    return int(os.environ.get(
+        "KBC_HIERARCHICAL_IMAGE_COST_BYTES", str(64 * 1024)))
+
+
 def _pdf_page_cost() -> int:
     return int(os.environ.get("KBC_BATCH_PDF_PAGE_COST_BYTES", str(8 * 1024)))
 
@@ -157,6 +165,12 @@ def corpus_bytes(inventory: list[dict[str, Any]]) -> int:
 
 def _eff(item: dict[str, Any]) -> int:
     return int(item.get("effective", item["bytes"]))
+
+
+def _hierarchical_eff(item: dict[str, Any]) -> int:
+    if Path(str(item["path"])).suffix.lower() in IMAGE_EXTS:
+        return max(_eff(item), _hierarchical_image_cost())
+    return _eff(item)
 
 
 def _text_eff(item: dict[str, Any]) -> int:
@@ -298,7 +312,7 @@ def pack_hierarchical_batches(
             "id": f"h{len(result) + 1:03d}",
             "sources": [str(i["path"]) for i in sources],
             "context_sources": [str(i["path"]) for i in context],
-            "bytes": sum(_eff(i) for i in sources + context),
+            "bytes": sum(_hierarchical_eff(i) for i in sources + context),
             "text_bytes": sum(_text_eff(i) for i in sources + context),
             "status": "pending",
         })
@@ -312,7 +326,7 @@ def pack_hierarchical_batches(
             current_text_bytes = 0
 
     for family in source_families(inventory):
-        family_bytes = sum(_eff(i) for i in family)
+        family_bytes = sum(_hierarchical_eff(i) for i in family)
         family_text_bytes = sum(_text_eff(i) for i in family)
         section = _top_dir(str(family[0]["path"]))
         if family_bytes <= limit and family_text_bytes <= text_limit:
@@ -334,30 +348,30 @@ def pack_hierarchical_batches(
         if anchor is not None:
             # The anchor itself is accounted once, in the first chunk.
             first = [remaining.pop(0)]
-            first_bytes = _eff(first[0])
+            first_bytes = _hierarchical_eff(first[0])
             first_text_bytes = _text_eff(first[0])
             while (
                 remaining
-                and first_bytes + _eff(remaining[0]) <= limit
+                and first_bytes + _hierarchical_eff(remaining[0]) <= limit
                 and first_text_bytes + _text_eff(remaining[0]) <= text_limit
             ):
                 item = remaining.pop(0)
                 first.append(item)
-                first_bytes += _eff(item)
+                first_bytes += _hierarchical_eff(item)
                 first_text_bytes += _text_eff(item)
             append_batch(first)
 
         # Re-reading an oversized anchor on every chunk would itself overflow
         # the context. In that rare case the chunks remain independent.
         context = [anchor] if (
-            anchor is not None and _eff(anchor) < limit and _text_eff(anchor) < text_limit
+            anchor is not None and _hierarchical_eff(anchor) < limit and _text_eff(anchor) < text_limit
         ) else []
-        context_bytes = sum(_eff(i) for i in context)
+        context_bytes = sum(_hierarchical_eff(i) for i in context)
         context_text_bytes = sum(_text_eff(i) for i in context)
         while remaining:
             batch_context = context
             if context and (
-                context_bytes + _eff(remaining[0]) > limit
+                context_bytes + _hierarchical_eff(remaining[0]) > limit
                 or context_text_bytes + _text_eff(remaining[0]) > text_limit
             ):
                 # A single oversized asset/file is allowed as a solo batch; do
@@ -365,18 +379,18 @@ def pack_hierarchical_batches(
                 # the anchor beside it.
                 batch_context = []
             chunk: list[dict[str, Any]] = []
-            chunk_bytes = sum(_eff(i) for i in batch_context)
+            chunk_bytes = sum(_hierarchical_eff(i) for i in batch_context)
             chunk_text_bytes = sum(_text_eff(i) for i in batch_context)
             while remaining and (
                 (
-                    chunk_bytes + _eff(remaining[0]) <= limit
+                    chunk_bytes + _hierarchical_eff(remaining[0]) <= limit
                     and chunk_text_bytes + _text_eff(remaining[0]) <= text_limit
                 )
                 or not chunk
             ):
                 item = remaining.pop(0)
                 chunk.append(item)
-                chunk_bytes += _eff(item)
+                chunk_bytes += _hierarchical_eff(item)
                 chunk_text_bytes += _text_eff(item)
             append_batch(chunk, batch_context)
     flush()
@@ -425,7 +439,8 @@ def validate_plan(
     toward the per-session budget."""
     b = budget if budget is not None else batch_budget_bytes()
     errors: list[str] = []
-    sizes = {i["path"]: _eff(i) for i in inventory}
+    effective = _hierarchical_eff if plan.get("mode") == "hierarchical" else _eff
+    sizes = {i["path"]: effective(i) for i in inventory}
     text_sizes = {i["path"]: _text_eff(i) for i in inventory}
     seen: dict[str, str] = {}
     seen_ids: set[str] = set()

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -7,8 +7,11 @@ baseline stands. Budgets are enforced by THIS code; the model never gets to
 overfill a session.
 
 Design invariants:
-- Small/medium KBs never enter batch mode (threshold gate) — their compile path
-  is byte-identical to today.
+- Small KBs never enter batch mode (threshold gate) — their compile path is
+  byte-identical to today. Medium KBs retain the original flat batch planner.
+- Only very large corpora enter hierarchical mode. Sibling ``*.assets`` files
+  stay with their Markdown anchor, and an oversized family repeats only that
+  anchor as read-only context while accounting each source exactly once.
 - Every raw source lands in exactly one batch (coverage is validated, and the
   final full-corpus SELFCHECK proves no batch dropped anything).
 - A single file larger than the budget still gets its own batch (we never split
@@ -25,6 +28,10 @@ from typing import Any
 
 DEFAULT_BATCH_THRESHOLD_BYTES = 400 * 1024
 DEFAULT_BATCH_BUDGET_BYTES = 200 * 1024
+DEFAULT_HIERARCHICAL_THRESHOLD_BYTES = 8 * 1024 * 1024
+DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES = 1024 * 1024
+DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 400 * 1024
+DEFAULT_REDUCTION_BUDGET_BYTES = 512 * 1024
 
 # ── effective-size weighting ─────────────────────────────────────────────────
 # Raw bytes are a terrible proxy for context cost on non-text sources: a 168KB
@@ -91,6 +98,28 @@ def batch_budget_bytes() -> int:
     return int(os.environ.get("KBC_BATCH_BUDGET_BYTES", str(DEFAULT_BATCH_BUDGET_BYTES)))
 
 
+def hierarchical_threshold_bytes() -> int:
+    return int(os.environ.get(
+        "KBC_HIERARCHICAL_THRESHOLD_BYTES", str(DEFAULT_HIERARCHICAL_THRESHOLD_BYTES)))
+
+
+def hierarchical_batch_budget_bytes() -> int:
+    return int(os.environ.get(
+        "KBC_HIERARCHICAL_BATCH_BUDGET_BYTES",
+        str(DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES)))
+
+
+def hierarchical_text_budget_bytes() -> int:
+    return int(os.environ.get(
+        "KBC_HIERARCHICAL_TEXT_BUDGET_BYTES",
+        str(DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES)))
+
+
+def reduction_budget_bytes() -> int:
+    return int(os.environ.get(
+        "KBC_REDUCTION_BUDGET_BYTES", str(DEFAULT_REDUCTION_BUDGET_BYTES)))
+
+
 def scan_sources(raw_dir: Path) -> list[dict[str, Any]]:
     """Inventory of raw sources: repo-relative path + size, sorted for stable
     plans. Hidden files and empty files are skipped (they carry no compile
@@ -130,12 +159,26 @@ def _eff(item: dict[str, Any]) -> int:
     return int(item.get("effective", item["bytes"]))
 
 
+def _text_eff(item: dict[str, Any]) -> int:
+    return int(item["bytes"]) if Path(str(item["path"])).suffix.lower() in TEXT_EXTS else 0
+
+
 def corpus_effective_bytes(inventory: list[dict[str, Any]]) -> int:
     return sum(_eff(i) for i in inventory)
 
 
 def should_batch(inventory: list[dict[str, Any]], threshold: int | None = None) -> bool:
     return corpus_effective_bytes(inventory) > (threshold if threshold is not None else batch_threshold_bytes())
+
+
+def should_hierarchical(
+    inventory: list[dict[str, Any]], threshold: int | None = None
+) -> bool:
+    """The second routing gate. Keeping it separate from ``should_batch`` is
+    intentional: changing the large-corpus strategy must not move the existing
+    small/single-session or medium/flat-batch boundaries."""
+    limit = threshold if threshold is not None else hierarchical_threshold_bytes()
+    return corpus_effective_bytes(inventory) > limit
 
 
 def _top_dir(path: str) -> str:
@@ -186,18 +229,185 @@ def pack_batches(inventory: list[dict[str, Any]], budget: int | None = None) -> 
     return batches
 
 
+def _asset_anchor(path: str, known: set[str]) -> str | None:
+    """Return the Markdown source owning a file below ``<name>.assets/``.
+
+    Feishu/Docx exports use this layout consistently. The anchor is recognized
+    only when the corresponding ``<name>.md`` is actually in the inventory, so
+    an unrelated directory whose name happens to end in ``.assets`` is never
+    invented as context.
+    """
+    parts = path.split("/")
+    for idx, part in enumerate(parts[:-1]):
+        if not part.endswith(".assets"):
+            continue
+        anchor = "/".join(parts[:idx] + [part[:-len(".assets")] + ".md"])
+        if anchor in known:
+            return anchor
+    return None
+
+
+def source_families(inventory: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Group every source into one deterministic document family.
+
+    A family is an anchor Markdown file plus all media below its sibling
+    ``*.assets`` directory. Everything else is a one-source family. Returning
+    inventory records (rather than just paths) keeps this function pure and
+    lets the packer enforce effective-byte budgets without rescanning disk.
+    """
+    by_path = {str(i["path"]): i for i in inventory}
+    known = set(by_path)
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for item in inventory:
+        path = str(item["path"])
+        key = _asset_anchor(path, known) or path
+        grouped.setdefault(key, []).append(item)
+    families: list[list[dict[str, Any]]] = []
+    for key in sorted(grouped):
+        items = grouped[key]
+        # Put the anchor first, then stable path order for its assets.
+        items.sort(key=lambda i: (str(i["path"]) != key, str(i["path"])))
+        families.append(items)
+    return families
+
+
+def pack_hierarchical_batches(
+    inventory: list[dict[str, Any]], budget: int | None = None,
+    text_budget: int | None = None,
+) -> list[dict[str, Any]]:
+    """Pack very large corpora without separating a document from its media.
+
+    Small families are greedily combined inside the same top-level section.
+    Oversized families are split across batches; later chunks may re-read the
+    Markdown anchor through ``context_sources``. Context is charged to every
+    chunk's budget but is not counted again by the coverage ledger.
+    """
+    limit = budget if budget is not None else hierarchical_batch_budget_bytes()
+    text_limit = text_budget if text_budget is not None else hierarchical_text_budget_bytes()
+    result: list[dict[str, Any]] = []
+    current: list[dict[str, Any]] = []
+    current_bytes = 0
+    current_text_bytes = 0
+    current_dir: str | None = None
+
+    def append_batch(
+        sources: list[dict[str, Any]], context: list[dict[str, Any]] | None = None
+    ) -> None:
+        context = context or []
+        result.append({
+            "id": f"h{len(result) + 1:03d}",
+            "sources": [str(i["path"]) for i in sources],
+            "context_sources": [str(i["path"]) for i in context],
+            "bytes": sum(_eff(i) for i in sources + context),
+            "text_bytes": sum(_text_eff(i) for i in sources + context),
+            "status": "pending",
+        })
+
+    def flush() -> None:
+        nonlocal current, current_bytes, current_text_bytes
+        if current:
+            append_batch(current)
+            current = []
+            current_bytes = 0
+            current_text_bytes = 0
+
+    for family in source_families(inventory):
+        family_bytes = sum(_eff(i) for i in family)
+        family_text_bytes = sum(_text_eff(i) for i in family)
+        section = _top_dir(str(family[0]["path"]))
+        if family_bytes <= limit and family_text_bytes <= text_limit:
+            if current and (
+                current_dir != section
+                or current_bytes + family_bytes > limit
+                or current_text_bytes + family_text_bytes > text_limit
+            ):
+                flush()
+            current_dir = section
+            current.extend(family)
+            current_bytes += family_bytes
+            current_text_bytes += family_text_bytes
+            continue
+
+        flush()
+        anchor = family[0] if str(family[0]["path"]).lower().endswith(".md") else None
+        remaining = family[:]
+        if anchor is not None:
+            # The anchor itself is accounted once, in the first chunk.
+            first = [remaining.pop(0)]
+            first_bytes = _eff(first[0])
+            first_text_bytes = _text_eff(first[0])
+            while (
+                remaining
+                and first_bytes + _eff(remaining[0]) <= limit
+                and first_text_bytes + _text_eff(remaining[0]) <= text_limit
+            ):
+                item = remaining.pop(0)
+                first.append(item)
+                first_bytes += _eff(item)
+                first_text_bytes += _text_eff(item)
+            append_batch(first)
+
+        # Re-reading an oversized anchor on every chunk would itself overflow
+        # the context. In that rare case the chunks remain independent.
+        context = [anchor] if (
+            anchor is not None and _eff(anchor) < limit and _text_eff(anchor) < text_limit
+        ) else []
+        context_bytes = sum(_eff(i) for i in context)
+        context_text_bytes = sum(_text_eff(i) for i in context)
+        while remaining:
+            batch_context = context
+            if context and (
+                context_bytes + _eff(remaining[0]) > limit
+                or context_text_bytes + _text_eff(remaining[0]) > text_limit
+            ):
+                # A single oversized asset/file is allowed as a solo batch; do
+                # not turn it into an invalid multi-source batch by repeating
+                # the anchor beside it.
+                batch_context = []
+            chunk: list[dict[str, Any]] = []
+            chunk_bytes = sum(_eff(i) for i in batch_context)
+            chunk_text_bytes = sum(_text_eff(i) for i in batch_context)
+            while remaining and (
+                (
+                    chunk_bytes + _eff(remaining[0]) <= limit
+                    and chunk_text_bytes + _text_eff(remaining[0]) <= text_limit
+                )
+                or not chunk
+            ):
+                item = remaining.pop(0)
+                chunk.append(item)
+                chunk_bytes += _eff(item)
+                chunk_text_bytes += _text_eff(item)
+            append_batch(chunk, batch_context)
+    flush()
+    return result
+
+
 def build_plan(
     inventory: list[dict[str, Any]],
     batches: list[dict[str, Any]],
     planner: str,
     threshold: int | None = None,
     budget: int | None = None,
+    text_budget: int | None = None,
 ) -> dict[str, Any]:
+    mode = "hierarchical" if planner == "hierarchical-code" else "flat"
     return {
-        "version": 1,
+        "version": 2 if mode == "hierarchical" else 1,
         "planner": planner,
-        "threshold": threshold if threshold is not None else batch_threshold_bytes(),
+        "mode": mode,
+        "phase": "map",
+        "threshold": (
+            threshold if threshold is not None
+            else hierarchical_threshold_bytes() if mode == "hierarchical"
+            else batch_threshold_bytes()
+        ),
         "budget": budget if budget is not None else batch_budget_bytes(),
+        "text_budget": (
+            text_budget if text_budget is not None
+            else hierarchical_text_budget_bytes() if mode == "hierarchical"
+            else None
+        ),
         "total_bytes": corpus_bytes(inventory),
         "total_effective_bytes": corpus_effective_bytes(inventory),
         "batches": batches,
@@ -205,14 +415,18 @@ def build_plan(
 
 
 def validate_plan(
-    plan: dict[str, Any], inventory: list[dict[str, Any]], budget: int | None = None
+    plan: dict[str, Any], inventory: list[dict[str, Any]], budget: int | None = None,
+    text_budget: int | None = None,
 ) -> list[str]:
     """Errors for a (possibly model-proposed) plan. Empty list = valid.
     Rules: every inventory source in exactly one batch, no unknown sources,
-    every batch within budget unless it is a single oversized file."""
+    every batch within budget unless it is a single oversized file. Optional
+    context sources may repeat across batches but are read-only and still count
+    toward the per-session budget."""
     b = budget if budget is not None else batch_budget_bytes()
     errors: list[str] = []
     sizes = {i["path"]: _eff(i) for i in inventory}
+    text_sizes = {i["path"]: _text_eff(i) for i in inventory}
     seen: dict[str, str] = {}
     seen_ids: set[str] = set()
     batches = plan.get("batches")
@@ -232,7 +446,12 @@ def validate_plan(
         if not isinstance(sources, list) or not sources:
             errors.append(f"batch {bid}: empty or missing sources")
             continue
+        context = batch.get("context_sources", [])
+        if not isinstance(context, list):
+            errors.append(f"batch {bid}: context_sources must be a list")
+            context = []
         total = 0
+        text_total = 0
         for path in sources:
             if path not in sizes:
                 errors.append(f"batch {bid}: unknown source {path}")
@@ -241,8 +460,25 @@ def validate_plan(
                 errors.append(f"source {path} appears in {seen[path]} and {bid}")
             seen[path] = bid
             total += sizes[path]
-        if total > b and len(sources) > 1:
+            text_total += text_sizes[path]
+        for path in context:
+            if path not in sizes:
+                errors.append(f"batch {bid}: unknown context source {path}")
+                continue
+            if path in sources:
+                errors.append(f"batch {bid}: source {path} is also repeated as context")
+                continue
+            total += sizes[path]
+            text_total += text_sizes[path]
+        if total > b and len(sources) + len(context) > 1:
             errors.append(f"batch {bid}: {total} bytes exceeds budget {b}")
+        if (
+            text_budget is not None
+            and text_total > text_budget
+            and len(sources) + len(context) > 1
+        ):
+            errors.append(
+                f"batch {bid}: {text_total} text bytes exceeds text budget {text_budget}")
     missing = [p for p in sizes if p not in seen]
     if missing:
         errors.append(f"sources not covered: {', '.join(sorted(missing)[:5])}" + ("…" if len(missing) > 5 else ""))
@@ -273,6 +509,67 @@ def pending_batches(plan: dict[str, Any]) -> list[dict[str, Any]]:
     return [b for b in plan.get("batches", []) if b.get("status") != "done"]
 
 
+def pack_section_reductions(
+    pages: dict[str, dict[str, Any]], budget: int | None = None
+) -> list[dict[str, Any]]:
+    """Build bounded candidate-page reduce groups after hierarchical mapping.
+
+    Pages are assigned to a source top-level section only when their provenance
+    points unambiguously to one section. Cross-section and derived pages stay
+    for the global final review. Single-page groups need no reduce session.
+    """
+    limit = budget if budget is not None else reduction_budget_bytes()
+    groups: dict[str, list[tuple[str, int]]] = {}
+    for path, page in pages.items():
+        if Path(path).name in {"index.md", "log.md"}:
+            continue
+        sections = {_top_dir(str(s)) for s in page.get("sources", [])}
+        if len(sections) != 1:
+            continue
+        section = next(iter(sections))
+        groups.setdefault(section, []).append((path, int(page.get("bytes", 0))))
+
+    reductions: list[dict[str, Any]] = []
+    for section in sorted(groups):
+        entries = sorted(groups[section])
+        if len(entries) < 2:
+            continue
+        current: list[tuple[str, int]] = []
+        current_bytes = 0
+
+        def flush() -> None:
+            nonlocal current, current_bytes
+            if len(current) >= 2:
+                reductions.append({
+                    "id": f"r{len(reductions) + 1:03d}",
+                    "section": section,
+                    "pages": [p for p, _ in current],
+                    "bytes": current_bytes,
+                    "status": "pending",
+                })
+            current = []
+            current_bytes = 0
+
+        for entry in entries:
+            if current and current_bytes + entry[1] > limit:
+                flush()
+            current.append(entry)
+            current_bytes += entry[1]
+        flush()
+    return reductions
+
+
+def pending_reductions(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    return [r for r in plan.get("reductions", []) if r.get("status") != "done"]
+
+
+def stamp_reduction_done(plan: dict[str, Any], reduction_id: str) -> dict[str, Any]:
+    for reduction in plan.get("reductions", []):
+        if reduction.get("id") == reduction_id:
+            reduction["status"] = "done"
+    return plan
+
+
 def stamp_done(plan: dict[str, Any], batch_id: str) -> dict[str, Any]:
     for b in plan.get("batches", []):
         if b.get("id") == batch_id:
@@ -298,6 +595,11 @@ def prune_missing_sources(plan: dict[str, Any], known: set[str]) -> list[str]:
             b["sources"] = sources
             if not sources:
                 b["status"] = "done"
+        context = [s for s in b.get("context_sources", []) if s in known]
+        context_gone = [s for s in b.get("context_sources", []) if s not in known]
+        if context_gone:
+            dropped.extend(context_gone)
+            b["context_sources"] = context
     return dropped
 
 

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1307,6 +1307,21 @@ def _media_verify_rounds() -> int:
     return max(1, int(os.environ.get("KBC_MEDIA_VERIFY_ROUNDS", "3")))
 
 
+def _batch_media_verify_round_limit(plan: dict, pending: dict[str, list[str]]) -> int:
+    """Keep the established tail bound for flat/smaller compiles, but give a
+    hierarchical train enough bounded rounds to visit every initially pending
+    image page (including its failed-attempt budget). A hard operator cap still
+    fences pathological repair loops; hierarchical completion fails closed if
+    pending work remains after that cap."""
+    ordinary = _media_verify_rounds()
+    if plan.get("mode") != "hierarchical":
+        return ordinary
+    cap = max(ordinary, int(os.environ.get(
+        "KBC_HIERARCHICAL_MEDIA_VERIFY_MAX_ROUNDS", "256")))
+    needed = len(pending) * _media_verify_attempts() + ordinary
+    return min(cap, max(ordinary, needed))
+
+
 def _settle_media_outcome(run, chunk: dict, result: dict | None) -> list[str]:
     """Post-verify bookkeeping (review fix: pages used to be marked verified
     BEFORE verification ran, so a total transcription failure shipped image
@@ -2797,17 +2812,28 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         if _media_verify_enabled():
             repaired_any = False
             rounds = 0
+            initial_pending = selfcheck.pending_media_verification(run.workdir)
+            round_limit = _batch_media_verify_round_limit(plan, initial_pending)
             while True:
                 pending = selfcheck.pending_media_verification(run.workdir)
                 if not pending:
                     break
                 rounds += 1
-                if rounds > _media_verify_rounds():
+                if rounds > round_limit:
                     # Repair turns can add new image citations that re-enter
-                    # pending — cap the loop; the remainder rides a later turn.
+                    # pending. Flat mode keeps its established fail-open tail;
+                    # a hierarchical train must not claim complete while a
+                    # large image backlog is still unverified. Its persisted
+                    # `final` phase makes the next trigger resume the tail
+                    # without replaying the map batches.
                     await run.emit({"type": "summary", "text": _loc(run,
-                        f"Self-check (images): verify/repair round cap ({_media_verify_rounds()}) reached — remaining pages will be picked up on the next trigger.",
-                        f"自检(图像):验修轮达到上限({_media_verify_rounds()} 轮)——剩余页将在下一轮触发时继续复核。")})
+                        f"Self-check (images): verify/repair round cap ({round_limit}) reached — remaining pages will be picked up on the next trigger.",
+                        f"自检(图像):验修轮达到上限({round_limit} 轮)——剩余页将在下一轮触发时继续复核。")})
+                    if plan.get("mode") == "hierarchical":
+                        raise BatchOutputError(
+                            f"hierarchical image verification left {len(pending)} "
+                            f"page(s) pending after {round_limit} round(s)"
+                        )
                     break
                 # Blind transcribe+compare per ≤max-images chunk (v2): engine
                 # sessions read one image each — no in-session image pileup.

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2330,6 +2330,61 @@ def _write_batch_file(run: "CompileRun", rel: str, value) -> None:
     p.write_text(batching.dump_json(value))
 
 
+def _materialize_batch_slices(run: "CompileRun", plan: dict) -> None:
+    """Build ephemeral, read-bounded excerpts for oversized Markdown sources.
+
+    The fragment is never a provenance identity and never enters durable
+    authoring state. It is recreated from Raw on every resume so a model turn
+    cannot read the entire oversized source behind the planner's back.
+    """
+    workdir = Path(run.workdir).resolve()
+    raw_root = (workdir / "raw").resolve()
+    slice_root = (workdir / ".kbc-batch-slices").resolve()
+    shutil.rmtree(slice_root, ignore_errors=True)
+    for batch in plan.get("batches", []):
+        ranges = batch.get("source_ranges")
+        if not isinstance(ranges, dict):
+            continue
+        for source, source_range in ranges.items():
+            if not isinstance(source_range, dict):
+                raise BatchOutputError(f"invalid source range for {source}")
+            source_path = (raw_root / source).resolve()
+            try:
+                source_path.relative_to(raw_root)
+            except ValueError as error:
+                raise BatchOutputError(f"text slice source escapes Raw: {source}") from error
+            if not source_path.is_file():
+                raise BatchOutputError(f"text slice source is missing: {source}")
+            rel_slice = PurePosixPath(str(source_range.get("slice_file") or ""))
+            if (
+                not rel_slice.parts
+                or rel_slice.parts[0] != ".kbc-batch-slices"
+                or ".." in rel_slice.parts
+            ):
+                raise BatchOutputError(f"unsafe text slice path for {source}")
+            target = (workdir / Path(*rel_slice.parts)).resolve()
+            try:
+                target.relative_to(slice_root)
+            except ValueError as error:
+                raise BatchOutputError(f"text slice path escapes workspace: {rel_slice}") from error
+            try:
+                start = int(source_range["start_line"])
+                end = int(source_range["end_line"])
+            except (KeyError, TypeError, ValueError) as error:
+                raise BatchOutputError(f"malformed text slice for {source}") from error
+            lines = source_path.read_bytes().splitlines(keepends=True)
+            if start < 1 or end < start or end > len(lines):
+                raise BatchOutputError(
+                    f"text slice range {start}-{end} is invalid for {source} ({len(lines)} lines)"
+                )
+            header = (
+                f"<!-- KBC read-only excerpt: raw/{source}, lines {start}-{end}. "
+                f"Candidate compiled_from must cite raw/{source}, never this helper path. -->\n"
+            ).encode("utf-8")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(header + b"".join(lines[start - 1:end]))
+
+
 def _unaccounted_batch_sources(run: "CompileRun", sources: list[str]) -> list[str]:
     """Assigned sources still absent from both Candidate provenance and exclusions."""
     pages = selfcheck.candidate_pages(run.workdir)
@@ -2381,7 +2436,24 @@ def _drain_batch_notes(run: "CompileRun") -> str:
 
 def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
                              locale: str | None = None) -> str:
-    listing = "\n".join(f"- raw/{p}" for p in batch["sources"])
+    source_ranges = batch.get("source_ranges", {})
+    listing_lines: list[str] = []
+    sliced_sources: list[str] = []
+    for path in batch["sources"]:
+        source_range = source_ranges.get(path) if isinstance(source_ranges, dict) else None
+        if isinstance(source_range, dict):
+            start = source_range["start_line"]
+            end = source_range["end_line"]
+            part = source_range["part"]
+            parts = source_range["parts"]
+            slice_file = source_range["slice_file"]
+            listing_lines.append(
+                f"- {slice_file} (read-only excerpt of raw/{path}, lines {start}-{end}, part {part}/{parts})"
+            )
+            sliced_sources.append(path)
+        else:
+            listing_lines.append(f"- raw/{path}")
+    listing = "\n".join(listing_lines)
     context_sources = batch.get("context_sources", [])
     context_listing = "\n".join(f"- raw/{p}" for p in context_sources)
     context_en = (
@@ -2392,6 +2464,20 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
     context_zh = (
         "\n\n只读的同族上下文(可重读这些锚点来理解本批附件,但它们已由其他批次入账,不要重复编译):\n" + context_listing
         if context_listing else ""
+    )
+    slice_en = (
+        "\n\nThis batch uses a bounded excerpt of an oversized Raw source. Read ONLY the listed "
+        "`.kbc-batch-slices/` helper, never open the original Raw file directly in this batch. "
+        "Compile only facts present in this excerpt; compiled_from must cite the original Raw path "
+        f"({', '.join('raw/' + path for path in sliced_sources)}), never the helper path."
+        if sliced_sources else ""
+    )
+    slice_zh = (
+        "\n\n本批使用超大 Raw 的有界片段。只读清单中的 `.kbc-batch-slices/` 辅助文件,本批绝不要直接打开原 Raw 全文。"
+        "只编译片段中实际出现的事实;compiled_from 必须引用原 Raw 路径("
+        + ", ".join("raw/" + path for path in sliced_sources)
+        + "),绝不能引用辅助文件。"
+        if sliced_sources else ""
     )
     if selfcheck._is_en(locale):
         return (
@@ -2404,7 +2490,7 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
             "candidate/index.md entries; contradictions as usual — best-guess + ⚠️ uncertain + file a ticket, "
             "never stop. Do not read any raw source outside this compile list and any explicitly listed "
             "read-only family context. When done, report briefly which pages "
-            "this batch produced." + context_en + notes
+            "this batch produced." + context_en + slice_en + notes
         )
     return (
         f"【分批编译 · 批 {k}/{n} · {batch['id']}】只编译下列源(见系统提示的分批纪律):\n{listing}\n"
@@ -2412,7 +2498,7 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
         "然后精读本批每个源,按定调把内容完整编入 candidate/ 页(可新建页或并入既有页,页 frontmatter 的 "
         "compiled_from 必须列出实际编自的源);更新 candidate/index.md 的相应条目;矛盾照常 best-guess+⚠️存疑+落工单,绝不停。"
         "除上面清单及明确列出的只读同族上下文外,其他 raw 源一个都不要读。完成后简短汇报本批编了哪些页。"
-        + context_zh + notes
+        + context_zh + slice_zh + notes
     )
 
 
@@ -2690,6 +2776,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                                              f"断点续批:{len(dropped)} 个源已不在 raw/ 中,已从待编批次剔除:")
                                         + ", ".join(sorted(dropped)[:5])
                                         + ("…" if len(dropped) > 5 else "")})
+        _materialize_batch_slices(run, plan)
         n = len(plan["batches"])
         pending = batching.pending_batches(plan)
         if plan.get("mode") == "hierarchical":
@@ -2722,8 +2809,10 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
             reply = await _drive_batch_session(run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"))
             if reply:
                 replies.append(_loc(run, f"[Batch {k}/{n}] {reply}", f"【批 {k}/{n}】{reply}"))
-            still_unaccounted = _unaccounted_batch_sources(
-                run, batch.get("sources") or [])
+            still_unaccounted = (
+                [] if batch.get("defer_accounting")
+                else _unaccounted_batch_sources(run, batch.get("sources") or [])
+            )
             if still_unaccounted:
                 shown = ", ".join(still_unaccounted[:5])
                 suffix = "…" if len(still_unaccounted) > 5 else ""
@@ -2918,6 +3007,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         except Exception:
             pass
     finally:
+        shutil.rmtree(Path(run.workdir) / ".kbc-batch-slices", ignore_errors=True)
         run._model_idle_timeout_s = previous_model_idle_timeout
         run._batch_active = False
     # Red-blue PK examines the train's FINAL state, in the background, after the

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -215,6 +215,14 @@ _MODEL_IDLE_TIMEOUT_S = float(os.environ.get("KBC_MODEL_IDLE_TIMEOUT_S", "90"))
 _MODEL_TOOL_IDLE_TIMEOUT_S = float(os.environ.get("KBC_MODEL_TOOL_IDLE_TIMEOUT_S", "660"))
 _MODEL_MAX_RETRIES = int(os.environ.get("KBC_MODEL_MAX_RETRIES", "3"))
 _MODEL_WATCHDOG_POLL_S = float(os.environ.get("KBC_MODEL_WATCHDOG_POLL_S", "10"))
+# Hierarchical batches deliberately carry a much larger bounded context than
+# ordinary turns and flat batches. A valid long-form Write tool call can spend
+# more than 90s producing its JSON argument without an SDK delta; the ordinary
+# watchdog then interrupts useful work four times and leaves the batch pending.
+# Relax only this new, >8MB-corpus path. Small/single-session and medium/flat
+# compiles retain the established 90s failure-detection bound.
+_HIERARCHICAL_MODEL_IDLE_TIMEOUT_S = float(os.environ.get(
+    "KBC_HIERARCHICAL_MODEL_IDLE_TIMEOUT_S", "240"))
 
 # ── Rate-limit resilience (C2) ───────────────────────────────────────────────
 # massapi under concurrency (5-10 boxes × the red-blue PK) can return 429/503/529.
@@ -342,6 +350,9 @@ class CompileRun:
         self._model_retries = 0             # stall retries used on the in-flight turn
         self._stall_retrying = False        # watchdog interrupted; awaiting the interrupted result
         self._stall_fatal = False           # stall retries exhausted → fail this turn
+        # Temporary orchestrator-scoped override. Only hierarchical batch mode
+        # sets this; every other turn continues to use _MODEL_IDLE_TIMEOUT_S.
+        self._model_idle_timeout_s: float | None = None
         self._rate_retries = 0              # rate-limit (429/503/529) retries on the in-flight turn
         # Typed machine-control receipts. A command id is accepted at most once
         # for this live run, and the first command pins the run to the consumer's
@@ -2538,6 +2549,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
     section-reduce, and final phases: BATCH_PLAN.json carries phase plus per-unit
     done stamps, and a later compile trigger resumes the unfinished phase."""
     run._batch_active = True
+    previous_model_idle_timeout = run._model_idle_timeout_s
     replies: list[str] = []
     try:
         raw_dir = Path(run.workdir) / "raw"
@@ -2571,6 +2583,8 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         n = len(plan["batches"])
         pending = batching.pending_batches(plan)
         if plan.get("mode") == "hierarchical":
+            run._model_idle_timeout_s = max(
+                _MODEL_IDLE_TIMEOUT_S, _HIERARCHICAL_MODEL_IDLE_TIMEOUT_S)
             plan_summary_en = (
                 f"Hierarchical batch plan: {n} map batch(es), "
                 f"{plan.get('budget', 0) // 1024}KB effective / "
@@ -2774,6 +2788,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         except Exception:
             pass
     finally:
+        run._model_idle_timeout_s = previous_model_idle_timeout
         run._batch_active = False
     # Red-blue PK examines the train's FINAL state, in the background, after the
     # single logical turn has closed (never inside it — turn_done latency is
@@ -2906,7 +2921,12 @@ async def _model_stall_watchdog(run: CompileRun) -> None:
         client = run.client
         if client is None:
             continue
-        bound = _MODEL_TOOL_IDLE_TIMEOUT_S if run._tool_pending else _MODEL_IDLE_TIMEOUT_S
+        model_idle_timeout = (
+            run._model_idle_timeout_s
+            if run._model_idle_timeout_s is not None
+            else _MODEL_IDLE_TIMEOUT_S
+        )
+        bound = _MODEL_TOOL_IDLE_TIMEOUT_S if run._tool_pending else model_idle_timeout
         idle = time.monotonic() - run._last_model_activity
         if idle <= bound:
             continue

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2573,7 +2573,8 @@ def _compose_final_directive(workdir: str, n: int, notes: str,
         step += 1
         lines.append(f"{step}) Check authoring/EXCLUSIONS.json: sources you decided not to compile (including "
                      "images/PDF and other media) must be explicitly accounted for.")
-        lines.append("Close out only — do not recompile pages that are already fine. When done, report "
+        lines.append("Close out only — do not read raw/ or recompile pages that are already fine. "
+                     "Use Candidate and the authoring ledgers for this cross-batch review. When done, report "
                      "briefly: total pages, which pages this close-out touched, which pairs were "
                      "merged/exempted and why, and anything worth the owner's attention.")
         return "\n".join(lines) + notes
@@ -2594,7 +2595,8 @@ def _compose_final_directive(workdir: str, n: int, notes: str,
                  "(如时间序取最新并保留沿革),定不了的才 best-guess+⚠️存疑+落工单;顺带检查既有 ⚠️ 里有没有其实能收敛的;")
     step += 1
     lines.append(f"{step}) 核对 authoring/EXCLUSIONS.json:决定不编的源(含图片/PDF 等媒体)必须显式入账。")
-    lines.append("只做收口,不重编已经完好的页。完成后简短汇报:总页数、本次收口动了哪些页、合并/豁免了哪几对及理由、还有什么值得负责人注意。")
+    lines.append("只做收口,不要读 raw/,也不重编已经完好的页;跨批核对只使用 Candidate 和 authoring 账本。"
+                 "完成后简短汇报:总页数、本次收口动了哪些页、合并/豁免了哪几对及理由、还有什么值得负责人注意。")
     return "\n".join(lines) + notes
 
 
@@ -2899,7 +2901,6 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         # add image-digesting pages), then one more ledger refresh so
         # SELFCHECK.json reflects the verified final state.
         if _media_verify_enabled():
-            repaired_any = False
             rounds = 0
             initial_pending = selfcheck.pending_media_verification(run.workdir)
             round_limit = _batch_media_verify_round_limit(plan, initial_pending)
@@ -2951,12 +2952,16 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                         _loc(run, "image verification", "图像复核"))
                     if verify_reply:
                         replies.append(_loc(run, f"[Image verification] {verify_reply}", f"【图像复核】{verify_reply}"))
-                    repaired_any = True
+                    # A media repair can introduce a malformed or dangling
+                    # source annotation. Repair the ledger BEFORE the next
+                    # blind comparison so the verified fingerprint belongs to
+                    # the final lint-clean bytes, not the pre-ledger revision.
+                    # The while loop then naturally re-verifies any page that
+                    # this bounded ledger pass changed.
+                    await _run_ledger_repairs(run, replies)
                 else:
                     await run.emit({"type": "summary",
                                     "text": f"自检(图像):{result['images']} 张图已核,断言与图一致 ✓"})
-            if repaired_any:
-                await _run_ledger_repairs(run, replies)
         # Owner notes that arrived during the tail phases (ledger repair / image
         # verify) were acked as "will be considered" but have no later batch to
         # ride — honor the contract with a bounded digest session before the

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -257,6 +257,19 @@ class ModelStallError(Exception):
     reason instead of the box sitting silently."""
 
 
+class ModelResultError(Exception):
+    """An internal compile session ended with an SDK error result.
+
+    Ordinary conversational turns keep their existing never-block behavior,
+    but a batch session must fail closed: otherwise an authentication or model
+    execution failure can be mistaken for a successful no-op and stamped done.
+    """
+
+
+class BatchOutputError(Exception):
+    """A successful internal session did not account for its assigned sources."""
+
+
 class CompileRun:
     def __init__(self, run_id: str, workdir: str, round_: int, instruction: str = ""):
         self.run_id = run_id
@@ -2302,6 +2315,16 @@ def _write_batch_file(run: "CompileRun", rel: str, value) -> None:
     p.write_text(batching.dump_json(value))
 
 
+def _unaccounted_batch_sources(run: "CompileRun", sources: list[str]) -> list[str]:
+    """Assigned sources still absent from both Candidate provenance and exclusions."""
+    pages = selfcheck.candidate_pages(run.workdir)
+    exclusions, _ = selfcheck.load_exclusions(run.workdir)
+    return sorted(
+        set(sources)
+        & set(selfcheck.coverage(run.workdir, pages, exclusions)["unaccounted"])
+    )
+
+
 async def _drive_batch_session(run: "CompileRun", directive: str, label: str) -> str:
     """One bounded internal session: fresh session_id, same role/tools/workspace.
     Streams its output through _emit_message with turn_done suppressed; returns
@@ -2319,7 +2342,8 @@ async def _drive_batch_session(run: "CompileRun", directive: str, label: str) ->
         await run.emit({"type": "log", "text": _loc(run, f"—— {label} started ——", f"—— {label} 开始 ——")})
         run._begin_turn(directive)
         await client.query(directive)
-        await _consume_turn_stream(run, client, stop_on_result=True)
+        await _consume_turn_stream(
+            run, client, stop_on_result=True, fail_on_error_result=True)
         return run._last_turn_reply
     finally:
         run._suppress_turn_done = False
@@ -2683,6 +2707,15 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
             reply = await _drive_batch_session(run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"))
             if reply:
                 replies.append(_loc(run, f"[Batch {k}/{n}] {reply}", f"【批 {k}/{n}】{reply}"))
+            still_unaccounted = _unaccounted_batch_sources(
+                run, batch.get("sources") or [])
+            if still_unaccounted:
+                shown = ", ".join(still_unaccounted[:5])
+                suffix = "…" if len(still_unaccounted) > 5 else ""
+                raise BatchOutputError(
+                    f"batch {batch['id']} left {len(still_unaccounted)} assigned "
+                    f"source(s) unaccounted: {shown}{suffix}"
+                )
             batching.stamp_done(plan, batch["id"])
             _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
             # Push the done-stamp (and the batch's pages) to the durable store
@@ -2892,7 +2925,13 @@ def _note_model_activity(run: CompileRun, msg) -> None:
         run._tool_pending = False
 
 
-async def _consume_turn_stream(run: CompileRun, client, *, stop_on_result: bool) -> None:
+async def _consume_turn_stream(
+    run: CompileRun,
+    client,
+    *,
+    stop_on_result: bool,
+    fail_on_error_result: bool = False,
+) -> None:
     """Relay a session's message stream through _emit_message, owning the
     stall-retry seam. A ResultMessage that the watchdog provoked (via interrupt())
     is NOT a real turn end: discard it and re-issue the directive (bounded), or
@@ -2918,7 +2957,8 @@ async def _consume_turn_stream(run: CompileRun, client, *, stop_on_result: bool)
             # is_error + api_error_status. Back off and re-issue rather than
             # surfacing it as a finished turn.
             status = getattr(msg, "api_error_status", None)
-            if getattr(msg, "is_error", False) and status in _MODEL_RATE_STATUSES:
+            is_error = bool(getattr(msg, "is_error", False))
+            if is_error and status in _MODEL_RATE_STATUSES:
                 if run._rate_retries < _MODEL_RATE_MAX_RETRIES:
                     run._rate_retries += 1
                     delay = _rate_backoff_delay(run._rate_retries)
@@ -2942,6 +2982,18 @@ async def _consume_turn_stream(run: CompileRun, client, *, stop_on_result: bool)
                                  f"模型限流(HTTP {status}),退避重试 {run._rate_retries} 次仍未通过,本轮先停,请稍后再开编。"),
                 })
                 # fall through: end the turn (run goes idle), do not crash
+            if is_error and fail_on_error_result:
+                # Never let an internal map/reduce/final session stamp its unit
+                # done when the SDK itself says the turn failed. Keep the
+                # diagnostic deliberately bounded: subtype/status are enough to
+                # route the failure without echoing provider payloads or tokens.
+                run._turn_active = False
+                run._turn_text = []
+                run._last_turn_reply = ""
+                subtype = str(getattr(msg, "subtype", "unknown") or "unknown")[:80]
+                raise ModelResultError(
+                    f"model result failed (subtype={subtype}, api_status={status})"
+                )
             run._turn_active = False
             await _emit_message(run, msg)
             if stop_on_result:

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1068,7 +1068,7 @@ def _prepare_command(run: "CompileRun", command: dict) -> None:
         raise CommandRejected("no structured source changes are available for incremental compile", 409)
     if action == "compile.resume":
         plan = _load_batch_plan(run)
-        if plan is None or not batching.pending_batches(plan):
+        if not _batch_plan_resumable(plan):
             raise CommandRejected("no interrupted batch plan is available to resume", 409)
     brief = params.get("brief")
     if brief is not None:
@@ -2243,11 +2243,7 @@ def _should_route_to_batch(run: "CompileRun", text: str, action: str | None = No
         return True
     # An interrupted batch/reduce/final run must finish in the orchestrator even
     # if raw shrank below the threshold after the plan was pinned.
-    plan = _load_batch_plan(run)
-    return plan is not None and (
-        len(batching.pending_batches(plan)) > 0
-        or plan.get("phase") in {"map", "reduce", "final"}
-    )
+    return _batch_plan_resumable(_load_batch_plan(run))
 
 
 async def _start_incremental(run: "CompileRun", text: str, *, strict: bool = False) -> None:
@@ -2324,6 +2320,20 @@ def _load_batch_plan(run: "CompileRun") -> dict | None:
         return None
 
 
+def _batch_plan_resumable(plan: dict | None) -> bool:
+    """Whether an interrupted batch train still owns executable work.
+
+    Hierarchical trains can fail after every map batch is stamped done, while
+    section reduction or final review is still pending. Keep the command gate,
+    routing gate, and orchestrator resume decision on this one definition so a
+    typed ``compile.resume`` cannot reject work the orchestrator can recover.
+    """
+    return plan is not None and (
+        len(batching.pending_batches(plan)) > 0
+        or plan.get("phase") in {"map", "reduce", "final"}
+    )
+
+
 def _write_batch_file(run: "CompileRun", rel: str, value) -> None:
     p = Path(run.workdir) / rel
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -2342,6 +2352,8 @@ def _materialize_batch_slices(run: "CompileRun", plan: dict) -> None:
     slice_root = (workdir / ".kbc-batch-slices").resolve()
     shutil.rmtree(slice_root, ignore_errors=True)
     for batch in plan.get("batches", []):
+        if batch.get("status") == "done":
+            continue
         ranges = batch.get("source_ranges")
         if not isinstance(ranges, dict):
             continue
@@ -2754,10 +2766,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         inventory = batching.scan_sources(raw_dir)
         total_kb = batching.corpus_bytes(inventory) // 1024
         plan = _load_batch_plan(run)
-        resuming = plan is not None and (
-            len(batching.pending_batches(plan)) > 0
-            or plan.get("phase") in {"map", "reduce", "final"}
-        )
+        resuming = _batch_plan_resumable(plan)
         if not resuming:
             _write_batch_file(run, batching.SOURCES_INVENTORY_PATH, inventory)
             await run.emit({"type": "summary", "text": _loc(run,

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2131,9 +2131,13 @@ def _should_route_to_batch(run: "CompileRun", text: str, action: str | None = No
     inventory = batching.scan_sources(raw_dir)
     if batching.should_batch(inventory):
         return True
-    # An interrupted batch run must finish as a batch run even if raw shrank.
+    # An interrupted batch/reduce/final run must finish in the orchestrator even
+    # if raw shrank below the threshold after the plan was pinned.
     plan = _load_batch_plan(run)
-    return plan is not None and len(batching.pending_batches(plan)) > 0
+    return plan is not None and (
+        len(batching.pending_batches(plan)) > 0
+        or plan.get("phase") in {"map", "reduce", "final"}
+    )
 
 
 async def _start_incremental(run: "CompileRun", text: str, *, strict: bool = False) -> None:
@@ -2257,6 +2261,17 @@ def _drain_batch_notes(run: "CompileRun") -> str:
 def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
                              locale: str | None = None) -> str:
     listing = "\n".join(f"- raw/{p}" for p in batch["sources"])
+    context_sources = batch.get("context_sources", [])
+    context_listing = "\n".join(f"- raw/{p}" for p in context_sources)
+    context_en = (
+        "\n\nRead-only family context (you MAY re-read these anchors to interpret the listed assets, "
+        "but they are already accounted by another batch; do not compile them again):\n" + context_listing
+        if context_listing else ""
+    )
+    context_zh = (
+        "\n\n只读的同族上下文(可重读这些锚点来理解本批附件,但它们已由其他批次入账,不要重复编译):\n" + context_listing
+        if context_listing else ""
+    )
     if selfcheck._is_en(locale):
         return (
             f"[Batch compile · batch {k}/{n} · {batch['id']}] Compile ONLY the sources below "
@@ -2266,15 +2281,40 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
             "into candidate/ pages (create new pages or merge into existing ones; each page's frontmatter "
             "compiled_from must list the sources it was actually compiled from); update the matching "
             "candidate/index.md entries; contradictions as usual — best-guess + ⚠️ uncertain + file a ticket, "
-            "never stop. Do not read ANY raw source outside this batch. When done, report briefly which pages "
-            "this batch produced." + notes
+            "never stop. Do not read any raw source outside this compile list and any explicitly listed "
+            "read-only family context. When done, report briefly which pages "
+            "this batch produced." + context_en + notes
         )
     return (
         f"【分批编译 · 批 {k}/{n} · {batch['id']}】只编译下列源(见系统提示的分批纪律):\n{listing}\n"
         "先读 authoring/BRIEF.json、authoring/INTENT.md 和 candidate/index.md 保持口径与结构一致;"
         "然后精读本批每个源,按定调把内容完整编入 candidate/ 页(可新建页或并入既有页,页 frontmatter 的 "
         "compiled_from 必须列出实际编自的源);更新 candidate/index.md 的相应条目;矛盾照常 best-guess+⚠️存疑+落工单,绝不停。"
-        "本批之外的 raw 源一个都不要读。完成后简短汇报本批编了哪些页。" + notes
+        "除上面清单及明确列出的只读同族上下文外,其他 raw 源一个都不要读。完成后简短汇报本批编了哪些页。"
+        + context_zh + notes
+    )
+
+
+def _compose_reduction_directive(
+    reduction: dict, k: int, n: int, notes: str, locale: str | None = None
+) -> str:
+    pages = "\n".join(f"- candidate/{p}" for p in reduction["pages"])
+    section = reduction.get("section") or "root"
+    if selfcheck._is_en(locale):
+        return (
+            f"[Hierarchical compile · section reduce {k}/{n} · {reduction['id']}] "
+            f"Consolidate the candidate pages for source section {section!r}:\n{pages}\n"
+            "Read ONLY the listed candidate pages plus candidate/index.md. Merge genuinely duplicate pages, "
+            "preserve all compiled_from entries and source-backed details, converge terminology and structure, "
+            "and repair index links for pages you merge or rename. Do not read raw/ in this reduce pass and do "
+            "not touch candidate pages outside this list. This is consolidation, not a new compilation. Report "
+            "the pages merged or edited." + notes
+        )
+    return (
+        f"【层级编译 · 分区归并 {k}/{n} · {reduction['id']}】归并来源分区 {section!r} 的下列候选页:\n{pages}\n"
+        "只读上列 candidate 页和 candidate/index.md。合并确实重复的页面,完整保留 compiled_from 与有来源支撑的细节,"
+        "统一术语和结构,并修复被合并或改名页面的 index 链接。本归并轮不要读 raw/,也不要改清单外的 candidate 页。"
+        "这是归并,不是重新编译。完成后汇报合并或修改了哪些页。" + notes
     )
 
 
@@ -2379,6 +2419,22 @@ def _planner_role(locale: str | None) -> str:
 async def _plan_batches(run: "CompileRun", inventory: list) -> dict:
     """Code baseline always exists; the model may regroup topically but ONLY a
     plan that passes deterministic validation replaces the baseline."""
+    if batching.should_hierarchical(inventory):
+        budget = batching.hierarchical_batch_budget_bytes()
+        text_budget = batching.hierarchical_text_budget_bytes()
+        batches = batching.pack_hierarchical_batches(
+            inventory, budget=budget, text_budget=text_budget)
+        plan = batching.build_plan(
+            inventory, batches, planner="hierarchical-code", budget=budget,
+            text_budget=text_budget)
+        errors = batching.validate_plan(
+            plan, inventory, budget=budget, text_budget=text_budget)
+        if errors:
+            raise RuntimeError(
+                "hierarchical batch planner produced an invalid plan: "
+                + "; ".join(errors[:3]))
+        return plan
+
     budget = batching.batch_budget_bytes()
     baseline = batching.build_plan(inventory, batching.pack_batches(inventory), planner="code")
     if os.environ.get("KBC_BATCH_PLANNER", "model") == "code":
@@ -2478,9 +2534,9 @@ async def _run_ledger_repairs(run: "CompileRun", replies: list[str]) -> None:
 
 async def _run_batch_compile(run: "CompileRun", trigger_text: str):
     """The batch orchestrator: ONE logical turn to the consumer (single turn_done at
-    the end), many bounded sessions inside. Crash-resumable at batch granularity:
-    BATCH_PLAN.json carries per-batch done stamps, and any later compile trigger
-    re-enters here and continues from the first pending batch."""
+    the end), many bounded sessions inside. Crash-resumable across map, optional
+    section-reduce, and final phases: BATCH_PLAN.json carries phase plus per-unit
+    done stamps, and a later compile trigger resumes the unfinished phase."""
     run._batch_active = True
     replies: list[str] = []
     try:
@@ -2488,7 +2544,10 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         inventory = batching.scan_sources(raw_dir)
         total_kb = batching.corpus_bytes(inventory) // 1024
         plan = _load_batch_plan(run)
-        resuming = plan is not None and len(batching.pending_batches(plan)) > 0
+        resuming = plan is not None and (
+            len(batching.pending_batches(plan)) > 0
+            or plan.get("phase") in {"map", "reduce", "final"}
+        )
         if not resuming:
             _write_batch_file(run, batching.SOURCES_INVENTORY_PATH, inventory)
             await run.emit({"type": "summary", "text": _loc(run,
@@ -2511,13 +2570,27 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                                         + ("…" if len(dropped) > 5 else "")})
         n = len(plan["batches"])
         pending = batching.pending_batches(plan)
+        if plan.get("mode") == "hierarchical":
+            plan_summary_en = (
+                f"Hierarchical batch plan: {n} map batch(es), "
+                f"{plan.get('budget', 0) // 1024}KB effective / "
+                f"{plan.get('text_budget', 0) // 1024}KB text per batch.")
+            plan_summary_zh = (
+                f"层级分批计划:共 {n} 个映射批次,每批有效预算 "
+                f"{plan.get('budget', 0) // 1024}KB、文本上限 "
+                f"{plan.get('text_budget', 0) // 1024}KB。")
+        else:
+            plan_summary_en = (
+                f"Batch plan ({plan.get('planner')}): {n} batch(es), "
+                f"budget {plan.get('budget', 0) // 1024}KB/batch.")
+            plan_summary_zh = (
+                f"分批计划({plan.get('planner')}):共 {n} 批,预算 "
+                f"{plan.get('budget', 0) // 1024}KB/批。")
         await run.emit({
             "type": "summary",
             "text": (_loc(run, f"Resuming batch compile: {len(pending)}/{n} batch(es) remaining.",
                           f"继续分批编译:剩余 {len(pending)}/{n} 批。") if resuming
-                     else _loc(run,
-                               f"Batch plan ({plan.get('planner')}): {n} batch(es), budget {plan.get('budget', 0) // 1024}KB/batch.",
-                               f"分批计划({plan.get('planner')}):共 {n} 批,预算 {plan.get('budget', 0) // 1024}KB/批。")),
+                     else _loc(run, plan_summary_en, plan_summary_zh)),
         })
         for batch in list(pending):
             k = next(i + 1 for i, b in enumerate(plan["batches"]) if b["id"] == batch["id"])
@@ -2538,6 +2611,60 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                     pass  # periodic sync will retry; the local stamp is already on disk
             await run.emit({"type": "summary", "text": _loc(run,
                 f"Batch {k}/{n} done — landed in the store.", f"批 {k}/{n} 完成,已落库。")})
+        if plan.get("mode") == "hierarchical":
+            if "reductions" not in plan:
+                plan["reductions"] = batching.pack_section_reductions(
+                    selfcheck.candidate_pages(run.workdir))
+            plan["phase"] = "reduce"
+            _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+            reductions = plan.get("reductions", [])
+            reduction_count = len(reductions)
+            pending_reductions = batching.pending_reductions(plan)
+            if reduction_count:
+                await run.emit({
+                    "type": "summary",
+                    "text": _loc(
+                        run,
+                        f"Hierarchical reduce: {len(pending_reductions)}/{reduction_count} section group(s) remaining.",
+                        f"层级归并:剩余 {len(pending_reductions)}/{reduction_count} 个分区组。",
+                    ),
+                })
+            for reduction in list(pending_reductions):
+                # A previous reduction may have merged a page that a persisted
+                # later group mentioned. Remove missing pages rather than ask a
+                # resumed session to read paths that no longer exist.
+                current_pages = selfcheck.candidate_pages(run.workdir)
+                reduction["pages"] = [
+                    p for p in reduction.get("pages", []) if p in current_pages]
+                if len(reduction["pages"]) < 2:
+                    batching.stamp_reduction_done(plan, reduction["id"])
+                    _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+                    continue
+                k = next(
+                    i + 1 for i, item in enumerate(reductions)
+                    if item["id"] == reduction["id"])
+                directive = _compose_reduction_directive(
+                    reduction, k, reduction_count, _drain_batch_notes(run),
+                    locale=getattr(run, "locale", None))
+                reply = await _drive_batch_session(
+                    run, directive,
+                    _loc(run, f"section reduce {k}/{reduction_count}",
+                         f"分区归并 {k}/{reduction_count}"))
+                if reply:
+                    replies.append(_loc(
+                        run,
+                        f"[Section reduce {k}/{reduction_count}] {reply}",
+                        f"【分区归并 {k}/{reduction_count}】{reply}"))
+                batching.stamp_reduction_done(plan, reduction["id"])
+                _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+                sent = getattr(run, "_sync_sent", None)
+                if sent is not None:
+                    try:
+                        await _sync_workspace(run, sent)
+                    except Exception:
+                        pass
+        plan["phase"] = "final"
+        _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
         final_reply = await _drive_batch_session(
             run, _compose_final_directive(run.workdir, n, _drain_batch_notes(run), locale=getattr(run, "locale", None)),
             _loc(run, "final review", "终审"))
@@ -2618,10 +2745,19 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 replies.append(_loc(run, f"[Note digest] {notes_reply}", f"【留言消化】{notes_reply}"))
             await _run_ledger_repairs(run, replies)  # the digest may have touched pages
         sent = getattr(run, "_sync_sent", None)
+        plan["phase"] = "complete"
+        _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
         if sent is not None:
             # Successful batch completion is one full-compile provenance commit.
             # Content and input revision must land atomically before turn_done.
-            await _sync_workspace(run, sent, commit_input=True)
+            try:
+                await _sync_workspace(run, sent, commit_input=True)
+            except Exception:
+                # The durable commit did not happen. Keep the plan resumable at
+                # final close-out rather than falsely claiming completion.
+                plan["phase"] = "final"
+                _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+                raise
         await run.emit({"type": "turn_done", "text": "\n\n".join(replies).strip()
                         or _loc(run, "Batch compile complete.", "分批编译完成。")})
     except Exception as e:

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1098,6 +1098,45 @@ def _compile_engine_tools(run: CompileRun) -> list[EngineTool]:
             reminder = ts["propose_plan"]["reminder"]
         return ts["propose_plan"]["ack"] + reminder
 
+    async def delete_candidate_page(args):
+        """Delete one dead Markdown page without granting shell/file-tree power.
+
+        The model already receives deterministic orphan/duplicate findings and
+        must occasionally remove the losing page after a merge. Edit/Write
+        cannot express deletion, while Bash would be far too broad. This tool is
+        therefore confined to a single regular ``candidate/**/*.md`` file and
+        protects routing pages at every level.
+        """
+        strings = ts["delete_candidate_page"]
+        raw_path = str(args.get("path", "")).strip()
+        try:
+            rel = _safe_tar_path(raw_path)
+        except ValueError:
+            return strings["invalid"].format(path=raw_path)
+        if rel.suffix.lower() != ".md":
+            return strings["markdown_only"].format(path=raw_path)
+        if rel.name.lower() in {"index.md", "log.md"}:
+            return strings["reserved"].format(path=raw_path)
+
+        root = (Path(run.workdir) / "candidate").resolve()
+        target = root.joinpath(*rel.parts)
+        try:
+            target.resolve(strict=False).relative_to(root)
+        except (ValueError, OSError):
+            return strings["invalid"].format(path=raw_path)
+        if target.is_symlink():
+            return strings["invalid"].format(path=raw_path)
+        if not target.exists():
+            return strings["not_found"].format(path=raw_path)
+        if not target.is_file():
+            return strings["not_file"].format(path=raw_path)
+        try:
+            target.unlink()
+        except OSError as e:
+            return strings["failed"].format(path=raw_path, e=e)
+        await run.emit({"type": "summary", "summary": strings["deleted"].format(path=rel.as_posix())})
+        return strings["deleted"].format(path=rel.as_posix())
+
     async def resolve_ticket(args):
         rt = ts["resolve_ticket"]
         tid = str(args.get("ticket_id", "")).strip()
@@ -1145,6 +1184,16 @@ def _compile_engine_tools(run: CompileRun) -> list[EngineTool]:
             ts["propose_plan"]["desc"],
             {"type": "object", "properties": {"plan": {"type": "string"}}, "required": ["plan"]},
             propose_plan,
+        ),
+        EngineTool(
+            "delete_candidate_page",
+            ts["delete_candidate_page"]["desc"],
+            {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            delete_candidate_page,
         ),
         EngineTool(
             "resolve_ticket",
@@ -1254,6 +1303,16 @@ def _settle_media_outcome(run, chunk: dict, result: dict | None) -> list[str]:
     means the whole flow failed → every page in the chunk is a failed attempt.
     Returns the pages exhausted this round."""
     completed = list((result or {}).get("completed_pages") or [])
+    # A successful comparison with a finding is not a verified final page: the
+    # repair turn is about to edit it, and even a no-op repair must not convert a
+    # known mismatch into a green ledger. Keep finding pages pending; the
+    # content-bound fingerprint then verifies the repaired bytes on the next
+    # drain/round.
+    finding_pages = {
+        str(item.get("page")) for item in ((result or {}).get("findings") or [])
+        if isinstance(item, dict) and item.get("page")
+    }
+    completed = [page for page in completed if page not in finding_pages]
     failed = list((result or {}).get("failed_pages") or [])
     if result is None:
         failed = list(chunk)
@@ -1353,6 +1412,7 @@ async def _run_media_verify_flow(run, chunk: dict[str, list[str]]) -> None:
     injected_repair = False
     settled = False        # the primary settle ran — the except must never settle AGAIN
     failed_pages: list[str] = []
+    finding_pages: list[str] = []
     exhausted: list[str] = []
     try:
         n_imgs = sum(len(v) for v in chunk.values())
@@ -1377,6 +1437,10 @@ async def _run_media_verify_flow(run, chunk: dict[str, list[str]]) -> None:
             except Exception:
                 pass
         findings, errors = result["findings"], result["errors"]
+        finding_pages = sorted({
+            str(item.get("page")) for item in findings
+            if isinstance(item, dict) and item.get("page")
+        })
         tail = _loc(run, f"; {len(errors)} transcription/comparison failure(s)",
                     f";{len(errors)} 项转写/比对失败") if errors else ""
         if findings:
@@ -1411,8 +1475,14 @@ async def _run_media_verify_flow(run, chunk: dict[str, list[str]]) -> None:
         # ones are marked verified and leave pending on their own): the chain
         # below then moves on to the not-yet-attempted chunks instead of
         # hot-looping the failed pages through the attempt budget.
+        # A finding page stays pending until the repair changes and re-verifies
+        # it. If injecting that repair failed, defer it for this drain so the
+        # same mismatch cannot hot-loop; a fresh turn retries it.
+        deferred_pages = set(failed_pages)
+        if finding_pages and not injected_repair:
+            deferred_pages.update(finding_pages)
         run._media_deferred = getattr(run, "_media_deferred", set()) | (
-            set(failed_pages) - set(exhausted))
+            deferred_pages - set(exhausted))
         run._media_inflight = getattr(run, "_media_inflight", set()) - set(chunk)
         # We ARE run._media_task and are completing: release the single-flight
         # reference first, or _media_verify_due's not-done() guard blocks the
@@ -1997,6 +2067,7 @@ DEFAULT_COMPILE_ALLOWED_TOOLS = [
     "Read", "Write", "Edit", "Glob", "Grep",
     "mcp__compile__report_summary",
     "mcp__compile__propose_plan",
+    "mcp__compile__delete_candidate_page",
     "mcp__compile__resolve_ticket",
 ]
 

--- a/kbc/platform/pod/prompts/en/tools.json
+++ b/kbc/platform/pod/prompts/en/tools.json
@@ -7,6 +7,16 @@
     "ack": "Plan submitted to the owner (the UI now shows the plan and the approve control); awaiting approval. Do not write candidate/ pages until the approval message arrives.",
     "reminder": " (Reminder: while you are at it, maintain the candidate-page list as `- [ ] page — one line` in the ## Next Pages section of authoring/PLAN.md as your working state, to make progress easy to track; this does not affect the plan you just submitted.)"
   },
+  "delete_candidate_page": {
+    "desc": "Delete exactly one genuinely dead Markdown page below candidate/ after merging duplicate or orphan content. Pass a path relative to candidate/ (for example `guide/old.md`). This tool cannot delete index.md/log.md, directories, non-Markdown files, symlinks, or anything outside candidate/. Fix incoming links before deleting the page.",
+    "invalid": "refused unsafe candidate path: {path}",
+    "markdown_only": "only candidate Markdown pages may be deleted: {path}",
+    "reserved": "reserved routing pages cannot be deleted: {path}",
+    "not_found": "candidate page does not exist: {path}",
+    "not_file": "candidate path is not a regular file: {path}",
+    "failed": "failed to delete candidate page {path}: {e}",
+    "deleted": "deleted candidate page: {path}"
+  },
   "resolve_ticket": {
     "desc": "Call once per contradiction ticket you have patched (one call per ticket, no batching): register which ticket (ticket_id), the value you applied (applied_value), the candidate files you actually edited (pages_edited — must cover the ticket's affected_pages), and a one-line note. This marks the ticket as patched and writes an auditable agent_report — the basis for the contradiction view showing 'AI patched' for the owner to verify. Echo dispatch_nonce verbatim from the apply directive's `nonce:` line (empty string when the directive carries none) — it matches this receipt to the exact dispatch round.",
     "need_id": "resolve_ticket requires ticket_id",

--- a/kbc/platform/pod/prompts/zh/tools.json
+++ b/kbc/platform/pod/prompts/zh/tools.json
@@ -7,6 +7,16 @@
     "ack": "计划已抛给负责人(UI 已显示计划与批准控件),等待批准。在收到批准消息前不要写 candidate/ 页面。",
     "reminder": "(提醒:顺手把候选页清单以 `- [ ] 页名 — 一句话` 维护进 authoring/PLAN.md 的 ## Next Pages 作为你的工作状态,便于追踪进度;这不影响本次计划已抛出。)"
   },
+  "delete_candidate_page": {
+    "desc": "归并重复页或孤儿页后，删除 candidate/ 下确属废弃的一篇 Markdown 页面。path 必须相对 candidate/（例如 `guide/old.md`）。不能删除 index.md/log.md、目录、非 Markdown、符号链接或 candidate/ 之外的内容；删除前先修好所有入链。",
+    "invalid": "拒绝不安全的 candidate 路径: {path}",
+    "markdown_only": "只能删除 candidate Markdown 页面: {path}",
+    "reserved": "不能删除保留的路由页面: {path}",
+    "not_found": "candidate 页面不存在: {path}",
+    "not_file": "candidate 路径不是普通文件: {path}",
+    "failed": "删除 candidate 页面 {path} 失败: {e}",
+    "deleted": "已删除 candidate 页面: {path}"
+  },
   "resolve_ticket": {
     "desc": "回修完一条矛盾工单后逐条调用(一条一次,别批量):登记你把哪条(ticket_id)按什么值(applied_value)回修了、实际改了哪几个 candidate 文件(pages_edited,必须覆盖该工单的 affected_pages)、一句话备注(note)。这会把该工单标为已回修并写下可审计的 agent_report —— 是「矛盾处理」显示「AI 已回修」、并让负责人核对的依据。 dispatch_nonce 原样回传指令里该工单的 nonce:(指令没带就传空字符串)——它把这份回执对到确切的派发轮。",
     "need_id": "resolve_ticket 需要 ticket_id",

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -23,6 +23,7 @@ import posixpath
 import re
 import uuid
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from urllib.parse import unquote
 
@@ -254,7 +255,8 @@ _BODY_SOURCE_START_RE = re.compile(
     r"(?P<open>[（(])\s*(?:source|src|源|来源)\s*[:：]\s*", re.IGNORECASE,
 )
 _SOURCE_LOCATOR_PATTERN = (
-    r"(?:§\s*[\w.-]+|p(?:age)?\.?\s*\d+(?:\s*[-–]\s*\d+)?|"
+    r"(?:§\s*[\w.-]+|(?:p(?:ages?)?|pp?)\.?\s*\d+"
+    r"(?:(?:\s*[-–]\s*|\s*,\s*)\d+)*|"
     r"lines?\s*\d+(?:\s*[-–]\s*\d+)?|第?\s*\d+\s*(?:页|行|节))"
 )
 _SOURCE_FILE_END_RE = re.compile(
@@ -992,6 +994,12 @@ def run_layer1(workdir: str) -> dict:
     cov = coverage(workdir, pages, exclusions)
     lint = lint_candidate(pages, exclusion_errors)
     previous = read_selfcheck(workdir) or {}
+    media_verify = previous.get("media_verify")
+    citing_media = media_citing_pages(workdir)
+    if media_verify is not None or citing_media:
+        media_verify = dict(media_verify or {})
+        media_verify["summary"] = media_verification_summary(
+            workdir, media_verify=media_verify, citing=citing_media)
     return {
         "version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
@@ -1000,7 +1008,7 @@ def run_layer1(workdir: str) -> dict:
         "lint": {"ok": lint["ok"], "violations": lint["violations"]},
         "dup_candidates": dup_candidates(pages),
         "pk": previous.get("pk"),  # Layer-2 results survive L1 re-checks
-        "media_verify": previous.get("media_verify"),
+        "media_verify": media_verify,
         # The converge signal survives too: _post_turn_selfcheck overwrites the
         # whole file with this report, and dropping the phase left a per-turn
         # window with no converge_phase before the seam re-set it (review).
@@ -1355,11 +1363,102 @@ def media_citing_pages(workdir: str) -> dict[str, list[str]]:
 
 
 def pending_media_verification(workdir: str) -> dict[str, list[str]]:
-    """Image-citing pages minus the ones SELFCHECK.json records as verified."""
+    """Image-citing pages whose current page+image fingerprint is not verified.
+
+    Page paths alone are not identities: a repair can edit the same page, and an
+    incremental source refresh can replace an image at the same raw path. The
+    previous path-only ledger silently skipped both cases. Reports without the
+    v2 fingerprint map intentionally re-enter once so they acquire a stable
+    content-bound identity on their next verification.
+    """
     citing = media_citing_pages(workdir)
     sc = read_selfcheck(workdir) or {}
-    done = set((sc.get("media_verify") or {}).get("verified_pages") or [])
-    return {p: imgs for p, imgs in citing.items() if p not in done}
+    fingerprints = (sc.get("media_verify") or {}).get("verified_fingerprints") or {}
+    current = media_page_fingerprints(workdir, citing)
+    return {p: imgs for p, imgs in citing.items()
+            if fingerprints.get(p) != current.get(p)}
+
+
+def media_page_fingerprints(
+    workdir: str, citing: dict[str, list[str]] | None = None,
+) -> dict[str, str]:
+    """Stable identity for every image-citing candidate page.
+
+    The digest covers the final page bytes, every cited raw-relative image path,
+    and each image's bytes. Hash each shared image once per scan so a page edit or
+    same-path image replacement deterministically re-arms verification without
+    turning a large shared asset into repeated I/O.
+    """
+    citing = citing if citing is not None else media_citing_pages(workdir)
+    root = Path(workdir)
+    image_hashes: dict[str, bytes] = {}
+    out: dict[str, str] = {}
+    for page, images in sorted(citing.items()):
+        page_path = root / "candidate" / page
+        try:
+            page_bytes = page_path.read_bytes()
+        except OSError:
+            continue
+        digest = hashlib.sha256()
+        digest.update(page_bytes)
+        for image in sorted(images):
+            digest.update(b"\0")
+            digest.update(image.encode("utf-8"))
+            if image not in image_hashes:
+                image_path = root / "raw" / image
+                try:
+                    stat = image_path.stat()
+                    image_hashes[image] = _cached_file_digest(
+                        str(image_path), stat.st_size, stat.st_mtime_ns,
+                        stat.st_ctime_ns, stat.st_ino)
+                except OSError:
+                    image_hashes[image] = b"missing"
+            digest.update(b"\0")
+            digest.update(image_hashes[image])
+        out[page] = digest.hexdigest()
+    return out
+
+
+@lru_cache(maxsize=8192)
+def _cached_file_digest(
+    path: str, _size: int, _mtime_ns: int, _ctime_ns: int, _inode: int,
+) -> bytes:
+    """Stream a file digest and reuse it while the filesystem identity is stable."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.digest()
+
+
+def media_verification_summary(
+    workdir: str,
+    media_verify: dict | None = None,
+    citing: dict[str, list[str]] | None = None,
+    current: dict[str, str] | None = None,
+) -> dict[str, int]:
+    """Machine-readable coverage that cannot confuse exhausted with passed."""
+    citing = citing if citing is not None else media_citing_pages(workdir)
+    media_verify = media_verify if media_verify is not None else (
+        (read_selfcheck(workdir) or {}).get("media_verify") or {})
+    current = current if current is not None else media_page_fingerprints(workdir, citing)
+    verified = media_verify.get("verified_fingerprints") or {}
+    exhausted_names = set(media_verify.get("exhausted") or [])
+    settled = {p for p, fingerprint in current.items()
+               if verified.get(p) == fingerprint}
+    exhausted = settled & exhausted_names
+    passed = settled - exhausted
+    pending = set(citing) - settled
+    all_images = {image for images in citing.values() for image in images}
+    pending_images = {image for page in pending for image in citing.get(page, [])}
+    return {
+        "total_pages": len(citing),
+        "passed_pages": len(passed),
+        "exhausted_pages": len(exhausted),
+        "pending_pages": len(pending),
+        "total_images": len(all_images),
+        "pending_images": len(pending_images),
+    }
 
 
 def mark_media_verified(workdir: str, pages: list[str], exhausted: bool = False) -> None:
@@ -1370,17 +1469,29 @@ def mark_media_verified(workdir: str, pages: list[str], exhausted: bool = False)
     must never read as a clean pass)."""
     report = read_selfcheck(workdir) or {"version": 1, "coverage": None, "lint": None, "state": None}
     mv = report.get("media_verify") or {}
+    mv["version"] = 2
+    citing = media_citing_pages(workdir)
+    current = media_page_fingerprints(workdir, citing)
     mv["verified_pages"] = sorted(set(mv.get("verified_pages") or []) | set(pages))
+    fingerprints = mv.get("verified_fingerprints") or {}
+    for page in pages:
+        if page in current:
+            fingerprints[page] = current[page]
+    mv["verified_fingerprints"] = fingerprints
     if exhausted:
         mv["exhausted"] = sorted(set(mv.get("exhausted") or []) | set(pages))
-    elif mv.get("attempts"):
+    else:
+        mv["exhausted"] = sorted(set(mv.get("exhausted") or []) - set(pages))
         # A COMPLETED verification clears the page's retry count: a stale
         # residue would otherwise push a later re-entry (page re-cited after a
         # recompile) to "exhausted" after fewer real failures than the budget
         # implies — and the map stays bounded. Exhausted pages keep their count
         # as forensics (they are marked verified and never re-enter pending).
         for p in pages:
-            mv["attempts"].pop(p, None)
+            (mv.get("attempts") or {}).pop(p, None)
+            (mv.get("attempt_fingerprints") or {}).pop(p, None)
+    mv["summary"] = media_verification_summary(
+        workdir, media_verify=mv, citing=citing, current=current)
     mv["at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
     report["media_verify"] = mv
     write_selfcheck(workdir, report)
@@ -1394,10 +1505,21 @@ def bump_media_attempts(workdir: str, pages: list[str]) -> dict[str, int]:
     (silent permanent false-pass) or unbounded re-runs."""
     report = read_selfcheck(workdir) or {"version": 1, "coverage": None, "lint": None, "state": None}
     mv = report.get("media_verify") or {}
+    mv["version"] = 2
     attempts = mv.get("attempts") or {}
+    attempt_fingerprints = mv.get("attempt_fingerprints") or {}
+    citing = media_citing_pages(workdir)
+    current = media_page_fingerprints(workdir, citing)
     for p in pages:
+        if attempt_fingerprints.get(p) != current.get(p):
+            attempts[p] = 0
         attempts[p] = int(attempts.get(p, 0)) + 1
+        if p in current:
+            attempt_fingerprints[p] = current[p]
     mv["attempts"] = attempts
+    mv["attempt_fingerprints"] = attempt_fingerprints
+    mv["summary"] = media_verification_summary(
+        workdir, media_verify=mv, citing=citing, current=current)
     report["media_verify"] = mv
     write_selfcheck(workdir, report)
     return {p: attempts[p] for p in pages}

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -88,14 +88,14 @@ def test_hierarchical_pack_keeps_document_assets_together(tmp_path):
         },
     )
     inv = bt.scan_sources(raw)
-    batches = bt.pack_hierarchical_batches(inv, budget=200_000)
+    batches = bt.pack_hierarchical_batches(inv, budget=300_000)
     gpu = next(b for b in batches if "gpu/guide.md" in b["sources"])
     assert set(gpu["sources"]) >= {
         "gpu/guide.md", "gpu/guide.assets/a.png", "gpu/guide.assets/b.png"}
     assert bt.validate_plan(
-        bt.build_plan(inv, batches, planner="hierarchical-code", budget=200_000),
+        bt.build_plan(inv, batches, planner="hierarchical-code", budget=300_000),
         inv,
-        budget=200_000,
+        budget=300_000,
     ) == []
 
 
@@ -110,9 +110,9 @@ def test_hierarchical_pack_splits_oversized_family_with_anchor_context(tmp_path)
         },
     )
     inv = bt.scan_sources(raw)
-    # Hierarchical images cost 64KB, so a 70KB budget forces one/chunk while
+    # Hierarchical images cost 128KB, so a 140KB budget forces one/chunk while
     # still leaving room to repeat the tiny Markdown anchor as context.
-    budget = 70 * 1024
+    budget = 140 * 1024
     batches = bt.pack_hierarchical_batches(inv, budget=budget)
     assert len(batches) == 3, batches
     assert batches[0]["sources"][0] == "gpu/guide.md"
@@ -152,9 +152,21 @@ def test_hierarchical_text_cap_preserves_session_context_safety(tmp_path):
         plan, inv, budget=1024 * 1024, text_budget=400 * 1024) == []
 
 
+def test_hierarchical_large_anchor_is_not_replayed_into_every_image_chunk(tmp_path):
+    files = {"gpu/manual.md": 120 * 1024}
+    files.update({f"gpu/manual.assets/page-{i:03d}.jpg": 1_000 for i in range(20)})
+    raw = _mk(tmp_path, files)
+    inv = bt.scan_sources(raw)
+    batches = bt.pack_hierarchical_batches(inv, budget=1024 * 1024)
+    manual_batches = [b for b in batches if any("manual" in p for p in b["sources"])]
+    assert "gpu/manual.md" in manual_batches[0]["sources"]
+    assert len(manual_batches) > 1
+    assert all(b["context_sources"] == [] for b in manual_batches[1:])
+
+
 def test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries(tmp_path):
     previous = os.environ.get("KBC_HIERARCHICAL_IMAGE_COST_BYTES")
-    os.environ["KBC_HIERARCHICAL_IMAGE_COST_BYTES"] = str(64 * 1024)
+    os.environ["KBC_HIERARCHICAL_IMAGE_COST_BYTES"] = str(128 * 1024)
     try:
         files = {"guide.md": 100 * 1024}
         files.update({f"guide.assets/page-{i:03d}.jpg": 1_000 for i in range(30)})
@@ -165,7 +177,7 @@ def test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries(
         assert image["effective"] == 30 * 1024
         batches = bt.pack_hierarchical_batches(inv, budget=1024 * 1024)
         image_counts = [sum(p.endswith(".jpg") for p in b["sources"]) for b in batches]
-        assert max(image_counts) <= 14, image_counts
+        assert max(image_counts) <= 8, image_counts
         plan = bt.build_plan(
             inv, batches, planner="hierarchical-code", budget=1024 * 1024)
         assert bt.validate_plan(plan, inv, budget=1024 * 1024) == []
@@ -345,6 +357,7 @@ def main():
         test_hierarchical_pack_splits_oversized_family_with_anchor_context,
         test_validate_hierarchical_context_is_known_and_budgeted,
         test_hierarchical_text_cap_preserves_session_context_safety,
+        test_hierarchical_large_anchor_is_not_replayed_into_every_image_chunk,
         test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries,
         test_validate_plan_accepts_code_baseline,
         test_validate_plan_rejects_missing_duplicate_unknown_overflow,

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -6,6 +6,7 @@ each test gets a fresh tmp dir from the main() harness.
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -87,14 +88,14 @@ def test_hierarchical_pack_keeps_document_assets_together(tmp_path):
         },
     )
     inv = bt.scan_sources(raw)
-    batches = bt.pack_hierarchical_batches(inv, budget=100_000)
+    batches = bt.pack_hierarchical_batches(inv, budget=200_000)
     gpu = next(b for b in batches if "gpu/guide.md" in b["sources"])
     assert set(gpu["sources"]) >= {
         "gpu/guide.md", "gpu/guide.assets/a.png", "gpu/guide.assets/b.png"}
     assert bt.validate_plan(
-        bt.build_plan(inv, batches, planner="hierarchical-code", budget=100_000),
+        bt.build_plan(inv, batches, planner="hierarchical-code", budget=200_000),
         inv,
-        budget=100_000,
+        budget=200_000,
     ) == []
 
 
@@ -109,8 +110,9 @@ def test_hierarchical_pack_splits_oversized_family_with_anchor_context(tmp_path)
         },
     )
     inv = bt.scan_sources(raw)
-    # Images each cost 30KB, so a 40KB hierarchical budget forces one/chunk.
-    budget = 40 * 1024
+    # Hierarchical images cost 64KB, so a 70KB budget forces one/chunk while
+    # still leaving room to repeat the tiny Markdown anchor as context.
+    budget = 70 * 1024
     batches = bt.pack_hierarchical_batches(inv, budget=budget)
     assert len(batches) == 3, batches
     assert batches[0]["sources"][0] == "gpu/guide.md"
@@ -148,6 +150,30 @@ def test_hierarchical_text_cap_preserves_session_context_safety(tmp_path):
         text_budget=400 * 1024)
     assert bt.validate_plan(
         plan, inv, budget=1024 * 1024, text_budget=400 * 1024) == []
+
+
+def test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries(tmp_path):
+    previous = os.environ.get("KBC_HIERARCHICAL_IMAGE_COST_BYTES")
+    os.environ["KBC_HIERARCHICAL_IMAGE_COST_BYTES"] = str(64 * 1024)
+    try:
+        files = {"guide.md": 100 * 1024}
+        files.update({f"guide.assets/page-{i:03d}.jpg": 1_000 for i in range(30)})
+        raw = _mk(tmp_path, files)
+        inv = bt.scan_sources(raw)
+        # The medium/flat route keeps its established 30KB estimate.
+        image = next(i for i in inv if i["path"].endswith("page-000.jpg"))
+        assert image["effective"] == 30 * 1024
+        batches = bt.pack_hierarchical_batches(inv, budget=1024 * 1024)
+        image_counts = [sum(p.endswith(".jpg") for p in b["sources"]) for b in batches]
+        assert max(image_counts) <= 14, image_counts
+        plan = bt.build_plan(
+            inv, batches, planner="hierarchical-code", budget=1024 * 1024)
+        assert bt.validate_plan(plan, inv, budget=1024 * 1024) == []
+    finally:
+        if previous is None:
+            os.environ.pop("KBC_HIERARCHICAL_IMAGE_COST_BYTES", None)
+        else:
+            os.environ["KBC_HIERARCHICAL_IMAGE_COST_BYTES"] = previous
 
 
 def test_validate_plan_accepts_code_baseline(tmp_path):
@@ -319,6 +345,7 @@ def main():
         test_hierarchical_pack_splits_oversized_family_with_anchor_context,
         test_validate_hierarchical_context_is_known_and_budgeted,
         test_hierarchical_text_cap_preserves_session_context_safety,
+        test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries,
         test_validate_plan_accepts_code_baseline,
         test_validate_plan_rejects_missing_duplicate_unknown_overflow,
         test_validate_plan_rejects_duplicate_and_empty_batch_ids,

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -164,6 +164,41 @@ def test_hierarchical_large_anchor_is_not_replayed_into_every_image_chunk(tmp_pa
     assert all(b["context_sources"] == [] for b in manual_batches[1:])
 
 
+def test_hierarchical_oversized_text_anchor_is_sliced_before_image_chunks(tmp_path):
+    raw = _mk(
+        tmp_path,
+        {f"gpu/manual.assets/page-{i:03d}.jpg": 1_000 for i in range(13)},
+    )
+    manual = raw / "gpu/manual.md"
+    manual.parent.mkdir(parents=True, exist_ok=True)
+    manual.write_text("".join(f"line {i:05d}\n" for i in range(18_000)))
+    inv = bt.scan_sources(raw)
+    batches = bt.pack_hierarchical_batches(inv)
+    slice_batches = [b for b in batches if b.get("source_ranges")]
+    assert len(slice_batches) >= 3
+    assert all(b["sources"] == ["gpu/manual.md"] for b in slice_batches)
+    assert all(b["text_bytes"] <= 64 * 1024 for b in slice_batches)
+    assert all(b["defer_accounting"] for b in slice_batches[:-1])
+    assert slice_batches[-1]["defer_accounting"] is False
+    assert all("gpu/manual.md" not in b["context_sources"] for b in batches)
+    assert max(sum(p.endswith(".jpg") for p in b["sources"]) for b in batches) <= 8
+    plan = bt.build_plan(inv, batches, planner="hierarchical-code")
+    assert plan["version"] == 3
+    assert bt.validate_plan(
+        plan, inv, budget=1024 * 1024, text_budget=128 * 1024) == []
+
+    broken = bt.build_plan(
+        inv, [dict(batch) for batch in batches], planner="hierarchical-code")
+    first_range = next(b for b in broken["batches"] if b.get("source_ranges"))
+    first_range["source_ranges"] = {
+        "gpu/manual.md": dict(first_range["source_ranges"]["gpu/manual.md"])
+    }
+    first_range["source_ranges"]["gpu/manual.md"]["end_line"] -= 1
+    errors = bt.validate_plan(
+        broken, inv, budget=1024 * 1024, text_budget=128 * 1024)
+    assert any("not contiguous" in error for error in errors), errors
+
+
 def test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries(tmp_path):
     previous = os.environ.get("KBC_HIERARCHICAL_IMAGE_COST_BYTES")
     os.environ["KBC_HIERARCHICAL_IMAGE_COST_BYTES"] = str(128 * 1024)
@@ -358,6 +393,7 @@ def main():
         test_validate_hierarchical_context_is_known_and_budgeted,
         test_hierarchical_text_cap_preserves_session_context_safety,
         test_hierarchical_large_anchor_is_not_replayed_into_every_image_chunk,
+        test_hierarchical_oversized_text_anchor_is_sliced_before_image_chunks,
         test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries,
         test_validate_plan_accepts_code_baseline,
         test_validate_plan_rejects_missing_duplicate_unknown_overflow,

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -34,6 +34,16 @@ def test_threshold_gate_small_kb_never_batches(tmp_path):
     assert bt.should_batch(inv, threshold=250 * 1024) is True
 
 
+def test_tiered_gate_keeps_small_and_medium_routes_stable(tmp_path):
+    raw = _mk(tmp_path, {"a.md": 500 * 1024})
+    inv = bt.scan_sources(raw)
+    assert bt.should_batch(inv, threshold=400 * 1024) is True
+    assert bt.should_hierarchical(inv, threshold=8 * 1024 * 1024) is False
+    huge = _mk(tmp_path / "huge", {"a.md": 9 * 1024 * 1024})
+    huge_inv = bt.scan_sources(huge)
+    assert bt.should_hierarchical(huge_inv, threshold=8 * 1024 * 1024) is True
+
+
 def test_pack_groups_by_top_dir_and_budget(tmp_path):
     raw = _mk(
         tmp_path,
@@ -63,6 +73,81 @@ def test_pack_oversized_single_file_gets_own_batch(tmp_path):
     batches = bt.pack_batches(inv, budget=200)
     assert batches[0]["sources"] == ["big/x.md"]
     assert batches[1]["sources"] == ["big/y.md"]
+
+
+def test_hierarchical_pack_keeps_document_assets_together(tmp_path):
+    raw = _mk(
+        tmp_path,
+        {
+            "gpu/guide.md": 100,
+            "gpu/guide.assets/a.png": 1_000,
+            "gpu/guide.assets/b.png": 1_000,
+            "gpu/other.md": 50,
+            "ops/runbook.md": 50,
+        },
+    )
+    inv = bt.scan_sources(raw)
+    batches = bt.pack_hierarchical_batches(inv, budget=100_000)
+    gpu = next(b for b in batches if "gpu/guide.md" in b["sources"])
+    assert set(gpu["sources"]) >= {
+        "gpu/guide.md", "gpu/guide.assets/a.png", "gpu/guide.assets/b.png"}
+    assert bt.validate_plan(
+        bt.build_plan(inv, batches, planner="hierarchical-code", budget=100_000),
+        inv,
+        budget=100_000,
+    ) == []
+
+
+def test_hierarchical_pack_splits_oversized_family_with_anchor_context(tmp_path):
+    raw = _mk(
+        tmp_path,
+        {
+            "gpu/guide.md": 10,
+            "gpu/guide.assets/a.png": 1_000,
+            "gpu/guide.assets/b.png": 1_000,
+            "gpu/guide.assets/c.png": 1_000,
+        },
+    )
+    inv = bt.scan_sources(raw)
+    # Images each cost 30KB, so a 40KB hierarchical budget forces one/chunk.
+    budget = 40 * 1024
+    batches = bt.pack_hierarchical_batches(inv, budget=budget)
+    assert len(batches) == 3, batches
+    assert batches[0]["sources"][0] == "gpu/guide.md"
+    assert all(b["context_sources"] == ["gpu/guide.md"] for b in batches[1:])
+    flat_sources = [p for b in batches for p in b["sources"]]
+    assert sorted(flat_sources) == sorted(i["path"] for i in inv)
+    plan = bt.build_plan(inv, batches, planner="hierarchical-code", budget=budget)
+    assert plan["mode"] == "hierarchical" and plan["phase"] == "map"
+    assert bt.validate_plan(plan, inv, budget=budget) == []
+
+
+def test_validate_hierarchical_context_is_known_and_budgeted(tmp_path):
+    raw = _mk(tmp_path, {"guide.md": 100, "guide.assets/a.png": 1_000})
+    inv = bt.scan_sources(raw)
+    unknown = {"batches": [{
+        "id": "h001", "sources": ["guide.md", "guide.assets/a.png"],
+        "context_sources": ["ghost.md"],
+    }]}
+    assert any("unknown context source" in e for e in bt.validate_plan(unknown, inv, budget=100_000))
+    duplicate = {"batches": [{
+        "id": "h001", "sources": ["guide.md", "guide.assets/a.png"],
+        "context_sources": ["guide.md"],
+    }]}
+    assert any("also repeated as context" in e for e in bt.validate_plan(duplicate, inv, budget=100_000))
+
+
+def test_hierarchical_text_cap_preserves_session_context_safety(tmp_path):
+    raw = _mk(tmp_path, {"docs/a.md": 300 * 1024, "docs/b.md": 300 * 1024})
+    inv = bt.scan_sources(raw)
+    batches = bt.pack_hierarchical_batches(
+        inv, budget=1024 * 1024, text_budget=400 * 1024)
+    assert len(batches) == 2, batches
+    plan = bt.build_plan(
+        inv, batches, planner="hierarchical-code", budget=1024 * 1024,
+        text_budget=400 * 1024)
+    assert bt.validate_plan(
+        plan, inv, budget=1024 * 1024, text_budget=400 * 1024) == []
 
 
 def test_validate_plan_accepts_code_baseline(tmp_path):
@@ -103,6 +188,25 @@ def test_normalize_model_plan_and_progress(tmp_path):
     assert [b["id"] for b in bt.pending_batches(plan)] == ["late"]
     assert bt.normalize_model_plan({"batches": "nope"}) is None
     assert bt.normalize_model_plan([1, 2]) is None
+
+
+def test_section_reductions_group_only_unambiguous_multi_page_sections(tmp_path):
+    pages = {
+        "gpu/a.md": {"sources": ["gpu/a.md"], "bytes": 100},
+        "gpu/b.md": {"sources": ["gpu/b.md"], "bytes": 100},
+        "ops/a.md": {"sources": ["ops/a.md"], "bytes": 100},
+        "mixed.md": {"sources": ["gpu/c.md", "ops/c.md"], "bytes": 100},
+        "derived.md": {"sources": [], "bytes": 100},
+        "index.md": {"sources": [], "bytes": 100},
+    }
+    reductions = bt.pack_section_reductions(pages, budget=500)
+    assert len(reductions) == 1, reductions
+    assert reductions[0]["section"] == "gpu"
+    assert reductions[0]["pages"] == ["gpu/a.md", "gpu/b.md"]
+    plan = {"reductions": reductions}
+    assert len(bt.pending_reductions(plan)) == 1
+    bt.stamp_reduction_done(plan, reductions[0]["id"])
+    assert bt.pending_reductions(plan) == []
 
 
 def test_effective_weights_images_pdf_binary(tmp_path: Path):
@@ -208,14 +312,20 @@ def main():
     tests = [
         test_scan_skips_hidden_and_empty,
         test_threshold_gate_small_kb_never_batches,
+        test_tiered_gate_keeps_small_and_medium_routes_stable,
         test_pack_groups_by_top_dir_and_budget,
         test_pack_oversized_single_file_gets_own_batch,
+        test_hierarchical_pack_keeps_document_assets_together,
+        test_hierarchical_pack_splits_oversized_family_with_anchor_context,
+        test_validate_hierarchical_context_is_known_and_budgeted,
+        test_hierarchical_text_cap_preserves_session_context_safety,
         test_validate_plan_accepts_code_baseline,
         test_validate_plan_rejects_missing_duplicate_unknown_overflow,
         test_validate_plan_rejects_duplicate_and_empty_batch_ids,
         test_scan_confines_symlinks,
         test_prune_missing_sources,
         test_normalize_model_plan_and_progress,
+        test_section_reductions_group_only_unambiguous_multi_page_sections,
         test_effective_weights_images_pdf_binary,
         test_pack_uses_effective_not_raw_bytes,
         test_pdf_fallback_when_no_markers,

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2303,6 +2303,48 @@ async def test_batch_orchestrator_routing_and_resume():
     print("\u2713 batch orchestrator: gate/stamps/single turn_done/resume/notes")
 
 
+def test_hierarchical_text_slice_materialization_and_directive():
+    """Oversized-text helpers are bounded, ephemeral views of Raw. The model
+    reads the helper, but durable Candidate provenance still names the original
+    Raw source rather than an internal slice path."""
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        source = wd / "raw" / "gpu" / "manual.md"
+        source.parent.mkdir(parents=True)
+        source.write_text("".join(f"line-{line}\n" for line in range(1, 7)))
+        batch = {
+            "id": "h001",
+            "sources": ["gpu/manual.md"],
+            "context_sources": [],
+            "source_ranges": {
+                "gpu/manual.md": {
+                    "start_line": 2,
+                    "end_line": 4,
+                    "part": 1,
+                    "parts": 2,
+                    "bytes": 21,
+                    "slice_file": ".kbc-batch-slices/manual-p001.md",
+                }
+            },
+            "defer_accounting": True,
+        }
+        run = compile_box.CompileRun("slice-materialize", str(wd), 1)
+        compile_box._materialize_batch_slices(run, {"batches": [batch]})
+
+        helper = wd / ".kbc-batch-slices" / "manual-p001.md"
+        excerpt = helper.read_text()
+        assert "raw/gpu/manual.md, lines 2-4" in excerpt, excerpt
+        assert "line-2\nline-3\nline-4\n" in excerpt, excerpt
+        assert "line-1" not in excerpt and "line-5" not in excerpt, excerpt
+
+        directive = compile_box._compose_batch_directive(batch, 1, 2, "", "zh-CN")
+        assert ".kbc-batch-slices/manual-p001.md" in directive, directive
+        assert "本批绝不要直接打开原 Raw 全文" in directive, directive
+        assert "compiled_from 必须引用原 Raw 路径(raw/gpu/manual.md)" in directive, directive
+        assert "compiled_from 必须引用原 Raw 路径(.kbc-batch-slices" not in directive
+    print("\u2713 hierarchical text slices: bounded helper with original-Raw provenance")
+
+
 async def test_hierarchical_batch_plan_and_section_reduce():
     """Only the second, very-large-corpus gate selects hierarchical planning.
     The map keeps anchor context explicit, section reduce runs after all maps,
@@ -3283,6 +3325,7 @@ async def main():
     await test_unchanged_owner_turn_does_not_migrate_legacy_format()
     await test_batch_final_ledger_check_requires_index()
     await test_batch_orchestrator_routing_and_resume()
+    test_hierarchical_text_slice_materialization_and_directive()
     await test_hierarchical_batch_plan_and_section_reduce()
     test_hierarchical_media_verify_round_limit()
     await test_batch_orchestrator_review_fixes()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2404,6 +2404,36 @@ async def test_hierarchical_batch_plan_and_section_reduce():
     print("\u2713 hierarchical batch: deterministic map / section reduce / complete phase")
 
 
+def test_hierarchical_media_verify_round_limit():
+    """Large trains scale the image-tail budget; ordinary/flat compiles retain
+    the established three-round latency bound, and an operator cap stays hard."""
+    names = (
+        "KBC_MEDIA_VERIFY_ROUNDS",
+        "KBC_MEDIA_VERIFY_ATTEMPTS",
+        "KBC_HIERARCHICAL_MEDIA_VERIFY_MAX_ROUNDS",
+    )
+    previous = {name: os.environ.get(name) for name in names}
+    try:
+        os.environ["KBC_MEDIA_VERIFY_ROUNDS"] = "3"
+        os.environ["KBC_MEDIA_VERIFY_ATTEMPTS"] = "2"
+        os.environ["KBC_HIERARCHICAL_MEDIA_VERIFY_MAX_ROUNDS"] = "256"
+        pending = {f"page-{i}.md": [f"image-{i}.png"] for i in range(4)}
+        assert compile_box._batch_media_verify_round_limit(
+            {"mode": "flat"}, pending) == 3
+        assert compile_box._batch_media_verify_round_limit(
+            {"mode": "hierarchical"}, pending) == 11
+        os.environ["KBC_HIERARCHICAL_MEDIA_VERIFY_MAX_ROUNDS"] = "5"
+        assert compile_box._batch_media_verify_round_limit(
+            {"mode": "hierarchical"}, pending) == 5
+    finally:
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+    print("\u2713 hierarchical media verify: scales by pending pages, flat unchanged, hard cap")
+
+
 async def test_batch_orchestrator_review_fixes():
     """Review fixes: (a) resume prunes sources deleted from raw/ (no directive
     points at a missing file; an emptied batch is skipped); (b) an orchestrator
@@ -3254,6 +3284,7 @@ async def main():
     await test_batch_final_ledger_check_requires_index()
     await test_batch_orchestrator_routing_and_resume()
     await test_hierarchical_batch_plan_and_section_reduce()
+    test_hierarchical_media_verify_round_limit()
     await test_batch_orchestrator_review_fixes()
     await test_model_stall_retries_then_completes()
     await test_model_stall_live_stream_not_reaped()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -1437,15 +1437,17 @@ async def test_propose_plan_never_bounces():
 
 
 async def test_delete_candidate_page_is_scoped():
-    """The compiler can remove a merged-away page without gaining Bash."""
+    """Both compiler engines can remove a merged-away page without Bash."""
     with tempfile.TemporaryDirectory() as td:
         wd = Path(td)
         (wd / "candidate/guide").mkdir(parents=True)
         (wd / "raw").mkdir()
         (wd / "candidate/index.md").write_text("# Index", encoding="utf-8")
         (wd / "candidate/guide/index.md").write_text("# Guide", encoding="utf-8")
-        dead = wd / "candidate/guide/dead.md"
-        dead.write_text("old", encoding="utf-8")
+        engine_dead = wd / "candidate/guide/engine-dead.md"
+        engine_dead.write_text("old", encoding="utf-8")
+        claude_dead = wd / "candidate/guide/claude-dead.md"
+        claude_dead.write_text("old", encoding="utf-8")
         outside = wd / "raw/source.md"
         outside.write_text("raw", encoding="utf-8")
         events = []
@@ -1456,6 +1458,19 @@ async def test_delete_candidate_page_is_scoped():
 
             async def emit(self, ev):
                 events.append(ev)
+
+        engine_tools = {
+            item.name: item for item in compile_box._compile_engine_tools(FakeRun())
+        }
+        engine_delete = engine_tools["delete_candidate_page"]
+        assert engine_delete.input_schema == {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }
+        engine_result = await engine_delete.handler({"path": "guide/engine-dead.md"})
+        assert not engine_dead.exists(), engine_result
+        assert "deleted candidate page" in engine_result
 
         captured = {}
         original = compile_box.create_sdk_mcp_server
@@ -1472,16 +1487,16 @@ async def test_delete_candidate_page_is_scoped():
         delete = captured["delete_candidate_page"].handler
 
         assert "mcp__compile__delete_candidate_page" in compile_box.DEFAULT_COMPILE_ALLOWED_TOOLS
-        result = await delete({"path": "guide/dead.md"})
-        assert not dead.exists(), result
-        assert events and events[-1]["type"] == "summary", events
+        result = await delete({"path": "guide/claude-dead.md"})
+        assert not claude_dead.exists(), result
+        assert len(events) == 2 and events[-1]["type"] == "summary", events
 
         for refused in ("../raw/source.md", "/tmp/out.md", "index.md",
                         "guide/index.md", "guide/data.json"):
             result = await delete({"path": refused})
             assert "deleted candidate page" not in result["content"][0]["text"], (refused, result)
         assert outside.read_text(encoding="utf-8") == "raw"
-    print("✓ delete_candidate_page is confined to non-routing candidate Markdown files")
+    print("✓ delete_candidate_page is engine-neutral and confined to non-routing candidate Markdown files")
 
 
 def test_install_wiki_snapshot_size_guard():
@@ -2488,7 +2503,7 @@ async def test_hierarchical_media_rechecks_after_ledger_repair():
     real_repairs = compile_box._run_ledger_repairs
     real_media_enabled = compile_box._media_verify_enabled
     real_blind_verify = compile_box.mediaverify.run_blind_verify
-    real_engine = compile_box.ClaudeEngine
+    real_engine_selector = compile_box.selected_readonly_engine
     try:
         with tempfile.TemporaryDirectory() as td:
             wd = Path(td)
@@ -2565,7 +2580,7 @@ async def test_hierarchical_media_rechecks_after_ledger_repair():
             compile_box._run_ledger_repairs = fake_repairs
             compile_box._media_verify_enabled = lambda: True
             compile_box.mediaverify.run_blind_verify = fake_blind_verify
-            compile_box.ClaudeEngine = lambda: object()
+            compile_box.selected_readonly_engine = lambda: object()
             await compile_box._run_batch_compile(run, "直接开始编译")
 
             assert media_calls == 2, order
@@ -2580,7 +2595,7 @@ async def test_hierarchical_media_rechecks_after_ledger_repair():
         compile_box._run_ledger_repairs = real_repairs
         compile_box._media_verify_enabled = real_media_enabled
         compile_box.mediaverify.run_blind_verify = real_blind_verify
-        compile_box.ClaudeEngine = real_engine
+        compile_box.selected_readonly_engine = real_engine_selector
     print("\u2713 hierarchical media verify: ledger-clean revision is rechecked")
 
 

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2476,6 +2476,114 @@ def test_hierarchical_media_verify_round_limit():
     print("\u2713 hierarchical media verify: scales by pending pages, flat unchanged, hard cap")
 
 
+async def test_hierarchical_media_rechecks_after_ledger_repair():
+    """A media repair followed by a ledger-format repair must be verified at
+    the ledger-clean fingerprint. The old tail verified the media edit first,
+    then changed the page in a final ledger pass and still marked the plan
+    complete with that final revision pending image verification."""
+    import batching
+    import selfcheck
+
+    real_drive = compile_box._drive_batch_session
+    real_repairs = compile_box._run_ledger_repairs
+    real_media_enabled = compile_box._media_verify_enabled
+    real_blind_verify = compile_box.mediaverify.run_blind_verify
+    real_engine = compile_box.ClaudeEngine
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            wd = Path(td)
+            (wd / "raw").mkdir()
+            (wd / "raw" / "chart.png").write_bytes(b"image")
+            (wd / "candidate").mkdir()
+            (wd / "candidate" / "index.md").write_text(
+                "---\nokf_version: \"0.1\"\n---\n# Index\n- [Page](page.md)\n")
+            page = wd / "candidate" / "page.md"
+            page.write_text(
+                "---\ntype: Topic\ntitle: Page\ncompiled_from:\n"
+                "  - chart.png\n---\ninitial (source: chart.png)\n")
+            (wd / "authoring").mkdir()
+            plan = {
+                "version": 2,
+                "planner": "hierarchical-code",
+                "mode": "hierarchical",
+                "phase": "final",
+                "batches": [{
+                    "id": "h001",
+                    "sources": ["chart.png"],
+                    "context_sources": [],
+                    "bytes": 5,
+                    "status": "done",
+                }],
+                "reductions": [],
+            }
+            (wd / batching.BATCH_PLAN_PATH).write_text(batching.dump_json(plan))
+            run = compile_box.CompileRun("media-ledger-fingerprint", str(wd), 1)
+            order: list[str] = []
+            media_calls = 0
+
+            async def fake_drive(run_, directive, label):
+                order.append(f"drive:{label}")
+                if label == "final review":
+                    assert "do not read raw/" in directive, directive
+                if label in {"image verification", "图像复核"}:
+                    page.write_text(page.read_text() + "media-repair\n")
+                return f"done {label}"
+
+            async def fake_repairs(run_, replies):
+                order.append("ledger")
+                if "media-repair" in page.read_text() and "ledger-repair" not in page.read_text():
+                    page.write_text(page.read_text() + "ledger-repair\n")
+
+            async def fake_blind_verify(engine, workdir, pending, progress=None, locale=None):
+                nonlocal media_calls
+                media_calls += 1
+                order.append(f"verify:{media_calls}:{'ledger-repair' in page.read_text()}")
+                if media_calls == 1:
+                    return {
+                        "findings": [{
+                            "page": "page.md",
+                            "image": "chart.png",
+                            "kind": "不一致",
+                            "claim": "initial",
+                            "expected": "corrected",
+                            "fix": "repair",
+                        }],
+                        "errors": [],
+                        "images": 1,
+                        "completed_pages": ["page.md"],
+                        "failed_pages": [],
+                    }
+                return {
+                    "findings": [],
+                    "errors": [],
+                    "images": 1,
+                    "completed_pages": ["page.md"],
+                    "failed_pages": [],
+                }
+
+            compile_box._drive_batch_session = fake_drive
+            compile_box._run_ledger_repairs = fake_repairs
+            compile_box._media_verify_enabled = lambda: True
+            compile_box.mediaverify.run_blind_verify = fake_blind_verify
+            compile_box.ClaudeEngine = lambda: object()
+            await compile_box._run_batch_compile(run, "直接开始编译")
+
+            assert media_calls == 2, order
+            assert order.index("ledger", order.index("verify:1:False")) < order.index("verify:2:True"), order
+            assert selfcheck.pending_media_verification(td) == {}, order
+            report = selfcheck.read_selfcheck(td)
+            assert report["media_verify"]["summary"]["pending_pages"] == 0, report
+            saved = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+            assert saved["phase"] == "complete", saved
+    finally:
+        compile_box._drive_batch_session = real_drive
+        compile_box._run_ledger_repairs = real_repairs
+        compile_box._media_verify_enabled = real_media_enabled
+        compile_box.mediaverify.run_blind_verify = real_blind_verify
+        compile_box.ClaudeEngine = real_engine
+    print("\u2713 hierarchical media verify: ledger-clean revision is rechecked")
+
+
 async def test_batch_orchestrator_review_fixes():
     """Review fixes: (a) resume prunes sources deleted from raw/ (no directive
     points at a missing file; an emptied batch is skipped); (b) an orchestrator
@@ -3328,6 +3436,7 @@ async def main():
     test_hierarchical_text_slice_materialization_and_directive()
     await test_hierarchical_batch_plan_and_section_reduce()
     test_hierarchical_media_verify_round_limit()
+    await test_hierarchical_media_rechecks_after_ledger_repair()
     await test_batch_orchestrator_review_fixes()
     await test_model_stall_retries_then_completes()
     await test_model_stall_live_stream_not_reaped()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2357,7 +2357,55 @@ def test_hierarchical_text_slice_materialization_and_directive():
         assert "本批绝不要直接打开原 Raw 全文" in directive, directive
         assert "compiled_from 必须引用原 Raw 路径(raw/gpu/manual.md)" in directive, directive
         assert "compiled_from 必须引用原 Raw 路径(.kbc-batch-slices" not in directive
+
+        # A completed map batch is durable history, not a future model turn.
+        # If its Raw source disappears before reduce/final resumes, rebuilding
+        # its ephemeral slice would make the train fail forever even though the
+        # batch's Candidate output has already landed.
+        batch["status"] = "done"
+        source.unlink()
+        compile_box._materialize_batch_slices(run, {"batches": [batch]})
+        assert not helper.exists()
     print("\u2713 hierarchical text slices: bounded helper with original-Raw provenance")
+
+
+def test_hierarchical_resume_state_contract():
+    """Typed resume accepts every unfinished hierarchical phase, including
+    reduce/final after all map batches are done, while complete stays closed."""
+    import batching
+
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        (wd / "authoring").mkdir()
+        run = compile_box.CompileRun("hier-resume-state", str(wd), 1)
+        command = {"action": "compile.resume", "parameters": {}}
+        plan = {
+            "version": 3,
+            "mode": "hierarchical",
+            "batches": [{"id": "h001", "sources": ["done.md"], "status": "done"}],
+            "reductions": [],
+        }
+
+        for phase in ("map", "reduce", "final"):
+            plan["phase"] = phase
+            (wd / batching.BATCH_PLAN_PATH).write_text(batching.dump_json(plan))
+            assert compile_box._batch_plan_resumable(plan), phase
+            compile_box._prepare_command(run, command)
+            assert compile_box._should_route_to_batch(
+                run, "ignored localized text", "compile.resume"
+            ), phase
+
+        plan["phase"] = "complete"
+        (wd / batching.BATCH_PLAN_PATH).write_text(batching.dump_json(plan))
+        assert not compile_box._batch_plan_resumable(plan)
+        try:
+            compile_box._prepare_command(run, command)
+        except compile_box.CommandRejected as error:
+            assert error.status == 409
+            assert "no interrupted batch plan" in str(error)
+        else:
+            raise AssertionError("complete batch plan must not be resumable")
+    print("\u2713 hierarchical resume: typed command covers map/reduce/final only")
 
 
 async def test_hierarchical_batch_plan_and_section_reduce():
@@ -3449,6 +3497,7 @@ async def main():
     await test_batch_final_ledger_check_requires_index()
     await test_batch_orchestrator_routing_and_resume()
     test_hierarchical_text_slice_materialization_and_directive()
+    test_hierarchical_resume_state_contract()
     await test_hierarchical_batch_plan_and_section_reduce()
     test_hierarchical_media_verify_round_limit()
     await test_hierarchical_media_rechecks_after_ledger_repair()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2254,11 +2254,14 @@ async def test_batch_orchestrator_routing_and_resume():
             return f"done {label}"
 
         real_drive = compile_box._drive_batch_session
+        real_accounted = compile_box._unaccounted_batch_sources
         compile_box._drive_batch_session = fake_drive
+        compile_box._unaccounted_batch_sources = lambda run_, sources: []
         try:
             await compile_box._run_batch_compile(run, "直接开始编译")
         finally:
             compile_box._drive_batch_session = real_drive
+            compile_box._unaccounted_batch_sources = real_accounted
 
         events = []
         while not run.events.empty():
@@ -2281,10 +2284,12 @@ async def test_batch_orchestrator_routing_and_resume():
         assert compile_box._should_route_to_batch(run, "直接开始编译")
         driven.clear()
         compile_box._drive_batch_session = fake_drive
+        compile_box._unaccounted_batch_sources = lambda run_, sources: []
         try:
             await compile_box._run_batch_compile(run, "直接开始编译")
         finally:
             compile_box._drive_batch_session = real_drive
+            compile_box._unaccounted_batch_sources = real_accounted
         assert len(driven) == 2 and driven[0].startswith("batch 2/2"), driven
 
         # mid-batch owner chat queues and is relayed into the next directive
@@ -2404,7 +2409,9 @@ async def test_batch_orchestrator_review_fixes():
     points at a missing file; an emptied batch is skipped); (b) an orchestrator
     error still CLOSES the logical turn (error + turn_done, never-block); (c)
     owner notes arriving during the tail phases get a bounded digest session
-    instead of being silently abandoned at turn_done."""
+    instead of being silently abandoned at turn_done; (e) an SDK error result
+    leaves the current batch pending instead of falsely stamping it done; (f)
+    even a successful no-op result cannot stamp unaccounted sources done."""
     import batching
 
     def _events(run):
@@ -2417,6 +2424,8 @@ async def test_batch_orchestrator_review_fixes():
     os.environ["KBC_BATCH_BUDGET_BYTES"] = "400"
     os.environ["KBC_BATCH_PLANNER"] = "code"
     real_drive = compile_box._drive_batch_session
+    real_accounted = compile_box._unaccounted_batch_sources
+    compile_box._unaccounted_batch_sources = lambda run_, sources: []
     try:
         # (a) resume after a source vanished: plan pins deleted.md in a pending
         # batch (and a fully-vanished batch) — directives must not mention them.
@@ -2505,8 +2514,73 @@ async def test_batch_orchestrator_review_fixes():
             assert any(d.startswith("批 1/1|【分批编译 · 批 1/1") for d in driven), driven
             turn = next(e for e in _events(run) if e["type"] == "turn_done")
             assert "【批 1/1】" in turn["text"] and "【终审】" in turn["text"], turn
+
+        # (e) The real GPU corpus exposed this path: Claude Code returned an
+        # authentication error ResultMessage with no assistant output. Treating
+        # it like a successful empty result stamped every map batch done. The
+        # batch must remain pending so the next valid run can resume honestly.
+        compile_box._drive_batch_session = real_drive
+        compile_box._unaccounted_batch_sources = real_accounted
+
+        class _ErrorResultClient:
+            def __init__(self, options=None):
+                self.options = options
+
+            async def connect(self, prompt=None):
+                pass
+
+            async def query(self, prompt, session_id="default"):
+                pass
+
+            async def receive_messages(self):
+                yield ResultMessage("error_during_execution", is_error=True)
+
+            async def disconnect(self):
+                pass
+
+        real_client = compile_box.ClaudeSDKClient
+        compile_box.ClaudeSDKClient = _ErrorResultClient
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                wd = Path(td)
+                (wd / "raw" / "a").mkdir(parents=True)
+                (wd / "raw" / "a" / "one.md").write_bytes(b"x" * 300)
+                run = compile_box.CompileRun("rf5", str(wd), 1)
+                await compile_box._run_batch_compile(run, "直接开始编译")
+                saved = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+                assert saved["batches"][0]["status"] == "pending", saved
+                evs = _events(run)
+                assert any(e["type"] == "error" and "ModelResultError" in e.get("error", "")
+                           for e in evs), evs
+                assert sum(e["type"] == "turn_done" for e in evs) == 1, evs
+        finally:
+            compile_box.ClaudeSDKClient = real_client
+
+        # (f) is_error=False is necessary but not sufficient: a provider/SDK
+        # regression may return an empty successful result. Every assigned
+        # source must now be cited or explicitly excluded before the done stamp.
+        class _NoopResultClient(_ErrorResultClient):
+            async def receive_messages(self):
+                yield ResultMessage()
+
+        compile_box.ClaudeSDKClient = _NoopResultClient
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                wd = Path(td)
+                (wd / "raw" / "a").mkdir(parents=True)
+                (wd / "raw" / "a" / "one.md").write_bytes(b"x" * 300)
+                run = compile_box.CompileRun("rf6", str(wd), 1)
+                await compile_box._run_batch_compile(run, "直接开始编译")
+                saved = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+                assert saved["batches"][0]["status"] == "pending", saved
+                evs = _events(run)
+                assert any(e["type"] == "error" and "BatchOutputError" in e.get("error", "")
+                           for e in evs), evs
+        finally:
+            compile_box.ClaudeSDKClient = real_client
     finally:
         compile_box._drive_batch_session = real_drive
+        compile_box._unaccounted_batch_sources = real_accounted
         del os.environ["KBC_BATCH_THRESHOLD_BYTES"]
         del os.environ["KBC_BATCH_BUDGET_BYTES"]
     print("✓ batch orchestrator review fixes: resume-prune / error turn_done / tail-note digest")

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -1436,6 +1436,54 @@ async def test_propose_plan_never_bounces():
     print("✓ propose_plan always signals; PROPOSED_PLAN.json written by code")
 
 
+async def test_delete_candidate_page_is_scoped():
+    """The compiler can remove a merged-away page without gaining Bash."""
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        (wd / "candidate/guide").mkdir(parents=True)
+        (wd / "raw").mkdir()
+        (wd / "candidate/index.md").write_text("# Index", encoding="utf-8")
+        (wd / "candidate/guide/index.md").write_text("# Guide", encoding="utf-8")
+        dead = wd / "candidate/guide/dead.md"
+        dead.write_text("old", encoding="utf-8")
+        outside = wd / "raw/source.md"
+        outside.write_text("raw", encoding="utf-8")
+        events = []
+
+        class FakeRun:
+            workdir = str(wd)
+            locale = "en"
+
+            async def emit(self, ev):
+                events.append(ev)
+
+        captured = {}
+        original = compile_box.create_sdk_mcp_server
+
+        def capture(name, tools):
+            captured.update({t.name: t for t in tools})
+            return original(name, tools=tools)
+
+        compile_box.create_sdk_mcp_server = capture
+        try:
+            compile_box._make_compile_tools(FakeRun())
+        finally:
+            compile_box.create_sdk_mcp_server = original
+        delete = captured["delete_candidate_page"].handler
+
+        assert "mcp__compile__delete_candidate_page" in compile_box.DEFAULT_COMPILE_ALLOWED_TOOLS
+        result = await delete({"path": "guide/dead.md"})
+        assert not dead.exists(), result
+        assert events and events[-1]["type"] == "summary", events
+
+        for refused in ("../raw/source.md", "/tmp/out.md", "index.md",
+                        "guide/index.md", "guide/data.json"):
+            result = await delete({"path": refused})
+            assert "deleted candidate page" not in result["content"][0]["text"], (refused, result)
+        assert outside.read_text(encoding="utf-8") == "raw"
+    print("✓ delete_candidate_page is confined to non-routing candidate Markdown files")
+
+
 def test_install_wiki_snapshot_size_guard():
     """Fix A: the published-snapshot installer rejects an oversized compressed
     bundle AND a decompression bomb (accumulated-unpacked cap), like its sibling
@@ -3114,6 +3162,7 @@ async def main():
     await test_recommendation_driver_is_minimal_and_submits_through_registered_mcp_tool()
     await test_recommendation_driver_reports_max_turn_exhaustion()
     await test_propose_plan_never_bounces()
+    await test_delete_candidate_page_is_scoped()
     test_apply_session_config()
     test_parse_brief_block()
     await test_message_captures_brief()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2267,11 +2267,13 @@ async def test_hierarchical_batch_plan_and_section_reduce():
     real_drive = compile_box._drive_batch_session
     real_repairs = compile_box._run_ledger_repairs
     real_media_enabled = compile_box._media_verify_enabled
+    real_hierarchical_idle_timeout = compile_box._HIERARCHICAL_MODEL_IDLE_TIMEOUT_S
     try:
         os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100"
         os.environ["KBC_HIERARCHICAL_THRESHOLD_BYTES"] = "100"
         os.environ["KBC_HIERARCHICAL_BATCH_BUDGET_BYTES"] = "400"
         os.environ["KBC_BATCH_PLANNER"] = "model"
+        compile_box._HIERARCHICAL_MODEL_IDLE_TIMEOUT_S = 123
 
         # Hierarchical mode is deterministic and must bypass the model planner.
         inventory = [
@@ -2291,9 +2293,11 @@ async def test_hierarchical_batch_plan_and_section_reduce():
             (wd / "raw" / "gpu" / "b.md").write_bytes(b"b" * 300)
             run = compile_box.CompileRun("hier-run", str(wd), 1)
             driven: list[str] = []
+            observed_idle_timeouts: list[float | None] = []
 
             async def fake_drive(run_, directive, label):
                 driven.append(label + "|" + directive.splitlines()[0])
+                observed_idle_timeouts.append(run_._model_idle_timeout_s)
                 if label.startswith("batch ") or label.startswith("批 "):
                     candidate = wd / "candidate"
                     candidate.mkdir(exist_ok=True)
@@ -2316,6 +2320,10 @@ async def test_hierarchical_batch_plan_and_section_reduce():
             assert sum(item.startswith("batch ") for item in driven) == 2, driven
             assert sum(item.startswith("section reduce ") for item in driven) == 1, driven
             assert driven[-1].startswith("final review"), driven
+            assert set(observed_idle_timeouts) == {
+                max(compile_box._MODEL_IDLE_TIMEOUT_S, 123)
+            }, observed_idle_timeouts
+            assert run._model_idle_timeout_s is None, run._model_idle_timeout_s
             saved = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
             assert saved["phase"] == "complete", saved
             assert all(r["status"] == "done" for r in saved["reductions"]), saved
@@ -2334,6 +2342,7 @@ async def test_hierarchical_batch_plan_and_section_reduce():
         compile_box._drive_batch_session = real_drive
         compile_box._run_ledger_repairs = real_repairs
         compile_box._media_verify_enabled = real_media_enabled
+        compile_box._HIERARCHICAL_MODEL_IDLE_TIMEOUT_S = real_hierarchical_idle_timeout
         for name, value in previous.items():
             if value is None:
                 os.environ.pop(name, None)

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2250,6 +2250,98 @@ async def test_batch_orchestrator_routing_and_resume():
     print("\u2713 batch orchestrator: gate/stamps/single turn_done/resume/notes")
 
 
+async def test_hierarchical_batch_plan_and_section_reduce():
+    """Only the second, very-large-corpus gate selects hierarchical planning.
+    The map keeps anchor context explicit, section reduce runs after all maps,
+    and the persisted phase closes as complete. No model planner is spent on a
+    huge inventory."""
+    import batching
+
+    env_names = [
+        "KBC_BATCH_THRESHOLD_BYTES",
+        "KBC_HIERARCHICAL_THRESHOLD_BYTES",
+        "KBC_HIERARCHICAL_BATCH_BUDGET_BYTES",
+        "KBC_BATCH_PLANNER",
+    ]
+    previous = {name: os.environ.get(name) for name in env_names}
+    real_drive = compile_box._drive_batch_session
+    real_repairs = compile_box._run_ledger_repairs
+    real_media_enabled = compile_box._media_verify_enabled
+    try:
+        os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100"
+        os.environ["KBC_HIERARCHICAL_THRESHOLD_BYTES"] = "100"
+        os.environ["KBC_HIERARCHICAL_BATCH_BUDGET_BYTES"] = "400"
+        os.environ["KBC_BATCH_PLANNER"] = "model"
+
+        # Hierarchical mode is deterministic and must bypass the model planner.
+        inventory = [
+            {"path": "gpu/a.md", "bytes": 300, "effective": 300},
+            {"path": "gpu/b.md", "bytes": 300, "effective": 300},
+        ]
+        with tempfile.TemporaryDirectory() as plan_td:
+            plan = await compile_box._plan_batches(
+                compile_box.CompileRun("hier-plan", plan_td, 1), inventory)
+        assert plan["planner"] == "hierarchical-code" and plan["mode"] == "hierarchical", plan
+        assert len(plan["batches"]) == 2, plan
+
+        with tempfile.TemporaryDirectory() as td:
+            wd = Path(td)
+            (wd / "raw" / "gpu").mkdir(parents=True)
+            (wd / "raw" / "gpu" / "a.md").write_bytes(b"a" * 300)
+            (wd / "raw" / "gpu" / "b.md").write_bytes(b"b" * 300)
+            run = compile_box.CompileRun("hier-run", str(wd), 1)
+            driven: list[str] = []
+
+            async def fake_drive(run_, directive, label):
+                driven.append(label + "|" + directive.splitlines()[0])
+                if label.startswith("batch ") or label.startswith("批 "):
+                    candidate = wd / "candidate"
+                    candidate.mkdir(exist_ok=True)
+                    source = "gpu/a.md" if not (candidate / "a.md").exists() else "gpu/b.md"
+                    page = Path(source).name
+                    (candidate / page).write_text(
+                        "---\n"
+                        f"type: Topic\ntitle: {page}\ncompiled_from:\n  - {source}\n"
+                        "---\n# Body\nsource-backed detail\n")
+                return f"done {label}"
+
+            async def no_repairs(run_, replies):
+                return None
+
+            compile_box._drive_batch_session = fake_drive
+            compile_box._run_ledger_repairs = no_repairs
+            compile_box._media_verify_enabled = lambda: False
+            await compile_box._run_batch_compile(run, "直接开始编译")
+
+            assert sum(item.startswith("batch ") for item in driven) == 2, driven
+            assert sum(item.startswith("section reduce ") for item in driven) == 1, driven
+            assert driven[-1].startswith("final review"), driven
+            saved = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+            assert saved["phase"] == "complete", saved
+            assert all(r["status"] == "done" for r in saved["reductions"]), saved
+
+            # A crash during final close-out resumes final only — it must never
+            # replay the expensive map or reduce train, even if raw has since
+            # shrunk below the ordinary batch threshold.
+            saved["phase"] = "final"
+            (wd / batching.BATCH_PLAN_PATH).write_text(json.dumps(saved))
+            os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100000"
+            assert compile_box._should_route_to_batch(run, "直接开始编译")
+            driven.clear()
+            await compile_box._run_batch_compile(run, "直接开始编译")
+            assert len(driven) == 1 and driven[0].startswith("final review"), driven
+    finally:
+        compile_box._drive_batch_session = real_drive
+        compile_box._run_ledger_repairs = real_repairs
+        compile_box._media_verify_enabled = real_media_enabled
+        for name, value in previous.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+    print("\u2713 hierarchical batch: deterministic map / section reduce / complete phase")
+
+
 async def test_batch_orchestrator_review_fixes():
     """Review fixes: (a) resume prunes sources deleted from raw/ (no directive
     points at a missing file; an emptied batch is skipped); (b) an orchestrator
@@ -3029,6 +3121,7 @@ async def main():
     await test_unchanged_owner_turn_does_not_migrate_legacy_format()
     await test_batch_final_ledger_check_requires_index()
     await test_batch_orchestrator_routing_and_resume()
+    await test_hierarchical_batch_plan_and_section_reduce()
     await test_batch_orchestrator_review_fixes()
     await test_model_stall_retries_then_completes()
     await test_model_stall_live_stream_not_reaped()

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -386,7 +386,10 @@ def test_body_source_annotations():
             f"More. (source: {Path(report_pdf).name} p.12)\n"
             f"更多。（来源: {Path(punctuated).name} 第3节）\n"
             f"Combined. (source: {Path(first).name} §3, "
-            f"{Path(report_pdf).name} lines 10-12)"
+            f"{Path(report_pdf).name} lines 10-12)\n"
+            f"Plural. (source: {Path(report_pdf).name} Pages 3-5)\n"
+            f"List. (source: {Path(report_pdf).name} Pages 2, 4)\n"
+            f"Short plural. (source: {Path(report_pdf).name} pp. 8-9)"
         )
         report = selfcheck.run_layer1(td)
         assert report["coverage"]["closed"] and report["lint"]["ok"], report
@@ -506,9 +509,56 @@ def test_media_verify_helpers():
         # run_layer1 must carry media_verify forward (not wipe it)
         report = selfcheck.run_layer1(td)
         assert report["media_verify"]["verified_pages"] == ["p1.md"], report["media_verify"]
+        assert report["media_verify"]["summary"] == {
+            "total_pages": 1, "passed_pages": 1, "exhausted_pages": 0,
+            "pending_pages": 0, "total_images": 2, "pending_images": 0,
+        }, report["media_verify"]
         selfcheck.write_selfcheck(td, report)
         assert selfcheck.pending_media_verification(td) == {}
     print("OK  media_citing_pages + pending/mark idempotency + carry-forward")
+
+
+def test_media_verify_content_identity_and_attempt_reset():
+    """A verified path is not a verified future revision of that page/image."""
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _mk(base, "raw/chart.png", "image-v1")
+        _mk(base, "candidate/index.md",
+            "---\nokf_version: \"0.1\"\n---\n# Index\n- [p](p.md)")
+        page = base / "candidate/p.md"
+        _mk(base, "candidate/p.md",
+            "---\ntype: Topic\ncompiled_from:\n  - chart.png\n---\nvalue 1")
+
+        selfcheck.mark_media_verified(td, ["p.md"])
+        assert selfcheck.pending_media_verification(td) == {}
+
+        # Same path, edited claim: must re-enter and get a fresh retry budget.
+        page.write_text(page.read_text() + "\nvalue 2", encoding="utf-8")
+        assert list(selfcheck.pending_media_verification(td)) == ["p.md"]
+        assert selfcheck.bump_media_attempts(td, ["p.md"])["p.md"] == 1
+        assert selfcheck.bump_media_attempts(td, ["p.md"])["p.md"] == 2
+
+        # Same page, same image path, replaced bytes: identity changes and the
+        # previous revision's two failed attempts must not exhaust this one.
+        (base / "raw/chart.png").write_text("image-v2", encoding="utf-8")
+        assert list(selfcheck.pending_media_verification(td)) == ["p.md"]
+        assert selfcheck.bump_media_attempts(td, ["p.md"])["p.md"] == 1
+
+        selfcheck.mark_media_verified(td, ["p.md"], exhausted=True)
+        report = selfcheck.read_selfcheck(td)
+        assert report["media_verify"]["summary"]["exhausted_pages"] == 1, report
+        assert report["media_verify"]["summary"]["passed_pages"] == 0, report
+
+        # A later repair re-arms an exhausted page; a clean verify clears the
+        # stale exhausted flag and records the repaired fingerprint as passed.
+        page.write_text(page.read_text() + "\nrepaired", encoding="utf-8")
+        assert list(selfcheck.pending_media_verification(td)) == ["p.md"]
+        selfcheck.mark_media_verified(td, ["p.md"])
+        report = selfcheck.read_selfcheck(td)
+        assert report["media_verify"]["summary"]["passed_pages"] == 1, report
+        assert report["media_verify"]["summary"]["exhausted_pages"] == 0, report
+        assert report["media_verify"]["exhausted"] == [], report
+    print("OK  media verification identity = page bytes + cited image bytes; retries reset per revision")
 
 
 def test_cap_media_pending():
@@ -1000,11 +1050,26 @@ async def test_media_verify_wiring():
             await run._media_task
             assert calls[0] == {"p.md": ["s/i1.png"]}, calls
             assert run.injected and "[System self-check · image verification]" in run.injected[-1] and "94% 是 MEM 条" in run.injected[-1]
-            assert compile_box._pk_due(run) is None         # q.md still pending → PK waits
-            assert _maybe_start_media_verify(run)           # remainder rolls: chunk 2 (q.md)
+            assert compile_box._pk_due(run) is None         # finding page + q.md pending → PK waits
+
+            # Simulate the injected repair editing the finding page. The path is
+            # unchanged, but its content fingerprint must re-arm verification.
+            p = base / "candidate/p.md"
+            p.write_text(p.read_text() + "\nfixed", encoding="utf-8")
+            assert _maybe_start_media_verify(run)           # repaired p.md verifies again
             await run._media_task
-            assert calls[1] == {"q.md": ["s/i2.png"]}, calls
-            assert len(run.injected) == 1                   # clean chunk → no injection
+            assert calls[1] == {"p.md": ["s/i1.png"]}, calls
+            # Clean p.md self-drains the remaining q.md chunk before settling.
+            for _ in range(4):
+                if len(calls) >= 3:
+                    break
+                task = run._media_task
+                if task is not None:
+                    await task
+                else:
+                    await asyncio.sleep(0)
+            assert calls[2] == {"q.md": ["s/i2.png"]}, calls
+            assert len(run.injected) == 1                   # clean recheck/chunk → no new injection
             assert not _maybe_start_media_verify(run)       # all verified → done
         finally:
             mv.run_blind_verify = orig
@@ -1052,9 +1117,10 @@ async def test_media_inject_failure_does_not_double_settle():
             await run._media_task
             sc = json.loads((base / "authoring/SELFCHECK.json").read_text())
             mvsec = sc["media_verify"]
-            assert "p.md" in mvsec["verified_pages"], mvsec       # the completed verification stands
+            assert "p.md" not in (mvsec.get("verified_pages") or []), mvsec  # known finding is not a pass
             assert "p.md" not in (mvsec.get("exhausted") or []), mvsec   # no spurious exhausted
             assert not (mvsec.get("attempts") or {}), mvsec       # no phantom failed-attempt bump
+            assert list(selfcheck.pending_media_verification(td)) == ["p.md"], mvsec
             assert sc.get("converge_phase") == "settled", sc      # inject failure falls through to the seam
         finally:
             mv.run_blind_verify = orig
@@ -1479,6 +1545,7 @@ def main():
     test_body_source_annotations()
     test_spaced_markdown_links()
     test_media_verify_helpers()
+    test_media_verify_content_identity_and_attempt_reset()
     test_cap_media_pending()
     test_dangling_alone_blocks_closed()
     test_file_residual_ticket()


### PR DESCRIPTION
## Summary

- preserve the existing single-session route at 400KB or below and the flat batch route through 8MB
- add deterministic document families so Markdown anchors stay with sibling .assets media
- split oversized families with explicit read-only anchor context, a 1MB effective budget, and a separate 400KB text cap
- add bounded source-section reduction before the existing global final review
- persist map, reduce, final, and complete phases so tail failures never replay completed map batches

## Regression boundary

- ordinary small corpora still use the original single-session path
- medium corpora still use the original flat planner and orchestrator behavior
- hierarchical planning activates only above the new 8MB effective threshold

## Verification

- KBC compile-box, batching, Office ingest, selfcheck, red-blue, mTLS, incremental, and media verification suites
- npm test: 227 files, 4482 passed, 2 skipped
- npm run build
- real GPU Raw dry-run: 1772 non-empty files, 628153605 raw bytes, 57192656 effective bytes; 290 flat batches reduced to 80 hierarchical batches; plan validation clean; largest text batch 313282 bytes under the 409600-byte cap

No deployment is included in this PR.