### PR TITLE
fix(tools): filter kubectl exec transport noise

### DIFF
--- a/src/tools/cmd-exec/pod-exec.ts
+++ b/src/tools/cmd-exec/pod-exec.ts
@@ -12,7 +12,7 @@ import { loadConfig } from "../../core/config.js";
 import { parseArgs, CONTAINER_SENSITIVE_PATHS } from "../infra/command-sets.js";
 import { preExecSecurity, postExecSecurity } from "../infra/security-pipeline.js";
 import { backgroundNotLineSafeError, backgroundLaunchedResult } from "./background-launch.js";
-import { validatePodName, prepareExecEnv } from "../infra/exec-utils.js";
+import { validatePodName, prepareExecEnv, filterPodNoise } from "../infra/exec-utils.js";
 import { resolveRequiredKubeconfig } from "../infra/kubeconfig-resolver.js";
 import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
 
@@ -236,7 +236,7 @@ Examples:
         );
 
         return {
-          content: [{ type: "text", text: postExecSecurity(stdout.trim(), pre.action, { stderr: stderr.trim() || undefined }) }],
+          content: [{ type: "text", text: postExecSecurity(stdout.trim(), pre.action, { stderr: filterPodNoise(stderr.trim()) || undefined }) }],
           details: { exitCode: 0 },
         };
       } catch (err: any) {
@@ -246,7 +246,7 @@ Examples:
           return { content: [{ type: "text", text: "Aborted." }], details: { error: true } };
         }
         const stdout = (err.stdout?.trim() ?? "") as string;
-        const stderr = (err.stderr?.trim() ?? err.message) as string;
+        const stderr = filterPodNoise((err.stderr?.trim() ?? err.message) as string);
         const exitCode = err.code ?? "unknown";
         return {
           content: [{ type: "text", text: postExecSecurity(`${stdout || "(no output)"}\n[exit code: ${exitCode}]`, pre.action, { stderr: stderr || undefined }) }],

--- a/src/tools/infra/exec-utils.test.ts
+++ b/src/tools/infra/exec-utils.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { stdinExecCmd } from "./exec-utils.js";
+import { filterPodNoise, stdinExecCmd } from "./exec-utils.js";
+
+describe("filterPodNoise", () => {
+  it("removes kubectl exec SPDY stream diagnostics but preserves the real error", () => {
+    const noisy = [
+      "I0722 15:03:20.306993   65357 log.go:244] (0x46) Create stream",
+      "I0722 15:03:20.355662   65357 log.go:244] Reply frame received for 1",
+      "error: executable file not found in $PATH",
+    ].join("\n");
+
+    expect(filterPodNoise(noisy)).toBe(
+      "error: executable file not found in $PATH",
+    );
+  });
+
+  it("keeps ordinary command stderr", () => {
+    expect(filterPodNoise("permission denied\ncommand failed")).toBe("permission denied\ncommand failed");
+  });
+});
 
 describe("stdinExecCmd", () => {
   it("generates correct bash stdin command without args", () => {

--- a/src/tools/infra/exec-utils.ts
+++ b/src/tools/infra/exec-utils.ts
@@ -165,13 +165,19 @@ export function stdinExecCmd(interpreter: "bash" | "python3", escapedArgs?: stri
 }
 
 /**
- * Filter out kubectl run informational lines from stderr
- * (e.g. 'pod "node-debug-xxx" deleted').
+ * Filter wrapper noise from kubectl/debug-pod stderr while preserving the actual
+ * command or Kubernetes error. The klog `log.go:244` lines are client-side
+ * SPDY/WebSocket stream diagnostics, not evidence from the target container.
  */
 export function filterPodNoise(stderr: string): string {
   return stderr
     .split("\n")
-    .filter((line) => !line.match(/^pod "node-debug-.*" deleted$/))
+    .filter((line) => {
+      if (line.match(/^pod "node-debug-.*" deleted$/)) return false;
+      return !line.match(
+        /^[IWEF]\d{4}\s+\d{2}:\d{2}:\d+\.\d+\s+\d+\s+log\.go:\d+\].*(?:Create stream|Stream added, broadcasting:|Reply frame received for|Data frame received for|Data frame handling|Data frame sent|Stream removed, broadcasting:|Go away received).*$/,
+      );
+    })
     .join("\n")
     .trim();
 }


### PR DESCRIPTION
Default debug mode can expose Docker/Moby and kubectl exec Go transport diagnostics in pod_exec stderr. These SPDY/WebSocket stream logs are wrapper noise and can overwhelm the agent context. Filter known transport lines while preserving actual container, OCI, and Kubernetes errors.

Adds regression coverage for the filter.