### PR TITLE
kbc: a spend cap is not a rate limit, and the owner should be told which

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -461,6 +461,15 @@ def _arm_test_turn(run: "TestRun") -> None:
 # scope), so this is graceful handling, not a fix. Exhaustion ends the turn with a
 # clear owner-facing note instead of a crash.
 _MODEL_RATE_STATUSES = frozenset({429, 503, 529})
+
+# 402 is 429's near relative and its opposite. A rate limit clears on its own in
+# seconds, so backing off is right; a spend cap does not clear until the billing
+# window rolls, so every retry is a request that cannot succeed. Production hit
+# `daily cost limit exceeded (504.29/500.00) … retry_after 84596` — twenty-three
+# hours — and the owner was told only "batch compile interrupted; trigger again
+# to resume", which invites exactly the retry that cannot work. Neither the code
+# nor the message knew what had happened: there was no 402 anywhere in this file.
+_MODEL_QUOTA_STATUS = 402
 _MODEL_RATE_MAX_RETRIES = int(os.environ.get("KBC_MODEL_RATE_MAX_RETRIES", "5"))
 _MODEL_RATE_BACKOFF_BASE_S = float(os.environ.get("KBC_MODEL_RATE_BACKOFF_BASE_S", "2"))
 _MODEL_RATE_BACKOFF_CAP_S = float(os.environ.get("KBC_MODEL_RATE_BACKOFF_CAP_S", "30"))
@@ -473,6 +482,26 @@ _MODEL_RATE_BACKOFF_CAP_S = float(os.environ.get("KBC_MODEL_RATE_BACKOFF_CAP_S",
 # window to drain. Best-effort within the grace period (F1 is the durable fix).
 _SHUTDOWN_DRAIN_S = float(os.environ.get("KBC_SHUTDOWN_DRAIN_S", "0.5"))
 _SHUTDOWN_DRAIN_MAX_S = float(os.environ.get("KBC_SHUTDOWN_DRAIN_MAX_S", "8"))
+
+
+def _quota_retry_after(msg) -> int:
+    """Seconds until the provider's spend window rolls, when it said so.
+
+    Reads a number and nothing else. The provider's message names the account's
+    spend ("504.29/500.00") and pod logs are operator-visible, so the text stays
+    out of stdout on the same whitelist grounds as every other provider payload
+    here; the owner gets the human sentence over SSE instead.
+    """
+    for attr in ("api_error_retry_after", "retry_after_sec", "retry_after"):
+        value = getattr(msg, attr, None)
+        if isinstance(value, (int, float)) and value > 0:
+            return int(value)
+    raw = getattr(msg, "result", None) or getattr(msg, "subtype", None) or ""
+    match = re.search(r'"?retry_after_sec"?\s*[:=]\s*(\d+)', str(raw))
+    if match:
+        return int(match.group(1))
+    match = re.search(r"[Rr]etry after (\d+)s", str(raw))
+    return int(match.group(1)) if match else 0
 
 
 def _rate_backoff_delay(attempt: int) -> float:
@@ -497,6 +526,21 @@ class ModelResultError(Exception):
 
 class BatchOutputError(Exception):
     """A successful internal session did not account for its assigned sources."""
+
+
+class ModelQuotaExhausted(RuntimeError):
+    """The model provider refused on billing, not on capacity.
+
+    Deterministic for a known, stated duration: retrying before the window rolls
+    cannot succeed, so `retry_after_s` carries the provider's own number and a
+    consumer is expected to wait it out rather than sweep. Separate from
+    ModelStallError (transient) and the rate-limit path (clears in seconds)."""
+
+    deterministic = True
+
+    def __init__(self, message: str, retry_after_s: int = 0):
+        super().__init__(message)
+        self.retry_after_s = retry_after_s
 
 
 class PlanIntegrityError(RuntimeError):
@@ -528,6 +572,8 @@ def _batch_error_code(exc: BaseException) -> str:
         return "model_result_error"
     if isinstance(exc, BatchOutputError):
         return "provider_fault" if getattr(exc, "provider_fault", False) else "content_shape"
+    if isinstance(exc, ModelQuotaExhausted):
+        return "quota_exhausted"
     if isinstance(exc, PlanIntegrityError):
         return "plan_integrity"
     if isinstance(exc, asyncio.CancelledError):
@@ -4492,11 +4538,32 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         # gating on turn_done would otherwise hang on an orchestrator error.
         # Done batches are stamped in BATCH_PLAN.json, so the honest story is
         # "interrupted, resumable from the first pending batch".
+        # A spend cap gets its own sentence. "Trigger again to resume" is true of
+        # every other interruption and false of this one — it sends the owner to
+        # do the single thing that cannot work, for as long as the window lasts.
+        if isinstance(e, ModelQuotaExhausted) and e.retry_after_s > 0:
+            hours = e.retry_after_s / 3600.0
+            when = (f"{hours:.1f} hours" if hours >= 1
+                    else f"{e.retry_after_s // 60} minutes")
+            when_zh = (f"约 {hours:.1f} 小时" if hours >= 1
+                       else f"约 {e.retry_after_s // 60} 分钟")
+            done_note = _loc(
+                run,
+                f"The model provider refused this request on billing: the API key's "
+                f"spend limit for the period is used up. It clears in about {when}. "
+                f"Finished batches are stored — triggering a compile before then "
+                f"will be refused the same way; after it clears, the run resumes "
+                f"from the first pending batch.",
+                f"模型服务按计费拒绝了本次请求:该 API key 本周期的额度已用尽,"
+                f"{when_zh}后恢复。已完成的批已落库——在恢复之前再次发起会被同样拒绝;"
+                f"恢复之后再发起,将从断点继续。")
+        else:
+            done_note = _loc(
+                run,
+                "Batch compile interrupted: finished batches are stored; trigger a compile again to resume from the first pending batch.",
+                "分批编译中断:已完成的批已落库,再次发起编译将从断点继续。")
         try:
-            await run.emit({"type": "turn_done",
-                            "text": _loc(run,
-                                         "Batch compile interrupted: finished batches are stored; trigger a compile again to resume from the first pending batch.",
-                                         "分批编译中断:已完成的批已落库,再次发起编译将从断点继续。")})
+            await run.emit({"type": "turn_done", "text": done_note})
         except Exception:
             pass
     finally:
@@ -4605,6 +4672,20 @@ async def _consume_turn_stream(
             # surfacing it as a finished turn.
             status = getattr(msg, "api_error_status", None)
             is_error = bool(getattr(msg, "is_error", False))
+            # A spend cap, before the rate-limit branch it would otherwise fall
+            # past. Retrying is the one thing that cannot help, so this does not
+            # back off: it ends the turn with the provider's own numbers, in
+            # words the owner can act on. Completed batches are already durable,
+            # which is what makes "come back after the window" a real answer
+            # rather than a loss.
+            if is_error and status == _MODEL_QUOTA_STATUS:
+                retry_after = _quota_retry_after(msg)
+                run._turn_active = False
+                run._turn_text = []
+                run._last_turn_reply = ""
+                raise ModelQuotaExhausted(
+                    f"model provider refused on billing (HTTP {status})",
+                    retry_after_s=retry_after)
             if is_error and status in _MODEL_RATE_STATUSES:
                 if run._rate_retries < _MODEL_RATE_MAX_RETRIES:
                     run._rate_retries += 1

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -462,13 +462,12 @@ def _arm_test_turn(run: "TestRun") -> None:
 # clear owner-facing note instead of a crash.
 _MODEL_RATE_STATUSES = frozenset({429, 503, 529})
 
-# 402 is 429's near relative and its opposite. A rate limit clears on its own in
-# seconds, so backing off is right; a spend cap does not clear until the billing
-# window rolls, so every retry is a request that cannot succeed. Production hit
-# `daily cost limit exceeded (504.29/500.00) … retry_after 84596` — twenty-three
-# hours — and the owner was told only "batch compile interrupted; trigger again
-# to resume", which invites exactly the retry that cannot work. Neither the code
-# nor the message knew what had happened: there was no 402 anywhere in this file.
+# 402 sits one status away from the rate-limit family and is not one: a rate
+# limit clears on its own in seconds, so backing off is right, while a spend cap
+# is cleared by a person raising the limit, which no amount of backoff reaches.
+# Production hit `daily cost limit exceeded (504.29/500.00)` and the owner was
+# told only "batch compile interrupted; trigger again to resume" — the cause was
+# never named, because there was no 402 anywhere in this file.
 _MODEL_QUOTA_STATUS = 402
 _MODEL_RATE_MAX_RETRIES = int(os.environ.get("KBC_MODEL_RATE_MAX_RETRIES", "5"))
 _MODEL_RATE_BACKOFF_BASE_S = float(os.environ.get("KBC_MODEL_RATE_BACKOFF_BASE_S", "2"))
@@ -482,26 +481,6 @@ _MODEL_RATE_BACKOFF_CAP_S = float(os.environ.get("KBC_MODEL_RATE_BACKOFF_CAP_S",
 # window to drain. Best-effort within the grace period (F1 is the durable fix).
 _SHUTDOWN_DRAIN_S = float(os.environ.get("KBC_SHUTDOWN_DRAIN_S", "0.5"))
 _SHUTDOWN_DRAIN_MAX_S = float(os.environ.get("KBC_SHUTDOWN_DRAIN_MAX_S", "8"))
-
-
-def _quota_retry_after(msg) -> int:
-    """Seconds until the provider's spend window rolls, when it said so.
-
-    Reads a number and nothing else. The provider's message names the account's
-    spend ("504.29/500.00") and pod logs are operator-visible, so the text stays
-    out of stdout on the same whitelist grounds as every other provider payload
-    here; the owner gets the human sentence over SSE instead.
-    """
-    for attr in ("api_error_retry_after", "retry_after_sec", "retry_after"):
-        value = getattr(msg, attr, None)
-        if isinstance(value, (int, float)) and value > 0:
-            return int(value)
-    raw = getattr(msg, "result", None) or getattr(msg, "subtype", None) or ""
-    match = re.search(r'"?retry_after_sec"?\s*[:=]\s*(\d+)', str(raw))
-    if match:
-        return int(match.group(1))
-    match = re.search(r"[Rr]etry after (\d+)s", str(raw))
-    return int(match.group(1)) if match else 0
 
 
 def _rate_backoff_delay(attempt: int) -> float:
@@ -529,18 +508,14 @@ class BatchOutputError(Exception):
 
 
 class ModelQuotaExhausted(RuntimeError):
-    """The model provider refused on billing, not on capacity.
+    """The model provider refused on billing (HTTP 402), not on capacity.
 
-    Deterministic for a known, stated duration: retrying before the window rolls
-    cannot succeed, so `retry_after_s` carries the provider's own number and a
-    consumer is expected to wait it out rather than sweep. Separate from
-    ModelStallError (transient) and the rate-limit path (clears in seconds)."""
-
-    deterministic = True
-
-    def __init__(self, message: str, retry_after_s: int = 0):
-        super().__init__(message)
-        self.retry_after_s = retry_after_s
+    Backing off is wrong here — a spend cap does not clear in seconds, so the
+    rate-limit loop would spend its retries for nothing — and that is the only
+    claim this type makes. It deliberately carries no time-to-clear: a spend cap
+    is lifted by a person raising the limit, so any deadline the box stated
+    would be a guess presented as a fact. Separate from ModelStallError
+    (transient) and the rate-limit path."""
 
 
 class PlanIntegrityError(RuntimeError):
@@ -3204,6 +3179,20 @@ def _load_batch_plan(run: "CompileRun") -> dict | None:
         return None
 
 
+def _batch_resume_point(plan: dict | None) -> tuple[int, int] | None:
+    """(1-based index of the first unstamped batch, total batches), or None.
+
+    Positional, never the batch id: ids can be model-written and are only
+    conditionally safe to echo (see _lifecycle_batch_ref), while the position is
+    always both safe and the thing an owner can count.
+    """
+    batches = (plan or {}).get("batches") or []
+    for i, b in enumerate(batches):
+        if isinstance(b, dict) and b.get("status") != "done":
+            return i + 1, len(batches)
+    return None
+
+
 def _batch_plan_resumable(plan: dict | None) -> bool:
     """Whether an interrupted batch train still owns executable work.
 
@@ -4538,25 +4527,30 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
         # gating on turn_done would otherwise hang on an orchestrator error.
         # Done batches are stamped in BATCH_PLAN.json, so the honest story is
         # "interrupted, resumable from the first pending batch".
-        # A spend cap gets its own sentence. "Trigger again to resume" is true of
-        # every other interruption and false of this one — it sends the owner to
-        # do the single thing that cannot work, for as long as the window lasts.
-        if isinstance(e, ModelQuotaExhausted) and e.retry_after_s > 0:
-            hours = e.retry_after_s / 3600.0
-            when = (f"{hours:.1f} hours" if hours >= 1
-                    else f"{e.retry_after_s // 60} minutes")
-            when_zh = (f"约 {hours:.1f} 小时" if hours >= 1
-                       else f"约 {e.retry_after_s // 60} 分钟")
+        # A spend cap gets its own sentence: the generic one names a remedy that
+        # is not the one that applies. State only what is known — the provider
+        # refused on billing — and where the work stopped. Nothing about when it
+        # clears: that depends on a person raising the limit, and the provider's
+        # retry_after describes only the case where nobody does. A time the box
+        # cannot stand behind is worse here than no time at all.
+        if isinstance(e, ModelQuotaExhausted):
+            resume = _batch_resume_point(_load_batch_plan(run))
+            if resume:
+                k, n = resume
+                at = _loc(run,
+                          f" {k - 1} of {n} batches are stored; the next compile starts at batch {k}."
+                          if k > 1 else
+                          f" No batch of {n} is stored yet; the next compile starts at batch 1.",
+                          f"已完成 {k - 1}/{n} 批并已落库,下次编译从第 {k} 批开始。"
+                          if k > 1 else
+                          f"共 {n} 批,尚无已完成的批,下次编译从第 1 批开始。")
+            else:
+                at = _loc(run, " Finished batches are stored.", "已完成的批已落库。")
             done_note = _loc(
                 run,
-                f"The model provider refused this request on billing: the API key's "
-                f"spend limit for the period is used up. It clears in about {when}. "
-                f"Finished batches are stored — triggering a compile before then "
-                f"will be refused the same way; after it clears, the run resumes "
-                f"from the first pending batch.",
-                f"模型服务按计费拒绝了本次请求:该 API key 本周期的额度已用尽,"
-                f"{when_zh}后恢复。已完成的批已落库——在恢复之前再次发起会被同样拒绝;"
-                f"恢复之后再发起,将从断点继续。")
+                f"The model provider refused this request on billing (HTTP 402): "
+                f"the API key's spend limit for the period is used up.{at}",
+                f"模型服务按计费拒绝了本次请求(HTTP 402):该 API key 本周期的额度已用尽。{at}")
         else:
             done_note = _loc(
                 run,
@@ -4673,19 +4667,18 @@ async def _consume_turn_stream(
             status = getattr(msg, "api_error_status", None)
             is_error = bool(getattr(msg, "is_error", False))
             # A spend cap, before the rate-limit branch it would otherwise fall
-            # past. Retrying is the one thing that cannot help, so this does not
-            # back off: it ends the turn with the provider's own numbers, in
-            # words the owner can act on. Completed batches are already durable,
-            # which is what makes "come back after the window" a real answer
-            # rather than a loss.
-            if is_error and status == _MODEL_QUOTA_STATUS:
-                retry_after = _quota_retry_after(msg)
+            # past: backing off 5 times over 30s cannot clear a billing refusal.
+            # Gated on fail_on_error_result so this changes NOTHING outside the
+            # batch orchestrator — a live session keeps ending the turn and
+            # staying up, because whether to try again under a spend cap is the
+            # account holder's call (the limit can be raised at any moment) and
+            # a box that kills itself has taken that decision away.
+            if is_error and status == _MODEL_QUOTA_STATUS and fail_on_error_result:
                 run._turn_active = False
                 run._turn_text = []
                 run._last_turn_reply = ""
                 raise ModelQuotaExhausted(
-                    f"model provider refused on billing (HTTP {status})",
-                    retry_after_s=retry_after)
+                    f"model provider refused on billing (HTTP {status})")
             if is_error and status in _MODEL_RATE_STATUSES:
                 if run._rate_retries < _MODEL_RATE_MAX_RETRIES:
                     run._rate_retries += 1

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -6303,41 +6303,66 @@ async def test_typed_authoring_commands():
 
 
 def test_a_spend_cap_is_not_a_rate_limit():
-    """402 and 429 look alike and want opposite handling. A rate limit clears in
-    seconds, so the backoff loop is right for it; a spend cap does not clear
-    until the billing window rolls, so every retry is a request that cannot
-    succeed.
+    """402 and 429 look alike and want different handling. A rate limit clears
+    in seconds, so the backoff loop is right for it; a spend cap does not, so
+    burning five retries over thirty seconds achieves nothing.
 
     Production hit `daily cost limit exceeded (504.29/500.00) … retry_after
-    84596` — twenty-three hours — and the owner was told "batch compile
-    interrupted; trigger a compile again to resume", which is true of every
-    other interruption and false of this one. There was no 402 anywhere in the
-    box before this test.
-    """
-    class Msg:
-        pass
+    84596` and the owner was told "batch compile interrupted; trigger a compile
+    again to resume", which is true of every other interruption and misleading
+    here. There was no 402 anywhere in the box before this test.
 
-    # Routable, and marked as not worth retrying.
-    err = compile_box.ModelQuotaExhausted("refused on billing", retry_after_s=84596)
+    The correction must not overshoot into the mirror-image error. A spend cap
+    is lifted by a PERSON — raise the limit, top up, swap the key — so the box
+    may not claim the refusal is deterministic, and may not state a
+    time-to-clear it cannot stand behind. What it CAN state is where the work
+    stopped, so that is what the owner gets.
+    """
+    err = compile_box.ModelQuotaExhausted("refused on billing")
     assert compile_box._batch_error_code(err) == "quota_exhausted"
-    assert getattr(err, "deterministic", False) is True
-    assert err.retry_after_s == 84596
+
+    # Neither claim may come back. `deterministic` is what a consumer would read
+    # to stop retrying, and a stated deadline is what an owner would wait out —
+    # both take a decision that belongs to whoever can raise the limit.
+    assert not hasattr(err, "deterministic"), "a spend cap is lifted by a person"
+    assert not hasattr(err, "retry_after_s"), "the box does not forecast the window"
+    assert not hasattr(compile_box, "_quota_retry_after")
 
     # 402 must not be mistaken for the rate-limit family it sits beside.
     assert compile_box._MODEL_QUOTA_STATUS not in compile_box._MODEL_RATE_STATUSES
 
-    # The provider's own number is read from whatever shape it arrived in, and
-    # only the number — the message names the account's spend.
-    m = Msg(); m.result = '{"code":"billing_denied","retry_after_sec":84596}'
-    assert compile_box._quota_retry_after(m) == 84596
-    m2 = Msg(); m2.result = "API key daily cost limit exceeded. Retry after 3600s."
-    assert compile_box._quota_retry_after(m2) == 3600
-    m3 = Msg(); m3.api_error_retry_after = 120
-    assert compile_box._quota_retry_after(m3) == 120
-    m4 = Msg(); m4.result = "no number here"
-    assert compile_box._quota_retry_after(m4) == 0
+    # What the owner is told instead: which batch the next compile starts at.
+    # Positional and 1-based; done batches are counted, not the ids.
+    plan = {"batches": [{"status": "done"}, {"status": "done"}, {"status": "pending"}]}
+    assert compile_box._batch_resume_point(plan) == (3, 3)
+    assert compile_box._batch_resume_point({"batches": [{"status": "pending"}]}) == (1, 1)
+    # Fully stamped, or no plan at all: nothing to point at, so say nothing.
+    assert compile_box._batch_resume_point({"batches": [{"status": "done"}]}) is None
+    assert compile_box._batch_resume_point(None) is None
+    assert compile_box._batch_resume_point({}) is None
 
-    print("OK  a spend cap is routable, deterministic, and not a rate limit")
+    print("OK  a spend cap is named, not forecast, and reports its resume point")
+
+
+async def test_a_spend_cap_does_not_kill_a_live_session():
+    """The typed refusal is scoped to the batch orchestrator (which cannot carry
+    on without model calls). A live session must be left exactly as it was.
+
+    Deciding that an owner should stop trying is not the box's decision to take:
+    the limit can be raised at any moment, and a session that killed itself has
+    removed the owner's ability to find out. This drives the live path — the
+    default fail_on_error_result=False — and asserts nothing propagates: the
+    turn ends, the run stays up, and no backoff retries are spent on a refusal
+    backing off cannot clear.
+    """
+    fake = _RateLimitedFakeClient(succeed_on_query=999, status=402)
+    run, evs, raised = await _run_stall_scenario(
+        fake, idle=90, poll=0.03, max_retries=3, rate_base=0.01, rate_cap=0.02, rate_max=2)
+    assert raised is None, raised                          # the session survives
+    assert [e for e in evs if e["type"] == "rate_limited"] == [], evs
+    assert run._turn_active is False                       # the turn ended cleanly
+    assert fake.queries == ["批 1/10"], fake.queries        # never re-issued
+    print("✓ spend cap: a live session ends the turn and stays up, no backoff")
 
 
 async def main():
@@ -6444,6 +6469,7 @@ async def main():
     await test_shutdown_flush_syncs_active_runs()
     test_pr382_review_fixes()
     test_a_spend_cap_is_not_a_rate_limit()
+    await test_a_spend_cap_does_not_kill_a_live_session()
     await test_typed_authoring_commands()
 
     compile_box._COMPILE_IMPL = fake_driver

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -6302,6 +6302,44 @@ async def test_typed_authoring_commands():
         await client.close()
 
 
+def test_a_spend_cap_is_not_a_rate_limit():
+    """402 and 429 look alike and want opposite handling. A rate limit clears in
+    seconds, so the backoff loop is right for it; a spend cap does not clear
+    until the billing window rolls, so every retry is a request that cannot
+    succeed.
+
+    Production hit `daily cost limit exceeded (504.29/500.00) … retry_after
+    84596` — twenty-three hours — and the owner was told "batch compile
+    interrupted; trigger a compile again to resume", which is true of every
+    other interruption and false of this one. There was no 402 anywhere in the
+    box before this test.
+    """
+    class Msg:
+        pass
+
+    # Routable, and marked as not worth retrying.
+    err = compile_box.ModelQuotaExhausted("refused on billing", retry_after_s=84596)
+    assert compile_box._batch_error_code(err) == "quota_exhausted"
+    assert getattr(err, "deterministic", False) is True
+    assert err.retry_after_s == 84596
+
+    # 402 must not be mistaken for the rate-limit family it sits beside.
+    assert compile_box._MODEL_QUOTA_STATUS not in compile_box._MODEL_RATE_STATUSES
+
+    # The provider's own number is read from whatever shape it arrived in, and
+    # only the number — the message names the account's spend.
+    m = Msg(); m.result = '{"code":"billing_denied","retry_after_sec":84596}'
+    assert compile_box._quota_retry_after(m) == 84596
+    m2 = Msg(); m2.result = "API key daily cost limit exceeded. Retry after 3600s."
+    assert compile_box._quota_retry_after(m2) == 3600
+    m3 = Msg(); m3.api_error_retry_after = 120
+    assert compile_box._quota_retry_after(m3) == 120
+    m4 = Msg(); m4.result = "no number here"
+    assert compile_box._quota_retry_after(m4) == 0
+
+    print("OK  a spend cap is routable, deterministic, and not a rate limit")
+
+
 async def main():
     # PK never fires in these wiring tests — a qualifying fixture must not spawn
     # a real ClaudeEngine in the background (test_selfcheck covers PK wiring).
@@ -6405,6 +6443,7 @@ async def main():
     await test_model_rate_limit_exhausts_gracefully()
     await test_shutdown_flush_syncs_active_runs()
     test_pr382_review_fixes()
+    test_a_spend_cap_is_not_a_rate_limit()
     await test_typed_authoring_commands()
 
     compile_box._COMPILE_IMPL = fake_driver
@@ -6627,3 +6666,4 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
+


### PR DESCRIPTION
Production stopped mid-compile and reported *"batch compile interrupted; finished batches are stored, trigger a compile again to resume."* The provider had in fact answered:

```
402 billing_denied — API key daily cost limit exceeded (504.29/500.00).
```

The cause was never named. There was no `402` anywhere in `compile_box.py`: it sits one status away from `429/503/529`, which have had a backoff loop for months, and wants different handling — a rate limit clears on its own in seconds, a spend cap is cleared by a person raising the limit, which no amount of backoff reaches.

## What changed

- Caught **before** the rate-limit branch and raised as `ModelQuotaExhausted`, so the retry budget is not spent on a billing refusal.
- Gated on `fail_on_error_result`, so this is scoped to the batch orchestrator, which cannot proceed without model calls. A live session ends the turn and stays up exactly as before.
- Coded `quota_exhausted` rather than `other` in the operator-visible lifecycle log.
- The `turn_done` note states the refusal and where the work stopped: *the provider refused on billing (HTTP 402), the key's spend limit for the period is used up, N of M batches are stored, the next compile starts at batch K.*

## What it deliberately does not do

An earlier revision of this branch told the owner the limit would clear in ~23 hours and that *"triggering before then will be refused the same way"*. That replaced one false statement with its mirror image. A spend cap is lifted by a person — raise the limit, top up, swap the key — so:

- **No `deterministic` flag.** That is what a consumer would read to stop retrying, and stopping is the account holder's call.
- **No `retry_after_s`, and no parser for it.** It is the provider's estimate for the case where nobody intervenes. A time the box cannot stand behind is worse than no time.
- **The box does not end a live session.** Deciding the owner should stop trying would remove their ability to find out otherwise.

The resume point is positional (`_batch_resume_point`), never the batch id — ids are model-written and only conditionally safe to echo.

## Tests

`test_a_spend_cap_is_not_a_rate_limit` pins the routable code, that `402` is not in the rate-limit set, the resume-point arithmetic including the empty and fully-stamped cases, and the **absence** of both `deterministic` and `retry_after_s`.

`test_a_spend_cap_does_not_kill_a_live_session` drives the live path (default `fail_on_error_result=False`) and asserts nothing propagates, no backoff is spent, and the query is never re-issued. Negative control: removing the gate fails it with the `ModelQuotaExhausted` a live session should never see.

`test_compile_box` (105 checks) and `test_selfcheck` green. Note that `test_batching.py` fails to start on `main` as well — its runner list references `test_hierarchical_pack_splits_oversized_family_with_anchor_context`, which is not defined anywhere in the repo. Pre-existing, untouched here.
