### PR TITLE
feat(mcp): surface a bounded progress_tail in working task responses

### DIFF
--- a/mcp/sicore-a2a-adapter/src/tools.test.ts
+++ b/mcp/sicore-a2a-adapter/src/tools.test.ts
@@ -80,21 +80,46 @@ describe("tool contract", () => {
     expect(result.structuredContent).toMatchObject({ state: "completed", result: "root cause" });
   });
 
-  it("keeps a working response compact until the terminal result", async () => {
+  it("keeps a working response compact but surfaces a progress tail", async () => {
     const api = fakeApi();
     vi.mocked(api.getTask).mockResolvedValue({
       ...task(),
-      result: "partial evidence that should not be repeated",
+      result: "partial evidence worth relaying to the caller",
       updated_at: "2026-07-18T00:00:00.000Z",
     });
     const result = await createToolHandler(api)("siclaw_get_task", { task_id: "task-1" });
-    expect(result.content[0].text).not.toContain("partial evidence that should not be repeated");
+    expect(result.content[0].text).toContain("progress_tail (latest excerpt):");
+    expect(result.content[0].text).toContain("partial evidence worth relaying to the caller");
     expect(result.content[0].text).toContain("siclaw_wait_task");
     expect(result.structuredContent).toMatchObject({
       state: "working",
-      progress_chars: 44,
+      progress_chars: 45,
+      progress_tail: "partial evidence worth relaying to the caller",
     });
     expect(result.structuredContent).not.toHaveProperty("result");
+  });
+
+  it("bounds the progress tail to the last 400 runes of a long partial report", async () => {
+    const api = fakeApi();
+    const partial = "x".repeat(700) + "the latest narrative sentence";
+    vi.mocked(api.getTask).mockResolvedValue({
+      ...task(),
+      result: partial,
+      updated_at: "2026-07-18T00:00:00.000Z",
+    });
+    const result = await createToolHandler(api)("siclaw_get_task", { task_id: "task-1" });
+    const tail = (result.structuredContent as { progress_tail: string }).progress_tail;
+    expect(tail.startsWith("…")).toBe(true);
+    expect(tail.endsWith("the latest narrative sentence")).toBe(true);
+    expect(Array.from(tail).length).toBe(401);
+    expect(result.structuredContent).toMatchObject({ progress_chars: 729 });
+    expect(result.content[0].text).not.toContain(partial);
+  });
+
+  it("omits the progress tail from terminal responses", async () => {
+    const result = await createToolHandler(fakeApi())("siclaw_get_task", { task_id: "task-1" });
+    expect(result.structuredContent).not.toHaveProperty("progress_tail");
+    expect(result.structuredContent).toMatchObject({ state: "completed", result: "root cause" });
   });
 
   it("keeps the submitted task_id when the bounded wait fails after submission", async () => {

--- a/mcp/sicore-a2a-adapter/src/tools.ts
+++ b/mcp/sicore-a2a-adapter/src/tools.ts
@@ -41,7 +41,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: "siclaw_wait_task",
-    description: "Wait for an existing Siclaw investigation without creating another task. Use this as the same-turn watchdog: call it repeatedly while the task is non-terminal, unless the user asks to stop or the overall investigation deadline is exhausted. Working responses are compact; the full report is returned once the task reaches a terminal state.",
+    description: "Wait for an existing Siclaw investigation without creating another task. Use this as the same-turn watchdog: call it repeatedly while the task is non-terminal, unless the user asks to stop or the overall investigation deadline is exhausted. Working responses are compact — a short progress_tail excerpt of the investigation narrative plus counters; the full report is returned once the task reaches a terminal state.",
     inputSchema: {
       type: "object",
       properties: {
@@ -110,14 +110,28 @@ type ToolResult = {
 type TaskToolView = Omit<SiclawTask, "result"> & {
   result?: string | null;
   progress_chars: number;
+  progress_tail?: string;
   wait_error?: string;
 };
 
+// Working responses withhold the partial report for compactness, but expose a
+// bounded tail so pollers can relay what the investigation is doing right now.
+const PROGRESS_TAIL_MAX_RUNES = 400;
+
+function progressTail(text: string | null | undefined): string | undefined {
+  if (!text) return undefined;
+  const runes = Array.from(text);
+  if (runes.length <= PROGRESS_TAIL_MAX_RUNES) return text;
+  return "…" + runes.slice(-PROGRESS_TAIL_MAX_RUNES).join("");
+}
+
 function taskView(task: SiclawTask, includeTerminalResult: boolean): TaskToolView {
   const { result, ...summary } = task;
+  const tail = task.is_terminal ? undefined : progressTail(result);
   return {
     ...summary,
-    progress_chars: result?.length ?? 0,
+    progress_chars: result ? Array.from(result).length : 0,
+    ...(tail !== undefined ? { progress_tail: tail } : {}),
     ...(includeTerminalResult && task.is_terminal ? { result } : {}),
   };
 }
@@ -165,8 +179,11 @@ function taskText(task: SiclawTask, waitError?: string): string {
   if (waitError) lines.push(`wait_error: ${waitError} (status polling failed, but the task was already created)`);
   if (task.is_terminal && task.result) lines.push("", task.result);
   if (!task.is_terminal) {
-    const progressChars = task.result?.length ?? 0;
-    if (progressChars > 0) lines.push(`progress_chars: ${progressChars} (partial report withheld until terminal)`);
+    const progressChars = task.result ? Array.from(task.result).length : 0;
+    if (progressChars > 0) {
+      lines.push(`progress_chars: ${progressChars} (full report is withheld until terminal)`);
+      lines.push("progress_tail (latest excerpt):", progressTail(task.result)!);
+    }
     lines.push("", "The investigation is still running. Call siclaw_wait_task with the task_id; do not submit the same investigation again.");
   }
   return lines.join("\n");


### PR DESCRIPTION
## What

Working responses from the five Siclaw MCP tools deliberately withheld the partial report for compactness, leaving pollers with only `progress_chars` and the last tool-event status string (e.g. `Finished tool: bash`) — enough to know the task is alive, not enough to relay what the investigation is currently doing.

This PR exposes the last **400 runes** of the partial report as `progress_tail` in working responses (both the text block and `structuredContent`), preserving the compactness property:

- the tail is bounded regardless of report size;
- terminal responses and task listings are unchanged;
- the `siclaw_wait_task` description is updated to advertise the excerpt.

Also aligns `progress_chars` to count Unicode code points (matching the sicore HTTP endpoint's rune count on CJK reports) instead of UTF-16 units.

## Why

Field feedback from driving the tools as an MCP caller: during a 2–5 minute investigation the only mid-flight signal was a coarse status string, so the calling agent could not tell the user anything meaningful ("正在实测 draco 节点 link_layer" vs "finished bash"). The narrative already exists server-side — `progress_chars` is computed from it — so this only exposes a bounded view of data both surfaces already hold.

## Sync contract

Mirror of sicore `feat/a2a-mcp-progress-tail` — tool descriptions and working/terminal response shapes stay verbatim-synced between the stdio adapter and the `/api/v1/mcp` endpoint.

## Tests

32 adapter tests green, including new cases: short partial passed through whole, long partial bounded to 401 runes (`…` + 400), terminal responses carry no tail.

Stacked on #440 (`feat/a2a-mcp-caller-guidance`); base set accordingly.
