### PR TITLE
fix(agentbox): distinguish probe failures from unreachable clusters

### DIFF
--- a/src/agentbox/credential-broker.test.ts
+++ b/src/agentbox/credential-broker.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { CredentialBroker } from "./credential-broker.js";
+import { CredentialBroker, classifyKubectlProbeError, withProbeTimeout } from "./credential-broker.js";
+import type { ProbeResult, ClusterLocalInfo } from "./credential-broker.js";
 import type {
   CredentialTransport,
   ClusterMeta,
@@ -524,37 +525,247 @@ describe("CredentialBroker — probeClusters batch", () => {
   // only the batch contract (order, per-item fold pass-through, concurrency
   // bound) rather than kubectl.
   it("preserves input order and folds each per-cluster result (batch never rejects)", async () => {
-    broker.probeCluster = (async (name: string) =>
+    broker.probeCluster = async (name: string): Promise<ProbeResult> =>
       name === "bad"
-        ? { name, reachable: false, probe_error: "boom" }
-        : { name, reachable: true, server_version: "v1.29.0" }) as any;
+        ? { name, probe_status: "unreachable", reachable: false, reason: "connection_refused", probe_error: "boom" }
+        : { name, probe_status: "success", reachable: true, server_version: "v1.29.0" };
 
     const results = await broker.probeClusters(["good1", "bad", "good2"]);
 
     expect(results.map((r) => r.name)).toEqual(["good1", "bad", "good2"]);
-    expect(results[1]).toEqual({ name: "bad", reachable: false, probe_error: "boom" });
-    expect(results[0].reachable).toBe(true);
-    expect(results[2].reachable).toBe(true);
+    expect(results[1]).toEqual({ name: "bad", probe_status: "unreachable", reachable: false, reason: "connection_refused", probe_error: "boom" });
+    expect(results[0].probe_status).toBe("success");
+    expect(results[2].probe_status).toBe("success");
   });
 
   it("bounds in-flight probes to the given concurrency", async () => {
     let active = 0;
     let maxActive = 0;
-    broker.probeCluster = ((name: string) => {
+    broker.probeCluster = (name: string): Promise<ProbeResult> => {
       active += 1;
       maxActive = Math.max(maxActive, active);
-      return new Promise((resolve) => {
+      return new Promise<ProbeResult>((resolve) => {
         setTimeout(() => {
           active -= 1;
-          resolve({ name, reachable: true });
+          resolve({ name, probe_status: "success", reachable: true, server_version: "unknown" });
         }, 5);
       });
-    }) as any;
+    };
 
     const names = ["a", "b", "c", "d", "e"];
     const results = await broker.probeClusters(names, { concurrency: 2 });
 
     expect(maxActive).toBe(2); // never more than the cap in flight at once
     expect(results.map((r) => r.name)).toEqual(names); // order still preserved
+  });
+
+  it("folds an acquire failure into probe_failed/credential (never a rejected batch)", async () => {
+    // FakeTransport.getClusterCredential throws when no payload is registered —
+    // i.e. the kubeconfig can't even be fetched. That is a local/credential
+    // problem, NOT a statement about the cluster.
+    transport.clusters = [{ name: "c1", is_production: true }];
+    await broker.refreshClusters();
+    const [result] = await broker.probeClusters(["c1"]);
+    expect(result.probe_status).toBe("probe_failed");
+    if (result.probe_status === "probe_failed") {
+      expect(result.reason).toBe("credential");
+      expect(result).not.toHaveProperty("reachable");
+    }
+  });
+});
+
+describe("classifyKubectlProbeError — evidence-based classification", () => {
+  // A killed child with a positive network error in stderr is a real network
+  // failure; without such evidence it is a local timeout of unknown reachability.
+  const killed = (message: string): Error =>
+    Object.assign(new Error(message), { killed: true });
+  const withCode = (message: string, code: string): Error =>
+    Object.assign(new Error(message), { code });
+
+  type Expectation = {
+    probe_status: ProbeResult["probe_status"];
+    reason?: string;
+    reachable?: true | false | "absent";
+  };
+
+  const cases: Array<{ desc: string; err: Error; stderr: string; expect: Expectation }> = [
+    {
+      desc: "ENOENT — kubectl binary missing",
+      err: withCode("spawn kubectl ENOENT", "ENOENT"),
+      stderr: "",
+      expect: { probe_status: "probe_failed", reason: "kubectl_missing", reachable: "absent" },
+    },
+    {
+      desc: "EACCES — kubectl not executable",
+      err: withCode("spawn kubectl EACCES", "EACCES"),
+      stderr: "",
+      expect: { probe_status: "probe_failed", reason: "kubectl_missing", reachable: "absent" },
+    },
+    {
+      desc: "localhost:8080 fallback — missing/empty kubeconfig",
+      err: new Error("exit 1"),
+      stderr: "The connection to the server localhost:8080 was refused - did you specify the right host or port?",
+      expect: { probe_status: "probe_failed", reason: "kubeconfig", reachable: "absent" },
+    },
+    {
+      desc: "no configuration provided — invalid kubeconfig",
+      err: new Error("exit 1"),
+      stderr: "error: no configuration has been provided, try setting KUBERNETES_MASTER environment variable",
+      expect: { probe_status: "probe_failed", reason: "kubeconfig", reachable: "absent" },
+    },
+    {
+      desc: "no context is currently set — kubeconfig",
+      err: new Error("exit 1"),
+      stderr: 'error: no context is currently set, use "kubectl config use-context <context>" to select a new one',
+      expect: { probe_status: "probe_failed", reason: "kubeconfig", reachable: "absent" },
+    },
+    {
+      desc: "hung exec credential plugin — kubeconfig (request never left the host)",
+      err: new Error("exit 1"),
+      stderr: "error: getting credentials: exec: executable aws-iam-authenticator not found",
+      expect: { probe_status: "probe_failed", reason: "kubeconfig", reachable: "absent" },
+    },
+    {
+      desc: "401 Unauthorized — auth, server answered so reachable:true",
+      err: new Error("exit 1"),
+      stderr: "error: You must be logged in to the server (Unauthorized)",
+      expect: { probe_status: "probe_failed", reason: "auth", reachable: true },
+    },
+    {
+      desc: "403 Forbidden — authz, server answered so reachable:true",
+      err: new Error("exit 1"),
+      stderr: 'Error from server (Forbidden): pods is forbidden: User "x" cannot list resource "pods"',
+      expect: { probe_status: "probe_failed", reason: "authz", reachable: true },
+    },
+    {
+      desc: "404 NotFound — endpoint answered but NOT proof of a healthy API (no reachable)",
+      err: new Error("exit 1"),
+      stderr: "Error from server (NotFound): the server could not find the requested resource",
+      expect: { probe_status: "probe_failed", reason: "endpoint", reachable: "absent" },
+    },
+    {
+      desc: "x509 — certificate validation failure, TLS not completed (no reachable)",
+      err: new Error("exit 1"),
+      stderr: "Unable to connect to the server: x509: certificate signed by unknown authority",
+      expect: { probe_status: "probe_failed", reason: "tls_cert", reachable: "absent" },
+    },
+    {
+      desc: "DNS — hostname did not resolve",
+      err: new Error("exit 1"),
+      stderr: 'Unable to connect to the server: dial tcp: lookup api.example.com on 10.0.0.1:53: no such host',
+      expect: { probe_status: "unreachable", reason: "dns", reachable: false },
+    },
+    {
+      desc: "connection refused — real API server host:port",
+      err: new Error("exit 1"),
+      stderr: "The connection to the server 10.0.0.5:6443 was refused - did you specify the right host or port?",
+      expect: { probe_status: "unreachable", reason: "connection_refused", reachable: false },
+    },
+    {
+      desc: "connection reset",
+      err: new Error("exit 1"),
+      stderr: "Unable to connect to the server: read tcp 10.0.0.9:443: connection reset by peer",
+      expect: { probe_status: "unreachable", reason: "connection_reset", reachable: false },
+    },
+    {
+      desc: "no route to host",
+      err: new Error("exit 1"),
+      stderr: "Unable to connect to the server: dial tcp 10.0.0.5:6443: connect: no route to host",
+      expect: { probe_status: "unreachable", reason: "network", reachable: false },
+    },
+    {
+      desc: "client-go request timeout — positive network-timeout evidence",
+      err: new Error("exit 1"),
+      stderr: "Unable to connect to the server: net/http: request canceled (Client.Timeout exceeded) i/o timeout",
+      expect: { probe_status: "unreachable", reason: "timeout", reachable: false },
+    },
+    {
+      desc: "child killed with client-go timeout evidence — evidence wins, unreachable",
+      err: killed("Command failed"),
+      stderr: "Unable to connect to the server: context deadline exceeded",
+      expect: { probe_status: "unreachable", reason: "timeout", reachable: false },
+    },
+    {
+      desc: "child killed WITHOUT network evidence — local timeout, reachability unknown",
+      err: killed("Command was killed with SIGTERM"),
+      stderr: "",
+      expect: { probe_status: "probe_failed", reason: "timeout", reachable: "absent" },
+    },
+    {
+      desc: "unrecognised stderr — unknown, no reachability claim",
+      err: new Error("exit 1"),
+      stderr: "error: some brand new kubectl failure we have never seen",
+      expect: { probe_status: "probe_failed", reason: "unknown", reachable: "absent" },
+    },
+  ];
+
+  for (const c of cases) {
+    it(c.desc, () => {
+      const r = classifyKubectlProbeError("c1", c.err, c.stderr);
+      expect(r.name).toBe("c1");
+      expect(r.probe_status).toBe(c.expect.probe_status);
+      if (c.expect.reason !== undefined && r.probe_status !== "success") {
+        expect(r.reason).toBe(c.expect.reason);
+      }
+      if (c.expect.reachable === "absent") {
+        expect(r).not.toHaveProperty("reachable");
+      } else if (c.expect.reachable !== undefined) {
+        expect((r as { reachable?: boolean }).reachable).toBe(c.expect.reachable);
+      }
+      // Every non-success result carries a non-empty probe_error.
+      if (r.probe_status !== "success") {
+        expect(typeof r.probe_error).toBe("string");
+        expect(r.probe_error.length).toBeGreaterThan(0);
+      }
+    });
+  }
+});
+
+describe("withProbeTimeout — aborts timed-out work before it reaches kubectl", () => {
+  it("resolves with probe_failed/timeout and never starts post-timeout work", async () => {
+    let startedWorkAfterTimeout = false;
+    const result = await withProbeTimeout(
+      "c1",
+      async (signal) => {
+        // Simulate a credential fetch that outlives the probe timeout.
+        await new Promise((r) => setTimeout(r, 40));
+        if (signal.aborted) {
+          // Correct: the guard prevents spawning kubectl after the timeout.
+          return { name: "c1", probe_status: "probe_failed", reason: "credential", probe_error: "aborted before kubectl" };
+        }
+        startedWorkAfterTimeout = true;
+        return { name: "c1", probe_status: "success", reachable: true, server_version: "v1" };
+      },
+      10,
+    );
+    expect(result.probe_status).toBe("probe_failed");
+    if (result.probe_status === "probe_failed") expect(result.reason).toBe("timeout");
+    // Let the late operation settle and confirm it took the aborted branch.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(startedWorkAfterTimeout).toBe(false);
+  });
+
+  it("returns the operation result verbatim when it finishes before the timeout", async () => {
+    const result = await withProbeTimeout(
+      "c1",
+      async () => ({ name: "c1", probe_status: "success", reachable: true, server_version: "v1.30.0" }),
+      1000,
+    );
+    expect(result).toEqual({ name: "c1", probe_status: "success", reachable: true, server_version: "v1.30.0" });
+  });
+
+  it("probeCluster does not run kubectl once the probe has timed out fetching credentials", async () => {
+    // ensureCluster resolves a (fake) path AFTER the probe timeout. If the guard
+    // is wired, probeKubeconfig is never called — so the reason stays `timeout`,
+    // NOT `kubectl_missing`/`unknown` (which is what a real kubectl spawn against
+    // a bogus path with no kubectl on PATH would produce).
+    broker.ensureCluster = (name: string): Promise<ClusterLocalInfo> =>
+      new Promise((res) =>
+        setTimeout(() => res({ meta: { name, is_production: false }, path: "/definitely/not/a/real/kubeconfig" }), 40),
+      );
+    const [result] = await broker.probeClusters(["c1"], { timeoutMs: 10 });
+    expect(result.probe_status).toBe("probe_failed");
+    if (result.probe_status === "probe_failed") expect(result.reason).toBe("timeout");
+    await new Promise((r) => setTimeout(r, 60)); // let the late ensureCluster settle
   });
 });

--- a/src/agentbox/credential-broker.ts
+++ b/src/agentbox/credential-broker.ts
@@ -71,12 +71,47 @@ export interface LocalInfo<TMeta extends { name: string }> {
 export type ClusterLocalInfo = LocalInfo<ClusterMeta>;
 export type HostLocalInfo = LocalInfo<HostMeta>;
 
-export interface ProbeResult {
-  name: string;
-  reachable: boolean;
-  server_version?: string;
-  probe_error?: string;
-}
+/**
+ * Why `unreachable` was concluded — the API server could not be contacted at the
+ * network layer. Every one of these is a statement ABOUT THE CLUSTER.
+ */
+export type UnreachableReason =
+  | "connection_refused" // TCP RST — nothing listening / firewalled at the API server host:port
+  | "dns"                // the API server hostname did not resolve
+  | "network"            // no route / network unreachable / generic transport failure
+  | "connection_reset"   // peer reset / EOF / broken pipe mid-request
+  | "timeout";           // i/o timeout / context deadline / TLS handshake timeout
+
+/**
+ * Why `probe_failed` was concluded. NONE of these say the cluster is down — they
+ * are LOCAL tooling, kubeconfig, credential, or auth/trust problems (or an
+ * operation timeout that never reached a verdict). Surfacing the specific reason
+ * stops a caller from reading "probe failed" as "cluster is unreachable".
+ */
+export type ProbeFailedReason =
+  | "kubectl_missing" // kubectl binary absent / not executable (local tooling)
+  | "kubeconfig"      // kubeconfig empty/invalid/no server/bad context/authinfo (local config)
+  | "credential"      // the kubeconfig could not even be acquired from the gateway
+  | "auth"            // API server ANSWERED and rejected the identity (401 Unauthorized)
+  | "authz"           // API server ANSWERED but RBAC denied the request (403 Forbidden)
+  | "endpoint"        // an HTTP endpoint answered 404 (NotFound) — proves SOMETHING replied,
+                      // but a wrong server URL or an intermediary can produce this too, so it
+                      // is NOT proof of a healthy Kubernetes API. Reachability stays unknown.
+  | "tls_cert"        // server reached at TCP but its certificate is untrusted/expired/mismatched
+  | "timeout"         // the probe operation itself did not return in time — verdict unknown
+  | "unknown";        // kubectl failed for a reason we cannot confidently attribute
+
+export type ProbeResult =
+  | { name: string; probe_status: "success"; reachable: true; server_version: string }
+  | { name: string; probe_status: "unreachable"; reachable: false; reason: UnreachableReason; probe_error: string }
+  // probe_failed carries reachable:true ONLY for auth (401) and authz (403) — the
+  // API server both ANSWERED and adjudicated the identity/RBAC, which is proof the
+  // cluster IS reachable; the problem is this side's credentials/RBAC, not a down
+  // cluster. Every other reason omits reachable: a local/config/timeout failure
+  // never established reachability; tls_cert reached TCP but not a full HTTP
+  // exchange; and a 404 (`endpoint`) only proves *an* HTTP responder answered,
+  // which a misrouted URL or intermediary can fake — not a healthy K8s API.
+  | { name: string; probe_status: "probe_failed"; reason: ProbeFailedReason; reachable?: true; probe_error: string };
 
 const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes (unused; payload carries ttl)
 void DEFAULT_TTL_MS;
@@ -447,42 +482,66 @@ export class CredentialBroker {
    * only on miss/expiry — a reachability check does not need FRESH credentials,
    * and reuse avoids a credential.get round-trip on every probe (also warming
    * the cache for the kubectl/script tools that follow). Any acquire failure
-   * (unbound, credential error) is folded into an unreachable result rather
-   * than thrown, so a batch probe never fails as a whole on one bad cluster.
+   * (unbound, credential error) is folded into probe_failed rather than thrown,
+   * so a batch probe never fails as a whole or misreports a local failure as a
+   * Kubernetes API reachability failure.
    */
-  async probeCluster(clusterName: string): Promise<ProbeResult> {
-    let info: ClusterLocalInfo;
-    try {
-      info = await this.ensureCluster(clusterName, "cluster_probe");
-    } catch (err) {
-      return {
-        name: clusterName,
-        reachable: false,
-        probe_error: err instanceof Error ? err.message : String(err),
-      };
-    }
-    if (!info?.path) {
-      return {
-        name: clusterName,
-        reachable: false,
-        probe_error: "kubeconfig path missing after acquire",
-      };
-    }
-    return probeKubeconfig(clusterName, info.path);
+  async probeCluster(clusterName: string, opts: { timeoutMs?: number } = {}): Promise<ProbeResult> {
+    // A probe is diagnostic work, not a general credential/tool request. Keep
+    // it bounded so a stalled Runtime/Portal RPC cannot make cluster_list look
+    // hung until the normal 30s RPC timeout expires. On timeout the signal is
+    // aborted; we check it before spawning kubectl so a slow credential fetch
+    // that outlives the timeout can NEVER continue into post-timeout kubectl work.
+    return withProbeTimeout(clusterName, async (signal) => {
+      let info: ClusterLocalInfo;
+      try {
+        info = await this.ensureCluster(clusterName, "cluster_probe");
+      } catch (err) {
+        return {
+          name: clusterName,
+          probe_status: "probe_failed",
+          reason: "credential",
+          probe_error: `could not acquire kubeconfig: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      // The credential fetch may have taken longer than the probe timeout. If we
+      // have already timed out, do NOT spawn kubectl — the caller was handed a
+      // timeout result and a late kubectl here would be unbounded work outside the
+      // concurrency limiter's slot.
+      if (signal.aborted) {
+        return {
+          name: clusterName,
+          probe_status: "probe_failed",
+          reason: "timeout",
+          probe_error: "probe timed out during credential acquisition; kubectl was not started",
+        };
+      }
+      if (!info?.path) {
+        return {
+          name: clusterName,
+          probe_status: "probe_failed",
+          reason: "credential",
+          probe_error: "kubeconfig path missing after acquire",
+        };
+      }
+      return probeKubeconfig(clusterName, info.path, signal);
+    }, opts.timeoutMs);
   }
 
   /**
    * Probe several clusters concurrently, bounded so an agent with many bound
    * clusters can't spawn an unbounded fan-out of kubectl processes. Each probe
-   * is independent — a per-cluster failure yields an unreachable ProbeResult in
-   * place, never a rejected batch. Results preserve input order.
+   * is independent — a per-cluster failure yields an unreachable or probe_failed
+   * result in place, never a rejected batch. Results preserve input order.
    */
   async probeClusters(
     clusterNames: string[],
-    opts: { concurrency?: number } = {},
+    opts: { concurrency?: number; timeoutMs?: number } = {},
   ): Promise<ProbeResult[]> {
     const limiter = new ConcurrencyLimiter(opts.concurrency ?? 8);
-    return Promise.all(clusterNames.map((name) => limiter.run(() => this.probeCluster(name))));
+    return Promise.all(
+      clusterNames.map((name) => limiter.run(() => this.probeCluster(name, { timeoutMs: opts.timeoutMs }))),
+    );
   }
 
   getClusterLocalInfo(clusterName: string): ClusterLocalInfo | undefined {
@@ -783,26 +842,233 @@ function reconstructClusterResponse(cached: ClusterLocalInfo): CredentialRespons
   };
 }
 
-function probeKubeconfig(name: string, kubeconfigPath: string): Promise<ProbeResult> {
+function probeErrorText(err: Error, stderr: string | Buffer): string {
+  // kubectl/client-go writes the useful API, TLS, auth, and kubeconfig errors to
+  // stderr. Keep the complete bounded message; selecting only one line loses the
+  // actual Kubernetes failure behind child_process's generic wrapper.
+  const kubeError = String(stderr).trim();
+  if (kubeError) return kubeError.slice(0, 2000);
+  const message = err.message.trim();
+  return (message || "kubectl probe failed").slice(0, 2000);
+}
+
+/**
+ * Map a failed `kubectl version` invocation to a three-state ProbeResult with a
+ * structured `reason`. The ORDER of the checks matters — several classes of
+ * failure share substrings, and getting the precedence wrong is exactly what
+ * makes a caller hallucinate a healthy cluster as "down" (or vice-versa):
+ *
+ *   1. spawn errors (ENOENT/EACCES)  → kubectl_missing   (local tooling)
+ *   2. localhost:8080 refusal        → kubeconfig        (client-go's no-config
+ *      fallback host — the REAL API server was never contacted, so this must be
+ *      caught BEFORE the generic "connection refused" network rule)
+ *   3. other kubeconfig/context errors → kubeconfig      (local config)
+ *   4. 401 Unauthorized              → auth (reachable)  (server adjudicated identity)
+ *   4b. 403 Forbidden                → authz (reachable) (server adjudicated RBAC)
+ *   4c. 404 NotFound                 → endpoint          (an HTTP responder answered,
+ *      but a wrong URL/intermediary can too — no reachability claim)
+ *   5. x509 / cert validation        → tls_cert          (TCP reached, TLS failed)
+ *   6. POSITIVE network-layer evidence → unreachable     (statement about cluster)
+ *   7. child killed, no such evidence  → timeout (probe_failed) — our execFile
+ *      timeout may have killed a hung LOCAL exec credential plugin before any
+ *      request left the machine, so reachability is unknown (NOT unreachable)
+ *   8. anything else                 → unknown           (report, don't guess)
+ */
+export function classifyKubectlProbeError(
+  name: string,
+  err: Error,
+  stderr: string | Buffer = "",
+): ProbeResult {
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === "ENOENT") {
+    return { name, probe_status: "probe_failed", reason: "kubectl_missing", probe_error: "kubectl executable not found on PATH — local tooling problem, says nothing about the cluster" };
+  }
+  if (code === "EACCES") {
+    return { name, probe_status: "probe_failed", reason: "kubectl_missing", probe_error: "kubectl exists but is not executable — local tooling problem, says nothing about the cluster" };
+  }
+
+  const probeError = probeErrorText(err, stderr);
+  const text = probeError.toLowerCase();
+
+  // (2)+(3) Local kubeconfig problems. localhost:8080 / 127.0.0.1:8080 is the
+  // client-go default when the kubeconfig has no usable server/context, so a
+  // refusal there is LOCAL — a real cluster shows its own host:port and falls
+  // through to the network rules below. Do NOT key on "did you specify the right
+  // host or port" — kubectl appends that to genuine refusals too.
+  if (
+    /localhost:8080|127\.0\.0\.1:8080/.test(text)
+    // kubeconfig / context / authinfo problems that never leave this machine.
+    // A local exec/authProvider credential plugin ("getting credentials: exec:
+    // <plugin> not found", "no auth provider found") fails BEFORE any request is
+    // sent, so it is a kubeconfig problem here — NOT proof the server answered.
+    || /no configuration has been provided|invalid configuration|error loading config|unable to (read|load).*config|missing or incomplete configuration|context ".*" does not exist|no such context|no context is currently set|current-context|no auth provider found|getting credentials|exec: executable .* (not found|failed)|exec plugin/.test(text)
+  ) {
+    return { name, probe_status: "probe_failed", reason: "kubeconfig", probe_error: probeError };
+  }
+
+  // (4) 401 Unauthorized: the API server ANSWERED and rejected the identity.
+  // The HTTP response is proof the cluster is reachable — reachable:true.
+  if (/unauthorized|must be logged in|asked for the client to provide credentials/.test(text)) {
+    return { name, probe_status: "probe_failed", reason: "auth", reachable: true, probe_error: probeError };
+  }
+
+  // (4b) 403 Forbidden from the server: TCP + TLS + HTTP all succeeded and the
+  // API server adjudicated RBAC. A proof-of-reachability response — reachable:true.
+  // Distinct from `auth` so callers can tell an identity (401) from an RBAC (403)
+  // denial. NotFound is deliberately NOT matched here (see 4c).
+  if (/error from server \(forbidden\)|is forbidden: user/.test(text)) {
+    return { name, probe_status: "probe_failed", reason: "authz", reachable: true, probe_error: probeError };
+  }
+
+  // (4c) 404 NotFound: an HTTP endpoint answered, but that is weaker evidence than
+  // a 401/403. A wrong server URL, a stale/misrouted context, or an intermediary
+  // (proxy/load balancer) can all return 404 without the Kubernetes API server
+  // ever adjudicating the request. Report it as an endpoint/config problem WITHOUT
+  // claiming the cluster is up — reachable is omitted.
+  if (/error from server \(notfound\)|the server could not find the requested resource/.test(text)) {
+    return { name, probe_status: "probe_failed", reason: "endpoint", probe_error: probeError };
+  }
+
+  // (5) TLS certificate validation: server reached at TCP but the TLS exchange
+  // failed (untrusted/expired/mismatched cert). A trust/config problem, not down.
+  // TLS never completed, so we do NOT claim reachable.
+  if (/x509|certificate signed by unknown authority|certificate has expired|certificate is valid for|failed to verify certificate|cannot validate certificate/.test(text)) {
+    return { name, probe_status: "probe_failed", reason: "tls_cert", probe_error: probeError };
+  }
+
+  // (6) Genuine network-layer unreachability — a statement about the cluster.
+  // These require POSITIVE evidence in stderr; a killed child alone is NOT enough
+  // (see (7)). client-go's own request/handshake timeout is such positive
+  // evidence, so it stays here — distinct from our local execFile kill.
+  if (/timed out|i\/o timeout|context deadline exceeded|tls handshake timeout|request timeout|deadline exceeded/.test(text)) {
+    return { name, probe_status: "unreachable", reachable: false, reason: "timeout", probe_error: probeError };
+  }
+  if (/no such host|server misbehaving|lookup .* on |name resolution|temporary failure in name resolution/.test(text)) {
+    return { name, probe_status: "unreachable", reachable: false, reason: "dns", probe_error: probeError };
+  }
+  // kubectl's own phrasing is "The connection to the server <host:port> was
+  // refused - did you specify the right host or port?" (client-go's ECONNREFUSED
+  // wrapper), which does NOT contain the substring "connection refused" — match
+  // it explicitly alongside the lower-level go phrasings. The localhost:8080
+  // variant of this message was already peeled off as `kubeconfig` above.
+  if (/connection refused|actively refused|the connection to the server .* was refused/.test(text)) {
+    return { name, probe_status: "unreachable", reachable: false, reason: "connection_refused", probe_error: probeError };
+  }
+  if (/connection reset|broken pipe|unexpected eof|\beof\b/.test(text)) {
+    return { name, probe_status: "unreachable", reachable: false, reason: "connection_reset", probe_error: probeError };
+  }
+  if (/network is unreachable|no route to host|host is unreachable|unable to connect to the server/.test(text)) {
+    return { name, probe_status: "unreachable", reachable: false, reason: "network", probe_error: probeError };
+  }
+
+  // (7) The child was killed (our execFile timeout fired) with NO network-layer
+  // evidence in stderr. The kill can also hit a hung LOCAL exec credential plugin
+  // that never sent a request, so we cannot say the API server was unreachable.
+  // Classify as a probe_failed/timeout with UNKNOWN reachability (reachable omitted)
+  // — never as `unreachable`, which would let a stuck local plugin masquerade as a
+  // down cluster.
+  const killed = (err as NodeJS.ErrnoException & { killed?: boolean }).killed === true;
+  if (killed) {
+    return {
+      name,
+      probe_status: "probe_failed",
+      reason: "timeout",
+      probe_error: `${probeError} (the local kubectl probe was killed by our timeout with no network-layer error — reachability unknown)`,
+    };
+  }
+
+  // (8) kubectl ran but failed for a reason we cannot confidently attribute to
+  // the cluster. Report stderr verbatim WITHOUT claiming unreachability.
+  return { name, probe_status: "probe_failed", reason: "unknown", probe_error: probeError };
+}
+
+export const PROBE_TOTAL_TIMEOUT_MS = 7_000;
+
+/**
+ * Bound `operation` to `timeoutMs`. On timeout we resolve promptly with a
+ * probe_failed/timeout result AND abort the shared AbortSignal handed to
+ * `operation`, so timed-out work cannot continue into kubectl: `operation`
+ * checks `signal.aborted` before spawning, and a kubectl child launched with
+ * this signal is killed when it fires. The aborted operation settles in the
+ * background and its late result is discarded (the guard below is idempotent).
+ *
+ * Because timed-out work is aborted rather than left running, releasing the
+ * concurrency-limiter slot early (in probeClusters) no longer leaks kubectl
+ * processes — the bounded fan-out holds.
+ *
+ * `timeoutMs` is injectable for tests; production callers use the default.
+ */
+export function withProbeTimeout(
+  name: string,
+  operation: (signal: AbortSignal) => Promise<ProbeResult>,
+  timeoutMs: number = PROBE_TOTAL_TIMEOUT_MS,
+): Promise<ProbeResult> {
   return new Promise((resolve) => {
+    const controller = new AbortController();
+    let settled = false;
+    const finish = (result: ProbeResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      controller.abort();
+      finish({
+        name,
+        probe_status: "probe_failed",
+        reason: "timeout",
+        probe_error: `cluster probe timed out after ${timeoutMs}ms (credential fetch or kubectl probe did not return — cluster reachability unknown)`,
+      });
+    }, timeoutMs);
+    timer.unref?.();
+    operation(controller.signal).then(
+      (result) => finish(result),
+      (err: unknown) => {
+        // A rejection caused by our own abort is expected — the timeout result
+        // has already been delivered, so finish() is a no-op here.
+        finish({
+          name,
+          probe_status: "probe_failed",
+          reason: "unknown",
+          probe_error: err instanceof Error ? err.message : String(err),
+        });
+      },
+    );
+  });
+}
+
+function probeKubeconfig(name: string, kubeconfigPath: string, signal?: AbortSignal): Promise<ProbeResult> {
+  return new Promise((resolve) => {
+    // Guard: the probe may have already timed out while the kubeconfig was being
+    // fetched. Do not spawn kubectl after the abort.
+    if (signal?.aborted) {
+      resolve({
+        name,
+        probe_status: "probe_failed",
+        reason: "timeout",
+        probe_error: "probe timed out before kubectl was spawned; reachability unknown",
+      });
+      return;
+    }
     execFile(
       "kubectl",
       ["version", "--output=json", `--kubeconfig=${kubeconfigPath}`, "--request-timeout=3s"],
-      { timeout: 5000 },
-      (err, stdout) => {
+      // Pass the abort signal so a still-running kubectl is killed the moment the
+      // total-probe timeout fires (Node sends SIGTERM); `timeout` is the local
+      // per-invocation ceiling.
+      { timeout: 5000, signal },
+      (err, stdout, stderr) => {
         if (err) {
-          const msg = err.message?.includes("timed out")
-            ? "connection timeout"
-            : err.message?.split("\n")[0] ?? "unknown error";
-          resolve({ name, reachable: false, probe_error: msg });
+          resolve(classifyKubectlProbeError(name, err, stderr));
           return;
         }
         try {
           const info = JSON.parse(stdout);
           const ver = info.serverVersion?.gitVersion ?? "unknown";
-          resolve({ name, reachable: true, server_version: ver });
+          resolve({ name, probe_status: "success", reachable: true, server_version: ver });
         } catch {
-          resolve({ name, reachable: true, server_version: "unknown" });
+          resolve({ name, probe_status: "success", reachable: true, server_version: "unknown" });
         }
       },
     );

--- a/src/tools/query/cluster-list.test.ts
+++ b/src/tools/query/cluster-list.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { createClusterListTool } from "./cluster-list.js";
 import { CredentialBroker } from "../../agentbox/credential-broker.js";
+import type { ProbeResult } from "../../agentbox/credential-broker.js";
 import type {
   CredentialTransport,
   ClusterMeta,
@@ -137,37 +138,42 @@ describe("cluster_list tool — lazy fill", () => {
 });
 
 describe("cluster_list tool — opt-in probe flag", () => {
+  // The fixtures below are typed as ProbeResult (no `as any`), so any future
+  // change to the probe contract fails these mocks at compile time.
   it("without probe: no cluster contact, entries carry no reachability", async () => {
     transport.clusters = [{ name: "c1", is_production: true }];
     let probeCalls = 0;
-    broker.probeClusters = (async (names: string[]) => {
+    broker.probeClusters = async (names: string[]): Promise<ProbeResult[]> => {
       probeCalls += 1;
-      return names.map((name) => ({ name, reachable: true }));
-    }) as any;
+      return names.map((name) => ({ name, probe_status: "success", reachable: true, server_version: "unknown" }));
+    };
     const tool = createClusterListTool(ref);
     const result = await tool.execute("id", {});
     const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
     expect(probeCalls).toBe(0);
     expect(parsed.clusters[0]).not.toHaveProperty("reachable");
+    expect(parsed.clusters[0]).not.toHaveProperty("probe_status");
   });
 
-  it("probe:true folds reachable + server_version into each entry", async () => {
+  it("probe:true (success) folds probe_status + reachable + server_version into each entry", async () => {
     transport.clusters = [
       { name: "c1", is_production: true },
       { name: "c2", is_production: false },
     ];
     const probedNames: string[][] = [];
-    broker.probeClusters = (async (names: string[]) => {
+    broker.probeClusters = async (names: string[]): Promise<ProbeResult[]> => {
       probedNames.push([...names]);
-      return names.map((name) => ({ name, reachable: true, server_version: "v1.29.0" }));
-    }) as any;
+      return names.map((name) => ({ name, probe_status: "success", reachable: true, server_version: "v1.29.0" }));
+    };
     const tool = createClusterListTool(ref);
     const result = await tool.execute("id", { probe: true });
     const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
     expect(probedNames).toEqual([["c1", "c2"]]);
     for (const c of parsed.clusters) {
+      expect(c.probe_status).toBe("success");
       expect(c.reachable).toBe(true);
       expect(c.server_version).toBe("v1.29.0");
+      expect(c).not.toHaveProperty("probe_reason");
     }
   });
 
@@ -178,24 +184,53 @@ describe("cluster_list tool — opt-in probe flag", () => {
       { name: "dev-c", is_production: false },
     ];
     let probedWith: string[] = [];
-    broker.probeClusters = (async (names: string[]) => {
+    broker.probeClusters = async (names: string[]): Promise<ProbeResult[]> => {
       probedWith = [...names];
-      return names.map((name) => ({ name, reachable: true }));
-    }) as any;
+      return names.map((name) => ({ name, probe_status: "success", reachable: true, server_version: "unknown" }));
+    };
     const tool = createClusterListTool(ref);
     await tool.execute("id", { name: "prod", probe: true });
     expect(probedWith.sort()).toEqual(["prod-a", "prod-b"]);
   });
 
-  it("unreachable probe surfaces reachable:false + probe_error, no server_version", async () => {
+  it("unreachable probe surfaces reachable:false + probe_reason + probe_error, no server_version", async () => {
     transport.clusters = [{ name: "c1", is_production: true }];
-    broker.probeClusters = (async (names: string[]) =>
-      names.map((name) => ({ name, reachable: false, probe_error: "connection timeout" }))) as any;
+    broker.probeClusters = async (names: string[]): Promise<ProbeResult[]> =>
+      names.map((name) => ({ name, probe_status: "unreachable", reachable: false, reason: "timeout", probe_error: "i/o timeout" }));
     const tool = createClusterListTool(ref);
     const result = await tool.execute("id", { probe: true });
     const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
+    expect(parsed.clusters[0].probe_status).toBe("unreachable");
+    expect(parsed.clusters[0].probe_reason).toBe("timeout");
     expect(parsed.clusters[0].reachable).toBe(false);
-    expect(parsed.clusters[0].probe_error).toBe("connection timeout");
+    expect(parsed.clusters[0].probe_error).toBe("i/o timeout");
+    expect(parsed.clusters[0]).not.toHaveProperty("server_version");
+  });
+
+  it("probe_failed surfaces probe_reason + error WITHOUT claiming the cluster is unreachable", async () => {
+    transport.clusters = [{ name: "c1", is_production: false }];
+    broker.probeClusters = async (names: string[]): Promise<ProbeResult[]> =>
+      names.map((name) => ({ name, probe_status: "probe_failed", reason: "kubeconfig", probe_error: "no configuration has been provided" }));
+    const tool = createClusterListTool(ref);
+    const result = await tool.execute("id", { probe: true });
+    const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
+    expect(parsed.clusters[0].probe_status).toBe("probe_failed");
+    expect(parsed.clusters[0].probe_reason).toBe("kubeconfig");
+    expect(parsed.clusters[0].probe_error).toBe("no configuration has been provided");
+    expect(parsed.clusters[0]).not.toHaveProperty("reachable");
+    expect(parsed.clusters[0]).not.toHaveProperty("server_version");
+  });
+
+  it("probe_failed/auth carries reachable:true (401 proves the API server answered — cluster is up)", async () => {
+    transport.clusters = [{ name: "c1", is_production: true }];
+    broker.probeClusters = async (names: string[]): Promise<ProbeResult[]> =>
+      names.map((name) => ({ name, probe_status: "probe_failed", reason: "auth", reachable: true, probe_error: "Unauthorized" }));
+    const tool = createClusterListTool(ref);
+    const result = await tool.execute("id", { probe: true });
+    const parsed = JSON.parse((result.content[0] as any).text.split("\n\n")[0]);
+    expect(parsed.clusters[0].probe_status).toBe("probe_failed");
+    expect(parsed.clusters[0].probe_reason).toBe("auth");
+    expect(parsed.clusters[0].reachable).toBe(true);
     expect(parsed.clusters[0]).not.toHaveProperty("server_version");
   });
 });

--- a/src/tools/query/cluster-list.ts
+++ b/src/tools/query/cluster-list.ts
@@ -5,6 +5,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { renderTextResult } from "../infra/tool-render.js";
 import { flattenClusterMeta } from "./cluster-meta.js";
 import type { KubeconfigRef } from "../../core/types.js";
+import type { ProbeResult } from "../../agentbox/credential-broker.js";
 
 /**
  * cluster_list — list and search the clusters bound to the current agent.
@@ -18,9 +19,23 @@ import type { KubeconfigRef } from "../../core/types.js";
  *
  * Connectivity is NOT tested by default (metadata is a cheap cached read that
  * touches no cluster). Pass `probe:true` to additionally run `kubectl version`
- * against every returned cluster in parallel and fold reachability into each
- * entry — use this only when reachability is actually the question, since the
- * first real kubectl/script command already surfaces an unreachable cluster.
+ * against every returned cluster in parallel and fold a three-state result into
+ * each entry: success, unreachable, or probe_failed. Each non-success entry also
+ * carries a structured `probe_reason` so the caller never has to infer intent
+ * from raw kubectl prose:
+ *   - `unreachable` (reason connection_refused/dns/network/connection_reset/
+ *     timeout) is the ONLY state that means the cluster's API server could not
+ *     be contacted — a statement about the cluster.
+ *   - `probe_failed` (reason kubectl_missing/kubeconfig/credential/auth/authz/
+ *     endpoint/tls_cert/timeout/unknown) is a LOCAL tooling, config, credential,
+ *     or trust problem (or an operation timeout). It says NOTHING about the
+ *     cluster being up — do not report the cluster as down on a probe_failed
+ *     result. Two reasons are special: `auth` (401) and `authz` (403) mean the API
+ *     server actually ANSWERED and adjudicated the identity/RBAC, so those entries
+ *     additionally carry `reachable:true` — the cluster is up and the fix is this
+ *     side's credentials/RBAC. A 404 is reported as `endpoint` WITHOUT
+ *     `reachable:true`: an HTTP responder answered, but a wrong URL or intermediary
+ *     can produce that without the real API server, so it is not proof of health.
  */
 export function createClusterListTool(kubeconfigRef: KubeconfigRef): ToolDefinition {
   return {
@@ -41,14 +56,27 @@ CNI plugin, node model, storage backend), given as key→value pairs.
 Pass \`name\` to narrow the list to clusters whose NAME contains that substring
 (case-insensitive). By default this does NOT test connectivity; pass
 \`probe:true\` to also run \`kubectl version\` against each returned cluster and
-add \`reachable\` (plus \`server_version\`/\`probe_error\`) to every entry — reach
-for it only when reachability is the question, as the first real kubectl/script
+add \`probe_status\` (\`success\`/\`unreachable\`/\`probe_failed\`) plus, on any
+non-success entry, a structured \`probe_reason\`.
+ONLY \`unreachable\` (reason connection_refused/dns/network/connection_reset/
+timeout) means the cluster's API server could not be reached. \`probe_failed\`
+(reason kubectl_missing/kubeconfig/credential/auth/authz/endpoint/tls_cert/timeout/
+unknown) is a LOCAL tooling, kubeconfig, credential, or certificate/trust problem
+on THIS side — it says nothing about whether the cluster is up, so never report the
+cluster as down or unreachable on a probe_failed result; surface the local/config
+issue instead. Exception: reason \`auth\` (401) and \`authz\` (403) mean the API
+server answered and adjudicated the request, so those entries carry
+\`reachable:true\` — the cluster is up and the problem is this side's credentials/
+RBAC. A 404 is reported as \`endpoint\` WITHOUT \`reachable\` (an HTTP responder
+answered, but a wrong URL/intermediary can fake that). \`reachable\` is otherwise
+omitted for \`probe_failed\`. Reach for
+\`probe\` only when reachability is the question, as the first real kubectl/script
 command already reveals an unreachable cluster. Call it before any kubectl/script
 work to discover the available clusters; when several remain, ask the user which
 to use rather than guessing.`,
     parameters: Type.Object({
       name: Type.Optional(Type.String({ description: "Narrow to clusters whose name contains this substring (case-insensitive). Omit to list all bound clusters." })),
-      probe: Type.Optional(Type.Boolean({ description: "When true, actively test connectivity to each returned cluster (kubectl version, in parallel) and include reachable/server_version/probe_error per entry. Default false: metadata only, no cluster contact." })),
+      probe: Type.Optional(Type.Boolean({ description: "When true, run kubectl version for each cluster and include probe_status + probe_reason. Only probe_status=unreachable means the cluster's API server couldn't be reached; probe_status=probe_failed (reason kubectl_missing/kubeconfig/credential/auth/authz/endpoint/tls_cert/timeout/unknown) is a local tooling/config/credential/trust issue and does NOT mean the cluster is down. reachable is included for success (true), unreachable (false), and auth/authz probe_failed (true — a 401/403 means the server answered, so the cluster is up); omitted for other probe_failed reasons including endpoint (404) and tls_cert." })),
     }),
     async execute(_toolCallId, rawParams) {
       const params = rawParams as { name?: string; probe?: boolean };
@@ -84,8 +112,8 @@ to use rather than guessing.`,
 
       // Opt-in connectivity: probe only the clusters we're about to return,
       // in parallel (bounded in the broker). A probe failure lands as an
-      // unreachable entry, never an error for the whole call.
-      let probeByName: Map<string, { reachable: boolean; server_version?: string; probe_error?: string }> | undefined;
+      // per-entry status, never an error for the whole call.
+      let probeByName: Map<string, ProbeResult> | undefined;
       if (params.probe && metas.length > 0) {
         const results = await broker.probeClusters(metas.map((meta) => meta.name));
         probeByName = new Map(results.map((r) => [r.name, r] as const));
@@ -103,9 +131,14 @@ to use rather than guessing.`,
           ...flattenClusterMeta(meta.meta),
           ...(probe
             ? {
-                reachable: probe.reachable,
-                ...(probe.server_version ? { server_version: probe.server_version } : {}),
-                ...(probe.probe_error ? { probe_error: probe.probe_error } : {}),
+                probe_status: probe.probe_status,
+                ...(probe.probe_status !== "success" ? { probe_reason: probe.reason } : {}),
+                // reachable is present for success (true), unreachable (false),
+                // and auth/authz probe_failed (true — the server answered). It is
+                // omitted for every other probe_failed reason (reachability unknown).
+                ...(probe.reachable !== undefined ? { reachable: probe.reachable } : {}),
+                ...(probe.probe_status === "success" ? { server_version: probe.server_version } : {}),
+                ...(probe.probe_status !== "success" ? { probe_error: probe.probe_error } : {}),
               }
             : {}),
         };


### PR DESCRIPTION
## Summary

The `cluster_list` probe collapsed every kubectl failure into `reachable: false`, so a local kubeconfig/credential/tooling problem read as "cluster down" and invited the model to hallucinate an outage. This replaces that boolean with a conservative, evidence-based contract.

### Problem

`kubectl` being unusable is not the same as the cluster being unreachable. The old probe returned `{ reachable: false }` for missing kubeconfig, bad context, expired cert, 401/403, and genuine network failures alike — the model could not tell "fix your config" from "the cluster is down".

### Solution

Three-state result with a structured `reason`, so the caller reads a stable label instead of parsing kubectl prose:

- **`unreachable`** (connection_refused / dns / network / connection_reset / timeout) — the only state that means the API server couldn't be reached. Requires **positive network-layer evidence**.
- **`probe_failed`** (kubectl_missing / kubeconfig / credential / auth / authz / endpoint / tls_cert / timeout / unknown) — local tooling/config/credential/trust, says nothing about cluster health.

Evidence boundary tightened per review:

- A child process killed by our own `execFile` timeout with **no** network evidence is `probe_failed/timeout` (reachability unknown), **not** `unreachable` — it may have killed a hung local exec credential plugin.
- **401 → `auth`** and **403 → `authz`** carry `reachable: true` (the API server adjudicated the request). **404 → `endpoint`** does **not** claim reachability — a wrong URL or intermediary can answer 404 without the real API server.
- The probe timeout now **aborts its own work** (AbortSignal → guard before `kubectl` spawn + kill a running child), so a slow credential fetch can't continue into `kubectl` after `cluster_list` has already returned.

Also fixes a latent bug: kubectl's real refusal message is `The connection to the server <host> was refused`, which the classifier's `connection refused` regex never matched.

The `.gitignore` block that globally ignored `*.test.*` was reverted — tests are versioned project source.

## Test Plan

- [x] `npm test` — 227 files, 4511 passed / 2 skipped
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Table-driven `classifyKubectlProbeError()` tests: ENOENT/EACCES, localhost:8080 fallback, invalid/missing kubeconfig, no-context, hung exec plugin, 401, 403, 404, x509, DNS, refused, reset, no-route, client-go request timeout, killed-with-evidence vs killed-without-evidence, unknown — asserting `probe_status`, `reason`, and `reachable` presence.
- [x] Three-state `cluster_list` serialized-output tests (success / unreachable / probe_failed + auth-reachable), strongly typed fixtures (no `as any`).
- [x] Timeout test proving a late operation does not start post-timeout `kubectl` work.
