### PR TITLE
kbc: the runtime owns the dispatch round, not the model

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -571,6 +571,18 @@ class CompileRun:
         self.allowed_tools: list[str] | None = None
         # Consumer-declared prompt/output locale (capability.fetchInput → /session).
         self.locale: str | None = None
+        # The dispatch round resolve_ticket receipts belong to, stamped by
+        # _prepare_command when an apply_rulings command is accepted.
+        #
+        # The runtime already validates this nonce as REQUIRED on the way in and
+        # then used to hand it to the model in prose to type back, defaulting to
+        # "" when it didn't. A fact the runtime holds does not become more true
+        # for having passed through the model's attention, and a bookkeeping
+        # field the model can silently omit is one the consumer cannot rely on:
+        # five tickets in production stuck at "已答·待重试" because the echo
+        # carried a superseded round, and closed only when a later retry omitted
+        # the nonce entirely and fell through to the weaker timestamp rule.
+        self.apply_dispatch_nonce: str = ""
         # Set once connect() has returned (success OR failure). A /message that
         # races ahead of the async connect waits on this so client.query() never
         # hits the SDK's "Not connected. Call connect() first." error.
@@ -1445,6 +1457,10 @@ def _prepare_command(run: "CompileRun", command: dict) -> None:
         plan = _load_batch_plan(run)
         if not _batch_plan_resumable(plan):
             raise CommandRejected("no interrupted batch plan is available to resume", 409)
+    if action == "compile.apply_rulings":
+        # Own the round here, where it is already validated, rather than asking
+        # the model to carry it. resolve_ticket stamps from this.
+        run.apply_dispatch_nonce = params["dispatch_nonce"]
     brief = params.get("brief")
     if brief is not None:
         # Structured command data replaces the old localized-text parser. The
@@ -1607,10 +1623,16 @@ def _compile_engine_tools(run: CompileRun) -> list[EngineTool]:
             "applied_value": str(args.get("applied_value", "")),
             "pages_edited": [str(p) for p in (args.get("pages_edited") or []) if str(p).strip()],
             "note": str(args.get("note", "")),
-            # Echo of the dispatch nonce from the apply directive: lets the
-            # consumer match this receipt to the EXACT dispatch round it answers
-            # (timestamps alone cannot distinguish two overlapping rounds).
-            "dispatch_nonce": str(args.get("dispatch_nonce", "")),
+            # The dispatch round this receipt answers, stamped by the runtime
+            # from the accepted apply_rulings command — NOT read back from the
+            # model. It lets the consumer match a receipt to the EXACT round
+            # (timestamps alone cannot separate two overlapping ones), which
+            # makes it a control-plane fact, and control-plane facts the runtime
+            # already holds never route through the model. The argument stays in
+            # the schema so an older directive still calls cleanly; its value is
+            # ignored. Empty here means the box resolved a ticket outside any
+            # apply round, which is exactly what the consumer should not close.
+            "dispatch_nonce": run.apply_dispatch_nonce,
             "at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
         try:
@@ -1672,9 +1694,13 @@ def _compile_engine_tools(run: CompileRun) -> list[EngineTool]:
                     "applied_value": {"type": "string"},
                     "pages_edited": {"type": "array", "items": {"type": "string"}},
                     "note": {"type": "string"},
+                    # Accepted and ignored: the runtime stamps the round itself.
+                    # Kept in the schema so a directive from an older runtime,
+                    # which still asks for the echo, calls cleanly instead of
+                    # failing schema validation mid-repair.
                     "dispatch_nonce": {"type": "string"},
                 },
-                "required": ["ticket_id", "applied_value", "pages_edited", "note", "dispatch_nonce"],
+                "required": ["ticket_id", "applied_value", "pages_edited", "note"],
             },
             resolve_ticket,
         ),

--- a/kbc/platform/pod/prompts/en/commands.json
+++ b/kbc/platform/pod/prompts/en/commands.json
@@ -7,8 +7,8 @@
   "compile.resume": "Resume the interrupted compiler-owned batch plan from its durable workspace state. Do not restart completed batches or ask for another approval.",
   "compile.submit_decisions_header": "Apply the following owner decisions to the durable brief and intent, then propose the resulting compile plan and stop for approval:",
   "compile.submit_decisions_line": "- {question_id}: {value}",
-  "compile.apply_rulings_header": "Apply the following structured rulings. Edit only the named candidate pages, remove the resolved uncertainty marker, and call resolve_ticket once per ruling with the exact dispatch nonce. After the repairs, resume any interrupted task:",
-  "compile.apply_rulings_value": "- ticket {ticket_id} (pages: {pages}): use \"{value}\"; nonce: {nonce}",
-  "compile.apply_rulings_suspect": "- ticket {ticket_id} (pages: {pages}): keep both sources as accepted uncertainty; call resolve_ticket without changing the value; nonce: {nonce}",
+  "compile.apply_rulings_header": "Apply the following structured rulings. Edit only the named candidate pages, remove the resolved uncertainty marker, and call resolve_ticket once per ruling. After the repairs, resume any interrupted task:",
+  "compile.apply_rulings_value": "- ticket {ticket_id} (pages: {pages}): use \"{value}\"",
+  "compile.apply_rulings_suspect": "- ticket {ticket_id} (pages: {pages}): keep both sources as accepted uncertainty; call resolve_ticket without changing the value",
   "compile.repair_test": "A regression test failed. Repair only the relevant candidate pages from source evidence. Question: {question}\nHuman-approved reference answer: {reference_answer}\nVerdict: {verdict}\nJudge note: {judge_note}\nDo not invent support that is absent from the sources; report the source gap instead. After the repair, resume any interrupted task."
 }

--- a/kbc/platform/pod/prompts/zh/commands.json
+++ b/kbc/platform/pod/prompts/zh/commands.json
@@ -7,8 +7,8 @@
   "compile.resume": "从持久化工作区状态继续被中断的编译器分批计划。不要重跑已完成批次，也不要再次等待批准。",
   "compile.submit_decisions_header": "把以下负责人定调写入持久化 brief 与 intent，然后提出据此形成的编译计划并停下等待批准：",
   "compile.submit_decisions_line": "- {question_id}：{value}",
-  "compile.apply_rulings_header": "应用以下结构化裁决。只修改点名的 candidate 页面，去掉已解决处的存疑标记；每条裁决都用原样 dispatch nonce 调一次 resolve_ticket。回修后继续此前未完成的任务：",
-  "compile.apply_rulings_value": "- ticket {ticket_id}（影响页：{pages}）：改为「{value}」；nonce：{nonce}",
-  "compile.apply_rulings_suspect": "- ticket {ticket_id}（影响页：{pages}）：接受存疑并保留双源，不改值，只调用 resolve_ticket 登记；nonce：{nonce}",
+  "compile.apply_rulings_header": "应用以下结构化裁决。只修改点名的 candidate 页面，去掉已解决处的存疑标记；每条裁决处理完调一次 resolve_ticket 登记。回修后继续此前未完成的任务：",
+  "compile.apply_rulings_value": "- ticket {ticket_id}（影响页：{pages}）：改为「{value}」",
+  "compile.apply_rulings_suspect": "- ticket {ticket_id}（影响页：{pages}）：接受存疑并保留双源，不改值，只调用 resolve_ticket 登记",
   "compile.repair_test": "测试回归失败。请只依据原料修复相关 candidate 页面。问题：{question}\n人工核准参考答案：{reference_answer}\n判分：{verdict}\n判语：{judge_note}\n若原料没有支撑，不得编造，直接报告来源缺口。修复后继续此前未完成的任务。"
 }

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -6405,6 +6405,7 @@ async def main():
     await test_model_rate_limit_exhausts_gracefully()
     await test_shutdown_flush_syncs_active_runs()
     test_pr382_review_fixes()
+    await test_the_runtime_owns_the_dispatch_round_not_the_model()
     await test_typed_authoring_commands()
 
     compile_box._COMPILE_IMPL = fake_driver
@@ -6623,6 +6624,126 @@ async def main():
         print("OK  compile_box protocol smoke (sources / authoring / health / session idempotent / SSE summary+turn_done+syncArtifacts+end / 409 / 404)")
     finally:
         await client.close()
+
+
+async def test_the_runtime_owns_the_dispatch_round_not_the_model():
+    """A resolve_ticket receipt is stamped with the round the RUNTIME accepted,
+    never with what the model typed.
+
+    The nonce exists so a consumer can match a receipt to the exact dispatch it
+    answers. The runtime validates it as REQUIRED on the way in, then used to
+    render it into prose for the model to hand back — and read it back with an
+    empty default. Production paid for that twice over: five tickets sat at
+    "已答·待重试" because the echo carried a superseded round, and they closed
+    only when a later retry omitted the nonce entirely, which fell through to
+    the weaker timestamp rule and let an unmatched receipt close a ticket.
+
+    Both halves are asserted here: the model cannot get the round WRONG, and the
+    model cannot get the round OMITTED.
+    """
+    class QueryClient:
+        def __init__(self):
+            self.queries = []
+
+        async def query(self, text):
+            self.queries.append(text)
+
+    compile_box.RUNS.clear()
+    client = TestClient(TestServer(compile_box.build_app()))
+    await client.start_server()
+    td = tempfile.TemporaryDirectory()
+    try:
+        run = compile_box.CompileRun("nonce-run", td.name, 1)
+        run.locale = "zh"
+        run.client = QueryClient()
+        run.connected.set()
+        compile_box.RUNS["nonce-run"] = run
+
+        tickets_path = Path(td.name) / "authoring" / "CONTRADICTIONS.json"
+        tickets_path.parent.mkdir(parents=True, exist_ok=True)
+        tickets_path.write_text(json.dumps([
+            {"id": "tk-1", "title": "H2O 还是 H200", "affected_pages": ["p1.md"]},
+            {"id": "tk-2", "title": "两个电话号", "affected_pages": ["p2.md"]},
+        ], ensure_ascii=False), "utf-8")
+
+        tools = {t.name: t for t in compile_box._compile_engine_tools(run)}
+        resolve = tools["resolve_ticket"]
+
+        # Before any dispatch the round is empty — a self-resolve the owner never
+        # asked for must not look like an answer to one.
+        await resolve.handler({
+            "ticket_id": "tk-1", "applied_value": "H200",
+            "pages_edited": ["p1.md"], "note": "", "dispatch_nonce": "invented-by-the-model",
+        })
+        rows = {tk["id"]: tk for tk in json.loads(tickets_path.read_text("utf-8"))}
+        assert rows["tk-1"]["agent_report"]["dispatch_nonce"] == "", rows["tk-1"]["agent_report"]
+
+        # Dispatch round "round-A".
+        r = await client.post("/command/nonce-run", json={
+            "command_id": "cmd-apply-A",
+            "command": {
+                "version": 1, "action": "compile.apply_rulings",
+                "operation_id": "op-apply-A", "generation": 1,
+                "parameters": {
+                    "dispatch_nonce": "round-A",
+                    "rulings": [{"ticket_id": "tk-1", "affected_pages": ["p1.md"],
+                                 "kind": "value", "value": "H200"}],
+                },
+            },
+        })
+        assert r.status == 200, await r.text()
+
+        # The model echoes a SUPERSEDED round — exactly what production did.
+        await resolve.handler({
+            "ticket_id": "tk-1", "applied_value": "H200",
+            "pages_edited": ["p1.md"], "note": "", "dispatch_nonce": "3a413abb-stale",
+        })
+        # ...and omits it entirely — the other half of the same production bug.
+        await resolve.handler({
+            "ticket_id": "tk-2", "applied_value": "保留双源",
+            "pages_edited": ["p2.md"], "note": "",
+        })
+        rows = {tk["id"]: tk for tk in json.loads(tickets_path.read_text("utf-8"))}
+        for tid in ("tk-1", "tk-2"):
+            got = rows[tid]["agent_report"]["dispatch_nonce"]
+            assert got == "round-A", f"{tid} stamped {got!r}, want the accepted round"
+            assert rows[tid]["status"] == "applied", rows[tid]
+
+        # A second dispatch re-stamps: receipts follow the CURRENT round. The
+        # first round's turn has to end first — a live turn refuses a second
+        # command, which is the same reason a real re-dispatch waits for idle.
+        run._turn_active = False
+        r = await client.post("/command/nonce-run", json={
+            # A re-dispatch is a new COMMAND inside the same authoring
+            # operation: the run pins to (operation_id, generation) for life.
+            "command_id": "cmd-apply-B",
+            "command": {
+                "version": 1, "action": "compile.apply_rulings",
+                "operation_id": "op-apply-A", "generation": 1,
+                "parameters": {
+                    "dispatch_nonce": "round-B",
+                    "rulings": [{"ticket_id": "tk-1", "affected_pages": ["p1.md"],
+                                 "kind": "value", "value": "H200"}],
+                },
+            },
+        })
+        assert r.status == 200, await r.text()
+        await resolve.handler({
+            "ticket_id": "tk-1", "applied_value": "H200",
+            "pages_edited": ["p1.md"], "note": "", "dispatch_nonce": "round-A",
+        })
+        rows = {tk["id"]: tk for tk in json.loads(tickets_path.read_text("utf-8"))}
+        assert rows["tk-1"]["agent_report"]["dispatch_nonce"] == "round-B", rows["tk-1"]
+
+        # The directive no longer asks the model for bookkeeping it cannot own.
+        directive = run.client.queries[-1]
+        assert "nonce" not in directive.lower(), directive
+        assert "resolve_ticket" in directive, directive
+    finally:
+        compile_box.RUNS.clear()
+        await client.close()
+        td.cleanup()
+    print("✓ dispatch round is stamped by the runtime; a wrong or missing echo cannot mislead it")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`resolve_ticket` stamped its receipt with whatever the model typed into `dispatch_nonce`, defaulting to `""` when it typed nothing — while the runtime had **already validated that exact nonce as REQUIRED** when it accepted the `compile.apply_rulings` command, and then rendered it into prose for the model to hand back.

```python
# accepting the dispatch — validated, bounded, required
nonce = _bounded_string(parameters.get("dispatch_nonce"), ..., required=True, limit=128)
# rendering it for the model to copy
nonce=params["dispatch_nonce"]
# registering the receipt — read back from the model, empty default
"dispatch_nonce": str(args.get("dispatch_nonce", "")),
```

A control-plane fact does not become more true for passing through the model's attention, and one the model can silently omit is one the consumer cannot rely on.

## What it cost

Production hit both halves of this on one library. Five contradiction tickets sat at 已答·待重试 because the echo carried a superseded round; they closed only when a later retry omitted the nonce entirely, which fell through to the consumer's weaker timestamp rule and let an unmatched receipt close a ticket.

Neither failure was visible to the box: `resolve_ticket` has no reject path, so it reported success both times. The owner had to relay the mismatch by hand.

## What changed

- The accepted `apply_rulings` command stamps `run.apply_dispatch_nonce`; `resolve_ticket` reads it and ignores the argument. Empty means the box resolved outside any apply round — exactly what a consumer should not treat as answering a dispatch.
- The argument stays in the schema, no longer `required`, so a directive from an older runtime still calls cleanly instead of failing schema validation mid-repair.
- The directive stops asking for the echo. It was asking the model to carry bookkeeping it cannot own, and the instruction is now false.

## Tests

`test_the_runtime_owns_the_dispatch_round_not_the_model` drives the real `/command` endpoint and asserts both production failure modes are now impossible: a superseded echo and an omitted one both stamp the accepted round, a second dispatch re-stamps, and a resolve before any dispatch stamps empty. It also pins that the directive no longer mentions a nonce.

Negative controls: restoring the argument read fails on the invented nonce; restoring the prose fails the directive assertion. Full suite green (104 checks), plus `test_selfcheck`.

## Scope

This is the first of three changes against a state-machine deadlock found in production (server and client disagreed on "ticket closed", the looser definition removed the surface the tickets live on, and the recovery action was gated on the belief that recovery was unnecessary). This one removes the failure mode where the round is lost in transit. The remaining two are sicore-side: one server-owned ticket state that the client renders rather than re-derives, and returning an unanswered dispatch to the queue.