### PR TITLE
feat(lark): add topic-scoped conversations

### DIFF
--- a/docs/features/channels.mdx
+++ b/docs/features/channels.mdx
@@ -73,12 +73,19 @@ Create a Lark bot app, enable message event subscriptions, then configure it in 
 - `appSecret`
 
 For a controlled group-topic pilot, set `runtime.env.SICLAW_LARK_THREAD_MODE`
-to `"1"`. A root `@bot` message then opens a Feishu topic with the streaming
-card inside it; follow-ups in that topic reuse its Agent session. Follow-ups
-without another `@bot` require the app's group-message event permission. If the
-app receives only mention events, users can still continue by mentioning the
-bot on each topic reply. Unrelated topics are ignored unless the bot already
-has a session for that topic root.
+to `"1"`. This is a rollout gate, not a second mode selector: the existing
+group context selector controls the user experience.
+
+- **Personal (per-user)**: a root `@bot` message opens a Feishu topic with the
+  streaming card inside it. Follow-ups in that topic reuse that user's Agent
+  session without another mention. Unrelated topics and another user's
+  unmentioned replies do not create or inherit the private session.
+- **Team (shared)**: users continue to `@bot` in the main group and the bot
+  replies on the existing main-group path. The whole group keeps one shared
+  Agent session; the topic rollout does not split it by Feishu topic.
+
+No additional Topic switch is required in the UI. Follow-ups without another
+`@bot` require the app's group-message event permission.
 
 ### Feishu test-bot capability checklist
 
@@ -94,7 +101,7 @@ Use these application-identity scopes for a complete Siclaw Agent test bot:
 | Send and reply to messages | `im:message` | Plain-text replies, CardKit card replies, topic replies, mode-switch announcements, and downloading images attached to received messages |
 | Receive direct messages | `im:message.p2p_msg:readonly` | Required separately even when `im:message` is enabled |
 | Receive group `@bot` messages | `im:message.group_at_msg:readonly` | Starts an investigation from a group root message |
-| Receive no-mention topic follow-ups | `im:message.group_msg` | Required for natural follow-up messages inside an existing bot topic; this is a sensitive permission, so restrict the app's availability for pilots |
+| Receive group messages without a mention | `im:message.group_msg` | Required for natural follow-ups inside an existing personal-mode bot topic and for passive shared-group discussion context; this is a sensitive permission, so restrict the app's availability for pilots |
 | Read group metadata | `im:chat:readonly` | Resolves the group title shown in Siclaw |
 | Create and stream cards | `cardkit:card:write` | Creates the thinking card, streams milestones, finalizes the answer, and updates feedback controls |
 | Upload reply images and files | `im:resource` | Uploads charts and other Agent-generated message resources; received-message downloads are covered by `im:message` |
@@ -122,9 +129,14 @@ The matching platform configuration is:
 Acceptance should cover each permission unit independently:
 
 - Direct message: send a unique text and confirm the bot replies.
-- Group root: `@bot` with a unique text and confirm the first reply opens a topic.
-- Topic continuity: reply inside that topic without another mention and confirm
-  the same Siclaw session is reused.
+- Personal-mode root: select **Personal**, send `@bot` with a unique text, and
+  confirm the first reply opens a topic.
+- Personal-mode continuity: reply inside that topic without another mention and
+  confirm the same Siclaw session is reused.
+- Team-mode root: select **Team**, send `@bot` with a unique text, and confirm
+  the bot replies in the main group without opening a topic.
+- Team-mode continuity: have another member `@bot` and confirm both turns reuse
+  the one shared group session.
 - Streaming card: confirm the thinking state, milestone updates, and final state.
 - Card callback: click feedback or a mode button and confirm the toast and state
   update.

--- a/docs/features/channels.mdx
+++ b/docs/features/channels.mdx
@@ -80,6 +80,56 @@ app receives only mention events, users can still continue by mentioning the
 bot on each topic reply. Unrelated topics are ignored unless the bot already
 has a session for that topic root.
 
+### Feishu test-bot capability checklist
+
+Do not treat a successful long connection or an `im.message.receive_v1`
+subscription as proof that every message path is enabled. Feishu filters that
+single event by the app's scopes; for example, group messages can work while
+direct messages are silently not delivered.
+
+Use these application-identity scopes for a complete Siclaw Agent test bot:
+
+| Capability unit | Scope | Why Siclaw needs it |
+|---|---|---|
+| Send and reply to messages | `im:message` | Plain-text replies, CardKit card replies, topic replies, mode-switch announcements, and downloading images attached to received messages |
+| Receive direct messages | `im:message.p2p_msg:readonly` | Required separately even when `im:message` is enabled |
+| Receive group `@bot` messages | `im:message.group_at_msg:readonly` | Starts an investigation from a group root message |
+| Receive no-mention topic follow-ups | `im:message.group_msg` | Required for natural follow-up messages inside an existing bot topic; this is a sensitive permission, so restrict the app's availability for pilots |
+| Read group metadata | `im:chat:readonly` | Resolves the group title shown in Siclaw |
+| Create and stream cards | `cardkit:card:write` | Creates the thinking card, streams milestones, finalizes the answer, and updates feedback controls |
+| Upload reply images and files | `im:resource` | Uploads charts and other Agent-generated message resources; received-message downloads are covered by `im:message` |
+| Read bot metadata (recommended) | `application:bot.basic_info:read` | Keeps the bot name and identity lookup explicit in the app configuration |
+
+Do not add contacts, Drive, Docs, Calendar, or tenant-admin scopes for this
+channel. The optional Sicore identity-binding flow only calls
+`authen/v1/user_info`, which requires no additional API scope for `open_id`,
+display name, and avatar.
+
+The matching platform configuration is:
+
+1. Enable the **Bot** capability.
+2. Select **Long connection** for events and callbacks.
+3. Subscribe to the `im.message.receive_v1` event.
+4. Subscribe to the `card.action.trigger` callback.
+5. Add the Sicore callback URL
+   `/api/v1/siclaw/personal-bot/oauth/feishu/callback` as an exact redirect URL
+   when identity binding is tested.
+6. Publish the app version after changing capabilities, events, callbacks,
+   permissions, redirect URLs, or availability.
+7. Restrict a pilot app to the intended test users, especially when
+   `im:message.group_msg` is enabled.
+
+Acceptance should cover each permission unit independently:
+
+- Direct message: send a unique text and confirm the bot replies.
+- Group root: `@bot` with a unique text and confirm the first reply opens a topic.
+- Topic continuity: reply inside that topic without another mention and confirm
+  the same Siclaw session is reused.
+- Streaming card: confirm the thinking state, milestone updates, and final state.
+- Card callback: click feedback or a mode button and confirm the toast and state
+  update.
+- Media: send an image to the bot and request a chart/image response.
+
 ## Discord Integration
 
 Configure a Discord bot in **Channels** with:

--- a/docs/features/channels.mdx
+++ b/docs/features/channels.mdx
@@ -72,6 +72,14 @@ Create a Lark bot app, enable message event subscriptions, then configure it in 
 - `appId`
 - `appSecret`
 
+For a controlled group-topic pilot, set `runtime.env.SICLAW_LARK_THREAD_MODE`
+to `"1"`. A root `@bot` message then opens a Feishu topic with the streaming
+card inside it; follow-ups in that topic reuse its Agent session. Follow-ups
+without another `@bot` require the app's group-message event permission. If the
+app receives only mention events, users can still continue by mentioning the
+bot on each topic reply. Unrelated topics are ignored unless the bot already
+has a session for that topic root.
+
 ## Discord Integration
 
 Configure a Discord bot in **Channels** with:

--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -79,6 +79,10 @@ export function isChannelAccessDenied(
  * for authorized group bots and choose the effective session key server-side
  * (open groups → shared chat session; authorized → per-user). It is separate
  * from `sessionKey` because the server may override the session key it returns.
+ * `conversationKey` is an optional provider conversation scope (for example a
+ * Feishu topic root). The Portal combines it with the binding's context mode
+ * and actor identity; the runtime must treat the returned `sessionKey` as
+ * authoritative.
  */
 export async function resolveBinding(
   channelId: string,
@@ -86,12 +90,16 @@ export async function resolveBinding(
   frontendClient: FrontendWsClient,
   sessionKey?: string,
   senderOpenId?: string,
+  conversationKey?: string,
+  conversationExistingOnly: boolean = false,
 ): Promise<ResolvedChannelBinding | ChannelAccessDenied | null> {
   const data = await frontendClient.request("channel.resolveBinding", {
     channel_id: channelId,
     route_key: routeKey,
     ...(sessionKey ? { session_key: sessionKey } : {}),
     ...(senderOpenId ? { sender_open_id: senderOpenId } : {}),
+    ...(conversationKey ? { conversation_key: conversationKey } : {}),
+    ...(conversationExistingOnly ? { conversation_existing_only: true } : {}),
   });
   return data.binding ?? null;
 }

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -207,6 +207,12 @@ describe("openTypingCard", () => {
     expect(cardJson.body.elements[0].content).toBe("Running tools…");
   });
 
+  it("can post the placeholder as a topic reply", async () => {
+    const { client, replySpy } = makeLarkClient();
+    await openTypingCard(client as any, "msg-1", "Running tools…", true);
+    expect(replySpy.mock.calls[0][0].data.reply_in_thread).toBe(true);
+  });
+
   it("returns null when card.create throws — caller should fall back", async () => {
     const { client } = makeLarkClient({ createThrows: new Error("boom") });
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -292,6 +292,7 @@ export async function sendModeCard(
   channelId: string,
   routeKey: string,
   locale: LarkLocale,
+  replyInThread: boolean = false,
 ): Promise<boolean> {
   try {
     const createRes = await larkClient.cardkit.v1.card.create({
@@ -304,7 +305,11 @@ export async function sendModeCard(
     }
     const replyRes = await larkClient.im.message.reply({
       path: { message_id: messageId },
-      data: { msg_type: "interactive", content: JSON.stringify({ type: "card", data: { card_id: cardId } }) },
+      data: {
+        msg_type: "interactive",
+        content: JSON.stringify({ type: "card", data: { card_id: cardId } }),
+        ...(replyInThread ? { reply_in_thread: true } : {}),
+      },
     });
     if (replyRes && typeof replyRes.code === "number" && replyRes.code !== 0) {
       console.error(`[lark-card] posting mode card failed: code=${replyRes.code} msg=${replyRes.msg}`);
@@ -473,6 +478,7 @@ export async function openTypingCard(
   larkClient: any,
   messageId: string,
   placeholder: string = DEFAULT_PLACEHOLDER,
+  replyInThread: boolean = false,
 ): Promise<CardSession | null> {
   try {
     const createRes = await larkClient.cardkit.v1.card.create({
@@ -496,6 +502,7 @@ export async function openTypingCard(
       data: {
         msg_type: "interactive",
         content: JSON.stringify({ type: "card", data: { card_id: cardId } }),
+        ...(replyInThread ? { reply_in_thread: true } : {}),
       },
     });
     if (replyRes && typeof replyRes.code === "number" && replyRes.code !== 0) {

--- a/src/gateway/channels/lark-image.test.ts
+++ b/src/gateway/channels/lark-image.test.ts
@@ -45,6 +45,12 @@ describe("replyImageToLark", () => {
     expect(JSON.parse(replyArg.data.content)).toEqual({ image_key: "img-nested" });
   });
 
+  it("can post the image inside a topic", async () => {
+    const lark = makeLarkClient();
+    await expect(replyImageToLark(lark, "mid-1", Buffer.from([1]), true)).resolves.toBe(true);
+    expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+  });
+
   it("falls back to the im.v1.image namespace when needed", async () => {
     const lark = {
       im: {

--- a/src/gateway/channels/lark-image.ts
+++ b/src/gateway/channels/lark-image.ts
@@ -2,6 +2,7 @@ export async function replyImageToLark(
   larkClient: any,
   messageId: string,
   image: Buffer,
+  replyInThread: boolean = false,
 ): Promise<boolean> {
   try {
     const imageApi = larkClient?.im?.image ?? larkClient?.im?.v1?.image;
@@ -27,6 +28,7 @@ export async function replyImageToLark(
       data: {
         msg_type: "image",
         content: JSON.stringify({ image_key: imageKey }),
+        ...(replyInThread ? { reply_in_thread: true } : {}),
       },
     });
     return true;

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1340,6 +1340,35 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(resolveBindingMock).not.toHaveBeenCalled();
   });
 
+  it("/mode resolves only the group mode and does not allocate a topic session", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionId: "shared-session",
+      sessionKey: "chat:oc_abc123",
+      contextMode: "shared",
+    }));
+
+    await handleLarkMessage(
+      makeTextEvent("/mode", { chat_type: "group", mentions: [] }),
+      makeLarkClient(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      BOT,
+    );
+
+    expect(resolveBindingMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "open_id:ou_user_1",
+      "ou_user_1",
+      undefined,
+    );
+  });
+
   it("thread mode creates a topic reply and accepts an unmentioned follow-up in the same root", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "thread-session",
@@ -1418,6 +1447,47 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     }));
   });
 
+  it("starts an explicitly mentioned quoted message as a new topic rooted at the current message", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionId: "quoted-topic-session",
+      sessionKey: "open_id:ou_user_1:lark_thread:mid-quoted-at",
+      contextMode: "per_user",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "quoted-topic-session" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "quoted answer" }] },
+      };
+    });
+    const client = makeLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("@_user_1 分析这条引用", {
+        message_id: "mid-quoted-at",
+        chat_type: "group",
+        root_id: "mid-older-message",
+        mentions: [{ key: "@_user_1", id: { open_id: BOT } }],
+      }),
+      client,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      BOT,
+    );
+
+    expect(resolveBindingMock.mock.calls.map((call) => call[5])).toEqual([
+      "lark_thread:mid-quoted-at",
+      "lark_thread:mid-quoted-at",
+    ]);
+    expect(resolveBindingMock.mock.calls.map((call) => call[6])).toEqual([false, false]);
+    expect(client.im.message.reply.mock.calls[0][0].path.message_id).toBe("mid-quoted-at");
+    expect(client.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+  });
+
   it("thread rollout keeps a shared group on the main-group reply path", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "shared-session",
@@ -1454,16 +1524,15 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(rootClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBeUndefined();
     expect(appendMessageMock.mock.calls[0][0].metadata).not.toHaveProperty("conversationKey");
 
-    const topicClient = makeLarkClient();
+    const quoteClient = makeLarkClient();
     await handleLarkMessage(
-      makeTextEvent("话题里的普通讨论", {
-        message_id: "mid-shared-followup",
+      makeTextEvent("引用回复里的共享讨论", {
+        message_id: "mid-shared-quote",
         chat_type: "group",
         root_id: "mid-1",
-        thread_id: "omt-shared-topic",
         mentions: [],
       }),
-      topicClient,
+      quoteClient,
       "lark",
       makeAgentBoxManager("a1") as any,
       undefined,
@@ -1474,7 +1543,27 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     );
 
     expect(promptMock).toHaveBeenCalledTimes(1);
-    expect(topicClient.im.message.reply).not.toHaveBeenCalled();
+    expect(resolveBindingMock).toHaveBeenCalledTimes(2);
+    expect(quoteClient.im.message.reply).not.toHaveBeenCalled();
+
+    await handleLarkMessage(
+      makeTextEvent("@_user_1 继续分析", {
+        message_id: "mid-shared-next",
+        chat_type: "group",
+        mentions: [{ key: "@_user_1", id: { open_id: BOT } }],
+      }),
+      makeLarkClient(),
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    expect(promptMock).toHaveBeenCalledTimes(2);
+    expect(promptMock.mock.calls[1][0].text).toContain("引用回复里的共享讨论");
   });
 
   it("thread mode ignores an unmentioned topic that has no existing bot session", async () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -564,7 +564,15 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     resolveBindingMock.mockResolvedValue(null);
     const mgr = makeAgentBoxManager();
     await handleLarkMessage(makeTextEvent("hello"), makeLarkClient(), "lark", mgr as any, undefined, {} as any);
-    expect(resolveBindingMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "open_id:ou_user_1", "ou_user_1");
+    expect(resolveBindingMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "open_id:ou_user_1",
+      "ou_user_1",
+      undefined,
+      false,
+    );
     expect(mgr.getOrCreate).not.toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();
   });
@@ -592,7 +600,15 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       },
     );
 
-    expect(resolveBindingMock).toHaveBeenCalledWith("lark", "oc_abc123", expect.anything(), "open_id:ou_user_1", "ou_user_1");
+    expect(resolveBindingMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "open_id:ou_user_1",
+      "ou_user_1",
+      undefined,
+      false,
+    );
     expect(resolvePersonalBindingMock).not.toHaveBeenCalled();
   });
 
@@ -998,6 +1014,44 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     expect(lark.im.message.reply.mock.calls[0][0].data.content).toContain("不支持单人重置");
   });
 
+  it("/new in a thread-scoped shared group resets only that topic session", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionId: "topic-old",
+      sessionKey: "lark_thread:mid-1",
+      contextMode: "shared",
+    }));
+    resetBindingSessionMock.mockResolvedValue({
+      success: true,
+      agentId: "a1",
+      oldSessionId: "topic-old",
+      sessionId: "topic-new",
+    });
+    const lark = makeLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("/new", {
+        chat_type: "group",
+        mentions: [{ key: "@_user_1", id: { open_id: "ou_bot_self" } }],
+      }),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      "ou_bot_self",
+    );
+
+    expect(resetBindingSessionMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "lark_thread:mid-1",
+    );
+    expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+  });
+
   it("queues concurrent messages for the same sender instead of starting a second prompt", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ sessionId: "queued-session" }));
     let releaseFirst!: () => void;
@@ -1284,6 +1338,119 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     const data = groupEvent("随便聊两句", []);
     await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
     expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("thread mode creates a topic reply and accepts an unmentioned follow-up in the same root", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionId: "thread-session",
+      sessionKey: "lark_thread:mid-1",
+      contextMode: "shared",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "thread-session" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "thread answer" }] },
+      };
+    });
+    const config = { app_id: "x", app_secret: "y", thread_mode: "group" } as const;
+
+    const rootClient = makeLarkClient();
+    await handleLarkMessage(
+      groupEvent("@_user_1 查一下集群", [{ key: "@_user_1", id: { open_id: BOT } }]),
+      rootClient,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    const followupClient = makeLarkClient();
+    await handleLarkMessage(
+      makeTextEvent("再看一下其他节点", {
+        message_id: "mid-followup",
+        chat_type: "group",
+        root_id: "mid-1",
+        thread_id: "omt-topic-1",
+        mentions: [],
+      }),
+      followupClient,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    expect(promptMock.mock.calls.map((call) => call[0].sessionId)).toEqual([
+      "thread-session",
+      "thread-session",
+    ]);
+    expect(resolveBindingMock.mock.calls.map((call) => call[5])).toEqual([
+      "lark_thread:mid-1",
+      "lark_thread:mid-1",
+      "lark_thread:mid-1",
+      "lark_thread:mid-1",
+    ]);
+    expect(resolveBindingMock.mock.calls.map((call) => call[6])).toEqual([
+      false,
+      false,
+      true,
+      true,
+    ]);
+    expect(rootClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+    expect(followupClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+    expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        conversationKey: "lark_thread:mid-1",
+        rootMessageId: "mid-1",
+      }),
+    }));
+    expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        threadId: "omt-topic-1",
+      }),
+    }));
+  });
+
+  it("thread mode ignores an unmentioned topic that has no existing bot session", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const lark = makeLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("普通话题里的聊天", {
+        message_id: "mid-followup",
+        chat_type: "group",
+        root_id: "mid-unrelated-root",
+        thread_id: "omt-unrelated",
+        mentions: [],
+      }),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      BOT,
+    );
+
+    expect(resolveBindingMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "open_id:ou_user_1",
+      "ou_user_1",
+      "lark_thread:mid-unrelated-root",
+      true,
+    );
+    expect(promptMock).not.toHaveBeenCalled();
+    expect(lark.im.message.reply).not.toHaveBeenCalled();
   });
 
   it("degraded (botOpenId unknown): still drops @所有人 by its @_all key", async () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1014,11 +1014,11 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     expect(lark.im.message.reply.mock.calls[0][0].data.content).toContain("不支持单人重置");
   });
 
-  it("/new in a thread-scoped shared group resets only that topic session", async () => {
+  it("/new in a per-user topic resets only that user's topic session", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "topic-old",
-      sessionKey: "lark_thread:mid-1",
-      contextMode: "shared",
+      sessionKey: "open_id:ou_user_1:lark_thread:mid-1",
+      contextMode: "per_user",
     }));
     resetBindingSessionMock.mockResolvedValue({
       success: true,
@@ -1047,7 +1047,7 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       "lark",
       "oc_abc123",
       expect.anything(),
-      "lark_thread:mid-1",
+      "open_id:ou_user_1:lark_thread:mid-1",
     );
     expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
   });
@@ -1343,8 +1343,8 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
   it("thread mode creates a topic reply and accepts an unmentioned follow-up in the same root", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "thread-session",
-      sessionKey: "lark_thread:mid-1",
-      contextMode: "shared",
+      sessionKey: "open_id:ou_user_1:lark_thread:mid-1",
+      contextMode: "per_user",
     }));
     promptMock.mockResolvedValue({ sessionId: "thread-session" });
     streamEventsMock.mockImplementation(async function* () {
@@ -1416,6 +1416,65 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         threadId: "omt-topic-1",
       }),
     }));
+  });
+
+  it("thread rollout keeps a shared group on the main-group reply path", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionId: "shared-session",
+      sessionKey: "chat:oc_abc123",
+      contextMode: "shared",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "shared-session" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "shared answer" }] },
+      };
+    });
+    const config = { app_id: "x", app_secret: "y", thread_mode: "group" } as const;
+    const rootClient = makeLarkClient();
+
+    await handleLarkMessage(
+      groupEvent("@_user_1 查一下集群", [{ key: "@_user_1", id: { open_id: BOT } }]),
+      rootClient,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    expect(promptMock).toHaveBeenCalledTimes(1);
+    expect(resolveBindingMock.mock.calls.map((call) => call[5])).toEqual([
+      "lark_thread:mid-1",
+      undefined,
+    ]);
+    expect(rootClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBeUndefined();
+    expect(appendMessageMock.mock.calls[0][0].metadata).not.toHaveProperty("conversationKey");
+
+    const topicClient = makeLarkClient();
+    await handleLarkMessage(
+      makeTextEvent("话题里的普通讨论", {
+        message_id: "mid-shared-followup",
+        chat_type: "group",
+        root_id: "mid-1",
+        thread_id: "omt-shared-topic",
+        mentions: [],
+      }),
+      topicClient,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    expect(promptMock).toHaveBeenCalledTimes(1);
+    expect(topicClient.im.message.reply).not.toHaveBeenCalled();
   });
 
   it("thread mode ignores an unmentioned topic that has no existing bot session", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -854,15 +854,17 @@ export async function handleLarkMessage(
   const chatType: string | undefined = message.chat_type;
   const senderOpenId = getLarkSenderOpenId(data);
   const sessionKey = buildLarkSessionKey(senderOpenId, chatId);
-  const threadMode = chatType === "group" && larkGroupThreadModeEnabled(channelConfig);
+  // Rollout gate only: whether personal group conversations MAY use Feishu
+  // topics. The binding's server-authoritative contextMode decides whether
+  // this specific message actually uses the topic path.
+  const topicFeatureEnabled = chatType === "group" && larkGroupThreadModeEnabled(channelConfig);
   const rootMessageId = typeof message.root_id === "string" && message.root_id.trim()
     ? message.root_id.trim()
     : messageId;
   const threadId = typeof message.thread_id === "string" && message.thread_id.trim()
     ? message.thread_id.trim()
     : null;
-  const conversationKey = threadMode ? `lark_thread:${rootMessageId}` : undefined;
-  const replyInThread = threadMode;
+  const topicConversationKey = topicFeatureEnabled ? `lark_thread:${rootMessageId}` : undefined;
 
   // Raw receipt log: fires for EVERY delivered event before any drop, so a
   // group message that arrives but is filtered (non-text, empty after @-strip)
@@ -1031,7 +1033,7 @@ export async function handleLarkMessage(
     const result = await handlePairingCode(code, groupChannelId, chatId, "group", frontendClient!, chatName ?? undefined);
 
     const replyText = formatPairReply(result, locale);
-    await replyToLark(larkClient, messageId, replyText, replyInThread);
+    await replyToLark(larkClient, messageId, replyText);
     return;
   }
 
@@ -1053,34 +1055,35 @@ export async function handleLarkMessage(
       frontendClient!,
       sessionKey,
       senderOpenId ?? undefined,
-      conversationKey,
+      topicConversationKey,
     );
     if (isChannelAccessDenied(modeBinding)) {
-      await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale), replyInThread);
+      await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale));
       return;
     }
     if (!modeBinding) {
-      await replyToLark(larkClient, messageId, MODE_UNBOUND_NOTICE_BY_LOCALE[locale], replyInThread);
+      await replyToLark(larkClient, messageId, MODE_UNBOUND_NOTICE_BY_LOCALE[locale]);
       return;
     }
     const current: GroupContextMode = modeBinding.contextMode === "shared" ? "shared" : "per_user";
+    const modeReplyInThread = topicFeatureEnabled && current === "per_user";
     rememberGroupMode(groupChannelId, chatId, current);
-    const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale, replyInThread);
+    const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale, modeReplyInThread);
     if (!sent) {
-      await replyToLark(larkClient, messageId, `${MODE_LABEL_BY_LOCALE[locale][current]}`, replyInThread);
+      await replyToLark(larkClient, messageId, `${MODE_LABEL_BY_LOCALE[locale][current]}`, modeReplyInThread);
     }
     return;
   }
 
   // Only respond when THIS bot is individually @-mentioned, except inside a
-  // topic that thread mode already scoped to a root message. Feishu also
+  // topic that personal mode already scoped to a root message. Feishu also
   // delivers "@所有人" to an @bot-scoped app (it mentions everyone, the bot
   // included), so an @所有人 announcement arrives looking just like a real
   // @bot — without this gate the bot replies to group-wide announcements that
   // were never aimed at it. Skips "@所有人" and "@someone-else"; PAIR above is
   // exempt (explicit command). Gated on chat_type==="group" so the binding/
   // access checks below stay reachable only for messages aimed at the bot.
-  const isThreadFollowup = threadMode && rootMessageId !== messageId;
+  const isThreadFollowup = topicFeatureEnabled && rootMessageId !== messageId;
   const conversationExistingOnly = isThreadFollowup && !isBotMentioned(message, botOpenId);
   if (chatType === "group" && !isBotMentioned(message, botOpenId) && !isThreadFollowup) {
     // Non-@ group message. In a group KNOWN to be shared, retain it as passive
@@ -1090,7 +1093,7 @@ export async function handleLarkMessage(
     // drop it immediately: privacy discipline — only a confirmed-shared group
     // may retain chatter (the receive-all-messages scope is app-level, so the
     // bot sees chatter from groups it must not buffer).
-    if (!threadMode && text.length > 0 && cachedGroupMode(groupChannelId, chatId) === "shared") {
+    if (text.length > 0 && cachedGroupMode(groupChannelId, chatId) === "shared") {
       appendDiscussion(groupChannelId, chatId, senderLabel(senderOpenId), text);
       console.log(`[lark] Buffered non-@ discussion for shared group chat=${chatId}`);
     } else {
@@ -1107,14 +1110,14 @@ export async function handleLarkMessage(
     frontendClient!,
     sessionKey,
     senderOpenId ?? undefined,
-    conversationKey,
+    topicConversationKey,
     conversationExistingOnly,
   );
   if (isChannelAccessDenied(binding)) {
     // sicore_authorized group: this sender isn't allowed. The message is either
     // an explicit @ or a follow-up in a previously established bot topic, so a
     // single short hint is appropriate.
-    await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(binding, locale), replyInThread);
+    await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(binding, locale));
     return;
   }
   if (!binding) {
@@ -1131,7 +1134,8 @@ export async function handleLarkMessage(
   // both the queue and the queued context, so the two-path contract holds:
   //   - open group     → open_id:<sender>  (per-sender: concurrent + isolated)
   //   - authorized group → sicore_user:<id> (per-user)
-  //   - thread-mode shared group → lark_thread:<root message>
+  //   - personal topic → <participant-key>:lark_thread:<root message>
+  //   - shared group → chat:<route-key> (topic candidates are ignored)
   //   - legacy single binding session → "" (binding-level queue + /new reset)
   // /new then resets the right session, and same-session senders serialize.
   // Cache the group's mode so the non-@ ingestion gate can decide whether to
@@ -1146,6 +1150,17 @@ export async function handleLarkMessage(
   if (cachedMode && cachedMode !== contextMode) forgetGroupState(groupChannelId, chatId);
   rememberGroupMode(groupChannelId, chatId, contextMode);
 
+  // A no-@ message inside a Feishu topic is a continuation only in personal
+  // mode. Team mode deliberately stays on the old main-group path; an
+  // unrelated/manual topic must not wake the shared Agent session.
+  if (isThreadFollowup && !isBotMentioned(message, botOpenId) && contextMode === "shared") {
+    console.log(`[lark] Ignoring no-@ topic message for shared group chat=${chatId}`);
+    return;
+  }
+
+  const personalTopicMode = topicFeatureEnabled && contextMode === "per_user";
+  const conversationKey = personalTopicMode ? topicConversationKey : undefined;
+  const replyInThread = personalTopicMode;
   const effectiveSessionKey = binding.sessionKey ?? "";
   const queueKey = `${binding.bindingId}:${binding.sessionKey ?? "__binding__"}`;
   const queued = enqueueBindingTask(queueKey, () => processQueuedLarkMessage({

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -135,6 +135,10 @@ export interface LarkChannelConfig {
   domain?: "feishu" | "lark";  // feishu = China (default), lark = Global
   app_id: string;
   app_secret: string;
+  /** Reply to group root messages as Feishu topics and scope sessions to the
+   *  topic root. Default-off; the test runtime can enable it with
+   *  SICLAW_LARK_THREAD_MODE=1 without changing stored channel config. */
+  thread_mode?: "group";
   group_channel_id?: string;
   verification_token?: string;
   encrypt_key?: string;
@@ -328,6 +332,12 @@ function getLarkSenderOpenId(data: any): string | null {
 
 function buildLarkSessionKey(senderOpenId: string | null, chatId: string): string {
   return senderOpenId ? `open_id:${senderOpenId}` : `chat:${chatId}`;
+}
+
+function larkGroupThreadModeEnabled(config?: LarkChannelConfig): boolean {
+  if (config?.thread_mode === "group") return true;
+  const env = process.env.SICLAW_LARK_THREAD_MODE?.trim().toLowerCase();
+  return env === "1" || env === "true";
 }
 
 /**
@@ -844,6 +854,15 @@ export async function handleLarkMessage(
   const chatType: string | undefined = message.chat_type;
   const senderOpenId = getLarkSenderOpenId(data);
   const sessionKey = buildLarkSessionKey(senderOpenId, chatId);
+  const threadMode = chatType === "group" && larkGroupThreadModeEnabled(channelConfig);
+  const rootMessageId = typeof message.root_id === "string" && message.root_id.trim()
+    ? message.root_id.trim()
+    : messageId;
+  const threadId = typeof message.thread_id === "string" && message.thread_id.trim()
+    ? message.thread_id.trim()
+    : null;
+  const conversationKey = threadMode ? `lark_thread:${rootMessageId}` : undefined;
+  const replyInThread = threadMode;
 
   // Raw receipt log: fires for EVERY delivered event before any drop, so a
   // group message that arrives but is filtered (non-text, empty after @-strip)
@@ -1012,7 +1031,7 @@ export async function handleLarkMessage(
     const result = await handlePairingCode(code, groupChannelId, chatId, "group", frontendClient!, chatName ?? undefined);
 
     const replyText = formatPairReply(result, locale);
-    await replyToLark(larkClient, messageId, replyText);
+    await replyToLark(larkClient, messageId, replyText, replyInThread);
     return;
   }
 
@@ -1028,32 +1047,42 @@ export async function handleLarkMessage(
   // /mode — summon the context-mode switch card. Handled before the @-gate so
   // it works with or without an @bot (like PAIR); command words are exact.
   if (/^\/mode$/i.test(text.trim())) {
-    const modeBinding = await resolveBinding(groupChannelId, chatId, frontendClient!, sessionKey, senderOpenId ?? undefined);
+    const modeBinding = await resolveBinding(
+      groupChannelId,
+      chatId,
+      frontendClient!,
+      sessionKey,
+      senderOpenId ?? undefined,
+      conversationKey,
+    );
     if (isChannelAccessDenied(modeBinding)) {
-      await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale));
+      await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale), replyInThread);
       return;
     }
     if (!modeBinding) {
-      await replyToLark(larkClient, messageId, MODE_UNBOUND_NOTICE_BY_LOCALE[locale]);
+      await replyToLark(larkClient, messageId, MODE_UNBOUND_NOTICE_BY_LOCALE[locale], replyInThread);
       return;
     }
     const current: GroupContextMode = modeBinding.contextMode === "shared" ? "shared" : "per_user";
     rememberGroupMode(groupChannelId, chatId, current);
-    const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale);
+    const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale, replyInThread);
     if (!sent) {
-      await replyToLark(larkClient, messageId, `${MODE_LABEL_BY_LOCALE[locale][current]}`);
+      await replyToLark(larkClient, messageId, `${MODE_LABEL_BY_LOCALE[locale][current]}`, replyInThread);
     }
     return;
   }
 
-  // Only respond when THIS bot is individually @-mentioned. Feishu also
+  // Only respond when THIS bot is individually @-mentioned, except inside a
+  // topic that thread mode already scoped to a root message. Feishu also
   // delivers "@所有人" to an @bot-scoped app (it mentions everyone, the bot
   // included), so an @所有人 announcement arrives looking just like a real
   // @bot — without this gate the bot replies to group-wide announcements that
   // were never aimed at it. Skips "@所有人" and "@someone-else"; PAIR above is
   // exempt (explicit command). Gated on chat_type==="group" so the binding/
   // access checks below stay reachable only for messages aimed at the bot.
-  if (chatType === "group" && !isBotMentioned(message, botOpenId)) {
+  const isThreadFollowup = threadMode && rootMessageId !== messageId;
+  const conversationExistingOnly = isThreadFollowup && !isBotMentioned(message, botOpenId);
+  if (chatType === "group" && !isBotMentioned(message, botOpenId) && !isThreadFollowup) {
     // Non-@ group message. In a group KNOWN to be shared, retain it as passive
     // discussion context for the next @-turn — WITHOUT running the agent or
     // touching the AgentBox (idle pods must not be woken by group chatter).
@@ -1061,7 +1090,7 @@ export async function handleLarkMessage(
     // drop it immediately: privacy discipline — only a confirmed-shared group
     // may retain chatter (the receive-all-messages scope is app-level, so the
     // bot sees chatter from groups it must not buffer).
-    if (text.length > 0 && cachedGroupMode(groupChannelId, chatId) === "shared") {
+    if (!threadMode && text.length > 0 && cachedGroupMode(groupChannelId, chatId) === "shared") {
       appendDiscussion(groupChannelId, chatId, senderLabel(senderOpenId), text);
       console.log(`[lark] Buffered non-@ discussion for shared group chat=${chatId}`);
     } else {
@@ -1072,12 +1101,20 @@ export async function handleLarkMessage(
 
   // Look up binding for this chat. Pass sender_open_id so the Portal can
   // auto-bind / per-sender resolve group bots and pick the session key.
-  const binding = await resolveBinding(groupChannelId, chatId, frontendClient!, sessionKey, senderOpenId ?? undefined);
+  const binding = await resolveBinding(
+    groupChannelId,
+    chatId,
+    frontendClient!,
+    sessionKey,
+    senderOpenId ?? undefined,
+    conversationKey,
+    conversationExistingOnly,
+  );
   if (isChannelAccessDenied(binding)) {
-    // sicore_authorized group: this sender isn't allowed. Feishu only delivers
-    // @-mentioned group messages, so the message is already directed at the bot
-    // — a single short hint is fine, not spam.
-    await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(binding, locale));
+    // sicore_authorized group: this sender isn't allowed. The message is either
+    // an explicit @ or a follow-up in a previously established bot topic, so a
+    // single short hint is appropriate.
+    await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(binding, locale), replyInThread);
     return;
   }
   if (!binding) {
@@ -1094,6 +1131,7 @@ export async function handleLarkMessage(
   // both the queue and the queued context, so the two-path contract holds:
   //   - open group     → open_id:<sender>  (per-sender: concurrent + isolated)
   //   - authorized group → sicore_user:<id> (per-user)
+  //   - thread-mode shared group → lark_thread:<root message>
   //   - legacy single binding session → "" (binding-level queue + /new reset)
   // /new then resets the right session, and same-session senders serialize.
   // Cache the group's mode so the non-@ ingestion gate can decide whether to
@@ -1120,6 +1158,11 @@ export async function handleLarkMessage(
     channelId: groupChannelId,
     route: "group",
     contextMode,
+    conversationKey,
+    rootMessageId,
+    threadId,
+    replyInThread,
+    conversationExistingOnly,
     larkClient,
     agentBoxManager,
     tlsOptions,
@@ -1127,7 +1170,7 @@ export async function handleLarkMessage(
     locale,
   }));
   if (!queued.accepted) {
-    await replyToLark(larkClient, messageId, QUEUE_FULL_NOTICE_BY_LOCALE[locale]);
+    await replyToLark(larkClient, messageId, QUEUE_FULL_NOTICE_BY_LOCALE[locale], replyInThread);
     return;
   }
   await queued.done;
@@ -1145,6 +1188,15 @@ interface QueuedLarkMessageContext {
   /** Group route only: "shared" drains the discussion buffer into the prompt
    *  and attributes the asker; absent/"per_user" behaves as an isolated chat. */
   contextMode?: GroupContextMode;
+  /** Provider-native conversation scope. For Feishu topics this is rooted at
+   *  the root message id and remains stable before/after thread_id exists. */
+  conversationKey?: string;
+  rootMessageId?: string;
+  threadId?: string | null;
+  replyInThread?: boolean;
+  /** No-@ topic follow-ups may reuse an existing topic session, but must never
+   *  create one for an unrelated Feishu topic. */
+  conversationExistingOnly?: boolean;
   larkClient: any;
   agentBoxManager: AgentBoxManager;
   tlsOptions?: { cert: string; key: string; ca: string };
@@ -1163,6 +1215,11 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     channelId,
     route,
     contextMode,
+    conversationKey,
+    rootMessageId,
+    threadId,
+    replyInThread = false,
+    conversationExistingOnly = false,
     larkClient,
     agentBoxManager,
     tlsOptions,
@@ -1175,11 +1232,23 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     // would clear everyone's context — reject it instead of resetting. (A
     // confirmation-gated "reset the whole room" is deferred.) per_user groups
     // and personal chats reset the caller's own session as before.
-    if (contextMode === "shared") {
-      await replyToLark(larkClient, messageId, SHARED_NEW_REJECTED_NOTICE_BY_LOCALE[locale]);
+    if (contextMode === "shared" && !conversationKey) {
+      await replyToLark(larkClient, messageId, SHARED_NEW_REJECTED_NOTICE_BY_LOCALE[locale], replyInThread);
       return;
     }
-    await handleNewCommand(route, channelId, chatId, sessionKey, messageId, larkClient, agentBoxManager, tlsOptions, frontendClient, locale);
+    await handleNewCommand(
+      route,
+      channelId,
+      chatId,
+      sessionKey,
+      messageId,
+      larkClient,
+      agentBoxManager,
+      tlsOptions,
+      frontendClient,
+      locale,
+      replyInThread,
+    );
     return;
   }
 
@@ -1191,13 +1260,22 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   // persisted user row, and logs all show "user sent image(s)".
   const effectiveText = text.length === 0 && imageRefs.length > 0 ? IMAGE_ONLY_PLACEHOLDER : text;
 
-  const binding = await resolveQueuedBinding(route, channelId, chatId, senderOpenId, frontendClient!, sessionKey);
+  const binding = await resolveQueuedBinding(
+    route,
+    channelId,
+    chatId,
+    senderOpenId,
+    frontendClient!,
+    sessionKey,
+    conversationKey,
+    conversationExistingOnly,
+  );
   if (!binding) {
     console.log(`[lark] Binding disappeared before queued run channel=${channelId} chat=${chatId} route=${route}`);
     return;
   }
   if (!binding.createdBy) {
-    await replyToLark(larkClient, messageId, MISSING_OWNER_NOTICE_BY_LOCALE[locale]);
+    await replyToLark(larkClient, messageId, MISSING_OWNER_NOTICE_BY_LOCALE[locale], replyInThread);
     return;
   }
 
@@ -1223,18 +1301,40 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       sessionId,
       role: "user",
       content: persistedText,
-      metadata: { source: "lark", channelId, chatId, messageId, bindingId: binding.bindingId, senderOpenId, sessionKey, route },
+      metadata: {
+        source: "lark",
+        channelId,
+        chatId,
+        messageId,
+        bindingId: binding.bindingId,
+        senderOpenId,
+        sessionKey,
+        route,
+        ...(conversationKey ? { conversationKey } : {}),
+        ...(rootMessageId ? { rootMessageId } : {}),
+        ...(threadId ? { threadId } : {}),
+      },
     });
   } catch (err) {
     console.error(`[lark] Failed to persist channel user message session=${sessionId}:`, err);
-    await replyToLark(larkClient, messageId, `❌ ${err instanceof Error ? err.message : String(err)}`.slice(0, 500));
+    await replyToLark(
+      larkClient,
+      messageId,
+      `❌ ${err instanceof Error ? err.message : String(err)}`.slice(0, 500),
+      replyInThread,
+    );
     return;
   }
 
   // Open the typing-indicator card FIRST so the user sees immediate feedback.
   // If the CardKit APIs fail we fall back to posting a plain text reply
   // once the agent is done (preserves the pre-card behaviour).
-  const cardSession = await openTypingCard(larkClient, messageId, PLACEHOLDER_BY_LOCALE[locale]);
+  const cardSession = await openTypingCard(
+    larkClient,
+    messageId,
+    PLACEHOLDER_BY_LOCALE[locale],
+    replyInThread,
+  );
   let deliveredTextChars = 0;
   // Live "current step" indicator. Two milestone sources feed it: explicit
   // channel_update tool calls (agent-curated) AND auto-derived first lines of
@@ -1286,7 +1386,14 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
 
       if (backgroundMessage.kind === "final") {
         const md = buildMilestoneCardMarkdown({ milestones: [], finalText: display });
-        const delivered = await deliverVisibleChannelText(larkClient, messageId, cardSession, md, true);
+        const delivered = await deliverVisibleChannelText(
+          larkClient,
+          messageId,
+          cardSession,
+          md,
+          true,
+          replyInThread,
+        );
         if (delivered) deliveredTextChars = md.length;
         return delivered;
       }
@@ -1307,7 +1414,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       }
       console.warn(`[lark] Background card update failed for session=${sessionId}; falling back to text reply`);
     }
-    await replyToLark(larkClient, messageId, md);
+    await replyToLark(larkClient, messageId, md, replyInThread);
     deliveredTextChars = md.length;
     return true;
   });
@@ -1343,7 +1450,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     : effectiveText;
   // Shared group: drain the chatter buffered since the last reply and attribute
   // the asker, so the agent answers @-turns with the whole group's context.
-  const drained = contextMode === "shared" ? drainDiscussion(channelId, chatId) : undefined;
+  const drained = contextMode === "shared" && !conversationKey
+    ? drainDiscussion(channelId, chatId)
+    : undefined;
   const sharedContext: SharedGroupContext | undefined = drained
     ? { discussion: drained.lines, truncated: drained.truncated, asker: senderLabel(senderOpenId) }
     : undefined;
@@ -1433,11 +1542,11 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     // Card could not be opened; fall back to a plain text reply with whatever we have —
     // a real answer, an error notice, OR the session-busy notice (sessionBusy carries no
     // resultText/agentError, so it must be listed explicitly or the busy notice is dropped).
-    await replyToLark(larkClient, messageId, finalCardBody);
+    await replyToLark(larkClient, messageId, finalCardBody, replyInThread);
     deliveredTextChars = finalCardBody.length;
   }
 
-  await replyVisualImages(larkClient, messageId, replyImages);
+  await replyVisualImages(larkClient, messageId, replyImages, replyInThread);
 }
 
 async function resolveQueuedBinding(
@@ -1447,12 +1556,22 @@ async function resolveQueuedBinding(
   senderOpenId: string | null,
   frontendClient: FrontendWsClient,
   sessionKey: string,
+  conversationKey?: string,
+  conversationExistingOnly: boolean = false,
 ): Promise<ResolvedChannelBinding | null> {
   if (route === "personal") {
     if (!senderOpenId) return null;
     return resolvePersonalBinding(channelId, senderOpenId, frontendClient);
   }
-  const result = await resolveBinding(channelId, chatId, frontendClient, sessionKey, senderOpenId ?? undefined);
+  const result = await resolveBinding(
+    channelId,
+    chatId,
+    frontendClient,
+    sessionKey,
+    senderOpenId ?? undefined,
+    conversationKey,
+    conversationExistingOnly,
+  );
   // If access was revoked between enqueue and run, treat as gone (the queued
   // task then skips). The pre-enqueue check already replied any access hint.
   return isChannelAccessDenied(result) ? null : result;
@@ -1484,12 +1603,13 @@ async function handleNewCommand(
   tlsOptions?: { cert: string; key: string; ca: string },
   frontendClient?: FrontendWsClient,
   locale: "zh-CN" | "en-US" = "zh-CN",
+  replyInThread: boolean = false,
 ): Promise<void> {
   const reset = route === "personal"
     ? await resetPersonalSession(channelId, sessionKey, frontendClient!)
     : await resetBindingSession(channelId, chatId, frontendClient!, sessionKey);
   if (!reset.success || !reset.sessionId || !reset.agentId) {
-    await replyToLark(larkClient, messageId, `❌ ${reset.error ?? "Failed to reset session"}`);
+    await replyToLark(larkClient, messageId, `❌ ${reset.error ?? "Failed to reset session"}`, replyInThread);
     return;
   }
 
@@ -1504,7 +1624,7 @@ async function handleNewCommand(
     }
   }
 
-  await replyToLark(larkClient, messageId, NEW_SESSION_NOTICE_BY_LOCALE[locale]);
+  await replyToLark(larkClient, messageId, NEW_SESSION_NOTICE_BY_LOCALE[locale], replyInThread);
 }
 
 /**
@@ -1712,14 +1832,23 @@ function formatApiKeyUsageReply(locale: LarkLocale): string {
  * already committed a side effect (see `/apikey`, which rotates before it can reply) must be able
  * to tell delivery failure from success instead of inferring it from a log line.
  */
-async function replyToLark(larkClient: any, messageId: string, text: string): Promise<boolean> {
+async function replyToLark(
+  larkClient: any,
+  messageId: string,
+  text: string,
+  replyInThread: boolean = false,
+): Promise<boolean> {
   try {
     // Feishu's SDK does NOT throw on a non-zero API code (e.g. missing
     // im:message send scope) — it returns {code,msg} in the body. Surface it,
     // otherwise a permission failure looks like a silent no-op.
     const resp = await larkClient.im.message.reply({
       path: { message_id: messageId },
-      data: { content: JSON.stringify({ text }), msg_type: "text" },
+      data: {
+        content: JSON.stringify({ text }),
+        msg_type: "text",
+        ...(replyInThread ? { reply_in_thread: true } : {}),
+      },
     });
     if (resp && typeof resp.code === "number" && resp.code !== 0) {
       console.error(`[lark] reply API returned non-zero code for messageId=${messageId}: code=${resp.code} msg=${resp.msg}`);
@@ -1781,6 +1910,7 @@ async function deliverVisibleChannelText(
   cardSession: Awaited<ReturnType<typeof openTypingCard>>,
   text: string,
   terminal: boolean,
+  replyInThread: boolean = false,
 ): Promise<boolean> {
   if (cardSession) {
     const ok = terminal
@@ -1789,13 +1919,18 @@ async function deliverVisibleChannelText(
     if (ok) return true;
     console.warn(`[lark] Channel-visible card update failed for messageId=${messageId}; falling back to text reply`);
   }
-  await replyToLark(larkClient, messageId, text);
+  await replyToLark(larkClient, messageId, text, replyInThread);
   return true;
 }
 
-async function replyVisualImages(larkClient: any, messageId: string, images: RenderedReplyImage[]): Promise<void> {
+async function replyVisualImages(
+  larkClient: any,
+  messageId: string,
+  images: RenderedReplyImage[],
+  replyInThread: boolean = false,
+): Promise<void> {
   for (const { kind, image } of images) {
-    const ok = await replyImageToLark(larkClient, messageId, image);
+    const ok = await replyImageToLark(larkClient, messageId, image, replyInThread);
     if (!ok) {
       console.warn(`[lark] ${kind} image reply failed for messageId=${messageId}; markdown card remains primary`);
     }

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -278,6 +278,8 @@ export function createLarkHandler(
 
 export function resetLarkBindingQueuesForTest(): void {
   bindingQueues.clear();
+  groupModeCache.clear();
+  discussionBuffers.clear();
 }
 
 function enqueueBindingTask(bindingId: string, run: () => Promise<void>): { accepted: true; done: Promise<void> } | { accepted: false } {
@@ -858,12 +860,16 @@ export async function handleLarkMessage(
   // topics. The binding's server-authoritative contextMode decides whether
   // this specific message actually uses the topic path.
   const topicFeatureEnabled = chatType === "group" && larkGroupThreadModeEnabled(channelConfig);
-  const rootMessageId = typeof message.root_id === "string" && message.root_id.trim()
+  const eventRootMessageId = typeof message.root_id === "string" && message.root_id.trim()
     ? message.root_id.trim()
     : messageId;
   const threadId = typeof message.thread_id === "string" && message.thread_id.trim()
     ? message.thread_id.trim()
     : null;
+  // Ordinary Feishu quote replies also carry root_id. Only thread_id proves
+  // that this event belongs to a Topic; otherwise an explicit @ starts a new
+  // bot conversation rooted at the current message.
+  const rootMessageId = threadId ? eventRootMessageId : messageId;
   const topicConversationKey = topicFeatureEnabled ? `lark_thread:${rootMessageId}` : undefined;
 
   // Raw receipt log: fires for EVERY delivered event before any drop, so a
@@ -1055,7 +1061,7 @@ export async function handleLarkMessage(
       frontendClient!,
       sessionKey,
       senderOpenId ?? undefined,
-      topicConversationKey,
+      undefined,
     );
     if (isChannelAccessDenied(modeBinding)) {
       await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale));
@@ -1083,9 +1089,10 @@ export async function handleLarkMessage(
   // were never aimed at it. Skips "@所有人" and "@someone-else"; PAIR above is
   // exempt (explicit command). Gated on chat_type==="group" so the binding/
   // access checks below stay reachable only for messages aimed at the bot.
-  const isThreadFollowup = topicFeatureEnabled && rootMessageId !== messageId;
-  const conversationExistingOnly = isThreadFollowup && !isBotMentioned(message, botOpenId);
-  if (chatType === "group" && !isBotMentioned(message, botOpenId) && !isThreadFollowup) {
+  const botMentioned = isBotMentioned(message, botOpenId);
+  const isThreadFollowup = topicFeatureEnabled && threadId !== null && rootMessageId !== messageId;
+  const conversationExistingOnly = isThreadFollowup && !botMentioned;
+  if (chatType === "group" && !botMentioned) {
     // Non-@ group message. In a group KNOWN to be shared, retain it as passive
     // discussion context for the next @-turn — WITHOUT running the agent or
     // touching the AgentBox (idle pods must not be woken by group chatter).
@@ -1096,10 +1103,12 @@ export async function handleLarkMessage(
     if (text.length > 0 && cachedGroupMode(groupChannelId, chatId) === "shared") {
       appendDiscussion(groupChannelId, chatId, senderLabel(senderOpenId), text);
       console.log(`[lark] Buffered non-@ discussion for shared group chat=${chatId}`);
-    } else {
-      console.log(`[lark] Group message not directed at bot (chat=${chatId}) — ignoring (@所有人 / @others / no @bot)`);
+      return;
     }
-    return;
+    if (!isThreadFollowup) {
+      console.log(`[lark] Group message not directed at bot (chat=${chatId}) — ignoring (@所有人 / @others / no @bot)`);
+      return;
+    }
   }
 
   // Look up binding for this chat. Pass sender_open_id so the Portal can
@@ -1114,6 +1123,10 @@ export async function handleLarkMessage(
     conversationExistingOnly,
   );
   if (isChannelAccessDenied(binding)) {
+    // A no-@ Topic/quote follow-up is never an authorization prompt. If the
+    // server cannot reuse an existing authorized topic session, stay silent;
+    // explicit @ messages still receive the normal access hint.
+    if (conversationExistingOnly) return;
     // sicore_authorized group: this sender isn't allowed. The message is either
     // an explicit @ or a follow-up in a previously established bot topic, so a
     // single short hint is appropriate.
@@ -1153,8 +1166,11 @@ export async function handleLarkMessage(
   // A no-@ message inside a Feishu topic is a continuation only in personal
   // mode. Team mode deliberately stays on the old main-group path; an
   // unrelated/manual topic must not wake the shared Agent session.
-  if (isThreadFollowup && !isBotMentioned(message, botOpenId) && contextMode === "shared") {
-    console.log(`[lark] Ignoring no-@ topic message for shared group chat=${chatId}`);
+  if (isThreadFollowup && !botMentioned && contextMode === "shared") {
+    if (text.length > 0) {
+      appendDiscussion(groupChannelId, chatId, senderLabel(senderOpenId), text);
+      console.log(`[lark] Buffered no-@ topic discussion after resolving shared group chat=${chatId}`);
+    }
     return;
   }
 

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1705,6 +1705,85 @@ describe("channel.resolveBinding", () => {
     });
   });
 
+  it("scopes a shared group session to the Feishu topic root", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "shared", created_by: "u1" }],
+      [],
+      [],
+      [{ session_id: "topic-session" }],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      {
+        channel_id: "ch1",
+        route_key: "group-123",
+        session_key: "open_id:ou_1",
+        conversation_key: "lark_thread:mid-root",
+      },
+      "a1",
+    );
+
+    expect(query.mock.calls[2][1]).toEqual([
+      expect.any(String),
+      "b1",
+      "lark_thread:mid-root",
+      expect.any(String),
+    ]);
+    expect(result.binding).toEqual(expect.objectContaining({
+      sessionId: "topic-session",
+      sessionKey: "lark_thread:mid-root",
+      contextMode: "shared",
+    }));
+  });
+
+  it("keeps per-user isolation inside a Feishu topic", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "per_user", created_by: "u1" }],
+      [],
+      [],
+      [{ session_id: "private-topic-session" }],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      {
+        channel_id: "ch1",
+        route_key: "group-123",
+        session_key: "open_id:ou_1",
+        conversation_key: "lark_thread:mid-root",
+      },
+      "a1",
+    );
+
+    expect(query.mock.calls[2][1]).toEqual([
+      expect.any(String),
+      "b1",
+      "open_id:ou_1:lark_thread:mid-root",
+      expect.any(String),
+    ]);
+    expect(result.binding.sessionKey).toBe("open_id:ou_1:lark_thread:mid-root");
+  });
+
+  it("does not create a session for an unmentioned unrelated topic", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "shared", created_by: "u1" }],
+      [],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      {
+        channel_id: "ch1",
+        route_key: "group-123",
+        session_key: "open_id:ou_1",
+        conversation_key: "lark_thread:unrelated",
+        conversation_existing_only: true,
+      },
+      "a1",
+    );
+
+    expect(result).toEqual({ binding: null });
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
   it("NULL context_mode grandfathers to per_user (uses the passed per-sender key, not chat:)", async () => {
     const query = mockQuery(
       [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", created_by: "u1" }], // context_mode absent → NULL

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1705,12 +1705,12 @@ describe("channel.resolveBinding", () => {
     });
   });
 
-  it("scopes a shared group session to the Feishu topic root", async () => {
+  it("keeps a shared group on its chat session when a topic candidate is present", async () => {
     const query = mockQuery(
       [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "shared", created_by: "u1" }],
       [],
       [],
-      [{ session_id: "topic-session" }],
+      [{ session_id: "chat-session" }],
     );
 
     const result = await getHandler("channel.resolveBinding")(
@@ -1726,12 +1726,12 @@ describe("channel.resolveBinding", () => {
     expect(query.mock.calls[2][1]).toEqual([
       expect.any(String),
       "b1",
-      "lark_thread:mid-root",
+      "chat:group-123",
       expect.any(String),
     ]);
     expect(result.binding).toEqual(expect.objectContaining({
-      sessionId: "topic-session",
-      sessionKey: "lark_thread:mid-root",
+      sessionId: "chat-session",
+      sessionKey: "chat:group-123",
       contextMode: "shared",
     }));
   });
@@ -1749,6 +1749,33 @@ describe("channel.resolveBinding", () => {
         channel_id: "ch1",
         route_key: "group-123",
         session_key: "open_id:ou_1",
+        conversation_key: "lark_thread:mid-root",
+      },
+      "a1",
+    );
+
+    expect(query.mock.calls[2][1]).toEqual([
+      expect.any(String),
+      "b1",
+      "open_id:ou_1:lark_thread:mid-root",
+      expect.any(String),
+    ]);
+    expect(result.binding.sessionKey).toBe("open_id:ou_1:lark_thread:mid-root");
+  });
+
+  it("keeps the per-user topic transform idempotent on the queued re-resolve", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "per_user", created_by: "u1" }],
+      [],
+      [],
+      [{ session_id: "private-topic-session" }],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      {
+        channel_id: "ch1",
+        route_key: "group-123",
+        session_key: "open_id:ou_1:lark_thread:mid-root",
         conversation_key: "lark_thread:mid-root",
       },
       "a1",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -150,15 +150,17 @@ function buildGroupSessionKey(
   participantKey?: string | null,
   conversationKey?: string | null,
 ): string | null {
+  const participant = participantKey?.trim() || null;
+  if (contextMode === "shared") return `chat:${routeKey}`;
+
   const conversation = conversationKey?.trim();
   if (conversation) {
-    return contextMode === "shared"
-      ? conversation
-      : participantKey
-        ? `${participantKey}:${conversation}`
-        : conversation;
+    if (!participant || participant === conversation || participant.endsWith(`:${conversation}`)) {
+      return participant ?? conversation;
+    }
+    return `${participant}:${conversation}`;
   }
-  return contextMode === "shared" ? `chat:${routeKey}` : participantKey?.trim() || null;
+  return participant;
 }
 
 async function resolveLegacyChannelBindingSession(

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -96,12 +96,15 @@ async function resolveChannelBinding(
   channelId: string,
   routeKey: string,
   sessionKey?: string | null,
+  conversationKey?: string | null,
+  conversationExistingOnly: boolean = false,
 ): Promise<ResolvedChannelBinding | null> {
   const row = await selectChannelBinding(db, channelId, routeKey);
   if (!row) {
     // No explicit binding. A per-agent open bot auto-serves any group it joins
     // (standalone supports open only — authorized requires Sicore's im_bindings).
-    return resolveOpenGroupBinding(db, channelId, routeKey);
+    if (conversationExistingOnly && conversationKey) return null;
+    return resolveOpenGroupBinding(db, channelId, routeKey, conversationKey);
   }
 
   const routeType = normalizeRouteType(row.route_type);
@@ -115,12 +118,19 @@ async function resolveChannelBinding(
   //   per_user → the per-sender key the runtime passed (open_id:{sender}).
   // Non-group (1:1 user) routes ignore the mode — they are single-user by
   // nature — and keep the legacy passed-key-or-binding-session behavior.
-  const session =
-    routeType === "group" && contextMode === "shared"
-      ? await resolveChannelBindingParticipantSession(db, row.id, `chat:${routeKey}`)
-      : sessionKey
-        ? await resolveChannelBindingParticipantSession(db, row.id, sessionKey)
-        : await resolveLegacyChannelBindingSession(db, row, channelId, routeKey);
+  const effectiveSessionKey = routeType === "group"
+    ? buildGroupSessionKey(routeKey, contextMode, sessionKey, conversationKey)
+    : sessionKey;
+  let session: { sessionId: string; sessionKey: string | null };
+  if (effectiveSessionKey && conversationExistingOnly && conversationKey) {
+    const existing = await selectChannelBindingParticipantSession(db, row.id, effectiveSessionKey);
+    if (!existing) return null;
+    session = { sessionId: existing, sessionKey: effectiveSessionKey };
+  } else {
+    session = effectiveSessionKey
+      ? await resolveChannelBindingParticipantSession(db, row.id, effectiveSessionKey)
+      : await resolveLegacyChannelBindingSession(db, row, channelId, routeKey);
+  }
 
   return {
     agentId: row.agent_id,
@@ -132,6 +142,23 @@ async function resolveChannelBinding(
     displayName: row.display_name ?? null,
     contextMode,
   };
+}
+
+function buildGroupSessionKey(
+  routeKey: string,
+  contextMode: ContextMode,
+  participantKey?: string | null,
+  conversationKey?: string | null,
+): string | null {
+  const conversation = conversationKey?.trim();
+  if (conversation) {
+    return contextMode === "shared"
+      ? conversation
+      : participantKey
+        ? `${participantKey}:${conversation}`
+        : conversation;
+  }
+  return contextMode === "shared" ? `chat:${routeKey}` : participantKey?.trim() || null;
 }
 
 async function resolveLegacyChannelBindingSession(
@@ -503,6 +530,7 @@ async function resolveOpenGroupBinding(
   db: Db,
   channelId: string,
   routeKey: string,
+  conversationKey?: string | null,
 ): Promise<ResolvedChannelBinding | null> {
   const channel = await selectPersonalChannel(db, channelId);
   const personalBot = channel?.config.personal_bot;
@@ -517,7 +545,7 @@ async function resolveOpenGroupBinding(
   // under the binding row id (not the channel id) so it stays consistent with
   // the row that now owns the group.
   const bindingId = await ensureOpenGroupBindingRow(db, channel.id, routeKey, personalBot.agent_id, createdBy);
-  const sessionKey = `chat:${routeKey}`;
+  const sessionKey = buildGroupSessionKey(routeKey, "shared", null, conversationKey) ?? `chat:${routeKey}`;
   const session = await resolveChannelBindingParticipantSession(db, bindingId, sessionKey);
   return {
     agentId: personalBot.agent_id,
@@ -1728,9 +1756,22 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
       sendJson(res, 401, { error: "Invalid internal token" });
       return;
     }
-    const body = await parseBody<{ channel_id: string; route_key: string; session_key?: string }>(req);
+    const body = await parseBody<{
+      channel_id: string;
+      route_key: string;
+      session_key?: string;
+      conversation_key?: string;
+      conversation_existing_only?: boolean;
+    }>(req);
     const db = getDb();
-    const binding = await resolveChannelBinding(db, body.channel_id, body.route_key, body.session_key);
+    const binding = await resolveChannelBinding(
+      db,
+      body.channel_id,
+      body.route_key,
+      body.session_key,
+      body.conversation_key,
+      body.conversation_existing_only === true,
+    );
     sendJson(res, 200, { binding });
   });
 
@@ -3070,7 +3111,16 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
 
   handlers.set("channel.resolveBinding", async (params) => {
     const db = getDb();
-    return { binding: await resolveChannelBinding(db, params.channel_id, params.route_key, params.session_key) };
+    return {
+      binding: await resolveChannelBinding(
+        db,
+        params.channel_id,
+        params.route_key,
+        params.session_key,
+        params.conversation_key,
+        params.conversation_existing_only === true,
+      ),
+    };
   });
 
   handlers.set("channel.pair", async (params) => {


### PR DESCRIPTION
## Summary
- enable native Feishu Topic conversations only for Personal (per-user) group context
- keep Team (shared) mode on the existing main-group reply path and one chat-scoped Agent session
- reuse an existing participant-scoped Topic session for no-mention follow-ups without letting another user inherit it
- keep text, card, image, background, error, and Topic-local reset replies on the selected delivery path
- document the rollout flag, complete test-bot permissions, and Personal/Team acceptance flow

## Validation
- npm run build
- npm test -- --run
- focused Lark suite: 134 passed
- Sicore companion MR: http://gitlab.scitix-inner.ai/k8s/sicore/-/merge_requests/770