### PR TITLE
fix(agentbox): refresh control-plane model config

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -363,6 +363,27 @@ describe("http-server — prompt + session lifecycle", () => {
     expect(session.brain.prompt.mock.calls[0][0]).toBe("hello there");
   });
 
+  it("POST /api/prompt refreshes the current model when control-plane modelConfig is supplied", async () => {
+    const session = await sm.getOrCreate("compat-refresh");
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "hi",
+      sessionId: "compat-refresh",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      modelConfig: {
+        ...modelConfigWithInput(["text"]),
+        models: [{
+          ...modelConfigWithInput(["text"]).models[0],
+          compat: { supportsUsageInStreaming: false },
+        }],
+      },
+    });
+
+    expect(r.status).toBe(200);
+    expect(session.brain.registerProvider).toHaveBeenCalledOnce();
+    expect(session.brain.setModel).toHaveBeenCalledOnce();
+  });
+
   it("POST /api/prompt forwards large valid images to brain.prompt", async () => {
     const session = await sm.getOrCreate("img-large");
     const data = "A".repeat(3 * 1024 * 1024);

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -770,7 +770,12 @@ export function createHttpServer(
         const found = managed.brain.findModel(body.modelProvider, body.modelId);
         if (found) {
           const currentModel = managed.brain.getModel();
-          const needsUpdate = !currentModel
+          // registerProvider can replace fields that BrainModelInfo does not expose
+          // (notably compat, baseUrl, and custom headers). When the control plane
+          // supplies modelConfig, refresh the session model unconditionally so a
+          // compat-only edit takes effect on the very next prompt.
+          const needsUpdate = body.modelConfig !== undefined
+            || !currentModel
             || currentModel.id !== found.id
             || currentModel.provider !== found.provider
             || currentModel.reasoning !== found.reasoning

--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -129,6 +129,9 @@ describe("PiAgentBrain", () => {
     const brain = new PiAgentBrain(session);
     await brain.prompt("q");
     expect(session.prompt).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Empty response persisted after 0 retries, stopReason=error"),
+    );
   });
 
   it("prompt retries up to MAX_EMPTY_RETRIES when content is empty", async () => {

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -159,7 +159,7 @@ export class PiAgentBrain implements BrainSession {
       if (!lastAssistantHadContent && !this.aborted) {
         const msg = lastAssistantMessage;
         console.error(
-          `[pi-agent-brain] Empty response persisted after ${PiAgentBrain.MAX_EMPTY_RETRIES} retries, ` +
+          `[pi-agent-brain] Empty response persisted after ${retries} retries, ` +
           `stopReason=${msg?.stopReason ?? "unknown"}, ` +
           `model=${msg?.model ?? "unknown"}, ` +
           `usage=${JSON.stringify(msg?.usage ?? {})}`,


### PR DESCRIPTION
## Summary
- refresh the active AgentBox model whenever the control plane supplies `modelConfig`, so compat-only edits take effect on the next prompt
- report the number of empty-response retries that actually ran
- keep model errors visible as zero-retry failures instead of claiming the configured maximum

## Root cause found during validation
`registerProvider()` can replace fields that `BrainModelInfo` does not expose, including `compat`. The previous `needsUpdate` comparison only checked provider/id/reasoning/context/maxTokens, so changing only `supportsUsageInStreaming` could leave the session on the stale model object.

The new regression test is red before the fix (`setModel` called 0 times) and green after it.

## Testing
- `npm test -- src/agentbox/http-server.test.ts` — 75 passed
- `npm run build`
- GitHub CI — Type Check, Test, Portal Web Test all passed at `64cc5f26`
- siflow-test warm crossover: OFF 20/20 and ON 20/20 assistant `stopReason=stop`, `text=OK`
- siflow-test cold ON: 5 distinct AgentBox Pod UIDs/IPs × 3 requests, 15/15 assistant success
- deployed AgentBox: `registry-ap-southeast.scitix.ai/k8s/siclaw-agentbox@sha256:0d06415d1c952c44e942344e75164df1fb799bb0fb8839ebc7cec79927b0279d`

## Gateway conclusion
The controlled sweep does not support `include_usage=true` as a deterministic reproducer: both OFF and ON succeeded. Pi sends the standard `stream_options.include_usage` field; `continuous_usage_stats` is still absent from Siclaw/Pi request construction. The original 400 remains consistent with an intermittent or heterogeneous MassAPI transformation/routing issue.
