### PR TITLE
fix(kbc): de-stream v2 — default-on session-scoped activation + stall-watchdog floor (follow-up to #434)

### DIFF
--- a/.github/workflows/kbc-ci.yml
+++ b/.github/workflows/kbc-ci.yml
@@ -37,6 +37,8 @@ jobs:
       - run: pip install -r kbc/platform/pod/requirements.txt
       - run: python test_compile_box.py
         working-directory: kbc/platform/pod
+      - run: python test_destream.py
+        working-directory: kbc/platform/pod
       - run: python test_codex_engine.py
         working-directory: kbc/platform/pod
       - run: python test_office_ingest.py

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -3532,6 +3532,18 @@ async def _consume_turn_stream(
 _STALL_INTERRUPT_DEADLINE_S = int(os.environ.get("KBC_STALL_INTERRUPT_DEADLINE_S", "120"))
 
 
+def _watchdog_idle_bound(tool_pending: bool, model_idle_timeout: float, destream_floor: float) -> float:
+    """Idle bound for the stall watchdog.
+
+    A pending tool is LOCAL execution and keeps its own (shorter) bound;
+    de-streaming only affects the model-request phase, so the de-stream floor
+    lifts ONLY the model bound — it must never extend a stuck tool's timeout.
+    """
+    if tool_pending:
+        return _MODEL_TOOL_IDLE_TIMEOUT_S
+    return max(model_idle_timeout, destream_floor) if destream_floor else model_idle_timeout
+
+
 async def _model_stall_watchdog(run: CompileRun) -> None:
     """Reap a turn wedged on a black-holed model request. Interrupt the attempt;
     _consume_turn_stream then re-issues it (or fails). Only judges an ACTIVE turn,
@@ -3576,13 +3588,12 @@ async def _model_stall_watchdog(run: CompileRun) -> None:
             if run._model_idle_timeout_s is not None
             else _MODEL_IDLE_TIMEOUT_S
         )
-        bound = _MODEL_TOOL_IDLE_TIMEOUT_S if run._tool_pending else model_idle_timeout
-        # De-streamed turns produce no SDK deltas mid-request: the idle bound
-        # must cover a whole model request or the watchdog false-kills long
-        # generations (see destream.model_idle_floor).
-        floor = destream.model_idle_floor()
-        if floor:
-            bound = max(bound, floor)
+        # De-streamed model turns emit no SDK deltas mid-request, so the model
+        # idle bound must cover a whole generation or the watchdog false-kills
+        # long ones. A pending tool is unaffected by de-streaming and keeps its
+        # own (shorter) bound (see _watchdog_idle_bound / destream.model_idle_floor).
+        bound = _watchdog_idle_bound(
+            run._tool_pending, model_idle_timeout, destream.model_idle_floor())
         idle = time.monotonic() - run._last_model_activity
         if idle <= bound:
             continue
@@ -4268,6 +4279,9 @@ def _recommendation_session_opts(
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=str(uuid.uuid4()),
         session_store=InMemorySessionStore(),
+        # Non-interactive red-team reviewer → de-streamed Anthropic route
+        # (charset fix); merged over the inherited env by the SDK.
+        env=destream.session_env("verify"),
         hooks={"PreToolUse": [HookMatcher(hooks=[_make_recommendation_path_guard(root, parent.locale)])]},
     )
 
@@ -4538,6 +4552,9 @@ def _reference_assist_session_opts(parent: "CompileRun", root: Path, submit_tool
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=str(uuid.uuid4()),
         session_store=InMemorySessionStore(),
+        # Non-interactive reference-answer assistant → de-streamed Anthropic
+        # route (charset fix); merged over the inherited env by the SDK.
+        env=destream.session_env("verify"),
         hooks={"PreToolUse": [HookMatcher(hooks=[_make_recommendation_path_guard(root, parent.locale)])]},
     )
 

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2219,6 +2219,9 @@ def _compile_session_opts(run: "CompileRun", wd: str, system_prompt: str, sessio
         max_buffer_size=SDK_MAX_BUFFER_BYTES,
         session_id=session_id,
         session_store=InMemorySessionStore(),
+        # Non-interactive session → de-streamed Anthropic route (charset fix);
+        # merged over the inherited env by the SDK, so credentials stay put.
+        env=destream.session_env("authoring"),
         hooks={"PreToolUse": [HookMatcher(hooks=[_make_compile_path_guard(
             Path(wd), run.locale, pdf_page_ranges=pdf_page_ranges,
             raw_read_allowlist=raw_read_allowlist,
@@ -3069,6 +3072,7 @@ async def _plan_batches(run: "CompileRun", inventory: list) -> dict:
                 max_buffer_size=SDK_MAX_BUFFER_BYTES,
                 session_id=planner_session_id,
                 session_store=InMemorySessionStore(),
+                env=destream.session_env("authoring"),
             )
             client = ClaudeSDKClient(options=opts)
         prev = run.client
@@ -3573,6 +3577,12 @@ async def _model_stall_watchdog(run: CompileRun) -> None:
             else _MODEL_IDLE_TIMEOUT_S
         )
         bound = _MODEL_TOOL_IDLE_TIMEOUT_S if run._tool_pending else model_idle_timeout
+        # De-streamed turns produce no SDK deltas mid-request: the idle bound
+        # must cover a whole model request or the watchdog false-kills long
+        # generations (see destream.model_idle_floor).
+        floor = destream.model_idle_floor()
+        if floor:
+            bound = max(bound, floor)
         idle = time.monotonic() - run._last_model_activity
         if idle <= bound:
             continue
@@ -4700,9 +4710,6 @@ def _apply_session_config(body: dict) -> None:
             if k == "KBC_PK_MODE" and _PK_KILL_AT_BOOT:
                 continue  # ops kill switch outranks consumer config
             os.environ[k] = str(value)
-    # After the final env state lands: opt the Anthropic route in/out of the
-    # in-pod de-streaming shim (KBC_DESTREAM, charset fix — see destream.py).
-    destream.maybe_activate()
 
 
 async def handle_session(request: web.Request):

--- a/kbc/platform/pod/destream.py
+++ b/kbc/platform/pod/destream.py
@@ -14,9 +14,13 @@ non-streaming switch, hence a localhost shim:
 Scope: only POST .../v1/messages bodies with "stream": true are de-streamed.
 Everything else (count_tokens, models, non-streaming posts) passes through
 verbatim as RAW BYTES — the shim must never introduce a decode step of its
-own. Activation is per-profile via the consumer-settings whitelist
-(KBC_DESTREAM=1 on the compile profile); test-session boxes keep true
-streaming for interactive UX.
+own. Activation is DEFAULT-ON and session-scoped in the binary (no deployment
+config): authoring/batch/planner/verify sessions get the shim via per-session
+CLI env, TEST sessions always keep true streaming for interactive UX, the
+codex/OpenAI route is untouched, and KBC_DESTREAM=0/off is the operator
+escape hatch (e.g. once the gateway ships cross-chunk incremental decoding).
+Blast radius is this container image only: the shim binds 127.0.0.1 inside
+the kbc-compile-box pod; runtime/agentbox/sicore LLM callers never see it.
 """
 
 from __future__ import annotations
@@ -48,24 +52,55 @@ def _upstream_timeout() -> float:
     return float(os.environ.get("KBC_DESTREAM_TIMEOUT", "3600"))
 
 
-def maybe_activate() -> None:
-    """Called after session config lands in os.environ (sync seam). When the
-    profile opts in and the engine is the Anthropic one, remember the real
-    upstream and point the CLI at the shim; when it opts out, restore."""
-    global _UPSTREAM
-    if _PORT is None:
-        return
-    shim_url = f"http://127.0.0.1:{_PORT}"
-    base = os.environ.get("ANTHROPIC_BASE_URL", "")
-    wanted = (_truthy(os.environ.get("KBC_DESTREAM"))
-              and os.environ.get("KBC_ENGINE", "claude_agent_sdk") != "codex_sdk")
-    if wanted:
-        if base and base != shim_url:
-            _UPSTREAM = base
-        if _UPSTREAM:
-            os.environ["ANTHROPIC_BASE_URL"] = shim_url
-    elif base == shim_url and _UPSTREAM:
-        os.environ["ANTHROPIC_BASE_URL"] = _UPSTREAM
+def _explicitly_off() -> bool:
+    return (os.environ.get("KBC_DESTREAM") or "").strip().lower() in (
+        "0", "off", "false", "no")
+
+
+def enabled() -> bool:
+    """Default ON for the Anthropic engine — the corruption is a standing
+    gateway bug and the compile box is non-interactive, so byte-correct text
+    is the right default. KBC_DESTREAM=0/off is the operator escape hatch
+    (e.g. after the gateway ships cross-chunk decoding). Codex/OpenAI routes
+    are out of scope."""
+    if _PORT is None or _explicitly_off():
+        return False
+    if os.environ.get("KBC_ENGINE", "claude_agent_sdk") == "codex_sdk":
+        return False
+    return bool(_UPSTREAM or os.environ.get("ANTHROPIC_BASE_URL"))
+
+
+def session_env(kind: str) -> dict:
+    """Per-session CLI env override (merged over the inherited environment by
+    the SDK). Authoring/verify sessions are non-interactive → de-streamed;
+    TEST sessions keep true streaming for interactive UX and always get {}."""
+    if kind not in ("authoring", "verify") or not enabled():
+        return {}
+    return {"ANTHROPIC_BASE_URL": f"http://127.0.0.1:{_PORT}"}
+
+
+def model_idle_floor() -> float:
+    """De-streamed turns emit no SDK deltas until the request completes, so
+    the fine-grained stall watchdog would false-kill any generation longer
+    than its idle bound. When the shim is active the idle bound must cover a
+    whole model request; black-hole reaping degrades from seconds to this
+    bound — the honest price of the charset fix, still far under the CLI's
+    own ~60min request timeout."""
+    if not enabled():
+        return 0.0
+    return float(os.environ.get("KBC_DESTREAM_MODEL_IDLE_TIMEOUT_S", "900"))
+
+
+def _upstream_url() -> str | None:
+    """Resolved per request: the box's own environment keeps pointing at the
+    REAL gateway (only CLI child processes get the shim URL), so no global
+    rewrite/restore bookkeeping is needed."""
+    if _UPSTREAM:
+        return _UPSTREAM
+    base = os.environ.get("ANTHROPIC_BASE_URL")
+    if base and _PORT is not None and f"127.0.0.1:{_PORT}" in base:
+        return None  # self-loop guard
+    return base or None
 
 
 def _fwd_headers(request: web.Request) -> dict:
@@ -142,7 +177,7 @@ async def _destream_messages(request: web.Request, body: dict) -> web.StreamResp
 
     ping_task = asyncio.create_task(_pings())
     try:
-        url = (_UPSTREAM or "").rstrip("/") + request.path_qs
+        url = (_upstream_url() or "").rstrip("/") + request.path_qs
         timeout = aiohttp.ClientTimeout(total=_upstream_timeout())
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(url, json={**body, "stream": False},
@@ -175,7 +210,7 @@ async def _destream_messages(request: web.Request, body: dict) -> web.StreamResp
 
 async def _passthrough(request: web.Request, body_bytes: bytes) -> web.StreamResponse:
     """Verbatim relay, RAW BYTES both ways — never decode here."""
-    url = (_UPSTREAM or "").rstrip("/") + request.path_qs
+    url = (_upstream_url() or "").rstrip("/") + request.path_qs
     timeout = aiohttp.ClientTimeout(total=_upstream_timeout())
     async with aiohttp.ClientSession(timeout=timeout, auto_decompress=False) as session:
         async with session.request(request.method, url, data=body_bytes,
@@ -190,7 +225,7 @@ async def _passthrough(request: web.Request, body_bytes: bytes) -> web.StreamRes
 
 
 async def _handle(request: web.Request) -> web.StreamResponse:
-    if not _UPSTREAM:
+    if not _upstream_url():
         return web.json_response(
             {"type": "error",
              "error": {"type": "api_error",

--- a/kbc/platform/pod/engine.py
+++ b/kbc/platform/pod/engine.py
@@ -169,6 +169,11 @@ class ClaudeEngine:
             session_id=str(uuid.uuid4()),
             session_store=InMemorySessionStore(),
         )
+        # Verify agents are non-interactive too — route them through the
+        # de-streaming shim when it is active (lazy import keeps this module
+        # importable without aiohttp).
+        import destream
+        opts.env = {**(opts.env or {}), **destream.session_env("verify")}
         client = ClaudeSDKClient(options=opts)
         parts: list[str] = []
 

--- a/kbc/platform/pod/test_destream.py
+++ b/kbc/platform/pod/test_destream.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+from pathlib import Path
 
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
@@ -209,8 +210,80 @@ def test_default_on_session_scoped_activation():
     print("OK  default-on session-scoped activation (test sessions stream, opt-out works)")
 
 
+def test_verify_caller_opts_carry_shim():
+    """Integration guard: the two non-interactive Claude reviewer sessions
+    (test recommendation + reference-answer assist) must thread the de-stream
+    shim into their SDK env, exactly like the authoring/verify entrypoints.
+    Without it they keep hitting the streaming gateway and re-expose the
+    cross-chunk charset corruption this PR fixes. Opt-out must clear it."""
+    import tempfile
+    import types
+
+    import compile_box
+
+    env_backup = {k: os.environ.get(k) for k in
+                  ("KBC_DESTREAM", "KBC_ENGINE", "ANTHROPIC_BASE_URL")}
+    destream._PORT = 45678
+    shim = {"ANTHROPIC_BASE_URL": "http://127.0.0.1:45678"}
+    try:
+        os.environ["ANTHROPIC_BASE_URL"] = "https://api.example/model-api"
+        os.environ.pop("KBC_DESTREAM", None)
+        os.environ.pop("KBC_ENGINE", None)
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            parent = types.SimpleNamespace(locale="en")
+
+            rec_submit = compile_box._make_recommendation_submit_tool(root, parent, {})
+            rec_opts = compile_box._recommendation_session_opts(parent, root, rec_submit)
+            assert rec_opts.env == shim, rec_opts.env
+
+            ref_submit, allowed = compile_box._make_reference_assist_submit_tool(
+                root, parent, "polish", {})
+            ref_opts = compile_box._reference_assist_session_opts(
+                parent, root, ref_submit, allowed)
+            assert ref_opts.env == shim, ref_opts.env
+
+            # operator opt-out drops both back to true streaming (empty env)
+            os.environ["KBC_DESTREAM"] = "off"
+            assert compile_box._recommendation_session_opts(
+                parent, root, rec_submit).env == {}
+            assert compile_box._reference_assist_session_opts(
+                parent, root, ref_submit, allowed).env == {}
+    finally:
+        destream._PORT = None
+        destream._UPSTREAM = None
+        for k, v in env_backup.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    print("OK  recommendation + reference-assist opts carry the shim env (opt-out clears it)")
+
+
+def test_watchdog_floor_scoped_to_model_phase():
+    """Integration guard for the stall watchdog: the de-stream idle floor lifts
+    ONLY the model-request bound. A pending tool is local execution and must
+    keep its own (shorter) bound, or a wedged tool would be reaped minutes
+    late."""
+    import compile_box
+
+    tool_bound = compile_box._MODEL_TOOL_IDLE_TIMEOUT_S  # 660s default
+    # tool pending: floor NEVER applies, even a large one
+    assert compile_box._watchdog_idle_bound(True, 90.0, 900.0) == tool_bound
+    assert compile_box._watchdog_idle_bound(True, 90.0, 0.0) == tool_bound
+    # model phase: floor lifts the model bound when the shim is active
+    assert compile_box._watchdog_idle_bound(False, 90.0, 900.0) == 900.0
+    # model phase, shim off: bound is untouched
+    assert compile_box._watchdog_idle_bound(False, 90.0, 0.0) == 90.0
+    # floor never shrinks an already-larger model bound
+    assert compile_box._watchdog_idle_bound(False, 1200.0, 900.0) == 1200.0
+    print("OK  watchdog de-stream floor applies to the model bound only, never a pending tool")
+
+
 if __name__ == "__main__":
     test_default_on_session_scoped_activation()
+    test_verify_caller_opts_carry_shim()
+    test_watchdog_floor_scoped_to_model_phase()
     for fn in (test_destream_synthesizes_valid_sse,
                test_destream_pings_while_upstream_is_slow,
                test_destream_upstream_error_becomes_stream_error_event,

--- a/kbc/platform/pod/test_destream.py
+++ b/kbc/platform/pod/test_destream.py
@@ -165,27 +165,39 @@ async def test_non_stream_and_other_routes_pass_through_verbatim():
     print("OK  non-streaming posts and other routes pass through as raw bytes")
 
 
-def test_maybe_activate_env_logic():
-    destream._PORT = 45678
-    shim = "http://127.0.0.1:45678"
+def test_default_on_session_scoped_activation():
+    """v2 semantics: default ON for non-interactive Anthropic sessions with no
+    deployment config; TEST sessions always stream; codex untouched; KBC_DESTREAM
+    stays as the operator opt-out escape hatch."""
     env_backup = {k: os.environ.get(k) for k in
                   ("KBC_DESTREAM", "KBC_ENGINE", "ANTHROPIC_BASE_URL")}
+    destream._PORT = 45678
+    shim = {"ANTHROPIC_BASE_URL": "http://127.0.0.1:45678"}
     try:
         os.environ["ANTHROPIC_BASE_URL"] = "https://api.example/model-api"
-        os.environ["KBC_DESTREAM"] = "1"
+        os.environ.pop("KBC_DESTREAM", None)
         os.environ.pop("KBC_ENGINE", None)
-        destream.maybe_activate()
-        assert os.environ["ANTHROPIC_BASE_URL"] == shim
-        assert destream._UPSTREAM == "https://api.example/model-api"
-        destream.maybe_activate()  # idempotent: shim url is not re-captured
-        assert destream._UPSTREAM == "https://api.example/model-api"
-        os.environ["KBC_DESTREAM"] = "0"
-        destream.maybe_activate()  # opt-out restores the real upstream
+        # default ON, session-scoped
+        assert destream.enabled()
+        assert destream.session_env("authoring") == shim
+        assert destream.session_env("verify") == shim
+        assert destream.session_env("test") == {}          # interactive: never
+        assert destream.model_idle_floor() == 900.0
+        # the box's own environment is NOT rewritten (per-session env only)
         assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.example/model-api"
-        os.environ["KBC_DESTREAM"] = "1"
+        # operator opt-out
+        os.environ["KBC_DESTREAM"] = "off"
+        assert not destream.enabled()
+        assert destream.session_env("authoring") == {}
+        assert destream.model_idle_floor() == 0.0
+        os.environ.pop("KBC_DESTREAM", None)
+        # codex engine out of scope
         os.environ["KBC_ENGINE"] = "codex_sdk"
-        destream.maybe_activate()  # codex engine is out of scope
-        assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.example/model-api"
+        assert not destream.enabled()
+        os.environ.pop("KBC_ENGINE", None)
+        # no shim listener -> off
+        destream._PORT = None
+        assert not destream.enabled()
     finally:
         destream._PORT = None
         destream._UPSTREAM = None
@@ -194,11 +206,11 @@ def test_maybe_activate_env_logic():
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
-    print("OK  maybe_activate: opt-in rewrites, opt-out restores, codex untouched")
+    print("OK  default-on session-scoped activation (test sessions stream, opt-out works)")
 
 
 if __name__ == "__main__":
-    test_maybe_activate_env_logic()
+    test_default_on_session_scoped_activation()
     for fn in (test_destream_synthesizes_valid_sse,
                test_destream_pings_while_upstream_is_slow,
                test_destream_upstream_error_becomes_stream_error_event,


### PR DESCRIPTION
## Summary

Follow-up fix to #434, which merged while the in-pod de-streaming shim was still at **v1**. v1 works but has two problems in the way it activates. This PR replaces the v1 activation model with a session-scoped, default-on one and handles the stall-watchdog interaction. Behavior of the shim's actual de-streaming (SSE synthesis, passthrough, charset fix) is unchanged.

## Why v1 needed a follow-up

**#434 merged at v1** — activation via a global `ANTHROPIC_BASE_URL` rewrite, gated on an opt-in `KBC_DESTREAM` flag, with no handling of the stall watchdog. Two concrete issues:

1. **Global env rewrite has blast radius beyond the compile session.** v1 rewrote the pod-wide `ANTHROPIC_BASE_URL` in `os.environ` (`destream.maybe_activate()` at the end of `_apply_session_config`). That redirection is inherited by *any* later CLI invocation in the same pod — including interactive **test sessions**, which must keep true streaming for UX.
2. **Stall-watchdog interaction unhandled.** De-streamed turns emit **no SDK deltas** mid-request (the whole response arrives at once after the upstream non-streaming call returns). The fine-grained model-idle bound (90s / 240s) would therefore false-kill any model generation longer than ~90s and retry it needlessly.

## What v2 changes

- **Activation is default-on and session-scoped, with zero deployment config.** Replaces `maybe_activate()` (global env rewrite) with:
  - `enabled()` — default ON for the Anthropic engine; `KBC_DESTREAM=0/off/false/no` is the sole operator escape hatch; `KBC_ENGINE=codex_sdk` and "no shim listener" both disable it.
  - `session_env(kind)` — returns the shim URL only for `authoring` / `verify` sessions; **`test` always returns `{}`** so interactive sessions keep true streaming. Injected via the SDK `options.env` (merges over the inherited environment, so credentials stay put) at `_compile_session_opts`, the batch planner session, and `ClaudeEngine.run_readonly_agent`.
  - `_upstream_url()` — resolves the real upstream **per request** from `os.environ` with a self-loop guard, so the box's own environment is never rewritten (no global rewrite/restore bookkeeping).
- **Stall-watchdog floor.** `model_idle_floor()` (default `900s`, env `KBC_DESTREAM_MODEL_IDLE_TIMEOUT_S`) floors the watchdog `bound` in `_model_stall_watchdog` while the shim is active. Black-hole reaping coarsens from seconds to minutes — the honest price of the charset fix, still far under the CLI's own ~60min request timeout.
- **Tests.** `test_destream.py` gains v2 semantics coverage (default-on, session-scoped, test always streams, opt-out, codex out of scope, box env not rewritten), replacing the old `maybe_activate` test; the other 5 destream tests are unchanged.

## Blast radius

The **kbc-compile-box image only** — the shim binds `127.0.0.1` inside the compile-box pod. runtime / agentbox / sicore-side LLM callers never see it.

## Verification

- `python3` AST parse of all four touched files — clean.
- `test_destream.py` — all 6 tests pass (5 original + the replacement v2 test).
- `import compile_box` — clean; adjacent `test_compile_box.py` tests pass: `test_apply_session_config`, `test_batch_planner_uses_compile_path_guard`, `test_run_wrapper_terminal_signals`.

## Merge note

This branch is cut from current `main` (post-#434). The compile_box.py hunks auto-merged cleanly over the L1-repair-budget changes from #430 that landed after v1 — no conflict; both change sets coexist.
