### PR TITLE
fix(kbc): scale L1 auto-repair budget with open-violation workload

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -305,6 +305,11 @@ class CompileRun:
         # loop; reset to 0 whenever the check passes).
         self._selfcheck_key: str | None = None
         self._l1_repairs_used = 0
+        # Per-episode repair-budget high-water mark (review, PR #430): the
+        # limit is derived from the OPEN workload, which shrinks as repairs
+        # succeed — gating on a per-turn recomputation would close the gate
+        # at ~half-repaired. Keep the episode's max; reset with the counter.
+        self._l1_round_limit = 0
         # Candidate/exclusion state captured immediately before each model
         # turn. A conversational turn that leaves this state byte-identical is
         # not a migration trigger for an inherited legacy draft. Compile,
@@ -1946,10 +1951,17 @@ async def _post_turn_selfcheck(run) -> str | None:
             "grandfathered_format_violations": grandfathered_format[:40],
         }
     ledger_clean = report["coverage"]["closed"] and report["lint"]["ok"]
+    # High-water, not per-turn recomputation: the workload SHRINKS as repairs
+    # succeed, so re-deriving the limit each turn strands the episode at
+    # ~half-repaired (review). max() also lets the budget grow if a repair
+    # legitimately reopens violations mid-episode.
+    run._l1_round_limit = max(getattr(run, "_l1_round_limit", 0),
+                              _l1_repair_round_limit(report))
     if ledger_clean and not incr_violations:
         run._l1_repairs_used = 0
+        run._l1_round_limit = 0
         report["state"] = "passed"
-    elif run._l1_repairs_used < _l1_repair_round_limit(report):
+    elif run._l1_repairs_used < run._l1_round_limit:
         report["state"] = "repairing"
         # The report carries the PREVIOUS converge_phase (possibly "settled");
         # the pre-turn_done sync would ship repairing+settled for one window
@@ -1960,7 +1972,7 @@ async def _post_turn_selfcheck(run) -> str | None:
     else:
         report["state"] = "unconverged"  # budget spent: publish card shows the rest
     report["repair_rounds_used"] = run._l1_repairs_used
-    report["repair_rounds_limit"] = _l1_repair_round_limit(report)
+    report["repair_rounds_limit"] = run._l1_round_limit
     selfcheck.write_selfcheck(workdir, report)
     locale = getattr(run, "locale", None)
     if restored_pages:
@@ -3112,6 +3124,7 @@ async def _run_ledger_repairs(run: "CompileRun", replies: list[str]) -> None:
     # for this phase's own findings. Each _run_ledger_repairs call is bounded
     # by its own budget; the batch tail calls it a bounded number of times.
     run._l1_repairs_used = 0
+    run._l1_round_limit = 0
     run._ledger_forced = True  # batch-final: the mid-Execute index exemption is off
     try:
         repair = await _post_turn_selfcheck(run)

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -1289,6 +1289,29 @@ def _l1_repair_rounds() -> int:
     return int(os.environ.get("KBC_L1_REPAIR_ROUNDS", "2"))
 
 
+def _l1_repair_round_limit(report: dict) -> int:
+    """Scale the ledger auto-repair budget with the ACTUAL workload instead of
+    a flat constant. A first full compile / wiki adoption over a large KB can
+    open dozens of mechanical violations at once; with the flat 2-round budget
+    it structurally lands unconverged and dumps the tail into the owner's
+    question queue (live adoption run, 2026-07-22: 55-item residual after two
+    rounds). Mirrors _batch_media_verify_round_limit: the flat value stays the
+    floor for ordinary drift, the open-violation count adds bounded rounds, and
+    a hard operator cap still fences pathological repair loops."""
+    base = _l1_repair_rounds()
+    cov = report.get("coverage") or {}
+    lint = report.get("lint") or {}
+    workload = (len(cov.get("unaccounted") or [])
+                + len(cov.get("dangling_citations") or [])
+                + len(lint.get("violations") or []))
+    if workload <= 0:
+        return base
+    per_round = max(1, int(os.environ.get(
+        "KBC_L1_REPAIR_VIOLATIONS_PER_ROUND", "12")))
+    cap = max(base, int(os.environ.get("KBC_L1_REPAIR_MAX_ROUNDS", "16")))
+    return min(cap, max(base, -(-workload // per_round)))
+
+
 def _media_verify_enabled() -> bool:
     return os.environ.get("KBC_MEDIA_VERIFY", "on") != "off"
 
@@ -1926,7 +1949,7 @@ async def _post_turn_selfcheck(run) -> str | None:
     if ledger_clean and not incr_violations:
         run._l1_repairs_used = 0
         report["state"] = "passed"
-    elif run._l1_repairs_used < _l1_repair_rounds():
+    elif run._l1_repairs_used < _l1_repair_round_limit(report):
         report["state"] = "repairing"
         # The report carries the PREVIOUS converge_phase (possibly "settled");
         # the pre-turn_done sync would ship repairing+settled for one window
@@ -1937,6 +1960,7 @@ async def _post_turn_selfcheck(run) -> str | None:
     else:
         report["state"] = "unconverged"  # budget spent: publish card shows the rest
     report["repair_rounds_used"] = run._l1_repairs_used
+    report["repair_rounds_limit"] = _l1_repair_round_limit(report)
     selfcheck.write_selfcheck(workdir, report)
     locale = getattr(run, "locale", None)
     if restored_pages:

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2296,6 +2296,51 @@ def test_l1_repair_budget_scales_with_workload():
     print("OK  L1 repair budget scales with open-violation workload (floor + cap)")
 
 
+async def test_l1_repair_budget_high_water_survives_shrinking_workload():
+    """Loop-level pin for the review finding on PR #430: the limit is derived
+    from the OPEN workload, which shrinks as repairs land. Gating on a per-turn
+    recomputation closes the gate at ~half-repaired; the episode must keep its
+    high-water allowance, and the persisted report must stay coherent
+    (used <= limit) even on the unconverged exit."""
+    import json as _json
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        (wd / "raw" / "snap").mkdir(parents=True)
+        (wd / "candidate").mkdir()
+        (wd / "authoring").mkdir()
+        (wd / "raw" / "snap" / "one.md").write_text("one")
+        for i in range(30):  # 30 unaccounted -> limit ceil(30/12)=3 with floor pinned to 1
+            (wd / "raw" / "snap" / f"orphan{i}.md").write_text("x")
+        (wd / "candidate" / "index.md").write_text("---\nokf_version: \"0.1\"\n---\n# Index\n- [a](a.md)")
+        (wd / "candidate" / "a.md").write_text("---\ntype: Topic\ntitle: a\ncompiled_from:\n  - snap/one.md\n---\n正文a。")
+        run = compile_box.CompileRun("noop", str(wd), 1)
+        run._selfcheck_key = None
+        os.environ["KBC_L1_REPAIR_ROUNDS"] = "1"
+        try:
+            repair = await compile_box._post_turn_selfcheck(run)
+            assert repair is not None  # round 1: repairing, high-water = 3
+            sc = _json.loads((wd / "authoring" / "SELFCHECK.json").read_text())
+            assert sc["repair_rounds_limit"] == 3, sc["repair_rounds_limit"]
+            # "repair" lands: 28 orphans fixed -> workload shrinks to 2 (limit would be 1)
+            for i in range(28):
+                (wd / "raw" / "snap" / f"orphan{i}.md").unlink()
+            run._begin_turn(repair)
+            repair2 = await compile_box._post_turn_selfcheck(run)
+            assert repair2 is not None, "high-water must keep the gate open (used=1 < 3)"
+            run._begin_turn(repair2)
+            repair3 = await compile_box._post_turn_selfcheck(run)
+            assert repair3 is not None, "used=2 < 3 still repairing"
+            run._begin_turn(repair3)
+            repair4 = await compile_box._post_turn_selfcheck(run)
+            assert repair4 is None  # used=3 == limit -> unconverged
+            sc = _json.loads((wd / "authoring" / "SELFCHECK.json").read_text())
+            assert sc["state"] == "unconverged", sc["state"]
+            assert sc["repair_rounds_used"] == 3 and sc["repair_rounds_limit"] == 3, sc
+        finally:
+            del os.environ["KBC_L1_REPAIR_ROUNDS"]
+    print("OK  L1 repair budget keeps its episode high-water while the workload shrinks")
+
+
 async def test_unchanged_owner_turn_does_not_migrate_legacy_format():
     """An ordinary conversation over an inherited draft must not become an
     implicit whole-library OKF migration merely because this is a fresh box.

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -2271,6 +2271,31 @@ def test_media_verify_suppresses_text_backed_beyond_transcript():
     print("OK  media verify suppresses text-backed beyond-transcript doubts (keeps real ones + conflicts)")
 
 
+def test_l1_repair_budget_scales_with_workload():
+    """Flat budget stays the floor for ordinary drift; a first-compile-sized
+    violation pile earns proportionally more bounded rounds; the operator cap
+    fences runaways (2026-07-22 adoption run: 55 residuals vs 2 flat rounds)."""
+    def rep(unacc=0, dangling=0, lint=0):
+        return {"coverage": {"unaccounted": ["x"] * unacc,
+                             "dangling_citations": ["y"] * dangling},
+                "lint": {"violations": [{}] * lint}}
+    assert compile_box._l1_repair_round_limit(rep()) == compile_box._l1_repair_rounds()
+    assert compile_box._l1_repair_round_limit(rep(unacc=3)) == compile_box._l1_repair_rounds()
+    assert compile_box._l1_repair_round_limit(rep(unacc=40, lint=15)) == 5  # ceil(55/12)
+    assert compile_box._l1_repair_round_limit(rep(unacc=500)) == 16  # capped
+    os.environ["KBC_L1_REPAIR_MAX_ROUNDS"] = "6"
+    try:
+        assert compile_box._l1_repair_round_limit(rep(unacc=500)) == 6
+    finally:
+        del os.environ["KBC_L1_REPAIR_MAX_ROUNDS"]
+    os.environ["KBC_L1_REPAIR_VIOLATIONS_PER_ROUND"] = "5"
+    try:
+        assert compile_box._l1_repair_round_limit(rep(unacc=20)) == 4
+    finally:
+        del os.environ["KBC_L1_REPAIR_VIOLATIONS_PER_ROUND"]
+    print("OK  L1 repair budget scales with open-violation workload (floor + cap)")
+
+
 async def test_unchanged_owner_turn_does_not_migrate_legacy_format():
     """An ordinary conversation over an inherited draft must not become an
     implicit whole-library OKF migration merely because this is a fresh box.


### PR DESCRIPTION
## Problem

The ledger auto-repair budget is a flat constant (`KBC_L1_REPAIR_ROUNDS`, default 2), sized for ordinary drift. A first full compile or a wiki **adoption** over a large KB opens dozens of mechanical violations at once (dangling citations, malformed source annotations, charset corruption from the gateway's per-chunk SSE decoding). With a flat budget the loop is structurally spent before it can converge, and the entire tail is dumped into the owner's question queue as one opaque residual ticket.

Live evidence (2026-07-22 adoption run on a 1575-source KB): 2 rounds spent → unconverged → a 55-item ticket containing raw SELFCHECK lint output shown to the end user.

## Change

- New `_l1_repair_round_limit(report)`: keeps the flat value as the **floor**, adds bounded rounds proportional to the open violation count (`KBC_L1_REPAIR_VIOLATIONS_PER_ROUND`, default 12/round), fenced by a hard operator cap (`KBC_L1_REPAIR_MAX_ROUNDS`, default 16). Mirrors the established `_batch_media_verify_round_limit` idiom.
- `SELFCHECK.json` gains `repair_rounds_limit` (additive, for observability).

## Non-goals / follow-ups

- Residual tickets should carry a `kind` (content contradiction vs infra residual) so mechanical leftovers stop surfacing in the user-facing question inbox — separate change (box ticket schema + sicore inbox routing).
- Deterministic violations (source-annotation normalization, U+FFFD replacement) could be demoted to a code-repair layer that does not consume model budget at all.

## Tests

All repair-related tests green, including the pre-existing flat-budget gate tests (small workloads keep the floor, so their behavior is unchanged) plus a new unit test covering floor / scaling / cap / env overrides.