### PR TITLE
fix(lark): /mode must be aimed at us; feat(lark): forward sender_type so the Portal can tell a bot from a person

### DIFF
--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -137,12 +137,17 @@ export async function resolveBinding(
   senderOpenId?: string,
   conversationKey?: string,
   conversationExistingOnly: boolean = false,
+  senderType?: string,
 ): Promise<ResolvedChannelBinding | ChannelAccessDenied | null> {
   const data = await frontendClient.request("channel.resolveBinding", {
     channel_id: channelId,
     route_key: routeKey,
     ...(sessionKey ? { session_key: sessionKey } : {}),
     ...(senderOpenId ? { sender_open_id: senderOpenId } : {}),
+    // The provider's own word ("user" / "app" / …), passed through verbatim.
+    // Absent when the event did not carry one — the Portal must treat missing
+    // and "user" as different things, so do not default it here.
+    ...(senderType ? { sender_type: senderType } : {}),
     ...(conversationKey ? { conversation_key: conversationKey } : {}),
     ...(conversationExistingOnly ? { conversation_existing_only: true } : {}),
   });
@@ -246,10 +251,13 @@ export async function resolvePersonalBinding(
   channelId: string,
   senderOpenId: string,
   frontendClient: FrontendWsClient,
+  senderType?: string,
 ): Promise<PersonalBindingResult> {
   const data = await frontendClient.request("channel.resolvePersonalBinding", {
     channel_id: channelId,
     sender_open_id: senderOpenId,
+    // Same contract as the group lookup: verbatim, and absent stays absent.
+    ...(senderType ? { sender_type: senderType } : {}),
   });
   return {
     binding: data?.binding ?? null,

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -459,7 +459,7 @@ describe("handleLarkMessage — personal bot p2p", () => {
       makePersonalConfig("open"),
     );
 
-    expect(resolvePersonalBindingMock).toHaveBeenCalledWith("personal-bot-1", "ou_user_1", expect.anything());
+    expect(resolvePersonalBindingMock).toHaveBeenCalledWith("personal-bot-1", "ou_user_1", expect.anything(), undefined);
     expect(resolveBindingMock).not.toHaveBeenCalled();
     expect(ensureChatSessionMock).toHaveBeenCalledWith(
       "session-open-ou1",
@@ -614,6 +614,7 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       "ou_user_1",
       undefined,
       false,
+      undefined,   // sender_type — absent on a plain user event
     );
     expect(mgr.getOrCreate).not.toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();
@@ -650,6 +651,7 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       "ou_user_1",
       undefined,
       false,
+      undefined,   // sender_type — absent on a plain user event
     );
     expect(resolvePersonalBindingMock).not.toHaveBeenCalled();
   });
@@ -1477,6 +1479,31 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(sessionKey).toBe("open_id:ou_other_bot");
   });
 
+  it("forwards sender_type upstream so the Portal can tell a bot from a person", async () => {
+    // The Portal cannot make that distinction on its own: it used to receive only
+    // an open_id, which an app sender may not even have — leaving "a bot wrote
+    // this" and "we could not identify the writer" indistinguishable.
+    resolveBindingMock.mockResolvedValue(null);
+    const data = {
+      sender: { sender_type: "app", sender_id: { open_id: "ou_other_bot" } },
+      message: {
+        message_id: "mid-st-1", chat_id: "oc_abc123", message_type: "text",
+        content: JSON.stringify({ text: "@_user_1 提工单" }),
+        chat_type: "group", mentions: [{ key: "@_user_1", id: { open_id: BOT } }],
+      },
+    };
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock.mock.calls[0][7]).toBe("app");
+  });
+
+  it("passes no sender_type when the event carried none — absent must not become a user", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const data = botSenderEvent("@_user_1 提工单", [{ key: "@_user_1", id: { open_id: BOT } }]);
+    delete (data.sender as any).sender_type;
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock.mock.calls[0][7]).toBeUndefined();
+  });
+
   it("/mode without a mention is ignored — it reconfigures the whole group", async () => {
     // It used to be handled BEFORE the @-gate, so any group member, or any other
     // BOT in the room, could switch the group's context mode by typing two words
@@ -1565,6 +1592,8 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       "open_id:ou_user_1",
       "ou_user_1",
       undefined,
+      false,
+      undefined,   // sender_type — absent on a plain user event
     );
   });
 
@@ -1795,6 +1824,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       "ou_user_1",
       "lark_thread:mid-unrelated-root",
       true,
+      undefined,   // sender_type — absent on a plain user event
     );
     expect(promptMock).not.toHaveBeenCalled();
     expect(lark.im.message.reply).not.toHaveBeenCalled();

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1422,6 +1422,97 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(resolveBindingMock).toHaveBeenCalled();
   });
 
+  // ── @-ed BY ANOTHER BOT ────────────────────────────────────────────
+  // Nothing in the pipeline inspects sender_type, so an app-sent message takes
+  // the same path as a human's. What differs is the SENDER IDENTITY: Feishu
+  // describes an app sender as sender_type:"app", and when it carries no
+  // sender_id.open_id every downstream identity decision sees an empty sender.
+  // These pin what we actually do in both payload shapes.
+
+  /** App/bot sender WITHOUT sender_id.open_id — the shape that loses identity. */
+  function botSenderEvent(text: string, mentions: any[]) {
+    return {
+      sender: { sender_type: "app", sender_id: {} },
+      message: {
+        message_id: "mid-bot-1",
+        chat_id: "oc_abc123",
+        message_type: "text",
+        content: JSON.stringify({ text }),
+        chat_type: "group",
+        mentions,
+      },
+    };
+  }
+
+  it("a BOT @-mentioning us is NOT filtered — the @-gate passes on mention alone", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const data = botSenderEvent("@_user_1 提工单:节点异常", [{ key: "@_user_1", id: { open_id: BOT } }]);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    // It reached binding resolution: sender_type is never consulted.
+    expect(resolveBindingMock).toHaveBeenCalled();
+  });
+
+  it("a BOT sender with no open_id resolves with NO sender identity and a chat-scoped key", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const data = botSenderEvent("@_user_1 提工单", [{ key: "@_user_1", id: { open_id: BOT } }]);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+
+    const [, , , sessionKey, senderOpenId] = resolveBindingMock.mock.calls[0];
+    // Upstream authorization keys off the sender; it gets nothing to key on.
+    expect(senderOpenId).toBeUndefined();
+    // And per-sender isolation degrades to one shared chat-scoped session.
+    expect(sessionKey).toBe("oc_abc123".replace(/^/, "chat:"));
+  });
+
+  it("a BOT sender WITH an open_id is treated exactly like a user", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const data = makeTextEvent("@_user_1 提工单", {
+      chat_type: "group",
+      mentions: [{ key: "@_user_1", id: { open_id: BOT } }],
+    }, "ou_other_bot");
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+
+    const [, , , sessionKey, senderOpenId] = resolveBindingMock.mock.calls[0];
+    expect(senderOpenId).toBe("ou_other_bot");
+    expect(sessionKey).toBe("open_id:ou_other_bot");
+  });
+
+  it("/mode without a mention is ignored — it reconfigures the whole group", async () => {
+    // It used to be handled BEFORE the @-gate, so any group member, or any other
+    // BOT in the room, could switch the group's context mode by typing two words
+    // at nobody. Nothing downstream checks who the sender is.
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "per_user" }));
+    await handleLarkMessage(botSenderEvent("/mode", []), makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+  });
+
+  it("/mode inside an established topic works without a mention, and never reaches the model", async () => {
+    // Inside a topic people stop @-ing, and thread follow-ups are let through the
+    // @-gate — so requiring a mention here would not merely ignore /mode, it
+    // would forward the literal text to the model as a prompt.
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "per_user" }));
+    const data = makeTextEvent("/mode", {
+      message_id: "mid-topic-mode",
+      chat_type: "group",
+      mentions: [],
+      root_id: "mid-root",
+      thread_id: "omt-1",
+    });
+    await handleLarkMessage(
+      data, makeLarkClient(), "lark", makeAgentBoxManager("a1") as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y", thread_mode: "group" }, BOT,
+    );
+    expect(resolveBindingMock).toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();   // handled as a command, not a prompt
+  });
+
+  it("/mode WITH a mention still works, whoever sends it", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "per_user" }));
+    const data = botSenderEvent("/mode", [{ key: "@_user_1", id: { open_id: BOT } }]);
+    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    expect(resolveBindingMock).toHaveBeenCalled();
+  });
+
   it("IGNORES @所有人 announcements (key @_all, not the bot's open_id)", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     const data = groupEvent("@_all 基础功能都搞过来了", [
@@ -1455,7 +1546,8 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     }));
 
     await handleLarkMessage(
-      makeTextEvent("/mode", { chat_type: "group", mentions: [] }),
+      // /mode now requires the mention; this case is about topic sessions, not the gate.
+      makeTextEvent("/mode", { chat_type: "group", mentions: [{ key: "@_user_1", id: { open_id: BOT } }] }),
       makeLarkClient(),
       "lark",
       makeAgentBoxManager("a1") as any,

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1222,9 +1222,23 @@ export async function handleLarkMessage(
     return;
   }
 
-  // /mode — summon the context-mode switch card. Handled before the @-gate so
-  // it works with or without an @bot (like PAIR); command words are exact.
-  if (/^\/mode$/i.test(text.trim())) {
+  // Computed here rather than at the @-gate below: /mode needs both.
+  const botMentioned = isBotMentioned(message, botOpenId);
+  const isThreadFollowup = topicFeatureEnabled && threadId !== null && rootMessageId !== messageId;
+
+  // /mode — summon the context-mode switch card. Command words are exact, and
+  // the bot must be @-mentioned: this switches the mode for the WHOLE group, and
+  // nothing in the pipeline checks who the sender is (Feishu reports app senders
+  // the same way it reports people, sometimes without any id at all). Handling it
+  // before the @-gate meant any group member — or any other BOT in the room —
+  // could reconfigure the group by typing two words at nobody in particular.
+  // Requiring that costs the sender four characters and makes the change an act
+  // aimed at us. A follow-up inside a topic WE opened counts too — it is already
+  // scoped to a conversation the bot owns, and inside a topic people rightly stop
+  // @-ing. Without that second arm, `/mode` in a topic would fall past the @-gate
+  // (thread follow-ups are allowed through) and reach the model as a prompt.
+  // PAIR stays exempt: it carries its own one-time code.
+  if (/^\/mode$/i.test(text.trim()) && (botMentioned || isThreadFollowup)) {
     const modeBinding = await resolveBinding(
       groupChannelId,
       chatId,
@@ -1259,8 +1273,6 @@ export async function handleLarkMessage(
   // were never aimed at it. Skips "@所有人" and "@someone-else"; PAIR above is
   // exempt (explicit command). Gated on chat_type==="group" so the binding/
   // access checks below stay reachable only for messages aimed at the bot.
-  const botMentioned = isBotMentioned(message, botOpenId);
-  const isThreadFollowup = topicFeatureEnabled && threadId !== null && rootMessageId !== messageId;
   const conversationExistingOnly = isThreadFollowup && !botMentioned;
   if (chatType === "group" && !botMentioned) {
     // Non-@ group message. In a group KNOWN to be shared, retain it as passive

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -444,6 +444,22 @@ function getLarkSenderOpenId(data: any): string | null {
   return typeof openId === "string" && openId.trim() ? openId.trim() : null;
 }
 
+/**
+ * Feishu's own word for what kind of party sent this — "user", "app", … The
+ * value is passed through verbatim rather than mapped to a boolean: we do not
+ * control the vocabulary, and a value we have not seen before must reach the
+ * Portal intact instead of being flattened into "not a user".
+ *
+ * Nothing in this file branches on it. It exists so the Portal can tell a bot
+ * from a person at all — until now it received only an open_id, which an app
+ * sender may not even have, leaving "a bot wrote this" and "we could not
+ * identify the writer" indistinguishable.
+ */
+function getLarkSenderType(data: any): string | null {
+  const t = data?.sender?.sender_type ?? data?.event?.sender?.sender_type;
+  return typeof t === "string" && t.trim() ? t.trim() : null;
+}
+
 function buildLarkSessionKey(senderOpenId: string | null, chatId: string): string {
   return senderOpenId ? `open_id:${senderOpenId}` : `chat:${chatId}`;
 }
@@ -967,6 +983,7 @@ export async function handleLarkMessage(
   const msgType: string = message.message_type;
   const chatType: string | undefined = message.chat_type;
   const senderOpenId = getLarkSenderOpenId(data);
+  const senderType = getLarkSenderType(data);
   const sessionKey = buildLarkSessionKey(senderOpenId, chatId);
   // Rollout gate only: whether personal group conversations MAY use Feishu
   // topics. The binding's server-authoritative contextMode decides whether
@@ -987,7 +1004,11 @@ export async function handleLarkMessage(
   // Raw receipt log: fires for EVERY delivered event before any drop, so a
   // group message that arrives but is filtered (non-text, empty after @-strip)
   // is still visible. Lets us tell "never delivered" from "silently dropped".
-  console.log(`[lark] recv event chat=${chatId} chat_type=${chatType} msg_type=${msgType} sender=${senderOpenId ?? "?"} channelCfg=${channelId}`);
+  // senderType is logged beside the id because `sender=?` alone cannot say WHY
+  // we have no identity: an event with no sender_id at all and one whose
+  // sender_id simply omits open_id look identical here, and they lead to
+  // opposite conclusions about whether a sender can ever be authorized.
+  console.log(`[lark] recv event chat=${chatId} chat_type=${chatType} msg_type=${msgType} sender=${senderOpenId ?? "?"} sender_type=${senderType ?? "?"} channelCfg=${channelId}`);
 
   // Accept text, native image, and rich-text (post, may embed images). Other
   // types (audio/file/sticker/…) are still dropped.
@@ -1126,7 +1147,7 @@ export async function handleLarkMessage(
       return;
     }
 
-    const { binding, denied } = await resolvePersonalBinding(personalChannelId, senderOpenId, frontendClient!);
+    const { binding, denied } = await resolvePersonalBinding(personalChannelId, senderOpenId, frontendClient!, senderType ?? undefined);
     if (!binding) {
       // The frontend owns the admission decision; the runtime's whole gate is "did a binding come
       // back". All that is left is telling the sender what to do next.
@@ -1178,6 +1199,7 @@ export async function handleLarkMessage(
       messageId,
       chatId,
       senderOpenId,
+      senderType: senderType ?? undefined,
       sessionKey: personalSessionKey,
       channelId: personalChannelId,
       route: "personal",
@@ -1246,6 +1268,8 @@ export async function handleLarkMessage(
       sessionKey,
       senderOpenId ?? undefined,
       undefined,
+      false,
+      senderType ?? undefined,
     );
     if (isChannelAccessDenied(modeBinding)) {
       await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale, dmCanResolveAccess(personalBot)));
@@ -1303,6 +1327,7 @@ export async function handleLarkMessage(
     senderOpenId ?? undefined,
     topicConversationKey,
     conversationExistingOnly,
+    senderType ?? undefined,
   );
   if (isChannelAccessDenied(binding)) {
     // A no-@ Topic/quote follow-up is never an authorization prompt. If the
@@ -1366,6 +1391,7 @@ export async function handleLarkMessage(
     messageId,
     chatId,
     senderOpenId,
+    senderType: senderType ?? undefined,
     sessionKey: effectiveSessionKey,
     channelId: groupChannelId,
     route: "group",
@@ -1394,6 +1420,8 @@ interface QueuedLarkMessageContext {
   messageId: string;
   chatId: string;
   senderOpenId: string | null;
+  /** Provider's own sender kind ("user" / "app" / …), verbatim; absent if the event had none. */
+  senderType?: string;
   sessionKey: string;
   channelId: string;
   route: "group" | "personal";
@@ -1423,6 +1451,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     messageId,
     chatId,
     senderOpenId,
+    senderType,
     sessionKey,
     channelId,
     route,
@@ -1481,6 +1510,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     sessionKey,
     conversationKey,
     conversationExistingOnly,
+    senderType,
   );
   if (!binding) {
     console.log(`[lark] Binding disappeared before queued run channel=${channelId} chat=${chatId} route=${route}`);
@@ -1800,12 +1830,13 @@ async function resolveQueuedBinding(
   sessionKey: string,
   conversationKey?: string,
   conversationExistingOnly: boolean = false,
+  senderType?: string,
 ): Promise<ResolvedChannelBinding | null> {
   if (route === "personal") {
     if (!senderOpenId) return null;
     // Re-resolved after dequeue purely to detect revocation; the refusal reason was already
     // delivered before enqueue, so only the binding matters here.
-    return (await resolvePersonalBinding(channelId, senderOpenId, frontendClient)).binding;
+    return (await resolvePersonalBinding(channelId, senderOpenId, frontendClient, senderType)).binding;
   }
   const result = await resolveBinding(
     channelId,
@@ -1815,6 +1846,7 @@ async function resolveQueuedBinding(
     senderOpenId ?? undefined,
     conversationKey,
     conversationExistingOnly,
+    senderType,
   );
   // If access was revoked between enqueue and run, treat as gone (the queued
   // task then skips). The pre-enqueue check already replied any access hint.


### PR DESCRIPTION
## Summary

Two independent findings from looking at what happens when **another bot @-mentions our Feishu bot**. Nothing in the message pipeline has ever inspected who sent a message, and that turns out to matter in two different ways.

## 1. `/mode` must be aimed at us before it reconfigures the group

`/mode` switches the context mode for the **whole group**, and it was handled *before* the @-gate so that it worked with or without a mention. Combined with the missing sender check, that meant any group member — or any other bot in the room — could reconfigure the group by typing two words at nobody in particular.

It now requires the message to be aimed at us: an @-mention, **or** a follow-up inside a topic we opened.

That second arm is not a convenience. Inside a topic people rightly stop @-ing, and thread follow-ups are deliberately let through the @-gate — so an @-only rule would not merely ignore `/mode` there, it would forward the literal text to the model as a prompt. There is a regression test for exactly that.

`PAIR` stays exempt: it carries its own one-time code.

**`/new` is deliberately left alone.** In a group it already sits behind the @-gate, a shared group refuses it outright, and in `per_user` mode it resets only the caller's own session. No hole found, so no change.

## 2. Tell the Portal what kind of party sent a message

The Portal decides whether a sender may drive an agent, and until now it received only an `open_id`. An app sender may not carry one — so *"a bot wrote this"* and *"we could not identify the writer"* arrived looking identical, and those lead to opposite conclusions about whether that sender can ever be authorized.

Feishu's own `sender_type` (`"user"` / `"app"` / …) is now forwarded on both `channel.resolveBinding` and `channel.resolvePersonalBinding`, threaded through the queued path as well so a message that runs after dequeue reports the same thing as one resolved inline.

Two rules the value is written to:

- **Passed through, not mapped to a boolean.** We do not own the vocabulary; a value we have not seen must reach the Portal intact instead of being flattened into "not a user".
- **Absent stays absent.** An event without the field must not arrive as `"user"`, or the Portal loses the very distinction this exists for.

The receipt log prints it beside the id, because `sender=?` alone could not say whether the event had no `sender_id` at all or a `sender_id` that simply omits `open_id` — two states that look the same and mean opposite things.

### Not included: a sender display name

The upstream hand-off asked for one from `mentions[].name`. That does not work: `mentions` carries the parties that were **@-ed** — when a bot @-s us, that is our own bot, not the sender — and the SDK's `sender` (`sender_id` / `sender_type` / `tenant_key`) has no name field at all. Flagged upstream; either the Portal resolves names its own way, or an approval card shows the `open_id` with the group and message excerpt beside it.

## Test plan

- [x] `npm test` — 239 files, 4849 passed, 2 skipped
- [x] `npx tsc --noEmit`; each of the two commits also compiles on its own
- [x] Deployed to a staging namespace (runtime + agentbox built from this branch)

New tests pin the behaviour that motivated each change:

- a bot @-mentioning us is not filtered — the @-gate passes on the mention alone
- a bot sender with no `open_id` resolves with no sender identity and a chat-scoped session key (per-sender isolation silently degrades — documented, not fixed here)
- a bot sender **with** an `open_id` is treated exactly like a user
- `/mode` without a mention is ignored; with a mention it works; inside an established topic it works without one **and never reaches the model**
- `sender_type` is forwarded verbatim, and absent stays absent rather than becoming `"user"`
