### PR TITLE
kbc box: content shape never wedges the batch train

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -3505,6 +3505,10 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         for batch in list(pending):
             k = next(i + 1 for i, b in enumerate(plan["batches"]) if b["id"] == batch["id"])
             try:
+                unaccounted_before = (
+                    [] if batch.get("defer_accounting")
+                    else _unaccounted_batch_sources(run, batch.get("sources") or [])
+                )
                 directive = _compose_batch_directive(batch, k, n, _drain_batch_notes(run), locale=getattr(run, "locale", None))
                 reply = await _drive_batch_session(
                     run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"),
@@ -3540,8 +3544,23 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                         replies.append(_loc(run, f"[Batch {k} fix] {fix_reply}", f"【批 {k} 补账】{fix_reply}"))
                     still_unaccounted = _unaccounted_batch_sources(run, batch.get("sources") or [])
                 if still_unaccounted:
+                    if unaccounted_before and set(still_unaccounted) == set(unaccounted_before):
+                        # ZERO accounting progress across the batch turn AND the
+                        # corrective pass. That is the empty/authentication-error
+                        # provider-result shape (the GPU-corpus incident), not
+                        # stubborn content — auto-excluding a whole batch over a
+                        # provider blip would silently drop good sources. Keep the
+                        # batch pending and interrupt resumably.
+                        stalled = BatchOutputError(
+                            f"batch {batch['id']} made no accounting progress over "
+                            f"{len(still_unaccounted)} assigned source(s) — treating as a "
+                            f"provider/model fault; the batch stays pending for resume"
+                        )
+                        stalled.provider_fault = True
+                        raise stalled
                     # Content shape must never wedge the train (2026-07-24 mandate:
-                    # humans may pile ANYTHING into a wiki). The ledger stays honest
+                    # humans may pile ANYTHING into a wiki). The batch made real
+                    # progress and only stragglers remain — the ledger stays honest
                     # instead: auto-exclude with a machine reason a human can read,
                     # revisit and lift.
                     _auto_exclude_batch_sources(
@@ -3558,6 +3577,8 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 # they heal on resume, and excluding content over them would lie.
                 raise
             except BatchOutputError as e:
+                if getattr(e, "provider_fault", False):
+                    raise  # zero-progress: interrupt resumably, batch stays pending
                 # A content/output-shape fault is deterministic: retrying the same
                 # batch forever is the wedge this train must never enter. Skip the
                 # batch, account its sources as machine exclusions, keep going.

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2807,23 +2807,38 @@ def _write_batch_file(run: "CompileRun", rel: str, value) -> None:
     p.write_text(batching.dump_json(value))
 
 
-def _materialize_batch_slices(run: "CompileRun", plan: dict) -> None:
+def _materialize_batch_slices(run: "CompileRun", plan: dict) -> dict[str, str]:
     """Build ephemeral, read-bounded excerpts for oversized Markdown sources.
 
     The fragment is never a provenance identity and never enters durable
     authoring state. It is recreated from Raw on every resume so a model turn
     cannot read the entire oversized source behind the planner's back.
+
+    Returns {batch_id: reason} for batches whose slice views could not be
+    built — a per-batch content/plan-shape fault must not kill the whole train
+    (the caller skips those batches with a recorded exclusion), while the other
+    batches keep their read-bounded views.
     """
     workdir = Path(run.workdir).resolve()
     raw_root = (workdir / "raw").resolve()
     slice_root = (workdir / ".kbc-batch-slices").resolve()
     shutil.rmtree(slice_root, ignore_errors=True)
+    failed: dict[str, str] = {}
     for batch in plan.get("batches", []):
         if batch.get("status") == "done":
             continue
-        ranges = batch.get("source_ranges")
-        if not isinstance(ranges, dict):
-            continue
+        try:
+            _materialize_one_batch_slices(workdir, raw_root, slice_root, batch)
+        except BatchOutputError as e:
+            failed[str(batch.get("id"))] = str(e)
+    return failed
+
+
+def _materialize_one_batch_slices(
+    workdir: Path, raw_root: Path, slice_root: Path, batch: dict,
+) -> None:
+    ranges = batch.get("source_ranges")
+    if isinstance(ranges, dict):
         for source, source_range in ranges.items():
             if not isinstance(source_range, dict):
                 raise BatchOutputError(f"invalid source range for {source}")
@@ -2862,6 +2877,20 @@ def _materialize_batch_slices(run: "CompileRun", plan: dict) -> None:
             ).encode("utf-8")
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(header + b"".join(lines[start - 1:end]))
+
+
+def _auto_exclude_batch_sources(run: "CompileRun", sources: list[str], reason: str) -> list[dict]:
+    """Write machine exclusion rows for sources the train cannot account.
+
+    The 2026-07-24 robustness mandate: a validation gate may keep the ledger
+    honest, but no content shape may deterministically kill the train. Rows are
+    exact-path (glob-escaped) and carry a machine reason a human can read in the
+    exclusion ledger, revisit, and lift."""
+    entries = [
+        {"pattern": selfcheck.glob_escape_path(s), "reason": reason}
+        for s in sources
+    ]
+    return selfcheck.append_exclusions(run.workdir, entries)
 
 
 def _unaccounted_batch_sources(run: "CompileRun", sources: list[str]) -> list[str]:
@@ -3385,27 +3414,68 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         total_kb = batching.corpus_bytes(inventory) // 1024
         plan = _load_batch_plan(run)
         resuming = _batch_plan_resumable(plan)
+        # Orphan media assets (standalone wiki file nodes no document embeds)
+        # can never satisfy the accounting gate — pre-exclude them with a
+        # machine reason BEFORE planning/resuming so no batch ever carries one.
+        inventory_paths = [i["path"] for i in inventory]
+        orphans = selfcheck.orphan_media_assets(run.workdir, inventory_paths)
+        if orphans:
+            added = selfcheck.append_exclusions(run.workdir, [
+                {"pattern": selfcheck.glob_escape_path(p),
+                 "reason": "auto-excluded: media asset not embedded by any document (sync residue)"}
+                for p in orphans])
+            if added:
+                await run.emit({"type": "summary", "text": _loc(run,
+                    f"{len(added)} standalone media asset(s) are embedded by no document — "
+                    f"auto-excluded from accounting (visible in the exclusion ledger).",
+                    f"{len(added)} 个未被任何文档引用的独立媒体资产已自动豁免记账"
+                    f"(豁免清单可见)。")})
+        exclusions_now, _ = selfcheck.load_exclusions(run.workdir)
+        plannable = {
+            p for p in inventory_paths
+            if not any(selfcheck._matches(p, e["pattern"]) for e in exclusions_now)
+        }
         if not resuming:
             _write_batch_file(run, batching.SOURCES_INVENTORY_PATH, inventory)
             await run.emit({"type": "summary", "text": _loc(run,
                 f"Corpus {total_kb}KB exceeds the single-session threshold — batch compile engaged.",
                 f"语料 {total_kb}KB 超过单会话阈值,启用分批编译。")})
-            plan = await _plan_batches(run, inventory)
+            plan = await _plan_batches(run, [i for i in inventory if i["path"] in plannable])
             _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
         else:
             # The pinned plan predates this run; a source deleted from raw/ in
-            # between would leave a batch directive pointing at a missing file.
-            # (Added sources are caught later by the coverage ledger.)
-            dropped = batching.prune_missing_sources(plan, {i["path"] for i in inventory})
+            # between would leave a batch directive pointing at a missing file,
+            # and a source excluded since (orphan assets above included) no
+            # longer needs a batch seat. (Added sources are caught later by the
+            # coverage ledger.)
+            dropped = batching.prune_missing_sources(plan, plannable)
             if dropped:
                 _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
                 await run.emit({"type": "summary",
                                 "text": _loc(run,
-                                             f"Batch resume: {len(dropped)} source(s) no longer in raw/ — removed from pending batches: ",
-                                             f"断点续批:{len(dropped)} 个源已不在 raw/ 中,已从待编批次剔除:")
+                                             f"Batch resume: {len(dropped)} source(s) no longer in raw/ or excluded since — removed from pending batches: ",
+                                             f"断点续批:{len(dropped)} 个源已不在 raw/ 中或已被豁免,已从待编批次剔除:")
                                         + ", ".join(sorted(dropped)[:5])
                                         + ("…" if len(dropped) > 5 else "")})
-        _materialize_batch_slices(run, plan)
+        slice_failures = _materialize_batch_slices(run, plan)
+        if slice_failures:
+            for bad_id, why in sorted(slice_failures.items()):
+                bad = next((b for b in plan["batches"] if str(b.get("id")) == bad_id), None)
+                if bad is None:
+                    continue
+                _auto_exclude_batch_sources(
+                    run,
+                    _unaccounted_batch_sources(run, bad.get("sources") or []),
+                    f"auto-excluded: batch {bad_id} was skipped (slice view failed: {why})",
+                )
+                batching.stamp_done(plan, bad.get("id"))
+                _print_compile_lifecycle("batch.skipped", run, extra=f"id={bad_id} reason={why}")
+            _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+            await run.emit({"type": "summary", "text": _loc(run,
+                f"{len(slice_failures)} batch(es) had unusable read-bounded views and were skipped; "
+                f"their unaccounted sources were auto-excluded with a reason. The train continues.",
+                f"{len(slice_failures)} 个批次的读界视图无法构建,已跳过;未记账的源已自动豁免并写明理由,"
+                f"列车继续。")})
         n = len(plan["batches"])
         pending = batching.pending_batches(plan)
         if plan.get("mode") == "hierarchical":
@@ -3434,25 +3504,73 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         })
         for batch in list(pending):
             k = next(i + 1 for i, b in enumerate(plan["batches"]) if b["id"] == batch["id"])
-            directive = _compose_batch_directive(batch, k, n, _drain_batch_notes(run), locale=getattr(run, "locale", None))
-            reply = await _drive_batch_session(
-                run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"),
-                pdf_page_ranges=batch.get("source_page_ranges"),
-                raw_read_allowlist=_batch_raw_read_allowlist(batch),
-            )
-            if reply:
-                replies.append(_loc(run, f"[Batch {k}/{n}] {reply}", f"【批 {k}/{n}】{reply}"))
-            still_unaccounted = (
-                [] if batch.get("defer_accounting")
-                else _unaccounted_batch_sources(run, batch.get("sources") or [])
-            )
-            if still_unaccounted:
-                shown = ", ".join(still_unaccounted[:5])
-                suffix = "…" if len(still_unaccounted) > 5 else ""
-                raise BatchOutputError(
-                    f"batch {batch['id']} left {len(still_unaccounted)} assigned "
-                    f"source(s) unaccounted: {shown}{suffix}"
+            try:
+                directive = _compose_batch_directive(batch, k, n, _drain_batch_notes(run), locale=getattr(run, "locale", None))
+                reply = await _drive_batch_session(
+                    run, directive, _loc(run, f"batch {k}/{n}", f"批 {k}/{n}"),
+                    pdf_page_ranges=batch.get("source_page_ranges"),
+                    raw_read_allowlist=_batch_raw_read_allowlist(batch),
                 )
+                if reply:
+                    replies.append(_loc(run, f"[Batch {k}/{n}] {reply}", f"【批 {k}/{n}】{reply}"))
+                still_unaccounted = (
+                    [] if batch.get("defer_accounting")
+                    else _unaccounted_batch_sources(run, batch.get("sources") or [])
+                )
+                if still_unaccounted:
+                    # One bounded corrective pass: most gaps are a model that
+                    # cited a page but forgot a source token, and it can fix
+                    # its own ledger cheaper than any machine heuristic.
+                    listed = "\n".join(f"- raw/{s}" for s in still_unaccounted[:40])
+                    fix_reply = await _drive_batch_session(
+                        run,
+                        _loc(run,
+                             "The following sources assigned to this batch are still unaccounted "
+                             "(neither cited by any Candidate page's compiled_from nor covered by an "
+                             "exclusion). For each one: cite it from the page that digests it, or add "
+                             "an exclusion row with a concrete reason.\n" + listed,
+                             "本批分配的下列源仍未记账(既没有被任何候选页的 compiled_from 引用,也没有"
+                             "豁免记录)。请逐个处理:要么在消化它的候选页里补引用,要么在豁免清单里"
+                             "写明具体理由:\n" + listed),
+                        _loc(run, f"batch {k} accounting fix", f"批 {k} 补账"),
+                        pdf_page_ranges=batch.get("source_page_ranges"),
+                        raw_read_allowlist=_batch_raw_read_allowlist(batch),
+                    )
+                    if fix_reply:
+                        replies.append(_loc(run, f"[Batch {k} fix] {fix_reply}", f"【批 {k} 补账】{fix_reply}"))
+                    still_unaccounted = _unaccounted_batch_sources(run, batch.get("sources") or [])
+                if still_unaccounted:
+                    # Content shape must never wedge the train (2026-07-24 mandate:
+                    # humans may pile ANYTHING into a wiki). The ledger stays honest
+                    # instead: auto-exclude with a machine reason a human can read,
+                    # revisit and lift.
+                    _auto_exclude_batch_sources(
+                        run, still_unaccounted,
+                        f"auto-excluded: batch {batch['id']} could not account for this source after a corrective pass",
+                    )
+                    await run.emit({"type": "summary", "text": _loc(run,
+                        f"Batch {k}/{n}: {len(still_unaccounted)} source(s) could not be accounted and were "
+                        f"auto-excluded with a reason (see the exclusion ledger); the train continues.",
+                        f"批 {k}/{n}:{len(still_unaccounted)} 个源无法记账,已自动豁免并写明理由"
+                        f"(见豁免清单),列车继续。")})
+            except (ModelStallError, asyncio.CancelledError):
+                # Infra faults (gateway stall, cancellation) stay interrupting:
+                # they heal on resume, and excluding content over them would lie.
+                raise
+            except BatchOutputError as e:
+                # A content/output-shape fault is deterministic: retrying the same
+                # batch forever is the wedge this train must never enter. Skip the
+                # batch, account its sources as machine exclusions, keep going.
+                _auto_exclude_batch_sources(
+                    run,
+                    _unaccounted_batch_sources(run, batch.get("sources") or []),
+                    f"auto-excluded: batch {batch['id']} was skipped ({e})",
+                )
+                _print_compile_lifecycle("batch.skipped", run, extra=f"batch={k}/{n} id={batch['id']} reason={e}")
+                await run.emit({"type": "summary", "text": _loc(run,
+                    f"Batch {k}/{n} could not complete ({e}); its unaccounted sources were auto-excluded "
+                    f"with a reason and the train continues.",
+                    f"批 {k}/{n} 无法完成({e});未记账的源已自动豁免并写明理由,列车继续。")})
             batching.stamp_done(plan, batch["id"])
             _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
             # Push the done-stamp (and the batch's pages) to the durable store
@@ -3547,19 +3665,21 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 rounds += 1
                 if rounds > round_limit:
                     # Repair turns can add new image citations that re-enter
-                    # pending. Flat mode keeps its established fail-open tail;
-                    # a hierarchical train must not claim complete while a
-                    # large image backlog is still unverified. Its persisted
-                    # `final` phase makes the next trigger resume the tail
-                    # without replaying the map batches.
+                    # pending. Reaching the cap is recorded honestly — pages
+                    # with unverified images are named in the reply — but it
+                    # must NOT fail the train (2026-07-24 mandate: a quality
+                    # tail may degrade with a visible record, never wedge the
+                    # whole compile into a deterministic interrupt loop).
                     await run.emit({"type": "summary", "text": _loc(run,
-                        f"Self-check (images): verify/repair round cap ({round_limit}) reached — remaining pages will be picked up on the next trigger.",
-                        f"自检(图像):验修轮达到上限({round_limit} 轮)——剩余页将在下一轮触发时继续复核。")})
-                    if plan.get("mode") == "hierarchical":
-                        raise BatchOutputError(
-                            f"hierarchical image verification left {len(pending)} "
-                            f"page(s) pending after {round_limit} round(s)"
-                        )
+                        f"Self-check (images): verify/repair round cap ({round_limit}) reached — "
+                        f"{len(pending)} page(s) keep image assertions that could not be verified; recorded, not blocking.",
+                        f"自检(图像):验修轮达到上限({round_limit} 轮)——{len(pending)} 页的图像断言未能核验,"
+                        f"已记录,不阻塞完成。")})
+                    replies.append(_loc(run,
+                        f"[Image verify] {len(pending)} page(s) completed with UNVERIFIED image assertions "
+                        f"after {round_limit} round(s): " + ", ".join(sorted(pending)[:10]) + ("…" if len(pending) > 10 else ""),
+                        f"【图像核验】{len(pending)} 页在 {round_limit} 轮后仍带未核验的图像断言:"
+                        + ", ".join(sorted(pending)[:10]) + ("…" if len(pending) > 10 else "")))
                     break
                 # Blind transcribe+compare per ≤max-images chunk (v2): engine
                 # sessions read one image each — no in-session image pileup.
@@ -3636,7 +3756,11 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         await run.emit({"type": "turn_done", "text": "\n\n".join(replies).strip()
                         or _loc(run, "Batch compile complete.", "分批编译完成。")})
     except Exception as e:
-        _print_compile_lifecycle("batch.interrupted", run, extra=f"reason={type(e).__name__}")
+        # The message text is load-bearing for operators: the class name alone
+        # cost a full pod-log stakeout to diagnose a deterministic wedge.
+        _print_compile_lifecycle(
+            "batch.interrupted", run,
+            extra=f"reason={type(e).__name__}: {str(e)[:300]}")
         await run.emit({"type": "error", "error": f"batch compile failed: {e!r}"})
         # never-block: the single logical turn must still CLOSE — a consumer
         # gating on turn_done would otherwise hang on an orchestrator error.

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -750,11 +750,14 @@ def append_exclusions(workdir: str, entries: list[dict]) -> list[dict]:
         if not isinstance(data, list):
             return []
     have = {str(item.get("pattern")) for item in data if isinstance(item, dict)}
-    added = [
-        {"pattern": str(e["pattern"]), "reason": str(e["reason"])}
-        for e in entries
-        if e.get("pattern") and e.get("reason") and str(e["pattern"]) not in have
-    ]
+    added: list[dict] = []
+    for e in entries:
+        pattern = str(e.get("pattern") or "")
+        reason = str(e.get("reason") or "")
+        if not pattern or not reason or pattern in have:
+            continue
+        have.add(pattern)  # de-duplicate within this call, not just vs the file
+        added.append({"pattern": pattern, "reason": reason})
     if not added:
         return []
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -711,6 +711,60 @@ def asset_attribution_edges(
     return edges
 
 
+def orphan_media_assets(workdir: str, sources: list[str] | None = None) -> list[str]:
+    """Media assets embedded by NO raw document — standalone wiki file nodes and
+    other sync residue with no text home. Coverage v2 deliberately refuses to
+    auto-attach them (a human must still see them), so without an exclusion row
+    they stay unaccounted forever; the batch train pre-excludes them with a
+    machine reason instead of demanding the model account for a bare image."""
+    sources = source_inventory(workdir) if sources is None else sources
+    media = {s for s in sources if is_media_asset(s)}
+    if not media:
+        return []
+    embedded: set[str] = set()
+    for targets in asset_attribution_edges(workdir, sources).values():
+        embedded.update(targets)
+    return sorted(media - embedded)
+
+
+def glob_escape_path(path: str) -> str:
+    """Escape a literal path for use as an exclusion pattern. Exclusion patterns
+    are segment-aware globs, and human titles legally contain `*`, `?`, `[` —
+    without escaping, a machine-written exact-path row could silently swallow
+    sibling files (the over-exclusion false-PASS)."""
+    return re.sub(r"([*?\[])", r"[\1]", path)
+
+
+def append_exclusions(workdir: str, entries: list[dict]) -> list[dict]:
+    """Append machine-written exclusion rows, de-duplicated by pattern. Returns
+    the rows actually added. An unreadable or malformed EXCLUSIONS.json is left
+    UNTOUCHED (returns []) — the lint already surfaces it, and appending to a
+    file we cannot parse risks destroying model-authored rows."""
+    path = Path(workdir) / EXCLUSIONS_PATH
+    data: list = []
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return []
+        if not isinstance(data, list):
+            return []
+    have = {str(item.get("pattern")) for item in data if isinstance(item, dict)}
+    added = [
+        {"pattern": str(e["pattern"]), "reason": str(e["reason"])}
+        for e in entries
+        if e.get("pattern") and e.get("reason") and str(e["pattern"]) not in have
+    ]
+    if not added:
+        return []
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data + added, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return added
+
+
 def _body_source_payload_spans(text: str) -> list[tuple[int, int, str]]:
     """Extract source payloads and exact source-text offsets outside code."""
     payloads: list[tuple[int, int, str]] = []

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3509,6 +3509,7 @@ async def test_batch_orphan_assets_pre_excluded_and_pruned():
     batch carries an orphan PNG — plan-time pre-exclusion writes the ledger
     row and the resume prune drops it from the pending batch."""
     import batching
+    import selfcheck
 
     with tempfile.TemporaryDirectory() as td:
         wd = Path(td)
@@ -3571,6 +3572,7 @@ async def test_batch_unaccounted_gets_corrective_then_auto_excluded():
     source gets ONE corrective session; whatever remains is auto-excluded with
     a machine reason and the train continues — it must never raise."""
     import batching
+    import selfcheck
 
     with tempfile.TemporaryDirectory() as td:
         wd = Path(td)

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3526,7 +3526,10 @@ async def test_batch_orphan_assets_pre_excluded_and_pruned():
         # The live shape: a PINNED plan already carries the orphan asset.
         inventory = batching.scan_sources(raw)
         plan = batching.build_plan(
-            inventory, [[i["path"] for i in inventory]], planner="code")
+            inventory, batching.pack_batches(inventory), planner="code")
+        assert any(
+            any("orphan.png" in s for s in b["sources"]) for b in plan["batches"]
+        ), plan  # the pinned plan really carries the orphan, like the incident
         compile_box._write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
 
         async def fake_drive(run_, directive, label, pdf_page_ranges=None,

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3666,7 +3666,8 @@ async def test_batch_content_fault_skips_batch_but_stall_interrupts():
         compile_box.BatchOutputError("batch h001 produced an unusable page"))
     assert all(b["status"] == "done" for b in plan["batches"]), plan
     assert not [e for e in events if e["type"] == "error"], events
-    skipped = [e for e in events if e["type"] == "summary" and ("skipped" in e["text"] or "无法完成" in e["text"])]
+    skipped = [e for e in events if e["type"] == "summary"
+               and ("could not complete" in e["text"] or "无法完成" in e["text"])]
     assert skipped, events
 
     # Infra fault: the train interrupts resumably — batch 1 NOT stamped, an

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3502,6 +3502,179 @@ async def test_batch_orchestrator_routing_and_resume():
     print("\u2713 batch orchestrator: gate/stamps/single turn_done/resume/notes")
 
 
+async def test_batch_orphan_assets_pre_excluded_and_pruned():
+    """2026-07-24 robustness mandate: a standalone media asset no document
+    embeds (a synced wiki file node) must never occupy a batch seat or wedge
+    the accounting gate. Reproduces the live incident: a pinned plan whose
+    batch carries an orphan PNG — plan-time pre-exclusion writes the ledger
+    row and the resume prune drops it from the pending batch."""
+    import batching
+
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        raw = wd / "raw"
+        (raw / "docs" / "assets").mkdir(parents=True)
+        (raw / "docs" / "one.md").write_bytes(
+            "# One\n![embedded](assets/linked.png)\n".encode("utf-8") + b"x" * 300)
+        (raw / "docs" / "assets" / "linked.png").write_bytes(b"\x89PNG-linked")
+        (raw / "docs" / "assets" / "orphan.png").write_bytes(b"\x89PNG-orphan")
+        run = compile_box.CompileRun("orb1", str(wd), 1)
+        os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100"
+        os.environ["KBC_BATCH_BUDGET_BYTES"] = "100000"
+        os.environ["KBC_BATCH_PLANNER"] = "code"
+
+        # The live shape: a PINNED plan already carries the orphan asset.
+        inventory = batching.scan_sources(raw)
+        plan = batching.build_plan(
+            inventory, [[i["path"] for i in inventory]], planner="code")
+        compile_box._write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+
+        async def fake_drive(run_, directive, label, pdf_page_ranges=None,
+                             raw_read_allowlist=None):
+            return f"done {label}"
+
+        real_drive = compile_box._drive_batch_session
+        real_accounted = compile_box._unaccounted_batch_sources
+        compile_box._drive_batch_session = fake_drive
+        compile_box._unaccounted_batch_sources = lambda run_, sources: []
+        try:
+            await compile_box._run_batch_compile(run, "直接开始编译")
+        finally:
+            compile_box._drive_batch_session = real_drive
+            compile_box._unaccounted_batch_sources = real_accounted
+
+        exclusions, errs = selfcheck.load_exclusions(str(wd))
+        assert not errs, errs
+        reasons = {e["pattern"]: e["reason"] for e in exclusions}
+        orphan_rows = [p for p in reasons if "orphan.png" in p]
+        assert orphan_rows and "not embedded by any document" in reasons[orphan_rows[0]], exclusions
+        assert not any("linked.png" in p for p in reasons), exclusions
+        plan = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+        for b in plan["batches"]:
+            assert not any("orphan.png" in s for s in b["sources"]), b
+            assert b["status"] == "done", b
+        events = []
+        while not run.events.empty():
+            events.append(run.events.get_nowait())
+        assert not [e for e in events if e["type"] == "error"], events
+        assert [e for e in events if e["type"] == "turn_done"], events
+        del os.environ["KBC_BATCH_THRESHOLD_BYTES"]
+        del os.environ["KBC_BATCH_BUDGET_BYTES"]
+    print("✓ batch orphan assets: pre-excluded with reason, pruned from pinned plan, train completes")
+
+
+async def test_batch_unaccounted_gets_corrective_then_auto_excluded():
+    """The accounting gate is an accountant, not a gatekeeper: an unaccounted
+    source gets ONE corrective session; whatever remains is auto-excluded with
+    a machine reason and the train continues — it must never raise."""
+    import batching
+
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        raw = wd / "raw"
+        raw.mkdir(parents=True)
+        (raw / "stubborn.md").write_bytes(b"z" * 400)
+        run = compile_box.CompileRun("gate1", str(wd), 1)
+        os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100"
+        os.environ["KBC_BATCH_BUDGET_BYTES"] = "100000"
+        os.environ["KBC_BATCH_PLANNER"] = "code"
+
+        driven: list[str] = []
+
+        async def fake_drive(run_, directive, label, pdf_page_ranges=None,
+                             raw_read_allowlist=None):
+            driven.append(label)
+            return f"done {label}"
+
+        real_drive = compile_box._drive_batch_session
+        real_accounted = compile_box._unaccounted_batch_sources
+        compile_box._drive_batch_session = fake_drive
+        # The model never fixes it: unaccounted before AND after the corrective.
+        compile_box._unaccounted_batch_sources = (
+            lambda run_, sources: ["stubborn.md"] if sources else [])
+        try:
+            await compile_box._run_batch_compile(run, "直接开始编译")
+        finally:
+            compile_box._drive_batch_session = real_drive
+            compile_box._unaccounted_batch_sources = real_accounted
+
+        assert any("补账" in l or "accounting fix" in l for l in driven), driven
+        exclusions, _ = selfcheck.load_exclusions(str(wd))
+        row = next(e for e in exclusions if "stubborn.md" in e["pattern"])
+        assert "could not account" in row["reason"], row
+        plan = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+        assert all(b["status"] == "done" for b in plan["batches"]), plan
+        events = []
+        while not run.events.empty():
+            events.append(run.events.get_nowait())
+        assert not [e for e in events if e["type"] == "error"], events
+        del os.environ["KBC_BATCH_THRESHOLD_BYTES"]
+        del os.environ["KBC_BATCH_BUDGET_BYTES"]
+    print("✓ batch accounting gate: corrective pass then auto-exclusion, never a raise")
+
+
+async def test_batch_content_fault_skips_batch_but_stall_interrupts():
+    """Failure classification is the load-bearing wall: a content/output-shape
+    fault (BatchOutputError) skips ONLY its batch with a recorded exclusion and
+    the train completes; an infra fault (ModelStallError) still interrupts the
+    train resumably — auto-excluding content over a gateway stall would lie."""
+    import batching
+
+    async def run_train(raiser):
+        td = tempfile.mkdtemp()
+        wd = Path(td)
+        raw = wd / "raw"
+        (raw / "a").mkdir(parents=True)
+        (raw / "b").mkdir(parents=True)
+        (raw / "a" / "one.md").write_bytes(b"x" * 300)
+        (raw / "b" / "two.md").write_bytes(b"y" * 300)
+        run = compile_box.CompileRun("cls1", str(wd), 1)
+        os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100"
+        os.environ["KBC_BATCH_BUDGET_BYTES"] = "400"
+        os.environ["KBC_BATCH_PLANNER"] = "code"
+
+        async def fake_drive(run_, directive, label, pdf_page_ranges=None,
+                             raw_read_allowlist=None):
+            if label.startswith(("batch 1/", "批 1/")):
+                raise raiser
+            return f"done {label}"
+
+        real_drive = compile_box._drive_batch_session
+        real_accounted = compile_box._unaccounted_batch_sources
+        compile_box._drive_batch_session = fake_drive
+        compile_box._unaccounted_batch_sources = lambda run_, sources: []
+        try:
+            await compile_box._run_batch_compile(run, "直接开始编译")
+        finally:
+            compile_box._drive_batch_session = real_drive
+            compile_box._unaccounted_batch_sources = real_accounted
+            del os.environ["KBC_BATCH_THRESHOLD_BYTES"]
+            del os.environ["KBC_BATCH_BUDGET_BYTES"]
+        events = []
+        while not run.events.empty():
+            events.append(run.events.get_nowait())
+        plan = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+        return wd, events, plan
+
+    # Content fault: batch 1 skipped+stamped, batch 2 ran, train completed clean.
+    wd, events, plan = await run_train(
+        compile_box.BatchOutputError("batch h001 produced an unusable page"))
+    assert all(b["status"] == "done" for b in plan["batches"]), plan
+    assert not [e for e in events if e["type"] == "error"], events
+    skipped = [e for e in events if e["type"] == "summary" and ("skipped" in e["text"] or "无法完成" in e["text"])]
+    assert skipped, events
+
+    # Infra fault: the train interrupts resumably — batch 1 NOT stamped, an
+    # error event surfaces, and the turn closes with the resumable story.
+    wd, events, plan = await run_train(compile_box.ModelStallError("gateway stalled"))
+    statuses = [b["status"] for b in plan["batches"]]
+    assert statuses[0] != "done", plan
+    assert [e for e in events if e["type"] == "error"], events
+    turn = next(e for e in events if e["type"] == "turn_done")
+    assert "断点" in turn["text"] or "resume" in turn["text"], turn
+    print("✓ batch failure classification: content skips one batch, infra interrupts resumably")
+
+
 def test_small_kb_batch_gate_skips_poppler_metadata():
     """Ordinary compile routing keeps the pre-PDF-slicing cheap scan. Poppler
     metadata is execution detail for a selected batch plan, never a new cost on
@@ -5203,6 +5376,9 @@ async def main():
     await test_unchanged_owner_turn_does_not_migrate_legacy_format()
     await test_batch_final_ledger_check_requires_index()
     await test_batch_orchestrator_routing_and_resume()
+    await test_batch_orphan_assets_pre_excluded_and_pruned()
+    await test_batch_unaccounted_gets_corrective_then_auto_excluded()
+    await test_batch_content_fault_skips_batch_but_stall_interrupts()
     test_small_kb_batch_gate_skips_poppler_metadata()
     test_hierarchical_text_slice_materialization_and_directive()
     test_hierarchical_resume_state_contract()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3578,6 +3578,7 @@ async def test_batch_unaccounted_gets_corrective_then_auto_excluded():
         wd = Path(td)
         raw = wd / "raw"
         raw.mkdir(parents=True)
+        (raw / "good.md").write_bytes(b"g" * 400)
         (raw / "stubborn.md").write_bytes(b"z" * 400)
         run = compile_box.CompileRun("gate1", str(wd), 1)
         os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100"
@@ -3591,12 +3592,21 @@ async def test_batch_unaccounted_gets_corrective_then_auto_excluded():
             driven.append(label)
             return f"done {label}"
 
+        # PARTIAL progress: before the turn both sources are unaccounted; the
+        # turn lands good.md but stubborn.md resists the corrective pass too.
+        # (Zero progress would instead be classified as a provider fault.)
+        calls = {"n": 0}
+
+        def fake_unaccounted(run_, sources):
+            if not sources:
+                return []
+            calls["n"] += 1
+            return ["good.md", "stubborn.md"] if calls["n"] == 1 else ["stubborn.md"]
+
         real_drive = compile_box._drive_batch_session
         real_accounted = compile_box._unaccounted_batch_sources
         compile_box._drive_batch_session = fake_drive
-        # The model never fixes it: unaccounted before AND after the corrective.
-        compile_box._unaccounted_batch_sources = (
-            lambda run_, sources: ["stubborn.md"] if sources else [])
+        compile_box._unaccounted_batch_sources = fake_unaccounted
         try:
             await compile_box._run_batch_compile(run, "直接开始编译")
         finally:
@@ -3607,6 +3617,7 @@ async def test_batch_unaccounted_gets_corrective_then_auto_excluded():
         exclusions, _ = selfcheck.load_exclusions(str(wd))
         row = next(e for e in exclusions if "stubborn.md" in e["pattern"])
         assert "could not account" in row["reason"], row
+        assert not any("good.md" in e["pattern"] for e in exclusions), exclusions
         plan = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
         assert all(b["status"] == "done" for b in plan["batches"]), plan
         events = []
@@ -3615,7 +3626,7 @@ async def test_batch_unaccounted_gets_corrective_then_auto_excluded():
         assert not [e for e in events if e["type"] == "error"], events
         del os.environ["KBC_BATCH_THRESHOLD_BYTES"]
         del os.environ["KBC_BATCH_BUDGET_BYTES"]
-    print("✓ batch accounting gate: corrective pass then auto-exclusion, never a raise")
+    print("✓ batch accounting gate: partial progress → corrective pass → auto-exclusion, never a raise")
 
 
 async def test_batch_content_fault_skips_batch_but_stall_interrupts():

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -1494,6 +1494,47 @@ async def test_seam_settles_when_nothing_pending():
     print("OK  seam settles converge_phase when nothing pending (verify-off authoritative)")
 
 
+def test_orphan_assets_and_machine_exclusions():
+    """The batch train's content-robustness primitives: orphan detection sees
+    only assets no document embeds; glob escaping keeps a literal path from
+    swallowing siblings; append_exclusions de-duplicates and refuses to touch a
+    malformed ledger."""
+    import selfcheck
+    with tempfile.TemporaryDirectory() as td:
+        raw = Path(td) / "raw"
+        (raw / "assets").mkdir(parents=True)
+        (raw / "one.md").write_text("![pic](assets/linked.png)\n", encoding="utf-8")
+        (raw / "assets" / "linked.png").write_bytes(b"png")
+        (raw / "assets" / "orphan.png").write_bytes(b"png")
+        (raw / "assets" / "notes.md").write_text("content file, not media", encoding="utf-8")
+        orphans = selfcheck.orphan_media_assets(td)
+        assert orphans == ["assets/orphan.png"], orphans
+
+        # glob escaping: a title with [brackets] must match itself and ONLY itself
+        weird = "docs/table [v2]*.png"
+        pat = selfcheck.glob_escape_path(weird)
+        assert selfcheck._matches(weird, pat)
+        assert not selfcheck._matches("docs/table Xv2Y_anything.png", pat)
+
+        added = selfcheck.append_exclusions(td, [
+            {"pattern": "assets/orphan.png", "reason": "auto: orphan"},
+            {"pattern": "assets/orphan.png", "reason": "dup ignored"},
+        ])
+        assert len(added) == 1, added
+        again = selfcheck.append_exclusions(td, [
+            {"pattern": "assets/orphan.png", "reason": "still dup"}])
+        assert again == [], again
+        entries, errs = selfcheck.load_exclusions(td)
+        assert not errs and len(entries) == 1, (entries, errs)
+
+        # malformed ledger: refuse to rewrite, surface nothing silently
+        excl = Path(td) / selfcheck.EXCLUSIONS_PATH
+        excl.write_text("{not json", encoding="utf-8")
+        assert selfcheck.append_exclusions(td, [{"pattern": "x.md", "reason": "r"}]) == []
+        assert excl.read_text(encoding="utf-8") == "{not json"
+    print("OK  orphan assets + machine exclusions (detect / escape / dedupe / malformed untouched)")
+
+
 def test_converge_phase_helper():
     """set_converge_phase: writes the durable authoritative signal (verifying/
     revising/settled), preserves the L1 coverage section, ignores junk phases."""
@@ -1799,6 +1840,7 @@ def main():
     asyncio.run(test_pk_failed_state_settles_converge())
     asyncio.run(test_pk_wiring())
     asyncio.run(test_seam_settles_when_nothing_pending())
+    test_orphan_assets_and_machine_exclusions()
     test_converge_phase_helper()
     print("ALL OK  test_selfcheck")
 


### PR DESCRIPTION
Stacked on #448 (GitHub will retarget to main once #448 merges).

## Mandate

Product decision (2026-07-24): humans may pile anything into a wiki — validation keeps the coverage ledger honest, but **no content shape may deterministically kill a compile**. Live incident: a whole-space managed sync imports standalone wiki file nodes as media assets that no document embeds; coverage v2 deliberately refuses to auto-attach orphans; the model cannot account a bare image; and the batch accounting gate killed the train at the same batch on every retry (3/3 identical deaths at batch 12/145, with more asset-carrying batches queued behind it).

## Changes (kbc/platform/pod)

- **Plan/resume time**: orphan media assets are pre-excluded with a machine reason and pruned from pending batches (`selfcheck.orphan_media_assets` / `glob_escape_path` / `append_exclusions`; append is dedup-safe and refuses to touch a malformed ledger).
- **The accounting gate becomes an accountant**: one bounded corrective session, then remaining stragglers are auto-excluded with a visible reason and the train continues — the gate itself never raises.
- **Failure classification**: `BatchOutputError` (content/output shape — deterministic) skips only its batch with recorded exclusions; `ModelStallError`/cancellation (infra — heals on retry) still interrupt resumably. **Zero accounting progress across both passes is classified as a provider fault** (the empty/auth-error result shape from the GPU-corpus incident): the batch stays pending for resume instead of being silently excluded.
- **Slice-view materialization is per-batch tolerant**: an unusable view skips that batch, not the train.
- **Hierarchical image-verify round cap** records the unverified backlog in the reply instead of failing the run.
- **Observability**: `batch.interrupted` logs the exception message, not just the class name (the class-only line cost a live pod-log stakeout to diagnose).

## Verification

All three suites green inside the built image (`test_selfcheck` / `test_batching` / `test_compile_box`), including 4 new fault-injection tests: orphan pre-exclusion on a pinned plan reproducing the incident, partial-progress corrective-then-exclude, content-vs-infra classification, and helper units. The existing empty-provider-result regression (batch must stay pending) forced the zero-progress classifier and still passes. Image `siclaw-kbc-box:robust-434de62` is deployed on siflow-test for live acceptance.