### PR TITLE
feat(agentbox): make a pool survive a node, a crash, and a deploy

### DIFF
--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AgentBoxInfo } from "./types.js";
 
 /**
  * Tests for K8sSpawner.
@@ -1400,8 +1401,13 @@ describe("K8sSpawner — every listing carries what staleness is judged on", () 
     expect(fromList.image).toBe("agentbox:v9");
     expect(fromList.instance).toBe(0);
 
+    // One mapper, one answer. Compared without the timestamps: both are stamped at call
+    // time, so they differ by however long the two calls are apart — which on a slow
+    // machine is enough to fail an equality that has nothing to do with what is being
+    // tested.
     const [forAgent] = await s.listForAgent("a");
-    expect(forAgent).toEqual(fromList);   // one mapper, one answer
+    const withoutClock = ({ createdAt: _c, lastActiveAt: _l, ...rest }: AgentBoxInfo) => rest;
+    expect(withoutClock(forAgent)).toEqual(withoutClock(fromList));
   });
 });
 

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -172,7 +172,7 @@ describe("K8sSpawner — pod name sanitization + invariant §3 (mTLS K8s-only)",
       }
       return {
         status: { phase: "Running", podIP: "10.1.2.3", conditions: [{ type: "Ready", status: "True" }] },
-        metadata: { name: "agentbox-default", labels: {} },
+        metadata: { name: "agentbox-default-0", labels: {} },
       };
     };
 
@@ -204,7 +204,7 @@ describe("K8sSpawner — pod name sanitization + invariant §3 (mTLS K8s-only)",
 
     // Uppercase → lowercase; "_" → "-"; 50-char cap keeps full name ≤ 63 chars.
     const handle = await s.spawn({ agentId: "Agent_With.Weird/Chars" });
-    expect(handle.boxId).toBe("agentbox-agent-with-weird-chars");
+    expect(handle.boxId).toBe("agentbox-agent-with-weird-chars-0");
   });
 });
 
@@ -699,11 +699,11 @@ describe("K8sSpawner — pod-name prefix (compile boxes vs chat) + upgrade migra
 
     const bodies = calls.createNamespacedPod.map((c: any) => c.body);
     const names = bodies.map((b: any) => b.metadata.name);
-    expect(names).toContain("agentbox-chatty");
-    expect(names).toContain("kbc-box-kbrun");
+    expect(names).toContain("agentbox-chatty-0");
+    expect(names).toContain("kbc-box-kbrun-0");
     // Resources derived from the pod name follow the prefix.
-    const compilePod = bodies.find((b: any) => b.metadata.name === "kbc-box-kbrun");
-    expect(compilePod.spec.hostname).toBe("kbc-box-kbrun");
+    const compilePod = bodies.find((b: any) => b.metadata.name === "kbc-box-kbrun-0");
+    expect(compilePod.spec.hostname).toBe("kbc-box-kbrun-0");
     const secretNames = calls.createNamespacedSecret.map((c: any) => c.body.metadata.name);
     expect(secretNames).toContain("kbc-box-kbrun-cert");
   });
@@ -736,7 +736,7 @@ describe("K8sSpawner — pod-name prefix (compile boxes vs chat) + upgrade migra
     // The legacy pod's Secret is left to the sweep — stop() no longer owns Secret lifetime.
     expect(calls.deleteNamespacedSecret).toHaveLength(0);
     // The new box is created under the renamed prefix, not the old one.
-    expect(calls.createNamespacedPod.map((c: any) => c.body.metadata.name)).toEqual(["kbc-box-migrated"]);
+    expect(calls.createNamespacedPod.map((c: any) => c.body.metadata.name)).toEqual(["kbc-box-migrated-0"]);
   });
 
   it("never reaps a legacy agentbox-named CHAT pod that happens to share the agentId", async () => {
@@ -759,7 +759,7 @@ describe("K8sSpawner — pod-name prefix (compile boxes vs chat) + upgrade migra
     await s.spawn({ agentId: "shared", profile: "kb-compile" });
 
     expect(calls.deleteNamespacedPod.some((c: any) => c.name === "agentbox-shared")).toBe(false);
-    expect(calls.createNamespacedPod.map((c: any) => c.body.metadata.name)).toEqual(["kbc-box-shared"]);
+    expect(calls.createNamespacedPod.map((c: any) => c.body.metadata.name)).toEqual(["kbc-box-shared-0"]);
   });
 });
 
@@ -770,9 +770,9 @@ describe("K8sSpawner — stop", () => {
     // read that races a replacement's spawn, which creates the Secret BEFORE its pod.
     // Deleting it then would strand the new pod in ContainerCreating forever.
     const s = new K8sSpawner();
-    await s.stop("agentbox-default");
+    await s.stop("agentbox-default-0");
     expect(calls.deleteNamespacedPod).toHaveLength(1);
-    expect(calls.deleteNamespacedPod[0].name).toBe("agentbox-default");
+    expect(calls.deleteNamespacedPod[0].name).toBe("agentbox-default-0");
     expect(calls.deleteNamespacedSecret).toHaveLength(0);
   });
 
@@ -904,7 +904,7 @@ describe("K8sSpawner — per-agent persistence (PVC override)", () => {
       if (r === 1) throw Object.assign(new Error("nf"), { code: 404 });
       return {
         status: { phase: "Running", podIP: "10.9.9.9", conditions: [{ type: "Ready", status: "True" }] },
-        metadata: { name: "agentbox-default", labels: {} },
+        metadata: { name: "agentbox-default-0", labels: {} },
       };
     };
   }
@@ -996,7 +996,7 @@ describe("K8sSpawner — nodeSelector", () => {
       if (r === 1) throw Object.assign(new Error("nf"), { code: 404 });
       return {
         status: { phase: "Running", podIP: "10.7.7.7", conditions: [{ type: "Ready", status: "True" }] },
-        metadata: { name: "agentbox-default", labels: {} },
+        metadata: { name: "agentbox-default-0", labels: {} },
       };
     };
   }
@@ -1235,8 +1235,8 @@ describe("K8sSpawner — replica identity and the shared certificate", () => {
 
   it("leaves instance 0 unsuffixed so no existing pod is renamed", async () => {
     const { handle, created } = await spawnOnce({ agentId: "agent-x", profile: "agent" });
-    expect(created.body.metadata.name).toBe("agentbox-agent-x");
-    expect(handle.boxId).toBe("agentbox-agent-x");
+    expect(created.body.metadata.name).toBe("agentbox-agent-x-0");
+    expect(handle.boxId).toBe("agentbox-agent-x-0");
     expect(created.body.metadata.labels["siclaw.io/instance"]).toBe("0");
   });
 
@@ -1347,3 +1347,61 @@ describe("K8sSpawner — concurrent replica spawns share one certificate Secret"
     await expect(s.spawn({ agentId: "agent-x", profile: "agent" } as any)).resolves.toBeTruthy();
   });
 });
+
+describe("K8sSpawner — spreading a pool over nodes", () => {
+  it("asks the scheduler to keep an agent's boxes apart, as a preference", async () => {
+    // Preferred, never required: a cluster with one eligible node — a nodeSelector that
+    // admits one, say — must still be able to place the pod. Spreading is worth a lot
+    // when it succeeds; refusing to schedule would cost everything.
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "10.0.0.9", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    await s.spawn({ agentId: "agent-a", instance: 1 });
+
+    const affinity = calls.createNamespacedPod[0].body.spec.affinity.podAntiAffinity;
+    expect(affinity.requiredDuringSchedulingIgnoredDuringExecution).toBeUndefined();
+    const term = affinity.preferredDuringSchedulingIgnoredDuringExecution[0];
+    expect(term.podAffinityTerm.topologyKey).toBe("kubernetes.io/hostname");
+    expect(term.podAffinityTerm.labelSelector.matchLabels).toMatchObject({
+      "siclaw.io/agent": "agent-a",
+      "siclaw.io/app": "agentbox",
+    });
+  });
+});
+
+describe("K8sSpawner — every listing carries what staleness is judged on", () => {
+  it("reports the CA fingerprint and image from list(), not only from listForAgent()", async () => {
+    // list() used to return a lighter projection. That was harmless while only acquisition
+    // judged staleness, and became a spawn loop the moment the reaper judged it too: a box
+    // with no fingerprint reads as signed by a CA we no longer trust, so every fresh box
+    // was drained on sight and replaced by one that met the same fate.
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    g.__k8sImpls.listNamespacedPod = async () => ({
+      items: [{
+        metadata: {
+          name: "agentbox-a-0",
+          labels: { "siclaw.io/app": "agentbox", "siclaw.io/agent": "a", "siclaw.io/ca-fp": "fp-1", "siclaw.io/instance": "0" },
+        },
+        spec: { containers: [{ image: "agentbox:v9" }] },
+        status: { phase: "Running", podIP: "10.0.0.1", conditions: [{ type: "Ready", status: "True" }] },
+      }],
+    });
+
+    const [fromList] = await s.list();
+    expect(fromList.caFingerprint).toBe("fp-1");
+    expect(fromList.image).toBe("agentbox:v9");
+    expect(fromList.instance).toBe(0);
+
+    const [forAgent] = await s.listForAgent("a");
+    expect(forAgent).toEqual(fromList);   // one mapper, one answer
+  });
+});
+

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -149,17 +149,44 @@ export class K8sSpawner implements BoxSpawner {
    * "kbc-box"). Both prefixes are ≤ 8 chars, so the 50-char agentId cap keeps the
    * full name well under 63.
    *
-   * **Instance 0 is deliberately unsuffixed** — it is the name every existing pod
-   * already has. Suffixing it would rename every pod in a running deployment, and each
-   * old one would be orphaned behind a name nothing looks up any more, for no benefit
-   * until an agent actually runs more than one box. Replicas 1..N-1 carry `-{n}`.
+   * Every instance carries its index, `-0` included. Instance 0 used to be unsuffixed,
+   * because that was the name every pod already had before an agent could run more than
+   * one — but the asymmetry cost more than it saved: a replacement for instance 0 took
+   * the identical name, so a box that had died and come back was indistinguishable from
+   * the one that had been there all along.
+   *
+   * The old name is still recognised for as long as such a pod can exist: the manager
+   * treats it as stale, so it drains and its replacement comes back as `-0`.
    *
    * Nothing parses the index back out of a name; the `instance` label is the record.
    */
   private podName(agentId: string, prefix = "agentbox", instance = 0): string {
+    return `${this.podBaseName(agentId, prefix)}-${instance}`;
+  }
+
+  /** The name every box of this agent shares, without an instance index. */
+  private podBaseName(agentId: string, prefix = "agentbox"): string {
     const sanitized = agentId.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 50);
-    const base = `${prefix}-${sanitized}`;
-    return instance > 0 ? `${base}-${instance}` : base;
+    return `${prefix}-${sanitized}`;
+  }
+
+  /**
+   * The pod name a box WOULD have. The manager asks rather than deriving it: two copies of
+   * a naming rule are two chances to disagree, and the last time they did, a `stop()`
+   * targeted a name no pod had — it 404'd, was swallowed, and the box ran on forever.
+   */
+  boxIdFor(agentId: string, profile?: string, instance = 0): string {
+    return this.podName(agentId, getBoxProfile(profile).podNamePrefix ?? "agentbox", instance);
+  }
+
+  /**
+   * What instance 0 was called before every instance carried its index.
+   *
+   * Exposed so the manager can recognise such a pod and roll it, rather than leaving it
+   * running under a name nothing looks up any more.
+   */
+  legacyPodName(agentId: string, profile?: string): string {
+    return this.podBaseName(agentId, getBoxProfile(profile).podNamePrefix ?? "agentbox");
   }
 
   /**
@@ -174,7 +201,11 @@ export class K8sSpawner implements BoxSpawner {
    * For a single-box agent this is byte-identical to the previous `${podName}-cert`.
    */
   private certSecretName(agentId: string, prefix = "agentbox"): string {
-    return `${this.podName(agentId, prefix)}-cert`;
+    // Deliberately the BASE name, not instance 0's pod name: this Secret is shared by
+    // every box of the agent, and it already exists under this name in every running
+    // deployment. Deriving it from the pod name would have renamed it the moment
+    // instance 0 gained its index, orphaning the old one and re-issuing every cert.
+    return `${this.podBaseName(agentId, prefix)}-cert`;
   }
 
   /** CA fingerprint stamped on an existing cert Secret, or undefined if unreadable. */
@@ -254,7 +285,8 @@ export class K8sSpawner implements BoxSpawner {
     // old-named pod (+ its cert Secret) first, but only when it is a compile box
     // (boxType "kb-compile*") — never a chat box that merely shares the agentId.
     if (podPrefix !== "agentbox") {
-      await this.reapRenamedLegacyPod(this.podName(agentId, "agentbox"), namespace, labelPrefix);
+      // The pod it is looking for predates instance indices, so it wants the BASE name.
+      await this.reapRenamedLegacyPod(this.legacyPodName(agentId, "agent"), namespace, labelPrefix);
     }
 
     // Stamp the pod + its cert Secret with the CA fingerprint. The runtime uses
@@ -330,7 +362,9 @@ export class K8sSpawner implements BoxSpawner {
     // agent's BASE pod name, not this instance's: it is the identity every box of the
     // agent presents, and the Gateway uses it as the authorization root when a box
     // reports which pod it actually is (see handleMetricsFlush).
-    const certBase = this.podName(agentId, podPrefix);
+    // The AGENT's name, not a pod's: this identity is shared by every box, and the
+    // metrics-flush authorizer accepts `<certBase>-<instance>` from any of them.
+    const certBase = this.podBaseName(agentId, podPrefix);
     const certBundle = this.certManager.issueAgentBoxCertificate(agentId, orgId, certBase);
     const certSecretName = this.certSecretName(agentId, podPrefix);
 
@@ -577,6 +611,29 @@ export class K8sSpawner implements BoxSpawner {
         ...(this.config.nodeSelector && Object.keys(this.config.nodeSelector).length > 0
           ? { nodeSelector: this.config.nodeSelector }
           : {}),
+        // Spread an agent's boxes over nodes. Without this the scheduler packs them, and
+        // a pool that exists to survive one box's loss ends up sharing one node's failure
+        // domain — the node goes, the whole agent goes with it.
+        //
+        // PREFERRED, never required: a small cluster (or one whose nodeSelector admits a
+        // single node) must still be able to place the pods. Spreading is worth a lot and
+        // costs nothing when it succeeds; refusing to schedule would cost everything.
+        affinity: {
+          podAntiAffinity: {
+            preferredDuringSchedulingIgnoredDuringExecution: [{
+              weight: 100,
+              podAffinityTerm: {
+                topologyKey: "kubernetes.io/hostname",
+                labelSelector: {
+                  matchLabels: {
+                    [`${labelPrefix}/app`]: "agentbox",
+                    [`${labelPrefix}/agent`]: agentId,
+                  },
+                },
+              },
+            }],
+          },
+        },
         // ── Security: dual-user isolation (ADR-010) ─────────────────
         // Container starts as root (entrypoint fixes volume permissions,
         // then drops to agentbox via runuser). Child processes run as
@@ -1026,6 +1083,7 @@ export class K8sSpawner implements BoxSpawner {
         boxId,
         agentId,
         status,
+        exitedUnexpectedly: this.exitedUnexpectedly(pod),
         endpoint: podIP ? `https://${podIP}:3000` : "",
         createdAt: pod.metadata?.creationTimestamp
           ? new Date(pod.metadata.creationTimestamp)
@@ -1067,21 +1125,11 @@ export class K8sSpawner implements BoxSpawner {
       namespace,
       labelSelector: `${labelPrefix}/app=agentbox,${labelPrefix}/agent=${agentId}`,
     });
-    return (pods.items ?? []).flatMap((pod: any) => {
-      const boxId = pod.metadata?.name;
-      if (!boxId) return [];
-      const podIP = pod.status?.podIP;
-      return [{
-        boxId,
-        agentId,
-        status: this.mapPodStatus(pod),
-        endpoint: podIP ? `https://${podIP}:3000` : "",
-        createdAt: pod.metadata?.creationTimestamp ? new Date(pod.metadata.creationTimestamp) : new Date(),
-        lastActiveAt: new Date(),
-        caFingerprint: pod.metadata?.labels?.[`${labelPrefix}/ca-fp`],
-        profile: pod.metadata?.labels?.[`${labelPrefix}/boxType`] || "agent",
-        ...this.replicaFields(pod),
-      } satisfies AgentBoxInfo];
+    return (pods.items ?? []).flatMap((pod: k8s.V1Pod) => {
+      if (!pod.metadata?.name) return [];
+      // agentId comes from the label like everywhere else; the selector already scoped
+      // this query to one agent, so the two always agree.
+      return [this.toBoxInfo(pod)];
     });
   }
 
@@ -1104,31 +1152,51 @@ export class K8sSpawner implements BoxSpawner {
       labelSelector: `${labelPrefix}/app=agentbox`,
     });
 
-    return podList.items.map((pod: k8s.V1Pod) => {
-      const agentId = pod.metadata?.labels?.[`${labelPrefix}/agent`] || "";
-      const status = this.mapPodStatus(pod);
-      const podIP = pod.status?.podIP;
-
-      return {
-        boxId: pod.metadata?.name || "",
-        agentId,
-        status,
-        endpoint: podIP ? `https://${podIP}:3000` : "",
-        createdAt: pod.metadata?.creationTimestamp
-          ? new Date(pod.metadata.creationTimestamp)
-          : new Date(),
-        lastActiveAt: new Date(),
-        profile: pod.metadata?.labels?.[`${labelPrefix}/boxType`] || "agent",
-        // Without these, every box reads as instance 0 and the pool-size reconciler's
-        // "drain the highest indices first" ordering silently degrades to list order.
-        ...this.replicaFields(pod),
-      };
-    });
+    return podList.items.map((pod: k8s.V1Pod) => this.toBoxInfo(pod));
   }
 
   /**
    * Map Pod phase to AgentBoxStatus
    */
+  /**
+   * Whether this pod's process ended without being asked to.
+   *
+   * `Failed` is the kubelet's word for "the container exited non-zero and nothing asked
+   * it to" — a crash, an OOM kill, an eviction. A clean exit (idle self-destruct) lands
+   * in `Succeeded`, and a pod being deleted still reports its old phase, so this stays
+   * false for the shutdowns the runtime itself started.
+   */
+  private exitedUnexpectedly(pod: k8s.V1Pod): boolean {
+    if (pod.metadata?.deletionTimestamp) return false;
+    return pod.status?.phase === "Failed";
+  }
+
+  /**
+   * Pod → AgentBoxInfo, for every path that reports a box.
+   *
+   * ONE mapper on purpose. `list()` used to return a lighter projection without the CA
+   * fingerprint or the image, which was harmless while only acquisition judged staleness —
+   * and became a spawn loop the moment the reaper judged it too: a box with no fingerprint
+   * reads as signed by a CA we no longer trust, so every freshly created box was drained
+   * on sight and replaced by another that met the same fate.
+   */
+  private toBoxInfo(pod: k8s.V1Pod): AgentBoxInfo {
+    const { labelPrefix } = this.config;
+    const podIP = pod.status?.podIP;
+    return {
+      boxId: pod.metadata?.name || "",
+      agentId: pod.metadata?.labels?.[`${labelPrefix}/agent`] || "",
+      status: this.mapPodStatus(pod),
+      exitedUnexpectedly: this.exitedUnexpectedly(pod),
+      endpoint: podIP ? `https://${podIP}:3000` : "",
+      createdAt: pod.metadata?.creationTimestamp ? new Date(pod.metadata.creationTimestamp) : new Date(),
+      lastActiveAt: new Date(),
+      caFingerprint: pod.metadata?.labels?.[`${labelPrefix}/ca-fp`],
+      profile: pod.metadata?.labels?.[`${labelPrefix}/boxType`] || "agent",
+      ...this.replicaFields(pod),
+    };
+  }
+
   private mapPodStatus(pod: k8s.V1Pod): AgentBoxStatus {
     // Terminating pods (deletionTimestamp set) may still report
     // phase=Running and Ready=True during the grace period, but their

--- a/src/gateway/agentbox/manager.test.ts
+++ b/src/gateway/agentbox/manager.test.ts
@@ -161,13 +161,13 @@ describe("AgentBoxManager — K8s mode", () => {
   it("returns existing pod info if already running", async () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", {
-      boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+    spawner.getReturns.set("agentbox-agent-a-0", {
+      boxId: "agentbox-agent-a-0", agentId: "agent-a", status: "running",
       endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
     });
 
     const handle = await mgr.getOrCreate("agent-a");
-    expect(handle.boxId).toBe("agentbox-agent-a");
+    expect(handle.boxId).toBe("agentbox-agent-a-0");
     expect(handle.endpoint).toBe("https://10.0.0.1:3000");
     expect(spawner.spawnCalls).toHaveLength(0);
   });
@@ -179,15 +179,15 @@ describe("AgentBoxManager — K8s mode", () => {
     expect(created.created).toBe(true);
 
     // A kb-compile box spawns under the "kbc-box-" prefix, not "agentbox-".
-    spawner.getReturns.set("kbc-box-live-run", {
-      boxId: "kbc-box-live-run", agentId: "live-run", status: "running",
+    spawner.getReturns.set("kbc-box-live-run-0", {
+      boxId: "kbc-box-live-run-0", agentId: "live-run", status: "running",
       endpoint: "https://10.0.0.9:3000", createdAt: new Date(), lastActiveAt: new Date(),
       profile: "kb-compile",
     });
     const adopted = await mgr.getOrCreateWithDisposition("live-run", { profile: "kb-compile" });
     expect(adopted).toMatchObject({
       created: false,
-      handle: { boxId: "kbc-box-live-run", endpoint: "https://10.0.0.9:3000" },
+      handle: { boxId: "kbc-box-live-run-0", endpoint: "https://10.0.0.9:3000" },
     });
   });
 
@@ -202,8 +202,8 @@ describe("AgentBoxManager — K8s mode", () => {
   it("reuses a running pod when the requested profile matches", async () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("kbc-box-run-1", {
-      boxId: "kbc-box-run-1", agentId: "run-1", status: "running",
+    spawner.getReturns.set("kbc-box-run-1-0", {
+      boxId: "kbc-box-run-1-0", agentId: "run-1", status: "running",
       endpoint: "https://10.0.0.9:3000", createdAt: new Date(), lastActiveAt: new Date(),
       profile: "kb-compile",
     });
@@ -218,14 +218,14 @@ describe("AgentBoxManager — K8s mode", () => {
     const mgr = new AgentBoxManager(spawner);
     // A pod is running as kb-compile, but the same id is now requested as
     // kb-compile-codex — a realistic same-prefix ("kbc-box-") profile switch.
-    spawner.getReturns.set("kbc-box-run-1", {
-      boxId: "kbc-box-run-1", agentId: "run-1", status: "running",
+    spawner.getReturns.set("kbc-box-run-1-0", {
+      boxId: "kbc-box-run-1-0", agentId: "run-1", status: "running",
       endpoint: "https://10.0.0.9:3000", createdAt: new Date(), lastActiveAt: new Date(),
       profile: "kb-compile",
     });
     const handle = await mgr.getOrCreate("run-1", { profile: "kb-compile-codex" });
     // Old-shaped pod stopped; a fresh box spawned with the requested profile.
-    expect(spawner.stopCalls).toEqual(["kbc-box-run-1"]);
+    expect(spawner.stopCalls).toEqual(["kbc-box-run-1-0"]);
     expect(spawner.spawnCalls).toHaveLength(1);
     expect(spawner.spawnCalls[0].profile).toBe("kb-compile-codex");
     expect(handle.boxId).toBe("box-run-1");
@@ -236,13 +236,13 @@ describe("AgentBoxManager — K8s mode", () => {
     const mgr = new AgentBoxManager(spawner);
     // Underscores and capitals → lowercase + dash. This is the exact class of
     // input that broke the old design (Lark chat_ids prefixed "oc_").
-    spawner.getReturns.set("agentbox-agent-oc-xyz", {
-      boxId: "agentbox-agent-oc-xyz", agentId: "Agent_OC_XYZ",
+    spawner.getReturns.set("agentbox-agent-oc-xyz-0", {
+      boxId: "agentbox-agent-oc-xyz-0", agentId: "Agent_OC_XYZ",
       status: "running", endpoint: "https://x",
       createdAt: new Date(), lastActiveAt: new Date(),
     });
     const handle = await mgr.getOrCreate("Agent_OC_XYZ");
-    expect(handle.boxId).toBe("agentbox-agent-oc-xyz");
+    expect(handle.boxId).toBe("agentbox-agent-oc-xyz-0");
   });
 
   it("active* / get / stats return empty in K8s mode (stateless)", async () => {
@@ -257,12 +257,12 @@ describe("AgentBoxManager — K8s mode", () => {
   it("getAsync returns a handle when the pod is running", async () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", {
-      boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+    spawner.getReturns.set("agentbox-agent-a-0", {
+      boxId: "agentbox-agent-a-0", agentId: "agent-a", status: "running",
       endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
     });
     const handle = await mgr.getAsync("agent-a");
-    expect(handle?.boxId).toBe("agentbox-agent-a");
+    expect(handle?.boxId).toBe("agentbox-agent-a-0");
   });
 
   it("getAsync returns undefined when the pod is absent", async () => {
@@ -276,26 +276,26 @@ describe("AgentBoxManager — K8s mode", () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
     await mgr.stop("agent-a");
-    expect(spawner.stopCalls).toEqual(["agentbox-agent-a"]);
+    expect(spawner.stopCalls).toEqual(["agentbox-agent-a-0"]);
   });
 
   it("stop(runId, 'kb-compile') targets the kbc-box-prefixed pod (reap must not leak it)", async () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
     await mgr.stop("run-1", "kb-compile");
-    expect(spawner.stopCalls).toEqual(["kbc-box-run-1"]);
+    expect(spawner.stopCalls).toEqual(["kbc-box-run-1-0"]);
   });
 
   it("getAsync(runId, 'kb-compile') finds the kbc-box-prefixed live box (adopt re-attach)", async () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("kbc-box-run-1", {
-      boxId: "kbc-box-run-1", agentId: "run-1", status: "running",
+    spawner.getReturns.set("kbc-box-run-1-0", {
+      boxId: "kbc-box-run-1-0", agentId: "run-1", status: "running",
       endpoint: "https://10.0.0.9:3000", createdAt: new Date(), lastActiveAt: new Date(),
       profile: "kb-compile",
     });
     const handle = await mgr.getAsync("run-1", "kb-compile");
-    expect(handle?.boxId).toBe("kbc-box-run-1");
+    expect(handle?.boxId).toBe("kbc-box-run-1-0");
     // Without the profile it would look under "agentbox-run-1" and miss.
     expect(await mgr.getAsync("run-1")).toBeUndefined();
   });
@@ -314,8 +314,8 @@ describe("AgentBoxManager — persistence anchored at cold spawn (warm reuse ign
   it("K8s: a running pod is reused without re-spawning when persistence flips", async () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", {
-      boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+    spawner.getReturns.set("agentbox-agent-a-0", {
+      boxId: "agentbox-agent-a-0", agentId: "agent-a", status: "running",
       endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
     });
 
@@ -398,8 +398,8 @@ describe("AgentBoxManager — persistence resolved by agentId via resolver", () 
     mgr.setPersistenceResolver(async () => { resolverCalls++; return true; });
 
     // Pod already running → warm reuse, resolver must not fire.
-    spawner.getReturns.set("agentbox-agent-a", {
-      boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+    spawner.getReturns.set("agentbox-agent-a-0", {
+      boxId: "agentbox-agent-a-0", agentId: "agent-a", status: "running",
       endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
     });
     await mgr.getOrCreate("agent-a");
@@ -506,7 +506,7 @@ describe("AgentBoxManager — cleanup", () => {
 
 describe("AgentBoxManager — K8s CA-fingerprint self-heal", () => {
   const runningPod = (caFingerprint?: string): AgentBoxInfo => ({
-    boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+    boxId: "agentbox-agent-a-0", agentId: "agent-a", status: "running",
     endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
     caFingerprint,
   });
@@ -515,7 +515,7 @@ describe("AgentBoxManager — K8s CA-fingerprint self-heal", () => {
     const spawner = new FakeSpawner("k8s");
     spawner.fingerprint = "ca-v2";
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", runningPod("ca-v2"));
+    spawner.getReturns.set("agentbox-agent-a-0", runningPod("ca-v2"));
 
     const handle = await mgr.getOrCreate("agent-a");
     expect(handle.endpoint).toBe("https://10.0.0.1:3000");
@@ -526,7 +526,7 @@ describe("AgentBoxManager — K8s CA-fingerprint self-heal", () => {
     const spawner = new FakeSpawner("k8s");
     spawner.fingerprint = "ca-v2";
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", runningPod("ca-v1-old"));
+    spawner.getReturns.set("agentbox-agent-a-0", runningPod("ca-v1-old"));
 
     await mgr.getOrCreate("agent-a");
     expect(spawner.spawnCalls).toHaveLength(1); // stale → respawn with current CA
@@ -536,7 +536,7 @@ describe("AgentBoxManager — K8s CA-fingerprint self-heal", () => {
     const spawner = new FakeSpawner("k8s");
     spawner.fingerprint = "ca-v2";
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", runningPod(undefined));
+    spawner.getReturns.set("agentbox-agent-a-0", runningPod(undefined));
 
     await mgr.getOrCreate("agent-a");
     expect(spawner.spawnCalls).toHaveLength(1);
@@ -546,7 +546,7 @@ describe("AgentBoxManager — K8s CA-fingerprint self-heal", () => {
     const spawner = new FakeSpawner("k8s");
     spawner.fingerprint = undefined; // spawner can't report a CA → nothing to validate
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", runningPod("whatever"));
+    spawner.getReturns.set("agentbox-agent-a-0", runningPod("whatever"));
 
     const handle = await mgr.getOrCreate("agent-a");
     expect(handle.endpoint).toBe("https://10.0.0.1:3000");
@@ -558,8 +558,8 @@ describe("AgentBoxManager — injected spawnEnvResolver", () => {
   it("does NOT call the resolver when a running pod is reused (warm path → no RPC)", async () => {
     const spawner = new FakeSpawner("k8s");
     const mgr = new AgentBoxManager(spawner);
-    spawner.getReturns.set("agentbox-agent-a", {
-      boxId: "agentbox-agent-a", agentId: "agent-a", status: "running",
+    spawner.getReturns.set("agentbox-agent-a-0", {
+      boxId: "agentbox-agent-a-0", agentId: "agent-a", status: "running",
       endpoint: "https://10.0.0.1:3000", createdAt: new Date(), lastActiveAt: new Date(),
     });
     let calls = 0;
@@ -620,9 +620,7 @@ class PoolSpawner extends FakeSpawner {
   expectedImage(_profile?: string): string { return this.image; }
   async spawn(config: AgentBoxConfig): Promise<AgentBoxHandle> {
     this.spawnCalls.push(config);
-    const boxId = (config.instance ?? 0) > 0
-      ? `agentbox-${config.agentId}-${config.instance}`
-      : `agentbox-${config.agentId}`;
+    const boxId = `agentbox-${config.agentId}-${config.instance ?? 0}`;
     return { boxId, endpoint: `http://10.0.0.${(config.instance ?? 0) + 1}:3000`, agentId: config.agentId };
   }
 }
@@ -650,7 +648,7 @@ describe("AgentBoxManager — pooled agents", () => {
     // The property everything else serves: a session being served never changes box, because
     // its background jobs' abort handles are in-memory closures that cannot follow it.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = pooledManager(spawner, 2);
 
     const first = await mgr.getOrCreate("agent-a", undefined, "s1");
@@ -662,7 +660,7 @@ describe("AgentBoxManager — pooled agents", () => {
 
   it("spreads different sessions across the pool", async () => {
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = pooledManager(spawner, 2);
     const a = await mgr.getOrCreate("agent-a", undefined, "s1");
     const b = await mgr.getOrCreate("agent-a", undefined, "s2");
@@ -673,7 +671,7 @@ describe("AgentBoxManager — pooled agents", () => {
     // A fresh manager has an empty binding table while sessions are still live in boxes.
     // Placing one fresh would send a running conversation to a box holding none of its state.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = pooledManager(spawner, 2, {
       one: { endpoint: "http://10.0.0.1:3000", sessionIds: [], turnsInFlight: 0, drained: true },
       two: { endpoint: "http://10.0.0.2:3000", sessionIds: ["s-live"], turnsInFlight: 1, drained: false },
@@ -685,7 +683,7 @@ describe("AgentBoxManager — pooled agents", () => {
     // Pod reuse never compared the image, which is why a new AgentBox image only took effect
     // when someone deleted pods by hand — and that delete was a hard kill.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0, { image: "agentbox:v1" }), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0, { image: "agentbox:v1" }), poolBox("agentbox-agent-a-1", 1)];
     const mgr = pooledManager(spawner, 2);
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s1");
@@ -783,7 +781,7 @@ describe("AgentBoxManager — regressions found in review", () => {
     // produced a spawn for the identical name, which the spawner then either reused (the
     // drain never rolls) or — on a CA-triggered drain — DELETED outright, mid-conversation.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0, { image: "agentbox:v1" }), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0, { image: "agentbox:v1" }), poolBox("agentbox-agent-a-1", 1)];
     const mgr = pooledManager(spawner, 2);
 
     await mgr.getOrCreate("agent-a", undefined, "s1");
@@ -798,7 +796,7 @@ describe("AgentBoxManager — regressions found in review", () => {
     // Failing to answer is what a wedged box does. Scoring it 0 in-flight made
     // least-loaded placement steer every new session straight onto it.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     mgr.setBoxStatusProbe(async (endpoint) => {
@@ -816,7 +814,7 @@ describe("AgentBoxManager — regressions found in review", () => {
     // ever looks up instance 0 by name. The extras are resident, so nothing else stops them.
     const spawner = new PoolSpawner("k8s");
     spawner.listReturns = [
-      poolBox("agentbox-agent-a", 0),
+      poolBox("agentbox-agent-a-0", 0),
       poolBox("agentbox-agent-a-1", 1),
       poolBox("agentbox-agent-a-2", 2),
     ];
@@ -831,7 +829,7 @@ describe("AgentBoxManager — regressions found in review", () => {
 
   it("leaves a correctly-sized pool alone", async () => {
     const spawner = new PoolSpawner("k8s");
-    spawner.listReturns = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.listReturns = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     await (mgr as any).reconcilePoolSizes();
@@ -845,9 +843,9 @@ describe("AgentBoxManager — a single-box agent still rolls onto a new image", 
     // under continuous traffic never idles out — so before this, a Runtime rollout left
     // every default agent (replicas=1) on the old AgentBox image indefinitely.
     const spawner = new PoolSpawner("k8s");
-    const stale = poolBox("agentbox-agent-a", 0, { image: "agentbox:v1" });
+    const stale = poolBox("agentbox-agent-a-0", 0, { image: "agentbox:v1" });
     spawner.pool = [stale];
-    spawner.getReturns.set("agentbox-agent-a", stale);
+    spawner.getReturns.set("agentbox-agent-a-0", stale);
     const mgr = pooledManager(spawner, 1);
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s1");
@@ -862,13 +860,13 @@ describe("AgentBoxManager — a single-box agent still rolls onto a new image", 
 
   it("leaves a current-image box alone on the fast path", async () => {
     const spawner = new PoolSpawner("k8s");
-    const fresh = poolBox("agentbox-agent-a", 0); // image === spawner.image
+    const fresh = poolBox("agentbox-agent-a-0", 0); // image === spawner.image
     spawner.pool = [fresh];
-    spawner.getReturns.set("agentbox-agent-a", fresh);
+    spawner.getReturns.set("agentbox-agent-a-0", fresh);
     const mgr = pooledManager(spawner, 1);
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s1");
-    expect(handle.boxId).toBe("agentbox-agent-a");
+    expect(handle.boxId).toBe("agentbox-agent-a-0");
     expect(spawner.spawnCalls).toHaveLength(0);
     expect(spawner.stopCalls).toHaveLength(0);
   });
@@ -877,13 +875,13 @@ describe("AgentBoxManager — a single-box agent still rolls onto a new image", 
     // A legacy pod may not report an image at all. Guessing stale would respawn on
     // every single acquisition.
     const spawner = new PoolSpawner("k8s");
-    const unlabelled = poolBox("agentbox-agent-a", 0, { image: undefined });
+    const unlabelled = poolBox("agentbox-agent-a-0", 0, { image: undefined });
     spawner.pool = [unlabelled];
-    spawner.getReturns.set("agentbox-agent-a", unlabelled);
+    spawner.getReturns.set("agentbox-agent-a-0", unlabelled);
     const mgr = pooledManager(spawner, 1);
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s1");
-    expect(handle.boxId).toBe("agentbox-agent-a");
+    expect(handle.boxId).toBe("agentbox-agent-a-0");
     expect(spawner.spawnCalls).toHaveLength(0);
   });
 });
@@ -894,24 +892,24 @@ describe("AgentBoxManager — PR review regressions", () => {
     // the session to the replacement would send its next Stop/Steer/send to a box holding
     // none of its state — the exact loss affinity exists to prevent.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0, { image: "agentbox:v1" })];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0, { image: "agentbox:v1" })];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 1);
     mgr.setBoxStatusProbe(async () => ({ sessionIds: ["s-live"], turnsInFlight: 1, drained: false }));
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s-live");
-    expect(handle.boxId).toBe("agentbox-agent-a"); // stays on the box actually running it
+    expect(handle.boxId).toBe("agentbox-agent-a-0"); // stays on the box actually running it
   });
 
   it("moves a released session off a draining box", async () => {
     const spawner = new PoolSpawner("k8s");
-    const stale = poolBox("agentbox-agent-a", 0, { image: "agentbox:v1" });
+    const stale = poolBox("agentbox-agent-a-0", 0, { image: "agentbox:v1" });
     spawner.pool = [stale, poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     // No box reports holding it → free.
     mgr.setBoxStatusProbe(async () => ({ sessionIds: [], turnsInFlight: 0, drained: true }));
-    (mgr as any).bindings.remember("agent-a", "s-released", "agentbox-agent-a");
+    (mgr as any).bindings.remember("agent-a", "s-released", "agentbox-agent-a-0");
     (mgr as any).draining.set("agentbox-agent-a", Date.now());
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s-released");
@@ -922,7 +920,7 @@ describe("AgentBoxManager — PR review regressions", () => {
     // Background sub-agents keep a session resident after its turn returned, so the box
     // is still appending to the transcript and the next turn has to go there.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     mgr.setBoxStatusProbe(async (endpoint) => endpoint === "http://10.0.0.1:3000"
@@ -930,14 +928,14 @@ describe("AgentBoxManager — PR review regressions", () => {
       : { sessionIds: [], turnsInFlight: 0, drained: true });
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s-busy");
-    expect(handle.boxId).toBe("agentbox-agent-a");
+    expect(handle.boxId).toBe("agentbox-agent-a-0");
   });
 
   it("finds a session's box without deriving instance 0", async () => {
     // Review #3. A session pinned to instance 1 must not read as not-running.
     const spawner = new PoolSpawner("k8s");
     const one = poolBox("agentbox-agent-a-1", 1);
-    spawner.pool = [poolBox("agentbox-agent-a", 0), one];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), one];
     spawner.getReturns.set("agentbox-agent-a-1", one);
     const mgr = new AgentBoxManager(spawner);
     (mgr as any).bindings.remember("agent-a", "s1", "agentbox-agent-a-1");
@@ -968,9 +966,9 @@ describe("AgentBoxManager — the replica count is cached", () => {
     // This runs once per turn from every entry point. Against an upstream control plane
     // that is a network round trip on the hot path of every conversation.
     const spawner = new PoolSpawner("k8s");
-    const box = poolBox("agentbox-agent-a", 0);
+    const box = poolBox("agentbox-agent-a-0", 0);
     spawner.pool = [box];
-    spawner.getReturns.set("agentbox-agent-a", box);
+    spawner.getReturns.set("agentbox-agent-a-0", box);
     let lookups = 0;
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => { lookups++; return 1; });
@@ -982,9 +980,9 @@ describe("AgentBoxManager — the replica count is cached", () => {
   it("retries a failed lookup instead of remembering the fallback", async () => {
     // A blip must not pin the agent at one box for the whole TTL.
     const spawner = new PoolSpawner("k8s");
-    const box = poolBox("agentbox-agent-a", 0);
+    const box = poolBox("agentbox-agent-a-0", 0);
     spawner.pool = [box];
-    spawner.getReturns.set("agentbox-agent-a", box);
+    spawner.getReturns.set("agentbox-agent-a-0", box);
     let lookups = 0;
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => { lookups++; throw new Error("control plane down"); });
@@ -1001,23 +999,23 @@ describe("AgentBoxManager — silence is not emptiness", () => {
     // them is silent. Reading silence as "holds nothing" hands the session to a second box
     // while the first may still be writing its transcript.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     mgr.setBoxStatusProbe(async (endpoint) => {
       if (endpoint === "http://10.0.0.1:3000") throw new Error("404 — old image, no such endpoint");
       return { sessionIds: [], turnsInFlight: 0, drained: true };
     });
-    (mgr as any).bindings.remember("agent-a", "s1", "agentbox-agent-a");
+    (mgr as any).bindings.remember("agent-a", "s1", "agentbox-agent-a-0");
 
     const handle = await mgr.getOrCreate("agent-a", undefined, "s1");
-    expect(handle.boxId).toBe("agentbox-agent-a");
+    expect(handle.boxId).toBe("agentbox-agent-a-0");
   });
 
   it("still places a session that never ran anywhere", async () => {
     // No last box means nothing to protect — silence must not block a first placement.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     mgr.setBoxStatusProbe(async () => { throw new Error("everything silent"); });
@@ -1032,7 +1030,7 @@ describe("AgentBoxManager — asking a box that predates box-status", () => {
     // Every box is one of these during the rollout that introduces box-status. The older
     // endpoint still says WHICH sessions it holds, which is the part placement needs.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     mgr.setBoxStatusProbe(async () => { throw new Error("404 — old image"); });
@@ -1048,7 +1046,7 @@ describe("AgentBoxManager — asking a box that predates box-status", () => {
     // Silence protects a session from being split — but a box that is silent because it is
     // wedged would otherwise keep every session it ever ran, failing every turn.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setReplicasResolver(async () => 2);
     mgr.setBoxStatusProbe(async (endpoint) => {
@@ -1056,11 +1054,11 @@ describe("AgentBoxManager — asking a box that predates box-status", () => {
       return { sessionIds: [], turnsInFlight: 0, drained: true };
     });
     mgr.setLegacySessionLister(async () => { throw new Error("wedged too"); });
-    (mgr as any).bindings.remember("agent-a", "s1", "agentbox-agent-a");
+    (mgr as any).bindings.remember("agent-a", "s1", "agentbox-agent-a-0");
 
     // The first few turns hold it there — the box may just be slow.
-    expect((await mgr.getOrCreate("agent-a", undefined, "s1")).boxId).toBe("agentbox-agent-a");
-    expect((await mgr.getOrCreate("agent-a", undefined, "s1")).boxId).toBe("agentbox-agent-a");
+    expect((await mgr.getOrCreate("agent-a", undefined, "s1")).boxId).toBe("agentbox-agent-a-0");
+    expect((await mgr.getOrCreate("agent-a", undefined, "s1")).boxId).toBe("agentbox-agent-a-0");
     // After the limit it is treated as gone and the session moves on.
     const handle = await mgr.getOrCreate("agent-a", undefined, "s1");
     expect(handle.boxId).toBe("agentbox-agent-a-1");
@@ -1070,7 +1068,7 @@ describe("AgentBoxManager — asking a box that predates box-status", () => {
 describe("AgentBoxManager — who is holding this session", () => {
   it("names the box that reports holding it", async () => {
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setBoxStatusProbe(async (endpoint) => endpoint === "http://10.0.0.2:3000"
       ? { sessionIds: ["s1"], turnsInFlight: 1, drained: false }
@@ -1084,7 +1082,7 @@ describe("AgentBoxManager — who is holding this session", () => {
     // a 404 the user did not cause — and a frontend that resends the text as a new prompt,
     // so the message gets answered twice.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setBoxStatusProbe(async () => ({ sessionIds: [], turnsInFlight: 0, drained: true }));
 
@@ -1094,15 +1092,15 @@ describe("AgentBoxManager — who is holding this session", () => {
   it("keeps trusting a box that cannot be asked", async () => {
     // Same rule placement uses: silence is not evidence the session moved.
     const spawner = new PoolSpawner("k8s");
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = new AgentBoxManager(spawner);
     mgr.setBoxStatusProbe(async (endpoint) => {
       if (endpoint === "http://10.0.0.1:3000") throw new Error("silent");
       return { sessionIds: [], turnsInFlight: 0, drained: true };
     });
-    (mgr as any).bindings.remember("agent-a", "s1", "agentbox-agent-a");
+    (mgr as any).bindings.remember("agent-a", "s1", "agentbox-agent-a-0");
 
-    expect((await mgr.getHolder("agent-a", "s1"))?.boxId).toBe("agentbox-agent-a");
+    expect((await mgr.getHolder("agent-a", "s1"))?.boxId).toBe("agentbox-agent-a-0");
   });
 
   it("answers nothing when the agent has no boxes at all", async () => {
@@ -1120,7 +1118,7 @@ describe("AgentBoxManager — pooling without shared session storage", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const spawner = new PoolSpawner("k8s") as PoolSpawner & { hasSharedSessionStorage(): boolean };
     spawner.hasSharedSessionStorage = () => false;
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = pooledManager(spawner, 2);
 
     await mgr.getOrCreate("agent-a", undefined, "s1");
@@ -1134,11 +1132,152 @@ describe("AgentBoxManager — pooling without shared session storage", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const spawner = new PoolSpawner("k8s") as PoolSpawner & { hasSharedSessionStorage(): boolean };
     spawner.hasSharedSessionStorage = () => true;
-    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), poolBox("agentbox-agent-a-1", 1)];
     const mgr = pooledManager(spawner, 2);
 
     await mgr.getOrCreate("agent-a", undefined, "s1");
     expect(warn.mock.calls.filter((c) => /NOT on shared/.test(String(c[0])))).toHaveLength(0);
+  });
+});
+
+describe("AgentBoxManager — a box that died without being asked to", () => {
+  const crashed = (boxId: string, instance: number) =>
+    poolBox(boxId, instance, { status: "stopped", exitedUnexpectedly: true });
+  const retired = (boxId: string, instance: number) =>
+    poolBox(boxId, instance, { status: "stopped", exitedUnexpectedly: false });
+
+  it("collects the corpse and puts the box back", async () => {
+    // A pool exists so that losing one box costs capacity, not service. Waiting for the
+    // next request to notice means the pool runs short for as long as the agent is quiet.
+    const spawner = new PoolSpawner("k8s");
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), crashed("agentbox-agent-a-1", 1)];
+    spawner.listReturns = spawner.pool;
+    const mgr = pooledManager(spawner, 2);
+
+    await (mgr as any).reconcilePoolSizes();
+    await new Promise((r) => setTimeout(r, 10)); // the replacement spawns in the background
+
+    expect(spawner.stopCalls).toContain("agentbox-agent-a-1");
+    expect(spawner.spawnCalls.map((c) => c.instance)).toEqual([1]);
+  });
+
+  it("does not replace a box that exited cleanly", async () => {
+    // The idle self-destruct is a feature. Replacing its work spawns a pod that idles out
+    // and is spawned again, forever, for an agent nobody is using.
+    const spawner = new PoolSpawner("k8s");
+    spawner.pool = [poolBox("agentbox-agent-a-0", 0), retired("agentbox-agent-a-1", 1)];
+    spawner.listReturns = spawner.pool;
+    const mgr = pooledManager(spawner, 2);
+
+    await (mgr as any).reconcilePoolSizes();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(spawner.stopCalls).toContain("agentbox-agent-a-1"); // corpse still collected
+    expect(spawner.spawnCalls).toHaveLength(0);                // but not replaced
+  });
+
+  it("stops replacing a box that keeps dying", async () => {
+    // An OOM on a prompt that rebuilds the same context kills the replacement too. The
+    // pool stays short rather than looping against the K8s API.
+    const spawner = new PoolSpawner("k8s");
+    const mgr = pooledManager(spawner, 2);
+    let allowed = 0;
+    for (let i = 0; i < 6; i++) if ((mgr as any).mayRespawn("agent-a#1")) allowed++;
+    expect(allowed).toBe(1); // the cooldown holds the rest back
+  });
+});
+
+describe("AgentBoxManager — a deploy rolls one box at a time", () => {
+  it("drains one stale box, not the whole pool", async () => {
+    // Marking every stale box at once leaves ZERO boxes able to take a new session, so a
+    // deploy turns every conversation started during it into a cold start.
+    const spawner = new PoolSpawner("k8s");
+    spawner.image = "agentbox:v3";
+    spawner.pool = [
+      poolBox("agentbox-agent-a-0", 0, { image: "agentbox:v2" }),
+      poolBox("agentbox-agent-a-1", 1, { image: "agentbox:v2" }),
+      poolBox("agentbox-agent-a-2", 2, { image: "agentbox:v2" }),
+    ];
+    const mgr = pooledManager(spawner, 3);
+
+    (mgr as any).markStaleBoxesDraining("agent-a", spawner.pool, "agent");
+    expect((mgr as any).draining.size).toBe(1);
+  });
+
+  it("moves on to the next box once the previous one is gone", async () => {
+    const spawner = new PoolSpawner("k8s");
+    spawner.image = "agentbox:v3";
+    spawner.pool = [
+      poolBox("agentbox-agent-a-1", 1, { image: "agentbox:v2" }),
+      poolBox("agentbox-agent-a-2", 2, { image: "agentbox:v2" }),
+    ];
+    const mgr = pooledManager(spawner, 2);
+
+    (mgr as any).markStaleBoxesDraining("agent-a", spawner.pool, "agent");
+    const first = [...(mgr as any).draining.keys()][0];
+    (mgr as any).draining.delete(first);                       // it finished draining and was removed
+    spawner.pool = spawner.pool.filter((b) => b.boxId !== first);
+    (mgr as any).markStaleBoxesDraining("agent-a", spawner.pool, "agent");
+    expect([...(mgr as any).draining.keys()]).toHaveLength(1);
+    expect([...(mgr as any).draining.keys()][0]).not.toBe(first);
+  });
+
+  it("does not make a box that cannot be talked to wait its turn", async () => {
+    // A stale CA means the runtime cannot reach the box at all. Keeping it in the pool
+    // for the sake of an orderly roll serves nobody.
+    const spawner = new PoolSpawner("k8s");
+    spawner.fingerprint = "current";
+    spawner.pool = [
+      poolBox("agentbox-agent-a-0", 0, { caFingerprint: "old" }),
+      poolBox("agentbox-agent-a-1", 1, { caFingerprint: "old" }),
+    ];
+    const mgr = pooledManager(spawner, 2);
+
+    (mgr as any).markStaleBoxesDraining("agent-a", spawner.pool, "agent");
+    expect((mgr as any).draining.size).toBe(2); // both, immediately
+  });
+
+  it("rolls a pod still named the way instance 0 used to be", async () => {
+    // It works, its image is current — but nothing looks that name up any more, so it
+    // would serve whatever it holds and never be counted, replaced or drained.
+    const spawner = new PoolSpawner("k8s") as PoolSpawner & { legacyPodName(a: string, p?: string): string };
+    spawner.legacyPodName = (agentId: string) => `agentbox-${agentId}`;
+    spawner.pool = [poolBox("agentbox-agent-a", 0), poolBox("agentbox-agent-a-1", 1)];
+    const mgr = pooledManager(spawner, 2);
+
+    (mgr as any).markStaleBoxesDraining("agent-a", spawner.pool, "agent");
+    expect([...(mgr as any).draining.keys()]).toEqual(["agentbox-agent-a"]);
+  });
+});
+
+describe("AgentBoxManager — a wrong staleness judgement must not spin", () => {
+  it("stops draining after a budget of replacements in one window", async () => {
+    // Observed in a cluster: the reaper judged staleness from a projection that carried no
+    // CA fingerprint, so every freshly created box read as signed by a CA we no longer
+    // trust — drained on sight, replaced, judged the same way. Pods churned until someone
+    // read the logs. The data bug is fixed; this is the fuse under it.
+    const spawner = new PoolSpawner("k8s");
+    spawner.fingerprint = "current";
+    const mgr = pooledManager(spawner, 1);
+
+    let drained = 0;
+    for (let i = 0; i < 20; i++) {
+      const box = poolBox(`agentbox-agent-a-${i}`, i, { caFingerprint: "wrong" });
+      (mgr as any).markStaleBoxesDraining("agent-a", [box], "agent");
+      if ((mgr as any).draining.has(box.boxId)) drained++;
+    }
+    expect(drained).toBe(8);       // the budget, not 20
+  });
+
+  it("keeps the budget per agent", async () => {
+    const spawner = new PoolSpawner("k8s");
+    spawner.fingerprint = "current";
+    const mgr = pooledManager(spawner, 1);
+    for (let i = 0; i < 20; i++) {
+      (mgr as any).markStaleBoxesDraining("agent-a", [poolBox(`a-${i}`, i, { caFingerprint: "wrong" })], "agent");
+    }
+    (mgr as any).markStaleBoxesDraining("agent-b", [poolBox("b-0", 0, { caFingerprint: "wrong" })], "agent");
+    expect((mgr as any).draining.has("b-0")).toBe(true);  // a different agent is unaffected
   });
 });
 

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -31,6 +31,34 @@ const BOX_STATUS_TTL_MS = 2_000;
 /** How long a draining box may keep work before it is removed anyway. */
 const DRAIN_DEADLINE_MS = 5 * 60_000;
 
+/**
+ * How long before a box that crashed is replaced again.
+ *
+ * A box killed by the thing that will kill its replacement — an OOM on a prompt that
+ * rebuilds the same context — would otherwise be respawned every reaper tick, turning one
+ * bad session into a loop against the K8s API. Long enough that the loop is slow, short
+ * enough that a one-off crash costs a fraction of a minute of capacity.
+ */
+const CRASH_RESPAWN_COOLDOWN_MS = 2 * 60_000;
+
+/**
+ * Drains one agent may start inside {@link DRAIN_BUDGET_WINDOW_MS} before the runtime
+ * stops and says so.
+ *
+ * Not a policy — a fuse. Every reason to drain a box is followed by creating another, so
+ * a judgement that is wrong about a FRESH box (it reads as stale, so it is replaced, and
+ * the replacement reads the same way) spins until someone notices. A whole pool rolling,
+ * or a CA rotation touching every box at once, stays well under this.
+ */
+const DRAIN_BUDGET = 8;
+const DRAIN_BUDGET_WINDOW_MS = 10 * 60_000;
+
+/** How long a slot must go without crashing before its history is forgotten. */
+const CRASH_RESPAWN_FORGET_MS = 60 * 60_000;
+
+/** Crashes of one instance before the runtime stops replacing it and says so. */
+const CRASH_RESPAWN_LIMIT = 3;
+
 /** How often drained boxes are collected. */
 const DRAIN_REAP_INTERVAL_MS = 10_000;
 
@@ -103,6 +131,10 @@ export class AgentBoxManager {
   private replicasCache = new Map<string, { at: number; value: number }>();
   /** Consecutive failed status probes per box — see UNRESPONSIVE_PROBE_LIMIT. */
   private probeFailures = new Map<string, number>();
+  /** Crashes per box, so a box that keeps dying is not respawned forever. */
+  private crashRespawns = new Map<string, { count: number; at: number }>();
+  /** Recent drains per agent, so a wrong staleness judgement cannot spin forever. */
+  private drainBudget = new Map<string, { count: number; since: number }>();
   /** Agents already warned about pooling without shared session storage. */
   private unsharedWarned = new Set<string>();
   private legacySessionLister?: (endpoint: string) => Promise<string[]>;
@@ -253,9 +285,21 @@ export class AgentBoxManager {
    * always was.
    */
   private podName(agentId: string, prefix = "agentbox", instance = 0): string {
+    // ASK the spawner when it can answer. Keeping a second copy of the rule here is what
+    // let the two drift when instance 0 gained its index: stop() aimed at a name no pod
+    // had, the 404 was swallowed, and the box ran on. A spawner without the method (Local,
+    // Process) does not name pods at all, so the local rule is only a fallback.
+    const spawner = this.spawner as { boxIdFor?(agentId: string, profile?: string, instance?: number): string };
+    if (typeof spawner.boxIdFor === "function") {
+      return spawner.boxIdFor(agentId, this.profileForPrefix(prefix), instance);
+    }
     const sanitized = agentId.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 50);
-    const base = `${prefix}-${sanitized}`;
-    return instance > 0 ? `${base}-${instance}` : base;
+    return `${prefix}-${sanitized}-${instance}`;
+  }
+
+  /** The profile that spawns under this pod-name prefix — the inverse of prefixForProfile. */
+  private profileForPrefix(prefix: string): string | undefined {
+    return prefix === "agentbox" ? "agent" : prefix;
   }
 
   /** Pod-name prefix a profile spawns under (see K8sSpawner / BoxProfile.podNamePrefix). */
@@ -640,17 +684,85 @@ export class AgentBoxManager {
    * comparisons, so there is nothing to persist and nothing to go stale.
    */
   private markStaleBoxesDraining(agentId: string, pool: AgentBoxInfo[], wantProfile: string): void {
+    // Whether a replacement is still in flight. A roll replaces ONE box at a time, and
+    // "in flight" has to include the box that is still COMING UP: advancing as soon as the
+    // previous corpse is gone means a replacement that never becomes ready (an image that
+    // cannot be pulled) never blocks anything, and the roll walks the whole pool into the
+    // ground one box at a time.
+    let rolling = pool.some((b) => this.draining.has(b.boxId) || b.status === "starting");
+
     for (const box of pool) {
       if (box.status !== "running" || this.draining.has(box.boxId)) continue;
-      const reason =
+      // A box that cannot be talked to (its cert is signed by a CA we no longer trust) or
+      // is the wrong shape entirely is not a candidate for an orderly roll — keeping it in
+      // the pool serves nobody, so it goes immediately regardless of what else is draining.
+      const urgent =
         !this.isCertFresh(box) ? "stale CA"
         : (box.profile ?? "agent") !== wantProfile ? `profile ${box.profile} != ${wantProfile}`
-        : this.isStaleImage(box, wantProfile) ? `image ${box.image} != ${(this.spawner as any).expectedImage(wantProfile)}`
         : null;
-      if (!reason) continue;
-      console.log(`[agentbox-manager] Draining ${box.boxId} (agent=${agentId}): ${reason}`);
+      // A new image, or a pod still named the way instance 0 was named before every
+      // instance carried its index. Both are working boxes: replace them one at a time so
+      // the pool never drops to zero boxes able to take a new session.
+      const rollable = urgent
+        ? null
+        : this.isStaleImage(box, wantProfile) ? `image ${box.image} != ${(this.spawner as any).expectedImage(wantProfile)}`
+        : this.isLegacyName(agentId, box, wantProfile) ? "pod name predates instance indices"
+        : null;
+
+      if (!urgent && !rollable) continue;
+      if (rollable) {
+        if (rolling) continue;   // one at a time
+        rolling = true;
+      }
+      if (!this.spendDrainBudget(agentId)) continue;
+      console.log(`[agentbox-manager] Draining ${box.boxId} (agent=${agentId}): ${urgent ?? rollable}`);
       this.draining.set(box.boxId, Date.now());
     }
+  }
+
+  /**
+   * Whether this agent may start another drain yet.
+   *
+   * Draining is always followed by creating, so a staleness judgement that is wrong about
+   * a FRESH box replaces it with one that will be judged the same way — a loop that ends
+   * only when someone reads the logs. This bounds it: past the budget the runtime stops
+   * draining and says so, leaving the pool as it is, which is far cheaper than churning
+   * pods against the API for hours.
+   */
+  private spendDrainBudget(agentId: string): boolean {
+    const now = Date.now();
+    const seen = this.drainBudget.get(agentId);
+    if (!seen || now - seen.since > DRAIN_BUDGET_WINDOW_MS) {
+      this.drainBudget.set(agentId, { count: 1, since: now });
+      return true;
+    }
+    if (seen.count >= DRAIN_BUDGET) {
+      if (seen.count === DRAIN_BUDGET) {
+        seen.count++; // say it once
+        console.error(
+          `[agentbox-manager] agent=${agentId} has drained ${DRAIN_BUDGET} boxes in ` +
+          `${Math.round(DRAIN_BUDGET_WINDOW_MS / 60_000)} minutes — that is a loop, not a deploy. ` +
+          `Leaving the pool alone; something is judging healthy boxes stale.`,
+        );
+      }
+      return false;
+    }
+    seen.count++;
+    return true;
+  }
+
+  /**
+   * Whether this pod still carries the name instance 0 had before every instance carried
+   * its index.
+   *
+   * Such a pod works, and its cert and image may both be current — but nothing looks up
+   * that name any more, so it would keep serving whatever it already holds and never be
+   * counted, replaced or drained. Rolling it turns the rename into an ordinary deploy.
+   */
+  private isLegacyName(agentId: string, box: AgentBoxInfo, wantProfile: string): boolean {
+    const spawner = this.spawner as { legacyPodName?(agentId: string, profile?: string): string };
+    if (typeof spawner.legacyPodName !== "function") return false;
+    return box.boxId === spawner.legacyPodName(agentId, wantProfile);
   }
 
   /**
@@ -697,6 +809,14 @@ export class AgentBoxManager {
     agentId: string,
     config: Partial<AgentBoxConfig> | undefined,
     instances: number[],
+    /**
+     * Whether these boxes belong to a POOL. Only a pooled box is forced resident: the
+     * agent's own idle window would otherwise let one box of the pool disappear while its
+     * siblings stay, which the pool cannot express. A single-box agent keeps the window it
+     * was configured with — the reaper replaces such a box too, and forcing residency
+     * there would quietly turn every agent in the cluster into a permanent pod.
+     */
+    pooled = true,
   ): Promise<AgentBoxHandle[]> {
     const resolvedEnv = await this.resolveEnv(agentId, config?.env);
     const persistence = await this.resolvePersistence(agentId, config?.persistence);
@@ -713,7 +833,7 @@ export class AgentBoxManager {
             // shrink itself the moment traffic dipped and pay a cold start on the next
             // turn — the opposite of why replicas were raised. Reuses the existing
             // non-positive-window contract rather than adding a second mechanism.
-            SICLAW_AGENTBOX_IDLE_TIMEOUT: "0",
+            ...(pooled ? { SICLAW_AGENTBOX_IDLE_TIMEOUT: "0" } : {}),
           },
         });
         handle.agentId = agentId;
@@ -795,6 +915,124 @@ export class AgentBoxManager {
    * Victims are the highest instance indices: the least disruptive order available without
    * asking every box what it holds, since index 0 is the oldest and likeliest to be busy.
    */
+  /**
+   * Collect boxes whose process has ended, and put back the ones that did not choose to.
+   *
+   * A pool exists so that losing one box costs capacity rather than service. Until now
+   * losing one cost capacity until the next request happened to arrive — the reaper only
+   * ever shrank a pool, so a crashed box sat as a corpse and the pool ran short, silently,
+   * for as long as the agent was quiet.
+   *
+   * Only an UNASKED-FOR exit is replaced. A box that exits cleanly is doing what it was
+   * told — the idle self-destruct is a feature, and replacing its work would spawn a pod
+   * that idles out and is spawned again, forever, for an agent nobody is using.
+   *
+   * The corpse is deleted either way: a terminal pod holds its name, and a reader looking
+   * at the namespace should not have to work out which failures are still meaningful.
+   */
+  /**
+   * Put back what a roll took away, without waiting for a request to notice.
+   *
+   * Only while a roll is actually in progress — a box of this agent is draining. Outside
+   * that, a pool below its replica count is either an agent nobody is using (its boxes
+   * idled out, and spawning them again would undo that) or a crash, which is handled
+   * where crashes are handled.
+   */
+  private async advanceRoll(agentId: string, pool: AgentBoxInfo[]): Promise<void> {
+    if (!pool.some((b) => this.draining.has(b.boxId))) return;
+    const replicas = await this.resolveReplicas(agentId);
+    const accepting = pool.filter((b) => b.status !== "stopped" && !this.draining.has(b.boxId));
+    if (accepting.length >= replicas) return;
+    const missing = this.missingInstances(pool, replicas, agentId)
+      // A slot that just crashed is under the same cooldown here as it is in the crash
+      // path; without this the roll happily respawns what crash healing declined to.
+      .filter((instance) => this.respawnCooledDown(`${agentId}#${instance}`));
+    if (missing.length === 0) return;
+    console.log(`[agentbox-manager] agent=${agentId} roll in progress; bringing instance(s) ${missing.join(",")} back`);
+    void this.spawnInstances(agentId, undefined, missing, replicas > 1).catch((err) =>
+      console.warn(`[agentbox-manager] roll replacement failed for agent=${agentId}:`, err));
+  }
+
+  /** Whether this slot is outside its crash cooldown — a read, unlike {@link mayRespawn}. */
+  private respawnCooledDown(key: string): boolean {
+    const seen = this.crashRespawns.get(key);
+    if (!seen) return true;
+    if (seen.count >= CRASH_RESPAWN_LIMIT) return false;
+    return Date.now() - seen.at >= CRASH_RESPAWN_COOLDOWN_MS;
+  }
+
+  private async healCrashedBoxes(agentId: string, pool: AgentBoxInfo[]): Promise<void> {
+    const terminal = pool.filter((b) => b.status === "stopped" && !this.draining.has(b.boxId));
+    if (terminal.length === 0) return;
+
+    const crashed = terminal.filter((b) => b.exitedUnexpectedly);
+    let stuck = false;
+    for (const box of terminal) {
+      if (box.exitedUnexpectedly) {
+        console.warn(`[agentbox-manager] ${box.boxId} (agent=${agentId}) ended without being asked to; collecting it`);
+      }
+      try {
+        await this.spawner.stop(box.boxId);
+        this.statusCache.delete(box.boxId);
+        this.probeFailures.delete(box.boxId);
+      } catch (err) {
+        // Keep collecting the others — one pod stuck behind a finalizer must not stop the
+        // agent's remaining corpses from being cleared. Replacement is skipped this round
+        // (the index is still occupied) and retried on the next.
+        console.warn(`[agentbox-manager] failed to collect ${box.boxId}:`, err);
+        stuck = true;
+      }
+    }
+    if (crashed.length === 0 || stuck) return;
+
+    // Replace only what crashed, and only up to what the agent is configured for.
+    const replicas = await this.resolveReplicas(agentId);
+    // The FULL pool decides which indices are free — a pod that is terminating still owns
+    // its name, and spawning into it lands on the dying pod instead of a new one.
+    const missing = this.missingInstances(pool, replicas, agentId);
+    if (missing.length === 0) return;
+
+    // Rate-limited per INSTANCE, not per pod name: the replacement takes the same index,
+    // so "this slot keeps dying" is the thing worth counting.
+    const allowed = missing.filter((instance) => this.mayRespawn(`${agentId}#${instance}`));
+    if (allowed.length === 0) return;
+    console.log(`[agentbox-manager] agent=${agentId} replacing ${allowed.length} crashed box(es); spawning instances ${allowed.join(",")}`);
+    void this.spawnInstances(agentId, undefined, allowed, replicas > 1).catch((err) =>
+      console.warn(`[agentbox-manager] failed to replace crashed box(es) for agent=${agentId}:`, err));
+  }
+
+  /**
+   * Whether this box may be replaced again yet.
+   *
+   * A box killed by what will kill its replacement — an OOM on a prompt that rebuilds the
+   * same context — must not be respawned every tick. After a few attempts the runtime
+   * stops and says so, leaving the pool short rather than hammering the API forever.
+   */
+  private mayRespawn(key: string): boolean {
+    const now = Date.now();
+    const seen = this.crashRespawns.get(key);
+    // Forget a slot that has been healthy for a while. Without this the count only ever
+    // rises, so three crashes spread across months retire an instance permanently — and
+    // silently, because the warning already fired the first time it hit the limit.
+    if (seen && now - seen.at > CRASH_RESPAWN_FORGET_MS) this.crashRespawns.delete(key);
+    const record = this.crashRespawns.get(key);
+    if (!record) {
+      this.crashRespawns.set(key, { count: 1, at: now });
+      return true;
+    }
+    const seenNow = record;
+    if (now - seenNow.at < CRASH_RESPAWN_COOLDOWN_MS) return false;
+    if (seenNow.count >= CRASH_RESPAWN_LIMIT) {
+      if (seenNow.count === CRASH_RESPAWN_LIMIT) {
+        console.warn(`[agentbox-manager] ${key} has crashed ${seenNow.count} times; not replacing it again — the pool stays short until someone looks`);
+        seenNow.count++; // report once
+      }
+      return false;
+    }
+    this.crashRespawns.set(key, { count: seenNow.count + 1, at: now });
+    return true;
+  }
+
   private async reconcilePoolSizes(): Promise<void> {
     const s: any = this.spawner;
     if (typeof s.list !== "function") return;
@@ -808,13 +1046,20 @@ export class AgentBoxManager {
 
     const byAgent = new Map<string, AgentBoxInfo[]>();
     for (const box of all) {
-      if ((box.profile ?? "agent") !== "agent" || box.status === "stopped" || !box.agentId) continue;
+      if ((box.profile ?? "agent") !== "agent" || !box.agentId) continue;
       const list = byAgent.get(box.agentId) ?? [];
       list.push(box);
       byAgent.set(box.agentId, list);
     }
 
-    for (const [agentId, boxes] of byAgent) {
+    for (const [agentId, pool] of byAgent) {
+      await this.healCrashedBoxes(agentId, pool);
+      const boxes = pool.filter((b) => b.status !== "stopped");
+      // Keep a roll moving without waiting for traffic: mark the next stale box once the
+      // previous one has gone, and put back what the roll removed. A deploy on a quiet
+      // agent would otherwise stop half-done until someone happened to send a message.
+      this.markStaleBoxesDraining(agentId, boxes, "agent");
+      await this.advanceRoll(agentId, boxes);
       const accepting = boxes.filter((b) => !this.draining.has(b.boxId));
       // One box is both "nothing to shrink" and the un-pooled shape — skip without
       // paying a replicas lookup for every agent in the cluster on every tick.
@@ -842,6 +1087,7 @@ export class AgentBoxManager {
       if (!info || info.status === "stopped") {
         this.draining.delete(boxId);
         this.statusCache.delete(boxId);
+        this.probeFailures.delete(boxId);
         continue;
       }
       const overdue = Date.now() - markedAt >= DRAIN_DEADLINE_MS;
@@ -861,6 +1107,9 @@ export class AgentBoxManager {
       }
       this.draining.delete(boxId);
       this.statusCache.delete(boxId);
+      // Indices — and therefore names — are reused. A leftover failure count would make
+      // the replacement's first transient probe failure look like its fourth.
+      this.probeFailures.delete(boxId);
     }
   }
 

--- a/src/gateway/agentbox/types.ts
+++ b/src/gateway/agentbox/types.ts
@@ -71,6 +71,15 @@ export interface AgentBoxInfo {
    * matches the runtime's current CA — see AgentBoxManager.getOrCreateK8s.
    */
   caFingerprint?: string;
+  /**
+   * The box's process ended without being asked to — a crash, an OOM kill, an eviction.
+   *
+   * Distinct from ending cleanly (idle self-destruct, or a shutdown the runtime asked
+   * for), which is a pod doing what it was told. Only the unasked-for kind should bring
+   * a replacement back: replacing the other kind fights the feature that removed it and
+   * churns a pod nobody is using.
+   */
+  exitedUnexpectedly?: boolean;
   /** BoxProfile name this pod was spawned with (from its label; "agent" if absent).
    *  Used by the manager to refuse reusing a pod whose profile no longer matches
    *  the requested one — otherwise a profile change silently reuses the old-shaped

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -719,10 +719,14 @@ describe("handleMetricsFlush", () => {
 
   it("rejects a claim that merely starts with the cert boxId but is not an instance", async () => {
     // "box-10" and "box-1-evil" both share the "box-1" prefix; neither is a replica of it.
-    for (const claimed of ["box-10", "box-1-evil", "box-1-", "box-1-0", "box-1-01"]) {
+    // "box-1-01" is not one either — an index is written one way, so a padded variant is
+    // a second name for the same box and a way to split its metrics in two.
+    for (const claimed of ["box-10", "box-1-evil", "box-1-", "box-1-01"]) {
       expect(resolveFlushBoxId("box-1", claimed)).toBe("box-1");
     }
     expect(resolveFlushBoxId("box-1", "box-1-7")).toBe("box-1-7");
+    // Instance 0 carries its index now, so its own claim is the ordinary case.
+    expect(resolveFlushBoxId("box-1", "box-1-0")).toBe("box-1-0");
     expect(resolveFlushBoxId("box-1", undefined)).toBe("box-1");
   });
 

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -727,9 +727,10 @@ export interface MetricsFlushCounters {
 export function resolveFlushBoxId(certBoxId: string, claimed: unknown): string {
   if (typeof claimed !== "string" || claimed === "" || claimed === certBoxId) return certBoxId;
   const suffix = claimed.startsWith(`${certBoxId}-`) ? claimed.slice(certBoxId.length + 1) : null;
-  // `-0` is not a replica: instance 0 is unsuffixed, so a "-0" claim is malformed by
-  // construction and only narrows what a lying box can name.
-  if (suffix !== null && /^[1-9]\d*$/.test(suffix)) return claimed;
+  // Every instance carries its index, `-0` included, and the certificate names the AGENT
+  // rather than any one pod — so a claim is exactly the cert's subject plus this box's
+  // index. Anything else is a box claiming to be another agent's.
+  if (suffix !== null && /^(0|[1-9]\d*)$/.test(suffix)) return claimed;
   console.warn(
     `[internal-api] metrics-flush claimed boxId="${claimed}" outside cert identity "${certBoxId}"; attributing to the cert`,
   );


### PR DESCRIPTION
## Why

A production cluster had one agent's five boxes on a single node, and a sixth
sitting in `Error` for minutes with nothing coming to replace it. Both are the
pool failing at the thing it exists for: losing a box should cost capacity, not
service.

## What changes

**Boxes spread over nodes.** A preferred `podAntiAffinity` against the agent's
own label. Preferred, never required — a cluster whose `nodeSelector` admits one
node must still be able to place them.

**A crashed box comes back.** The reaper collects a box whose process ended and
replaces the ones that did not choose to end. K8s already draws that line —
`Failed` for a crash, an OOM kill, a kubelet eviction; `Succeeded` for the idle
self-destruct — so the runtime reads it rather than inventing its own. Replacing
a clean exit would spawn a pod that idles out and is spawned again, forever, for
an agent nobody is using. Replacement is rate limited per instance, and the
record decays so crashes months apart do not retire a slot permanently.

**A deploy rolls one box at a time.** The box stops accepting new sessions,
finishes what it holds, is removed, and its index comes back on the new image
before the next one starts — so the pool keeps N-1 boxes serving throughout,
rather than having none until the first replacement is ready. A box still coming
up counts as work in progress, so an image that cannot be pulled stalls the roll
instead of walking the pool into the ground. A stale CA or a wrong profile still
goes immediately: an orderly roll assumes a box that can still serve. The reaper
drives the roll as well as acquisition does, so a deploy finishes on a quiet
agent instead of stopping half-done.

**Instance 0 carries its index.** It was unsuffixed because that was the name
every pod had before an agent could run more than one, and the asymmetry cost
more than it saved: a replacement took the identical name, so a box that had
died and come back was indistinguishable from the one that had always been
there. A pod under the old name is recognised and rolled like any other stale
box.

## Two defects found while testing this

Both the same shape — one question with two answers:

- `list()` returned a lighter view of a pod than `listForAgent()` did. Harmless
  while only acquisition judged staleness; a spawn loop the moment the reaper
  judged it too, because a box with no CA fingerprint reads as untrusted. Every
  fresh box was drained on sight and replaced by one that met the same fate.
- The manager kept its own copy of the pod-naming rule (its comment says the
  copy must mirror the spawner's exactly). Giving instance 0 an index in the
  spawner alone left `stop()` aiming at a name no pod had: the 404 was swallowed
  and a finished capability box ran on forever.

Both now have a single author, and under them a fuse: draining is always
followed by creating, so any judgement that is wrong about a fresh box loops by
construction. An agent that drains eight boxes in ten minutes is not deploying —
the runtime says so and leaves the pool alone.

## Verified in a cluster

Deployed to a test namespace and driven through the real product:

- Rolling: bumping the agentbox image produced exactly one drain, one create and
  one removal, then silence.
- Crash: a pod carrying the agent's labels and exiting non-zero was recognised
  (`ended without being asked to; collecting it`), collected, and — when the
  pool was left short — replaced on the same index with the real image.
- Cooldown: a second crash of the same instance was collected but NOT replaced.
- Naming and affinity read off the live pod spec: `-0` present, `preferred` only,
  no `required`.
- The spawn loop above was caught here, in this namespace, and is what the fuse
  and the single mapper were written for.

Not verified in-cluster, and honest about it: spreading across nodes needs an
agent with `replicas > 1`, and "a clean exit is not replaced" cannot be staged
while the container's entrypoint turns SIGTERM into a non-zero exit (see below).
Both are covered by unit tests.

## Compatibility

- **Nothing for an upstream store to implement.** No RPC contract changes.
- **Pod names change**: `agentbox-<agentId>` → `agentbox-<agentId>-0`. Prefix
  matching is unaffected; anything pinning the exact name (an exec script, a
  dashboard filtering on a literal `box_id`) needs the suffix. Old-named pods
  roll themselves, one at a time.
- **The certificate Secret keeps its name**, so no cert churn on upgrade.
- Deploy as usual: runtime image and `SICLAW_AGENTBOX_IMAGE` on the same tag. No
  values changes.

## Known, not fixed here

The container entrypoint drops privileges with `runuser`, which forks rather
than execs — so PID 1 is `runuser`, not the box. On SIGTERM it kills the child
and exits non-zero, which means an ordinary pod deletion ends in `Failed`
instead of `Succeeded`, and the box's own shutdown (evicting debug pods,
flushing metrics and traces) may not run at all. `setpriv` or `gosu` would fix
it; that is an image change and belongs in its own PR.
