### PR TITLE
feat: add knowledge runtime bindings

### DIFF
--- a/src/agentbox/gateway-client.ts
+++ b/src/agentbox/gateway-client.ts
@@ -12,6 +12,10 @@ import path from "node:path";
 import type { DelegationPersistenceEvent, DelegationPersistenceResponse } from "../shared/delegation-persistence.js";
 import type { MetricsFlushPayload } from "../shared/metrics-types.js";
 import type { DelegateRequest, DelegateResponse, DelegatesResponse } from "../shared/agent-delegate.js";
+import type {
+  KnowledgeEvidenceSet,
+  KnowledgeRetrieveRequest,
+} from "../knowledge/contracts.js";
 
 export interface GatewayClientOptions {
   gatewayUrl: string;
@@ -83,6 +87,24 @@ export class GatewayClient {
    */
   async fetchTracingConfig(): Promise<any> {
     return this.request("/api/internal/tracing-config", "GET");
+  }
+
+  /**
+   * Execute the stable knowledge.retrieve/v1 contract through Runtime.
+   * Runtime derives agent identity from mTLS and resolves sessionId to the
+   * current user before forwarding to the management plane.
+   */
+  async retrieveKnowledge(
+    request: KnowledgeRetrieveRequest,
+    sessionId: string,
+  ): Promise<KnowledgeEvidenceSet> {
+    return this.request("/api/internal/knowledge/retrieve", "POST", {
+      session_id: sessionId,
+      query: request.query,
+      repo_ids: request.repoIds,
+      filters: request.filters,
+      top_k: request.topK,
+    }, 15_000);
   }
 
   /**

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -80,6 +80,7 @@ import {
   type ModelRouteState,
 } from "../core/model-routing.js";
 import type { GatewayClient } from "./gateway-client.js";
+import type { KnowledgeRetrieveExecutor } from "../knowledge/contracts.js";
 // topic-consolidator import removed — consolidation disabled
 
 /**
@@ -629,6 +630,12 @@ export class AgentBoxSessionManager {
         throttled?.cancel();
       }
     };
+  }
+
+  private createKnowledgeRetrieveExecutor(sessionId: string): KnowledgeRetrieveExecutor | undefined {
+    const client = this.gatewayClient;
+    if (!client) return undefined;
+    return (request) => client.retrieveKnowledge(request, sessionId);
   }
 
   /**
@@ -2009,6 +2016,7 @@ export class AgentBoxSessionManager {
       isSubagent: true,
       // The agent-type's prompt flavour for this child.
       systemPromptAppend: type.systemPromptAddendum,
+      knowledgeRetrieveExecutor: this.createKnowledgeRetrieveExecutor(childSessionId),
       // Deliberately omit spawnSubagentExecutor + delegate executors → the child
       // never sees spawn_subagent (no recursion).
     });
@@ -2549,6 +2557,7 @@ export class AgentBoxSessionManager {
       backgroundExecExecutor: this.createBackgroundExecExecutor(),
       taskOutputReader: this.createTaskOutputReader(),
       channelMessageExecutor: this.createChannelMessageExecutor(),
+      knowledgeRetrieveExecutor: this.createKnowledgeRetrieveExecutor(id),
     });
 
     // Populate sessionIdRef so skill_call events can associate with this session

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -943,7 +943,7 @@ describe("knowledgeHandler empty-bundle guard", () => {
   it("wipes and returns 0 when empty bundle arrives and knowledgeDir is empty (first spawn)", async () => {
     const count = await knowledgeHandler.materialize({ version: "v1", repos: [] });
     expect(count).toBe(0);
-    expect(fs.readdirSync(knowledgeTmpDir)).toEqual([]);
+    expect(fs.readdirSync(knowledgeTmpDir)).toEqual([".sync-manifest.json"]);
   });
 
   it("preserves knowledgeDir contents when empty bundle arrives but content already materialized", async () => {
@@ -970,6 +970,26 @@ describe("knowledgeHandler empty-bundle guard", () => {
     const count = await knowledgeHandler.materialize({ version: "v1", repos: [] });
     // No meaningful content → falls through to wipe path → reports 0.
     expect(count).toBe(0);
+  });
+
+  it("treats v2 bindings as authoritative and clears stale Wiki content for retrieval-only bindings", async () => {
+    fs.writeFileSync(path.join(knowledgeTmpDir, "index.md"), "# stale");
+    const count = await knowledgeHandler.materialize({
+      version: "2",
+      repos: [],
+      bindings: [{
+        repoId: "ticket-1",
+        name: "Ticket History",
+        version: "index-4",
+        capabilities: [{ kind: "retrieve", contract: "knowledge.retrieve/v1" }],
+      }],
+    });
+    expect(count).toBe(1);
+    expect(fs.existsSync(path.join(knowledgeTmpDir, "index.md"))).toBe(false);
+    const manifest = JSON.parse(fs.readFileSync(path.join(knowledgeTmpDir, ".sync-manifest.json"), "utf8"));
+    expect(manifest.bindings).toEqual([
+      expect.objectContaining({ repoId: "ticket-1", capabilities: [{ kind: "retrieve", contract: "knowledge.retrieve/v1" }] }),
+    ]);
   });
 });
 
@@ -1015,5 +1035,27 @@ describe("knowledgeHandler multi-repo identity", () => {
     const index = fs.readFileSync(path.join(knowledgeTmpDir, "index.md"), "utf8");
     expect(index).toContain(`[[repos/${platformDir}/index]] - 平台知识 v3`);
     expect(index).toContain(`[[repos/${businessDir}/index]] - 业务知识 v7`);
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(knowledgeTmpDir, ".sync-manifest.json"), "utf8"));
+    expect(manifest.bindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        repoId: "repo-cn-platform",
+        capabilities: [expect.objectContaining({ kind: "materialized", rootPath: `repos/${platformDir}` })],
+      }),
+      expect.objectContaining({
+        repoId: "repo-cn-business",
+        capabilities: [expect.objectContaining({ kind: "materialized", rootPath: `repos/${businessDir}` })],
+      }),
+    ]));
+  });
+});
+
+describe("knowledgeHandler postReload", () => {
+  it("invalidates sessions because knowledge capability changes may alter the tool schema", async () => {
+    const invalidate = vi.fn();
+    await knowledgeHandler.postReload!({
+      sessions: [{ id: "s1", brain: { reload: vi.fn(async () => {}) }, invalidate }],
+    });
+    expect(invalidate).toHaveBeenCalledOnce();
   });
 });

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -26,6 +26,10 @@ import type {
 import { GATEWAY_SYNC_DESCRIPTORS } from "../shared/gateway-sync.js";
 import { resolveUnderDir } from "../shared/path-utils.js";
 import { decodeSkillFileContent, normalizeSkillFiles, type SkillPackageFile } from "../shared/skill-package.js";
+import {
+  normalizeKnowledgeRuntimeBindings,
+  type KnowledgeRuntimeBinding,
+} from "../knowledge/contracts.js";
 
 // ── MCP handler ───────────────────────────────────────────────────────
 
@@ -236,7 +240,7 @@ export const skillsHandler: AgentBoxSyncHandler<SkillBundlePayload> = {
 
 // ── Knowledge handler ─────────────────────────────────────────────────
 
-interface KnowledgeBundlePayload {
+export interface KnowledgeBundlePayload {
   version: string;
   repos: Array<{
     id: string;
@@ -248,6 +252,12 @@ interface KnowledgeBundlePayload {
     fileCount?: number | null;
     dataBase64: string;
   }>;
+  /**
+   * v2 runtime descriptors. Omitted by legacy management servers. Presence,
+   * including an empty array, is authoritative for non-materialized capability
+   * state; active bundles below are still projected as materialized bindings.
+   */
+  bindings?: KnowledgeRuntimeBinding[];
 }
 
 interface KnowledgeSyncStatus {
@@ -263,6 +273,50 @@ interface KnowledgeSyncStatus {
 let lastKnowledgeSyncStatus: KnowledgeSyncStatus | null = null;
 export function getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null { return lastKnowledgeSyncStatus; }
 
+function resolvedKnowledgeBindings(
+  payload: KnowledgeBundlePayload,
+  roots: Map<string, string>,
+): KnowledgeRuntimeBinding[] {
+  const supplied = normalizeKnowledgeRuntimeBindings(payload.bindings);
+  const byID = new Map(supplied.map((binding) => [binding.repoId, binding]));
+  for (const repo of payload.repos ?? []) {
+    const existing = byID.get(repo.id);
+    const capabilities = [
+      ...(existing?.capabilities.filter((capability) => capability.kind !== "materialized") ?? []),
+      {
+        kind: "materialized" as const,
+        contract: "knowledge.materialize/v1" as const,
+        rootPath: roots.get(repo.id) ?? ".",
+      },
+    ];
+    byID.set(repo.id, {
+      repoId: repo.id,
+      name: existing?.name ?? repo.name,
+      description: existing?.description,
+      version: existing?.version ?? String(repo.version),
+      capabilities,
+    });
+  }
+  return [...byID.values()];
+}
+
+function writeKnowledgeManifest(
+  targetDir: string,
+  payload: KnowledgeBundlePayload,
+  syncedAt: string,
+  repos: KnowledgeSyncStatus["repos"],
+  bindings: KnowledgeRuntimeBinding[],
+): void {
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(path.join(targetDir, ".sync-manifest.json"),
+    JSON.stringify({
+      syncedAt,
+      version: payload.version ?? "1",
+      repos,
+      bindings,
+    }, null, 2) + "\n");
+}
+
 export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
   type: "knowledge",
 
@@ -275,6 +329,7 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
 
   async materialize(payload: KnowledgeBundlePayload): Promise<number> {
     const repos = payload?.repos ?? [];
+    const hasAuthoritativeBindings = Array.isArray(payload?.bindings);
     const config = loadConfig();
     const knowledgeDir = path.resolve(process.cwd(), config.paths.knowledgeDir);
     const syncedAt = new Date().toISOString();
@@ -286,7 +341,7 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
       // knowledge materialized, keep what we have and let the next reload retry.
       // Legitimate "unbind-all" admin operations can force a fresh wipe by
       // restarting the pod — which is cheap and explicit.
-      if (fs.existsSync(knowledgeDir)) {
+      if (!hasAuthoritativeBindings && fs.existsSync(knowledgeDir)) {
         const existing = fs.readdirSync(knowledgeDir).filter((name) => {
           if (name.startsWith(".sync-staging")) return false;
           try { return fs.statSync(path.join(knowledgeDir, name)).isDirectory() || fs.statSync(path.join(knowledgeDir, name)).isFile(); }
@@ -308,14 +363,17 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
           fs.rmSync(path.join(knowledgeDir, entry), { recursive: true, force: true });
         }
       }
+      const bindings = resolvedKnowledgeBindings(payload, new Map());
+      writeKnowledgeManifest(knowledgeDir, payload, syncedAt, [], bindings);
       lastKnowledgeSyncStatus = { syncedAt, targetDir: knowledgeDir, repoCount: 0, repos: [] };
-      return 0;
+      return bindings.length;
     }
 
     fs.mkdirSync(knowledgeDir, { recursive: true });
     const stagingDir = path.join(knowledgeDir, `.sync-staging-${Date.now()}-${process.pid}`);
     fs.mkdirSync(stagingDir, { recursive: true });
     const syncedRepos: KnowledgeSyncStatus["repos"] = [];
+    const roots = new Map<string, string>();
 
     try {
       if (repos.length === 1) {
@@ -326,6 +384,7 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
         }
         syncedRepos.push({ id: repos[0].id, name: repos[0].name, version: repos[0].version,
           sha256: info.sha256, expectedSha256: repos[0].sha256 ?? null, fileCount: info.fileCount, sizeBytes: repos[0].sizeBytes });
+        roots.set(repos[0].id, ".");
       } else {
         const repoRoot = path.join(stagingDir, "repos");
         fs.mkdirSync(repoRoot, { recursive: true });
@@ -350,16 +409,17 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
           }
           syncedRepos.push({ id: repo.id, name: repo.name, version: repo.version,
             sha256: info.sha256, expectedSha256: repo.sha256 ?? null, fileCount: info.fileCount, sizeBytes: repo.sizeBytes });
+          roots.set(repo.id, `repos/${dirName}`);
           indexLines.push(`- [[repos/${dirName}/index]] - ${repo.name} v${repo.version}`);
         }
         fs.writeFileSync(path.join(stagingDir, "index.md"), indexLines.join("\n") + "\n");
       }
 
-      fs.writeFileSync(path.join(stagingDir, ".sync-manifest.json"),
-        JSON.stringify({ syncedAt, version: payload.version ?? "1", repos: syncedRepos }, null, 2) + "\n");
+      const bindings = resolvedKnowledgeBindings(payload, roots);
+      writeKnowledgeManifest(stagingDir, payload, syncedAt, syncedRepos, bindings);
       await replaceDirectoryContentsFromStaging(knowledgeDir, stagingDir);
       lastKnowledgeSyncStatus = { syncedAt, targetDir: knowledgeDir, repoCount: syncedRepos.length, repos: syncedRepos };
-      return repos.length;
+      return bindings.length;
     } catch (err) {
       fs.rmSync(stagingDir, { recursive: true, force: true });
       throw err;
@@ -369,13 +429,11 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
   async postReload(context: ReloadContext): Promise<void> {
     if (!context.sessions?.length) return;
     for (const session of context.sessions) {
-      try {
-        await session.brain.reload();
-        console.log(`[resource-sync] Knowledge reloaded for session ${session.id}`);
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(`[resource-sync] Failed to reload knowledge for session ${session.id}: ${msg}`);
-      }
+      // v2 knowledge bindings may add or remove the stable
+      // knowledge_retrieve tool. Tool schemas are immutable for an in-memory
+      // pi-agent session, so use the same in-flight-safe turnover contract as
+      // MCP instead of hot-reloading only the file catalog.
+      session.invalidate?.();
     }
   },
 };

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -41,6 +41,14 @@ import { PiAgentBrain } from "./brains/pi-agent-brain.js";
 import type { BrainSession } from "./brain-session.js";
 import { convertOpenAIPdfPayload } from "./openai-file-payload.js";
 import { McpClientManager } from "./mcp-client.js";
+import {
+  buildKnowledgeRuntime,
+  loadKnowledgeRuntimeBindings,
+} from "../knowledge/runtime.js";
+import type {
+  KnowledgeRetrieveExecutor,
+  KnowledgeRuntimeBinding,
+} from "../knowledge/contracts.js";
 import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryEnabled } from "./config.js";
 import { initExtraCommands } from "../tools/infra/extra-commands.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
@@ -79,6 +87,10 @@ export interface CreateSiclawSessionOpts {
   mcpManager?: McpClientManager;
   /** Pre-resolved MCP tools from shared mcpManager — avoids re-discovery */
   mcpTools?: ToolDefinition[];
+  /** Runtime-resolved knowledge bindings. Omit to load the AgentBox sync manifest. */
+  knowledgeBindings?: KnowledgeRuntimeBinding[];
+  /** Runtime bridge used by the stable knowledge_retrieve tool. */
+  knowledgeRetrieveExecutor?: KnowledgeRetrieveExecutor;
   /** User ID for per-user skill directory isolation (local spawner mode) */
   userId?: string;
   /** Agent ID — used for metrics labeling (tool_call / skill_call events). Null if no agent context (TUI/CLI). */
@@ -491,6 +503,16 @@ export async function createSiclawSession(
   const knowledgeDir = opts?.portalKnowledgeDir && fs.existsSync(opts.portalKnowledgeDir)
     ? opts.portalKnowledgeDir
     : path.resolve(cwd, config.paths.knowledgeDir);
+  const knowledgeBindings = opts?.knowledgeBindings ?? loadKnowledgeRuntimeBindings(knowledgeDir);
+  const knowledgeRuntime = buildKnowledgeRuntime({
+    bindings: knowledgeBindings,
+    retrieve: opts?.knowledgeRetrieveExecutor,
+    knowledgeDir,
+  });
+  // Knowledge tools are governed by the orthogonal agent↔knowledge binding.
+  // Provider-specific tools never reach pi-agent, and the generic tool still
+  // revalidates the binding server-side on every execution.
+  customTools.push(...knowledgeRuntime.tools);
   const readAllowedDirs = [
     builtinSkillsRoot, skillsBase, userDataDir, reportsDir, tracesDir, reposDir, docsDir, knowledgeDir,
     os.tmpdir(),
@@ -662,6 +684,9 @@ export async function createSiclawSession(
       systemPromptOverride: () => buildSreSystemPrompt(mode, opts?.systemPromptTemplate),
       appendSystemPromptOverride: () => {
         const parts = buildAppendSystemPrompt(memoryEnabled ? memoryDir : null, knowledgeDir);
+        if (knowledgeRuntime.promptContext) {
+          parts.push("\n\n" + knowledgeRuntime.promptContext);
+        }
         if (agentSystemPromptAppend) {
           parts.push("\n\n" + agentSystemPromptAppend);
         }

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -8,6 +8,7 @@ import {
   handleToolCapabilities,
   handleSkillsBundle,
   handleKnowledgeBundle,
+  handleKnowledgeRetrieve,
   handleAgentTasksList,
   handleAgentTasksCreate,
   handleAgentTasksUpdate,
@@ -281,6 +282,49 @@ describe("handleKnowledgeBundle", () => {
     await handleKnowledgeBundle(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
     expect(frontend.calls[0].params).toEqual({ agentId: "agent-1" });
     expect(res.statusCode).toBe(200);
+  });
+});
+
+describe("handleKnowledgeRetrieve", () => {
+  it("derives the agent from mTLS and forwards the normalized retrieval request", async () => {
+    frontend.responses.set("knowledge.retrieve", { retrievalId: "ret-1", evidence: [] });
+    const res = new FakeRes();
+    await handleKnowledgeRetrieve(
+      asReq(new FakeReq(JSON.stringify({
+        session_id: "unknown-session",
+        query: " GPU scheduling ",
+        repo_ids: ["repo-1"],
+        top_k: 5,
+      }))),
+      asRes(res),
+      identity,
+      frontend as unknown as FrontendWsClient,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(frontend.calls[0]).toEqual({
+      method: "knowledge.retrieve",
+      params: {
+        agentId: "agent-1",
+        userId: "",
+        sessionId: "unknown-session",
+        query: "GPU scheduling",
+        repo_ids: ["repo-1"],
+        filters: undefined,
+        top_k: 5,
+      },
+    });
+  });
+
+  it("rejects malformed retrieval requests before RPC", async () => {
+    const res = new FakeRes();
+    await handleKnowledgeRetrieve(
+      asReq(new FakeReq(JSON.stringify({ query: "", top_k: 100 }))),
+      asRes(res),
+      identity,
+      frontend as unknown as FrontendWsClient,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(frontend.calls).toEqual([]);
   });
 });
 

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -355,6 +355,79 @@ export async function handleKnowledgeBundle(
 }
 
 /**
+ * POST /api/internal/knowledge/retrieve
+ *
+ * Executes knowledge.retrieve/v1 for the calling AgentBox. Agent identity comes
+ * only from mTLS; session_id recovers the current user for audit and future
+ * query-time ACL enforcement.
+ */
+export async function handleKnowledgeRetrieve(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  identity: CertificateIdentity,
+  frontendClient: FrontendWsClient,
+): Promise<void> {
+  try {
+    const body = await readJsonBody(req) as Record<string, unknown>;
+    const query = typeof body.query === "string" ? body.query.trim() : "";
+    if (!query || query.length > 4_000) {
+      sendJson(res, 400, { error: "query must contain 1-4000 characters" });
+      return;
+    }
+    const repoIDs = body.repo_ids;
+    if (repoIDs !== undefined && (
+      !Array.isArray(repoIDs) ||
+      repoIDs.length > 50 ||
+      repoIDs.some((id) => typeof id !== "string" || !id)
+    )) {
+      sendJson(res, 400, { error: "repo_ids must be an array of at most 50 non-empty strings" });
+      return;
+    }
+    if (body.top_k !== undefined && (
+      typeof body.top_k !== "number" ||
+      !Number.isInteger(body.top_k) ||
+      body.top_k < 1 ||
+      body.top_k > 50
+    )) {
+      sendJson(res, 400, { error: "top_k must be an integer between 1 and 50" });
+      return;
+    }
+    if (body.filters !== undefined && (
+      !body.filters ||
+      typeof body.filters !== "object" ||
+      Array.isArray(body.filters)
+    )) {
+      sendJson(res, 400, { error: "filters must be an object" });
+      return;
+    }
+
+    const sessionID = typeof body.session_id === "string" ? body.session_id : "";
+    const { userId, ok } = await resolveUserForIdentity(sessionID, identity);
+    if (!ok) {
+      sendJson(res, 403, { error: "session ownership mismatch" });
+      return;
+    }
+    const data = await frontendClient.request("knowledge.retrieve", {
+      agentId: identity.agentId,
+      userId,
+      sessionId: sessionID,
+      query,
+      repo_ids: repoIDs,
+      filters: body.filters,
+      top_k: body.top_k,
+    }, 15_000);
+    sendJson(res, 200, data);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      sendJson(res, 400, { error: "Invalid JSON body" });
+      return;
+    }
+    console.error("[internal-api] knowledge/retrieve error:", err);
+    sendJson(res, 500, { error: "Internal server error" });
+  }
+}
+
+/**
  * GET /api/internal/agent-tasks
  *
  * Returns the scheduled tasks for the agent identified by the mTLS certificate.

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -79,6 +79,7 @@ import {
   handleToolCapabilities,
   handleSkillsBundle,
   handleKnowledgeBundle,
+  handleKnowledgeRetrieve,
   handleAgentTasksList,
   handleAgentTasksCreate,
   handleAgentTasksUpdate,
@@ -1492,6 +1493,12 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           if (url === "/api/internal/knowledge/bundle" && method === "GET") {
             if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
             handleKnowledgeBundle(req, res, identity, frontendClient);
+            return;
+          }
+
+          if (url === "/api/internal/knowledge/retrieve" && method === "POST") {
+            if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
+            handleKnowledgeRetrieve(req, res, identity, frontendClient);
             return;
           }
 

--- a/src/knowledge/contracts.ts
+++ b/src/knowledge/contracts.ts
@@ -1,0 +1,115 @@
+export type KnowledgeMaterializedCapability = {
+  kind: "materialized";
+  contract: "knowledge.materialize/v1";
+  rootPath?: string;
+};
+
+export type KnowledgeRetrieveCapability = {
+  kind: "retrieve";
+  contract: "knowledge.retrieve/v1";
+  features?: string[];
+  indexVersion?: string;
+  status?: "ready" | "degraded" | "not_ready";
+};
+
+export type KnowledgeCapability =
+  | KnowledgeMaterializedCapability
+  | KnowledgeRetrieveCapability;
+
+export interface KnowledgeRuntimeBinding {
+  repoId: string;
+  name: string;
+  description?: string;
+  version: string;
+  capabilities: KnowledgeCapability[];
+}
+
+export interface KnowledgeRetrieveRequest {
+  query: string;
+  repoIds?: string[];
+  filters?: Record<string, unknown>;
+  topK?: number;
+}
+
+export interface KnowledgeEvidence {
+  repoId: string;
+  sourceId: string;
+  title: string;
+  content: string;
+  score?: number;
+  citation?: Record<string, unknown>;
+  indexVersion?: string;
+}
+
+export interface KnowledgeEvidenceSet {
+  retrievalId: string;
+  evidence: KnowledgeEvidence[];
+}
+
+export type KnowledgeRetrieveExecutor = (
+  request: KnowledgeRetrieveRequest,
+  signal?: AbortSignal,
+) => Promise<KnowledgeEvidenceSet>;
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeCapability(value: unknown): KnowledgeCapability | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  if (raw.kind === "materialized" && raw.contract === "knowledge.materialize/v1") {
+    return {
+      kind: "materialized",
+      contract: "knowledge.materialize/v1",
+      ...(optionalString(raw.rootPath) ? { rootPath: optionalString(raw.rootPath) } : {}),
+    };
+  }
+  if (raw.kind === "retrieve" && raw.contract === "knowledge.retrieve/v1") {
+    const features = Array.isArray(raw.features)
+      ? raw.features.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+      : undefined;
+    const status = raw.status === "ready" || raw.status === "degraded" || raw.status === "not_ready"
+      ? raw.status
+      : undefined;
+    return {
+      kind: "retrieve",
+      contract: "knowledge.retrieve/v1",
+      ...(features?.length ? { features } : {}),
+      ...(optionalString(raw.indexVersion) ? { indexVersion: optionalString(raw.indexVersion) } : {}),
+      ...(status ? { status } : {}),
+    };
+  }
+  return null;
+}
+
+/**
+ * Treat the Gateway payload and on-disk manifest as untrusted wire data.
+ * Unknown future capabilities are ignored so an older Runtime can still use
+ * the capabilities it understands without inventing behavior.
+ */
+export function normalizeKnowledgeRuntimeBindings(value: unknown): KnowledgeRuntimeBinding[] {
+  if (!Array.isArray(value)) return [];
+  const result: KnowledgeRuntimeBinding[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const raw = item as Record<string, unknown>;
+    const repoId = optionalString(raw.repoId);
+    const name = optionalString(raw.name);
+    if (!repoId || !name || seen.has(repoId)) continue;
+    const capabilities = Array.isArray(raw.capabilities)
+      ? raw.capabilities.map(normalizeCapability).filter((cap): cap is KnowledgeCapability => cap !== null)
+      : [];
+    if (capabilities.length === 0) continue;
+    seen.add(repoId);
+    result.push({
+      repoId,
+      name,
+      description: optionalString(raw.description),
+      version: optionalString(raw.version) ?? "unknown",
+      capabilities,
+    });
+  }
+  return result;
+}

--- a/src/knowledge/runtime.test.ts
+++ b/src/knowledge/runtime.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildKnowledgeRuntime } from "./runtime.js";
+import type { KnowledgeRuntimeBinding } from "./contracts.js";
+
+const wikiBinding: KnowledgeRuntimeBinding = {
+  repoId: "wiki-1",
+  name: "Operations Wiki",
+  version: "3",
+  capabilities: [{ kind: "materialized", contract: "knowledge.materialize/v1", rootPath: "." }],
+};
+
+const retrievalBinding: KnowledgeRuntimeBinding = {
+  repoId: "ticket-1",
+  name: "Ticket History",
+  description: "Resolved incidents",
+  version: "index-7",
+  capabilities: [{ kind: "retrieve", contract: "knowledge.retrieve/v1", features: ["citation"] }],
+};
+
+describe("buildKnowledgeRuntime", () => {
+  it("keeps wiki-only bindings file-native without adding a retrieval tool", () => {
+    const runtime = buildKnowledgeRuntime({ bindings: [wikiBinding], knowledgeDir: "/tmp/kb" });
+    expect(runtime.tools).toEqual([]);
+    expect(runtime.materializedRoots).toEqual(["/tmp/kb"]);
+    expect(runtime.promptContext).toContain("Operations Wiki");
+  });
+
+  it("adds one stable retrieval tool for one or more retrieval bindings", async () => {
+    const retrieve = vi.fn(async () => ({
+      retrievalId: "ret-1",
+      evidence: [{
+        repoId: "ticket-1",
+        sourceId: "INC-42",
+        title: "GPU scheduling incident",
+        content: "Restarted the device plugin.",
+        citation: { url: "https://tickets.example/INC-42" },
+      }],
+    }));
+    const runtime = buildKnowledgeRuntime({ bindings: [wikiBinding, retrievalBinding], retrieve });
+    expect(runtime.tools.map((tool) => tool.name)).toEqual(["knowledge_retrieve"]);
+    expect(runtime.promptContext).toContain("Wiki");
+    expect(runtime.promptContext).toContain("retrieval");
+
+    const result = await runtime.tools[0].execute("call-1", { query: "GPU scheduling" });
+    expect(retrieve).toHaveBeenCalledWith({
+      query: "GPU scheduling",
+      repoIds: ["ticket-1"],
+      filters: undefined,
+      topK: undefined,
+    }, undefined);
+    expect(JSON.parse((result.content[0] as { text: string }).text)).toMatchObject({
+      retrievalId: "ret-1",
+      evidence: [{ sourceId: "INC-42" }],
+    });
+  });
+
+  it("rejects an unbound repo before crossing the retrieval seam", async () => {
+    const retrieve = vi.fn();
+    const runtime = buildKnowledgeRuntime({ bindings: [retrievalBinding], retrieve });
+    const result = await runtime.tools[0].execute("call-1", {
+      query: "secret",
+      repo_ids: ["not-bound"],
+    });
+    expect(retrieve).not.toHaveBeenCalled();
+    expect((result.content[0] as { text: string }).text).toContain("not bound");
+  });
+});

--- a/src/knowledge/runtime.ts
+++ b/src/knowledge/runtime.ts
@@ -1,0 +1,211 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { Text } from "@earendil-works/pi-tui";
+import { renderTextResult } from "../tools/infra/tool-render.js";
+import {
+  normalizeKnowledgeRuntimeBindings,
+  type KnowledgeEvidence,
+  type KnowledgeEvidenceSet,
+  type KnowledgeRetrieveExecutor,
+  type KnowledgeRetrieveRequest,
+  type KnowledgeRuntimeBinding,
+} from "./contracts.js";
+
+const MAX_QUERY_CHARS = 4_000;
+const MAX_TOP_K = 50;
+const MAX_EVIDENCE = 20;
+const MAX_EVIDENCE_CONTENT_CHARS = 2_000;
+
+export interface KnowledgeRuntimeResult {
+  tools: ToolDefinition[];
+  promptContext: string;
+  materializedRoots: string[];
+}
+
+export function loadKnowledgeRuntimeBindings(knowledgeDir: string): KnowledgeRuntimeBinding[] {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(knowledgeDir, ".sync-manifest.json"), "utf8")) as {
+      bindings?: unknown;
+    };
+    return normalizeKnowledgeRuntimeBindings(raw.bindings);
+  } catch {
+    return [];
+  }
+}
+
+function hasCapability(binding: KnowledgeRuntimeBinding, kind: "materialized" | "retrieve"): boolean {
+  return binding.capabilities.some((capability) => capability.kind === kind);
+}
+
+function buildPromptContext(bindings: KnowledgeRuntimeBinding[]): string {
+  if (bindings.length === 0) return "";
+  const lines = [
+    "# Bound Knowledge Bases",
+    "",
+    "Use only the knowledge bases listed below. Whole-page Wiki content is available through Read; " +
+      "large or incident-oriented collections are available through `knowledge_retrieve`. " +
+      "When both are available, prefer Wiki pages for normative procedures and retrieval for historical or long-tail cases. " +
+      "Cite the evidence you use and report conflicts instead of silently merging them.",
+    "",
+  ];
+  for (const binding of bindings) {
+    const modes = [
+      ...(hasCapability(binding, "materialized") ? ["Wiki"] : []),
+      ...(hasCapability(binding, "retrieve") ? ["retrieval"] : []),
+    ].join(" + ");
+    lines.push(`- ${binding.name} (\`${binding.repoId}\`, ${modes}, version ${binding.version})` +
+      `${binding.description ? ` — ${binding.description}` : ""}`);
+  }
+  return lines.join("\n");
+}
+
+function normalizeRequest(
+  raw: unknown,
+  retrievableRepoIds: Set<string>,
+): KnowledgeRetrieveRequest | { error: string } {
+  if (!raw || typeof raw !== "object") return { error: "knowledge_retrieve requires an object input." };
+  const params = raw as Record<string, unknown>;
+  const query = typeof params.query === "string" ? params.query.trim() : "";
+  if (!query) return { error: "knowledge_retrieve requires a non-empty query." };
+  if (query.length > MAX_QUERY_CHARS) {
+    return { error: `knowledge_retrieve query exceeds ${MAX_QUERY_CHARS} characters.` };
+  }
+
+  let repoIds: string[] | undefined;
+  if (params.repo_ids !== undefined) {
+    if (!Array.isArray(params.repo_ids)) return { error: "repo_ids must be an array." };
+    repoIds = [...new Set(params.repo_ids.filter((item): item is string => typeof item === "string" && item.length > 0))];
+    if (repoIds.length === 0) return { error: "repo_ids must contain at least one repository id." };
+    const forbidden = repoIds.filter((repoId) => !retrievableRepoIds.has(repoId));
+    if (forbidden.length > 0) {
+      return { error: `Repository is not bound for retrieval: ${forbidden.join(", ")}` };
+    }
+  } else {
+    repoIds = [...retrievableRepoIds];
+  }
+
+  let topK: number | undefined;
+  if (params.top_k !== undefined) {
+    if (typeof params.top_k !== "number" || !Number.isInteger(params.top_k)) {
+      return { error: "top_k must be an integer." };
+    }
+    topK = Math.min(MAX_TOP_K, Math.max(1, params.top_k));
+  }
+
+  const filters = params.filters && typeof params.filters === "object" && !Array.isArray(params.filters)
+    ? params.filters as Record<string, unknown>
+    : undefined;
+  return { query, repoIds, filters, topK };
+}
+
+function compactEvidence(item: KnowledgeEvidence): KnowledgeEvidence {
+  return {
+    ...item,
+    content: item.content.length > MAX_EVIDENCE_CONTENT_CHARS
+      ? `${item.content.slice(0, MAX_EVIDENCE_CONTENT_CHARS)}…`
+      : item.content,
+  };
+}
+
+function compactEvidenceSet(result: KnowledgeEvidenceSet): KnowledgeEvidenceSet {
+  return {
+    retrievalId: result.retrievalId,
+    evidence: result.evidence.slice(0, MAX_EVIDENCE).map(compactEvidence),
+  };
+}
+
+function createKnowledgeRetrieveTool(
+  bindings: KnowledgeRuntimeBinding[],
+  executeRetrieve: KnowledgeRetrieveExecutor,
+): ToolDefinition {
+  const retrievable = bindings.filter((binding) => hasCapability(binding, "retrieve"));
+  const retrievableRepoIds = new Set(retrievable.map((binding) => binding.repoId));
+  const catalog = retrievable
+    .map((binding) => `- ${binding.name}: ${binding.repoId}${binding.description ? ` — ${binding.description}` : ""}`)
+    .join("\n");
+
+  return {
+    name: "knowledge_retrieve",
+    label: "Knowledge Retrieve",
+    description: `Retrieve evidence from knowledge bases bound to this agent.
+Use for historical incidents, semantic similarity, and large collections that are not practical to browse page-by-page.
+Omit repo_ids to search every bound retrieval knowledge base.
+
+Bound retrieval knowledge bases:
+${catalog}
+
+Returns an EvidenceSet with retrieval_id, source ids, citations, scores, and index versions.`,
+    parameters: Type.Object({
+      query: Type.String({ description: "Natural-language or exact-identifier query" }),
+      repo_ids: Type.Optional(Type.Array(Type.String(), {
+        description: "Bound repository ids to search. Omit to search all retrieval-enabled bindings.",
+      })),
+      filters: Type.Optional(Type.Object({}, {
+        additionalProperties: true,
+        description: "Provider-supported structured filters",
+      })),
+      top_k: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_TOP_K })),
+    }),
+    renderCall(args: unknown, theme: { fg(name: string, value: string): string; bold(value: string): string }) {
+      const query = args && typeof args === "object" && typeof (args as { query?: unknown }).query === "string"
+        ? (args as { query: string }).query
+        : "";
+      return new Text(
+        theme.fg("toolTitle", theme.bold("knowledge_retrieve")) +
+          (query ? ` ${theme.fg("accent", query)}` : ""),
+        0,
+        0,
+      );
+    },
+    renderResult: renderTextResult,
+    async execute(_toolCallId, rawParams, signal) {
+      const request = normalizeRequest(rawParams, retrievableRepoIds);
+      if ("error" in request) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: request.error }) }],
+          details: { status: "invalid_request" },
+        };
+      }
+      try {
+        const result = compactEvidenceSet(await executeRetrieve(request, signal));
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          details: {
+            status: "success",
+            retrieval_id: result.retrievalId,
+            evidence_count: result.evidence.length,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+          details: { status: "error" },
+        };
+      }
+    },
+  };
+}
+
+export function buildKnowledgeRuntime(input: {
+  bindings: KnowledgeRuntimeBinding[];
+  retrieve?: KnowledgeRetrieveExecutor;
+  knowledgeDir?: string;
+}): KnowledgeRuntimeResult {
+  const bindings = normalizeKnowledgeRuntimeBindings(input.bindings);
+  const retrievable = bindings.some((binding) => hasCapability(binding, "retrieve"));
+  const materializedRoots = bindings.flatMap((binding) =>
+    binding.capabilities
+      .filter((capability) => capability.kind === "materialized")
+      .map((capability) => path.resolve(input.knowledgeDir ?? process.cwd(), capability.rootPath ?? ".")),
+  );
+  return {
+    tools: retrievable && input.retrieve
+      ? [createKnowledgeRetrieveTool(bindings, input.retrieve)]
+      : [],
+    promptContext: buildPromptContext(bindings),
+    materializedRoots,
+  };
+}


### PR DESCRIPTION
## Summary
- add a versioned KnowledgeRuntime contract for materialized, retrieval, and hybrid bindings
- expose one stable knowledge_retrieve tool to pi-agent and proxy calls through the mTLS Gateway
- make knowledge reloads invalidate sessions when the tool schema changes

## Verification
- npm test (236 files, 4611 passed, 2 skipped)
- npm run build
- npx vitest run src/knowledge/runtime.test.ts src/agentbox/sync-handlers.test.ts src/gateway/internal-api.test.ts