### PR TITLE
feat(gateway): persist prompt trace attribution

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -998,11 +998,16 @@ describe("http-server — steer / abort / clear-queue", () => {
   });
 
   it("POST /api/sessions/:id/steer calls brain.steer", async () => {
+    const s = await sm.getOrCreate("st2");
+    let finishPrompt!: () => void;
+    s.brain.prompt.mockImplementation(() => new Promise<void>((resolve) => { finishPrompt = resolve; }));
     await getJson(port, "/api/prompt", "POST", { text: "hi", sessionId: "st2" });
-    const s = sm.sessions.get("st2")!;
     const r = await getJson(port, "/api/sessions/st2/steer", "POST", { text: "stop" });
     expect(r.status).toBe(200);
+    expect(r.data.traceId).toMatch(/^[0-9a-f]{32}$/);
     expect(s.brain.steer).toHaveBeenCalledWith("stop");
+    finishPrompt();
+    await flushAsync();
   });
 
   it("POST /api/sessions/:id/steer forwards images to brain.steer", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -1212,13 +1212,17 @@ export function createHttpServer(
       ? body.text
       : defaultPromptTextForMedia(promptMedia);
     console.log(`[agentbox-http] Steering session ${sessionId}: ${steerText.slice(0, 80)}`);
+    // Capture before awaiting brain.steer(): the active prompt may finish and
+    // clear the recorder while the steer call is being accepted. A steer is an
+    // addition to that active prompt, so it inherits this existing trace.
+    const traceId = tracingRecorder.getRootTraceId(sessionId);
     try {
       if (promptMedia) {
         await managed.brain.steer(steerText, promptMedia);
       } else {
         await managed.brain.steer(steerText);
       }
-      sendJson(res, 200, { ok: true });
+      sendJson(res, 200, { ok: true, traceId });
     } catch (err) {
       console.error(`[agentbox-http] Steer error for session ${sessionId}:`, err);
       const message = err instanceof Error ? err.message : "Steer failed";

--- a/src/gateway/agentbox/client.test.ts
+++ b/src/gateway/agentbox/client.test.ts
@@ -92,7 +92,7 @@ describe("AgentBoxClient — prompt + session CRUD", () => {
         res.end(JSON.stringify({ ok: true }));
       } else if (req.method === "POST" && url === "/api/sessions/s1/steer") {
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: true }));
+        res.end(JSON.stringify({ ok: true, traceId: "0123456789abcdef0123456789abcdef" }));
       } else if (req.method === "POST" && url === "/api/sessions/s1/abort") {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ ok: true }));
@@ -166,7 +166,8 @@ describe("AgentBoxClient — prompt + session CRUD", () => {
   });
 
   it("steerSession() posts the text body", async () => {
-    await client.steerSession("s1", "stop the pod");
+    const result = await client.steerSession("s1", "stop the pod");
+    expect(result.traceId).toBe("0123456789abcdef0123456789abcdef");
     const req = srv.captures.find((c) => c.url === "/api/sessions/s1/steer")!;
     expect(req.method).toBe("POST");
     expect(JSON.parse(req.body)).toEqual({ text: "stop the pod" });

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -77,6 +77,12 @@ export interface PromptResponse {
   traceId?: string;
 }
 
+export interface SteerResponse {
+  ok: boolean;
+  /** Trace of the active prompt that accepted this additional user input. */
+  traceId?: string;
+}
+
 export interface SessionInfo {
   id: string;
   createdAt: string;
@@ -261,10 +267,10 @@ export class AgentBoxClient {
   /**
    * Send a steer instruction (inserts a user message after interrupting the current tool)
    */
-  async steerSession(sessionId: string, text: string, media?: PromptMediaOptions): Promise<void> {
+  async steerSession(sessionId: string, text: string, media?: PromptMediaOptions): Promise<SteerResponse> {
     const images = media?.images;
     const files = media?.files;
-    await this.fetch(`/api/sessions/${sessionId}/steer`, {
+    const resp = await this.fetch(`/api/sessions/${sessionId}/steer`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -273,6 +279,7 @@ export class AgentBoxClient {
         ...(files && files.length > 0 ? { files } : {}),
       }),
     });
+    return resp.json();
   }
 
   /**

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -38,9 +38,11 @@ vi.mock("../channel-manager.js", () => ({
 // collectResponse) assistant/tool rows for audit. Mock it to assert the writes.
 const ensureChatSessionMock = vi.fn();
 const appendMessageMock = vi.fn();
+const bindMessageTraceIdMock = vi.fn();
 vi.mock("../chat-repo.js", () => ({
   ensureChatSession: (...args: unknown[]) => ensureChatSessionMock(...args),
   appendMessage: (...args: unknown[]) => appendMessageMock(...args),
+  bindMessageTraceId: (...args: unknown[]) => bindMessageTraceIdMock(...args),
   incrementMessageCount: () => Promise.resolve(),
 }));
 
@@ -85,6 +87,7 @@ beforeEach(() => {
   ensureChatSessionMock.mockResolvedValue(undefined);
   appendMessageMock.mockReset();
   appendMessageMock.mockResolvedValue("msg-db-1");
+  bindMessageTraceIdMock.mockReset();
   resetConversationSessionsForTest();
   fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
   vi.stubGlobal("fetch", fetchMock);
@@ -302,7 +305,7 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
 
   it("audits the session: persists origin=channel + user/assistant/tool rows when the binding has an owner", async () => {
     resolveBindingMock.mockResolvedValue({ agentId: "agent-7", bindingId: "b1", createdBy: "owner-1" });
-    promptMock.mockResolvedValue({ sessionId: "remote-7" });
+    promptMock.mockResolvedValue({ sessionId: "remote-7", traceId: "0123456789abcdef0123456789abcdef" });
     streamEventsMock.mockImplementation(async function* () {
       yield { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods" } };
       yield { type: "tool_execution_end", toolName: "bash", result: { content: [{ type: "text", text: "pods ok" }], details: {} } };
@@ -327,6 +330,14 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
     expect(rows.filter((m) => m.role === "tool")).toHaveLength(1);
     expect(rows.find((m) => m.role === "tool")).toMatchObject({ toolName: "bash", outcome: "success" });
     expect(rows.find((m) => m.role === "assistant")?.content).toBe("done.");
+    expect(bindMessageTraceIdMock).toHaveBeenCalledWith(
+      "msg-db-1",
+      "remote-7",
+      "0123456789abcdef0123456789abcdef",
+    );
+    expect(rows.filter((message) => message.role !== "user").every(
+      (message) => message.traceId === "0123456789abcdef0123456789abcdef",
+    )).toBe(true);
   });
 
   it("does NOT persist when the binding has no owner (no false user_id)", async () => {

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
   appendMessageMock.mockReset();
   appendMessageMock.mockResolvedValue("msg-db-1");
   bindMessageTraceIdMock.mockReset();
+  bindMessageTraceIdMock.mockResolvedValue(undefined);
   resetConversationSessionsForTest();
   fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
   vi.stubGlobal("fetch", fetchMock);

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -39,7 +39,7 @@ import { resolveBinding, handlePairingCode, isChannelAccessDenied } from "../cha
 import { resolveAgentModelBinding, resolveAgentSystemPrompt } from "../agent-model-binding.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
-import { appendMessage, ensureChatSession } from "../chat-repo.js";
+import { appendMessage, bindMessageTraceId, ensureChatSession } from "../chat-repo.js";
 import { collectChannelResponse } from "./lark.js";
 import type { RenderedReplyImage } from "./visual-image.js";
 import { deliverImages } from "./dingtalk-image.js";
@@ -329,10 +329,11 @@ export async function handleDingTalkMessage(
   // id is the "same person" key for channel audit; it is stamped on the SESSION
   // (chat_sessions), never falls back to the binding owner. NULL when absent.
   const senderExternalId = message.senderStaffId ?? null;
+  let promptMessageId: string | null = null;
   if (auditable) {
     try {
       await ensureChatSession(sessionId, agentId, binding.createdBy!, text, text, "channel", undefined, { senderExternalId, channelId });
-      await appendMessage({
+      promptMessageId = await appendMessage({
         sessionId,
         role: "user",
         content: text,
@@ -359,11 +360,16 @@ export async function handleDingTalkMessage(
   let agentError: Error | null = null;
   try {
     const promptResult = await client.prompt(promptOpts);
+    if (promptMessageId) {
+      await bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
+        console.warn(`[dingtalk] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
+      });
+    }
     // Collect the reply with audit persistence (assistant + tool rows, when the
     // session row exists) AND image artifacts for channel delivery.
     const collected = await collectChannelResponse(client, promptResult.sessionId, "dingtalk", {
       includeImages: true,
-      persist: auditable ? { agentId, modelConfig: modelBinding?.modelConfig } : undefined,
+      persist: auditable ? { agentId, modelConfig: modelBinding?.modelConfig, traceId: promptResult.traceId } : undefined,
     });
     resultText = collected.text;
     replyImages = collected.images;

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -361,7 +361,7 @@ export async function handleDingTalkMessage(
   try {
     const promptResult = await client.prompt(promptOpts);
     if (promptMessageId) {
-      await bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
+      void bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
         console.warn(`[dingtalk] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
       });
     }

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -63,12 +63,14 @@ vi.mock("../agent-model-binding.js", () => ({
 
 const ensureChatSessionMock = vi.fn();
 const appendMessageMock = vi.fn();
+const bindMessageTraceIdMock = vi.fn();
 
 const recordChannelFeedbackMock = vi.fn();
 
 vi.mock("../chat-repo.js", () => ({
   ensureChatSession: (...args: unknown[]) => ensureChatSessionMock(...args),
   appendMessage: (...args: unknown[]) => appendMessageMock(...args),
+  bindMessageTraceId: (...args: unknown[]) => bindMessageTraceIdMock(...args),
   recordChannelFeedback: (...args: unknown[]) => recordChannelFeedbackMock(...args),
 }));
 
@@ -200,6 +202,7 @@ beforeEach(() => {
   resolveAgentModelBindingMock.mockReset();
   ensureChatSessionMock.mockReset();
   appendMessageMock.mockReset();
+  bindMessageTraceIdMock.mockReset();
   resolveAgentModelBindingMock.mockResolvedValue(null);
   ensureChatSessionMock.mockResolvedValue(undefined);
   appendMessageMock.mockResolvedValue("msg-db-1");
@@ -793,7 +796,10 @@ describe("handleLarkMessage — routing to AgentBox", () => {
 
   it("persists channel sessions/messages before prompting and wraps the current request", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
-    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    promptMock.mockResolvedValue({
+      sessionId: "session-fixed",
+      traceId: "0123456789abcdef0123456789abcdef",
+    });
     streamEventsMock.mockImplementation(async function* () { /* empty */ });
 
     await handleLarkMessage(
@@ -839,6 +845,11 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     });
     expect(promptMock.mock.calls[0][0].text).toContain("<channel-turn>");
     expect(promptMock.mock.calls[0][0].text).toContain("检查当前集群");
+    expect(bindMessageTraceIdMock).toHaveBeenCalledWith(
+      "msg-db-1",
+      "session-fixed",
+      "0123456789abcdef0123456789abcdef",
+    );
   });
 
   it("records the raw open_id as the channel sender even for a sicore_user session key", async () => {
@@ -2414,12 +2425,15 @@ describe("collectChannelResponse — audit persistence", () => {
       { type: "tool_execution_end", toolName: "bash", result: { content: [{ type: "text", text: "node ok" }], details: {} } },
       { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "All healthy." }] } },
     ];
-    const collected = await collectChannelResponse(fakeClient(events), "s-audit", "lark", { persist: { agentId: "a1" } });
+    const collected = await collectChannelResponse(fakeClient(events), "s-audit", "lark", {
+      persist: { agentId: "a1", traceId: "0123456789abcdef0123456789abcdef" },
+    });
     // Reply text is still the final assistant turn.
     expect(collected.text).toBe("All healthy.");
 
     const calls = appendMessageMock.mock.calls.map((c) => c[0] as any);
     expect(calls.filter((m) => m.role === "assistant").map((m) => m.content)).toEqual(["Checking nodes", "All healthy."]);
+    expect(calls.every((message) => message.traceId === "0123456789abcdef0123456789abcdef")).toBe(true);
     const toolRows = calls.filter((m) => m.role === "tool");
     expect(toolRows).toHaveLength(1);
     expect(toolRows[0]).toMatchObject({ sessionId: "s-audit", toolName: "bash", outcome: "success" });

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -203,6 +203,7 @@ beforeEach(() => {
   ensureChatSessionMock.mockReset();
   appendMessageMock.mockReset();
   bindMessageTraceIdMock.mockReset();
+  bindMessageTraceIdMock.mockResolvedValue(undefined);
   resolveAgentModelBindingMock.mockResolvedValue(null);
   ensureChatSessionMock.mockResolvedValue(undefined);
   appendMessageMock.mockResolvedValue("msg-db-1");

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -25,7 +25,7 @@ import {
 } from "../channel-manager.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
-import { appendMessage, ensureChatSession, recordChannelFeedback } from "../chat-repo.js";
+import { appendMessage, bindMessageTraceId, ensureChatSession, recordChannelFeedback } from "../chat-repo.js";
 import { buildRedactionConfigForModelConfig, redactText } from "../output-redactor.js";
 import { resolveAgentModelBinding } from "../agent-model-binding.js";
 import {
@@ -1111,9 +1111,10 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   // URL — see promptText below — so resolution is unaffected). Keeps DB rows /
   // session title free of plaintext Signature/AccessKeyId.
   const persistedText = redactImageUrlsInText(effectiveText);
+  let promptMessageId: string;
   try {
     await ensureChatSession(sessionId, agentId, binding.createdBy, persistedText, persistedText, "channel", undefined, { senderExternalId, channelId });
-    await appendMessage({
+    promptMessageId = await appendMessage({
       sessionId,
       role: "user",
       content: persistedText,
@@ -1260,6 +1261,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   try {
     // queue-until-idle: wait out a busy session instead of dumping a raw 409.
     const promptResult = await promptWithBusyRetry(client, promptOpts);
+    await bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
+      console.warn(`[lark] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
+    });
     const collected = await collectChannelResponse(client, promptResult.sessionId, "lark", {
       includeImages: true,
       onMilestone: addMilestone,
@@ -1267,7 +1271,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       // Audit: persist assistant + tool rows so the channel transcript matches
       // web/api/a2a (origin="channel" set on the session above). Tool output on
       // this stream is already sanitized at the agentbox boundary.
-      persist: { agentId, modelConfig: modelBinding?.modelConfig },
+      persist: { agentId, modelConfig: modelBinding?.modelConfig, traceId: promptResult.traceId },
     });
     resultText = collected.text;
     replyImages = collected.images;
@@ -1552,6 +1556,7 @@ export async function collectResponse(
 export interface ChannelPersistContext {
   agentId: string;
   modelConfig?: { apiKey?: string; baseUrl?: string };
+  traceId?: string;
 }
 
 export async function collectChannelResponse(
@@ -1585,7 +1590,7 @@ export async function collectChannelResponse(
   const pushQ = <T,>(m: Map<string, T[]>, k: string, v: T): void => { const a = m.get(k) ?? []; a.push(v); m.set(k, a); };
   const shiftQ = <T,>(m: Map<string, T[]>, k: string): T | undefined => m.get(k)?.shift();
   const persistRow = async (msg: Parameters<typeof appendMessage>[0]): Promise<void> => {
-    try { await appendMessage(msg); }
+    try { await appendMessage({ ...msg, traceId: persist?.traceId ?? msg.traceId }); }
     catch (err) { console.warn(`[${logPrefix}] audit persist failed session=${sessionId}:`, err); }
   };
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1261,7 +1261,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   try {
     // queue-until-idle: wait out a busy session instead of dumping a raw 409.
     const promptResult = await promptWithBusyRetry(client, promptOpts);
-    await bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
+    void bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
       console.warn(`[lark] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
     });
     const collected = await collectChannelResponse(client, promptResult.sessionId, "lark", {

--- a/src/gateway/chat-repo.test.ts
+++ b/src/gateway/chat-repo.test.ts
@@ -3,6 +3,7 @@ import {
   initChatRepo,
   ensureChatSession,
   appendMessage,
+  bindMessageTraceId,
   appendDelegationEvent,
   updateMessage,
   updateDelegationToolMessage,
@@ -185,6 +186,25 @@ describe("appendMessage", () => {
       delegation_id: "delegation-1",
       target_agent_id: "target-agent",
     });
+  });
+});
+
+describe("bindMessageTraceId", () => {
+  it("sends the exact message/session/trace binding", async () => {
+    await bindMessageTraceId("msg-1", "sid", "0123456789abcdef0123456789abcdef");
+    expect(fake.calls).toEqual([{
+      method: "chat.bindMessageTraceId",
+      params: {
+        id: "msg-1",
+        session_id: "sid",
+        trace_id: "0123456789abcdef0123456789abcdef",
+      },
+    }]);
+  });
+
+  it("is a no-op when a rolling-upgrade ACK has no trace id", async () => {
+    await bindMessageTraceId("msg-1", "sid", undefined);
+    expect(fake.calls).toHaveLength(0);
   });
 });
 

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -174,9 +174,11 @@ export async function appendMessage(msg: AppendMessageInput): Promise<string> {
 
 /**
  * Attach the AgentBox prompt trace to the exact user message that initiated it.
- * The Portal RPC enforces user-role, runtime ownership, and NULL-to-value
- * idempotency. Missing trace ids are tolerated for rolling upgrades where an
- * older AgentBox does not yet include traceId in its prompt/steer ACK.
+ * The Portal RPC enforces the exact message/session pair, user role, and
+ * NULL-to-value idempotency. SiCore additionally verifies Runtime ownership;
+ * standalone Portal uses its portal-secret-authenticated Runtime trust domain.
+ * Missing trace ids are tolerated for rolling upgrades where an older AgentBox
+ * does not yet include traceId in its prompt/steer ACK.
  */
 export async function bindMessageTraceId(
   messageId: string,

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -173,6 +173,25 @@ export async function appendMessage(msg: AppendMessageInput): Promise<string> {
 }
 
 /**
+ * Attach the AgentBox prompt trace to the exact user message that initiated it.
+ * The Portal RPC enforces user-role, runtime ownership, and NULL-to-value
+ * idempotency. Missing trace ids are tolerated for rolling upgrades where an
+ * older AgentBox does not yet include traceId in its prompt/steer ACK.
+ */
+export async function bindMessageTraceId(
+  messageId: string,
+  sessionId: string,
+  traceId?: string | null,
+): Promise<void> {
+  if (!traceId) return;
+  await getClient().request("chat.bindMessageTraceId", {
+    id: messageId,
+    session_id: sessionId,
+    trace_id: traceId,
+  });
+}
+
+/**
  * Record (or re-vote) end-user feedback on a channel reply. `messageRef` is a
  * channel-level reply reference (Feishu CardKit card_id), not a chat_messages
  * id — see the message_feedback DDL comment. One vote per (reply, person);

--- a/src/gateway/server-capability-command.test.ts
+++ b/src/gateway/server-capability-command.test.ts
@@ -13,6 +13,7 @@ const streamState = vi.hoisted(() => ({
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 vi.mock("./output-redactor.js", () => ({ buildRedactionConfigForModelConfig: vi.fn(() => ({})) }));

--- a/src/gateway/server-capability-command.test.ts
+++ b/src/gateway/server-capability-command.test.ts
@@ -14,6 +14,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 vi.mock("./output-redactor.js", () => ({ buildRedactionConfigForModelConfig: vi.fn(() => ({})) }));

--- a/src/gateway/server-capability-input-revision.test.ts
+++ b/src/gateway/server-capability-input-revision.test.ts
@@ -8,6 +8,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-capability-input-revision.test.ts
+++ b/src/gateway/server-capability-input-revision.test.ts
@@ -7,6 +7,7 @@ const boxPosts = vi.hoisted(() => [] as Array<{ path: string; body: unknown }>);
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-capability-message-id.test.ts
+++ b/src/gateway/server-capability-message-id.test.ts
@@ -8,6 +8,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-capability-message-id.test.ts
+++ b/src/gateway/server-capability-message-id.test.ts
@@ -7,6 +7,7 @@ const box = vi.hoisted(() => ({
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-capability-setup-failure.test.ts
+++ b/src/gateway/server-capability-setup-failure.test.ts
@@ -12,6 +12,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-capability-setup-failure.test.ts
+++ b/src/gateway/server-capability-setup-failure.test.ts
@@ -11,6 +11,7 @@ const postJsonMock = vi.hoisted(() => vi.fn());
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-capability-test-close.test.ts
+++ b/src/gateway/server-capability-test-close.test.ts
@@ -6,6 +6,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 vi.mock("./output-redactor.js", () => ({ buildRedactionConfigForModelConfig: vi.fn(() => ({})) }));

--- a/src/gateway/server-capability-test-close.test.ts
+++ b/src/gateway/server-capability-test-close.test.ts
@@ -5,6 +5,7 @@ const postJsonMock = vi.hoisted(() => vi.fn());
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 vi.mock("./output-redactor.js", () => ({ buildRedactionConfigForModelConfig: vi.fn(() => ({})) }));

--- a/src/gateway/server-capability-test-recommend.test.ts
+++ b/src/gateway/server-capability-test-recommend.test.ts
@@ -5,6 +5,7 @@ const posts = vi.hoisted(() => [] as Array<{ path: string; body: unknown; timeou
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 vi.mock("./output-redactor.js", () => ({ buildRedactionConfigForModelConfig: vi.fn(() => ({})) }));

--- a/src/gateway/server-capability-test-recommend.test.ts
+++ b/src/gateway/server-capability-test-recommend.test.ts
@@ -6,6 +6,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 vi.mock("./output-redactor.js", () => ({ buildRedactionConfigForModelConfig: vi.fn(() => ({})) }));

--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -12,9 +12,12 @@
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
 
+const bindMessageTraceIdMock = vi.hoisted(() => vi.fn(async () => {}));
+
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: bindMessageTraceIdMock,
   incrementMessageCount: vi.fn(async () => {}),
 }));
 
@@ -40,6 +43,7 @@ vi.mock("./sse-consumer.js", () => ({
 
 const abortSessionCalls: string[] = [];
 const promptCalls: unknown[] = [];
+let promptError: Error | undefined;
 vi.mock("./agentbox/client.js", () => ({
   AgentBoxClient: class {
     endpoint: string;
@@ -48,12 +52,13 @@ vi.mock("./agentbox/client.js", () => ({
     }
     prompt = vi.fn(async (opts: { sessionId: string }) => {
       promptCalls.push(opts);
-      return { sessionId: opts.sessionId };
+      if (promptError) throw promptError;
+      return { sessionId: opts.sessionId, traceId: "0123456789abcdef0123456789abcdef" };
     });
     abortSession = vi.fn(async (sessionId: string) => {
       abortSessionCalls.push(sessionId);
     });
-    steerSession = vi.fn(async () => {});
+    steerSession = vi.fn(async () => ({ ok: true, traceId: "fedcba9876543210fedcba9876543210" }));
     streamEvents = async function* () {};
   },
 }));
@@ -104,6 +109,7 @@ afterEach(async () => {
   capturedSignal = undefined;
   abortSessionCalls.length = 0;
   promptCalls.length = 0;
+  promptError = undefined;
   vi.clearAllMocks();
 });
 
@@ -120,6 +126,11 @@ describe("startRuntime — chat.abort wiring", () => {
     // The IIFE must reach consumeAgentSse (ensureChatSession → prompt → register).
     await waitFor(() => capturedSignal !== undefined);
     expect(capturedSignal!.aborted).toBe(false);
+    expect(bindMessageTraceIdMock).toHaveBeenCalledWith(
+      "msg-id",
+      "S",
+      "0123456789abcdef0123456789abcdef",
+    );
 
     const res = await abort({ agentId: "a", sessionId: "S" });
     expect(res).toMatchObject({ ok: true });
@@ -136,6 +147,34 @@ describe("startRuntime — chat.abort wiring", () => {
     await expect(abort({ agentId: "a", sessionId: "missing" })).resolves.toMatchObject({ ok: true });
     // The agentbox is still asked to stop even with no live gateway consumer.
     expect(abortSessionCalls).toEqual(["missing"]);
+  });
+
+  it("binds an explicit steer message to the active prompt trace", async () => {
+    server = await bootRuntime();
+    const steer = server.rpcMethods.get("chat.steer")!;
+
+    await expect(steer({ agentId: "a", sessionId: "S", text: "also check logs" })).resolves.toMatchObject({ ok: true });
+
+    expect(bindMessageTraceIdMock).toHaveBeenCalledWith(
+      "msg-id",
+      "S",
+      "fedcba9876543210fedcba9876543210",
+    );
+  });
+
+  it("binds a concurrent send to the active trace after the automatic steer", async () => {
+    promptError = new Error("Session is already running");
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+
+    await send({ agentId: "a", userId: "u", text: "one more detail", sessionId: "S" }, { sendEvent: vi.fn() });
+    await waitFor(() => bindMessageTraceIdMock.mock.calls.length > 0);
+
+    expect(bindMessageTraceIdMock).toHaveBeenCalledWith(
+      "msg-id",
+      "S",
+      "fedcba9876543210fedcba9876543210",
+    );
   });
 
   it("clears the registration after the turn settles (no leak / no stale abort)", async () => {

--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -13,11 +13,13 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 const bindMessageTraceIdMock = vi.hoisted(() => vi.fn(async () => {}));
+const updateMessageMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: bindMessageTraceIdMock,
+  updateMessage: updateMessageMock,
   incrementMessageCount: vi.fn(async () => {}),
 }));
 
@@ -162,7 +164,7 @@ describe("startRuntime — chat.abort wiring", () => {
     );
   });
 
-  it("binds a concurrent send to the active trace after the automatic steer", async () => {
+  it("marks and binds a concurrent send after the automatic steer", async () => {
     promptError = new Error("Session is already running");
     server = await bootRuntime();
     const send = server.rpcMethods.get("chat.send")!;
@@ -170,10 +172,19 @@ describe("startRuntime — chat.abort wiring", () => {
     await send({ agentId: "a", userId: "u", text: "one more detail", sessionId: "S" }, { sendEvent: vi.fn() });
     await waitFor(() => bindMessageTraceIdMock.mock.calls.length > 0);
 
+    expect(updateMessageMock).toHaveBeenCalledWith({
+      messageId: "msg-id",
+      sessionId: "S",
+      content: "one more detail",
+      metadata: { kind: "steer" },
+    });
     expect(bindMessageTraceIdMock).toHaveBeenCalledWith(
       "msg-id",
       "S",
       "fedcba9876543210fedcba9876543210",
+    );
+    expect(updateMessageMock.mock.invocationCallOrder[0]).toBeLessThan(
+      bindMessageTraceIdMock.mock.invocationCallOrder[0],
     );
   });
 

--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -116,6 +116,19 @@ afterEach(async () => {
 });
 
 describe("startRuntime — chat.abort wiring", () => {
+  it("starts consuming the reply without waiting for trace binding", async () => {
+    bindMessageTraceIdMock.mockImplementationOnce(() => new Promise<void>(() => {}));
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+    const abort = server.rpcMethods.get("chat.abort")!;
+
+    await send({ agentId: "a", userId: "u", text: "hi", sessionId: "S" }, { sendEvent: vi.fn() });
+    await waitFor(() => capturedSignal !== undefined);
+
+    expect(bindMessageTraceIdMock).toHaveBeenCalled();
+    await abort({ agentId: "a", sessionId: "S" });
+  });
+
   it("aborts the in-flight chat.send consumer signal AND the agentbox", async () => {
     server = await bootRuntime();
     const send = server.rpcMethods.get("chat.send")!;

--- a/src/gateway/server-session-status.test.ts
+++ b/src/gateway/server-session-status.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-session-status.test.ts
+++ b/src/gateway/server-session-status.test.ts
@@ -11,6 +11,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-tracing-reload.test.ts
+++ b/src/gateway/server-tracing-reload.test.ts
@@ -13,6 +13,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server-tracing-reload.test.ts
+++ b/src/gateway/server-tracing-reload.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -85,7 +85,7 @@ import {
 } from "./internal-api.js";
 import { handleDelegate, handleDelegates } from "./delegate-api.js";
 // siclaw-api.ts routes moved to Portal — Runtime no longer registers CRUD routes.
-import { appendMessage, incrementMessageCount, ensureChatSession } from "./chat-repo.js";
+import { appendMessage, bindMessageTraceId, incrementMessageCount, ensureChatSession } from "./chat-repo.js";
 import { consumeAgentSse } from "./sse-consumer.js";
 import { buildRedactionConfigForModelConfig } from "./output-redactor.js";
 import { MetricsAggregator } from "./metrics-aggregator.js";
@@ -316,7 +316,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         // could land. consumeAgentSse writes assistant/tool rows with FK
         // referencing chat_sessions, so the row has to exist first.
         await ensureChatSession(sessionId, agentId, userId, text, undefined, origin);
-        await appendMessage({ sessionId, role: "user", content: text });
+        const promptMessageId = await appendMessage({ sessionId, role: "user", content: text });
         await incrementMessageCount(sessionId);
 
         // Persistence is resolved by agentId in the manager's persistenceResolver
@@ -338,11 +338,18 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           // prompt will fire its own when it actually finishes, and an
           // extra one would close the frontend stream prematurely.
           if (err instanceof Error && err.message.includes("Session is already running")) {
-            await client.steerSession(sessionId, text, { images, files });
+            const steerResult = await client.steerSession(sessionId, text, { images, files });
+            await bindMessageTraceId(promptMessageId, sessionId, steerResult.traceId).catch((bindErr) => {
+              console.warn(`[runtime] failed to bind steer trace session=${sessionId} message=${promptMessageId}:`, bindErr);
+            });
             return;
           }
           throw err;
         }
+
+        await bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
+          console.warn(`[runtime] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
+        });
 
         const redactionConfig = buildRedactionConfigForModelConfig(modelConfig);
         const abortCtrl = new AbortController();
@@ -1004,12 +1011,15 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // = "steer" lets the frontend render it as a steer bubble, not a plain user
     // message. No ensureChatSession: a steer always targets an already-running
     // session, so the row exists and we must not clobber its title/preview.
-    await appendMessage({ sessionId, role: "user", content: text, metadata: { kind: "steer" } });
+    const steerMessageId = await appendMessage({ sessionId, role: "user", content: text, metadata: { kind: "steer" } });
     await incrementMessageCount(sessionId);
 
     const handle = await agentBoxManager.getOrCreate(agentId);
     const client = new AgentBoxClient(handle.endpoint, 10000, agentBoxTlsOptions);
-    await client.steerSession(sessionId, text, { images, files });
+    const steerResult = await client.steerSession(sessionId, text, { images, files });
+    await bindMessageTraceId(steerMessageId, sessionId, steerResult.traceId).catch((bindErr) => {
+      console.warn(`[runtime] failed to bind explicit steer trace session=${sessionId} message=${steerMessageId}:`, bindErr);
+    });
     return { ok: true };
   });
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -85,7 +85,7 @@ import {
 } from "./internal-api.js";
 import { handleDelegate, handleDelegates } from "./delegate-api.js";
 // siclaw-api.ts routes moved to Portal — Runtime no longer registers CRUD routes.
-import { appendMessage, bindMessageTraceId, incrementMessageCount, ensureChatSession } from "./chat-repo.js";
+import { appendMessage, bindMessageTraceId, incrementMessageCount, ensureChatSession, updateMessage } from "./chat-repo.js";
 import { consumeAgentSse } from "./sse-consumer.js";
 import { buildRedactionConfigForModelConfig } from "./output-redactor.js";
 import { MetricsAggregator } from "./metrics-aggregator.js";
@@ -339,6 +339,18 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           // extra one would close the frontend stream prematurely.
           if (err instanceof Error && err.message.includes("Session is already running")) {
             const steerResult = await client.steerSession(sessionId, text, { images, files });
+            // chat.send persisted this row before it knew the active session would
+            // reject a fresh prompt. Once the fallback steer is accepted, label the
+            // existing row so transcript/trace readers do not mistake it for the
+            // prompt that started the active trace.
+            await updateMessage({
+              messageId: promptMessageId,
+              sessionId,
+              content: text,
+              metadata: { kind: "steer" },
+            }).catch((updateErr) => {
+              console.warn(`[runtime] failed to mark automatic steer message session=${sessionId} message=${promptMessageId}:`, updateErr);
+            });
             await bindMessageTraceId(promptMessageId, sessionId, steerResult.traceId).catch((bindErr) => {
               console.warn(`[runtime] failed to bind steer trace session=${sessionId} message=${promptMessageId}:`, bindErr);
             });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -351,7 +351,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             }).catch((updateErr) => {
               console.warn(`[runtime] failed to mark automatic steer message session=${sessionId} message=${promptMessageId}:`, updateErr);
             });
-            await bindMessageTraceId(promptMessageId, sessionId, steerResult.traceId).catch((bindErr) => {
+            void bindMessageTraceId(promptMessageId, sessionId, steerResult.traceId).catch((bindErr) => {
               console.warn(`[runtime] failed to bind steer trace session=${sessionId} message=${promptMessageId}:`, bindErr);
             });
             return;
@@ -359,7 +359,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           throw err;
         }
 
-        await bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
+        void bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
           console.warn(`[runtime] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
         });
 
@@ -1029,7 +1029,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const handle = await agentBoxManager.getOrCreate(agentId);
     const client = new AgentBoxClient(handle.endpoint, 10000, agentBoxTlsOptions);
     const steerResult = await client.steerSession(sessionId, text, { images, files });
-    await bindMessageTraceId(steerMessageId, sessionId, steerResult.traceId).catch((bindErr) => {
+    void bindMessageTraceId(steerMessageId, sessionId, steerResult.traceId).catch((bindErr) => {
       console.warn(`[runtime] failed to bind explicit steer trace session=${sessionId} message=${steerMessageId}:`, bindErr);
     });
     return { ok: true };

--- a/src/gateway/task-coordinator.test.ts
+++ b/src/gateway/task-coordinator.test.ts
@@ -26,9 +26,9 @@ class FakeAgentBoxClient {
   constructor(endpoint: string, _timeoutMs?: number, _tls?: any) {
     this.endpoint = endpoint;
   }
-  async prompt(opts: any): Promise<{ ok: true; sessionId: string }> {
+  async prompt(opts: any): Promise<{ ok: true; sessionId: string; traceId: string }> {
     this.promptCalls.push(opts);
-    return { ok: true, sessionId: opts.sessionId };
+    return { ok: true, sessionId: opts.sessionId, traceId: "0123456789abcdef0123456789abcdef" };
   }
   async *streamEvents(_sid: string): AsyncIterable<unknown> {
     for (const e of this.streamList) yield e;
@@ -323,6 +323,9 @@ describe("TaskCoordinator execution", () => {
     expect(received.taskName).toBe("Good Task");
     expect(received.userId).toBe("u1");
     expect(received.resultText).toBe("done");
+    expect(appendCalls.find((message) => message.role === "user")?.traceId).toBe(
+      "0123456789abcdef0123456789abcdef",
+    );
   });
 
   it("passes modelRouting from resolved binding to AgentBox prompt", async () => {

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -293,7 +293,7 @@ export class TaskCoordinator {
       // activity from interactive chat — without it every cron-triggered
       // session collapses into the default Interactive world.
       await ensureChatSession(sessionId, agentId, userId, job.name, prompt, "task");
-      await appendMessage({ sessionId, role: "user", content: prompt });
+      await appendMessage({ sessionId, role: "user", content: prompt, traceId: promptResult.traceId });
       await incrementMessageCount(sessionId);
 
       const redactionConfig = buildRedactionConfigForModelConfig(binding.modelConfig);

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1144,6 +1144,68 @@ describe("chat.appendMessage", () => {
   });
 });
 
+describe("chat.bindMessageTraceId", () => {
+  const traceId = "0123456789abcdef0123456789abcdef";
+
+  it("binds an unassigned user message to the exact session and trace", async () => {
+    const query = vi.fn().mockResolvedValueOnce([{ affectedRows: 1 }, []]);
+    (getDb as any).mockReturnValue({ query, getConnection: vi.fn() });
+
+    const result = await getHandler("chat.bindMessageTraceId")({
+      id: "msg-1",
+      session_id: "sess-1",
+      trace_id: traceId,
+    }, "runtime");
+
+    expect(result).toEqual({ ok: true });
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toContain("role = 'user'");
+    expect(query.mock.calls[0][0]).toContain("trace_id IS NULL OR trace_id = ?");
+    expect(query.mock.calls[0][1]).toEqual([traceId, "msg-1", "sess-1", traceId]);
+  });
+
+  it("accepts an idempotent same-trace retry when the update reports no changed row", async () => {
+    const query = vi.fn()
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []])
+      .mockResolvedValueOnce([[{ role: "user", trace_id: traceId }], []]);
+    (getDb as any).mockReturnValue({ query, getConnection: vi.fn() });
+
+    await expect(getHandler("chat.bindMessageTraceId")({
+      id: "msg-1",
+      session_id: "sess-1",
+      trace_id: traceId,
+    }, "runtime")).resolves.toEqual({ ok: true });
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects an invalid trace id without touching the database", async () => {
+    const query = mockQuery();
+    await expect(getHandler("chat.bindMessageTraceId")({
+      id: "msg-1",
+      session_id: "sess-1",
+      trace_id: "INVALID",
+    }, "runtime")).rejects.toThrow("32 lowercase hexadecimal characters");
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "a missing message", row: undefined, error: "chat message not found" },
+    { name: "a non-user message", row: { role: "assistant", trace_id: null }, error: "only be bound to a user message" },
+    { name: "a conflicting trace", row: { role: "user", trace_id: "fedcba9876543210fedcba9876543210" }, error: "already bound to a different trace" },
+  ])("rejects $name", async ({ row, error }) => {
+    const query = vi.fn()
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []])
+      .mockResolvedValueOnce([row ? [row] : [], []]);
+    (getDb as any).mockReturnValue({ query, getConnection: vi.fn() });
+
+    await expect(getHandler("chat.bindMessageTraceId")({
+      id: "msg-1",
+      session_id: "sess-1",
+      trace_id: traceId,
+    }, "runtime")).rejects.toThrow(error);
+  });
+});
+
 describe("chat.recordFeedback", () => {
   it("upserts a vote keyed by (message_ref, sender)", async () => {
     const query = mockQuery([]);
@@ -2134,9 +2196,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 55 handlers", () => {
+  it("registers exactly 56 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(55);
+    expect(handlers.size).toBe(56);
   });
 
   it("all expected handler names are registered", () => {
@@ -2148,7 +2210,7 @@ describe("buildAdapterRpcHandlers", () => {
       "config.getDelegates",
       "credential.list", "credential.get", "credential.checkAccess",
       "credential.resourceManifest", "credential.hostSearch",
-      "chat.ensureSession", "chat.resolveSession", "chat.appendMessage", "chat.recordFeedback", "chat.updateMessage", "chat.updateDelegationToolMessage", "chat.getMessages",
+      "chat.ensureSession", "chat.resolveSession", "chat.appendMessage", "chat.bindMessageTraceId", "chat.recordFeedback", "chat.updateMessage", "chat.updateDelegationToolMessage", "chat.getMessages",
       "task.listActive", "task.getStatus", "task.list", "task.create",
       "task.update", "task.delete", "task.runRecord", "task.runStart",
       "task.runFinalize", "task.updateMeta", "task.fireNow", "task.notify", "task.prune",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -2734,6 +2734,42 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     return { id };
   });
 
+  handlers.set("chat.bindMessageTraceId", async (params) => {
+    const messageId = typeof params.id === "string" ? params.id : "";
+    const sessionId = typeof params.session_id === "string" ? params.session_id : "";
+    const traceId = typeof params.trace_id === "string" ? params.trace_id : "";
+    if (!messageId) throw new Error("message id is required");
+    if (!sessionId) throw new Error("session_id is required");
+    if (!/^[0-9a-f]{32}$/.test(traceId)) {
+      throw new Error("trace_id must be 32 lowercase hexadecimal characters");
+    }
+
+    // Standalone Portal has one portal-secret-authenticated Runtime trust
+    // domain and no runtime_id relation. Scope ownership to the exact
+    // message/session pair here; SiCore additionally enforces per-Runtime
+    // ownership in its own implementation of this RPC.
+    const db = getDb();
+    const [result] = await db.query(
+      `UPDATE chat_messages SET trace_id = ?
+       WHERE id = ? AND session_id = ? AND role = 'user'
+         AND (trace_id IS NULL OR trace_id = ?)`,
+      [traceId, messageId, sessionId, traceId],
+    ) as any;
+    if (Number(result?.affectedRows ?? 0) > 0) return { ok: true };
+
+    // MySQL may report zero affected rows for a same-value update. Read only
+    // on that path to distinguish an idempotent retry from a conflicting bind.
+    const [rows] = await db.query(
+      `SELECT role, trace_id FROM chat_messages WHERE id = ? AND session_id = ? LIMIT 1`,
+      [messageId, sessionId],
+    ) as any;
+    if (!rows?.length) throw new Error("chat message not found");
+    if (rows[0].role !== "user") throw new Error("trace_id can only be bound to a user message");
+    if (rows[0].trace_id === traceId) return { ok: true };
+    if (rows[0].trace_id != null) throw new Error("chat message is already bound to a different trace");
+    throw new Error("chat message trace binding was not applied");
+  });
+
   handlers.set("chat.recordFeedback", async (params) => {
     const db = getDb();
     return recordMessageFeedback(db, params);


### PR DESCRIPTION
## Summary

Persist per-prompt trace attribution across Siclaw's interactive, channel, scheduled, and steer entry points so SiCore can group each user prompt with the complete agent loop that it started.

### Problem

Siclaw persists inbound user messages before AgentBox assigns a per-prompt trace ID. Assistant and tool events can carry the trace ID later, but the initiating user row may remain unbound. In a long-lived session with multiple prompts, this prevents SiCore's Trace audit view from identifying the exact prompt reliably.

Steer messages have the inverse problem: they join an already-running prompt and therefore need the active trace ID rather than a new trace. The automatic `chat.send` to steer fallback also persisted the additional input as a normal user row, which could make transcript and trace readers treat it as a new prompt.

### Solution

This PR introduces an ACK-and-bind integration between AgentBox, Siclaw Runtime, and SiCore:

1. AgentBox prompt and steer acknowledgements expose the relevant trace ID. A prompt returns its new root trace; a steer returns the active prompt's trace.
2. Siclaw keeps the exact persisted user message ID and calls the Portal's `chat.bindMessageTraceId` RPC after the acknowledgement. The binding is message-specific rather than inferred from session order, and both SiCore and Siclaw's standalone Portal implement the same guarded contract.
3. Web/API/A2A prompts and explicit steers bind their user rows after ACK. The 409 automatic-steer fallback additionally relabels the persisted row as `metadata.kind="steer"` before binding it.
4. Lark and DingTalk bind their existing audited user rows after prompt ACK and stamp the same trace ID on channel assistant/tool persistence.
5. Scheduled tasks already receive the prompt ACK before creating their audit row, so they persist the trace ID directly.

The new trace fields are optional for rolling upgrades. Missing trace IDs are a no-op, and trace binding runs best-effort in the background so failures never delay or interrupt the user response. This PR adds no database schema or production dependency changes.

### Compatibility and deployment

Both SiCore and Siclaw's in-repo Portal implement the `chat.bindMessageTraceId` internal RPC. In managed deployments, deploying SiCore first and Siclaw second minimizes the rolling-upgrade window; an older SiCore causes only a best-effort binding warning. Standalone and `siclaw local` deployments use the in-repo Portal handler directly.

Out of scope:

- Reordering the existing DingTalk cold-start persistence flow.
- Historical trace backfill.
- Langfuse trace trees, LLM-call views, or trace review workflows.

## Test Plan

- [x] `npx tsc --noEmit` passes after rebasing onto the latest `main`.
- [x] `git diff --check origin/main...HEAD` passes.
- [x] GitHub Actions `Test` passes, including Portal RPC and non-blocking trace-binding regression coverage. Local Vitest execution is unavailable because the checked-out `esbuild` binary is not executable in the development environment.
- [ ] Manual smoke test with the paired SiCore branch: Web prompt, explicit steer, 409 automatic steer, Lark/DingTalk, and scheduled task attribution.

## Architecture Checklist

- Deployment mode: no resource sync or filesystem-write behavior changed.
- Security model: no shell execution or tool-policy path changed.
- DB parity: no schema or migration change.
- Tool protocol: no diagnostic tool added or modified.

## General Checklist

- [x] Changes are focused on one logical trace-attribution feature.
- [x] Commit messages follow Conventional Commits.
- [x] No unrelated changes are included.

