### PR TITLE
fix(kbc): normalize unambiguous source citations

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1839,7 +1839,6 @@ async def _post_turn_selfcheck(run) -> str | None:
     # snapshot covers and the ledger/lint flags the rest. The early-returns
     # used to fire after the guard state was already consumed, letting an
     # index-deleting turn escape the byte freeze entirely (review finding).
-    run._selfcheck_key = key
     # Scoped-incremental byte-integrity guard: on an incremental turn, pages OUTSIDE
     # the authorized set (affected ∪ declared added-targets ∪ index) must be byte-
     # identical to their pre-turn state. Violations are RESTORED BY CODE first —
@@ -1851,6 +1850,7 @@ async def _post_turn_selfcheck(run) -> str | None:
     incr_violations: list[str] = []
     restored_pages: list[str] = []
     editable: set[str] = set()
+    after: dict[str, str] | None = None
     if incr:
         after = incremental.page_hashes(workdir)
         # repair_pages (set on re-arm): a ledger/lint repair turn legitimately
@@ -1866,7 +1866,28 @@ async def _post_turn_selfcheck(run) -> str | None:
             if restored_pages:
                 after = incremental.page_hashes(workdir)
                 incr_violations = incremental.integrity_violations(incr["before"], after, editable)
+    # Mechanical provenance repair belongs before Layer-1 and before the model
+    # repair budget. It is deliberately scoped to pages already editable in an
+    # incremental turn; ordinary guarded owner edits are limited to pages that
+    # actually changed, so this cannot become an implicit whole-library rewrite.
+    mechanical_allowed: set[str] | None = None
+    if incr:
+        mechanical_allowed = editable
+    elif turn_format_guard:
+        current = incremental.page_hashes(workdir)
+        mechanical_allowed = set(incremental.changed_pages(
+            turn_format_guard.get("before") or {}, current))
+    mechanical_fixes = selfcheck.normalize_body_source_annotations(
+        workdir, allowed_pages=mechanical_allowed)
+    if mechanical_fixes:
+        after = incremental.page_hashes(workdir)
+        key = selfcheck.state_key(workdir)
+    run._selfcheck_key = key
     report = selfcheck.run_layer1(workdir)
+    report["mechanical_fixes"] = {
+        "count": len(mechanical_fixes),
+        "items": mechanical_fixes[:40],
+    }
     grandfathered_format: list[dict] = []
     if incr:
         format_changed_pages = set(incremental.changed_pages(incr["before"], after))
@@ -1923,6 +1944,10 @@ async def _post_turn_selfcheck(run) -> str | None:
         await run.emit({"type": "summary", "text": _loc(run,
             f"[Incremental guard] {len(restored_pages)} out-of-scope page(s) auto-restored byte-exact: {shown}",
             f"【增量护栏】{len(restored_pages)} 页越界改动已自动按字节还原:{shown}")})
+    if mechanical_fixes:
+        await run.emit({"type": "summary", "text": _loc(run,
+            f"Self-check normalized {len(mechanical_fixes)} unambiguous source citation(s) without using a repair round.",
+            f"自检已机械规范化 {len(mechanical_fixes)} 处可唯一判定的来源标注,未消耗回修轮次。")})
     await run.emit({"type": "summary", "text": selfcheck.narration(report, locale)})
     if report["state"] == "unconverged":
         # Budget spent with residuals → land a ticket in the owner's question

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -691,6 +691,13 @@ def normalize_body_source_annotations(
             found, malformed = _body_source_references(f"(source: {payload})")
             if found or len(malformed) != 1:
                 continue
+            if malformed[0] != payload.strip(" \t\r\n,，;；、"):
+                # The ASCII-wrapped re-parse closed before the span's true end
+                # (e.g. an unbalanced ")" inside a full-width marker), so the
+                # parsed item covers only a prefix of the span. Rewriting the
+                # whole span would silently drop the tail — leave it malformed
+                # for semantic repair instead.
+                continue
             label, locator = _split_trailing_locator(malformed[0])
             matches = aliases.get(_source_alias_key(label), set())
             if len(matches) != 1:

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -21,6 +21,7 @@ import json
 import os
 import posixpath
 import re
+import unicodedata
 import uuid
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -321,9 +322,20 @@ def _markdown_prose(md_text: str) -> str:
     the code constructs the compiler emits without adding another production
     markdown dependency.
     """
-    _, body, error = parse_okf_frontmatter(md_text)
-    if error and not md_text.startswith("---"):
-        body = md_text
+    # Mask valid frontmatter instead of dropping it. Keeping the returned text
+    # byte-for-byte aligned with ``md_text`` lets deterministic repair code use
+    # match offsets safely while preserving the existing rendered-prose lint
+    # semantics. Malformed/absent frontmatter remains prose, as before.
+    body_start = 0
+    lines = md_text.splitlines(keepends=True)
+    if lines and lines[0].strip() == "---":
+        offset = len(lines[0])
+        for line in lines[1:]:
+            offset += len(line)
+            if line.strip() in ("---", "..."):
+                body_start = offset
+                break
+    body = md_text[body_start:]
 
     # Fenced blocks: CommonMark allows up to three leading spaces and either a
     # backtick or tilde fence. A closing fence uses the same character and is at
@@ -381,7 +393,7 @@ def _markdown_prose(md_text: str) -> str:
             if chars[i] != "\n":
                 chars[i] = " "
         pos = found
-    return "".join(chars)
+    return _mask_span(md_text[:body_start]) + "".join(chars)
 
 
 def _okf_index_violations(rel: str, text: str, concept_pages: set[str]) -> list[dict]:
@@ -577,9 +589,9 @@ def _markdown_link_targets(text: str) -> list[str]:
     return targets
 
 
-def _body_source_payloads(text: str) -> list[str]:
-    """Extract source-marker payloads while preserving nested filename pairs."""
-    payloads: list[str] = []
+def _body_source_payload_spans(text: str) -> list[tuple[int, int, str]]:
+    """Extract source payloads and exact source-text offsets outside code."""
+    payloads: list[tuple[int, int, str]] = []
     prose = _markdown_prose(text)
     for match in _BODY_SOURCE_START_RE.finditer(prose):
         stack = [")" if match.group("open") == "(" else "）"]
@@ -591,9 +603,113 @@ def _body_source_payloads(text: str) -> list[str]:
             elif char == stack[-1]:
                 stack.pop()
                 if not stack:
-                    payloads.append(prose[match.end():pos])
+                    payloads.append((match.end(), pos, text[match.end():pos]))
                     break
     return payloads
+
+
+def _body_source_payloads(text: str) -> list[str]:
+    """Extract source-marker payloads while preserving nested filename pairs."""
+    return [payload for _, _, payload in _body_source_payload_spans(text)]
+
+
+_SOURCE_ALIAS_QUOTES = {
+    '"': '"', "'": "'", "`": "`", "“": "”", "‘": "’",
+}
+
+
+def _source_alias_key(value: str) -> str:
+    """Conservative comparison key for an incomplete body source label."""
+    value = unicodedata.normalize("NFC", value).strip()
+    while len(value) >= 2 and value[0] in _SOURCE_ALIAS_QUOTES:
+        if value[-1] != _SOURCE_ALIAS_QUOTES[value[0]]:
+            break
+        value = value[1:-1].strip()
+    return value.casefold()
+
+
+def _source_without_known_extension(value: str) -> str | None:
+    lower = value.casefold()
+    for ext in sorted(KNOWN_SOURCE_EXTS, key=len, reverse=True):
+        if lower.endswith(ext.casefold()):
+            return value[:-len(ext)]
+    return None
+
+
+def _source_aliases(source: str) -> set[str]:
+    """Exact aliases accepted for a source; no fuzzy title matching."""
+    aliases = {source, posixpath.basename(source)}
+    for value in tuple(aliases):
+        stem = _source_without_known_extension(value)
+        if stem:
+            aliases.add(stem)
+    return {key for value in aliases if (key := _source_alias_key(value))}
+
+
+def _split_trailing_locator(value: str) -> tuple[str, str]:
+    """Separate a supported trailing locator while retaining its whitespace."""
+    matches = list(_SOURCE_LOCATOR_PREFIX_RE.finditer(value))
+    if matches and matches[-1].end() == len(value):
+        match = matches[-1]
+        return value[:match.start()], value[match.start():]
+    return value, ""
+
+
+def normalize_body_source_annotations(
+    workdir: str,
+    allowed_pages: set[str] | None = None,
+) -> list[dict[str, str]]:
+    """Repair unambiguous missing-extension body citations without a model.
+
+    Only a single malformed payload that exactly matches one unique
+    ``compiled_from`` alias is rewritten. Mixed lists, arbitrary prose, and
+    duplicate stems remain lint failures for semantic repair. Code fences and
+    inline code are masked by ``_body_source_payload_spans``. When supplied,
+    ``allowed_pages`` keeps incremental byte-isolation intact.
+    """
+    candidate = Path(workdir) / "candidate"
+    fixes: list[dict[str, str]] = []
+    if not candidate.is_dir():
+        return fixes
+    for path in sorted(candidate.rglob("*.md")):
+        rel = path.relative_to(candidate).as_posix()
+        if allowed_pages is not None and rel not in allowed_pages:
+            continue
+        try:
+            text = path.read_bytes().decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        sources, _, _ = parse_compiled_from(text)
+        if not sources:
+            continue
+        aliases: dict[str, set[str]] = {}
+        for source in sources:
+            for alias in _source_aliases(source):
+                aliases.setdefault(alias, set()).add(source)
+        replacements: list[tuple[int, int, str, str]] = []
+        for start, end, payload in _body_source_payload_spans(text):
+            found, malformed = _body_source_references(f"(source: {payload})")
+            if found or len(malformed) != 1:
+                continue
+            label, locator = _split_trailing_locator(malformed[0])
+            matches = aliases.get(_source_alias_key(label), set())
+            if len(matches) != 1:
+                continue
+            source = next(iter(matches))
+            replacement = source + locator
+            if replacement == payload:
+                continue
+            replacements.append((start, end, payload, replacement))
+        if not replacements:
+            continue
+        updated = text
+        for start, end, before, after in reversed(replacements):
+            updated = updated[:start] + after + updated[end:]
+            fixes.append({"rule": "body_source_exact_alias", "page": rel,
+                          "from": before, "to": after})
+        _write_text_atomic(path, updated)
+    fixes.sort(key=lambda item: (item["page"], item["from"], item["to"]))
+    return fixes
 
 
 def _body_source_references(text: str) -> tuple[list[str], list[str]]:

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -1961,6 +1961,44 @@ async def test_unconverged_files_residual_ticket():
     print("OK  unconverged files a residual ticket (once, code-written, question queue)")
 
 
+async def test_exact_source_alias_is_repaired_before_l1_budget():
+    """Mechanical provenance repair settles without spending a model round."""
+    import json as _json
+
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        (wd / "raw" / "docs").mkdir(parents=True)
+        (wd / "candidate").mkdir()
+        (wd / "authoring").mkdir()
+        (wd / "raw" / "docs" / "专题目录.md").write_text("source")
+        (wd / "candidate" / "index.md").write_text(
+            "---\nokf_version: \"0.1\"\n---\n# Index\n- [Guide](guide.md)\n")
+        (wd / "candidate" / "guide.md").write_text(
+            "---\ntype: Guide\ntitle: Guide\ncompiled_from:\n"
+            "  - docs/专题目录.md\n---\n正文。(source: 专题目录)\n")
+        run = compile_box.CompileRun("mechanical-source", str(wd), 1)
+        run._selfcheck_key = None
+        run._l1_repairs_used = 0
+        run._full_compile_pending = True
+
+        repair = await compile_box._post_turn_selfcheck(run)
+
+        assert repair is None, repair
+        assert run._l1_repairs_used == 0
+        assert "(source: docs/专题目录.md)" in (
+            wd / "candidate" / "guide.md").read_text()
+        sc = _json.loads((wd / "authoring" / "SELFCHECK.json").read_text())
+        assert sc["state"] == "passed" and sc["lint"]["ok"], sc
+        assert sc["mechanical_fixes"]["count"] == 1, sc
+        events = []
+        while not run.events.empty():
+            events.append(run.events.get_nowait())
+        summaries = [event.get("text", "") for event in events
+                     if event.get("type") == "summary"]
+        assert any("without using a repair round" in text for text in summaries), summaries
+    print("OK  exact source alias auto-repairs before L1 model budget")
+
+
 async def test_incremental_grandfathers_untouched_format_debt():
     """An ordinary scoped edit must not turn a legacy page into a migration
     target merely because it was authorized. The same rule still blocks a new
@@ -3772,6 +3810,7 @@ async def main():
     await test_incremental_guard_rearms_on_ledger_repair()
     await test_incremental_violation_auto_restored()
     await test_unconverged_files_residual_ticket()
+    await test_exact_source_alias_is_repaired_before_l1_budget()
     await test_incremental_grandfathers_untouched_format_debt()
     await test_repair_turn_may_edit_ledger_target_pages()
     await test_incremental_index_deletion_cannot_escape_guard()

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -477,6 +477,20 @@ def test_deterministic_body_source_normalization():
         assert any(v["page"] == "ambiguous.md" and v["kind"] == "body_source_malformed"
                    for v in report["lint"]["violations"]), report["lint"]
 
+        # An unbalanced ASCII ")" inside a full-width marker makes the
+        # ASCII-wrapped re-parse close early; rewriting would silently drop
+        # the ")节选" tail. The span must stay put as a lint failure.
+        truncating = (
+            "---\ntype: Guide\ntitle: Truncating\ncompiled_from:\n"
+            "  - docs/报告.md\n---\n正文。（source: 报告)节选）\n"
+        )
+        _mk(base, "candidate/truncating.md", truncating)
+        assert selfcheck.normalize_body_source_annotations(
+            td, allowed_pages={"truncating.md"}) == []
+        assert (base / "candidate" / "truncating.md").read_text() == truncating
+        assert any(v["page"] == "truncating.md" and v["kind"] == "body_source_malformed"
+                   for v in selfcheck.run_layer1(td)["lint"]["violations"])
+
         scoped = (
             "---\ntype: Guide\ntitle: Scoped\ncompiled_from:\n"
             "  - docs/only-this.md\n---\n正文。(source: only-this)\n"
@@ -485,7 +499,7 @@ def test_deterministic_body_source_normalization():
         assert selfcheck.normalize_body_source_annotations(
             td, allowed_pages={"ambiguous.md"}) == []
         assert (base / "candidate" / "scoped.md").read_text() == scoped
-    print("OK  deterministic source normalization (unique / locator / code / ambiguous / idempotent)")
+    print("OK  deterministic source normalization (unique / locator / code / ambiguous / truncation-guard / idempotent)")
 
 
 def test_spaced_markdown_links():

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -429,6 +429,65 @@ def test_body_source_annotations():
     print("OK  body source annotations (spaces / combined / locator / unknown / missing extension)")
 
 
+def test_deterministic_body_source_normalization():
+    """Exact, unique aliases repair mechanically; ambiguity and code stay put."""
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _mk(base, "candidate/index.md", "---\nokf_version: \"0.1\"\n---\n# Index\n")
+        page = base / "candidate" / "guide.md"
+        original = (
+            "---\ntype: Guide\ntitle: Guide\ncompiled_from:\n"
+            "  - docs/专题目录.md\n---\n"
+            "正文。（source: “专题目录” 第3节）\n"
+            "```markdown\n(source: 专题目录)\n```\n"
+        )
+        _mk(base, "candidate/guide.md", original)
+
+        fixes = selfcheck.normalize_body_source_annotations(td)
+        assert fixes == [{
+            "rule": "body_source_exact_alias",
+            "page": "guide.md",
+            "from": "“专题目录” 第3节",
+            "to": "docs/专题目录.md 第3节",
+        }], fixes
+        updated = page.read_text()
+        assert "（source: docs/专题目录.md 第3节）" in updated, updated
+        assert "```markdown\n(source: 专题目录)\n```" in updated, updated
+        assert not any(v["kind"] == "body_source_malformed"
+                       for v in selfcheck.run_layer1(td)["lint"]["violations"])
+
+        # A second pass is byte-identical and emits no duplicate audit record.
+        stable = page.read_bytes()
+        assert selfcheck.normalize_body_source_annotations(td) == []
+        assert page.read_bytes() == stable
+
+        # Duplicate stems are genuinely ambiguous and must remain for semantic
+        # repair rather than silently choosing one source.
+        ambiguous = (
+            "---\ntype: Guide\ntitle: Ambiguous\ncompiled_from:\n"
+            "  - a/专题目录.md\n  - b/专题目录.pdf\n---\n"
+            "正文。(source: 专题目录)\n"
+        )
+        _mk(base, "candidate/ambiguous.md", ambiguous)
+        before = (base / "candidate" / "ambiguous.md").read_bytes()
+        assert selfcheck.normalize_body_source_annotations(
+            td, allowed_pages={"ambiguous.md"}) == []
+        assert (base / "candidate" / "ambiguous.md").read_bytes() == before
+        report = selfcheck.run_layer1(td)
+        assert any(v["page"] == "ambiguous.md" and v["kind"] == "body_source_malformed"
+                   for v in report["lint"]["violations"]), report["lint"]
+
+        scoped = (
+            "---\ntype: Guide\ntitle: Scoped\ncompiled_from:\n"
+            "  - docs/only-this.md\n---\n正文。(source: only-this)\n"
+        )
+        _mk(base, "candidate/scoped.md", scoped)
+        assert selfcheck.normalize_body_source_annotations(
+            td, allowed_pages={"ambiguous.md"}) == []
+        assert (base / "candidate" / "scoped.md").read_text() == scoped
+    print("OK  deterministic source normalization (unique / locator / code / ambiguous / idempotent)")
+
+
 def test_spaced_markdown_links():
     """Spaced page paths resolve in both CommonMark and URL-encoded forms."""
     with tempfile.TemporaryDirectory() as td:
@@ -1543,6 +1602,7 @@ def main():
     test_candidate_credential_lint()
     test_media_ledger_and_new_lint()
     test_body_source_annotations()
+    test_deterministic_body_source_normalization()
     test_spaced_markdown_links()
     test_media_verify_helpers()
     test_media_verify_content_identity_and_attempt_reset()


### PR DESCRIPTION
## Summary

- normalize a malformed body source marker when its label maps exactly and uniquely to one page-level `compiled_from` source
- preserve supported locators while leaving fenced/inline code, mixed payloads, and ambiguous duplicate stems unchanged
- run the mechanical repair before Layer-1 model repair, bounded by the active incremental page scope
- record applied changes in `SELFCHECK.json.mechanical_fixes`

## Why

A missing filename extension such as `(source: 专题目录)` is a deterministic formatting defect when the page already declares exactly one matching `compiled_from` source. Sending that defect through two model repair rounds and then asking the knowledge owner to accept or retry wastes model budget and exposes harness plumbing as a product decision.

## Safety

- exact alias matching only; no fuzzy title inference
- duplicate stems fail closed and remain lint findings
- clean pages are byte-identical
- incremental and guarded owner turns only normalize pages already in their editable or changed scope
- no prompt or dependency changes

## Validation

- `python kbc/platform/pod/test_selfcheck.py`
- `python kbc/platform/pod/test_incremental.py`
- `python kbc/platform/pod/test_compile_box.py`
- `git diff --check`
