### PR TITLE
fix(agentbox): never invert podNamePrefix into BoxProfile

### DIFF
--- a/src/gateway/agentbox/manager.test.ts
+++ b/src/gateway/agentbox/manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { AgentBoxManager } from "./manager.js";
+import { getBoxProfile } from "./box-profile.js";
 import type { BoxSpawner } from "./spawner.js";
 import type { AgentBoxConfig, AgentBoxHandle, AgentBoxInfo } from "./types.js";
 
@@ -18,9 +19,23 @@ class FakeSpawner implements BoxSpawner {
   getReturns = new Map<string, AgentBoxInfo | null>();
   listReturns: AgentBoxInfo[] = [];
   cleanupCalls = 0;
+  /** Profiles last passed into boxIdFor — proves naming uses real profiles, not prefixes. */
+  boxIdForProfiles: Array<string | undefined> = [];
   /** When set, the manager enforces CA-fingerprint matching for pod reuse. */
   fingerprint: string | undefined = undefined;
   caFingerprint(): string | undefined { return this.fingerprint; }
+
+  /**
+   * Same contract as K8sSpawner.boxIdFor: second arg is a **BoxProfile name**,
+   * never a podNamePrefix. Without this method the manager uses a local fallback
+   * that never calls getBoxProfile — which hid the v0.3.2 production bug.
+   */
+  boxIdFor(agentId: string, profile?: string, instance = 0): string {
+    this.boxIdForProfiles.push(profile);
+    const prefix = getBoxProfile(profile).podNamePrefix ?? "agentbox";
+    const sanitized = agentId.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 50);
+    return `${prefix}-${sanitized}-${instance}`;
+  }
 
   async spawn(config: AgentBoxConfig): Promise<AgentBoxHandle> {
     this.spawnCalls.push(config);
@@ -298,6 +313,38 @@ describe("AgentBoxManager — K8s mode", () => {
     expect(handle?.boxId).toBe("kbc-box-run-1-0");
     // Without the profile it would look under "agentbox-run-1" and miss.
     expect(await mgr.getAsync("run-1")).toBeUndefined();
+  });
+
+  it("names kb-compile boxes via profile, never treating podNamePrefix as a profile (v0.3.2 regression)", async () => {
+    // Production bug: podName(prefix) → profileForPrefix("kbc-box") → "kbc-box"
+    // → boxIdFor(..., "kbc-box") → getBoxProfile("kbc-box") → throw.
+    // Naming must stay profile → prefix only; kb-compile and kb-compile-codex
+    // share the kbc-box prefix so prefix→profile is not invertible.
+    const spawner = new FakeSpawner("k8s");
+    const mgr = new AgentBoxManager(spawner);
+
+    await expect(
+      mgr.getOrCreateWithDisposition("cap-run-1", { profile: "kb-compile" }),
+    ).resolves.toMatchObject({ created: true });
+    expect(spawner.boxIdForProfiles).toContain("kb-compile");
+    expect(spawner.boxIdForProfiles).not.toContain("kbc-box");
+
+    spawner.boxIdForProfiles = [];
+    await mgr.stop("cap-run-1", "kb-compile");
+    expect(spawner.stopCalls).toEqual(["kbc-box-cap-run-1-0"]);
+    expect(spawner.boxIdForProfiles).toEqual(["kb-compile"]);
+
+    spawner.boxIdForProfiles = [];
+    spawner.getReturns.set("kbc-box-cap-run-2-0", {
+      boxId: "kbc-box-cap-run-2-0", agentId: "cap-run-2", status: "running",
+      endpoint: "https://10.0.0.9:3000", createdAt: new Date(), lastActiveAt: new Date(),
+      profile: "kb-compile-codex",
+    });
+    await expect(mgr.getAsync("cap-run-2", "kb-compile-codex")).resolves.toMatchObject({
+      boxId: "kbc-box-cap-run-2-0",
+    });
+    expect(spawner.boxIdForProfiles).toEqual(["kb-compile-codex"]);
+    expect(spawner.boxIdForProfiles).not.toContain("kbc-box");
   });
 });
 

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -274,32 +274,28 @@ export class AgentBoxManager {
   }
 
   /**
-   * Pod / box name. Trims agentId to stay under the 63-char K8s name limit and only
-   * sanitizes forbidden characters.
+   * Pod / box name for a profile (+ instance).
    *
-   * The prefix is profile-derived and this MUST stay identical to K8sSpawner.podName
-   * (compile boxes are "kbc-box-", everything else "agentbox-"): the manager looks a pod
-   * up by this computed name for warm reuse, liveness and stop, so a mismatch would miss
-   * the real pod (a leaked box on stop, a missed re-attach on adopt). That includes the
-   * instance rule — 0 is unsuffixed, so an agent running one box is named exactly as it
-   * always was.
+   * Naming is one-way only: **profile → podNamePrefix → pod name**. Never invert
+   * prefix → profile. Several profiles share one prefix (`kb-compile` and
+   * `kb-compile-codex` both use `kbc-box`), so any inverse is ill-defined and
+   * previously passed `"kbc-box"` into `getBoxProfile`, which throws
+   * `unknown BoxProfile: kbc-box` and aborts compile-box spawn before the pod
+   * is created (production v0.3.2 / PR #466).
+   *
+   * Prefer the spawner's `boxIdFor` so manager and K8sSpawner cannot drift on
+   * sanitization/instance rules; local/process spawners fall back to the same
+   * prefix derivation.
    */
-  private podName(agentId: string, prefix = "agentbox", instance = 0): string {
-    // ASK the spawner when it can answer. Keeping a second copy of the rule here is what
-    // let the two drift when instance 0 gained its index: stop() aimed at a name no pod
-    // had, the 404 was swallowed, and the box ran on. A spawner without the method (Local,
-    // Process) does not name pods at all, so the local rule is only a fallback.
+  private podName(agentId: string, profile: string | undefined, instance = 0): string {
     const spawner = this.spawner as { boxIdFor?(agentId: string, profile?: string, instance?: number): string };
     if (typeof spawner.boxIdFor === "function") {
-      return spawner.boxIdFor(agentId, this.profileForPrefix(prefix), instance);
+      // Pass the real profile — boxIdFor resolves podNamePrefix itself.
+      return spawner.boxIdFor(agentId, profile, instance);
     }
+    const prefix = this.prefixForProfile(profile);
     const sanitized = agentId.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, 50);
     return `${prefix}-${sanitized}-${instance}`;
-  }
-
-  /** The profile that spawns under this pod-name prefix — the inverse of prefixForProfile. */
-  private profileForPrefix(prefix: string): string | undefined {
-    return prefix === "agentbox" ? "agent" : prefix;
   }
 
   /** Pod-name prefix a profile spawns under (see K8sSpawner / BoxProfile.podNamePrefix). */
@@ -375,7 +371,7 @@ export class AgentBoxManager {
     sessionId?: string,
   ): Promise<AgentBoxAcquisition> {
     const wantProfile = config?.profile ?? "agent";
-    const name = this.podName(agentId, this.prefixForProfile(wantProfile));
+    const name = this.podName(agentId, wantProfile);
 
     const info = await this.spawner.get(name);
 
@@ -1193,7 +1189,7 @@ export class AgentBoxManager {
 
   async getAsync(agentId: string, profile?: string): Promise<AgentBoxHandle | undefined> {
     if (this.isK8s) {
-      const name = this.podName(agentId, this.prefixForProfile(profile));
+      const name = this.podName(agentId, profile);
       const info = await this.spawner.get(name);
       if (info && info.status === "running" && info.endpoint) {
         return { boxId: name, endpoint: info.endpoint, agentId };
@@ -1205,7 +1201,7 @@ export class AgentBoxManager {
 
   async stop(agentId: string, profile?: string): Promise<void> {
     if (this.isK8s) {
-      const name = this.podName(agentId, this.prefixForProfile(profile));
+      const name = this.podName(agentId, profile);
       console.log(`[agentbox-manager] Stopping AgentBox ${name}`);
       await this.spawner.stop(name);
       return;


### PR DESCRIPTION
## Summary

Production `siclaw-runtime:v0.3.2` fails every KB compile with:

```text
capability.start rejected: unknown BoxProfile: kbc-box
```

even though SiCore correctly sends `profile=kb-compile` (and persists it on `siclaw_capability_runs`).

**Root cause (PR #466 pool resilience):** `AgentBoxManager.podName` asked `K8sSpawner.boxIdFor` after running `profileForPrefix(prefix)`. For compile boxes that prefix is `kbc-box`, and `profileForPrefix` returned it unchanged — then `boxIdFor` called `getBoxProfile("kbc-box")`, which is not a registered profile.

```text
kb-compile → prefix kbc-box → profileForPrefix("kbc-box") → getBoxProfile("kbc-box") ✗
```

`kb-compile` and `kb-compile-codex` **share** the `kbc-box` prefix, so prefix→profile is not invertible and must not exist.

## Fix

- Naming is **one-way only**: profile → `podNamePrefix` → pod name.
- `podName(agentId, profile, instance)` passes the **real profile** into `boxIdFor`.
- Delete `profileForPrefix`.
- Regression test with a `boxIdFor` FakeSpawner (production path); assert `kb-compile` / `kb-compile-codex` never pass `"kbc-box"` as a profile.

## Multi-replica design note

Capability/compile boxes stay **replicas=1** (per-run jobs). Chat multi-box pooling is unchanged and still keys pool membership by agent + labels; this fix only corrects how a single pod name is derived from a profile.

## Test plan

- [x] `vitest run src/gateway/agentbox/manager.test.ts` (92 tests)
- [x] siflow-test: deploy `siclaw-runtime@sha256:20630fb4…` (`pr469-4ad56bea`)
- [x] smoke KB `8bb5de66-…` compile.generate → pod `kbc-box-8cc784d8-…-0` Running; agent progress ("reading the workspace…"); no `unknown BoxProfile: kbc-box`

## Reviewer focus

- Is one-way naming sufficient for multi-replica chat pools? (compile path is replicas=1; pool path uses listForAgent + spawn with profile, not profileForPrefix)
- No new BoxProfile registration for `kbc-box` (prefix only)