### PR TITLE
Fix Feishu Topic routing to follow group mode

### DIFF
--- a/docs/design/2026-07-11-lark-group-context-mode.md
+++ b/docs/design/2026-07-11-lark-group-context-mode.md
@@ -98,6 +98,16 @@ group message arrives
                    └─ per_user → drop immediately (today's behavior)
 ```
 
+Feishu Topic placement is derived directly from the resolved group mode; it is
+not a separate runtime or deployment setting:
+
+- `per_user`: each root `@bot` message starts a Topic-scoped session, and
+  follow-ups in that Topic reuse it without another mention.
+- `shared`: replies and the shared session stay on the main-group path; provider
+  Topic identifiers never split the group session.
+- Existing pre-Topic `per_user` session history is not migrated into a new
+  Topic root. Each new root intentionally starts its own scoped conversation.
+
 - The mode cache is invalidated by the existing channel-reload notification
   (also the propagation path for console edits) and by TTL expiry. A switch
   originating from the group's own card additionally busts the local cache
@@ -216,7 +226,6 @@ vocabulary. For this feature a portal MUST provide:
 
 ## Non-goals
 
-- Thread-level scoping (Lark group events carry no thread/root id).
 - Migrating existing session history across a mode switch.
 - Cross-group or cross-channel shared contexts.
 - DingTalk (groups are ephemeral-per-message by design; adopts the contract

--- a/docs/features/channels.mdx
+++ b/docs/features/channels.mdx
@@ -72,9 +72,8 @@ Create a Lark bot app, enable message event subscriptions, then configure it in 
 - `appId`
 - `appSecret`
 
-For a controlled group-topic pilot, set `runtime.env.SICLAW_LARK_THREAD_MODE`
-to `"1"`. This is a rollout gate, not a second mode selector: the existing
-group context selector controls the user experience.
+The existing group context selector determines Topic behavior directly; there
+is no separate Topic switch or deployment setting.
 
 - **Personal (per-user)**: a root `@bot` message opens a Feishu topic with the
   streaming card inside it. Follow-ups in that topic reuse that user's Agent
@@ -82,7 +81,7 @@ group context selector controls the user experience.
   unmentioned replies do not create or inherit the private session.
 - **Team (shared)**: users continue to `@bot` in the main group and the bot
   replies on the existing main-group path. The whole group keeps one shared
-  Agent session; the topic rollout does not split it by Feishu topic.
+  Agent session; Feishu topics do not split it into separate sessions.
 
 No additional Topic switch is required in the UI. Follow-ups without another
 `@bot` require the app's group-message event permission.

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1525,19 +1525,23 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       root_id: "mid-root",
       thread_id: "omt-1",
     });
+    const lark = makeLarkClient();
     await handleLarkMessage(
-      data, makeLarkClient(), "lark", makeAgentBoxManager("a1") as any, undefined, {} as any,
+      data, lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any,
       "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
     );
     expect(resolveBindingMock).toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();   // handled as a command, not a prompt
+    expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
   });
 
-  it("/mode WITH a mention still works, whoever sends it", async () => {
+  it("/mode at the group root stays on the main-group path", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "per_user" }));
     const data = botSenderEvent("/mode", [{ key: "@_user_1", id: { open_id: BOT } }]);
-    await handleLarkMessage(data, makeLarkClient(), "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+    const lark = makeLarkClient();
+    await handleLarkMessage(data, lark, "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
     expect(resolveBindingMock).toHaveBeenCalled();
+    expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBeUndefined();
   });
 
   it("IGNORES @所有人 announcements (key @_all, not the bot's open_id)", async () => {
@@ -1673,6 +1677,38 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         threadId: "omt-topic-1",
       }),
     }));
+  });
+
+  it("never enables Topic delivery for an unknown chat type", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionId: "unknown-chat-session",
+      sessionKey: "open_id:ou_user_1",
+      contextMode: "per_user",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "unknown-chat-session" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "plain answer" }] },
+      };
+    });
+    const lark = makeLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("future chat type", { chat_type: "future" }),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      { app_id: "x", app_secret: "y" },
+      BOT,
+    );
+
+    expect(resolveBindingMock.mock.calls.map((call) => call[5])).toEqual([undefined, undefined]);
+    expect(appendMessageMock.mock.calls[0][0].metadata).not.toHaveProperty("conversationKey");
+    expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBeUndefined();
   });
 
   it("starts an explicitly mentioned quoted message as a new topic rooted at the current message", async () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1148,7 +1148,7 @@ describe("handleLarkMessage — routing to AgentBox", () => {
       undefined,
       {} as any,
       "zh-CN",
-      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      { app_id: "x", app_secret: "y" },
       "ou_bot_self",
     );
 
@@ -1527,7 +1527,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     });
     await handleLarkMessage(
       data, makeLarkClient(), "lark", makeAgentBoxManager("a1") as any, undefined, {} as any,
-      "zh-CN", { app_id: "x", app_secret: "y", thread_mode: "group" }, BOT,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
     );
     expect(resolveBindingMock).toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();   // handled as a command, not a prompt
@@ -1581,7 +1581,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       undefined,
       {} as any,
       "zh-CN",
-      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      { app_id: "x", app_secret: "y" },
       BOT,
     );
 
@@ -1597,7 +1597,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     );
   });
 
-  it("thread mode creates a topic reply and accepts an unmentioned follow-up in the same root", async () => {
+  it("personal mode always creates a topic reply and accepts an unmentioned follow-up in the same root", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "thread-session",
       sessionKey: "open_id:ou_user_1:lark_thread:mid-1",
@@ -1610,7 +1610,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         message: { role: "assistant", content: [{ type: "text", text: "thread answer" }] },
       };
     });
-    const config = { app_id: "x", app_secret: "y", thread_mode: "group" } as const;
+    const config = { app_id: "x", app_secret: "y" } as const;
 
     const rootClient = makeLarkClient();
     await handleLarkMessage(
@@ -1703,7 +1703,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       undefined,
       {} as any,
       "zh-CN",
-      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      { app_id: "x", app_secret: "y" },
       BOT,
     );
 
@@ -1716,7 +1716,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(client.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
   });
 
-  it("thread rollout keeps a shared group on the main-group reply path", async () => {
+  it("team mode always keeps the shared group on the main-group reply path", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "shared-session",
       sessionKey: "chat:oc_abc123",
@@ -1729,7 +1729,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         message: { role: "assistant", content: [{ type: "text", text: "shared answer" }] },
       };
     });
-    const config = { app_id: "x", app_secret: "y", thread_mode: "group" } as const;
+    const config = { app_id: "x", app_secret: "y" } as const;
     const rootClient = makeLarkClient();
 
     await handleLarkMessage(
@@ -1794,7 +1794,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(promptMock.mock.calls[1][0].text).toContain("引用回复里的共享讨论");
   });
 
-  it("thread mode ignores an unmentioned topic that has no existing bot session", async () => {
+  it("personal mode ignores an unmentioned topic that has no existing bot session", async () => {
     resolveBindingMock.mockResolvedValue(null);
     const lark = makeLarkClient();
 
@@ -1812,7 +1812,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       undefined,
       {} as any,
       "zh-CN",
-      { app_id: "x", app_secret: "y", thread_mode: "group" },
+      { app_id: "x", app_secret: "y" },
       BOT,
     );
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1270,7 +1270,9 @@ export async function handleLarkMessage(
       return;
     }
     const current: GroupContextMode = modeBinding.contextMode === "shared" ? "shared" : "per_user";
-    const modeReplyInThread = current === "per_user";
+    // /mode changes the whole group. Keep a root invocation visible on the
+    // main-group path; only retain the card inside an already-established Topic.
+    const modeReplyInThread = isThreadFollowup && current === "per_user";
     rememberGroupMode(groupChannelId, chatId, current);
     const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale, modeReplyInThread);
     if (!sent) {
@@ -1370,7 +1372,7 @@ export async function handleLarkMessage(
     return;
   }
 
-  const personalTopicMode = contextMode === "per_user";
+  const personalTopicMode = isGroupMessage && contextMode === "per_user";
   const conversationKey = personalTopicMode ? topicConversationKey : undefined;
   const replyInThread = personalTopicMode;
   const effectiveSessionKey = binding.sessionKey ?? "";

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -242,10 +242,6 @@ export interface LarkChannelConfig {
   domain?: "feishu" | "lark";  // feishu = China (default), lark = Global
   app_id: string;
   app_secret: string;
-  /** Reply to group root messages as Feishu topics and scope sessions to the
-   *  topic root. Default-off; the test runtime can enable it with
-   *  SICLAW_LARK_THREAD_MODE=1 without changing stored channel config. */
-  thread_mode?: "group";
   group_channel_id?: string;
   verification_token?: string;
   encrypt_key?: string;
@@ -462,12 +458,6 @@ function getLarkSenderType(data: any): string | null {
 
 function buildLarkSessionKey(senderOpenId: string | null, chatId: string): string {
   return senderOpenId ? `open_id:${senderOpenId}` : `chat:${chatId}`;
-}
-
-function larkGroupThreadModeEnabled(config?: LarkChannelConfig): boolean {
-  if (config?.thread_mode === "group") return true;
-  const env = process.env.SICLAW_LARK_THREAD_MODE?.trim().toLowerCase();
-  return env === "1" || env === "true";
 }
 
 /**
@@ -985,10 +975,10 @@ export async function handleLarkMessage(
   const senderOpenId = getLarkSenderOpenId(data);
   const senderType = getLarkSenderType(data);
   const sessionKey = buildLarkSessionKey(senderOpenId, chatId);
-  // Rollout gate only: whether personal group conversations MAY use Feishu
-  // topics. The binding's server-authoritative contextMode decides whether
-  // this specific message actually uses the topic path.
-  const topicFeatureEnabled = chatType === "group" && larkGroupThreadModeEnabled(channelConfig);
+  // Every group message carries a provider-native Topic candidate. The
+  // server-authoritative contextMode decides the product behavior after binding
+  // resolution: per_user uses the Topic; shared stays on the main-group path.
+  const isGroupMessage = chatType === "group";
   const eventRootMessageId = typeof message.root_id === "string" && message.root_id.trim()
     ? message.root_id.trim()
     : messageId;
@@ -999,7 +989,7 @@ export async function handleLarkMessage(
   // that this event belongs to a Topic; otherwise an explicit @ starts a new
   // bot conversation rooted at the current message.
   const rootMessageId = threadId ? eventRootMessageId : messageId;
-  const topicConversationKey = topicFeatureEnabled ? `lark_thread:${rootMessageId}` : undefined;
+  const topicConversationKey = isGroupMessage ? `lark_thread:${rootMessageId}` : undefined;
 
   // Raw receipt log: fires for EVERY delivered event before any drop, so a
   // group message that arrives but is filtered (non-text, empty after @-strip)
@@ -1246,7 +1236,7 @@ export async function handleLarkMessage(
 
   // Computed here rather than at the @-gate below: /mode needs both.
   const botMentioned = isBotMentioned(message, botOpenId);
-  const isThreadFollowup = topicFeatureEnabled && threadId !== null && rootMessageId !== messageId;
+  const isThreadFollowup = isGroupMessage && threadId !== null && rootMessageId !== messageId;
 
   // /mode — summon the context-mode switch card. Command words are exact, and
   // the bot must be @-mentioned: this switches the mode for the WHOLE group, and
@@ -1280,7 +1270,7 @@ export async function handleLarkMessage(
       return;
     }
     const current: GroupContextMode = modeBinding.contextMode === "shared" ? "shared" : "per_user";
-    const modeReplyInThread = topicFeatureEnabled && current === "per_user";
+    const modeReplyInThread = current === "per_user";
     rememberGroupMode(groupChannelId, chatId, current);
     const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale, modeReplyInThread);
     if (!sent) {
@@ -1380,7 +1370,7 @@ export async function handleLarkMessage(
     return;
   }
 
-  const personalTopicMode = topicFeatureEnabled && contextMode === "per_user";
+  const personalTopicMode = contextMode === "per_user";
   const conversationKey = personalTopicMode ? topicConversationKey : undefined;
   const replyInThread = personalTopicMode;
   const effectiveSessionKey = binding.sessionKey ?? "";


### PR DESCRIPTION
## Summary
- remove the hidden SICLAW_LARK_THREAD_MODE and thread_mode rollout gates
- make personal/per-user groups use Feishu Topics deterministically
- keep team/shared groups on the main-group reply path
- update Topic routing tests and channel documentation

## Deployment contract
- no Helm values, manifests, runtime environment variables, or database migrations are added or changed
- the existing production Helm values remain valid as-is
- personal/per-user session keys become Topic-scoped by design; team/shared session behavior is unchanged
- existing pre-Topic personal-session history is intentionally not migrated into new Topic roots

## Validation
- npx vitest run src/gateway/channels/lark.test.ts src/gateway/channels/lark-card.test.ts src/gateway/channels/lark-image.test.ts (237 passed)
- npm test (243 files, 5016 passed, 2 skipped)
- npm run build