### PR TITLE
feat(kbc): support attachment-aware PDF batch slices

### DIFF
--- a/kbc/platform/pod/Dockerfile
+++ b/kbc/platform/pod/Dockerfile
@@ -12,7 +12,7 @@
 #     kbc-compile-pod
 FROM python:3.11-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates bubblewrap \
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates bubblewrap poppler-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # Pin the SDK: an unpinned install drifts on every rebuild, and the bundled
@@ -20,7 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ca-certific
 # massapi/Bedrock path). 0.2.110 is production-proven on the KB compile path.
 # PyYAML backs deterministic OKF frontmatter validation. python-pptx/openpyxl/
 # python-docx let office_ingest pre-render .pptx/.xlsx/.docx sources to markdown
-# (pdf/text/images are read natively by the agent's Read tool).
+# (PDFs are rendered by the agent's Read tool through poppler-utils; text and
+# images are read directly).
 COPY platform/pod/requirements.txt /tmp/kbc-requirements.txt
 RUN pip install --no-cache-dir -r /tmp/kbc-requirements.txt
 

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -79,11 +79,12 @@ def _hierarchical_text_slice_bytes() -> int:
 
 def hierarchical_pdf_slice_pages() -> int:
     """Claude Code's Read tool accepts at most 20 PDF pages per call. Keep the
-    planner limit explicit and configurable for provider-specific deployments,
-    but never allow a zero-width slice."""
-    return max(1, int(os.environ.get(
+    planner limit configurable downwards for tighter deployments, but never
+    let configuration exceed the provider's hard limit or create a zero-width
+    slice."""
+    return min(DEFAULT_HIERARCHICAL_PDF_SLICE_PAGES, max(1, int(os.environ.get(
         "KBC_HIERARCHICAL_PDF_SLICE_PAGES",
-        str(DEFAULT_HIERARCHICAL_PDF_SLICE_PAGES))))
+        str(DEFAULT_HIERARCHICAL_PDF_SLICE_PAGES)))))
 
 
 def _text_slices(path: Path, size: int) -> tuple[int, list[dict[str, int]]] | None:

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -250,7 +250,9 @@ def reduction_budget_bytes() -> int:
         "KBC_REDUCTION_BUDGET_BYTES", str(DEFAULT_REDUCTION_BUDGET_BYTES)))
 
 
-def scan_sources(raw_dir: Path) -> list[dict[str, Any]]:
+def scan_sources(
+    raw_dir: Path, *, include_pdf_execution_metadata: bool = True,
+) -> list[dict[str, Any]]:
     """Inventory of raw sources: repo-relative path + size, sorted for stable
     plans. Hidden files and empty files are skipped (they carry no compile
     content; the installer never writes them, but a defensive skip is cheap).
@@ -273,7 +275,14 @@ def scan_sources(raw_dir: Path) -> list[dict[str, Any]]:
         size = p.stat().st_size
         if size == 0:
             continue
-        page_count = pdf_page_count(p) if p.suffix.lower() == ".pdf" else None
+        # Routing small/ordinary KBs must remain the established cheap scan.
+        # Authoritative Poppler metadata is only needed after batch mode has
+        # already been selected and the hierarchical planner may split a PDF.
+        page_count = (
+            pdf_page_count(p)
+            if include_pdf_execution_metadata and p.suffix.lower() == ".pdf"
+            else None
+        )
         item = {
             "path": str(p.relative_to(raw_dir)),
             "bytes": size,

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -14,8 +14,9 @@ Design invariants:
   anchor as read-only context while accounting each source exactly once.
 - Every raw source lands in exactly one batch (coverage is validated, and the
   final full-corpus SELFCHECK proves no batch dropped anything).
-- A single file larger than the budget still gets its own batch (we never split
-  a file; the page that compiles it needs the whole file anyway).
+- Raw provenance remains one source identity. Oversized Markdown and PDF work
+  is segmented into bounded line/page batches; other oversized files keep the
+  historical one-file batch behavior.
 """
 
 from __future__ import annotations
@@ -24,6 +25,9 @@ import hashlib
 import json
 import os
 import re
+import shutil
+import subprocess
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +37,7 @@ DEFAULT_HIERARCHICAL_THRESHOLD_BYTES = 8 * 1024 * 1024
 DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES = 1024 * 1024
 DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 128 * 1024
 DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES = 64 * 1024
+DEFAULT_HIERARCHICAL_PDF_SLICE_PAGES = 20
 DEFAULT_REDUCTION_BUDGET_BYTES = 512 * 1024
 
 # ── effective-size weighting ─────────────────────────────────────────────────
@@ -72,6 +77,15 @@ def _hierarchical_text_slice_bytes() -> int:
         str(DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES))))
 
 
+def hierarchical_pdf_slice_pages() -> int:
+    """Claude Code's Read tool accepts at most 20 PDF pages per call. Keep the
+    planner limit explicit and configurable for provider-specific deployments,
+    but never allow a zero-width slice."""
+    return max(1, int(os.environ.get(
+        "KBC_HIERARCHICAL_PDF_SLICE_PAGES",
+        str(DEFAULT_HIERARCHICAL_PDF_SLICE_PAGES))))
+
+
 def _text_slices(path: Path, size: int) -> tuple[int, list[dict[str, int]]] | None:
     """Line-bounded chunks for a Markdown source that cannot safely fit one
     hierarchical model turn. The Raw file remains the provenance identity;
@@ -99,6 +113,25 @@ def _text_slices(path: Path, size: int) -> tuple[int, list[dict[str, int]]] | No
     return len(lines), slices
 
 
+def _pdf_slices(page_count: int) -> list[dict[str, int]] | None:
+    """Contiguous Read-tool page ranges for a PDF that is too large for one
+    bounded model turn. The original PDF remains the sole provenance identity;
+    page ranges are internal execution metadata."""
+    limit = hierarchical_pdf_slice_pages()
+    if page_count <= limit:
+        return None
+    count = (page_count + limit - 1) // limit
+    return [
+        {
+            "start_page": start,
+            "end_page": min(page_count, start + limit - 1),
+            "part": index,
+            "parts": count,
+        }
+        for index, start in enumerate(range(1, page_count + 1, limit), start=1)
+    ]
+
+
 def _pdf_page_cost() -> int:
     return int(os.environ.get("KBC_BATCH_PDF_PAGE_COST_BYTES", str(8 * 1024)))
 
@@ -108,13 +141,59 @@ def _binary_weight() -> float:
 
 
 _PDF_PAGE_RE = re.compile(rb"/Type\s*/Page(?![s/])")
+_PDFINFO_PAGES_RE = re.compile(r"^Pages:\s*([0-9]+)\s*$", re.MULTILINE)
+
+
+def _pdfinfo_page_count(path: Path) -> int | None:
+    """Ask Poppler for the authoritative page count when it is installed.
+
+    ``pdfinfo`` and the Read tool's ``pdftoppm`` renderer ship in the same
+    ``poppler-utils`` package, so a production compile image either has both or
+    falls through to the dependency-free marker estimate below.
+    """
+    executable = shutil.which("pdfinfo")
+    if executable is None:
+        return None
+    env = dict(os.environ)
+    env["LC_ALL"] = "C"
+    try:
+        result = subprocess.run(
+            [executable, str(path)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    match = _PDFINFO_PAGES_RE.search(result.stdout)
+    if match is None:
+        return None
+    count = int(match.group(1))
+    return count or None
 
 
 def pdf_page_count(path: Path) -> int | None:
-    """Cheap page estimate: count /Type /Page object markers (excluding /Pages
-    tree nodes) in a single pass. Works for most non-encrypted PDFs; None when
-    nothing is found (e.g. fully compressed object streams) so the caller can
-    fall back to a byte heuristic."""
+    """Page count for planning: authoritative Poppler metadata first, then a
+    cheap /Type /Page marker estimate (excluding /Pages tree nodes). None is
+    reserved for unreadable/encrypted inputs where both methods fail, so the
+    caller can keep the historical byte heuristic."""
+    page_count = _pdfinfo_page_count(path)
+    if page_count is not None:
+        return page_count
+    return _pdf_marker_page_count(path)
+
+
+def _pdf_marker_page_count(path: Path) -> int | None:
+    """Historical dependency-free estimator used by effective-size routing.
+
+    Keep this separate from authoritative Poppler metadata so adding stable
+    page slicing cannot move the established small/medium KB thresholds.
+    """
     try:
         data = path.read_bytes()
     except OSError:
@@ -131,7 +210,7 @@ def effective_bytes(path: Path, size: int) -> int:
     if ext in IMAGE_EXTS:
         return _image_cost()
     if ext == ".pdf":
-        pages = pdf_page_count(path)
+        pages = _pdf_marker_page_count(path)
         if pages is not None:
             return pages * _pdf_page_cost()
         return max(30 * 1024, min(int(size * 0.1), 400 * 1024))
@@ -194,11 +273,20 @@ def scan_sources(raw_dir: Path) -> list[dict[str, Any]]:
         size = p.stat().st_size
         if size == 0:
             continue
+        page_count = pdf_page_count(p) if p.suffix.lower() == ".pdf" else None
         item = {
             "path": str(p.relative_to(raw_dir)),
             "bytes": size,
+            # Preserve the established small/medium routing signal. Poppler's
+            # authoritative page_count below is execution metadata for the
+            # hierarchical planner, not a threshold migration.
             "effective": effective_bytes(p, size),
         }
+        if page_count is not None:
+            item["page_count"] = page_count
+            pdf_slices = _pdf_slices(page_count)
+            if pdf_slices is not None:
+                item["pdf_slices"] = pdf_slices
         sliced = _text_slices(p, size)
         if sliced is not None:
             item["line_count"], item["text_slices"] = sliced
@@ -308,26 +396,103 @@ def _asset_anchor(path: str, known: set[str]) -> str | None:
     return None
 
 
+_ATTACHMENT_EXTS = {"pdf", "doc", "docx", "ppt", "pptx", "xls", "xlsx"}
+_ATTACHMENT_ANCHOR_RE = re.compile(
+    r"^(?:[0-9]+-)?(.+?) \((pdf|doc|docx|ppt|pptx|xls|xlsx)附件\)\.md$",
+    re.IGNORECASE,
+)
+
+
+def _identity_part(value: str) -> str:
+    return unicodedata.normalize("NFC", value).casefold()
+
+
+def _attachment_identity(path: str) -> tuple[str, str, str] | None:
+    """Stable identity for an original file (or its exact sibling Markdown)
+    below ``_attachments/``. Directory + full stem + real extension must match;
+    no fuzzy title matching is allowed."""
+    parts = path.split("/")
+    if len(parts) < 3 or parts[0] != "_attachments":
+        return None
+    filename = parts[-1]
+    if filename.lower().endswith(".md"):
+        filename = filename[:-3]
+    stem, dot, ext = filename.rpartition(".")
+    if not dot or ext.casefold() not in _ATTACHMENT_EXTS:
+        return None
+    return (
+        _identity_part("/".join(parts[1:-1])),
+        _identity_part(stem),
+        ext.casefold(),
+    )
+
+
+def _attachment_anchor_identity(path: str) -> tuple[str, str, str] | None:
+    parts = path.split("/")
+    if len(parts) < 2 or parts[0] == "_attachments":
+        return None
+    match = _ATTACHMENT_ANCHOR_RE.fullmatch(parts[-1])
+    if match is None:
+        return None
+    return (
+        _identity_part("/".join(parts[:-1])),
+        _identity_part(match.group(1)),
+        match.group(2).casefold(),
+    )
+
+
+def _attachment_anchors(known: set[str]) -> dict[tuple[str, str, str], str]:
+    """Return only unambiguous exporter identities. If two anchors normalize
+    to the same identity, omit the key so both attachments remain independent
+    rather than being silently attached to the wrong document."""
+    matches: dict[tuple[str, str, str], list[str]] = {}
+    for path in known:
+        identity = _attachment_anchor_identity(path)
+        if identity is not None:
+            matches.setdefault(identity, []).append(path)
+    return {
+        identity: paths[0]
+        for identity, paths in matches.items()
+        if len(paths) == 1
+    }
+
+
 def source_families(inventory: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
     """Group every source into one deterministic document family.
 
     A family is an anchor Markdown file plus all media below its sibling
-    ``*.assets`` directory. Everything else is a one-source family. Returning
+    ``*.assets`` directory, plus an exactly matched original/sidecar below
+    ``_attachments/``. Everything else is a one-source family. Returning
     inventory records (rather than just paths) keeps this function pure and
     lets the packer enforce effective-byte budgets without rescanning disk.
     """
     by_path = {str(i["path"]): i for i in inventory}
     known = set(by_path)
+    attachment_anchors = _attachment_anchors(known)
     grouped: dict[str, list[dict[str, Any]]] = {}
     for item in inventory:
         path = str(item["path"])
-        key = _asset_anchor(path, known) or path
+        attachment_identity = _attachment_identity(path)
+        key = (
+            _asset_anchor(path, known)
+            or (attachment_anchors.get(attachment_identity) if attachment_identity else None)
+            or path
+        )
         grouped.setdefault(key, []).append(item)
     families: list[list[dict[str, Any]]] = []
     for key in sorted(grouped):
         items = grouped[key]
-        # Put the anchor first, then stable path order for its assets.
-        items.sort(key=lambda i: (str(i["path"]) != key, str(i["path"])))
+        # Put the anchor first, then the exact original/sidecar attachment, then
+        # derived page images. Lexical order alone is wrong when the section
+        # name sorts before ``_attachments`` (the real GPU export does): it
+        # would spend vision batches on rendered pages before reading the
+        # source PDF that gives those pages stable semantics.
+        items.sort(key=lambda i: (
+            0 if str(i["path"]) == key
+            else 1 if _attachment_identity(str(i["path"])) is not None
+            else 2,
+            str(i["path"]),
+        ))
         families.append(items)
     return families
 
@@ -388,6 +553,23 @@ def pack_hierarchical_batches(
                 "status": "pending",
             })
 
+    def append_pdf_slices(item: dict[str, Any]) -> None:
+        slices = item.get("pdf_slices") or []
+        source = str(item["path"])
+        count = len(slices)
+        for index, page_slice in enumerate(slices, start=1):
+            pages = int(page_slice["end_page"]) - int(page_slice["start_page"]) + 1
+            result.append({
+                "id": f"h{len(result) + 1:03d}",
+                "sources": [source],
+                "context_sources": [],
+                "source_page_ranges": {source: dict(page_slice)},
+                "defer_accounting": index < count,
+                "bytes": pages * _pdf_page_cost(),
+                "text_bytes": 0,
+                "status": "pending",
+            })
+
     def flush() -> None:
         nonlocal current, current_bytes, current_text_bytes
         if current:
@@ -400,7 +582,8 @@ def pack_hierarchical_batches(
         family_bytes = sum(_hierarchical_eff(i) for i in family)
         family_text_bytes = sum(_text_eff(i) for i in family)
         section = _top_dir(str(family[0]["path"]))
-        if family_bytes <= limit and family_text_bytes <= text_limit:
+        has_slices = any(i.get("text_slices") or i.get("pdf_slices") for i in family)
+        if not has_slices and family_bytes <= limit and family_text_bytes <= text_limit:
             if current and (
                 current_dir != section
                 or current_bytes + family_bytes > limit
@@ -427,6 +610,8 @@ def pack_hierarchical_batches(
             first_text_bytes = _text_eff(first[0])
             while (
                 remaining
+                and not remaining[0].get("text_slices")
+                and not remaining[0].get("pdf_slices")
                 and first_bytes + _hierarchical_eff(remaining[0]) <= limit
                 and first_text_bytes + _text_eff(remaining[0]) <= text_limit
             ):
@@ -446,6 +631,12 @@ def pack_hierarchical_batches(
         context_bytes = sum(_hierarchical_eff(i) for i in context)
         context_text_bytes = sum(_text_eff(i) for i in context)
         while remaining:
+            if remaining[0].get("text_slices"):
+                append_text_slices(remaining.pop(0))
+                continue
+            if remaining[0].get("pdf_slices"):
+                append_pdf_slices(remaining.pop(0))
+                continue
             batch_context = context
             if context and (
                 context_bytes + _hierarchical_eff(remaining[0]) > limit
@@ -460,7 +651,9 @@ def pack_hierarchical_batches(
             chunk_text_bytes = sum(_text_eff(i) for i in batch_context)
             while remaining and (
                 (
-                    chunk_bytes + _hierarchical_eff(remaining[0]) <= limit
+                    not remaining[0].get("text_slices")
+                    and not remaining[0].get("pdf_slices")
+                    and chunk_bytes + _hierarchical_eff(remaining[0]) <= limit
                     and chunk_text_bytes + _text_eff(remaining[0]) <= text_limit
                 )
                 or not chunk
@@ -484,9 +677,11 @@ def build_plan(
 ) -> dict[str, Any]:
     mode = "hierarchical" if planner == "hierarchical-code" else "flat"
     has_text_slices = any(batch.get("source_ranges") for batch in batches)
+    has_pdf_slices = any(batch.get("source_page_ranges") for batch in batches)
     return {
         "version": (
-            3 if mode == "hierarchical" and has_text_slices
+            4 if mode == "hierarchical" and has_pdf_slices
+            else 3 if mode == "hierarchical" and has_text_slices
             else 2 if mode == "hierarchical"
             else 1
         ),
@@ -512,7 +707,7 @@ def build_plan(
 
 def validate_plan(
     plan: dict[str, Any], inventory: list[dict[str, Any]], budget: int | None = None,
-    text_budget: int | None = None,
+    text_budget: int | None = None, pdf_slice_pages: int | None = None,
 ) -> list[str]:
     """Errors for a (possibly model-proposed) plan. Empty list = valid.
     Rules: every inventory source in exactly one batch, no unknown sources,
@@ -527,7 +722,12 @@ def validate_plan(
     text_sizes = {path: _text_eff(item) for path, item in records.items()}
     seen: dict[str, str] = {}
     slice_appearances: dict[str, list[dict[str, Any]]] = {}
+    page_slice_appearances: dict[str, list[dict[str, Any]]] = {}
     seen_ids: set[str] = set()
+    pdf_page_limit = (
+        pdf_slice_pages if pdf_slice_pages is not None
+        else hierarchical_pdf_slice_pages()
+    )
     batches = plan.get("batches")
     if not isinstance(batches, list) or not batches:
         return ["plan has no batches"]
@@ -560,6 +760,19 @@ def validate_plan(
                 + ", ".join(sorted(unknown_range_sources)[:3]))
         if source_ranges and (len(sources) != 1 or context):
             errors.append(f"batch {bid}: a text-slice batch must contain one source and no context")
+        source_page_ranges = batch.get("source_page_ranges", {})
+        if not isinstance(source_page_ranges, dict):
+            errors.append(f"batch {bid}: source_page_ranges must be an object")
+            source_page_ranges = {}
+        unknown_page_range_sources = set(source_page_ranges) - set(sources)
+        if unknown_page_range_sources:
+            errors.append(
+                f"batch {bid}: source_page_ranges names unassigned source(s): "
+                + ", ".join(sorted(unknown_page_range_sources)[:3]))
+        if source_page_ranges and (len(sources) != 1 or context):
+            errors.append(f"batch {bid}: a PDF page-slice batch must contain one source and no context")
+        if source_ranges and source_page_ranges:
+            errors.append(f"batch {bid}: cannot mix text and PDF source ranges")
         total = 0
         text_total = 0
         for path in sources:
@@ -567,43 +780,79 @@ def validate_plan(
                 errors.append(f"batch {bid}: unknown source {path}")
                 continue
             source_range = source_ranges.get(path)
+            source_page_range = source_page_ranges.get(path)
             if path in seen:
-                if source_range is None or path not in slice_appearances:
+                if (
+                    source_range is None
+                    and source_page_range is None
+                ) or (
+                    source_range is not None and path not in slice_appearances
+                ) or (
+                    source_page_range is not None and path not in page_slice_appearances
+                ):
                     errors.append(f"source {path} appears in {seen[path]} and {bid}")
             else:
                 seen[path] = bid
-            if source_range is None:
-                if path in slice_appearances:
+            if source_range is None and source_page_range is None:
+                if path in slice_appearances or path in page_slice_appearances:
                     errors.append(f"source {path} mixes sliced and unsliced assignments")
                 total += sizes[path]
                 text_total += text_sizes[path]
                 continue
-            if not isinstance(source_range, dict):
+            if source_range is not None and source_page_range is not None:
+                errors.append(f"batch {bid}: source {path} mixes text and PDF ranges")
+                continue
+            if source_range is not None and not isinstance(source_range, dict):
                 errors.append(f"batch {bid}: invalid source range for {path}")
                 continue
+            if source_range is not None:
+                try:
+                    parsed_range = {
+                        "bid": bid,
+                        "start_line": int(source_range["start_line"]),
+                        "end_line": int(source_range["end_line"]),
+                        "bytes": int(source_range["bytes"]),
+                        "part": int(source_range["part"]),
+                        "parts": int(source_range["parts"]),
+                        "slice_file": str(source_range["slice_file"]),
+                        "defer_accounting": bool(batch.get("defer_accounting", False)),
+                    }
+                except (KeyError, TypeError, ValueError):
+                    errors.append(f"batch {bid}: malformed source range for {path}")
+                    continue
+                if parsed_range["start_line"] < 1 or parsed_range["end_line"] < parsed_range["start_line"]:
+                    errors.append(f"batch {bid}: invalid line range for {path}")
+                if parsed_range["bytes"] < 1:
+                    errors.append(f"batch {bid}: empty text slice for {path}")
+                if not parsed_range["slice_file"].startswith(".kbc-batch-slices/"):
+                    errors.append(f"batch {bid}: unsafe slice file for {path}")
+                slice_appearances.setdefault(path, []).append(parsed_range)
+                total += max(0, parsed_range["bytes"])
+                text_total += max(0, parsed_range["bytes"])
+                continue
+            if not isinstance(source_page_range, dict):
+                errors.append(f"batch {bid}: invalid PDF page range for {path}")
+                continue
             try:
-                parsed_range = {
+                parsed_page_range = {
                     "bid": bid,
-                    "start_line": int(source_range["start_line"]),
-                    "end_line": int(source_range["end_line"]),
-                    "bytes": int(source_range["bytes"]),
-                    "part": int(source_range["part"]),
-                    "parts": int(source_range["parts"]),
-                    "slice_file": str(source_range["slice_file"]),
+                    "start_page": int(source_page_range["start_page"]),
+                    "end_page": int(source_page_range["end_page"]),
+                    "part": int(source_page_range["part"]),
+                    "parts": int(source_page_range["parts"]),
                     "defer_accounting": bool(batch.get("defer_accounting", False)),
                 }
             except (KeyError, TypeError, ValueError):
-                errors.append(f"batch {bid}: malformed source range for {path}")
+                errors.append(f"batch {bid}: malformed PDF page range for {path}")
                 continue
-            if parsed_range["start_line"] < 1 or parsed_range["end_line"] < parsed_range["start_line"]:
-                errors.append(f"batch {bid}: invalid line range for {path}")
-            if parsed_range["bytes"] < 1:
-                errors.append(f"batch {bid}: empty text slice for {path}")
-            if not parsed_range["slice_file"].startswith(".kbc-batch-slices/"):
-                errors.append(f"batch {bid}: unsafe slice file for {path}")
-            slice_appearances.setdefault(path, []).append(parsed_range)
-            total += max(0, parsed_range["bytes"])
-            text_total += max(0, parsed_range["bytes"])
+            page_span = parsed_page_range["end_page"] - parsed_page_range["start_page"] + 1
+            if parsed_page_range["start_page"] < 1 or page_span < 1:
+                errors.append(f"batch {bid}: invalid PDF page range for {path}")
+            if page_span > pdf_page_limit:
+                errors.append(
+                    f"batch {bid}: PDF page range for {path} exceeds {pdf_page_limit} pages")
+            page_slice_appearances.setdefault(path, []).append(parsed_page_range)
+            total += max(0, page_span) * _pdf_page_cost()
         for path in context:
             if path not in sizes:
                 errors.append(f"batch {bid}: unknown context source {path}")
@@ -642,6 +891,26 @@ def validate_plan(
                 errors.append(f"source {path} has invalid deferred-accounting boundary")
         if expected_start != line_count + 1:
             errors.append(f"source {path} text slices do not cover all {line_count} lines")
+    for path, appearances in page_slice_appearances.items():
+        page_count = int(records.get(path, {}).get("page_count", 0))
+        ordered = sorted(appearances, key=lambda item: item["part"])
+        declared_parts = {item["parts"] for item in ordered}
+        if page_count < 1 or len(declared_parts) != 1 or next(iter(declared_parts), 0) != len(ordered):
+            errors.append(f"source {path} has incomplete PDF page-slice metadata")
+            continue
+        if [item["part"] for item in ordered] != list(range(1, len(ordered) + 1)):
+            errors.append(f"source {path} has non-sequential PDF page slices")
+        expected_start = 1
+        for index, item in enumerate(ordered):
+            if item["start_page"] != expected_start:
+                errors.append(f"source {path} PDF page slices are not contiguous")
+                break
+            expected_start = item["end_page"] + 1
+            should_defer = index < len(ordered) - 1
+            if item["defer_accounting"] != should_defer:
+                errors.append(f"source {path} has invalid PDF deferred-accounting boundary")
+        if expected_start != page_count + 1:
+            errors.append(f"source {path} PDF slices do not cover all {page_count} pages")
     missing = [p for p in sizes if p not in seen]
     if missing:
         errors.append(f"sources not covered: {', '.join(sorted(missing)[:5])}" + ("…" if len(missing) > 5 else ""))
@@ -760,6 +1029,10 @@ def prune_missing_sources(plan: dict[str, Any], known: set[str]) -> list[str]:
             if isinstance(ranges, dict):
                 for source in gone:
                     ranges.pop(source, None)
+            page_ranges = b.get("source_page_ranges")
+            if isinstance(page_ranges, dict):
+                for source in gone:
+                    page_ranges.pop(source, None)
             if not sources:
                 b["status"] = "done"
         context = [s for s in b.get("context_sources", []) if s in known]

--- a/kbc/platform/pod/codex_engine.py
+++ b/kbc/platform/pod/codex_engine.py
@@ -418,6 +418,7 @@ class CodexSDKClient:
         allowed_read_roots: list[str] | None = None,
         allowed_read_tools: list[str] | None = None,
         tools: list[EngineTool] | None = None,
+        writer_filesystem_access: Mapping[str, str] | None = None,
         reasoning_effort: str | None = None,
         max_tool_calls: int | None = None,
     ):
@@ -428,6 +429,8 @@ class CodexSDKClient:
         self.read_only = read_only
         declared_tools = list(tools or [])
         if read_only:
+            if writer_filesystem_access:
+                raise ValueError("writer_filesystem_access is only valid for writer Codex sessions")
             file_access = _ReadOnlyFileAccess(cwd, allowed_read_roots or [cwd])
             read_tools = file_access.selected_tools(allowed_read_tools)
             reserved = set(_READ_TOOL_NAME_MAP.values())
@@ -443,6 +446,21 @@ class CodexSDKClient:
                 raise ValueError("allowed_read_tools is only valid for read-only Codex sessions")
             self.allowed_read_roots = ()
             self.tools = declared_tools
+        self.writer_filesystem_access: dict[str, str] = {}
+        workspace_root = Path(self.cwd)
+        for raw_path, access in (writer_filesystem_access or {}).items():
+            if access not in {"read", "write", "deny"}:
+                raise ValueError(f"invalid writer filesystem access {access!r} for {raw_path!r}")
+            target = Path(raw_path).resolve()
+            try:
+                target.relative_to(workspace_root)
+            except ValueError as error:
+                raise ValueError(
+                    f"writer filesystem override is outside the session workspace: {raw_path!r}"
+                ) from error
+            if target == workspace_root:
+                raise ValueError("writer filesystem override cannot replace the workspace root")
+            self.writer_filesystem_access[str(target)] = access
         # Mass GPT-5.6 high/medium can spend longer than KBC's 90s model-idle
         # safety bound before its first actionable item. Low still retains the
         # model's agentic workflow and is the reliable unattended default; a
@@ -536,7 +554,7 @@ class CodexSDKClient:
                 + " }, network = { enabled = false } }",
             ])
         else:
-            writable_roots = {
+            filesystem_roots = {
                 # Codex expands :minimal to platform binaries, libraries and
                 # system config only; it deliberately excludes user data and
                 # process metadata such as /proc.
@@ -548,9 +566,10 @@ class CodexSDKClient:
                 self.cwd: "write",
                 str(Path(self._shell_home).resolve()): "write",
             }
+            filesystem_roots.update(self.writer_filesystem_access)
             filesystem = ", ".join(
                 f"{_toml(root)} = {_toml(access)}"
-                for root, access in writable_roots.items()
+                for root, access in filesystem_roots.items()
             )
             overrides.extend([
                 "features.shell_tool=true",
@@ -610,9 +629,14 @@ class CodexSDKClient:
                 + "Read only these declared snapshot roots: " + ", ".join(self.allowed_read_roots)
             )
         else:
+            scoped = (
+                " Batch sessions may add denied Raw and temporary read-only source-view subtrees "
+                "through this same profile."
+                if self.writer_filesystem_access else ""
+            )
             read_contract = (
                 "\n\nWriter filesystem contract: shell and file tools are sandboxed to the current "
-                "KBC workspace, with process metadata and network access denied."
+                "KBC workspace, with process metadata and network access denied." + scoped
             )
         self._thread = await self._codex.thread_start(
             # KBC is an unattended compiler. auto_review still routes workspace

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2244,7 +2244,10 @@ def _should_route_to_batch(run: "CompileRun", text: str, action: str | None = No
     if not _batch_mode_enabled() or run._batch_active or not full_compile:
         return False
     raw_dir = Path(run.workdir) / "raw"
-    inventory = batching.scan_sources(raw_dir)
+    # This gate runs for every normal compile trigger. Keep it metadata-light:
+    # Poppler page counting belongs to the batch planner, not the small-KB path.
+    inventory = batching.scan_sources(
+        raw_dir, include_pdf_execution_metadata=False)
     if batching.should_batch(inventory):
         return True
     # An interrupted batch/reduce/final run must finish in the orchestrator even
@@ -2516,10 +2519,14 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
         + "),绝不能引用辅助文件。"
         if sliced_sources else ""
     )
+    page_example = (
+        f'{paged_sources[0][1]}-{paged_sources[0][2]}'
+        if paged_sources else ""
+    )
     page_en = (
         "\n\nThis batch is one bounded page range of an oversized PDF. Read each listed PDF "
-        "with the Read tool's `pages` argument set to the EXACT listed range (for example, "
-        "`pages: \"21-40\"`). Do not read pages outside that range in this batch. Compile only "
+        "with the Read tool's `pages` argument set to the EXACT listed range (for this batch, "
+        f"`pages: \"{page_example}\"`). Do not read pages outside that range in this batch. Compile only "
         "facts visible in those pages; compiled_from must cite the original Raw PDF path ("
         + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
         + ")."
@@ -2527,7 +2534,7 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
     )
     page_zh = (
         "\n\n本批只处理超大 PDF 的一个有界页段。读取清单中的 PDF 时,Read 工具的 `pages` 参数必须严格等于"
-        "清单页段(例如 `pages: \"21-40\"`),本批不得读取范围外页面。只编译该页段可见的事实;"
+        f"清单页段(本批为 `pages: \"{page_example}\"`),本批不得读取范围外页面。只编译该页段可见的事实;"
         "compiled_from 必须引用原 Raw PDF 路径("
         + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
         + ")."

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -42,6 +42,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import tarfile
 import tempfile
 import time
@@ -2168,21 +2169,228 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
     )
 
 
+def _batch_raw_target(root: Path, source: str) -> Path:
+    """Resolve one plan-owned Raw source without allowing lexical or symlink escape."""
+    if not isinstance(source, str) or not source.strip():
+        raise BatchOutputError("batch Raw source must be a non-empty relative path")
+    raw_root = (root / "raw").resolve()
+    target = (raw_root / source).resolve()
+    try:
+        target.relative_to(raw_root)
+    except ValueError as error:
+        raise BatchOutputError(f"batch Raw source escapes workspace: {source}") from error
+    return target
+
+
+def _codex_batch_filesystem_access(
+    root: Path,
+    raw_read_allowlist: list[str] | None,
+    source_view: Path | None,
+) -> dict[str, str] | None:
+    """Translate the engine-neutral batch scope into a Codex permission profile.
+
+    The workspace remains writable for Candidate/authoring state, but Raw is a
+    deny-by-default subtree. Linux bubblewrap cannot reliably carve a readable
+    child back out of a denied parent, so allowed non-sliced sources live in a
+    disposable read-only view outside Raw. Page-sliced PDFs stay denied to
+    shell/file tools and are exposed only by the fixed-range
+    ``read_assigned_pdf_pages`` MCP tool below.
+    """
+    if raw_read_allowlist is None:
+        return None
+    root = root.resolve()
+    raw_root = (root / "raw").resolve()
+    access = {str(raw_root): "deny"}
+    if source_view is not None:
+        resolved_view = source_view.resolve()
+        try:
+            resolved_view.relative_to(root)
+        except ValueError as error:
+            raise BatchOutputError("Codex batch source view escapes workspace") from error
+        access[str(resolved_view)] = "read"
+    return access
+
+
+def _materialize_codex_batch_source_view(
+    root: Path,
+    raw_read_allowlist: list[str] | None,
+    pdf_page_ranges: dict | None,
+    session_id: str,
+) -> Path | None:
+    """Copy this batch's shell-readable Raw sources into an ephemeral view.
+
+    The view avoids platform-dependent deny-parent/read-child sandbox rules.
+    It intentionally contains no page-sliced PDF: those bytes remain reachable
+    only through ``read_assigned_pdf_pages``. Copies, rather than links, keep
+    the original frozen Raw inode isolated even before the view is mounted
+    read-only by Codex.
+    """
+    if raw_read_allowlist is None:
+        return None
+    root = root.resolve()
+    page_sources = set(pdf_page_ranges) if isinstance(pdf_page_ranges, dict) else set()
+    readable_sources = sorted({
+        source for source in raw_read_allowlist
+        if isinstance(source, str) and source not in page_sources
+    })
+    if not readable_sources:
+        return None
+    if not isinstance(session_id, str) or not session_id:
+        raise BatchOutputError("Codex batch source view requires a session id")
+    source_view = (root / f".kbc-batch-sources-{session_id}").resolve()
+    try:
+        source_view.relative_to(root)
+    except ValueError as error:
+        raise BatchOutputError("Codex batch source view escapes workspace") from error
+    shutil.rmtree(source_view, ignore_errors=True)
+    try:
+        for source in readable_sources:
+            source_path = _batch_raw_target(root, source)
+            if not source_path.is_file():
+                raise BatchOutputError(f"batch Raw source is missing: {source}")
+            relative_source = PurePosixPath(source)
+            if not relative_source.parts or ".." in relative_source.parts:
+                raise BatchOutputError(f"unsafe batch Raw source path: {source}")
+            target = (source_view / Path(*relative_source.parts)).resolve()
+            try:
+                target.relative_to(source_view)
+            except ValueError as error:
+                raise BatchOutputError(f"batch source view path escapes workspace: {source}") from error
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, target)
+    except BaseException:
+        shutil.rmtree(source_view, ignore_errors=True)
+        raise
+    return source_view
+
+
+def _codex_batch_source_view_note(
+    root: Path,
+    source_view: Path | None,
+    raw_read_allowlist: list[str] | None,
+    pdf_page_ranges: dict | None,
+    locale: str | None,
+) -> str:
+    """Explain the disposable view without changing durable Raw provenance."""
+    if source_view is None or raw_read_allowlist is None:
+        return ""
+    root = root.resolve()
+    view_rel = source_view.resolve().relative_to(root).as_posix()
+    page_sources = set(pdf_page_ranges) if isinstance(pdf_page_ranges, dict) else set()
+    sources = sorted({
+        source for source in raw_read_allowlist
+        if isinstance(source, str) and source not in page_sources
+    })
+    mappings = "\n".join(
+        f"- raw/{source} -> {view_rel}/{source}"
+        for source in sources
+    )
+    if selfcheck._is_en(locale):
+        return (
+            "\n\nCodex batch source view: original Raw is mechanically hidden from shell/file "
+            "tools. Read the batch copies below instead. These helper paths are temporary; "
+            "compiled_from must still cite the original raw/... path shown on the left:\n"
+            + mappings
+        )
+    return (
+        "\n\nCodex 批次原料视图:原 Raw 已对 shell/文件工具机械隐藏,请改读下列本批只读副本。"
+        "这些辅助路径是临时的;compiled_from 仍必须引用左侧原 raw/... 路径:\n"
+        + mappings
+    )
+
+
+def _codex_pdf_pages_engine_tool(root: Path, page_ranges: dict) -> EngineTool:
+    """Expose exactly one validated PDF page slice to a Codex batch session.
+
+    Codex writer sessions use native shell rather than Claude's guarded Read
+    tool. Their Raw permission profile denies the original sliced PDF, while
+    this host-side tool runs Poppler with fixed ``-f/-l`` arguments and returns
+    only the assigned pages' text. Derived page images remain separate source
+    batches, preserving visual evidence without widening this text slice.
+    """
+    if not isinstance(page_ranges, dict) or len(page_ranges) != 1:
+        raise BatchOutputError("a Codex PDF page batch must contain exactly one source range")
+    source, raw_range = next(iter(page_ranges.items()))
+    if not isinstance(raw_range, dict):
+        raise BatchOutputError(f"malformed PDF page range for {source}")
+    try:
+        start = int(raw_range["start_page"])
+        end = int(raw_range["end_page"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise BatchOutputError(f"malformed PDF page range for {source}") from error
+    if start < 1 or end < start or end - start + 1 > batching.hierarchical_pdf_slice_pages():
+        raise BatchOutputError(f"invalid PDF page range {start}-{end} for {source}")
+    target = _batch_raw_target(root.resolve(), source)
+    max_chars = max(1, int(os.environ.get("KBC_CODEX_PDF_TEXT_MAX_CHARS", "500000")))
+
+    async def read_assigned_pages(args: dict) -> str:
+        if args:
+            raise ValueError("read_assigned_pdf_pages does not accept arguments")
+        executable = shutil.which("pdftotext")
+        if executable is None:
+            raise RuntimeError("pdftotext is unavailable in the compile image")
+
+        def extract() -> str:
+            result = subprocess.run(
+                [
+                    executable, "-f", str(start), "-l", str(end),
+                    "-layout", "-enc", "UTF-8", str(target), "-",
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or "pdftotext failed").strip()[:1000]
+                raise RuntimeError(f"could not extract raw/{source} pages {start}-{end}: {detail}")
+            text = result.stdout or ""
+            if not text.strip():
+                return (
+                    f"raw/{source} pages {start}-{end}: no extractable text; "
+                    "use the separately assigned derived page-image sources for visual evidence"
+                )
+            suffix = "\n[PDF page text truncated at the KBC batch limit]" if len(text) > max_chars else ""
+            return (
+                f"raw/{source} (PDF pages {start}-{end})\n"
+                + text[:max_chars]
+                + suffix
+            )
+
+        return await asyncio.to_thread(extract)
+
+    return EngineTool(
+        "read_assigned_pdf_pages",
+        f"Read the fixed assigned text slice raw/{source}, PDF pages {start}-{end}. "
+        "This tool accepts no arguments and cannot read any other page range.",
+        {"type": "object", "properties": {}, "additionalProperties": False},
+        read_assigned_pages,
+    )
+
+
 def _compile_session_client(run: "CompileRun", wd: str, system_prompt: str, session_id: str,
                             pdf_page_ranges: dict | None = None,
-                            raw_read_allowlist: list[str] | None = None):
+                            raw_read_allowlist: list[str] | None = None,
+                            codex_source_view: Path | None = None):
     """Create the selected persistent compiler adapter.
 
     The mature turn/sync/watchdog orchestration consumes the same client shape
     for both engines; only this construction seam knows which SDK is active.
     """
     if _engine_kind() == "codex_sdk":
+        tools = _compile_engine_tools(run)
+        if pdf_page_ranges:
+            tools.append(_codex_pdf_pages_engine_tool(Path(wd), pdf_page_ranges))
         return CodexSDKClient(
             cwd=wd,
             system_prompt=system_prompt,
             model=_compile_model(),
             session_id=session_id,
-            tools=_compile_engine_tools(run),
+            tools=tools,
+            writer_filesystem_access=_codex_batch_filesystem_access(
+                Path(wd), raw_read_allowlist, codex_source_view
+            ),
             max_tool_calls=int(os.environ.get("KBC_MAX_TURNS", "150")),
         )
     return ClaudeSDKClient(options=_compile_session_opts(
@@ -2428,17 +2636,28 @@ async def _drive_batch_session(run: "CompileRun", directive: str, label: str,
     Streams its output through _emit_message with turn_done suppressed; returns
     the session's final reply text. run.client points at the live session so the
     park/ruling MCP tools and the inject seam keep working."""
-    wd = str(Path(run.workdir).resolve())
+    root = Path(run.workdir).resolve()
+    wd = str(root)
     session_id = str(uuid.uuid4())
-    client = _compile_session_client(
-        run, wd, _compile_system_prompt(run), session_id,
-        pdf_page_ranges=pdf_page_ranges,
-        raw_read_allowlist=raw_read_allowlist,
-    )
+    source_view = None
+    client = None
     prev_client = run.client
     run._suppress_turn_done = True
     run._last_turn_reply = ""
     try:
+        if _engine_kind() == "codex_sdk" and raw_read_allowlist is not None:
+            source_view = _materialize_codex_batch_source_view(
+                root, raw_read_allowlist, pdf_page_ranges, session_id)
+            directive += _codex_batch_source_view_note(
+                root, source_view, raw_read_allowlist, pdf_page_ranges,
+                getattr(run, "locale", None),
+            )
+        client = _compile_session_client(
+            run, wd, _compile_system_prompt(run), session_id,
+            pdf_page_ranges=pdf_page_ranges,
+            raw_read_allowlist=raw_read_allowlist,
+            codex_source_view=source_view,
+        )
         await client.connect()
         run.client = client
         await run.emit({"type": "log", "text": _loc(run, f"—— {label} started ——", f"—— {label} 开始 ——")})
@@ -2450,10 +2669,13 @@ async def _drive_batch_session(run: "CompileRun", directive: str, label: str,
     finally:
         run._suppress_turn_done = False
         run.client = prev_client
-        try:
-            await client.disconnect()
-        except Exception:
-            pass
+        if client is not None:
+            try:
+                await client.disconnect()
+            except Exception:
+                pass
+        if source_view is not None:
+            shutil.rmtree(source_view, ignore_errors=True)
 
 
 def _drain_batch_notes(run: "CompileRun") -> str:
@@ -2553,23 +2775,43 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
         f'{paged_sources[0][1]}-{paged_sources[0][2]}'
         if paged_sources else ""
     )
-    page_en = (
-        "\n\nThis batch is one bounded page range of an oversized PDF. Read each listed PDF "
-        "with the Read tool's `pages` argument set to the EXACT listed range (for this batch, "
-        f"`pages: \"{page_example}\"`). Do not read pages outside that range in this batch. Compile only "
-        "facts visible in those pages; compiled_from must cite the original Raw PDF path ("
-        + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
-        + ")."
-        if paged_sources else ""
-    )
-    page_zh = (
-        "\n\n本批只处理超大 PDF 的一个有界页段。读取清单中的 PDF 时,Read 工具的 `pages` 参数必须严格等于"
-        f"清单页段(本批为 `pages: \"{page_example}\"`),本批不得读取范围外页面。只编译该页段可见的事实;"
-        "compiled_from 必须引用原 Raw PDF 路径("
-        + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
-        + ")."
-        if paged_sources else ""
-    )
+    if paged_sources and _engine_kind() == "codex_sdk":
+        page_en = (
+            "\n\nThis batch is one bounded page range of an oversized PDF. The original PDF is "
+            "mechanically hidden from shell/file tools. Call the KBC `read_assigned_pdf_pages` tool "
+            "with no arguments; it exposes ONLY the assigned pages ("
+            + page_example
+            + "). Compile only facts returned by that tool; compiled_from must cite the original "
+            "Raw PDF path ("
+            + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
+            + ")."
+        )
+        page_zh = (
+            "\n\n本批只处理超大 PDF 的一个有界页段。原 PDF 已对 shell/文件工具机械隐藏;请无参数调用 "
+            "KBC `read_assigned_pdf_pages` 工具,它只会返回本批页段("
+            + page_example
+            + ")。只编译该工具返回的事实;compiled_from 必须引用原 Raw PDF 路径("
+            + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
+            + ")."
+        )
+    else:
+        page_en = (
+            "\n\nThis batch is one bounded page range of an oversized PDF. Read each listed PDF "
+            "with the Read tool's `pages` argument set to the EXACT listed range (for this batch, "
+            f"`pages: \"{page_example}\"`). Do not read pages outside that range in this batch. Compile only "
+            "facts visible in those pages; compiled_from must cite the original Raw PDF path ("
+            + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
+            + ")."
+            if paged_sources else ""
+        )
+        page_zh = (
+            "\n\n本批只处理超大 PDF 的一个有界页段。读取清单中的 PDF 时,Read 工具的 `pages` 参数必须严格等于"
+            f"清单页段(本批为 `pages: \"{page_example}\"`),本批不得读取范围外页面。只编译该页段可见的事实;"
+            "compiled_from 必须引用原 Raw PDF 路径("
+            + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
+            + ")."
+            if paged_sources else ""
+        )
     if selfcheck._is_en(locale):
         return (
             f"[Batch compile · batch {k}/{n} · {batch['id']}] Compile ONLY the sources below "

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2133,7 +2133,8 @@ def _reference_assist_model() -> str:
 
 
 def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, session_id: str,
-                          pdf_page_ranges: dict | None = None) -> "ClaudeAgentOptions":
+                          pdf_page_ranges: dict | None = None,
+                          raw_read_allowlist: list[str] | None = None) -> "ClaudeAgentOptions":
     """One options builder for the persistent session AND every batch session —
     identical role/tools/model so a batch page is written under exactly the same
     conventions as a single-session page."""
@@ -2155,7 +2156,8 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
         session_id=session_id,
         session_store=InMemorySessionStore(),
         hooks={"PreToolUse": [HookMatcher(hooks=[_make_compile_path_guard(
-            Path(wd), run.locale, pdf_page_ranges=pdf_page_ranges
+            Path(wd), run.locale, pdf_page_ranges=pdf_page_ranges,
+            raw_read_allowlist=raw_read_allowlist,
         )])]},
         # Stream partial deltas so the stall watchdog sees fine-grained model
         # liveness: a live-but-slow generation keeps emitting StreamEvents (idle
@@ -2167,7 +2169,8 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
 
 
 def _compile_session_client(run: "CompileRun", wd: str, system_prompt: str, session_id: str,
-                            pdf_page_ranges: dict | None = None):
+                            pdf_page_ranges: dict | None = None,
+                            raw_read_allowlist: list[str] | None = None):
     """Create the selected persistent compiler adapter.
 
     The mature turn/sync/watchdog orchestration consumes the same client shape
@@ -2183,7 +2186,9 @@ def _compile_session_client(run: "CompileRun", wd: str, system_prompt: str, sess
             max_tool_calls=int(os.environ.get("KBC_MAX_TURNS", "150")),
         )
     return ClaudeSDKClient(options=_compile_session_opts(
-        run, wd, system_prompt, session_id, pdf_page_ranges=pdf_page_ranges
+        run, wd, system_prompt, session_id,
+        pdf_page_ranges=pdf_page_ranges,
+        raw_read_allowlist=raw_read_allowlist,
     ))
 
 
@@ -2417,7 +2422,8 @@ def _unaccounted_batch_sources(run: "CompileRun", sources: list[str]) -> list[st
 
 
 async def _drive_batch_session(run: "CompileRun", directive: str, label: str,
-                               pdf_page_ranges: dict | None = None) -> str:
+                               pdf_page_ranges: dict | None = None,
+                               raw_read_allowlist: list[str] | None = None) -> str:
     """One bounded internal session: fresh session_id, same role/tools/workspace.
     Streams its output through _emit_message with turn_done suppressed; returns
     the session's final reply text. run.client points at the live session so the
@@ -2427,6 +2433,7 @@ async def _drive_batch_session(run: "CompileRun", directive: str, label: str,
     client = _compile_session_client(
         run, wd, _compile_system_prompt(run), session_id,
         pdf_page_ranges=pdf_page_ranges,
+        raw_read_allowlist=raw_read_allowlist,
     )
     prev_client = run.client
     run._suppress_turn_done = True
@@ -2457,6 +2464,29 @@ def _drain_batch_notes(run: "CompileRun") -> str:
     return _loc(run,
                 f"\n\nThe owner added during the compile (take it into account; it affects the remaining batches):\n{notes}",
                 f"\n\n负责人在编译过程中补充说(一并考虑,影响后续各批):\n{notes}")
+
+
+def _batch_raw_read_allowlist(batch: dict) -> list[str]:
+    """Raw files one map session may inspect directly.
+
+    Text-sliced sources are intentionally absent: the session must read their
+    bounded ``.kbc-batch-slices`` helper instead. PDF slices remain present
+    because the Read tool needs the original PDF plus the exact page-range
+    guard. Family anchors are explicit read-only context for the batch.
+    """
+    source_ranges = batch.get("source_ranges")
+    sliced = set(source_ranges) if isinstance(source_ranges, dict) else set()
+    allowed = {
+        source
+        for source in batch.get("sources", [])
+        if isinstance(source, str) and source not in sliced
+    }
+    allowed.update(
+        source
+        for source in batch.get("context_sources", [])
+        if isinstance(source, str)
+    )
+    return sorted(allowed)
 
 
 def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
@@ -2869,6 +2899,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
             reply = await _drive_batch_session(
                 run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"),
                 pdf_page_ranges=batch.get("source_page_ranges"),
+                raw_read_allowlist=_batch_raw_read_allowlist(batch),
             )
             if reply:
                 replies.append(_loc(run, f"[Batch {k}/{n}] {reply}", f"【批 {k}/{n}】{reply}"))
@@ -2934,7 +2965,9 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 reply = await _drive_batch_session(
                     run, directive,
                     _loc(run, f"section reduce {k}/{reduction_count}",
-                         f"分区归并 {k}/{reduction_count}"))
+                         f"分区归并 {k}/{reduction_count}"),
+                    raw_read_allowlist=[],
+                )
                 if reply:
                     replies.append(_loc(
                         run,
@@ -2952,7 +2985,9 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
         final_reply = await _drive_batch_session(
             run, _compose_final_directive(run.workdir, n, _drain_batch_notes(run), locale=getattr(run, "locale", None)),
-            _loc(run, "final review", "终审"))
+            _loc(run, "final review", "终审"),
+            raw_read_allowlist=[],
+        )
         if final_reply:
             replies.append(_loc(run, f"[Final review] {final_reply}", f"【终审】{final_reply}"))
         # Full-corpus selfcheck + bounded repair rounds, each a fresh bounded
@@ -3525,8 +3560,55 @@ def _pdf_page_range_violation(root: Path, page_ranges: dict | None,
     return None
 
 
+def _raw_read_scope_violation(root: Path, raw_read_allowlist: list[str] | None,
+                              tool_name: str, tool_input: dict) -> str | None:
+    """Keep one internal batch session inside its validated Raw source list.
+
+    ``None`` means an ordinary compiler session with no batch scope. An empty
+    list means a reduce/final session that may inspect Candidate and authoring
+    state but no Raw content. Text-slice sessions deliberately omit the
+    original source from the allowlist and read only their materialized helper.
+
+    Read exposes one file directly. Grep can expose many files at once, so a
+    scoped session must name either an allowed Raw file or a path that cannot
+    include Raw at all; cwd-wide and raw-directory searches fail closed. Glob
+    only lists paths, while every subsequent content read remains guarded.
+    """
+    if raw_read_allowlist is None or tool_name not in {"Read", "Grep"}:
+        return None
+    root = root.resolve()
+    raw_root = (root / "raw").resolve()
+    allowed: set[Path] = set()
+    for source in raw_read_allowlist:
+        if not isinstance(source, str) or not source.strip():
+            continue
+        target = (raw_root / source).resolve()
+        try:
+            target.relative_to(raw_root)
+        except ValueError:
+            continue
+        allowed.add(target)
+
+    field = "file_path" if tool_name == "Read" else "path"
+    value = tool_input.get(field)
+    if not isinstance(value, str) or not value.strip():
+        return "path=<missing> would search the batch workspace including raw/" if tool_name == "Grep" else None
+    path = Path(value)
+    target = (path if path.is_absolute() else root / path).resolve()
+    if tool_name == "Grep" and (target == root or target in raw_root.parents):
+        return f"path={value} would search outside the batch Raw allowlist"
+    try:
+        target.relative_to(raw_root)
+    except ValueError:
+        return None
+    if target not in allowed:
+        return f"{field}={value} is outside the batch Raw allowlist"
+    return None
+
+
 def _make_path_guard(root: Path, locale: str | None = None, *, deny_bash: bool = False,
-                     pdf_page_ranges: dict | None = None):
+                     pdf_page_ranges: dict | None = None,
+                     raw_read_allowlist: list[str] | None = None):
     """PreToolUse hook confining one SDK session to its workspace. Hooks fire
     under bypassPermissions; compiler sessions also deny Bash as defense in
     depth if a future profile accidentally adds it back."""
@@ -3538,6 +3620,10 @@ def _make_path_guard(root: Path, locale: str | None = None, *, deny_bash: bool =
         offender = "tool=Bash" if deny_bash and tool_name == "Bash" else _test_path_escape(
             root, tool_name, tool_input
         )
+        if not offender:
+            offender = _raw_read_scope_violation(
+                root, raw_read_allowlist, tool_name, tool_input
+            )
         if not offender:
             offender = _pdf_page_range_violation(
                 root, pdf_page_ranges, tool_name, tool_input
@@ -3561,10 +3647,12 @@ def _make_test_path_guard(root: Path, locale: str | None = None):
 
 
 def _make_compile_path_guard(root: Path, locale: str | None = None,
-                             pdf_page_ranges: dict | None = None):
+                             pdf_page_ranges: dict | None = None,
+                             raw_read_allowlist: list[str] | None = None):
     """Constrain compiler and planner sessions to their /work workspace."""
     return _make_path_guard(
-        root, locale, deny_bash=True, pdf_page_ranges=pdf_page_ranges
+        root, locale, deny_bash=True, pdf_page_ranges=pdf_page_ranges,
+        raw_read_allowlist=raw_read_allowlist,
     )
 
 

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2132,7 +2132,8 @@ def _reference_assist_model() -> str:
             or _compile_model())
 
 
-def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, session_id: str) -> "ClaudeAgentOptions":
+def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, session_id: str,
+                          pdf_page_ranges: dict | None = None) -> "ClaudeAgentOptions":
     """One options builder for the persistent session AND every batch session —
     identical role/tools/model so a batch page is written under exactly the same
     conventions as a single-session page."""
@@ -2153,7 +2154,9 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=session_id,
         session_store=InMemorySessionStore(),
-        hooks={"PreToolUse": [HookMatcher(hooks=[_make_compile_path_guard(Path(wd), run.locale)])]},
+        hooks={"PreToolUse": [HookMatcher(hooks=[_make_compile_path_guard(
+            Path(wd), run.locale, pdf_page_ranges=pdf_page_ranges
+        )])]},
         # Stream partial deltas so the stall watchdog sees fine-grained model
         # liveness: a live-but-slow generation keeps emitting StreamEvents (idle
         # clock stays fresh), while a black-holed request emits nothing at all.
@@ -2163,7 +2166,8 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
     )
 
 
-def _compile_session_client(run: "CompileRun", wd: str, system_prompt: str, session_id: str):
+def _compile_session_client(run: "CompileRun", wd: str, system_prompt: str, session_id: str,
+                            pdf_page_ranges: dict | None = None):
     """Create the selected persistent compiler adapter.
 
     The mature turn/sync/watchdog orchestration consumes the same client shape
@@ -2178,7 +2182,9 @@ def _compile_session_client(run: "CompileRun", wd: str, system_prompt: str, sess
             tools=_compile_engine_tools(run),
             max_tool_calls=int(os.environ.get("KBC_MAX_TURNS", "150")),
         )
-    return ClaudeSDKClient(options=_compile_session_opts(run, wd, system_prompt, session_id))
+    return ClaudeSDKClient(options=_compile_session_opts(
+        run, wd, system_prompt, session_id, pdf_page_ranges=pdf_page_ranges
+    ))
 
 
 def _compile_system_prompt(run: "CompileRun") -> str:
@@ -2407,14 +2413,18 @@ def _unaccounted_batch_sources(run: "CompileRun", sources: list[str]) -> list[st
     )
 
 
-async def _drive_batch_session(run: "CompileRun", directive: str, label: str) -> str:
+async def _drive_batch_session(run: "CompileRun", directive: str, label: str,
+                               pdf_page_ranges: dict | None = None) -> str:
     """One bounded internal session: fresh session_id, same role/tools/workspace.
     Streams its output through _emit_message with turn_done suppressed; returns
     the session's final reply text. run.client points at the live session so the
     park/ruling MCP tools and the inject seam keep working."""
     wd = str(Path(run.workdir).resolve())
     session_id = str(uuid.uuid4())
-    client = _compile_session_client(run, wd, _compile_system_prompt(run), session_id)
+    client = _compile_session_client(
+        run, wd, _compile_system_prompt(run), session_id,
+        pdf_page_ranges=pdf_page_ranges,
+    )
     prev_client = run.client
     run._suppress_turn_done = True
     run._last_turn_reply = ""
@@ -2449,10 +2459,16 @@ def _drain_batch_notes(run: "CompileRun") -> str:
 def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
                              locale: str | None = None) -> str:
     source_ranges = batch.get("source_ranges", {})
+    source_page_ranges = batch.get("source_page_ranges", {})
     listing_lines: list[str] = []
     sliced_sources: list[str] = []
+    paged_sources: list[tuple[str, int, int]] = []
     for path in batch["sources"]:
         source_range = source_ranges.get(path) if isinstance(source_ranges, dict) else None
+        page_range = (
+            source_page_ranges.get(path)
+            if isinstance(source_page_ranges, dict) else None
+        )
         if isinstance(source_range, dict):
             start = source_range["start_line"]
             end = source_range["end_line"]
@@ -2463,6 +2479,15 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
                 f"- {slice_file} (read-only excerpt of raw/{path}, lines {start}-{end}, part {part}/{parts})"
             )
             sliced_sources.append(path)
+        elif isinstance(page_range, dict):
+            start = page_range["start_page"]
+            end = page_range["end_page"]
+            part = page_range["part"]
+            parts = page_range["parts"]
+            listing_lines.append(
+                f"- raw/{path} (PDF pages {start}-{end}, part {part}/{parts})"
+            )
+            paged_sources.append((path, start, end))
         else:
             listing_lines.append(f"- raw/{path}")
     listing = "\n".join(listing_lines)
@@ -2491,6 +2516,23 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
         + "),绝不能引用辅助文件。"
         if sliced_sources else ""
     )
+    page_en = (
+        "\n\nThis batch is one bounded page range of an oversized PDF. Read each listed PDF "
+        "with the Read tool's `pages` argument set to the EXACT listed range (for example, "
+        "`pages: \"21-40\"`). Do not read pages outside that range in this batch. Compile only "
+        "facts visible in those pages; compiled_from must cite the original Raw PDF path ("
+        + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
+        + ")."
+        if paged_sources else ""
+    )
+    page_zh = (
+        "\n\n本批只处理超大 PDF 的一个有界页段。读取清单中的 PDF 时,Read 工具的 `pages` 参数必须严格等于"
+        "清单页段(例如 `pages: \"21-40\"`),本批不得读取范围外页面。只编译该页段可见的事实;"
+        "compiled_from 必须引用原 Raw PDF 路径("
+        + ", ".join(f"raw/{path}" for path, _, _ in paged_sources)
+        + ")."
+        if paged_sources else ""
+    )
     if selfcheck._is_en(locale):
         return (
             f"[Batch compile · batch {k}/{n} · {batch['id']}] Compile ONLY the sources below "
@@ -2502,7 +2544,7 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
             "candidate/index.md entries; contradictions as usual — best-guess + ⚠️ uncertain + file a ticket, "
             "never stop. Do not read any raw source outside this compile list and any explicitly listed "
             "read-only family context. When done, report briefly which pages "
-            "this batch produced." + context_en + slice_en + notes
+            "this batch produced." + context_en + slice_en + page_en + notes
         )
     return (
         f"【分批编译 · 批 {k}/{n} · {batch['id']}】只编译下列源(见系统提示的分批纪律):\n{listing}\n"
@@ -2510,7 +2552,7 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
         "然后精读本批每个源,按定调把内容完整编入 candidate/ 页(可新建页或并入既有页,页 frontmatter 的 "
         "compiled_from 必须列出实际编自的源);更新 candidate/index.md 的相应条目;矛盾照常 best-guess+⚠️存疑+落工单,绝不停。"
         "除上面清单及明确列出的只读同族上下文外,其他 raw 源一个都不要读。完成后简短汇报本批编了哪些页。"
-        + context_zh + slice_zh + notes
+        + context_zh + slice_zh + page_zh + notes
     )
 
 
@@ -2817,7 +2859,10 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         for batch in list(pending):
             k = next(i + 1 for i, b in enumerate(plan["batches"]) if b["id"] == batch["id"])
             directive = _compose_batch_directive(batch, k, n, _drain_batch_notes(run), locale=getattr(run, "locale", None))
-            reply = await _drive_batch_session(run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"))
+            reply = await _drive_batch_session(
+                run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"),
+                pdf_page_ranges=batch.get("source_page_ranges"),
+            )
             if reply:
                 replies.append(_loc(run, f"[Batch {k}/{n}] {reply}", f"【批 {k}/{n}】{reply}"))
             still_unaccounted = (
@@ -3444,7 +3489,37 @@ def _test_path_escape(root: Path, tool_name: str, tool_input: dict) -> str | Non
     return None
 
 
-def _make_path_guard(root: Path, locale: str | None = None, *, deny_bash: bool = False):
+def _pdf_page_range_violation(root: Path, page_ranges: dict | None,
+                              tool_name: str, tool_input: dict) -> str | None:
+    """Require a sliced-PDF map batch to read exactly its assigned pages.
+
+    The directive tells the model which range to read; this hook makes that
+    boundary deterministic under ``bypassPermissions``. Other Raw and workspace
+    paths remain governed by the normal compile guard.
+    """
+    if tool_name != "Read" or not isinstance(page_ranges, dict) or not page_ranges:
+        return None
+    value = tool_input.get("file_path")
+    if not isinstance(value, str) or not value.strip():
+        return None
+    path = Path(value)
+    target = (path if path.is_absolute() else root / path).resolve()
+    for source, page_range in page_ranges.items():
+        if not isinstance(source, str) or not isinstance(page_range, dict):
+            continue
+        expected_target = (root / "raw" / source).resolve()
+        if target != expected_target:
+            continue
+        expected = f"{page_range.get('start_page')}-{page_range.get('end_page')}"
+        actual_value = tool_input.get("pages")
+        actual = str(actual_value).strip() if actual_value is not None else ""
+        if actual != expected:
+            return f"pages={actual or '<missing>'} expected={expected} for raw/{source}"
+    return None
+
+
+def _make_path_guard(root: Path, locale: str | None = None, *, deny_bash: bool = False,
+                     pdf_page_ranges: dict | None = None):
     """PreToolUse hook confining one SDK session to its workspace. Hooks fire
     under bypassPermissions; compiler sessions also deny Bash as defense in
     depth if a future profile accidentally adds it back."""
@@ -3452,9 +3527,14 @@ def _make_path_guard(root: Path, locale: str | None = None, *, deny_bash: bool =
 
     async def guard(input_data, tool_use_id, context):
         tool_name = str(input_data.get("tool_name", ""))
+        tool_input = input_data.get("tool_input") or {}
         offender = "tool=Bash" if deny_bash and tool_name == "Bash" else _test_path_escape(
-            root, tool_name, input_data.get("tool_input") or {}
+            root, tool_name, tool_input
         )
+        if not offender:
+            offender = _pdf_page_range_violation(
+                root, pdf_page_ranges, tool_name, tool_input
+            )
         if offender:
             return {
                 "hookSpecificOutput": {
@@ -3473,9 +3553,12 @@ def _make_test_path_guard(root: Path, locale: str | None = None):
     return _make_path_guard(root, locale)
 
 
-def _make_compile_path_guard(root: Path, locale: str | None = None):
+def _make_compile_path_guard(root: Path, locale: str | None = None,
+                             pdf_page_ranges: dict | None = None):
     """Constrain compiler and planner sessions to their /work workspace."""
-    return _make_path_guard(root, locale, deny_bash=True)
+    return _make_path_guard(
+        root, locale, deny_bash=True, pdf_page_ranges=pdf_page_ranges
+    )
 
 
 def _recommendation_path_escape(root: Path, tool_name: str, tool_input: dict) -> str | None:

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -272,6 +272,23 @@ def test_hierarchical_pdf_is_split_into_contiguous_read_page_ranges(tmp_path):
     assert any("not contiguous" in error for error in errors), errors
 
 
+def test_hierarchical_pdf_slice_configuration_cannot_exceed_read_limit(tmp_path):
+    previous = os.environ.get("KBC_HIERARCHICAL_PDF_SLICE_PAGES")
+    try:
+        os.environ["KBC_HIERARCHICAL_PDF_SLICE_PAGES"] = "99"
+        assert bt.hierarchical_pdf_slice_pages() == 20
+        assert [(item["start_page"], item["end_page"]) for item in bt._pdf_slices(41)] == [
+            (1, 20), (21, 40), (41, 41),
+        ]
+        os.environ["KBC_HIERARCHICAL_PDF_SLICE_PAGES"] = "7"
+        assert bt.hierarchical_pdf_slice_pages() == 7
+    finally:
+        if previous is None:
+            os.environ.pop("KBC_HIERARCHICAL_PDF_SLICE_PAGES", None)
+        else:
+            os.environ["KBC_HIERARCHICAL_PDF_SLICE_PAGES"] = previous
+
+
 def test_linked_original_pdf_ranges_run_before_derived_page_images(tmp_path):
     raw = _mk(
         tmp_path,
@@ -521,6 +538,7 @@ def main():
         test_hierarchical_large_anchor_is_not_replayed_into_every_image_chunk,
         test_hierarchical_oversized_text_anchor_is_sliced_before_image_chunks,
         test_hierarchical_pdf_is_split_into_contiguous_read_page_ranges,
+        test_hierarchical_pdf_slice_configuration_cannot_exceed_read_limit,
         test_linked_original_pdf_ranges_run_before_derived_page_images,
         test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries,
         test_validate_plan_accepts_code_baseline,

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -99,6 +99,50 @@ def test_hierarchical_pack_keeps_document_assets_together(tmp_path):
     ) == []
 
 
+def test_hierarchical_family_links_exact_original_attachment_and_sidecar(tmp_path):
+    raw = _mk(
+        tmp_path,
+        {
+            "gpu/14-manual (pdf附件).md": 100,
+            "gpu/14-manual (pdf附件).assets/page-001.jpg": 1_000,
+            "_attachments/gpu/manual.pdf": 1_000,
+            "_attachments/gpu/manual.pdf.md": 100,
+            "_attachments/other/manual.pdf": 1_000,
+        },
+    )
+    families = bt.source_families(bt.scan_sources(raw))
+    linked = next(
+        family for family in families
+        if family[0]["path"] == "gpu/14-manual (pdf附件).md"
+    )
+    assert [item["path"] for item in linked] == [
+        "gpu/14-manual (pdf附件).md",
+        "_attachments/gpu/manual.pdf",
+        "_attachments/gpu/manual.pdf.md",
+        "gpu/14-manual (pdf附件).assets/page-001.jpg",
+    ]
+    assert any(
+        [item["path"] for item in family] == ["_attachments/other/manual.pdf"]
+        for family in families
+    )
+
+
+def test_hierarchical_family_does_not_guess_ambiguous_attachment_anchor(tmp_path):
+    raw = _mk(
+        tmp_path,
+        {
+            "gpu/14-manual (pdf附件).md": 100,
+            "gpu/manual (pdf附件).md": 100,
+            "_attachments/gpu/manual.pdf": 1_000,
+        },
+    )
+    families = bt.source_families(bt.scan_sources(raw))
+    assert any(
+        [item["path"] for item in family] == ["_attachments/gpu/manual.pdf"]
+        for family in families
+    )
+
+
 def test_hierarchical_pack_splits_oversized_family_with_anchor_context(tmp_path):
     raw = _mk(
         tmp_path,
@@ -197,6 +241,60 @@ def test_hierarchical_oversized_text_anchor_is_sliced_before_image_chunks(tmp_pa
     errors = bt.validate_plan(
         broken, inv, budget=1024 * 1024, text_budget=128 * 1024)
     assert any("not contiguous" in error for error in errors), errors
+
+
+def test_hierarchical_pdf_is_split_into_contiguous_read_page_ranges(tmp_path):
+    raw = _mk(tmp_path, {})
+    pdf = raw / "docs/manual.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"%PDF-1.7 /Type /Pages " + b"/Type /Page 1 " * 45)
+    inv = bt.scan_sources(raw)
+    item = inv[0]
+    assert item["page_count"] == 45
+    assert len(item["pdf_slices"]) == 3
+    batches = bt.pack_hierarchical_batches(inv)
+    ranges = [batch["source_page_ranges"]["docs/manual.pdf"] for batch in batches]
+    assert [(r["start_page"], r["end_page"]) for r in ranges] == [
+        (1, 20), (21, 40), (41, 45)]
+    assert [batch["defer_accounting"] for batch in batches] == [True, True, False]
+    plan = bt.build_plan(inv, batches, planner="hierarchical-code")
+    assert plan["version"] == 4
+    assert bt.validate_plan(plan, inv) == []
+
+    broken = bt.build_plan(
+        inv, [dict(batch) for batch in batches], planner="hierarchical-code")
+    middle = broken["batches"][1]
+    middle["source_page_ranges"] = {
+        "docs/manual.pdf": dict(middle["source_page_ranges"]["docs/manual.pdf"])
+    }
+    middle["source_page_ranges"]["docs/manual.pdf"]["start_page"] = 22
+    errors = bt.validate_plan(broken, inv)
+    assert any("not contiguous" in error for error in errors), errors
+
+
+def test_linked_original_pdf_ranges_run_before_derived_page_images(tmp_path):
+    raw = _mk(
+        tmp_path,
+        {
+            "gpu/14-manual (pdf附件).md": 100,
+            "gpu/14-manual (pdf附件).assets/page-001.jpg": 1_000,
+        },
+    )
+    pdf = raw / "_attachments/gpu/manual.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"%PDF-1.7 /Type /Pages " + b"/Type /Page 1 " * 45)
+    inv = bt.scan_sources(raw)
+    batches = bt.pack_hierarchical_batches(inv)
+    anchor_index = next(
+        i for i, batch in enumerate(batches)
+        if "gpu/14-manual (pdf附件).md" in batch["sources"])
+    pdf_indexes = [i for i, batch in enumerate(batches) if batch.get("source_page_ranges")]
+    image_index = next(
+        i for i, batch in enumerate(batches)
+        if "gpu/14-manual (pdf附件).assets/page-001.jpg" in batch["sources"])
+    assert anchor_index < min(pdf_indexes) < max(pdf_indexes) < image_index
+    plan = bt.build_plan(inv, batches, planner="hierarchical-code")
+    assert bt.validate_plan(plan, inv) == []
 
 
 def test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries(tmp_path):
@@ -321,6 +419,32 @@ def test_pdf_fallback_when_no_markers(tmp_path: Path):
     assert 30 * 1024 <= eff <= 400 * 1024  # clamped byte heuristic
 
 
+def test_pdfinfo_page_count_parser(tmp_path: Path):
+    del tmp_path
+    match = bt._PDFINFO_PAGES_RE.search(
+        "Title:          GPU Manual\nPages:          112\nEncrypted:      no\n"
+    )
+    assert match is not None and int(match.group(1)) == 112
+
+
+def test_pdfinfo_metadata_does_not_move_effective_size_route(tmp_path: Path):
+    raw = _mk(tmp_path, {})
+    raw.mkdir()
+    pdf = raw / "opaque.pdf"
+    pdf.write_bytes(b"%PDF-1.7 compressed-object-streams " + b"q" * 2_000_000)
+    real_pdfinfo = bt._pdfinfo_page_count
+    bt._pdfinfo_page_count = lambda path: 50
+    try:
+        item = bt.scan_sources(raw)[0]
+    finally:
+        bt._pdfinfo_page_count = real_pdfinfo
+    assert item["page_count"] == 50
+    assert len(item["pdf_slices"]) == 3
+    # Baseline byte fallback: max(30KB, min(10% of 2MB, 400KB)). If Poppler
+    # leaked into routing this would instead be 50 * 8KB.
+    assert item["effective"] == int(pdf.stat().st_size * 0.1)
+
+
 def test_plan_fragmentation_guard(tmp_path: Path):
     base = [{"id": f"b{i:02d}", "sources": [f"s{i}"]} for i in range(14)]
     ok_model = [{"id": f"m{i:02d}", "sources": [f"s{i}"]} for i in range(16)]      # 14→16: fine
@@ -389,11 +513,15 @@ def main():
         test_pack_groups_by_top_dir_and_budget,
         test_pack_oversized_single_file_gets_own_batch,
         test_hierarchical_pack_keeps_document_assets_together,
+        test_hierarchical_family_links_exact_original_attachment_and_sidecar,
+        test_hierarchical_family_does_not_guess_ambiguous_attachment_anchor,
         test_hierarchical_pack_splits_oversized_family_with_anchor_context,
         test_validate_hierarchical_context_is_known_and_budgeted,
         test_hierarchical_text_cap_preserves_session_context_safety,
         test_hierarchical_large_anchor_is_not_replayed_into_every_image_chunk,
         test_hierarchical_oversized_text_anchor_is_sliced_before_image_chunks,
+        test_hierarchical_pdf_is_split_into_contiguous_read_page_ranges,
+        test_linked_original_pdf_ranges_run_before_derived_page_images,
         test_hierarchical_image_cost_is_conservative_without_moving_flat_boundaries,
         test_validate_plan_accepts_code_baseline,
         test_validate_plan_rejects_missing_duplicate_unknown_overflow,
@@ -405,6 +533,8 @@ def main():
         test_effective_weights_images_pdf_binary,
         test_pack_uses_effective_not_raw_bytes,
         test_pdf_fallback_when_no_markers,
+        test_pdfinfo_page_count_parser,
+        test_pdfinfo_metadata_does_not_move_effective_size_route,
         test_plan_fragmentation_guard,
     ]
     for fn in tests:

--- a/kbc/platform/pod/test_codex_engine.py
+++ b/kbc/platform/pod/test_codex_engine.py
@@ -165,6 +165,32 @@ async def test_codex_config_is_tenant_isolated():
             assert "process metadata and network access denied" in captured["thread"]["developer_instructions"]
             await writer.disconnect()
             assert not writer_home.exists() and not writer_shell_home.exists()
+
+            raw = Path(td) / "raw"
+            raw.mkdir()
+            view = Path(td) / ".kbc-batch-sources-test"
+            view.mkdir()
+            allowed = view / "allowed.md"
+            allowed.write_text("allowed", encoding="utf-8")
+            scoped = CodexSDKClient(
+                cwd=td,
+                system_prompt="scoped writer",
+                model="gpt-5.6-luna",
+                session_id="pending-scoped-writer",
+                writer_filesystem_access={
+                    str(raw): "deny",
+                    str(view): "read",
+                },
+            )
+            await scoped.connect()
+            scoped_overrides = set(captured["config"]["config_overrides"])
+            scoped_profile = next(
+                value for value in scoped_overrides if value.startswith("permissions.kbc_writer=")
+            )
+            assert f'"{raw.resolve()}" = "deny"' in scoped_profile, scoped_profile
+            assert f'"{view.resolve()}" = "read"' in scoped_profile, scoped_profile
+            assert "temporary read-only source-view subtrees" in captured["thread"]["developer_instructions"]
+            await scoped.disconnect()
     finally:
         if previous is None:
             sys.modules.pop("openai_codex", None)
@@ -189,6 +215,16 @@ async def test_real_codex_writer_sandbox_confines_commands():
             root = Path(td).resolve()
             workspace = root / "workspace"
             workspace.mkdir()
+            raw = workspace / "raw"
+            raw.mkdir()
+            allowed_raw = raw / "allowed.md"
+            denied_raw = raw / "denied.md"
+            allowed_raw.write_text("allowed-raw-sentinel", encoding="utf-8")
+            denied_raw.write_text("denied-raw-sentinel", encoding="utf-8")
+            source_view = workspace / ".kbc-batch-sources-probe"
+            source_view.mkdir()
+            allowed_view = source_view / "allowed.md"
+            allowed_view.write_text("allowed-raw-sentinel", encoding="utf-8")
             secret = root / "provider-secret.txt"
             secret_value = "writer-sandbox-secret-sentinel"
             secret.write_text(secret_value, encoding="utf-8")
@@ -238,6 +274,46 @@ async def test_real_codex_writer_sandbox_confines_commands():
                 assert secret_value not in process_metadata.stdout + process_metadata.stderr
             finally:
                 await client.disconnect()
+
+            scoped = CodexSDKClient(
+                cwd=str(workspace),
+                system_prompt="writer Raw scope probe",
+                model="gpt-5.6-luna",
+                session_id="writer-raw-scope-probe",
+                writer_filesystem_access={
+                    str(raw): "deny",
+                    str(source_view): "read",
+                },
+            )
+            try:
+                await scoped.connect()
+                rpc = scoped._codex._client
+                allowed_read = await rpc.request(
+                    "command/exec",
+                    {"command": ["/bin/cat", str(allowed_view)], "cwd": scoped.cwd},
+                    response_model=CommandExecResponse,
+                )
+                assert allowed_read.exit_code == 0
+                assert "allowed-raw-sentinel" in allowed_read.stdout
+                allowed_write = await rpc.request(
+                    "command/exec",
+                    {
+                        "command": ["/usr/bin/touch", str(allowed_view)],
+                        "cwd": scoped.cwd,
+                    },
+                    response_model=CommandExecResponse,
+                )
+                assert allowed_write.exit_code != 0
+                assert allowed_view.read_text(encoding="utf-8") == "allowed-raw-sentinel"
+                denied_read = await rpc.request(
+                    "command/exec",
+                    {"command": ["/bin/cat", str(denied_raw)], "cwd": scoped.cwd},
+                    response_model=CommandExecResponse,
+                )
+                assert denied_read.exit_code != 0
+                assert "denied-raw-sentinel" not in denied_read.stdout + denied_read.stderr
+            finally:
+                await scoped.disconnect()
     finally:
         for name, value in previous.items():
             if value is None:

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2346,6 +2346,28 @@ async def test_batch_orchestrator_routing_and_resume():
     print("\u2713 batch orchestrator: gate/stamps/single turn_done/resume/notes")
 
 
+def test_small_kb_batch_gate_skips_poppler_metadata():
+    """Ordinary compile routing keeps the pre-PDF-slicing cheap scan. Poppler
+    metadata is execution detail for a selected batch plan, never a new cost on
+    every small-KB compile trigger."""
+    import batching
+
+    real_pdfinfo = batching._pdfinfo_page_count
+    try:
+        batching._pdfinfo_page_count = lambda path: (_ for _ in ()).throw(
+            AssertionError("pdfinfo must not run in the small-KB route gate"))
+        with tempfile.TemporaryDirectory() as td:
+            raw = Path(td) / "raw"
+            raw.mkdir()
+            (raw / "small.pdf").write_bytes(b"%PDF-1.7 /Type /Page")
+            run = compile_box.CompileRun("small-pdf-route", td, 1)
+            assert not compile_box._should_route_to_batch(
+                run, "", action="compile.generate")
+    finally:
+        batching._pdfinfo_page_count = real_pdfinfo
+    print("\u2713 small KB route: no Poppler metadata subprocess")
+
+
 def test_hierarchical_text_slice_materialization_and_directive():
     """Oversized-text helpers are bounded, ephemeral views of Raw. The model
     reads the helper, but durable Candidate provenance still names the original
@@ -2455,11 +2477,12 @@ def test_hierarchical_pdf_page_directive():
     }
     directive = compile_box._compose_batch_directive(batch, 42, 50, "", "en")
     assert "raw/gpu/manual.pdf (PDF pages 41-53, part 3/3)" in directive, directive
-    assert '`pages: "21-40"`' in directive, directive
+    assert '`pages: "41-53"`' in directive, directive
     assert "EXACT listed range" in directive, directive
     assert "compiled_from must cite the original Raw PDF path (raw/gpu/manual.pdf)" in directive
 
     directive_zh = compile_box._compose_batch_directive(batch, 42, 50, "", "zh-CN")
+    assert '`pages: "41-53"`' in directive_zh, directive_zh
     assert "Read 工具的 `pages` 参数必须严格等于清单页段" in directive_zh, directive_zh
     assert "compiled_from 必须引用原 Raw PDF 路径(raw/gpu/manual.pdf)" in directive_zh
     print("\u2713 hierarchical PDF slices: exact Read.pages directive and Raw provenance")
@@ -3553,6 +3576,7 @@ async def main():
     await test_unchanged_owner_turn_does_not_migrate_legacy_format()
     await test_batch_final_ledger_check_requires_index()
     await test_batch_orchestrator_routing_and_resume()
+    test_small_kb_batch_gate_skips_poppler_metadata()
     test_hierarchical_text_slice_materialization_and_directive()
     test_hierarchical_resume_state_contract()
     test_hierarchical_pdf_page_directive()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2534,17 +2534,148 @@ def test_hierarchical_pdf_page_directive():
         },
         "defer_accounting": False,
     }
-    directive = compile_box._compose_batch_directive(batch, 42, 50, "", "en")
-    assert "raw/gpu/manual.pdf (PDF pages 41-53, part 3/3)" in directive, directive
-    assert '`pages: "41-53"`' in directive, directive
-    assert "EXACT listed range" in directive, directive
-    assert "compiled_from must cite the original Raw PDF path (raw/gpu/manual.pdf)" in directive
+    previous_engine = os.environ.get("KBC_ENGINE")
+    os.environ["KBC_ENGINE"] = "claude_agent_sdk"
+    try:
+        directive = compile_box._compose_batch_directive(batch, 42, 50, "", "en")
+        assert "raw/gpu/manual.pdf (PDF pages 41-53, part 3/3)" in directive, directive
+        assert '`pages: "41-53"`' in directive, directive
+        assert "EXACT listed range" in directive, directive
+        assert "compiled_from must cite the original Raw PDF path (raw/gpu/manual.pdf)" in directive
 
-    directive_zh = compile_box._compose_batch_directive(batch, 42, 50, "", "zh-CN")
-    assert '`pages: "41-53"`' in directive_zh, directive_zh
-    assert "Read 工具的 `pages` 参数必须严格等于清单页段" in directive_zh, directive_zh
-    assert "compiled_from 必须引用原 Raw PDF 路径(raw/gpu/manual.pdf)" in directive_zh
+        directive_zh = compile_box._compose_batch_directive(batch, 42, 50, "", "zh-CN")
+        assert '`pages: "41-53"`' in directive_zh, directive_zh
+        assert "Read 工具的 `pages` 参数必须严格等于清单页段" in directive_zh, directive_zh
+        assert "compiled_from 必须引用原 Raw PDF 路径(raw/gpu/manual.pdf)" in directive_zh
+    finally:
+        if previous_engine is None:
+            os.environ.pop("KBC_ENGINE", None)
+        else:
+            os.environ["KBC_ENGINE"] = previous_engine
     print("\u2713 hierarchical PDF slices: exact Read.pages directive and Raw provenance")
+
+
+async def test_codex_batch_scope_and_pdf_page_tool():
+    """Codex gets the same batch Raw boundary through its filesystem profile;
+    a page-sliced PDF is withheld from shell and exposed only through a fixed
+    host-side Poppler tool."""
+    previous_engine = os.environ.get("KBC_ENGINE")
+    original_client = compile_box.CodexSDKClient
+    original_client_factory = compile_box._compile_session_client
+    original_which = compile_box.shutil.which
+    original_run = compile_box.subprocess.run
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class FakeResult:
+        returncode = 0
+        stdout = "page forty-one\npage forty-two\n"
+        stderr = ""
+
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "raw" / "gpu").mkdir(parents=True)
+            (root / "raw" / "gpu" / "manual.pdf").write_bytes(b"%PDF-test")
+            (root / "raw" / "gpu" / "anchor.md").write_text("anchor")
+            page_ranges = {
+                "gpu/manual.pdf": {
+                    "start_page": 41,
+                    "end_page": 53,
+                    "part": 3,
+                    "parts": 3,
+                }
+            }
+            allowlist = ["gpu/anchor.md", "gpu/manual.pdf"]
+            source_view = compile_box._materialize_codex_batch_source_view(
+                root, allowlist, page_ranges, "test-session")
+            assert source_view is not None
+            assert (source_view / "gpu" / "anchor.md").read_text() == "anchor"
+            assert not (source_view / "gpu" / "manual.pdf").exists()
+            access = compile_box._codex_batch_filesystem_access(
+                root, allowlist, source_view)
+            assert access == {
+                str((root / "raw").resolve()): "deny",
+                str(source_view.resolve()): "read",
+            }
+            note = compile_box._codex_batch_source_view_note(
+                root, source_view, allowlist, page_ranges, "en")
+            assert "raw/gpu/anchor.md -> .kbc-batch-sources-test-session/gpu/anchor.md" in note
+            assert "compiled_from must still cite the original raw/... path" in note
+
+            os.environ["KBC_ENGINE"] = "codex_sdk"
+            compile_box.CodexSDKClient = FakeClient
+            run = compile_box.CompileRun("codex-pdf-slice", td, 1)
+            client = compile_box._compile_session_client(
+                run, td, "system", "session",
+                pdf_page_ranges=page_ranges,
+                raw_read_allowlist=allowlist,
+                codex_source_view=source_view,
+            )
+            assert isinstance(client, FakeClient)
+            assert captured["writer_filesystem_access"] == access
+            pdf_tools = [
+                item for item in captured["tools"]
+                if item.name == "read_assigned_pdf_pages"
+            ]
+            assert len(pdf_tools) == 1
+
+            observed_commands = []
+            compile_box.shutil.which = lambda name: "/usr/bin/pdftotext" if name == "pdftotext" else None
+
+            def fake_run(command, **kwargs):
+                observed_commands.append(command)
+                return FakeResult()
+
+            compile_box.subprocess.run = fake_run
+            extracted = await pdf_tools[0].handler({})
+            assert "raw/gpu/manual.pdf (PDF pages 41-53)" in extracted
+            assert observed_commands and observed_commands[0][1:5] == ["-f", "41", "-l", "53"]
+
+            batch = {
+                "id": "h042",
+                "sources": ["gpu/manual.pdf"],
+                "context_sources": [],
+                "source_page_ranges": page_ranges,
+                "defer_accounting": False,
+            }
+            directive = compile_box._compose_batch_directive(batch, 42, 50, "", "en")
+            assert "read_assigned_pdf_pages" in directive
+            assert "mechanically hidden from shell/file tools" in directive
+            assert "Read tool's `pages`" not in directive
+
+            cleanup = {}
+
+            def exploding_factory(*args, codex_source_view=None, **kwargs):
+                cleanup["view"] = codex_source_view
+                raise RuntimeError("client construction failed")
+
+            compile_box._compile_session_client = exploding_factory
+            try:
+                await compile_box._drive_batch_session(
+                    run, "compile anchor", "cleanup probe",
+                    raw_read_allowlist=["gpu/anchor.md"],
+                )
+                raise AssertionError("expected client construction failure")
+            except RuntimeError as error:
+                assert str(error) == "client construction failed"
+            finally:
+                compile_box._compile_session_client = original_client_factory
+            assert cleanup["view"] is not None
+            assert not cleanup["view"].exists()
+    finally:
+        compile_box.CodexSDKClient = original_client
+        compile_box._compile_session_client = original_client_factory
+        compile_box.shutil.which = original_which
+        compile_box.subprocess.run = original_run
+        if previous_engine is None:
+            os.environ.pop("KBC_ENGINE", None)
+        else:
+            os.environ["KBC_ENGINE"] = previous_engine
+    print("\u2713 Codex batch scope: Raw deny-by-default + fixed PDF page tool")
 
 
 async def test_hierarchical_batch_plan_and_section_reduce():
@@ -3653,6 +3784,7 @@ async def main():
     test_hierarchical_text_slice_materialization_and_directive()
     test_hierarchical_resume_state_contract()
     test_hierarchical_pdf_page_directive()
+    await test_codex_batch_scope_and_pdf_page_tool()
     await test_hierarchical_batch_plan_and_section_reduce()
     test_hierarchical_media_verify_round_limit()
     await test_hierarchical_media_rechecks_after_ledger_repair()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -525,6 +525,46 @@ async def test_test_path_escape_guard():
         }, "p3", None)
         assert allow == {}, allow
 
+        # Batch sessions are mechanically confined to the validated Raw list.
+        # A text-slice batch omits the original Markdown and may read only its
+        # helper; a regular/PDF source remains directly readable. Directory or
+        # cwd-wide Grep cannot bypass the per-file Read boundary.
+        (root / "raw" / "other.md").touch()
+        scoped_guard = compile_box._make_compile_path_guard(
+            root, raw_read_allowlist=["manual.pdf"])
+        allow = await scoped_guard({
+            "tool_name": "Read",
+            "tool_input": {"file_path": "raw/manual.pdf"},
+        }, "s1", None)
+        assert allow == {}, allow
+        allow = await scoped_guard({
+            "tool_name": "Read",
+            "tool_input": {"file_path": "candidate/index.md"},
+        }, "s2", None)
+        assert allow == {}, allow
+        for tool_name, tool_input in (
+            ("Read", {"file_path": "raw/other.md"}),
+            ("Grep", {"pattern": "secret"}),
+            ("Grep", {"path": ".", "pattern": "secret"}),
+            ("Grep", {"path": "raw", "pattern": "secret"}),
+            ("Grep", {"path": "raw/other.md", "pattern": "secret"}),
+        ):
+            deny = await scoped_guard({
+                "tool_name": tool_name, "tool_input": tool_input,
+            }, "s3", None)
+            assert deny["hookSpecificOutput"]["permissionDecision"] == "deny", deny
+        allow = await scoped_guard({
+            "tool_name": "Grep",
+            "tool_input": {"path": "raw/manual.pdf", "pattern": "needle"},
+        }, "s4", None)
+        assert allow == {}, allow
+        deny_all_raw = compile_box._make_compile_path_guard(
+            root, raw_read_allowlist=[])
+        deny = await deny_all_raw({
+            "tool_name": "Read", "tool_input": {"file_path": "raw/manual.pdf"},
+        }, "s5", None)
+        assert deny["hookSpecificOutput"]["permissionDecision"] == "deny", deny
+
         # The recommendation session is narrower than a compiler: only raw/
         # and candidate/ may inform the proposed test. Internal workflow,
         # evaluation and release artifacts remain invisible to the red team.
@@ -2292,7 +2332,8 @@ async def test_batch_orchestrator_routing_and_resume():
         # stub the session driver: record directives, pretend each session works
         driven: list[str] = []
 
-        async def fake_drive(run_, directive, label, pdf_page_ranges=None):
+        async def fake_drive(run_, directive, label, pdf_page_ranges=None,
+                             raw_read_allowlist=None):
             driven.append(label + "|" + directive.split("\n")[0])
             return f"done {label}"
 
@@ -2407,7 +2448,6 @@ def test_hierarchical_text_slice_materialization_and_directive():
         assert "本批绝不要直接打开原 Raw 全文" in directive, directive
         assert "compiled_from 必须引用原 Raw 路径(raw/gpu/manual.md)" in directive, directive
         assert "compiled_from 必须引用原 Raw 路径(.kbc-batch-slices" not in directive
-
         # A completed map batch is durable history, not a future model turn.
         # If its Raw source disappears before reduce/final resumes, rebuilding
         # its ephemeral slice would make the train fail forever even though the
@@ -2416,6 +2456,25 @@ def test_hierarchical_text_slice_materialization_and_directive():
         source.unlink()
         compile_box._materialize_batch_slices(run, {"batches": [batch]})
         assert not helper.exists()
+
+        assert compile_box._batch_raw_read_allowlist(batch) == []
+
+        regular = {
+            "sources": ["gpu/spec.md", "gpu/manual.pdf"],
+            "context_sources": ["gpu/anchor.md"],
+            "source_ranges": {
+                "gpu/spec.md": {
+                    "start_line": 1,
+                    "end_line": 2,
+                    "part": 1,
+                    "parts": 2,
+                    "slice_file": ".kbc-batch-slices/spec-p001.md",
+                }
+            },
+        }
+        assert compile_box._batch_raw_read_allowlist(regular) == [
+            "gpu/anchor.md", "gpu/manual.pdf",
+        ]
     print("\u2713 hierarchical text slices: bounded helper with original-Raw provenance")
 
 
@@ -2532,10 +2591,13 @@ async def test_hierarchical_batch_plan_and_section_reduce():
             run = compile_box.CompileRun("hier-run", str(wd), 1)
             driven: list[str] = []
             observed_idle_timeouts: list[float | None] = []
+            observed_raw_allowlists: list[tuple[str, list[str] | None]] = []
 
-            async def fake_drive(run_, directive, label, pdf_page_ranges=None):
+            async def fake_drive(run_, directive, label, pdf_page_ranges=None,
+                                 raw_read_allowlist=None):
                 driven.append(label + "|" + directive.splitlines()[0])
                 observed_idle_timeouts.append(run_._model_idle_timeout_s)
+                observed_raw_allowlists.append((label, raw_read_allowlist))
                 if label.startswith("batch ") or label.startswith("批 "):
                     candidate = wd / "candidate"
                     candidate.mkdir(exist_ok=True)
@@ -2558,6 +2620,12 @@ async def test_hierarchical_batch_plan_and_section_reduce():
             assert sum(item.startswith("batch ") for item in driven) == 2, driven
             assert sum(item.startswith("section reduce ") for item in driven) == 1, driven
             assert driven[-1].startswith("final review"), driven
+            assert observed_raw_allowlists[:2] == [
+                ("batch 1/2", ["gpu/a.md"]),
+                ("batch 2/2", ["gpu/b.md"]),
+            ], observed_raw_allowlists
+            assert all(allowed == [] for label, allowed in observed_raw_allowlists[2:]
+                       if label.startswith(("section reduce ", "final review"))), observed_raw_allowlists
             assert set(observed_idle_timeouts) == {
                 max(compile_box._MODEL_IDLE_TIMEOUT_S, 123)
             }, observed_idle_timeouts
@@ -2664,7 +2732,8 @@ async def test_hierarchical_media_rechecks_after_ledger_repair():
             order: list[str] = []
             media_calls = 0
 
-            async def fake_drive(run_, directive, label, pdf_page_ranges=None):
+            async def fake_drive(run_, directive, label, pdf_page_ranges=None,
+                                 raw_read_allowlist=None):
                 order.append(f"drive:{label}")
                 if label == "final review":
                     assert "do not read raw/" in directive, directive
@@ -2767,7 +2836,8 @@ async def test_batch_orchestrator_review_fixes():
             run = compile_box.CompileRun("rf1", str(wd), 1)
             driven: list[str] = []
 
-            async def fake_drive(run_, directive, label, pdf_page_ranges=None):
+            async def fake_drive(run_, directive, label, pdf_page_ranges=None,
+                                 raw_read_allowlist=None):
                 driven.append(f"{label}|{directive}")
                 return f"done {label}"
 
@@ -2788,7 +2858,8 @@ async def test_batch_orchestrator_review_fixes():
             (wd / "raw" / "a" / "one.md").write_bytes(b"x" * 300)
             run = compile_box.CompileRun("rf2", str(wd), 1)
 
-            async def boom(run_, directive, label, pdf_page_ranges=None):
+            async def boom(run_, directive, label, pdf_page_ranges=None,
+                           raw_read_allowlist=None):
                 raise RuntimeError("session exploded")
 
             compile_box._drive_batch_session = boom
@@ -2805,7 +2876,8 @@ async def test_batch_orchestrator_review_fixes():
             run = compile_box.CompileRun("rf3", str(wd), 1)
             driven = []
 
-            async def drive_and_note(run_, directive, label, pdf_page_ranges=None):
+            async def drive_and_note(run_, directive, label, pdf_page_ranges=None,
+                                     raw_read_allowlist=None):
                 driven.append(f"{label}|{directive}")
                 if label == "final review":  # owner speaks while the tail is running
                     run_._batch_notes.append("附录不要发布")
@@ -2827,7 +2899,8 @@ async def test_batch_orchestrator_review_fixes():
             run.locale = "zh"
             driven = []
 
-            async def fake_zh(run_, directive, label, pdf_page_ranges=None):
+            async def fake_zh(run_, directive, label, pdf_page_ranges=None,
+                              raw_read_allowlist=None):
                 driven.append(f"{label}|{directive}")
                 return f"done {label}"
 

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -497,6 +497,34 @@ async def test_test_path_escape_guard():
         allow = await compile_guard({"tool_name": "Write", "tool_input": {"file_path": "candidate/a.md"}}, "c3", None)
         assert allow == {}, allow
 
+        # A PDF-slice map session may read its assigned Raw PDF only with the
+        # exact pages from the validated plan. The same guard leaves unrelated
+        # workspace reads alone.
+        pdf = root / "raw" / "manual.pdf"
+        pdf.touch()
+        pdf_guard = compile_box._make_compile_path_guard(
+            root,
+            pdf_page_ranges={
+                "manual.pdf": {"start_page": 21, "end_page": 40, "part": 2, "parts": 3}
+            },
+        )
+        allow = await pdf_guard({
+            "tool_name": "Read",
+            "tool_input": {"file_path": "raw/manual.pdf", "pages": "21-40"},
+        }, "p1", None)
+        assert allow == {}, allow
+        for tool_input in (
+            {"file_path": "raw/manual.pdf"},
+            {"file_path": str(pdf), "pages": "1-20"},
+        ):
+            deny = await pdf_guard({"tool_name": "Read", "tool_input": tool_input}, "p2", None)
+            assert deny["hookSpecificOutput"]["permissionDecision"] == "deny", deny
+        allow = await pdf_guard({
+            "tool_name": "Read",
+            "tool_input": {"file_path": "candidate/index.md"},
+        }, "p3", None)
+        assert allow == {}, allow
+
         # The recommendation session is narrower than a compiler: only raw/
         # and candidate/ may inform the proposed test. Internal workflow,
         # evaluation and release artifacts remain invisible to the red team.
@@ -2264,7 +2292,7 @@ async def test_batch_orchestrator_routing_and_resume():
         # stub the session driver: record directives, pretend each session works
         driven: list[str] = []
 
-        async def fake_drive(run_, directive, label):
+        async def fake_drive(run_, directive, label, pdf_page_ranges=None):
             driven.append(label + "|" + directive.split("\n")[0])
             return f"done {label}"
 
@@ -2408,6 +2436,35 @@ def test_hierarchical_resume_state_contract():
     print("\u2713 hierarchical resume: typed command covers map/reduce/final only")
 
 
+def test_hierarchical_pdf_page_directive():
+    """A PDF slice stays on its original Raw identity while the directive
+    requires the exact validated Read.pages range."""
+    batch = {
+        "id": "h042",
+        "sources": ["gpu/manual.pdf"],
+        "context_sources": [],
+        "source_page_ranges": {
+            "gpu/manual.pdf": {
+                "start_page": 41,
+                "end_page": 53,
+                "part": 3,
+                "parts": 3,
+            }
+        },
+        "defer_accounting": False,
+    }
+    directive = compile_box._compose_batch_directive(batch, 42, 50, "", "en")
+    assert "raw/gpu/manual.pdf (PDF pages 41-53, part 3/3)" in directive, directive
+    assert '`pages: "21-40"`' in directive, directive
+    assert "EXACT listed range" in directive, directive
+    assert "compiled_from must cite the original Raw PDF path (raw/gpu/manual.pdf)" in directive
+
+    directive_zh = compile_box._compose_batch_directive(batch, 42, 50, "", "zh-CN")
+    assert "Read 工具的 `pages` 参数必须严格等于清单页段" in directive_zh, directive_zh
+    assert "compiled_from 必须引用原 Raw PDF 路径(raw/gpu/manual.pdf)" in directive_zh
+    print("\u2713 hierarchical PDF slices: exact Read.pages directive and Raw provenance")
+
+
 async def test_hierarchical_batch_plan_and_section_reduce():
     """Only the second, very-large-corpus gate selects hierarchical planning.
     The map keeps anchor context explicit, section reduce runs after all maps,
@@ -2453,7 +2510,7 @@ async def test_hierarchical_batch_plan_and_section_reduce():
             driven: list[str] = []
             observed_idle_timeouts: list[float | None] = []
 
-            async def fake_drive(run_, directive, label):
+            async def fake_drive(run_, directive, label, pdf_page_ranges=None):
                 driven.append(label + "|" + directive.splitlines()[0])
                 observed_idle_timeouts.append(run_._model_idle_timeout_s)
                 if label.startswith("batch ") or label.startswith("批 "):
@@ -2584,7 +2641,7 @@ async def test_hierarchical_media_rechecks_after_ledger_repair():
             order: list[str] = []
             media_calls = 0
 
-            async def fake_drive(run_, directive, label):
+            async def fake_drive(run_, directive, label, pdf_page_ranges=None):
                 order.append(f"drive:{label}")
                 if label == "final review":
                     assert "do not read raw/" in directive, directive
@@ -2687,7 +2744,7 @@ async def test_batch_orchestrator_review_fixes():
             run = compile_box.CompileRun("rf1", str(wd), 1)
             driven: list[str] = []
 
-            async def fake_drive(run_, directive, label):
+            async def fake_drive(run_, directive, label, pdf_page_ranges=None):
                 driven.append(f"{label}|{directive}")
                 return f"done {label}"
 
@@ -2708,7 +2765,7 @@ async def test_batch_orchestrator_review_fixes():
             (wd / "raw" / "a" / "one.md").write_bytes(b"x" * 300)
             run = compile_box.CompileRun("rf2", str(wd), 1)
 
-            async def boom(run_, directive, label):
+            async def boom(run_, directive, label, pdf_page_ranges=None):
                 raise RuntimeError("session exploded")
 
             compile_box._drive_batch_session = boom
@@ -2725,7 +2782,7 @@ async def test_batch_orchestrator_review_fixes():
             run = compile_box.CompileRun("rf3", str(wd), 1)
             driven = []
 
-            async def drive_and_note(run_, directive, label):
+            async def drive_and_note(run_, directive, label, pdf_page_ranges=None):
                 driven.append(f"{label}|{directive}")
                 if label == "final review":  # owner speaks while the tail is running
                     run_._batch_notes.append("附录不要发布")
@@ -2747,7 +2804,7 @@ async def test_batch_orchestrator_review_fixes():
             run.locale = "zh"
             driven = []
 
-            async def fake_zh(run_, directive, label):
+            async def fake_zh(run_, directive, label, pdf_page_ranges=None):
                 driven.append(f"{label}|{directive}")
                 return f"done {label}"
 
@@ -3498,6 +3555,7 @@ async def main():
     await test_batch_orchestrator_routing_and_resume()
     test_hierarchical_text_slice_materialization_and_directive()
     test_hierarchical_resume_state_contract()
+    test_hierarchical_pdf_page_directive()
     await test_hierarchical_batch_plan_and_section_reduce()
     test_hierarchical_media_verify_round_limit()
     await test_hierarchical_media_rechecks_after_ledger_repair()


### PR DESCRIPTION
## Summary

- group exported `_attachments` originals and sidecars with their exact document family using directory + normalized full stem + extension; ambiguous identities remain independent
- obtain authoritative PDF page counts with Poppler while preserving the existing small/medium effective-size routing signal
- split oversized PDFs into validated contiguous ranges of at most 20 pages and enforce the assigned `Read.pages` range with a compile hook
- keep batch Raw scope mechanical on both engines: Claude uses its PreToolUse guard; Codex denies original Raw and copies only the allowed non-sliced sources into a per-session read-only view
- expose a page-sliced PDF to Codex only through a fixed-range `read_assigned_pdf_pages` Poppler tool, while keeping the original PDF hidden from shell/file tools
- remove each temporary Codex source view after the batch, including client-construction and turn failures
- install `poppler-utils` so Claude Code can render PDF pages and Codex can extract only its assigned PDF text range in the compile image

## Verification

- `python kbc/platform/pod/test_batching.py`
- `uv run --python 3.11 --with-requirements kbc/platform/pod/requirements.txt python kbc/platform/pod/test_compile_box.py`
- `uv run --python 3.11 --with-requirements kbc/platform/pod/requirements.txt python kbc/platform/pod/test_codex_engine.py`
- `test_office_ingest.py`, `test_selfcheck.py`, `test_redblue.py`, and `test_mtls_auth.py`
- GitHub KBC Box CI on Ubuntu 24.04 exercises real bubblewrap commands: the batch view is readable but not writable, and original Raw remains unreadable
- full unified-hardware Raw plan: 1,772 sources, 20/20 PDFs counted (517 pages), 304 hierarchical batches, 26 PDF slice batches, zero validation errors
- test image built as linux/amd64 and deployed by digest to `sicore-siflow-test`
- live Claude Code probe issued `Read` with `pages: "53-53"` against the 112-page ASUS GPU manual and recovered the independently verified DMLAN IP/mask, section heading, and TPM pin designation

## Integration

Rebased onto `main` after #422 merged. The conflict resolution preserves the merged Snapshot v2, Codex engine, phase-aware resume, and completed-batch slice behavior.
