### PR TITLE
fix(delegation): coordinator alias routing + answer/route triage; fix(lark): never lose the answer to a rejected card update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,8 @@ mTLS is **K8s mode only**. Do not add mTLS dependencies to local mode code paths
 | `src/core/tool-result-context-guard.ts` | guards.md §5 | `npm test` | Context guard; context budget enforcement |
 | `src/core/stream-wrappers.ts` | guards.md §5 | `npm test` | Output guards; stream event repair |
 | `src/core/tool-call-repair.ts` | guards.md §5 | `npm test` | Input guard; malformed tool call sanitization |
-| `src/core/prompt.ts` | **⚠️ REQUIRES HUMAN APPROVAL** | — | Describe intent and wait for OK before editing |
+| `src/core/prompt.ts`, `src/core/agent-types.ts` (persona text) | **⚠️ REQUIRES HUMAN APPROVAL**; coordinator-routing.md for coordinator changes | — | Describe intent and wait for OK before editing; persona changes alter agent behavior and product tone |
+| `src/tools/workflow/list-delegates.ts` | tools.md §2, coordinator-routing.md | `npm test` (`list-delegates.test.ts`) | Coverage requires exact cluster/host binding matches; names, descriptions, and partial matches are not authorization evidence; confirmed alias retry must terminate |
 | `src/memory/` | invariants.md §7, decisions.md ADR-005 | `npm test` | Requires embedding config; pi-agent only |
 | `Dockerfile.agentbox` | security.md §3-5 | `docker build` | Dual-user model; capability set; setgid kubectl |
 | `kbc/platform/pod/*` (KB compile box, Python) | kbc/platform/pod/README.md | `cd kbc/platform/pod && python test_compile_box.py` (needs `pip install claude-agent-sdk aiohttp`; CI: kbc-ci.yml, path-filtered) | Box↔runtime HTTP+SSE contract is shared with `src/gateway/capability/session-driver.ts` + `server.ts` (`/session` body, event vocabulary) and `agentbox/box-profile.ts` (allowedTools names, ANTHROPIC env forward) — change both sides together. Behavior changes need a `siclaw-kbc-box` image rebuild + redeploy (runtime env `SICLAW_COMPILE_BOX_IMAGE`); a rolled-out runtime does NOT pick up a new box image for existing live sessions |

--- a/docs/design/coordinator-routing.md
+++ b/docs/design/coordinator-routing.md
@@ -1,0 +1,54 @@
+---
+title: "Coordinator Routing"
+sidebarTitle: "Coordinator Routing"
+description: "Stable resource-coverage and alias-resolution contract for coordinator agents."
+---
+
+# Coordinator Routing
+
+The coordinator routes work; it does not diagnose resources itself. Delegation
+is authorized only after `list_delegates` finds an exact cluster or host binding
+on a roster member.
+
+## Coverage lookup
+
+- The first lookup uses the target exactly as established from the user's
+  request. This keeps canonical-name requests to one in-box tool call and works
+  when the coordinator has no skills, which is the default.
+- A non-empty query matches bound cluster and host names exactly,
+  case-insensitively. Delegate names, descriptions, and partial resource-name
+  matches are not coverage evidence.
+- A successful lookup identifies the roster member that may receive the task.
+  The roster remains the authorization source; a routing helper never grants
+  coverage.
+
+## Optional alias resolution
+
+When the first lookup misses and the target may be a cluster alias, the
+coordinator may consult a routing-helper skill that was explicitly attached to
+it. Routing helpers are optional and have no fixed implementation or serialized
+field name, but their semantic result must distinguish:
+
+- one confirmed canonical Siclaw binding name;
+- an ambiguous result; or
+- an unresolved result.
+
+Only the first outcome permits one retry. The retry passes the canonical name
+with `binding_name_confirmed=true`. That flag records the routing state so a
+second miss is terminal; it is not an authorization assertion and does not
+weaken exact roster matching.
+
+If no helper is attached, the helper is ambiguous or unresolved, or the
+confirmed retry misses, the coordinator does not guess or loop. It tells the
+user that no authorized agent covers the supplied name and that the name may be
+an alias.
+
+## Behavioral invariants
+
+Tests for coordinator routing should verify observable routing behavior rather
+than exact persona wording:
+
+- canonical cluster and host bindings match case-insensitively;
+- partial bindings and delegate metadata do not prove coverage;
+- the first miss offers at most one optional alias-resolution retry; and
+- a confirmed binding-name miss is terminal.

--- a/docs/design/coordinator-routing.md
+++ b/docs/design/coordinator-routing.md
@@ -37,6 +37,18 @@ Answering depends on the coordinator actually having skills or a knowledge base
 attached; it is `defaultNoSkills` at creation, so a coordinator left without
 them can only route.
 
+### The triage stays invisible
+
+Which mode was chosen is machinery, and the reader must never see it. A reply
+opens with the answer, not with the classification that produced it — no "this
+is a knowledge question", no "I looked this up in the knowledge base", no "as a
+coordinator I do not do hands-on work". Naming the mode is not merely noise: it
+invites the reader to doubt whether the answer is authoritative.
+
+When no answer is possible, the reply states the **outcome** the reader needs —
+the specialist covering that resource could not be reached, or which detail is
+still missing — rather than the internal rule that produced it.
+
 ## Coverage lookup
 
 - The first lookup uses the target exactly as established from the user's

--- a/docs/design/coordinator-routing.md
+++ b/docs/design/coordinator-routing.md
@@ -6,9 +6,36 @@ description: "Stable resource-coverage and alias-resolution contract for coordin
 
 # Coordinator Routing
 
-The coordinator routes work; it does not diagnose resources itself. Delegation
-is authorized only after `list_delegates` finds an exact cluster or host binding
-on a roster member.
+The coordinator answers what it can and routes what it cannot; it never
+diagnoses resources itself. Delegation is authorized only after `list_delegates`
+finds an exact cluster or host binding on a roster member.
+
+## Answer or route
+
+The coordinator has two modes, chosen per request:
+
+- **Answer** — a knowledge question (concepts, how-to, definitions,
+  comparisons, documented facts) is answered directly from the coordinator's
+  own skills and knowledge base. Delegating such a question only to have a
+  specialist restate the answer costs a round trip and buys nothing.
+- **Route** — anything needing the live state of a specific resource, hands-on
+  inspection/diagnosis/remediation, or a conclusion only the resource's
+  authorized specialist can stand behind is delegated.
+
+The deciding question is whether a correct answer depends on a specific
+environment's **live state** or on a **hands-on action**. If it does, or if that
+is uncertain, the coordinator routes: a specific cluster's current state is
+never answered from the coordinator's own knowledge. This is why answering is
+bounded to environment-independent knowledge — the coordinator holds no
+authorization over any resource, so it can never be the authority on one.
+
+Skills and knowledge also inform *where* to route: the specialist domain and
+target are worked out from them rather than guessed by scanning the roster.
+`list_delegates` remains the authorization step, not the discovery mechanism.
+
+Answering depends on the coordinator actually having skills or a knowledge base
+attached; it is `defaultNoSkills` at creation, so a coordinator left without
+them can only route.
 
 ## Coverage lookup
 

--- a/src/core/agent-types.test.ts
+++ b/src/core/agent-types.test.ts
@@ -26,6 +26,17 @@ describe("agent-types", () => {
     expect(persona).not.toContain("search_memory");
   });
 
+  it("coordinator keeps its triage invisible — the reply must not narrate its own rules", () => {
+    // Observed in a real Feishu reply: "这是知识性问题,我已从内部知识库查到原理" and
+    // "由于我是协调者,不做直接的 hands-on 诊断". The user asked about RoCE, not about
+    // how the bot decides things.
+    const persona = AGENT_TYPES.coordinator.persona!;
+    expect(persona).toContain("KEEP THIS TRIAGE INVISIBLE");
+    expect(persona).toContain("never announce which mode you picked");
+    // On failure, report the outcome the user needs — not the role that blocks it.
+    expect(persona).toContain("state the OUTCOME the user needs");
+  });
+
   it("normalizeAgentType defaults unknown/absent to custom", () => {
     expect(normalizeAgentType("sre")).toBe("sre");
     expect(normalizeAgentType("coordinator")).toBe("coordinator");

--- a/src/core/agent-types.test.ts
+++ b/src/core/agent-types.test.ts
@@ -27,4 +27,12 @@ describe("agent-types", () => {
     expect(effectiveCapabilityKeys("custom", ["read_files"])).toEqual(["read_files"]);
     expect(effectiveCapabilityKeys("custom", null)).toBeNull();
   });
+
+  it("coordinator resolves cluster aliases before coverage lookup", () => {
+    const persona = AGENT_TYPES.coordinator.persona!;
+    expect(persona).toContain("BEFORE the first `list_delegates` query");
+    expect(persona).toContain("confirmed `binding_names[]` value");
+    expect(persona).toContain("never send an unresolved localized name");
+    expect(persona).toContain("Only after `list_delegates` returns no match for a confirmed binding name");
+  });
 });

--- a/src/core/agent-types.test.ts
+++ b/src/core/agent-types.test.ts
@@ -13,6 +13,19 @@ describe("agent-types", () => {
     expect(AGENT_TYPES.custom.persona).toBeNull();
   });
 
+  it("coordinator is dual-mode (answer from knowledge OR route) and no longer uses memory", () => {
+    const persona = AGENT_TYPES.coordinator.persona!;
+    // (A) answer knowledge questions directly from skills / knowledge base
+    expect(persona).toContain("answer it YOURSELF from your skills / knowledge base");
+    // (B) route live/hands-on work; the routing decision is knowledge-informed,
+    // not a raw scan of the delegate list
+    expect(persona).toContain("To ROUTE:");
+    expect(persona).toContain("do NOT merely scan the raw delegate list to guess");
+    // memory is disabled fleet-wide; the coordinator relies on skills/KB, never search_memory
+    expect(AGENT_TYPES.coordinator.capabilities).not.toContain("search_memory");
+    expect(persona).not.toContain("search_memory");
+  });
+
   it("normalizeAgentType defaults unknown/absent to custom", () => {
     expect(normalizeAgentType("sre")).toBe("sre");
     expect(normalizeAgentType("coordinator")).toBe("coordinator");

--- a/src/core/agent-types.test.ts
+++ b/src/core/agent-types.test.ts
@@ -27,12 +27,4 @@ describe("agent-types", () => {
     expect(effectiveCapabilityKeys("custom", ["read_files"])).toEqual(["read_files"]);
     expect(effectiveCapabilityKeys("custom", null)).toBeNull();
   });
-
-  it("coordinator resolves cluster aliases before coverage lookup", () => {
-    const persona = AGENT_TYPES.coordinator.persona!;
-    expect(persona).toContain("BEFORE the first `list_delegates` query");
-    expect(persona).toContain("confirmed `binding_names[]` value");
-    expect(persona).toContain("never send an unresolved localized name");
-    expect(persona).toContain("Only after `list_delegates` returns no match for a confirmed binding name");
-  });
 });

--- a/src/core/agent-types.test.ts
+++ b/src/core/agent-types.test.ts
@@ -13,28 +13,13 @@ describe("agent-types", () => {
     expect(AGENT_TYPES.custom.persona).toBeNull();
   });
 
-  it("coordinator is dual-mode (answer from knowledge OR route) and no longer uses memory", () => {
-    const persona = AGENT_TYPES.coordinator.persona!;
-    // (A) answer knowledge questions directly from skills / knowledge base
-    expect(persona).toContain("answer it YOURSELF from your skills / knowledge base");
-    // (B) route live/hands-on work; the routing decision is knowledge-informed,
-    // not a raw scan of the delegate list
-    expect(persona).toContain("To ROUTE:");
-    expect(persona).toContain("do NOT merely scan the raw delegate list to guess");
-    // memory is disabled fleet-wide; the coordinator relies on skills/KB, never search_memory
+  it("coordinator does not reach for memory (disabled fleet-wide)", () => {
+    // Asserted as structure and as an ABSENCE, so it survives any rewording of
+    // the persona. The answer/route contract itself lives in
+    // docs/design/coordinator-routing.md — pinning its prose here would only
+    // restate the diff and would break on every future improvement.
     expect(AGENT_TYPES.coordinator.capabilities).not.toContain("search_memory");
-    expect(persona).not.toContain("search_memory");
-  });
-
-  it("coordinator keeps its triage invisible — the reply must not narrate its own rules", () => {
-    // Observed in a real Feishu reply: "这是知识性问题,我已从内部知识库查到原理" and
-    // "由于我是协调者,不做直接的 hands-on 诊断". The user asked about RoCE, not about
-    // how the bot decides things.
-    const persona = AGENT_TYPES.coordinator.persona!;
-    expect(persona).toContain("KEEP THIS TRIAGE INVISIBLE");
-    expect(persona).toContain("never announce which mode you picked");
-    // On failure, report the outcome the user needs — not the role that blocks it.
-    expect(persona).toContain("state the OUTCOME the user needs");
+    expect(AGENT_TYPES.coordinator.persona).not.toContain("search_memory");
   });
 
   it("normalizeAgentType defaults unknown/absent to custom", () => {

--- a/src/core/agent-types.ts
+++ b/src/core/agent-types.ts
@@ -38,7 +38,12 @@ const SRE_PERSONA =
 
 const COORDINATOR_PERSONA =
   "You are a COORDINATOR whose ONLY job is ROUTING. To route: (1) determine the TARGET resource (cluster / " +
-  "host / node) from the user's request; (2) call `list_delegates` with query=<that target> to find WHICH " +
+  "host / node) from the user's request. For a cluster target, BEFORE the first `list_delegates` query, " +
+  "consult an available routing-helper skill unless the exact Siclaw binding name is already established in " +
+  "verified context. Use the helper's confirmed `binding_names[]` value for coverage lookup; never send an " +
+  "unresolved localized name, local nickname, alias, or spelling variant directly to `list_delegates`. If the " +
+  "helper cannot confirm a binding name, ASK THE USER instead of guessing. (2) call `list_delegates` with " +
+  "query=<confirmed binding name for a cluster, otherwise the established target> to find WHICH " +
   "delegate is bound to it — this authoritative coverage lookup (NOT your own cluster_list, which is YOUR " +
   "bindings) is how you confirm who covers the target; (3) delegate to the matching agent via " +
   "`delegate_to_agent`. If you CANNOT determine the target from the request — it is missing, ambiguous, or a " +
@@ -49,12 +54,14 @@ const COORDINATOR_PERSONA =
   "to the resource you already established — do NOT re-ask the user for it, and do NOT re-run `list_delegates` " +
   "discovery; carry forward what you already know and delegate straight to the same specialist. Re-determine " +
   "the target and re-query `list_delegates` ONLY when the target is genuinely NEW or has CHANGED. If you " +
-  "queried and NO delegate covers the target, tell the user that no authorized agent covers that resource. " +
+  "queried and NO delegate covers the target, first verify that a cluster query used a confirmed binding name " +
+  "and resolve/retry it if not. Only after `list_delegates` returns no match for a confirmed binding name may " +
+  "you tell the user that no authorized agent covers that resource. " +
   "Forward the task at a HIGH LEVEL, essentially as the user phrased it. You do NOT decide HOW the task is " +
   "done: do NOT read the specialist's execution procedures/skills or enumerate the steps for it, and do NOT " +
   "attempt any hands-on work yourself. The specialist owns the tools and the know-how and will work out the " +
-  "steps on its own. You MAY consult your own knowledge or a routing-helper skill you were given, but ONLY to " +
-  "decide WHICH specialist to route to — not to solve the problem. When you delegate, describe the GOAL in " +
+  "steps on its own. Use routing helpers and any knowledge you consult ONLY to decide WHICH specialist to " +
+  "route to — not to solve the problem. When you delegate, describe the GOAL in " +
   "the user's own terms and INCLUDE any concrete facts you already gathered so the specialist need not " +
   "re-look-them-up; but do NOT name specific skills, scripts, or steps for the specialist to run — it will " +
   "choose those itself. " +

--- a/src/core/agent-types.ts
+++ b/src/core/agent-types.ts
@@ -38,14 +38,15 @@ const SRE_PERSONA =
 
 const COORDINATOR_PERSONA =
   "You are a COORDINATOR whose ONLY job is ROUTING. To route: (1) determine the TARGET resource (cluster / " +
-  "host / node) from the user's request. For a cluster target, BEFORE the first `list_delegates` query, " +
-  "consult an available routing-helper skill unless the exact Siclaw binding name is already established in " +
-  "verified context. Use the helper's confirmed `binding_names[]` value for coverage lookup; never send an " +
-  "unresolved localized name, local nickname, alias, or spelling variant directly to `list_delegates`. If the " +
-  "helper cannot confirm a binding name, ASK THE USER instead of guessing. (2) call `list_delegates` with " +
-  "query=<confirmed binding name for a cluster, otherwise the established target> to find WHICH " +
+  "host / node) from the user's request; (2) call `list_delegates` first with query=<that target exactly as " +
+  "established> to find WHICH " +
   "delegate is bound to it — this authoritative coverage lookup (NOT your own cluster_list, which is YOUR " +
-  "bindings) is how you confirm who covers the target; (3) delegate to the matching agent via " +
+  "bindings) is how you confirm who covers the target. If it returns no exact binding match and the target " +
+  "may be a cluster alias, consult a routing-helper skill you were given, if any. Only when the helper confirms " +
+  "one canonical Siclaw binding name, retry `list_delegates` once with that name and " +
+  "`binding_name_confirmed=true`; do not guess from an ambiguous or unresolved result. If no helper is " +
+  "attached, it cannot confirm one name, or the confirmed retry also misses, tell the user that no authorized " +
+  "agent covers the name and that it may be an alias. (3) delegate to the matching agent via " +
   "`delegate_to_agent`. If you CANNOT determine the target from the request — it is missing, ambiguous, or a " +
   "node/pod is named without its cluster — ASK THE USER to supply the missing detail. Do NOT guess, do NOT " +
   "browse the whole delegate list hoping to infer it, and do NOT pick the closest match. EXCEPTION — a " +
@@ -54,9 +55,7 @@ const COORDINATOR_PERSONA =
   "to the resource you already established — do NOT re-ask the user for it, and do NOT re-run `list_delegates` " +
   "discovery; carry forward what you already know and delegate straight to the same specialist. Re-determine " +
   "the target and re-query `list_delegates` ONLY when the target is genuinely NEW or has CHANGED. If you " +
-  "queried and NO delegate covers the target, first verify that a cluster query used a confirmed binding name " +
-  "and resolve/retry it if not. Only after `list_delegates` returns no match for a confirmed binding name may " +
-  "you tell the user that no authorized agent covers that resource. " +
+  "queried and NO delegate covers the target, follow the one-retry alias flow above; never repeat it. " +
   "Forward the task at a HIGH LEVEL, essentially as the user phrased it. You do NOT decide HOW the task is " +
   "done: do NOT read the specialist's execution procedures/skills or enumerate the steps for it, and do NOT " +
   "attempt any hands-on work yourself. The specialist owns the tools and the know-how and will work out the " +

--- a/src/core/agent-types.ts
+++ b/src/core/agent-types.ts
@@ -6,9 +6,9 @@
  *
  *   - sre         — a specialist that operates hands-on within its authorized
  *                   clusters/hosts (full read + exec + scripts). Persona fixed.
- *   - coordinator — a read-only router: sees the fleet, delegates hands-on work
- *                   to specialists via delegate_to_agent. No skills by default.
- *                   Persona fixed.
+ *   - coordinator — answers knowledge questions from its skills/knowledge base and
+ *                   routes hands-on work to specialists via delegate_to_agent.
+ *                   No skills by default. Persona fixed.
  *   - custom      — the legacy free-form agent: the operator picks capabilities
  *                   (tool_capabilities) AND writes the system_prompt. Nothing is
  *                   locked. Existing agents map here (zero behaviour change).
@@ -37,7 +37,18 @@ const SRE_PERSONA =
   "Take the task end to end and report concrete, evidence-backed findings.";
 
 const COORDINATOR_PERSONA =
-  "You are a COORDINATOR whose ONLY job is ROUTING. To route: (1) determine the TARGET resource (cluster / " +
+  "You are a COORDINATOR. Your skills and knowledge base are your primary aid in BOTH of your modes. " +
+  "TRIAGE every request first. (A) ANSWER — when the request is a knowledge question answerable from your " +
+  "skills / knowledge base (concepts, how-to, definitions, comparisons, documented facts) WITHOUT the live " +
+  "state of a specific resource and WITHOUT any hands-on action, answer it YOURSELF from your skills / " +
+  "knowledge base; do NOT delegate a question just to have a specialist restate the answer. (B) ROUTE — when " +
+  "the request needs the live/current state of a specific resource, hands-on inspection / diagnosis / " +
+  "remediation, or a conclusion only the resource's authorized specialist can stand behind, ROUTE it. When " +
+  "you are unsure whether a correct answer depends on a specific environment's live state, ROUTE — never " +
+  "answer about a specific cluster's live state from your own knowledge. To decide WHERE to route, use your " +
+  "skills / knowledge to work out which specialist domain and which target the request belongs to — do NOT " +
+  "merely scan the raw delegate list to guess. " +
+  "To ROUTE: (1) determine the TARGET resource (cluster / " +
   "host / node) from the user's request; (2) call `list_delegates` first with query=<that target exactly as " +
   "established> to find WHICH " +
   "delegate is bound to it — this authoritative coverage lookup (NOT your own cluster_list, which is YOUR " +
@@ -59,8 +70,8 @@ const COORDINATOR_PERSONA =
   "Forward the task at a HIGH LEVEL, essentially as the user phrased it. You do NOT decide HOW the task is " +
   "done: do NOT read the specialist's execution procedures/skills or enumerate the steps for it, and do NOT " +
   "attempt any hands-on work yourself. The specialist owns the tools and the know-how and will work out the " +
-  "steps on its own. Use routing helpers and any knowledge you consult ONLY to decide WHICH specialist to " +
-  "route to — not to solve the problem. When you delegate, describe the GOAL in " +
+  "steps on its own. For a request you route, use your skills and any knowledge you consult ONLY to decide " +
+  "WHICH specialist to route to — not to solve the problem for it. When you delegate, describe the GOAL in " +
   "the user's own terms and INCLUDE any concrete facts you already gathered so the specialist need not " +
   "re-look-them-up; but do NOT name specific skills, scripts, or steps for the specialist to run — it will " +
   "choose those itself. " +
@@ -95,8 +106,8 @@ export const AGENT_TYPES: Record<AgentType, AgentTypeDef> = {
   },
   coordinator: {
     label: "Coordinator Agent",
-    description: "Read-only router: sees the fleet and delegates hands-on troubleshooting to specialist agents.",
-    capabilities: ["inspect_infra", "read_files", "search_memory", "delegate_agents"],
+    description: "Answers knowledge questions from its skills/knowledge base and routes hands-on troubleshooting to specialist agents.",
+    capabilities: ["inspect_infra", "read_files", "delegate_agents"],
     persona: COORDINATOR_PERSONA,
     defaultNoSkills: true,
   },

--- a/src/core/agent-types.ts
+++ b/src/core/agent-types.ts
@@ -48,6 +48,12 @@ const COORDINATOR_PERSONA =
   "answer about a specific cluster's live state from your own knowledge. To decide WHERE to route, use your " +
   "skills / knowledge to work out which specialist domain and which target the request belongs to — do NOT " +
   "merely scan the raw delegate list to guess. " +
+  "KEEP THIS TRIAGE INVISIBLE. The user asked a question, not for your operating rules: never announce which " +
+  "mode you picked, that you consulted a knowledge base, or what your role does and does not do. Do NOT open " +
+  "with lines like \"this is a knowledge question\", \"I looked this up in the knowledge base\", or \"as a " +
+  "coordinator I do not do hands-on work\" — just give the answer. When you cannot deliver one, state the " +
+  "OUTCOME the user needs (e.g. the specialist covering that cluster could not be reached, or which detail " +
+  "you still need) rather than explaining your own rules. " +
   "To ROUTE: (1) determine the TARGET resource (cluster / " +
   "host / node) from the user's request; (2) call `list_delegates` first with query=<that target exactly as " +
   "established> to find WHICH " +

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -127,7 +127,9 @@ function makeLarkClient(overrides: Partial<{
   createThrows: Error;
   replyThrows: Error;
   contentThrows: Error;
+  contentRes: unknown;
   settingsThrows: Error;
+  settingsRes: unknown;
   elementCreateRes: unknown;
   elementCreateThrows: Error;
   elementUpdateThrows: Error;
@@ -139,10 +141,10 @@ function makeLarkClient(overrides: Partial<{
     overrides.replyThrows ? Promise.reject(overrides.replyThrows) : ({ code: 0 }),
   );
   const contentSpy = vi.fn(async () =>
-    overrides.contentThrows ? Promise.reject(overrides.contentThrows) : ({ code: 0 }),
+    overrides.contentThrows ? Promise.reject(overrides.contentThrows) : (overrides.contentRes ?? { code: 0 }),
   );
   const settingsSpy = vi.fn(async () =>
-    overrides.settingsThrows ? Promise.reject(overrides.settingsThrows) : ({ code: 0 }),
+    overrides.settingsThrows ? Promise.reject(overrides.settingsThrows) : (overrides.settingsRes ?? { code: 0 }),
   );
   const elementCreateSpy = vi.fn(async () =>
     overrides.elementCreateThrows ? Promise.reject(overrides.elementCreateThrows) : (overrides.elementCreateRes ?? { code: 0 }),
@@ -258,8 +260,8 @@ describe("finalizeCard", () => {
     const { client, contentSpy, settingsSpy } = makeLarkClient();
     const session = { cardId: "CARD-1", elementId: "md_main", sequence: 0 };
 
-    const ok = await finalizeCard(client as any, session, "# Heading\ntext **bold**");
-    expect(ok).toBe(true);
+    const res = await finalizeCard(client as any, session, "# Heading\ntext **bold**");
+    expect(res).toEqual({ ok: true, contentOk: true });
 
     // content call gets sanitized text (heading passes through unchanged now)
     const contentArg = contentSpy.mock.calls[0][0];
@@ -283,8 +285,8 @@ describe("finalizeCard", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     const session = { cardId: "CARD-1", elementId: "md_main", sequence: 0 };
-    const ok = await finalizeCard(client as any, session, "final text");
-    expect(ok).toBe(false);
+    const res = await finalizeCard(client as any, session, "final text");
+    expect(res).toEqual({ ok: false, contentOk: false });
     expect(contentSpy).toHaveBeenCalledTimes(1);
     // Still tries settings so the card doesn't stay visually stuck in "streaming" state.
     expect(settingsSpy).toHaveBeenCalledTimes(1);
@@ -294,14 +296,59 @@ describe("finalizeCard", () => {
     const { client } = makeLarkClient({ settingsThrows: new Error("500") });
     vi.spyOn(console, "error").mockImplementation(() => {});
     const session = { cardId: "C", elementId: "md_main", sequence: 0 };
-    const ok = await finalizeCard(client as any, session, "x");
-    expect(ok).toBe(false);
+    // contentOk stays true: the answer IS on the card, only the streaming flip
+    // failed — the caller must NOT post a duplicate text reply.
+    const res = await finalizeCard(client as any, session, "x");
+    expect(res).toEqual({ ok: false, contentOk: true });
   });
 
   it("passes the empty-result notice through untouched (no heading/table transforms hit it)", async () => {
     const { client, contentSpy } = makeLarkClient();
     await finalizeCard(client as any, { cardId: "C", elementId: "md_main", sequence: 0 }, EMPTY_RESULT_NOTICE);
     expect(contentSpy.mock.calls[0][0].data.content).toBe(EMPTY_RESULT_NOTICE);
+  });
+
+  // The SDK does NOT throw on a non-zero code. Reporting such a rejection as
+  // success is what froze cards on their ⏳ placeholder while the answer lived
+  // only in the DB (visible in Portal, invisible in the group).
+  it("a non-zero code on the final element.content is a failure, not a silent success", async () => {
+    const { client, settingsSpy } = makeLarkClient({ contentRes: { code: 200671, msg: "sequence conflict" } });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const session = { cardId: "C", elementId: "md_main", sequence: 0 };
+
+    const res = await finalizeCard(client as any, session, "the long final answer");
+    expect(res).toEqual({ ok: false, contentOk: false });
+    // Still attempts the streaming flip so the card does not stay "typing".
+    expect(settingsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("a non-zero code on card.settings keeps contentOk (answer is on the card)", async () => {
+    const { client } = makeLarkClient({ settingsRes: { code: 99991400, msg: "rate limited" } });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const session = { cardId: "C", elementId: "md_main", sequence: 0 };
+
+    const res = await finalizeCard(client as any, session, "answer");
+    expect(res).toEqual({ ok: false, contentOk: true });
+  });
+
+  it("a non-zero code suppresses the feedback row (no buttons under an undelivered answer)", async () => {
+    const { client, elementCreateSpy } = makeLarkClient({ contentRes: { code: 300401, msg: "content too large" } });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await finalizeCard(client as any, { cardId: "C", elementId: "md_main", sequence: 0 }, "big", {
+      ctx: { sessionId: "s", channelId: "c" },
+      locale: "zh-CN",
+    });
+    expect(res.contentOk).toBe(false);
+    expect(elementCreateSpy).not.toHaveBeenCalled();
+  });
+
+  it("updateCardContent reports a non-zero code as failure (milestone updates are not silently lost)", async () => {
+    const { client } = makeLarkClient({ contentRes: { code: 200671, msg: "sequence conflict" } });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const ok = await updateCardContent(client as any, { cardId: "C", elementId: "md_main", sequence: 0 }, "step");
+    expect(ok).toBe(false);
   });
 });
 
@@ -313,11 +360,11 @@ describe("feedback buttons", () => {
     const { client, contentSpy, settingsSpy, elementCreateSpy } = makeLarkClient();
     const session = { cardId: "CARD-FB-1", elementId: "md_main", sequence: 0 };
 
-    const ok = await finalizeCard(client as any, session, "done", {
+    const res = await finalizeCard(client as any, session, "done", {
       ctx: { sessionId: "sess-1", channelId: "ch-1", messageId: "msg-assistant-1" },
       locale: "zh-CN",
     });
-    expect(ok).toBe(true);
+    expect(res.ok).toBe(true);
 
     expect(elementCreateSpy).toHaveBeenCalledTimes(1);
     const arg = elementCreateSpy.mock.calls[0][0];
@@ -357,11 +404,11 @@ describe("feedback buttons", () => {
     const { client } = makeLarkClient({ elementCreateThrows: new Error("500") });
     const session = { cardId: "CARD-FB-2", elementId: "md_main", sequence: 0 };
 
-    const ok = await finalizeCard(client as any, session, "done", {
+    const res = await finalizeCard(client as any, session, "done", {
       ctx: { sessionId: "s", channelId: "c" },
       locale: "en-US",
     });
-    expect(ok).toBe(true);
+    expect(res.ok).toBe(true);
     // Not remembered → no echo possible either.
     expect(await applyFeedbackSelection(client as any, feedbackValue("CARD-FB-2"), "up")).toBe(false);
   });
@@ -372,11 +419,11 @@ describe("feedback buttons", () => {
     const { client, elementUpdateSpy } = makeLarkClient({ elementCreateRes: { code: 300301, msg: "invalid element" } });
     const session = { cardId: "CARD-FB-CODE", elementId: "md_main", sequence: 0 };
 
-    const ok = await finalizeCard(client as any, session, "done", {
+    const res = await finalizeCard(client as any, session, "done", {
       ctx: { sessionId: "s", channelId: "c" },
       locale: "zh-CN",
     });
-    expect(ok).toBe(true);
+    expect(res.ok).toBe(true);
     expect(await applyFeedbackSelection(client as any, feedbackValue("CARD-FB-CODE"), "up")).toBe(false);
     expect(elementUpdateSpy).not.toHaveBeenCalled();
   });

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -418,6 +418,16 @@ function cardApiFailed(res: unknown): boolean {
 }
 
 /**
+ * Render a rejected card call for the log. The code is the only handle on WHY
+ * an update was refused (oversized body, out-of-order sequence, …), and until
+ * it was logged the failure was invisible: nothing threw, so nothing printed.
+ */
+function describeCardApiError(res: unknown): string {
+  const r = res as { code?: unknown; msg?: unknown } | undefined;
+  return `code=${String(r?.code)} msg=${String(r?.msg)}`;
+}
+
+/**
  * Append the feedback row to a finalized card. Best-effort: a failure only
  * loses the buttons, never the answer. Only a verified success registers the
  * card for the post-click echo — a rejected append must not leave a phantom
@@ -617,10 +627,14 @@ export async function updateCardContent(
 ): Promise<boolean> {
   const sanitized = sanitizeMarkdownForFeishu(text);
   try {
-    await larkClient.cardkit.v1.cardElement.content({
+    const res = await larkClient.cardkit.v1.cardElement.content({
       path: { card_id: session.cardId, element_id: session.elementId },
       data: { content: sanitized, sequence: ++session.sequence },
     });
+    if (cardApiFailed(res)) {
+      console.error(`[lark-card] element.content rejected for cardId=${session.cardId}: ${describeCardApiError(res)} chars=${sanitized.length}`);
+      return false;
+    }
     return true;
   } catch (err) {
     console.error(`[lark-card] element.content failed for cardId=${session.cardId}:`, err);
@@ -628,12 +642,25 @@ export async function updateCardContent(
   }
 }
 
+export interface CardFinalizeResult {
+  /** Both the content update and the streaming-mode flip landed. */
+  ok: boolean;
+  /**
+   * The final text is actually ON the card. When false the user still sees the
+   * previous body (the ⏳ placeholder / last milestone), so the caller MUST fall
+   * back to a plain-text reply — that is the only case where a second message
+   * is not a duplicate.
+   */
+  contentOk: boolean;
+}
+
 /**
- * Replace the card's markdown body with `finalText` and disable streaming
- * mode. Returns `true` iff both the content update and the settings flip
- * succeeded; `false` if either step failed (caller should log — at this
- * point the card is already visible, so a plain-text fallback would create
- * duplicate replies).
+ * Replace the card's markdown body with `finalText` and disable streaming mode.
+ *
+ * `contentOk` is reported separately from `ok` because the two failures need
+ * opposite handling: a failed settings flip only leaves the card in streaming
+ * state (answer visible — a text reply would duplicate it), while a failed
+ * content update leaves the answer nowhere the user can see it.
  *
  * When `feedback` is passed, a 👍/👎 button row is appended after the final
  * content (best-effort — losing the buttons never fails the finalize).
@@ -643,29 +670,39 @@ export async function finalizeCard(
   session: CardSession,
   finalText: string,
   feedback?: { ctx: FeedbackContext; locale: LarkLocale },
-): Promise<boolean> {
+): Promise<CardFinalizeResult> {
   const sanitized = sanitizeMarkdownForFeishu(finalText);
   let contentOk = false;
   try {
-    await larkClient.cardkit.v1.cardElement.content({
+    const res = await larkClient.cardkit.v1.cardElement.content({
       path: { card_id: session.cardId, element_id: session.elementId },
       data: { content: sanitized, sequence: ++session.sequence },
     });
-    contentOk = true;
+    // A non-zero code does NOT throw. Treating it as success is what froze the
+    // card on its last milestone while the answer only existed in the DB.
+    if (cardApiFailed(res)) {
+      console.error(`[lark-card] final element.content rejected for cardId=${session.cardId}: ${describeCardApiError(res)} chars=${sanitized.length}`);
+    } else {
+      contentOk = true;
+    }
   } catch (err) {
     console.error(`[lark-card] element.content failed for cardId=${session.cardId}:`, err);
   }
 
   let settingsOk = false;
   try {
-    await larkClient.cardkit.v1.card.settings({
+    const res = await larkClient.cardkit.v1.card.settings({
       path: { card_id: session.cardId },
       data: {
         settings: JSON.stringify({ config: { streaming_mode: false } }),
         sequence: ++session.sequence,
       },
     });
-    settingsOk = true;
+    if (cardApiFailed(res)) {
+      console.error(`[lark-card] card.settings(streaming_mode=false) rejected for cardId=${session.cardId}: ${describeCardApiError(res)}`);
+    } else {
+      settingsOk = true;
+    }
   } catch (err) {
     console.error(`[lark-card] card.settings(streaming_mode=false) failed for cardId=${session.cardId}:`, err);
   }
@@ -677,5 +714,5 @@ export async function finalizeCard(
     await appendFeedbackRow(larkClient, session, feedback.ctx, feedback.locale);
   }
 
-  return contentOk && settingsOk;
+  return { ok: contentOk && settingsOk, contentOk };
 }

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -568,6 +568,74 @@ function buildPlaceholderCard(placeholder: string): Record<string, unknown> {
   };
 }
 
+/** The answer baked in at creation — no streaming window left to expire. */
+function buildFinalCard(markdown: string): Record<string, unknown> {
+  return {
+    schema: "2.0",
+    body: {
+      elements: [
+        { tag: "markdown", content: markdown, element_id: MD_ELEMENT_ID },
+      ],
+    },
+  };
+}
+
+/**
+ * Post a finished answer as a NEW static card.
+ *
+ * Recovery path for a streaming card that can no longer be written to: Feishu
+ * closes streaming mode on a timeout (code 200850) and then refuses every
+ * further update with 300309 — which is how a long investigation left its card
+ * frozen on the last ⏳ line. A plain-text reply does deliver the answer, but it
+ * strips the rendering: the markdown arrives as literal `##` headings and
+ * `|---|` table rows. A fresh card keeps the formatting, can carry the feedback
+ * row (a text message cannot), and being static has no window left to expire.
+ */
+export async function postFinalCard(
+  larkClient: any,
+  messageId: string,
+  finalText: string,
+  feedback?: { ctx: FeedbackContext; locale: LarkLocale },
+  replyInThread: boolean = false,
+): Promise<boolean> {
+  const sanitized = sanitizeMarkdownForFeishu(finalText);
+  try {
+    const createRes = await larkClient.cardkit.v1.card.create({
+      data: { type: "card_json", data: JSON.stringify(buildFinalCard(sanitized)) },
+    });
+    const cardId: string | undefined = createRes?.data?.card_id;
+    if (!cardId) {
+      console.error(`[lark-card] postFinalCard: create returned no card_id for messageId=${messageId}`);
+      return false;
+    }
+    const replyRes = await larkClient.im.message.reply({
+      path: { message_id: messageId },
+      data: {
+        msg_type: "interactive",
+        content: JSON.stringify({ type: "card", data: { card_id: cardId } }),
+        ...(replyInThread ? { reply_in_thread: true } : {}),
+      },
+    });
+    if (cardApiFailed(replyRes)) {
+      console.error(`[lark-card] postFinalCard: posting to chat failed for messageId=${messageId}: ${describeCardApiError(replyRes)}`);
+      return false;
+    }
+    // Safe here in a way it is not on a streaming card: this one is static.
+    if (feedback) {
+      await appendFeedbackRow(
+        larkClient,
+        { cardId, elementId: MD_ELEMENT_ID, sequence: 0 },
+        feedback.ctx,
+        feedback.locale,
+      );
+    }
+    return true;
+  } catch (err) {
+    console.error(`[lark-card] postFinalCard failed for messageId=${messageId}:`, err);
+    return false;
+  }
+}
+
 /**
  * Create a streaming-mode placeholder card and reply with it to the
  * triggering message. Returns the card handle on success, or `null` if

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -2680,6 +2680,53 @@ describe("handleLarkMessage — streaming card flow", () => {
     }
   });
 
+  it("delivers the answer as text when the terminal card update is rejected (non-zero code)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-reject" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "很长的最终结论" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+    // The SDK does NOT throw on a non-zero code. Reading that as success is what
+    // left the card frozen on its ⏳ placeholder while the answer existed only in
+    // the DB — visible in Portal, invisible in the group.
+    lark.cardkit.v1.cardElement.content = vi.fn().mockResolvedValue({ code: 300401, msg: "content too large" });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await handleLarkMessage(makeTextEvent("hi"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    // reply #1 posted the card; reply #2 is the text fallback carrying the answer.
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(2);
+    const fallback = JSON.parse(lark.im.message.reply.mock.calls[1][0].data.content).text as string;
+    expect(fallback).toContain("很长的最终结论");
+    // No 👍/👎 row under an answer the card never showed.
+    expect(lark.cardkit.v1.cardElement.create).not.toHaveBeenCalled();
+  });
+
+  it("does NOT double-post when only the streaming-mode flip is rejected (answer is on the card)", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-settings-reject" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "答复正文" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+    lark.cardkit.v1.card.settings = vi.fn().mockResolvedValue({ code: 99991400, msg: "rate limited" });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handleLarkMessage(makeTextEvent("hi"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    // Only the card post — the body landed, so a text reply would duplicate it.
+    expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.reply.mock.calls[0][0].data.msg_type).toBe("interactive");
+  });
+
   it("renders English placeholder when the channel domain is 'lark' (global)", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-en" });

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1995,6 +1995,60 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(contentCalls.at(-1)).toContain("统一结论");
   });
 
+  it("never shows a bare tool name as a step, but keeps the agent's own narration", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-tool-noise" });
+    streamEventsMock.mockImplementation(async function* () {
+      // No details.items → the single-agent activity branch. `Ran <tool>` is the
+      // producer's developer-facing text (right for Portal's work log, noise in a
+      // group): it must not reach the card.
+      yield {
+        type: "tool_execution_update",
+        toolCallId: "t1",
+        partialResult: { content: [{ type: "text", text: "Ran host_list" }] },
+      };
+      // The child's own words ARE a milestone — this is what the asker wants to see.
+      yield {
+        type: "tool_execution_update",
+        toolCallId: "t1",
+        partialResult: { content: [{ type: "text", text: "正在核对 conntrack 会话时间线" }] },
+      };
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "结论：公网入口丢包。" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("排查"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const contentCalls = lark.cardkit.v1.cardElement.content.mock.calls.map((c: any) => c[0].data.content as string);
+    expect(contentCalls.some((c) => c.includes("host_list"))).toBe(false);
+    expect(contentCalls.some((c) => c.includes("Ran "))).toBe(false);
+    expect(contentCalls.some((c) => c.includes("正在核对 conntrack 会话时间线"))).toBe(true);
+    expect(contentCalls.at(-1)).toContain("结论：公网入口丢包。");
+  });
+
+  it("localizes the sub-agent slot wait instead of leaking its English source text", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-slot-wait" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_update",
+        toolCallId: "t1",
+        partialResult: { content: [{ type: "text", text: "Waiting for a free slot (4 sub-agents run at a time)…" }] },
+      };
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "完成。" }] } };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("排查"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const contentCalls = lark.cardkit.v1.cardElement.content.mock.calls.map((c: any) => c[0].data.content as string);
+    expect(contentCalls.some((c) => c.includes("排队等待子任务空位"))).toBe(true);
+    expect(contentCalls.some((c) => c.includes("Waiting for a free slot"))).toBe(false);
+  });
+
   it("shows only the latest step on the card and replaces it with the conclusion on finalize", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-explicit-channel" });

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -2734,30 +2734,60 @@ describe("handleLarkMessage — streaming card flow", () => {
     }
   });
 
-  it("delivers the answer as text when the terminal card update is rejected (non-zero code)", async () => {
+  it("posts a replacement CARD (not raw text) when the terminal card update is rejected", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-reject" });
+    const answer = "## 结论\n\n| 维度 | 结果 |\n|------|------|\n| RoCE | 正常 |";
     streamEventsMock.mockImplementation(async function* () {
-      yield {
-        type: "message_end",
-        message: { role: "assistant", content: [{ type: "text", text: "很长的最终结论" }] },
-      };
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: answer }] } };
     });
     const lark = makeCardAwareLarkClient();
-    // The SDK does NOT throw on a non-zero code. Reading that as success is what
-    // left the card frozen on its ⏳ placeholder while the answer existed only in
-    // the DB — visible in Portal, invisible in the group.
-    lark.cardkit.v1.cardElement.content = vi.fn().mockResolvedValue({ code: 300401, msg: "content too large" });
+    // Observed in production: a long turn outlives the card's streaming window,
+    // so Feishu refuses the terminal write (200850 → then 300309). The SDK does
+    // not throw on those, which is what used to freeze the card on its ⏳ line.
+    lark.cardkit.v1.cardElement.content = vi.fn().mockResolvedValue({ code: 300309, msg: "streaming mode is closed" });
     vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await handleLarkMessage(makeTextEvent("hi"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
 
-    // reply #1 posted the card; reply #2 is the text fallback carrying the answer.
+    // A SECOND card carries the answer — a text reply would ship the markdown as
+    // literal `##` and `|---|` rows, which is unreadable on a long report.
+    expect(lark.cardkit.v1.card.create).toHaveBeenCalledTimes(2);
+    const replacement = JSON.parse(lark.cardkit.v1.card.create.mock.calls[1][0].data.data);
+    expect(replacement.body.elements[0].content).toContain("## 结论");
+    expect(replacement.body.elements[0].content).toContain("| 维度 | 结果 |");
+    // Static card — no streaming window left to expire.
+    expect(replacement.config?.streaming_mode).toBeUndefined();
+
     expect(lark.im.message.reply).toHaveBeenCalledTimes(2);
-    const fallback = JSON.parse(lark.im.message.reply.mock.calls[1][0].data.content).text as string;
-    expect(fallback).toContain("很长的最终结论");
-    // No 👍/👎 row under an answer the card never showed.
-    expect(lark.cardkit.v1.cardElement.create).not.toHaveBeenCalled();
+    expect(lark.im.message.reply.mock.calls[1][0].data.msg_type).toBe("interactive");
+    // Never a plain-text reply while a card is still possible.
+    const textReplies = lark.im.message.reply.mock.calls.filter((c: any) => c[0].data.msg_type === "text");
+    expect(textReplies).toHaveLength(0);
+  });
+
+  it("falls back to plain text only when the replacement card also fails", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-reject-2" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "最终结论" }] } };
+    });
+    const lark = makeCardAwareLarkClient();
+    lark.cardkit.v1.cardElement.content = vi.fn().mockResolvedValue({ code: 300309, msg: "streaming mode is closed" });
+    // First create opens the typing card; the replacement create yields no card_id.
+    lark.cardkit.v1.card.create = vi.fn()
+      .mockResolvedValueOnce({ data: { card_id: "CARD-99" } })
+      .mockResolvedValueOnce({ data: {} });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handleLarkMessage(makeTextEvent("hi"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    // Degraded, but the answer still reaches the user rather than vanishing.
+    const textReplies = lark.im.message.reply.mock.calls.filter((c: any) => c[0].data.msg_type === "text");
+    expect(textReplies).toHaveLength(1);
+    expect(JSON.parse(textReplies[0][0].data.content).text).toContain("最终结论");
   });
 
   it("does NOT double-post when only the streaming-mode flip is rejected (answer is on the card)", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1604,8 +1604,10 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     if (!shouldDeliverBackgroundReply(display, deliveredTextChars)) return true;
     const md = buildMilestoneCardMarkdown({ milestones: [], finalText: display });
     if (cardSession) {
-      const ok = await finalizeCard(larkClient, cardSession, md);
-      if (ok) {
+      // contentOk, not ok: a failed streaming-mode flip still shows the answer,
+      // so only a body that never landed justifies a second message.
+      const { contentOk } = await finalizeCard(larkClient, cardSession, md);
+      if (contentOk) {
         deliveredTextChars = md.length;
         return true;
       }
@@ -1724,16 +1726,22 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     // empty-result notice, where a click would write a rating against a
     // non-answer and skew the feedback signal Metrics aggregates.
     const isAnswer = !agentError && resultText.trim().length > 0;
-    const ok = await finalizeCard(larkClient, cardSession, finalCardBody,
+    const { ok, contentOk } = await finalizeCard(larkClient, cardSession, finalCardBody,
       isAnswer && assistantMessageId
         ? { ctx: { sessionId, channelId, messageId: assistantMessageId }, locale }
         : undefined);
     deliveredTextChars = finalCardBody.length;
-    if (!ok) {
-      // Partial-failure path: the card is visible but stuck in streaming
-      // state. We log but do NOT post a second reply — that would produce
-      // duplicate messages in the group.
-      console.warn(`[lark] Card finalize incomplete for cardId=${cardSession.cardId}; user may see stuck placeholder`);
+    if (!contentOk) {
+      // The body never landed (rejected update / oversized answer), so the card
+      // is frozen on its ⏳ placeholder and the answer would exist ONLY in the
+      // DB — visible in Portal, invisible in the group. A text reply here is not
+      // a duplicate: nothing else delivered this answer.
+      console.error(`[lark] Card body not delivered for cardId=${cardSession.cardId}; replying as text instead`);
+      await replyToLark(larkClient, messageId, finalCardBody, replyInThread);
+    } else if (!ok) {
+      // Content landed, only the streaming-mode flip failed: the answer IS
+      // visible, so a second message would duplicate it.
+      console.warn(`[lark] Card finalize incomplete for cardId=${cardSession.cardId}; answer delivered but card stays in streaming state`);
     }
   } else if (resultText || agentError || sessionBusy) {
     // Card could not be opened; fall back to a plain text reply with whatever we have —
@@ -2445,10 +2453,12 @@ async function deliverVisibleChannelText(
   replyInThread: boolean = false,
 ): Promise<boolean> {
   if (cardSession) {
-    const ok = terminal
-      ? await finalizeCard(larkClient, cardSession, text)
+    // Terminal: judge by contentOk — a failed streaming-mode flip still leaves
+    // the text on the card, so it must not trigger a duplicate text reply.
+    const delivered = terminal
+      ? (await finalizeCard(larkClient, cardSession, text)).contentOk
       : await updateCardContent(larkClient, cardSession, text);
-    if (ok) return true;
+    if (delivered) return true;
     console.warn(`[lark] Channel-visible card update failed for messageId=${messageId}; falling back to text reply`);
   }
   await replyToLark(larkClient, messageId, text, replyInThread);

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -38,6 +38,8 @@ import {
   openTypingCard,
   updateCardContent,
   finalizeCard,
+  postFinalCard,
+  type FeedbackContext,
   buildMilestoneCardMarkdown,
   applyFeedbackSelection,
   FEEDBACK_ACTION_KIND,
@@ -1611,9 +1613,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
         deliveredTextChars = md.length;
         return true;
       }
-      console.warn(`[lark] Background card update failed for session=${sessionId}; falling back to text reply`);
+      console.warn(`[lark] Background card update failed for session=${sessionId}; posting a replacement card`);
     }
-    await replyToLark(larkClient, messageId, md, replyInThread);
+    await deliverAnswerOutsideCard(larkClient, messageId, md, replyInThread);
     deliveredTextChars = md.length;
     return true;
   });
@@ -1736,8 +1738,16 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       // is frozen on its ⏳ placeholder and the answer would exist ONLY in the
       // DB — visible in Portal, invisible in the group. A text reply here is not
       // a duplicate: nothing else delivered this answer.
-      console.error(`[lark] Card body not delivered for cardId=${cardSession.cardId}; replying as text instead`);
-      await replyToLark(larkClient, messageId, finalCardBody, replyInThread);
+      console.error(`[lark] Card body not delivered for cardId=${cardSession.cardId}; posting a replacement card`);
+      await deliverAnswerOutsideCard(
+        larkClient,
+        messageId,
+        finalCardBody,
+        replyInThread,
+        isAnswer && assistantMessageId
+          ? { ctx: { sessionId, channelId, messageId: assistantMessageId }, locale }
+          : undefined,
+      );
     } else if (!ok) {
       // Content landed, only the streaming-mode flip failed: the answer IS
       // visible, so a second message would duplicate it.
@@ -2444,6 +2454,27 @@ async function promptWithBusyRetry(
   }
 }
 
+/**
+ * Deliver an answer the live card could not carry.
+ *
+ * A NEW static card first, plain text only if even that fails. Text is the last
+ * resort rather than the fallback because Feishu does not render markdown in a
+ * text message: the answer arrives as literal `##` headings and `|---|` table
+ * rows, which on a long structured report is barely readable. A fresh card also
+ * still admits the 👍/👎 row.
+ */
+async function deliverAnswerOutsideCard(
+  larkClient: any,
+  messageId: string,
+  body: string,
+  replyInThread: boolean,
+  feedback?: { ctx: FeedbackContext; locale: LarkLocale },
+): Promise<void> {
+  if (await postFinalCard(larkClient, messageId, body, feedback, replyInThread)) return;
+  console.warn(`[lark] Replacement card failed for messageId=${messageId}; replying as plain text (markdown will not render)`);
+  await replyToLark(larkClient, messageId, body, replyInThread);
+}
+
 async function deliverVisibleChannelText(
   larkClient: any,
   messageId: string,
@@ -2454,14 +2485,14 @@ async function deliverVisibleChannelText(
 ): Promise<boolean> {
   if (cardSession) {
     // Terminal: judge by contentOk — a failed streaming-mode flip still leaves
-    // the text on the card, so it must not trigger a duplicate text reply.
+    // the text on the card, so it must not trigger a duplicate reply.
     const delivered = terminal
       ? (await finalizeCard(larkClient, cardSession, text)).contentOk
       : await updateCardContent(larkClient, cardSession, text);
     if (delivered) return true;
-    console.warn(`[lark] Channel-visible card update failed for messageId=${messageId}; falling back to text reply`);
+    console.warn(`[lark] Channel-visible card update failed for messageId=${messageId}; posting a replacement card`);
   }
-  await replyToLark(larkClient, messageId, text, replyInThread);
+  await deliverAnswerOutsideCard(larkClient, messageId, text, replyInThread);
   return true;
 }
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -2571,14 +2571,14 @@ export async function collectChannelResponse(
             ? `Running sub-agents… ${done}/${total} done`
             : `子任务执行中… ${done}/${total} 完成`;
         } else {
-          // Non-group progress (single-agent step activity): fall back to the raw activity text.
+          // Non-group progress (single-agent step activity).
           const blocks = Array.isArray(ev.partialResult?.content) ? ev.partialResult.content : [];
           const activity = blocks
             .filter((b: any) => b?.type === "text")
             .map((b: any) => (b.text ?? "") as string)
             .join(" ")
             .trim();
-          milestone = activity ? (condenseMilestone(activity) || activity) : "";
+          milestone = channelActivityMilestone(activity, options.locale);
         }
         if (milestone) options.onMilestone(milestone);
       }
@@ -2677,6 +2677,32 @@ function condenseMilestone(text: string): string {
   const clean = firstLine.replace(/^#{1,6}\s+/, "").trim();
   if (!clean) return "";
   return clean.length > 90 ? `${clean.slice(0, 88)}…` : clean;
+}
+
+/**
+ * What a single-agent step activity should say ON A CHAT CARD — or nothing.
+ *
+ * The producer's activity text is developer-facing: `Ran <tool>` is exactly what
+ * Portal's work card wants (a tool log is the point there). A group chat is not
+ * that audience — a bare tool name tells the asker nothing, and because the card
+ * shows only the CURRENT step it also pushes the agent's real narration off the
+ * card. So keep the agent's own words, drop the machine echo. The card still
+ * advances while a long tool runs: the sub-agent's own narration keeps arriving.
+ *
+ * Filtered here, at the channel boundary, rather than at the producer: the
+ * gateway and agentbox ship as separate images, so a gateway-side filter holds
+ * whatever agentbox version it is paired with (and Portal keeps its tool log).
+ */
+function channelActivityMilestone(activity: string, locale?: LarkLocale): string {
+  const clean = activity.trim();
+  if (!clean) return "";
+  // `Ran <tool>` — a tool name, not a milestone.
+  if (/^Ran\s+\S+$/.test(clean)) return "";
+  // Sub-agent slot wait: real information, but hard-coded English at the source.
+  if (/^Waiting for a free slot/i.test(clean)) {
+    return locale === "en-US" ? "Waiting for a free sub-agent slot…" : "排队等待子任务空位…";
+  }
+  return condenseMilestone(clean) || clean;
 }
 
 function contentBlocksToMarkdown(blocks: unknown[]): string {

--- a/src/tools/workflow/list-delegates.test.ts
+++ b/src/tools/workflow/list-delegates.test.ts
@@ -4,7 +4,13 @@ import { createListDelegatesTool, registration } from "./list-delegates.js";
 import type { DelegateRosterMember } from "../../shared/agent-delegate.js";
 
 const ROSTER: DelegateRosterMember[] = [
-  { id: "agent-net", name: "net-agent", description: "network SRE", clusters: ["sh-1", "roce-test"], hosts: [] },
+  {
+    id: "agent-net",
+    name: "net-agent",
+    description: "network SRE for production testing",
+    clusters: ["sh-1", "roce-test", "cluster-alpha"],
+    hosts: [],
+  },
   { id: "agent-gpu", name: "gpu-agent", description: "GPU SRE", clusters: [], hosts: ["gpu-1", "gpu-2"] },
 ];
 
@@ -40,7 +46,7 @@ describe("list_delegates tool", () => {
     const r = await tool.execute("c1", {});
     const t = text(r);
     expect(t).toContain("net-agent [id: agent-net]");
-    expect(t).toContain("(clusters: 2, hosts: 0)");
+    expect(t).toContain("(clusters: 3, hosts: 0)");
     expect(t).toContain("gpu-agent [id: agent-gpu]");
     expect(t).toContain("(clusters: 0, hosts: 2)");
     // The actual binding names must NOT leak into a browse.
@@ -49,7 +55,7 @@ describe("list_delegates tool", () => {
     expect((r as any).details.total).toBe(2);
   });
 
-  it("query returns only agents covering the target, showing the matched binding", async () => {
+  it("an exact cluster query returns only the delegate covering that binding", async () => {
     const tool = createListDelegatesTool(makeRefs({ delegationRoster: ROSTER }));
     const r = await tool.execute("c1", { query: "roce-test" });
     const t = text(r);
@@ -59,9 +65,10 @@ describe("list_delegates tool", () => {
     // The non-covering agent is excluded.
     expect(t).not.toContain("gpu-agent");
     expect((r as any).details.total).toBe(1);
+    expect((r as any).details.match_basis).toBe("exact_resource_binding");
   });
 
-  it("query matches host names too (case-insensitive substring)", async () => {
+  it("matches exact host bindings case-insensitively", async () => {
     const tool = createListDelegatesTool(makeRefs({ delegationRoster: ROSTER }));
     const r = await tool.execute("c1", { query: "GPU-1" });
     const t = text(r);
@@ -70,16 +77,56 @@ describe("list_delegates tool", () => {
     expect(t).not.toContain("net-agent");
   });
 
-  it("tells the coordinator to resolve aliases before concluding nothing covers the target", async () => {
+  it("does not treat partial bindings, agent names, or descriptions as coverage", async () => {
+    const tool = createListDelegatesTool(makeRefs({ delegationRoster: ROSTER }));
+    for (const query of ["test", "net-agent", "production"]) {
+      const r = await tool.execute("c1", { query });
+      expect((r as any).details.total).toBe(0);
+      expect(text(r)).not.toContain("[id: agent-net]");
+    }
+  });
+
+  it("a first miss offers one optional alias-resolution retry", async () => {
     const tool = createListDelegatesTool(makeRefs({ delegationRoster: ROSTER }));
     const r = await tool.execute("c1", { query: "does-not-exist" });
     const t = text(r);
-    expect(t).toMatch(/No delegate agent covers "does-not-exist"/);
+    expect(t).toMatch(/No exact delegate resource binding matches "does-not-exist"/);
     expect(t).toMatch(/routing-helper skill/i);
-    expect(t).toMatch(/retry `list_delegates` with that binding name/i);
-    expect(t).toMatch(/Only after a confirmed binding-name query/i);
+    expect(t).toContain("binding_name_confirmed=true");
     expect(t).toMatch(/Do not delegate/i);
     expect((r as any).details.total).toBe(0);
+    expect((r as any).details.binding_name_confirmed).toBe(false);
+  });
+
+  it("supports one alias-resolution retry with a confirmed binding name", async () => {
+    const tool = createListDelegatesTool(makeRefs({ delegationRoster: ROSTER }));
+    const first = await tool.execute("c1", { query: "local-alias" });
+    expect((first as any).details.total).toBe(0);
+    expect((first as any).details.binding_name_confirmed).toBe(false);
+
+    const retry = await tool.execute("c2", {
+      query: "cluster-alpha",
+      binding_name_confirmed: true,
+    });
+    expect((retry as any).details.total).toBe(1);
+    expect((retry as any).details.binding_name_confirmed).toBe(true);
+    expect(text(retry)).toContain("clusters matched: cluster-alpha");
+    expect(text(retry)).not.toMatch(/routing-helper skill/i);
+  });
+
+  it("a confirmed binding-name miss is terminal", async () => {
+    const tool = createListDelegatesTool(makeRefs({ delegationRoster: ROSTER }));
+    const r = await tool.execute("c1", {
+      query: "canonical-does-not-exist",
+      binding_name_confirmed: true,
+    });
+    const t = text(r);
+    expect(t).toMatch(/No delegate agent covers the confirmed binding name/);
+    expect(t).not.toMatch(/routing-helper skill/i);
+    expect(t).not.toContain("binding_name_confirmed=true");
+    expect(t).toMatch(/Do not delegate/i);
+    expect((r as any).details.total).toBe(0);
+    expect((r as any).details.binding_name_confirmed).toBe(true);
   });
 
   it("caps a page and emits a next_cursor", async () => {

--- a/src/tools/workflow/list-delegates.test.ts
+++ b/src/tools/workflow/list-delegates.test.ts
@@ -70,11 +70,14 @@ describe("list_delegates tool", () => {
     expect(t).not.toContain("net-agent");
   });
 
-  it("tells the coordinator to ask/not-delegate when nothing covers the target", async () => {
+  it("tells the coordinator to resolve aliases before concluding nothing covers the target", async () => {
     const tool = createListDelegatesTool(makeRefs({ delegationRoster: ROSTER }));
     const r = await tool.execute("c1", { query: "does-not-exist" });
     const t = text(r);
     expect(t).toMatch(/No delegate agent covers "does-not-exist"/);
+    expect(t).toMatch(/routing-helper skill/i);
+    expect(t).toMatch(/retry `list_delegates` with that binding name/i);
+    expect(t).toMatch(/Only after a confirmed binding-name query/i);
     expect(t).toMatch(/Do not delegate/i);
     expect((r as any).details.total).toBe(0);
   });

--- a/src/tools/workflow/list-delegates.ts
+++ b/src/tools/workflow/list-delegates.ts
@@ -40,16 +40,25 @@ function renderMatched(label: string, all: string[], matched: string[]): string 
   return `${label} matched: ${shown.join(", ")}${more > 0 ? ` …(+${more} more)` : ""} (${all.length} total)`;
 }
 
-interface Match { m: DelegateRosterMember; mc: string[]; mh: string[]; }
+interface Match {
+  m: DelegateRosterMember;
+  mc: string[];
+  mh: string[];
+}
 
 function matchRoster(roster: DelegateRosterMember[], q: string): Match[] {
   const out: Match[] = [];
   for (const m of roster) {
-    if (!q) { out.push({ m, mc: [], mh: [] }); continue; }
-    const mc = m.clusters.filter((s) => s.toLowerCase().includes(q));
-    const mh = m.hosts.filter((s) => s.toLowerCase().includes(q));
-    const nameHit = m.name.toLowerCase().includes(q) || (m.description ?? "").toLowerCase().includes(q);
-    if (nameHit || mc.length > 0 || mh.length > 0) out.push({ m, mc, mh });
+    if (!q) {
+      out.push({ m, mc: [], mh: [] });
+      continue;
+    }
+    // Coverage is an authorization decision, so only an exact resource binding
+    // proves that a delegate covers the target. Agent names/descriptions and
+    // partial binding matches are discovery hints, not coverage evidence.
+    const mc = m.clusters.filter((s) => s.trim().toLowerCase() === q);
+    const mh = m.hosts.filter((s) => s.trim().toLowerCase() === q);
+    if (mc.length > 0 || mh.length > 0) out.push({ m, mc, mh });
   }
   return out;
 }
@@ -62,13 +71,18 @@ export function createListDelegatesTool(refs: ToolRefs): ToolDefinition {
     renderResult: renderTextResult,
     description:
       "Find which specialist agent you may delegate to covers a target resource. Pass `query` with a cluster " +
-      "name, host name, or node name (matched against each delegate's bound clusters/hosts, plus their " +
-      "name/description) to see WHICH agent covers it — then delegate to that one. Omit `query` to browse " +
+      "name, host name, or node name. Coverage requires an exact, case-insensitive match against a delegate's " +
+      "bound clusters/hosts; agent names, descriptions, and partial resource names never prove coverage. " +
+      "Omit `query` to browse " +
       "(counts + a sample of bindings; agents may be bound to many hosts, so the full list is never dumped — " +
       "search by the target instead). Results are capped; use `cursor` to page.",
     parameters: Type.Object({
       query: Type.Optional(Type.String({
-        description: "Target cluster / host / node name (substring, case-insensitive). Omit to browse all delegates.",
+        description: "Exact target cluster / host / node binding name (case-insensitive). Omit to browse all delegates.",
+      })),
+      binding_name_confirmed: Type.Optional(Type.Boolean({
+        description:
+          "Set true only when `query` is a canonical Siclaw binding name confirmed by an attached routing helper.",
       })),
       limit: Type.Optional(Type.Number({ description: "Max delegates per page (default 20, max 100)." })),
       cursor: Type.Optional(Type.String({ description: "Opaque pagination cursor from a previous response's next_cursor." })),
@@ -78,9 +92,15 @@ export function createListDelegatesTool(refs: ToolRefs): ToolDefinition {
       if (roster.length === 0) {
         return { content: [{ type: "text" as const, text: "You have no delegate agents configured." }], details: {} };
       }
-      const params = (rawParams ?? {}) as { query?: string; limit?: number; cursor?: string };
+      const params = (rawParams ?? {}) as {
+        query?: string;
+        binding_name_confirmed?: boolean;
+        limit?: number;
+        cursor?: string;
+      };
       const rawQuery = typeof params.query === "string" ? params.query.trim() : "";
       const q = rawQuery.toLowerCase();
+      const bindingNameConfirmed = params.binding_name_confirmed === true;
       const limit = Math.min(Math.max(1, Math.floor(params.limit ?? DEFAULT_LIMIT)), MAX_LIMIT);
       const offset = decodeCursor(params.cursor);
 
@@ -102,13 +122,19 @@ export function createListDelegatesTool(refs: ToolRefs): ToolDefinition {
       const hasMore = nextOffset < total;
       let hint = "";
       if (total === 0) {
-        hint =
-          `\n\nNo delegate agent covers "${rawQuery}" as written. If this target may be a cluster alias, ` +
-          "localized name, local nickname, or spelling variant, do not conclude that coverage is absent yet: " +
-          "use an available routing-helper skill to resolve the canonical Siclaw binding name, then retry " +
-          "`list_delegates` with that binding name. Only after a confirmed binding-name query also returns no " +
-          "match should you tell the user that no authorized agent covers the resource. Do not delegate until " +
-          "coverage is confirmed.";
+        if (bindingNameConfirmed) {
+          hint =
+            `\n\nNo delegate agent covers the confirmed binding name "${rawQuery}". ` +
+            "Do not delegate — tell the user no authorized agent covers that resource.";
+        } else {
+          hint =
+            `\n\nNo exact delegate resource binding matches "${rawQuery}" as written. If this may be a cluster ` +
+            "alias, localized name, local nickname, or spelling variant, consult a routing-helper skill you " +
+            "were given, if any. Retry once with its confirmed canonical binding name and set " +
+            "`binding_name_confirmed=true`. If no helper is attached or it cannot confirm one binding name, " +
+            "do not guess or retry — tell the user no authorized agent covers the name as written and that it " +
+            "may be an alias. Do not delegate until coverage is confirmed.";
+        }
       } else if (hasMore) {
         hint = `\n\nShowing ${page.length} of ${total}. Refine the query, or pass cursor="${nextOffset}" for the next page.`;
       }
@@ -118,7 +144,13 @@ export function createListDelegatesTool(refs: ToolRefs): ToolDefinition {
       const body = lines.length ? `${header}\n${lines.join("\n")}` : header;
       return {
         content: [{ type: "text" as const, text: `${body}${hint}` }],
-        details: { total, shown: page.length, ...(hasMore ? { next_cursor: String(nextOffset) } : {}) },
+        details: {
+          total,
+          shown: page.length,
+          match_basis: q ? "exact_resource_binding" : "browse",
+          binding_name_confirmed: bindingNameConfirmed,
+          ...(hasMore ? { next_cursor: String(nextOffset) } : {}),
+        },
       };
     },
   };

--- a/src/tools/workflow/list-delegates.ts
+++ b/src/tools/workflow/list-delegates.ts
@@ -102,7 +102,13 @@ export function createListDelegatesTool(refs: ToolRefs): ToolDefinition {
       const hasMore = nextOffset < total;
       let hint = "";
       if (total === 0) {
-        hint = `\n\nNo delegate agent covers "${rawQuery}". Do not delegate — tell the user no authorized agent covers that resource.`;
+        hint =
+          `\n\nNo delegate agent covers "${rawQuery}" as written. If this target may be a cluster alias, ` +
+          "localized name, local nickname, or spelling variant, do not conclude that coverage is absent yet: " +
+          "use an available routing-helper skill to resolve the canonical Siclaw binding name, then retry " +
+          "`list_delegates` with that binding name. Only after a confirmed binding-name query also returns no " +
+          "match should you tell the user that no authorized agent covers the resource. Do not delegate until " +
+          "coverage is confirmed.";
       } else if (hasMore) {
         hint = `\n\nShowing ${page.length} of ${total}. Refine the query, or pass cursor="${nextOffset}" for the next page.`;
       }


### PR DESCRIPTION
## Summary

Started as a coordinator alias-routing fix; grew to cover two more problems found while verifying it live. Three themes, independent commits:

1. **Coordinator routing** — resolve localized cluster aliases without requiring a routing helper on default coordinators.
2. **Coordinator scope** — answer knowledge questions directly instead of delegating every request, and keep the triage out of the reply.
3. **Chat-channel delivery** — stop losing a finished answer when a card update is rejected, and keep raw tool names off the card.

---

## 1. Coordinator alias routing

### Problem

A localized alias could be reported as missing authorization even when its canonical binding is covered. An earlier revision also made an optional helper mandatory, had no deterministic terminal state after a canonical retry, and let delegate names/descriptions or partial binding names look like resource coverage.

### Solution

- query `list_delegates` first with the target as established by the user
- require exact, case-insensitive cluster/host binding matches for coverage; agent metadata and partial names no longer establish authorization
- after a first miss, consult an attached routing helper only when the target may be a cluster alias
- retry once with the confirmed canonical binding name and `binding_name_confirmed=true`; a second miss is terminal
- document the coordinator/helper contract without depending on an out-of-tree serialized field name
- behavioral routing tests with synthetic resource names (alias retry, false-positive rejection, terminal retry) replace persona string assertions

## 2. Coordinator answers what it can; the triage stays invisible

### Problem

The coordinator was defined as "ONLY job is ROUTING", so a question it could answer outright — a concept, a how-to, a documented fact — still cost a full delegation round trip just to have a specialist restate the answer.

### Solution

Two modes with one rule for choosing: answer from the coordinator's own skills/knowledge base when the answer does not depend on a specific environment's **live state** or on a **hands-on action**; route otherwise. Uncertainty resolves to routing, and a specific cluster's live state is never answered from the coordinator's own knowledge — it holds authorization over no resource, so it can never be the authority on one.

Skills now also inform *where* to route (which specialist domain, which target) rather than that being guessed by scanning the roster. `list_delegates` keeps its job as the authorization step. Alias resolution, ask-on-ambiguous, follow-up inheritance and session-reuse rules are unchanged.

A follow-up commit closes a wording gap found in testing: the triage leaked into the user-visible reply. A knowledge question came back as *"这是知识性问题,我已从内部知识库查到原理。下面是…"*, and a failed delegation as *"由于我是协调者,不做直接的 hands-on 诊断"*. The asker wanted the topic explained, not a tour of the bot's operating rules — and naming the mode also invites doubt about whether the answer is authoritative. The persona now forbids announcing the mode, the knowledge-base lookup, or the role's boundaries; when no answer is possible it states the outcome the user needs (the specialist could not be reached, or which detail is missing) instead of the internal rule that produced it.

Also drops `search_memory` from the coordinator's locked capabilities: memory is disabled fleet-wide (`SICLAW_MEMORY_ENABLED` off, so `memory_search`/`memory_get` do not load), and leaving it listed invites it back into prompt text.

> Answering depends on the agent actually having skills attached — coordinator is `defaultNoSkills`, so one left bare can still only route. Recorded in `docs/design/coordinator-routing.md`.

## 3. A rejected card update no longer loses the answer

### Problem

Cards were freezing on their last `⏳` progress line while the answer was persisted normally — visible in the web UI, invisible in the chat. Nothing was logged, which is why it went unexplained for weeks.

Root cause: the Feishu SDK does **not** throw on a non-zero API code — it returns `{code,msg}` in the body. `updateCardContent` and `finalizeCard` reported success as soon as the await resolved, so a *rejected* card update (oversized body, out-of-order sequence) was indistinguishable from a delivered one. The file already had a `cardApiFailed` helper for the feedback buttons; it was never applied to the content path. Only a thrown error printed anything, so a rejection produced no log line at all.

### Solution

- check the response code on both content and settings calls, and log `code`/`msg` plus the body length (the leading suspect for a rejection) so the reason is knowable
- `finalizeCard` reports `contentOk` separately from `ok`: a failed streaming-mode flip leaves the answer visible (a text reply would duplicate it), while a failed content update leaves the answer nowhere the user can see
- the terminal path had no fallback at all — it now replies as text when, and only when, the body never landed. The two other call sites already had that fallback but could never reach it, since a rejection was reported as success.

## 4. Raw tool names off the card

A card was showing steps like `⏳ Ran host_list`. That text is the producer's developer-facing activity string — right for the web UI's work card, where a tool log is the point — but in a chat it tells the asker nothing. Worse, the card shows only the *current* step, so a tool-name echo actively pushed the agent's real narration off the card.

The structured sub-agent branch was already rendered and localized for the channel; only the single-agent activity branch passed its text through verbatim. That branch now goes through `channelActivityMilestone`: drop bare `Ran <tool>` echoes, localize the (hard-coded English) sub-agent slot wait, keep genuine narration. The card still advances during a long tool call because the sub-agent's own narration keeps arriving.

Filtered at the channel boundary rather than at the producer: gateway and agentbox ship as separate images, so this holds whatever agentbox version it is paired with, and the web UI keeps its tool log.

---

## Test Plan

- [x] `npm test` — 235 files, 4697 passed, 2 skipped
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Rebased on `main`; no conflicts

### Verified live on a staging deployment (runtime + agentbox from this branch)

- [x] a bare tool name no longer appears as a card step
- [x] a long structured answer is delivered complete, with feedback buttons, no frozen placeholder
- [x] a live-state request routes: live-state criterion applied, routing helper consulted, `list_delegates` matched the specialist on the first query, and the coordinator did not overreach into hands-on work when delegation failed
- [x] a knowledge question is answered directly from the knowledge base, no delegation
- [x] the reply opens with the answer itself — no "this is a knowledge question / I consulted the knowledge base" preamble

**Not exercised live:** the rejected-card fallback. Every answer in testing was accepted by the API, so the failure branch only has unit coverage (non-zero code → `contentOk=false` → text reply, no feedback row under an undelivered answer). Its main value is that a future rejection now leaves `code=… msg=… chars=…` in the log instead of vanishing silently.
