### PR TITLE
feat(kbc): de-stream the compile box's Anthropic calls to dodge the gateway charset bug

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -62,6 +62,7 @@ from claude_agent_sdk import (
 )
 
 import batching
+import destream
 import incremental
 import mediaverify
 import office_ingest
@@ -4637,6 +4638,9 @@ def _apply_session_config(body: dict) -> None:
             if k == "KBC_PK_MODE" and _PK_KILL_AT_BOOT:
                 continue  # ops kill switch outranks consumer config
             os.environ[k] = str(value)
+    # After the final env state lands: opt the Anthropic route in/out of the
+    # in-pod de-streaming shim (KBC_DESTREAM, charset fix — see destream.py).
+    destream.maybe_activate()
 
 
 async def handle_session(request: web.Request):
@@ -5300,6 +5304,7 @@ def build_app() -> web.Application:
         client_max_size=_http_max_request_bytes(),
         middlewares=[_client_certificate_middleware],
     )
+    app.on_startup.append(destream.start)
     app.on_shutdown.append(_flush_on_shutdown)
     app.add_routes([
         web.post("/sources", handle_sources),

--- a/kbc/platform/pod/destream.py
+++ b/kbc/platform/pod/destream.py
@@ -1,0 +1,222 @@
+"""In-pod de-streaming shim for the Anthropic Messages route (charset fix).
+
+massapi's Anthropic-compatible STREAMING route corrupts multibyte characters
+whose bytes straddle an SSE chunk boundary (the gateway decodes each chunk
+independently with errors=replace → U+FFFD); its NON-streaming route returns
+the same bytes intact (gateway bug report, 2026-07). The compile box is
+non-interactive — nobody reads its model output token-by-token — so it can
+trade streaming latency for byte-correct text. The CLI (Claude Code) has no
+non-streaming switch, hence a localhost shim:
+
+    CLI --stream:true--> 127.0.0.1 shim --stream:false--> upstream gateway
+                         <-- synthesized SSE (+ pings while waiting) --
+
+Scope: only POST .../v1/messages bodies with "stream": true are de-streamed.
+Everything else (count_tokens, models, non-streaming posts) passes through
+verbatim as RAW BYTES — the shim must never introduce a decode step of its
+own. Activation is per-profile via the consumer-settings whitelist
+(KBC_DESTREAM=1 on the compile profile); test-session boxes keep true
+streaming for interactive UX.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import aiohttp
+from aiohttp import web
+
+_PORT: int | None = None
+_UPSTREAM: str | None = None
+_HOP_BY_HOP = {"host", "content-length", "connection", "transfer-encoding",
+               "keep-alive", "upgrade", "te", "trailers", "proxy-authorization"}
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "on", "yes")
+
+
+def _ping_seconds() -> float:
+    return float(os.environ.get("KBC_DESTREAM_PING_SECONDS", "15"))
+
+
+def _upstream_timeout() -> float:
+    # A single non-streaming turn can legitimately run for minutes; the ping
+    # task keeps the CLIENT side warm while this governs the upstream leg.
+    return float(os.environ.get("KBC_DESTREAM_TIMEOUT", "3600"))
+
+
+def maybe_activate() -> None:
+    """Called after session config lands in os.environ (sync seam). When the
+    profile opts in and the engine is the Anthropic one, remember the real
+    upstream and point the CLI at the shim; when it opts out, restore."""
+    global _UPSTREAM
+    if _PORT is None:
+        return
+    shim_url = f"http://127.0.0.1:{_PORT}"
+    base = os.environ.get("ANTHROPIC_BASE_URL", "")
+    wanted = (_truthy(os.environ.get("KBC_DESTREAM"))
+              and os.environ.get("KBC_ENGINE", "claude_agent_sdk") != "codex_sdk")
+    if wanted:
+        if base and base != shim_url:
+            _UPSTREAM = base
+        if _UPSTREAM:
+            os.environ["ANTHROPIC_BASE_URL"] = shim_url
+    elif base == shim_url and _UPSTREAM:
+        os.environ["ANTHROPIC_BASE_URL"] = _UPSTREAM
+
+
+def _fwd_headers(request: web.Request) -> dict:
+    return {k: v for k, v in request.headers.items()
+            if k.lower() not in _HOP_BY_HOP}
+
+
+def _sse(event: str, obj: dict) -> bytes:
+    return (f"event: {event}\ndata: "
+            + json.dumps(obj, ensure_ascii=False)
+            + "\n\n").encode("utf-8")
+
+
+def synth_events(msg: dict) -> list[bytes]:
+    """A complete (non-streaming) Message → the standard SSE event sequence.
+    Whole-block deltas are valid SSE; the CLI accumulates them the same way."""
+    usage = msg.get("usage") or {}
+    head = dict(msg)
+    head["content"] = []
+    head["stop_reason"] = None
+    head["stop_sequence"] = None
+    head["usage"] = {"input_tokens": usage.get("input_tokens", 0),
+                     "output_tokens": 0}
+    out = [_sse("message_start", {"type": "message_start", "message": head})]
+    for i, block in enumerate(msg.get("content") or []):
+        btype = block.get("type")
+        if btype == "text":
+            start = {"type": "text", "text": ""}
+            deltas = [{"type": "text_delta", "text": block.get("text", "")}]
+        elif btype == "tool_use":
+            start = {"type": "tool_use", "id": block.get("id"),
+                     "name": block.get("name"), "input": {}}
+            deltas = [{"type": "input_json_delta",
+                       "partial_json": json.dumps(block.get("input") or {},
+                                                  ensure_ascii=False)}]
+        elif btype == "thinking":
+            start = {"type": "thinking", "thinking": ""}
+            deltas = [{"type": "thinking_delta",
+                       "thinking": block.get("thinking", "")}]
+            if block.get("signature"):
+                deltas.append({"type": "signature_delta",
+                               "signature": block["signature"]})
+        else:
+            start, deltas = dict(block), []  # unknown: ship whole, no delta
+        out.append(_sse("content_block_start",
+                        {"type": "content_block_start", "index": i,
+                         "content_block": start}))
+        for d in deltas:
+            out.append(_sse("content_block_delta",
+                            {"type": "content_block_delta", "index": i,
+                             "delta": d}))
+        out.append(_sse("content_block_stop",
+                        {"type": "content_block_stop", "index": i}))
+    out.append(_sse("message_delta",
+                    {"type": "message_delta",
+                     "delta": {"stop_reason": msg.get("stop_reason"),
+                               "stop_sequence": msg.get("stop_sequence")},
+                     "usage": {"output_tokens": usage.get("output_tokens", 0)}}))
+    out.append(_sse("message_stop", {"type": "message_stop"}))
+    return out
+
+
+async def _destream_messages(request: web.Request, body: dict) -> web.StreamResponse:
+    resp = web.StreamResponse(status=200, headers={
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+    })
+    await resp.prepare(request)
+
+    async def _pings():
+        while True:
+            await asyncio.sleep(_ping_seconds())
+            await resp.write(_sse("ping", {"type": "ping"}))
+
+    ping_task = asyncio.create_task(_pings())
+    try:
+        url = (_UPSTREAM or "").rstrip("/") + request.path_qs
+        timeout = aiohttp.ClientTimeout(total=_upstream_timeout())
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, json={**body, "stream": False},
+                                    headers=_fwd_headers(request)) as up:
+                raw = await up.read()
+        ping_task.cancel()
+        if not (200 <= (up.status or 0) < 300):
+            try:
+                err = json.loads(raw)
+            except (ValueError, UnicodeDecodeError):
+                err = {"type": "error",
+                       "error": {"type": "api_error",
+                                 "message": raw[:500].decode("utf-8", "replace")}}
+            await resp.write(_sse("error", err if err.get("type") == "error"
+                                  else {"type": "error", "error": err}))
+            return resp
+        for chunk in synth_events(json.loads(raw)):
+            await resp.write(chunk)
+        return resp
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # network/parse: surface as a stream error event
+        await resp.write(_sse("error", {
+            "type": "error",
+            "error": {"type": "api_error", "message": f"destream shim: {exc!r}"}}))
+        return resp
+    finally:
+        ping_task.cancel()
+
+
+async def _passthrough(request: web.Request, body_bytes: bytes) -> web.StreamResponse:
+    """Verbatim relay, RAW BYTES both ways — never decode here."""
+    url = (_UPSTREAM or "").rstrip("/") + request.path_qs
+    timeout = aiohttp.ClientTimeout(total=_upstream_timeout())
+    async with aiohttp.ClientSession(timeout=timeout, auto_decompress=False) as session:
+        async with session.request(request.method, url, data=body_bytes,
+                                   headers=_fwd_headers(request)) as up:
+            headers = {k: v for k, v in up.headers.items()
+                       if k.lower() not in _HOP_BY_HOP}
+            resp = web.StreamResponse(status=up.status, headers=headers)
+            await resp.prepare(request)
+            async for chunk in up.content.iter_chunked(65536):
+                await resp.write(chunk)
+            return resp
+
+
+async def _handle(request: web.Request) -> web.StreamResponse:
+    if not _UPSTREAM:
+        return web.json_response(
+            {"type": "error",
+             "error": {"type": "api_error",
+                       "message": "destream shim: no upstream configured"}},
+            status=502)
+    body_bytes = await request.read()
+    if request.method == "POST" and request.path.rstrip("/").endswith("/messages"):
+        try:
+            body = json.loads(body_bytes)
+        except (ValueError, UnicodeDecodeError):
+            body = None
+        if isinstance(body, dict) and body.get("stream"):
+            return await _destream_messages(request, body)
+    return await _passthrough(request, body_bytes)
+
+
+async def start(app: web.Application) -> None:
+    """on_startup hook: bind the shim on an ephemeral localhost port. Costs one
+    idle listener when the profile never opts in."""
+    global _PORT
+    shim = web.Application(client_max_size=64 * 1024 * 1024)
+    shim.router.add_route("*", "/{tail:.*}", _handle)
+    runner = web.AppRunner(shim)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    _PORT = site._server.sockets[0].getsockname()[1]
+    app["_destream_runner"] = runner
+    app.on_shutdown.append(lambda _app: runner.cleanup())

--- a/kbc/platform/pod/test_destream.py
+++ b/kbc/platform/pod/test_destream.py
@@ -1,0 +1,206 @@
+"""Tests for the in-pod de-streaming shim (destream.py)."""
+
+import asyncio
+import json
+import os
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import destream
+
+
+def _parse_sse(raw: bytes) -> list[tuple[str, dict]]:
+    events = []
+    for block in raw.decode("utf-8").split("\n\n"):
+        lines = [ln for ln in block.splitlines() if ln]
+        if not lines:
+            continue
+        ev = next((ln[7:] for ln in lines if ln.startswith("event: ")), "")
+        data = next((ln[6:] for ln in lines if ln.startswith("data: ")), "{}")
+        events.append((ev, json.loads(data)))
+    return events
+
+
+UPSTREAM_MSG = {
+    "id": "msg_01", "type": "message", "role": "assistant",
+    "model": "claude-opus-4-6",
+    "content": [
+        {"type": "text", "text": "中文正文，多字节字符完好。"},
+        {"type": "tool_use", "id": "tu_1", "name": "Write",
+         "input": {"path": "候选/页.md", "content": "含中文内容"}},
+    ],
+    "stop_reason": "tool_use", "stop_sequence": None,
+    "usage": {"input_tokens": 321, "output_tokens": 54},
+}
+
+
+async def _run_with_fake_upstream(upstream_handler, exercise):
+    up_app = web.Application()
+    up_app.router.add_route("*", "/{tail:.*}", upstream_handler)
+    up_server = TestServer(up_app)
+    await up_server.start_server()
+
+    shim_app = web.Application()
+    await destream.start(shim_app)
+    try:
+        destream._UPSTREAM = str(up_server.make_url("")).rstrip("/")
+        shim_client_app = web.Application()
+        shim_client_app.router.add_route("*", "/{tail:.*}", destream._handle)
+        client = TestClient(TestServer(shim_client_app))
+        await client.start_server()
+        try:
+            await exercise(client)
+        finally:
+            await client.close()
+    finally:
+        destream._UPSTREAM = None
+        await shim_app["_destream_runner"].cleanup()
+        await up_server.close()
+
+
+async def test_destream_synthesizes_valid_sse():
+    seen = {}
+
+    async def upstream(request):
+        seen["body"] = await request.json()
+        seen["path"] = request.path
+        return web.json_response(UPSTREAM_MSG)
+
+    async def exercise(client):
+        resp = await client.post("/v1/messages", json={
+            "model": "claude-opus-4-6", "stream": True, "max_tokens": 2048,
+            "messages": [{"role": "user", "content": "hi"}]})
+        assert resp.status == 200
+        assert resp.headers["Content-Type"].startswith("text/event-stream")
+        events = _parse_sse(await resp.read())
+        kinds = [e for e, _ in events if e != "ping"]
+        assert kinds == ["message_start", "content_block_start",
+                        "content_block_delta", "content_block_stop",
+                        "content_block_start", "content_block_delta",
+                        "content_block_stop", "message_delta",
+                        "message_stop"], kinds
+        # upstream leg was NON-streaming (the whole point)
+        assert seen["body"]["stream"] is False
+        assert seen["path"] == "/v1/messages"
+        # text reconstructs byte-perfect
+        text = "".join(d["delta"]["text"] for e, d in events
+                       if e == "content_block_delta"
+                       and d["delta"].get("type") == "text_delta")
+        assert text == "中文正文，多字节字符完好。"
+        # tool_use input travels as one valid partial_json
+        pj = next(d["delta"]["partial_json"] for e, d in events
+                  if e == "content_block_delta"
+                  and d["delta"].get("type") == "input_json_delta")
+        assert json.loads(pj) == UPSTREAM_MSG["content"][1]["input"]
+        # usage split across start/delta
+        start = next(d for e, d in events if e == "message_start")
+        assert start["message"]["usage"] == {"input_tokens": 321, "output_tokens": 0}
+        md = next(d for e, d in events if e == "message_delta")
+        assert md["usage"] == {"output_tokens": 54}
+        assert md["delta"]["stop_reason"] == "tool_use"
+
+    await _run_with_fake_upstream(upstream, exercise)
+    print("OK  destream synthesizes a valid SSE sequence from a non-streaming turn")
+
+
+async def test_destream_pings_while_upstream_is_slow():
+    async def upstream(request):
+        await request.json()
+        await asyncio.sleep(0.25)
+        return web.json_response(UPSTREAM_MSG)
+
+    async def exercise(client):
+        os.environ["KBC_DESTREAM_PING_SECONDS"] = "0.05"
+        try:
+            resp = await client.post("/v1/messages", json={"stream": True,
+                                                           "messages": []})
+            events = _parse_sse(await resp.read())
+        finally:
+            del os.environ["KBC_DESTREAM_PING_SECONDS"]
+        pings = [e for e, _ in events if e == "ping"]
+        assert pings, "expected keepalive pings while upstream was pending"
+        assert events[-1][0] == "message_stop"
+
+    await _run_with_fake_upstream(upstream, exercise)
+    print("OK  destream keeps the client warm with pings while upstream runs")
+
+
+async def test_destream_upstream_error_becomes_stream_error_event():
+    async def upstream(request):
+        return web.json_response(
+            {"type": "error",
+             "error": {"type": "rate_limit_error", "message": "slow down"}},
+            status=429)
+
+    async def exercise(client):
+        resp = await client.post("/v1/messages", json={"stream": True,
+                                                       "messages": []})
+        assert resp.status == 200  # SSE already open; error rides the stream
+        events = _parse_sse(await resp.read())
+        ev, data = next((e, d) for e, d in events if e == "error")
+        assert data["error"]["type"] == "rate_limit_error", data
+
+    await _run_with_fake_upstream(upstream, exercise)
+    print("OK  destream maps upstream HTTP errors to SSE error events")
+
+
+async def test_non_stream_and_other_routes_pass_through_verbatim():
+    async def upstream(request):
+        if request.path.endswith("/models"):
+            return web.Response(body=b'{"data":[{"id":"claude-opus-4-6"}]}',
+                                content_type="application/json")
+        body = await request.read()
+        return web.Response(body=body, content_type="application/octet-stream")
+
+    async def exercise(client):
+        r1 = await client.get("/v1/models")
+        assert json.loads(await r1.read())["data"][0]["id"] == "claude-opus-4-6"
+        payload = json.dumps({"stream": False, "messages": []}).encode()
+        r2 = await client.post("/v1/messages", data=payload,
+                               headers={"Content-Type": "application/json"})
+        assert await r2.read() == payload  # untouched bytes, no synthesis
+
+    await _run_with_fake_upstream(upstream, exercise)
+    print("OK  non-streaming posts and other routes pass through as raw bytes")
+
+
+def test_maybe_activate_env_logic():
+    destream._PORT = 45678
+    shim = "http://127.0.0.1:45678"
+    env_backup = {k: os.environ.get(k) for k in
+                  ("KBC_DESTREAM", "KBC_ENGINE", "ANTHROPIC_BASE_URL")}
+    try:
+        os.environ["ANTHROPIC_BASE_URL"] = "https://api.example/model-api"
+        os.environ["KBC_DESTREAM"] = "1"
+        os.environ.pop("KBC_ENGINE", None)
+        destream.maybe_activate()
+        assert os.environ["ANTHROPIC_BASE_URL"] == shim
+        assert destream._UPSTREAM == "https://api.example/model-api"
+        destream.maybe_activate()  # idempotent: shim url is not re-captured
+        assert destream._UPSTREAM == "https://api.example/model-api"
+        os.environ["KBC_DESTREAM"] = "0"
+        destream.maybe_activate()  # opt-out restores the real upstream
+        assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.example/model-api"
+        os.environ["KBC_DESTREAM"] = "1"
+        os.environ["KBC_ENGINE"] = "codex_sdk"
+        destream.maybe_activate()  # codex engine is out of scope
+        assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.example/model-api"
+    finally:
+        destream._PORT = None
+        destream._UPSTREAM = None
+        for k, v in env_backup.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    print("OK  maybe_activate: opt-in rewrites, opt-out restores, codex untouched")
+
+
+if __name__ == "__main__":
+    test_maybe_activate_env_logic()
+    for fn in (test_destream_synthesizes_valid_sse,
+               test_destream_pings_while_upstream_is_slow,
+               test_destream_upstream_error_becomes_stream_error_event,
+               test_non_stream_and_other_routes_pass_through_verbatim):
+        asyncio.run(fn())


### PR DESCRIPTION
## Problem

massapi's Anthropic-compatible **streaming** route corrupts multibyte characters whose bytes straddle an SSE chunk boundary (per-chunk UTF-8 decode with `errors=replace` → U+FFFD). Its **non-streaming** route returns the same bytes intact (gateway bug report). Compile runs write long Chinese pages, so every turn is a corruption lottery; the charset guard heals what it catches but burns repair budget.

## Change (v2 — default-on, session-scoped, zero deployment config)

A localhost de-streaming shim inside the pod (`destream.py`):

```
CLI --stream:true--> 127.0.0.1 shim --stream:false--> gateway
                     <-- synthesized SSE + keepalive pings --
```

- **Default ON in the binary, scoped by session kind** via per-session CLI env (`ClaudeAgentOptions.env`, merged over the inherited environment): authoring / batch / planner sessions and the readonly verify agents are de-streamed; **test sessions always keep true streaming** (interactive UX); the codex/OpenAI route never rewrites. No helm/env change to deploy; `KBC_DESTREAM=0/off` is the operator escape hatch — and leaving the shim on after the gateway is fixed is harmless (identical turn wall-time, MB-level buffering).
- The box's own environment is never rewritten; the shim resolves the real upstream per request (self-loop guard included).
- Only `POST …/messages` with `stream:true` is de-streamed; everything else passes through as **raw bytes** — the shim never introduces a decode step of its own.
- Full SSE synthesis: `message_start` / `content_block_*` with whole-block deltas (text, `tool_use` `input_json_delta`, `thinking` + `signature_delta`) / `message_delta` with usage / `message_stop`; upstream HTTP errors ride the open stream as SSE `error` events.
- **Stall-watchdog interaction handled**: de-streamed turns emit no SDK deltas mid-request, so the fine-grained idle bound (90s/240s) would false-kill long generations. When the shim is active the watchdog bound is floored at `KBC_DESTREAM_MODEL_IDLE_TIMEOUT_S` (default 900s) — black-hole reaping coarsens from seconds to minutes as the honest price, still far under the CLI's own ~60min request timeout.

**Blast radius**: the kbc-compile-box image only (127.0.0.1 listener). runtime / agentbox / sicore-side LLM callers (workflow nodes etc.) are untouched.

## Residual risk to verify at rollout

One live long-turn test against massapi non-streaming (whether the gateway caps non-streaming response duration).

## Tests

Six tests: SSE synthesis round-trip (byte-perfect CJK, tool_use partial_json, usage split), keepalive under a slow upstream, error mapping, raw passthrough, and default-on/session-scoped/opt-out/codex activation semantics. `compile_box`/`engine` import + adjacent suites green.