### PR TITLE
feat(lark): add user-confirmed ticket intake flow

### DIFF
--- a/docs/design/lark-ticket-intake.md
+++ b/docs/design/lark-ticket-intake.md
@@ -1,0 +1,85 @@
+# Lark customer-support ticket intake
+
+## Delivery boundary
+
+This flow implements the product-facing work that does not depend on a ticket
+backend:
+
+1. The normal knowledge-enabled channel agent answers a consultation.
+2. The requester clicks **Prepare ticket** on that answer.
+3. The agent classifies the request and collects missing facts in chat.
+4. Siclaw renders a deterministic review preview.
+5. The same requester clicks **Confirm**.
+6. Siclaw freezes and returns a `siclaw.ticket_intake.v1` payload.
+
+No step reads or operates a cluster, host, VM, or production system. The agent
+can update the draft through `ticket_intake_draft`; that tool has no confirm or
+submit operation. Confirmation is accepted only from a Lark card callback whose
+operator `open_id` matches the persisted requester.
+
+## State model
+
+`collecting -> review -> confirmed`
+
+`collecting|review -> cancelled`
+
+Draft updates and card transitions use optimistic `revision` checks. Repeating
+the same start click is idempotent, and repeating a successful confirmation
+returns the already-frozen payload.
+
+## Handoff contract
+
+```json
+{
+  "schema_version": "siclaw.ticket_intake.v1",
+  "intake_id": "uuid",
+  "session_id": "uuid",
+  "channel": {
+    "type": "lark",
+    "channel_id": "channel-config-id",
+    "requester_external_id": "ou_xxx",
+    "source_message_id": "om_xxx"
+  },
+  "draft": {
+    "classification": "incident_candidate",
+    "summary": "...",
+    "product": "...",
+    "category": "...",
+    "impact": "...",
+    "affected_object": "...",
+    "occurred_at": "...",
+    "actual_behavior": "...",
+    "expected_behavior": "...",
+    "attempted_actions": [],
+    "source_refs": [],
+    "open_questions": [],
+    "ready_for_review": true
+  },
+  "confirmed_at": "ISO-8601"
+}
+```
+
+The future ticket-system adapter consumes this frozen payload after
+`channel.transitionTicketIntake(action=confirm)`. It must add its own delivery
+receipt, retry policy, and remote ticket identifier; those concerns are not
+represented as successful ticket creation in this phase.
+
+## Agent configuration
+
+Use a dedicated custom agent with knowledge/skills required for product support
+and explicitly select the `ticket_intake` capability group. Do not select
+`inspect_infra`, `run_commands`, or `run_scripts` for this agent.
+
+The Lark channel is also opt-in: set `ticket_intake_enabled: true` in its
+configuration only after that agent setup is complete. Existing Lark bots keep
+the feature disabled by default.
+
+Standalone Portal implements all four RPCs:
+
+- `channel.beginTicketIntake`
+- `channel.getActiveTicketIntake`
+- `channel.updateTicketIntakeDraft`
+- `channel.transitionTicketIntake`
+
+An upstream control plane must implement the same RPC contract before this flow
+is enabled against that environment.

--- a/docs/design/lark-ticket-intake.md
+++ b/docs/design/lark-ticket-intake.md
@@ -6,7 +6,7 @@ This flow implements the product-facing work that does not depend on a ticket
 backend:
 
 1. The normal knowledge-enabled channel agent answers a consultation.
-2. The requester clicks **Prepare ticket** on that answer.
+2. The requester clicks **Submit ticket** on that answer.
 3. The agent classifies the request and collects missing facts in chat.
 4. Siclaw renders a deterministic review preview.
 5. The same requester clicks **Confirm**.
@@ -16,6 +16,11 @@ No step reads or operates a cluster, host, VM, or production system. The agent
 can update the draft through `ticket_intake_draft`; that tool has no confirm or
 submit operation. Confirmation is accepted only from a Lark card callback whose
 operator `open_id` matches the persisted requester.
+
+The user-facing card exposes only the business journey: **Submit ticket**, add
+details, and **Confirm submission**. Internal classification values, state and
+revision fields, and intake IDs stay in the backend contract and must not be
+rendered in the card or chat replies.
 
 ## State model
 

--- a/portal-web/src/components/AgentSettings.tsx
+++ b/portal-web/src/components/AgentSettings.tsx
@@ -1019,6 +1019,7 @@ interface PersonalBotInfo {
   app_id: string
   access_mode: string
   group_auto_bind: boolean
+  ticket_intake_enabled: boolean
   status: string
 }
 
@@ -1038,7 +1039,7 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
   // Collapsed to a summary line once active; only admins can edit.
   const [bot, setBot] = useState<PersonalBotInfo | null>(null)
   const [botExpanded, setBotExpanded] = useState(false)
-  const [botForm, setBotForm] = useState({ domain: "feishu", app_id: "", app_secret: "", group_auto_bind: true })
+  const [botForm, setBotForm] = useState({ domain: "feishu", app_id: "", app_secret: "", group_auto_bind: true, ticket_intake_enabled: false })
   const [savingBot, setSavingBot] = useState(false)
 
   const applyBot = (b: PersonalBotInfo | null) => {
@@ -1048,6 +1049,7 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
       app_id: b?.app_id ?? "",
       app_secret: "",
       group_auto_bind: b ? b.group_auto_bind : true,
+      ticket_intake_enabled: b?.ticket_intake_enabled === true,
     })
     setBotExpanded(!(b && b.status === "active"))
   }
@@ -1085,6 +1087,7 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
           app_id: botForm.app_id,
           app_secret: botForm.app_secret,
           group_auto_bind: botForm.group_auto_bind,
+          ticket_intake_enabled: botForm.ticket_intake_enabled,
         },
       })
       toast.success("Bot saved and enabled")
@@ -1188,6 +1191,13 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
               <label className="flex items-center gap-2 text-[12px] cursor-pointer">
                 <input type="checkbox" checked={botForm.group_auto_bind} onChange={e => setBotForm(p => ({ ...p, group_auto_bind: e.target.checked }))} className="rounded" />
                 <span>Auto-serve groups — just add the bot to a group and it works, no pairing. When off, it serves direct messages only.</span>
+              </label>
+              <label className="flex items-start gap-2 text-[12px] cursor-pointer">
+                <input type="checkbox" checked={botForm.ticket_intake_enabled} onChange={e => setBotForm(p => ({ ...p, ticket_intake_enabled: e.target.checked }))} className="mt-0.5 rounded" />
+                <span>
+                  Enable customer-support ticket intake — adds user-clicked prepare/review/confirm cards.
+                  Configure this agent with the <code>ticket_intake</code> capability and without infrastructure execution capabilities first.
+                </span>
               </label>
               <div className="flex items-center gap-2">
                 <button onClick={handleSaveBot} disabled={savingBot || !botForm.app_id} className="h-8 px-4 text-[12px] rounded-md bg-primary text-primary-foreground disabled:opacity-50">

--- a/portal-web/src/components/CapabilityGroupSelector.test.tsx
+++ b/portal-web/src/components/CapabilityGroupSelector.test.tsx
@@ -30,7 +30,7 @@ describe("CapabilityGroupSelector — render contract", () => {
     expect(html).toContain("Unrestricted")
     expect(html).not.toContain("Restricted")
     expect(html).toContain("agent can use ALL tools")
-    expect(html).toContain("Capability groups (0 / 11)")
+    expect(html).toContain("Capability groups (0 / 12)")
     expect(countChecked(html)).toBe(0)
   })
 
@@ -40,7 +40,7 @@ describe("CapabilityGroupSelector — render contract", () => {
     expect(html).not.toContain("Unrestricted")
     // read_files grants 4 tools; "1 group" must be singular.
     expect(html).toContain("1 group · 4 tools")
-    expect(html).toContain("Capability groups (1 / 11)")
+    expect(html).toContain("Capability groups (1 / 12)")
     expect(countChecked(html)).toBe(1)
   })
 
@@ -48,7 +48,7 @@ describe("CapabilityGroupSelector — render contract", () => {
     const html = render(new Set(["read_files", "run_commands"]))
     // 4 + 4 distinct tools, plural "groups".
     expect(html).toContain("2 groups · 8 tools")
-    expect(html).toContain("Capability groups (2 / 11)")
+    expect(html).toContain("Capability groups (2 / 12)")
     expect(countChecked(html)).toBe(2)
   })
 

--- a/portal-web/src/lib/toolCapabilities.test.ts
+++ b/portal-web/src/lib/toolCapabilities.test.ts
@@ -9,7 +9,7 @@ const KNOWN_KEYS = CAPABILITY_GROUPS.map((g) => g.key)
 
 describe("CAPABILITY_GROUPS shape", () => {
   it("declares exactly the 11 designed groups", () => {
-    expect(CAPABILITY_GROUPS).toHaveLength(11)
+    expect(CAPABILITY_GROUPS).toHaveLength(12)
     expect([...KNOWN_KEYS].sort()).toEqual([
       "delegate_agents",
       "inspect_infra",
@@ -21,6 +21,7 @@ describe("CAPABILITY_GROUPS shape", () => {
       "search_memory",
       "session_output",
       "spawn_subagents",
+      "ticket_intake",
       "write_sandbox",
     ])
   })

--- a/portal-web/src/lib/toolCapabilities.ts
+++ b/portal-web/src/lib/toolCapabilities.ts
@@ -29,6 +29,7 @@ export const CAPABILITY_GROUPS: CapabilityGroup[] = [
   { key: "delegate_agents", name: "Delegate to agents", description: "Delegate a bounded task to a peer agent (roster-gated) + inspect delegate coverage", tools: ["delegate_to_agent", "list_delegates"] },
   { key: "scheduling", name: "Scheduling", description: "Manage scheduled / recurring runs", tools: ["manage_schedule"] },
   { key: "session_output", name: "Session output", description: "Report findings, post channel updates & submit feedback", tools: ["task_report", "save_feedback", "channel_update", "report_findings", "request_input"] },
+  { key: "ticket_intake", name: "Ticket intake", description: "Update user-started support ticket drafts; confirmation remains user-controlled", tools: ["ticket_intake_draft"] },
 ]
 
 /** Total distinct tools across the selected group keys (for the UI summary). */

--- a/portal-web/src/pages/Channels.tsx
+++ b/portal-web/src/pages/Channels.tsx
@@ -20,7 +20,7 @@ const CHANNEL_TYPES = [
 
 // Per-type config field definitions
 interface ConfigField {
-  key: string; label: string; type: "text" | "password" | "select"; placeholder?: string; required?: boolean
+  key: string; label: string; type: "text" | "password" | "select" | "checkbox"; placeholder?: string; required?: boolean
   options?: { value: string; label: string }[]
 }
 
@@ -34,6 +34,7 @@ const CONFIG_FIELDS: Record<string, ConfigField[]> = {
     { key: "app_secret", label: "App Secret", type: "password", placeholder: "App secret from console", required: true },
     { key: "verification_token", label: "Verification Token", type: "text", placeholder: "Optional" },
     { key: "encrypt_key", label: "Encrypt Key", type: "text", placeholder: "Optional" },
+    { key: "ticket_intake_enabled", label: "Enable user-clicked customer-support ticket intake", type: "checkbox" },
   ],
   dingtalk: [
     { key: "client_id", label: "Client ID (AppKey)", type: "text", placeholder: "dingxxxxxxxxxx", required: true },
@@ -53,7 +54,7 @@ const CONFIG_FIELDS: Record<string, ConfigField[]> = {
 }
 
 function ConfigForm({ type, config, onChange }: {
-  type: string; config: Record<string, string>; onChange: (config: Record<string, string>) => void
+  type: string; config: Record<string, unknown>; onChange: (config: Record<string, unknown>) => void
 }) {
   const fields = CONFIG_FIELDS[type] || []
   if (fields.length === 0) return <p className="text-[11px] text-muted-foreground">No configuration needed for this type.</p>
@@ -67,16 +68,23 @@ function ConfigForm({ type, config, onChange }: {
           </label>
           {f.type === "select" ? (
             <select
-              value={config[f.key] || f.options?.[0]?.value || ""}
+              value={String(config[f.key] || f.options?.[0]?.value || "")}
               onChange={e => onChange({ ...config, [f.key]: e.target.value })}
               className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background"
             >
               {f.options?.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
             </select>
+          ) : f.type === "checkbox" ? (
+            <input
+              type="checkbox"
+              checked={config[f.key] === true}
+              onChange={e => onChange({ ...config, [f.key]: e.target.checked })}
+              className="h-4 w-4 rounded"
+            />
           ) : (
             <input
               type={f.type}
-              value={config[f.key] || ""}
+              value={String(config[f.key] || "")}
               onChange={e => onChange({ ...config, [f.key]: e.target.value })}
               placeholder={f.placeholder}
               className="w-full h-8 px-3 text-sm rounded-md border border-border bg-background"
@@ -94,10 +102,10 @@ export function Channels() {
   const [showCreate, setShowCreate] = useState(false)
   const [formName, setFormName] = useState("")
   const [formType, setFormType] = useState("lark")
-  const [formConfig, setFormConfig] = useState<Record<string, string>>({})
+  const [formConfig, setFormConfig] = useState<Record<string, unknown>>({})
   const [creating, setCreating] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
-  const [editConfig, setEditConfig] = useState<Record<string, string>>({})
+  const [editConfig, setEditConfig] = useState<Record<string, unknown>>({})
   const [editName, setEditName] = useState("")
   const [saving, setSaving] = useState(false)
   const toast = useToast()
@@ -138,7 +146,7 @@ export function Channels() {
   const startEdit = async (ch: Channel) => {
     try {
       const full = await api<Channel>(`/channels/${ch.id}`)
-      const cfg = (typeof full.config === "string" ? JSON.parse(full.config as unknown as string) : full.config) as Record<string, string>
+      const cfg = (typeof full.config === "string" ? JSON.parse(full.config as unknown as string) : full.config) as Record<string, unknown>
       setEditingId(ch.id)
       setEditName(ch.name)
       setEditConfig(cfg)

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -1240,6 +1240,30 @@ export class AgentBoxSessionManager {
     };
   }
 
+  private createTicketIntakeDraftExecutor(): import("../core/tool-registry.js").TicketIntakeDraftExecutor {
+    return async (request) => {
+      if (!(this.gatewayClient && this.agentId)) {
+        return { accepted: false, message: "Ticket intake is unavailable in this AgentBox." };
+      }
+      const response = await this.persistDelegationEvent({
+        type: "channel.ticket_intake_draft",
+        intake: {
+          sessionId: request.sessionId,
+          intakeId: request.intakeId,
+          expectedRevision: request.expectedRevision,
+          draft: request.draft,
+          fromAgentId: this.agentId,
+        },
+      });
+      return {
+        accepted: response.ok,
+        message: response.ok
+          ? "Ticket draft saved. The user must confirm it from the Feishu review card."
+          : "No active user-started ticket intake accepted this draft.",
+      };
+    };
+  }
+
   /**
    * Stop ALL running background jobs (background exec + background sub-agents) of a session.
    * Called from the /abort handler so the user's "Stop" button halts everything the session is
@@ -2683,6 +2707,7 @@ export class AgentBoxSessionManager {
       backgroundExecExecutor: this.createBackgroundExecExecutor(),
       taskOutputReader: this.createTaskOutputReader(),
       channelMessageExecutor: this.createChannelMessageExecutor(),
+      ticketIntakeDraftExecutor: this.createTicketIntakeDraftExecutor(),
     });
 
     // Populate sessionIdRef so skill_call events can associate with this session

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -134,6 +134,7 @@ export interface CreateSiclawSessionOpts {
   taskOutputReader?: import("./tool-registry.js").TaskOutputReader;
   /** Runtime bridge for explicit IM-channel visible updates. Injected by agentbox. */
   channelMessageExecutor?: import("./tool-registry.js").ChannelMessageExecutor;
+  ticketIntakeDraftExecutor?: import("./tool-registry.js").TicketIntakeDraftExecutor;
 }
 
 export interface SiclawSessionResult {
@@ -437,6 +438,7 @@ export async function createSiclawSession(
       backgroundExecExecutor: opts?.backgroundExecExecutor,
       taskOutputReader: opts?.taskOutputReader,
       channelMessageExecutor: opts?.channelMessageExecutor,
+      ticketIntakeDraftExecutor: opts?.ticketIntakeDraftExecutor,
       delegation: opts?.delegation,
       delegationRoster: opts?.delegationRoster,
       delegateToAgentExecutor: opts?.delegateToAgentExecutor,

--- a/src/core/tool-capabilities.test.ts
+++ b/src/core/tool-capabilities.test.ts
@@ -61,7 +61,7 @@ describe("resolveCapabilities", () => {
     expect(result).toEqual(["manage_schedule"]);
   });
 
-  it("CAPABILITY_GROUPS contains the 11 designed groups", () => {
+  it("CAPABILITY_GROUPS contains the designed groups", () => {
     expect(Object.keys(CAPABILITY_GROUPS).sort()).toEqual([
       "delegate_agents",
       "inspect_infra",
@@ -73,6 +73,7 @@ describe("resolveCapabilities", () => {
       "search_memory",
       "session_output",
       "spawn_subagents",
+      "ticket_intake",
       "write_sandbox",
     ]);
   });

--- a/src/core/tool-capabilities.ts
+++ b/src/core/tool-capabilities.ts
@@ -37,6 +37,7 @@ export const CAPABILITY_GROUPS: Record<string, string[]> = {
   delegate_agents: ["delegate_to_agent", "list_delegates"],   // delegate a bounded task to a peer agent (roster-gated) + inspect delegate coverage; distinct from spawn
   scheduling:      ["manage_schedule"],
   session_output:  ["task_report", "save_feedback", "channel_update", "report_findings", "request_input"],   // IM-channel-visible updates + delegation result artifact + clarification request
+  ticket_intake:   ["ticket_intake_draft"],
 };
 
 /**

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -247,6 +247,17 @@ export interface ChannelMessageResult {
 
 export type ChannelMessageExecutor = (request: ChannelMessageRequest) => Promise<ChannelMessageResult>;
 
+export interface TicketIntakeDraftRequest {
+  sessionId: string;
+  intakeId: string;
+  expectedRevision: number;
+  draft: import("../shared/ticket-intake.js").TicketIntakeDraft;
+}
+
+export type TicketIntakeDraftExecutor = (
+  request: TicketIntakeDraftRequest,
+) => Promise<{ accepted: boolean; message: string }>;
+
 // ── background exec (run_in_background on bash / node_exec / pod_exec) ──────
 
 /**
@@ -434,6 +445,8 @@ export interface ToolRefs {
   taskOutputReader?: TaskOutputReader;
   /** Sends an agent-selected visible update to the active IM channel; Gateway owns delivery policy. */
   channelMessageExecutor?: ChannelMessageExecutor;
+  /** Updates the current user-started ticket draft. It can never confirm or submit it. */
+  ticketIntakeDraftExecutor?: TicketIntakeDraftExecutor;
   /**
    * Present when this turn was delegated by a coordinator agent to a peer,
    * siclaw-native via the gateway's internal delegate API. Its presence marks a

--- a/src/gateway/agent-model-binding.test.ts
+++ b/src/gateway/agent-model-binding.test.ts
@@ -46,7 +46,7 @@ describe("resolveAgentModelBinding", () => {
         name: "Anthropic",
         baseUrl: "https://api.anthropic.com",
         apiKey: "sk-123",
-        api: "anthropic",
+        api: "anthropic-messages",
         authHeader: true,
         models: [
           {
@@ -60,6 +60,34 @@ describe("resolveAgentModelBinding", () => {
     fake.responses.set("config.getModelBinding", { binding });
     const result = await resolveAgentModelBinding("agent-1", fake as unknown as FrontendWsClient);
     expect(result).toEqual(binding);
+  });
+
+  it("normalizes legacy protocol aliases from older Sicore runtimes", async () => {
+    const binding: ResolvedModelBinding = {
+      modelProvider: "company-anthropic",
+      modelId: "claude-sonnet-4-6",
+      modelConfig: {
+        name: "Company Gateway",
+        baseUrl: "https://example.invalid/v1",
+        apiKey: "test-key",
+        api: "anthropic",
+        authHeader: true,
+        models: [
+          {
+            id: "claude-sonnet-4-6", name: "Claude", api: "anthropic",
+            reasoning: false, input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 200_000, maxTokens: 64_000,
+          },
+        ],
+      },
+    };
+    fake.responses.set("config.getModelBinding", { binding });
+
+    const result = await resolveAgentModelBinding("agent-1", fake as unknown as FrontendWsClient);
+
+    expect(result?.modelConfig.api).toBe("anthropic-messages");
+    expect(result?.modelConfig.models[0].api).toBe("anthropic-messages");
   });
 
   it("returns null when the payload binding is null", async () => {

--- a/src/gateway/agent-model-binding.ts
+++ b/src/gateway/agent-model-binding.ts
@@ -7,6 +7,7 @@
 
 import type { FrontendWsClient } from "./frontend-ws-client.js";
 import type { ModelRoutePolicy } from "../core/model-routing.js";
+import { normalizeProviderApi } from "../core/model-compat.js";
 
 export interface ResolvedModelBinding {
   modelProvider: string;
@@ -47,7 +48,19 @@ export async function resolveAgentModelBinding(
 ): Promise<ResolvedModelBinding | null> {
   try {
     const data = await frontendClient.request("config.getModelBinding", { agentId }) as { binding: ResolvedModelBinding | null };
-    return data.binding;
+    if (!data.binding) return null;
+    const binding = data.binding;
+    return {
+      ...binding,
+      modelConfig: {
+        ...binding.modelConfig,
+        api: normalizeProviderApi(binding.modelConfig.api),
+        models: binding.modelConfig.models.map((model) => ({
+          ...model,
+          ...(model.api ? { api: normalizeProviderApi(model.api) } : {}),
+        })),
+      },
+    };
   } catch (err) {
     console.error(`[agent-model-binding] RPC error:`, err);
     return null;

--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -12,6 +12,7 @@ import type { AgentBoxManager } from "./agentbox/manager.js";
 import type { FrontendWsClient } from "./frontend-ws-client.js";
 import { createLarkHandler } from "./channels/lark.js";
 import { createDingTalkHandler } from "./channels/dingtalk.js";
+import type { TicketIntakeDraft, TicketIntakeRecord, TicketIntakeSubmissionPayload } from "../shared/ticket-intake.js";
 
 export interface ChannelHandler {
   start(): Promise<void>;
@@ -171,6 +172,45 @@ export async function setChannelContextMode(
     channel_id: channelId,
     route_key: routeKey,
     mode,
+  });
+}
+
+export async function beginTicketIntake(
+  input: { sessionId: string; channelId: string; requesterExternalId: string; sourceMessageId: string },
+  frontendClient?: FrontendWsClient,
+): Promise<{ success: boolean; intake?: TicketIntakeRecord; error?: string }> {
+  if (!frontendClient) return { success: false, error: "Ticket intake storage is unavailable" };
+  return frontendClient.request("channel.beginTicketIntake", {
+    session_id: input.sessionId,
+    channel_id: input.channelId,
+    requester_external_id: input.requesterExternalId,
+    source_message_id: input.sourceMessageId,
+  });
+}
+
+export async function getActiveTicketIntake(
+  sessionId: string,
+  requesterExternalId: string,
+  frontendClient?: FrontendWsClient,
+): Promise<TicketIntakeRecord | null> {
+  if (!frontendClient) return null;
+  const result = await frontendClient.request("channel.getActiveTicketIntake", {
+    session_id: sessionId,
+    requester_external_id: requesterExternalId,
+  });
+  return result?.intake ?? null;
+}
+
+export async function transitionTicketIntake(
+  input: { intakeId: string; requesterExternalId: string; revision: number; action: "confirm" | "continue" | "cancel" },
+  frontendClient?: FrontendWsClient,
+): Promise<{ success: boolean; intake?: TicketIntakeRecord; payload?: TicketIntakeSubmissionPayload; error?: string }> {
+  if (!frontendClient) return { success: false, error: "Ticket intake storage is unavailable" };
+  return frontendClient.request("channel.transitionTicketIntake", {
+    intake_id: input.intakeId,
+    requester_external_id: input.requesterExternalId,
+    expected_revision: input.revision,
+    action: input.action,
   });
 }
 

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -474,6 +474,7 @@ describe("ticket intake cards", () => {
       { ctx: { mode: "start", sessionId: "s1", channelId: "c1", requesterExternalId: "ou_1", sourceMessageId: "om_1" }, locale: "zh-CN" },
     );
     const [startRow] = JSON.parse(elementCreateSpy.mock.calls[0][0].data.elements);
+    expect(startRow.columns[0].elements[0].text.content).toBe("提交工单");
     const startValue = startRow.columns[0].elements[0].behaviors[0].value;
     expect(startValue).toEqual(expect.objectContaining({
       kind: TICKET_INTAKE_ACTION_KIND, action: "start", session_id: "s1",
@@ -503,8 +504,10 @@ describe("ticket intake cards", () => {
         attempted_actions: [], source_refs: [], open_questions: [], ready_for_review: true,
       },
     }, "zh-CN");
-    expect(markdown).toContain("工单提交预览");
+    expect(markdown).toContain("请确认工单信息");
     expect(markdown).toContain("Login fails");
+    expect(markdown).not.toContain("incident_candidate");
+    expect(markdown).not.toContain("分类");
     expect(markdown).not.toMatch(/reasoning|思维链|chain.of.thought/i);
   });
 });

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -15,6 +15,8 @@ import {
   localeForDomain,
   buildModeCard,
   MODE_ACTION_KIND,
+  TICKET_INTAKE_ACTION_KIND,
+  buildTicketIntakeReviewMarkdown,
 } from "./lark-card.js";
 
 // ── sanitizeMarkdownForFeishu ──────────────────────────────────
@@ -458,6 +460,52 @@ describe("feedback buttons", () => {
     const { client, elementUpdateSpy } = makeLarkClient();
     expect(await applyFeedbackSelection(client as any, feedbackValue("CARD-UNKNOWN"), "up")).toBe(false);
     expect(elementUpdateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("ticket intake cards", () => {
+  it("renders a user-scoped start button and review-only confirm controls", async () => {
+    const { client, elementCreateSpy } = makeLarkClient();
+    await finalizeCard(
+      client as any,
+      { cardId: "CARD-TICKET", elementId: "md_main", sequence: 0 },
+      "answer",
+      undefined,
+      { ctx: { mode: "start", sessionId: "s1", channelId: "c1", requesterExternalId: "ou_1", sourceMessageId: "om_1" }, locale: "zh-CN" },
+    );
+    const [startRow] = JSON.parse(elementCreateSpy.mock.calls[0][0].data.elements);
+    const startValue = startRow.columns[0].elements[0].behaviors[0].value;
+    expect(startValue).toEqual(expect.objectContaining({
+      kind: TICKET_INTAKE_ACTION_KIND, action: "start", session_id: "s1",
+      requester_external_id: "ou_1", source_message_id: "om_1",
+    }));
+
+    elementCreateSpy.mockClear();
+    await finalizeCard(
+      client as any,
+      { cardId: "CARD-REVIEW", elementId: "md_main", sequence: 0 },
+      "review",
+      undefined,
+      { ctx: { mode: "active", intakeId: "i1", revision: 3, requesterExternalId: "ou_1", sourceMessageId: "om_2", reviewable: true }, locale: "zh-CN" },
+    );
+    const [reviewRow] = JSON.parse(elementCreateSpy.mock.calls[0][0].data.elements);
+    expect(reviewRow.columns.map((c: any) => c.elements[0].behaviors[0].value.action)).toEqual(["confirm", "continue", "cancel"]);
+    expect(reviewRow.columns[0].elements[0].behaviors[0].value).toEqual(expect.objectContaining({ intake_id: "i1", revision: 3 }));
+  });
+
+  it("builds a deterministic structured preview without hidden reasoning", () => {
+    const markdown = buildTicketIntakeReviewMarkdown({
+      id: "i1", sessionId: "s1", channelId: "c1", requesterExternalId: "ou_1", sourceMessageId: "om_1",
+      state: "review", revision: 2,
+      draft: {
+        classification: "incident_candidate", summary: "Login fails", product: "Siclaw", category: "Auth",
+        impact: "Tenant A", affected_object: "tenant-a", actual_behavior: "500", expected_behavior: "success",
+        attempted_actions: [], source_refs: [], open_questions: [], ready_for_review: true,
+      },
+    }, "zh-CN");
+    expect(markdown).toContain("工单提交预览");
+    expect(markdown).toContain("Login fails");
+    expect(markdown).not.toMatch(/reasoning|思维链|chain.of.thought/i);
   });
 });
 

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -477,6 +477,7 @@ describe("ticket intake cards", () => {
     expect(startRow.element_id).toBe("ticket_actions");
     expect(startRow.columns[0].elements[0].text.content).toBe("提交工单");
     expect(startRow.columns[0].elements[0].element_id).toBe("ticket_start");
+    expect(startRow.columns[0].elements[0].type).toBe("primary");
     const startValue = startRow.columns[0].elements[0].behaviors[0].value;
     expect(startValue).toEqual(expect.objectContaining({
       kind: TICKET_INTAKE_ACTION_KIND, action: "start", session_id: "s1",
@@ -497,6 +498,23 @@ describe("ticket intake cards", () => {
     expect(elementIds.every((id: string) => /^[A-Za-z][A-Za-z0-9_]{0,19}$/.test(id))).toBe(true);
     expect(reviewRow.columns.map((c: any) => c.elements[0].behaviors[0].value.action)).toEqual(["confirm", "continue", "cancel"]);
     expect(reviewRow.columns[0].elements[0].behaviors[0].value).toEqual(expect.objectContaining({ intake_id: "i1", revision: 3 }));
+  });
+
+  it("places the primary ticket action before secondary answer feedback", async () => {
+    const { client, elementCreateSpy } = makeLarkClient();
+    await finalizeCard(
+      client as any,
+      { cardId: "CARD-TICKET-FB", elementId: "md_main", sequence: 0 },
+      "answer",
+      { ctx: { sessionId: "s1", channelId: "c1", messageId: "om_answer" }, locale: "zh-CN" },
+      { ctx: { mode: "start", sessionId: "s1", channelId: "c1", requesterExternalId: "ou_1", sourceMessageId: "om_1" }, locale: "zh-CN" },
+    );
+
+    expect(elementCreateSpy).toHaveBeenCalledTimes(2);
+    const rows = elementCreateSpy.mock.calls.map((call) => JSON.parse(call[0].data.elements)[0]);
+    expect(rows.map((row) => row.element_id)).toEqual(["ticket_actions", "fb_row"]);
+    expect(rows[0].columns[0].elements[0].type).toBe("primary");
+    expect(elementCreateSpy.mock.calls.map((call) => call[0].data.sequence)).toEqual([3, 4]);
   });
 
   it("builds a deterministic structured preview without hidden reasoning", () => {

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -474,7 +474,9 @@ describe("ticket intake cards", () => {
       { ctx: { mode: "start", sessionId: "s1", channelId: "c1", requesterExternalId: "ou_1", sourceMessageId: "om_1" }, locale: "zh-CN" },
     );
     const [startRow] = JSON.parse(elementCreateSpy.mock.calls[0][0].data.elements);
+    expect(startRow.element_id).toBe("ticket_actions");
     expect(startRow.columns[0].elements[0].text.content).toBe("提交工单");
+    expect(startRow.columns[0].elements[0].element_id).toBe("ticket_start");
     const startValue = startRow.columns[0].elements[0].behaviors[0].value;
     expect(startValue).toEqual(expect.objectContaining({
       kind: TICKET_INTAKE_ACTION_KIND, action: "start", session_id: "s1",
@@ -490,6 +492,9 @@ describe("ticket intake cards", () => {
       { ctx: { mode: "active", intakeId: "i1", revision: 3, requesterExternalId: "ou_1", sourceMessageId: "om_2", reviewable: true }, locale: "zh-CN" },
     );
     const [reviewRow] = JSON.parse(elementCreateSpy.mock.calls[0][0].data.elements);
+    const elementIds = [reviewRow.element_id, ...reviewRow.columns.map((c: any) => c.elements[0].element_id)];
+    expect(elementIds).toEqual(["ticket_actions", "ticket_confirm", "ticket_continue", "ticket_cancel"]);
+    expect(elementIds.every((id: string) => /^[A-Za-z][A-Za-z0-9_]{0,19}$/.test(id))).toBe(true);
     expect(reviewRow.columns.map((c: any) => c.elements[0].behaviors[0].value.action)).toEqual(["confirm", "continue", "cancel"]);
     expect(reviewRow.columns[0].elements[0].behaviors[0].value).toEqual(expect.objectContaining({ intake_id: "i1", revision: 3 }));
   });

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -234,7 +234,7 @@ function buildTicketIntakeRow(ctx: TicketIntakeCardContext, locale: LarkLocale):
     };
   };
   const actions: Array<[TicketIntakeActionValue["action"], "primary" | "default"]> = ctx.mode === "start"
-    ? [["start", "default"]]
+    ? [["start", "primary"]]
     : [
         ...(ctx.reviewable ? [["confirm", "primary"]] as Array<[TicketIntakeActionValue["action"], "primary" | "default"]> : []),
         ["continue", "default"], ["cancel", "default"],
@@ -838,8 +838,9 @@ export interface CardFinalizeResult {
  * state (answer visible — a text reply would duplicate it), while a failed
  * content update leaves the answer nowhere the user can see it.
  *
- * When `feedback` is passed, a 👍/👎 button row is appended after the final
- * content (best-effort — losing the buttons never fails the finalize).
+ * Business continuation controls are appended before the optional 👍/👎 row,
+ * so ticket intake remains the primary action and answer feedback stays
+ * visually secondary. Both rows are best-effort.
  */
 export async function finalizeCard(
   larkClient: any,
@@ -887,11 +888,11 @@ export async function finalizeCard(
   // Buttons go in AFTER streaming mode is off: structural element ops on a
   // streaming card risk rejection, and this keeps the user-visible finalize
   // (content + settings) off the extra round-trip.
-  if (feedback && contentOk && settingsOk) {
-    await appendFeedbackRow(larkClient, session, feedback.ctx, feedback.locale);
-  }
   if (ticketIntake && contentOk && settingsOk) {
     await appendTicketIntakeRow(larkClient, session, ticketIntake.ctx, ticketIntake.locale);
+  }
+  if (feedback && contentOk && settingsOk) {
+    await appendFeedbackRow(larkClient, session, feedback.ctx, feedback.locale);
   }
 
   return { ok: contentOk && settingsOk, contentOk };

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -225,7 +225,9 @@ function buildTicketIntakeRow(ctx: TicketIntakeCardContext, locale: LarkLocale):
         };
     return {
       tag: "button",
-      element_id: `ticket_intake_${action}`,
+      // CardKit element_id: starts with a letter, [A-Za-z0-9_], max 20 chars.
+      // `ticket_intake_continue` is 22 chars and makes the whole append fail.
+      element_id: `ticket_${action}`,
       text: { tag: "plain_text", content: labels[action] },
       type,
       behaviors: [{ type: "callback", value }],
@@ -239,7 +241,7 @@ function buildTicketIntakeRow(ctx: TicketIntakeCardContext, locale: LarkLocale):
       ];
   return {
     tag: "column_set",
-    element_id: "ticket_intake_actions",
+    element_id: "ticket_actions",
     columns: actions.map(([action, type]) => ({ tag: "column", width: "auto", elements: [button(action, type)] })),
   };
 }

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -26,6 +26,9 @@
  *    the platform can order updates; we increment inside `CardSession`.
  */
 
+import { TICKET_INTAKE_ACTION_KIND, type TicketIntakeRecord } from "../../shared/ticket-intake.js";
+export { TICKET_INTAKE_ACTION_KIND } from "../../shared/ticket-intake.js";
+
 /**
  * Locale-aware placeholder + notice strings. "feishu" maps to zh-CN (the
  * domestic Feishu install base is predominantly Chinese-speaking); "lark"
@@ -186,6 +189,104 @@ function buildFeedbackRow(
       { tag: "column", width: "auto", elements: [button("down")] },
     ],
   };
+}
+
+export type TicketIntakeCardContext =
+  | { mode: "start"; sessionId: string; channelId: string; requesterExternalId: string; sourceMessageId: string }
+  | { mode: "active"; intakeId: string; revision: number; requesterExternalId: string; sourceMessageId: string; reviewable: boolean };
+
+export interface TicketIntakeActionValue {
+  kind: typeof TICKET_INTAKE_ACTION_KIND;
+  action: "start" | "confirm" | "continue" | "cancel";
+  locale: LarkLocale;
+  session_id?: string;
+  channel_id?: string;
+  requester_external_id: string;
+  source_message_id?: string;
+  intake_id?: string;
+  revision?: number;
+}
+
+function buildTicketIntakeRow(ctx: TicketIntakeCardContext, locale: LarkLocale): Record<string, unknown> {
+  const labels = locale === "zh-CN"
+    ? { start: "整理为工单", confirm: "确认提交", continue: "继续补充", cancel: "取消" }
+    : { start: "Prepare ticket", confirm: "Confirm", continue: "Add details", cancel: "Cancel" };
+  const button = (action: TicketIntakeActionValue["action"], type: "primary" | "default" = "default") => {
+    const value: TicketIntakeActionValue = ctx.mode === "start"
+      ? {
+          kind: TICKET_INTAKE_ACTION_KIND, action, locale,
+          session_id: ctx.sessionId, channel_id: ctx.channelId,
+          requester_external_id: ctx.requesterExternalId, source_message_id: ctx.sourceMessageId,
+        }
+      : {
+          kind: TICKET_INTAKE_ACTION_KIND, action, locale,
+          intake_id: ctx.intakeId, revision: ctx.revision,
+          requester_external_id: ctx.requesterExternalId, source_message_id: ctx.sourceMessageId,
+        };
+    return {
+      tag: "button",
+      element_id: `ticket_intake_${action}`,
+      text: { tag: "plain_text", content: labels[action] },
+      type,
+      behaviors: [{ type: "callback", value }],
+    };
+  };
+  const actions: Array<[TicketIntakeActionValue["action"], "primary" | "default"]> = ctx.mode === "start"
+    ? [["start", "default"]]
+    : [
+        ...(ctx.reviewable ? [["confirm", "primary"]] as Array<[TicketIntakeActionValue["action"], "primary" | "default"]> : []),
+        ["continue", "default"], ["cancel", "default"],
+      ];
+  return {
+    tag: "column_set",
+    element_id: "ticket_intake_actions",
+    columns: actions.map(([action, type]) => ({ tag: "column", width: "auto", elements: [button(action, type)] })),
+  };
+}
+
+async function appendTicketIntakeRow(
+  larkClient: any,
+  session: CardSession,
+  ctx: TicketIntakeCardContext,
+  locale: LarkLocale,
+): Promise<void> {
+  try {
+    const res = await larkClient.cardkit.v1.cardElement.create({
+      path: { card_id: session.cardId },
+      data: { type: "append", sequence: ++session.sequence, elements: JSON.stringify([buildTicketIntakeRow(ctx, locale)]) },
+    });
+    if (cardApiFailed(res)) console.warn(`[lark-card] appending ticket intake buttons rejected for cardId=${session.cardId}: ${describeCardApiError(res)}`);
+  } catch (err) {
+    console.warn(`[lark-card] appending ticket intake buttons failed for cardId=${session.cardId}:`, err);
+  }
+}
+
+export function buildTicketIntakeReviewMarkdown(record: TicketIntakeRecord, locale: LarkLocale): string {
+  const d = record.draft;
+  const rows = locale === "zh-CN"
+    ? [
+        "## 工单提交预览",
+        `- **摘要**：${d.summary || "待补充"}`,
+        `- **分类**：${d.classification}`,
+        `- **产品/模块**：${[d.product, d.category].filter(Boolean).join(" / ") || "待补充"}`,
+        `- **影响**：${d.impact || "待补充"}`,
+        `- **影响对象**：${d.affected_object || "待补充"}`,
+        `- **实际情况**：${d.actual_behavior || "待补充"}`,
+        `- **期望情况**：${d.expected_behavior || "待补充"}`,
+        "\n请核对后点击“确认提交”；需要修改可点击“继续补充”。",
+      ]
+    : [
+        "## Ticket submission preview",
+        `- **Summary**: ${d.summary || "Missing"}`,
+        `- **Classification**: ${d.classification}`,
+        `- **Product/category**: ${[d.product, d.category].filter(Boolean).join(" / ") || "Missing"}`,
+        `- **Impact**: ${d.impact || "Missing"}`,
+        `- **Affected object**: ${d.affected_object || "Missing"}`,
+        `- **Actual**: ${d.actual_behavior || "Missing"}`,
+        `- **Expected**: ${d.expected_behavior || "Missing"}`,
+        "\nReview the draft, then confirm or add more details.",
+      ];
+  return rows.join("\n");
 }
 
 // Cards whose feedback row we can still edit (sequence must keep increasing
@@ -597,6 +698,7 @@ export async function postFinalCard(
   finalText: string,
   feedback?: { ctx: FeedbackContext; locale: LarkLocale },
   replyInThread: boolean = false,
+  ticketIntake?: { ctx: TicketIntakeCardContext; locale: LarkLocale },
 ): Promise<boolean> {
   const sanitized = sanitizeMarkdownForFeishu(finalText);
   try {
@@ -623,13 +725,17 @@ export async function postFinalCard(
       return false;
     }
     // Safe here in a way it is not on a streaming card: this one is static.
+    const staticSession: CardSession = { cardId, elementId: MD_ELEMENT_ID, sequence: 0 };
     if (feedback) {
       await appendFeedbackRow(
         larkClient,
-        { cardId, elementId: MD_ELEMENT_ID, sequence: 0 },
+        staticSession,
         feedback.ctx,
         feedback.locale,
       );
+    }
+    if (ticketIntake) {
+      await appendTicketIntakeRow(larkClient, staticSession, ticketIntake.ctx, ticketIntake.locale);
     }
     return true;
   } catch (err) {
@@ -740,6 +846,7 @@ export async function finalizeCard(
   session: CardSession,
   finalText: string,
   feedback?: { ctx: FeedbackContext; locale: LarkLocale },
+  ticketIntake?: { ctx: TicketIntakeCardContext; locale: LarkLocale },
 ): Promise<CardFinalizeResult> {
   const sanitized = sanitizeMarkdownForFeishu(finalText);
   let contentOk = false;
@@ -782,6 +889,9 @@ export async function finalizeCard(
   // (content + settings) off the extra round-trip.
   if (feedback && contentOk && settingsOk) {
     await appendFeedbackRow(larkClient, session, feedback.ctx, feedback.locale);
+  }
+  if (ticketIntake && contentOk && settingsOk) {
+    await appendTicketIntakeRow(larkClient, session, ticketIntake.ctx, ticketIntake.locale);
   }
 
   return { ok: contentOk && settingsOk, contentOk };

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -209,8 +209,8 @@ export interface TicketIntakeActionValue {
 
 function buildTicketIntakeRow(ctx: TicketIntakeCardContext, locale: LarkLocale): Record<string, unknown> {
   const labels = locale === "zh-CN"
-    ? { start: "整理为工单", confirm: "确认提交", continue: "继续补充", cancel: "取消" }
-    : { start: "Prepare ticket", confirm: "Confirm", continue: "Add details", cancel: "Cancel" };
+    ? { start: "提交工单", confirm: "确认提交", continue: "继续补充", cancel: "取消" }
+    : { start: "Submit ticket", confirm: "Confirm submission", continue: "Add details", cancel: "Cancel" };
   const button = (action: TicketIntakeActionValue["action"], type: "primary" | "default" = "default") => {
     const value: TicketIntakeActionValue = ctx.mode === "start"
       ? {
@@ -265,26 +265,24 @@ export function buildTicketIntakeReviewMarkdown(record: TicketIntakeRecord, loca
   const d = record.draft;
   const rows = locale === "zh-CN"
     ? [
-        "## 工单提交预览",
-        `- **摘要**：${d.summary || "待补充"}`,
-        `- **分类**：${d.classification}`,
+        "## 请确认工单信息",
+        `- **问题概述**：${d.summary || "待补充"}`,
         `- **产品/模块**：${[d.product, d.category].filter(Boolean).join(" / ") || "待补充"}`,
-        `- **影响**：${d.impact || "待补充"}`,
-        `- **影响对象**：${d.affected_object || "待补充"}`,
+        `- **影响范围**：${d.impact || "待补充"}`,
+        `- **涉及对象**：${d.affected_object || "待补充"}`,
         `- **实际情况**：${d.actual_behavior || "待补充"}`,
-        `- **期望情况**：${d.expected_behavior || "待补充"}`,
+        `- **期望结果**：${d.expected_behavior || "待补充"}`,
         "\n请核对后点击“确认提交”；需要修改可点击“继续补充”。",
       ]
     : [
-        "## Ticket submission preview",
-        `- **Summary**: ${d.summary || "Missing"}`,
-        `- **Classification**: ${d.classification}`,
+        "## Confirm ticket details",
+        `- **Issue summary**: ${d.summary || "Missing"}`,
         `- **Product/category**: ${[d.product, d.category].filter(Boolean).join(" / ") || "Missing"}`,
-        `- **Impact**: ${d.impact || "Missing"}`,
-        `- **Affected object**: ${d.affected_object || "Missing"}`,
+        `- **Impact scope**: ${d.impact || "Missing"}`,
+        `- **Affected item**: ${d.affected_object || "Missing"}`,
         `- **Actual**: ${d.actual_behavior || "Missing"}`,
         `- **Expected**: ${d.expected_behavior || "Missing"}`,
-        "\nReview the draft, then confirm or add more details.",
+        "\nReview the details, then confirm or add more information.",
       ];
   return rows.join("\n");
 }

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -43,6 +43,9 @@ const updateBindingMetaMock = vi.fn();
 const setChannelContextModeMock = vi.fn();
 const issuePersonalApiKeyMock = vi.fn();
 const getPersonalApiKeyStatusMock = vi.fn();
+const beginTicketIntakeMock = vi.fn();
+const getActiveTicketIntakeMock = vi.fn();
+const transitionTicketIntakeMock = vi.fn();
 
 vi.mock("../channel-manager.js", () => ({
   resolveBinding: (...args: unknown[]) => resolveBindingMock(...args),
@@ -53,6 +56,9 @@ vi.mock("../channel-manager.js", () => ({
   resetPersonalSession: (...args: unknown[]) => resetPersonalSessionMock(...args),
   issuePersonalApiKey: (...args: unknown[]) => issuePersonalApiKeyMock(...args),
   getPersonalApiKeyStatus: (...args: unknown[]) => getPersonalApiKeyStatusMock(...args),
+  beginTicketIntake: (...args: unknown[]) => beginTicketIntakeMock(...args),
+  getActiveTicketIntake: (...args: unknown[]) => getActiveTicketIntakeMock(...args),
+  transitionTicketIntake: (...args: unknown[]) => transitionTicketIntakeMock(...args),
   updateBindingMeta: (...args: unknown[]) => updateBindingMetaMock(...args),
   setChannelContextMode: (...args: unknown[]) => setChannelContextModeMock(...args),
   isChannelAccessDenied: (v: unknown) =>
@@ -216,6 +222,10 @@ beforeEach(() => {
   resetPersonalSessionMock.mockReset();
   issuePersonalApiKeyMock.mockReset();
   getPersonalApiKeyStatusMock.mockReset();
+  beginTicketIntakeMock.mockReset();
+  getActiveTicketIntakeMock.mockReset();
+  transitionTicketIntakeMock.mockReset();
+  getActiveTicketIntakeMock.mockResolvedValue(null);
   resolveAgentModelBindingMock.mockReset();
   ensureChatSessionMock.mockReset();
   appendMessageMock.mockReset();
@@ -1407,6 +1417,41 @@ describe("handleLarkCardAction — /mode context switch", () => {
   });
 });
 
+describe("handleLarkCardAction — ticket intake", () => {
+  const flush = () => new Promise((r) => setImmediate(r));
+  function action(value: Record<string, unknown>, operator = "ou_requester") {
+    return { operator: { open_id: operator }, action: { tag: "button", value: { kind: "siclaw_ticket_intake", locale: "zh-CN", requester_external_id: "ou_requester", ...value } } };
+  }
+
+  it("starts only from an explicit requester click and returns before persistence", async () => {
+    beginTicketIntakeMock.mockResolvedValue({ success: true, intake: { id: "i1" } });
+    const lark = makeLarkClient();
+    const result = handleLarkCardAction(action({ action: "start", session_id: "s1", channel_id: "c1", source_message_id: "om1" }), lark, {} as any);
+    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("开始") } });
+    await flush();
+    expect(beginTicketIntakeMock).toHaveBeenCalledWith({
+      sessionId: "s1", channelId: "c1", requesterExternalId: "ou_requester", sourceMessageId: "om1",
+    }, expect.anything());
+  });
+
+  it("rejects another group member before any transition RPC", async () => {
+    const result = handleLarkCardAction(action({ action: "confirm", intake_id: "i1", revision: 2 }, "ou_other"), makeLarkClient(), {} as any);
+    expect(result).toEqual({ toast: { type: "error", content: expect.stringContaining("发起人") } });
+    await flush();
+    expect(transitionTicketIntakeMock).not.toHaveBeenCalled();
+  });
+
+  it("confirms by opaque id and optimistic revision, never from an agent callback", async () => {
+    transitionTicketIntakeMock.mockResolvedValue({ success: true, intake: { id: "i1" }, payload: { schema_version: "siclaw.ticket_intake.v1" } });
+    const result = handleLarkCardAction(action({ action: "confirm", intake_id: "i1", revision: 7, source_message_id: "om1" }), makeLarkClient(), {} as any);
+    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("确认") } });
+    await flush();
+    expect(transitionTicketIntakeMock).toHaveBeenCalledWith({
+      intakeId: "i1", requesterExternalId: "ou_requester", revision: 7, action: "confirm",
+    }, expect.anything());
+  });
+});
+
 describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => {
   const BOT = "ou_bot_self";
 
@@ -1968,6 +2013,29 @@ describe("handleLarkMessage — streaming card flow", () => {
     };
   }
 
+  it("injects the persisted intake contract only after the requester clicked start", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    getActiveTicketIntakeMock.mockResolvedValue({
+      id: "intake-1", sessionId: "session-fixed", channelId: "lark",
+      requesterExternalId: "ou_user_1", sourceMessageId: "om-start", state: "collecting", revision: 4,
+      draft: { classification: "needs_clarification", summary: "Login issue", attempted_actions: [], source_refs: [], open_questions: ["impact"], ready_for_review: false },
+    });
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "请补充影响范围" }] } };
+    });
+    await handleLarkMessage(
+      makeTextEvent("登录失败"), makeCardAwareLarkClient(), "lark", makeAgentBoxManager("a1") as any,
+      undefined, {} as any, "zh-CN", { app_id: "app", app_secret: "secret", ticket_intake_enabled: true },
+    );
+    const sent = promptMock.mock.calls[0][0].text as string;
+    expect(sent).toContain("<siclaw_ticket_intake>");
+    expect(sent).toContain('"id":"intake-1"');
+    expect(sent).toContain('"revision":4');
+    expect(sent).toContain("Do not inspect or operate clusters");
+    expect(sent).toContain("The tool cannot confirm");
+  });
+
   it("opens typing card before agent runs, then finalizes with the final assistant text", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-int" });
@@ -2072,7 +2140,8 @@ describe("handleLarkMessage — streaming card flow", () => {
     );
 
     expect(lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content).toContain("answer still delivered");
-    expect(lark.cardkit.v1.cardElement.create).not.toHaveBeenCalled();
+    const appendedRows = lark.cardkit.v1.cardElement.create.mock.calls.flatMap((call) => JSON.parse(call[0].data.elements));
+    expect(appendedRows).not.toEqual(expect.arrayContaining([expect.objectContaining({ element_id: "fb_row" })]));
   });
 
   it("updates the Lark card when a background channel report arrives after the first SSE turn", async () => {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1427,7 +1427,7 @@ describe("handleLarkCardAction — ticket intake", () => {
     beginTicketIntakeMock.mockResolvedValue({ success: true, intake: { id: "i1" } });
     const lark = makeLarkClient();
     const result = handleLarkCardAction(action({ action: "start", session_id: "s1", channel_id: "c1", source_message_id: "om1" }), lark, {} as any);
-    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("开始") } });
+    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("提交工单") } });
     await flush();
     expect(beginTicketIntakeMock).toHaveBeenCalledWith({
       sessionId: "s1", channelId: "c1", requesterExternalId: "ou_requester", sourceMessageId: "om1",
@@ -1443,12 +1443,16 @@ describe("handleLarkCardAction — ticket intake", () => {
 
   it("confirms by opaque id and optimistic revision, never from an agent callback", async () => {
     transitionTicketIntakeMock.mockResolvedValue({ success: true, intake: { id: "i1" }, payload: { schema_version: "siclaw.ticket_intake.v1" } });
-    const result = handleLarkCardAction(action({ action: "confirm", intake_id: "i1", revision: 7, source_message_id: "om1" }), makeLarkClient(), {} as any);
+    const lark = makeLarkClient();
+    const result = handleLarkCardAction(action({ action: "confirm", intake_id: "i1", revision: 7, source_message_id: "om1" }), lark, {} as any);
     expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("确认") } });
     await flush();
     expect(transitionTicketIntakeMock).toHaveBeenCalledWith({
       intakeId: "i1", requesterExternalId: "ou_requester", revision: 7, action: "confirm",
     }, expect.anything());
+    const replyContent = JSON.parse(lark.im.message.reply.mock.calls[0][0].data.content).text;
+    expect(replyContent).toBe("✅ 已确认工单信息。");
+    expect(replyContent).not.toContain("i1");
   });
 });
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -28,6 +28,9 @@ import {
   type PersonalApiKeyIssueResult,
   type PersonalApiKeyStatusResult,
   type PersonalAccessDenied,
+  beginTicketIntake,
+  getActiveTicketIntake,
+  transitionTicketIntake,
 } from "../channel-manager.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
@@ -54,6 +57,10 @@ import {
   type ModeActionValue,
   type GroupContextMode,
   type LarkLocale,
+  TICKET_INTAKE_ACTION_KIND,
+  type TicketIntakeActionValue,
+  type TicketIntakeCardContext,
+  buildTicketIntakeReviewMarkdown,
 } from "./lark-card.js";
 import { collectImageAttachments, stripVisualBlocks, type RenderedReplyImage } from "./visual-image.js";
 import { replyImageToLark } from "./lark-image.js";
@@ -61,6 +68,7 @@ import { collectInboundImages, type LarkImageRef } from "./inbound-image.js";
 import { modelOptionsSupportImageInput } from "../../core/model-routing.js";
 import { redactImageUrlsInText } from "../agentbox/image-url-ingest.js";
 import { registerBackgroundChannelDelivery } from "./background-delivery.js";
+import { buildTicketIntakeAgentContext, type TicketIntakeRecord } from "../../shared/ticket-intake.js";
 
 const VISUAL_ONLY_NOTICE_BY_LOCALE = {
   "zh-CN": "已生成图片如下。",
@@ -245,6 +253,8 @@ export interface LarkChannelConfig {
   group_channel_id?: string;
   verification_token?: string;
   encrypt_key?: string;
+  /** Opt-in support intake; disabled on existing bots until their agent is configured for it. */
+  ticket_intake_enabled?: boolean;
   personal_bot?: {
     channel_id?: string;
     agent_id: string;
@@ -562,10 +572,14 @@ const FEEDBACK_TOAST_BY_LOCALE: Record<LarkLocale, { ok: string; fail: string }>
   "en-US": { ok: "Feedback recorded — thanks!", fail: "Could not record feedback. Please try again." },
 };
 
+const TICKET_INTAKE_TOAST_BY_LOCALE = {
+  "zh-CN": { start: "已开始整理，请继续发送问题背景。", confirm: "正在确认工单信息。", continue: "请继续发送需要补充或修改的信息。", cancel: "正在取消。", fail: "操作失败，请刷新后重试。", forbidden: "只有发起人可以操作这份工单草稿。" },
+  "en-US": { start: "Intake started. Send more context in chat.", confirm: "Confirming the ticket details.", continue: "Send the details you want to add or change.", cancel: "Cancelling.", fail: "Action failed. Refresh and try again.", forbidden: "Only the requester can operate this ticket draft." },
+} as const;
+
 /**
- * Handle a `card.action.trigger` callback. Only feedback buttons (our
- * FEEDBACK_ACTION_KIND discriminator) are processed; anything else returns
- * undefined so future card actions can add their own handling.
+ * Handle a `card.action.trigger` callback for feedback, group mode, and
+ * user-started ticket intake. Unknown discriminators return undefined.
  *
  * The return value is the card-callback response Feishu shows as a toast.
  * Feishu enforces a hard ~3s budget on that response measured END-TO-END
@@ -601,6 +615,10 @@ export function handleLarkCardAction(
   // toast + detached side-effect shape as feedback (200671 discipline).
   if (value.kind === MODE_ACTION_KIND) {
     return handleModeSwitchAction(value as Partial<ModeActionValue>, data, larkClient, frontendClient);
+  }
+
+  if (value.kind === TICKET_INTAKE_ACTION_KIND) {
+    return handleTicketIntakeAction(value as Partial<TicketIntakeActionValue>, data, larkClient, frontendClient);
   }
 
   if (value.kind !== FEEDBACK_ACTION_KIND) return undefined;
@@ -642,6 +660,69 @@ export function handleLarkCardAction(
   })();
 
   return { toast: { type: "success", content: toasts.ok } };
+}
+
+function handleTicketIntakeAction(
+  value: Partial<TicketIntakeActionValue>,
+  data: any,
+  larkClient: any,
+  frontendClient?: FrontendWsClient,
+): { toast: { type: string; content: string } } {
+  const locale: LarkLocale = value.locale === "en-US" ? "en-US" : "zh-CN";
+  const copy = TICKET_INTAKE_TOAST_BY_LOCALE[locale];
+  const operator = typeof data?.operator?.open_id === "string" ? data.operator.open_id : "";
+  const action = value.action;
+  if (!operator || operator !== value.requester_external_id) {
+    return { toast: { type: "error", content: copy.forbidden } };
+  }
+  if (!action || !["start", "confirm", "continue", "cancel"].includes(action)) {
+    return { toast: { type: "error", content: copy.fail } };
+  }
+  if (action === "start") {
+    if (!value.session_id || !value.channel_id || !value.source_message_id) {
+      return { toast: { type: "error", content: copy.fail } };
+    }
+  } else if (!value.intake_id || !Number.isInteger(value.revision) || Number(value.revision) < 1) {
+    return { toast: { type: "error", content: copy.fail } };
+  }
+
+  void (async () => {
+    try {
+      const sourceMessageId = typeof value.source_message_id === "string" ? value.source_message_id : "";
+      const result = action === "start"
+        ? await beginTicketIntake({
+            sessionId: String(value.session_id ?? ""),
+            channelId: String(value.channel_id ?? ""),
+            requesterExternalId: operator,
+            sourceMessageId: String(value.source_message_id ?? ""),
+          }, frontendClient)
+        : await transitionTicketIntake({
+            intakeId: String(value.intake_id ?? ""),
+            requesterExternalId: operator,
+            revision: Number(value.revision),
+            action,
+          }, frontendClient);
+      if (!result.success) {
+        console.warn(`[lark] Ticket intake ${action} rejected: ${result.error ?? "unknown"}`);
+        if (sourceMessageId) await replyToLark(larkClient, sourceMessageId, copy.fail);
+        return;
+      }
+      if (sourceMessageId) {
+        const notice = action === "confirm"
+          ? (locale === "zh-CN" ? `✅ 工单信息已确认，编号：${result.intake?.id ?? value.intake_id}` : `✅ Ticket details confirmed: ${result.intake?.id ?? value.intake_id}`)
+          : action === "cancel"
+            ? (locale === "zh-CN" ? "已取消这份工单草稿。" : "Ticket draft cancelled.")
+            : action === "continue"
+              ? copy.continue
+              : copy.start;
+        await replyToLark(larkClient, sourceMessageId, notice);
+      }
+    } catch (err) {
+      console.error(`[lark] Ticket intake ${action} failed:`, err);
+    }
+  })();
+
+  return { toast: { type: "success", content: copy[action] } };
 }
 
 /**
@@ -1198,6 +1279,7 @@ export async function handleLarkMessage(
       tlsOptions,
       frontendClient,
       locale,
+      ticketIntakeEnabled: channelConfig?.ticket_intake_enabled === true,
     }));
     if (!queued.accepted) {
       await replyToLark(larkClient, messageId, QUEUE_FULL_NOTICE_BY_LOCALE[locale]);
@@ -1398,6 +1480,7 @@ export async function handleLarkMessage(
     tlsOptions,
     frontendClient,
     locale,
+    ticketIntakeEnabled: channelConfig?.ticket_intake_enabled === true,
   }));
   if (!queued.accepted) {
     await replyToLark(larkClient, messageId, QUEUE_FULL_NOTICE_BY_LOCALE[locale], replyInThread);
@@ -1434,6 +1517,7 @@ interface QueuedLarkMessageContext {
   tlsOptions?: { cert: string; key: string; ca: string };
   frontendClient?: FrontendWsClient;
   locale: "zh-CN" | "en-US";
+  ticketIntakeEnabled?: boolean;
 }
 
 async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<void> {
@@ -1458,6 +1542,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     tlsOptions,
     frontendClient,
     locale,
+    ticketIntakeEnabled = false,
   } = ctx;
 
   if (/^\/new$/i.test(text)) {
@@ -1558,6 +1643,18 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       replyInThread,
     );
     return;
+  }
+
+  // The intake is opt-in: this query can only find a row created by the
+  // requester's earlier card click. In a shared group it is scoped by both
+  // session and open_id, so two members can collect independent drafts.
+  let activeTicketIntake: TicketIntakeRecord | null = null;
+  if (ticketIntakeEnabled && senderOpenId) {
+    try {
+      activeTicketIntake = await getActiveTicketIntake(sessionId, senderOpenId, frontendClient);
+    } catch (err) {
+      console.warn(`[lark] Failed to load active ticket intake session=${sessionId}:`, err);
+    }
   }
 
   // Open the typing-indicator card FIRST so the user sees immediate feedback.
@@ -1708,8 +1805,11 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const sharedContext: SharedGroupContext | undefined = drained
     ? { discussion: drained.lines, truncated: drained.truncated, asker: senderLabel(senderOpenId) }
     : undefined;
+  const agentPromptText = activeTicketIntake
+    ? `${buildChannelTurnPrompt(promptText, sharedContext)}\n\n${buildTicketIntakeAgentContext(activeTicketIntake)}`
+    : buildChannelTurnPrompt(promptText, sharedContext);
   const promptOpts: PromptOptions = {
-    text: buildChannelTurnPrompt(promptText, sharedContext),
+    text: agentPromptText,
     agentId,
     mode: "channel",
     sessionId,
@@ -1738,6 +1838,13 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     resultText = collected.text;
     replyImages = collected.images;
     assistantMessageId = collected.assistantMessageId;
+    if (activeTicketIntake && senderOpenId) {
+      try {
+        activeTicketIntake = await getActiveTicketIntake(sessionId, senderOpenId, frontendClient);
+      } catch (err) {
+        console.warn(`[lark] Failed to refresh ticket intake session=${sessionId}:`, err);
+      }
+    }
   } catch (err) {
     if (isSessionBusyError(err)) {
       // Still busy after the retry window — surface a friendly notice, don't clobber.
@@ -1764,7 +1871,10 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     || VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
   // The final card is JUST the conclusion — the live step indicator is replaced
   // entirely, no milestone trail is kept on the card.
-  const finalCardBody = buildMilestoneCardMarkdown({ milestones: [], finalText: displayBody });
+  let finalCardBody = buildMilestoneCardMarkdown({ milestones: [], finalText: displayBody });
+  if (!agentError && activeTicketIntake?.state === "review") {
+    finalCardBody += `\n\n${buildTicketIntakeReviewMarkdown(activeTicketIntake, locale)}`;
+  }
 
   // Stop any further coalesced milestone renders and let the in-flight one
   // settle, so finalizeCard isn't overwritten by a later (higher-sequence)
@@ -1777,10 +1887,27 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     // empty-result notice, where a click would write a rating against a
     // non-answer and skew the feedback signal Metrics aggregates.
     const isAnswer = !agentError && resultText.trim().length > 0;
+    const ticketIntakeCard: { ctx: TicketIntakeCardContext; locale: LarkLocale } | undefined =
+      isAnswer && ticketIntakeEnabled && senderOpenId
+        ? activeTicketIntake
+          ? {
+              ctx: {
+                mode: "active", intakeId: activeTicketIntake.id, revision: activeTicketIntake.revision,
+                requesterExternalId: senderOpenId, sourceMessageId: messageId,
+                reviewable: activeTicketIntake.state === "review",
+              },
+              locale,
+            }
+          : {
+              ctx: { mode: "start", sessionId, channelId, requesterExternalId: senderOpenId, sourceMessageId: messageId },
+              locale,
+            }
+        : undefined;
     const { ok, contentOk } = await finalizeCard(larkClient, cardSession, finalCardBody,
       isAnswer && assistantMessageId
         ? { ctx: { sessionId, channelId, messageId: assistantMessageId }, locale }
-        : undefined);
+        : undefined,
+      ticketIntakeCard);
     deliveredTextChars = finalCardBody.length;
     if (!contentOk) {
       // The body never landed (rejected update / oversized answer), so the card
@@ -1796,6 +1923,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
         isAnswer && assistantMessageId
           ? { ctx: { sessionId, channelId, messageId: assistantMessageId }, locale }
           : undefined,
+        ticketIntakeCard,
       );
     } else if (!ok) {
       // Content landed, only the streaming-mode flip failed: the answer IS
@@ -2523,8 +2651,9 @@ async function deliverAnswerOutsideCard(
   body: string,
   replyInThread: boolean,
   feedback?: { ctx: FeedbackContext; locale: LarkLocale },
+  ticketIntake?: { ctx: TicketIntakeCardContext; locale: LarkLocale },
 ): Promise<void> {
-  if (await postFinalCard(larkClient, messageId, body, feedback, replyInThread)) return;
+  if (await postFinalCard(larkClient, messageId, body, feedback, replyInThread, ticketIntake)) return;
   console.warn(`[lark] Replacement card failed for messageId=${messageId}; replying as plain text (markdown will not render)`);
   await replyToLark(larkClient, messageId, body, replyInThread);
 }

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -573,8 +573,8 @@ const FEEDBACK_TOAST_BY_LOCALE: Record<LarkLocale, { ok: string; fail: string }>
 };
 
 const TICKET_INTAKE_TOAST_BY_LOCALE = {
-  "zh-CN": { start: "已开始整理，请继续发送问题背景。", confirm: "正在确认工单信息。", continue: "请继续发送需要补充或修改的信息。", cancel: "正在取消。", fail: "操作失败，请刷新后重试。", forbidden: "只有发起人可以操作这份工单草稿。" },
-  "en-US": { start: "Intake started. Send more context in chat.", confirm: "Confirming the ticket details.", continue: "Send the details you want to add or change.", cancel: "Cancelling.", fail: "Action failed. Refresh and try again.", forbidden: "Only the requester can operate this ticket draft." },
+  "zh-CN": { start: "好的，我来帮你提交工单。", confirm: "正在确认工单信息。", continue: "请继续发送需要补充或修改的信息。", cancel: "正在取消。", fail: "操作失败，请刷新后重试。", forbidden: "只有发起人可以操作这份工单。" },
+  "en-US": { start: "Okay, I'll help you submit a ticket.", confirm: "Confirming the ticket details.", continue: "Send the details you want to add or change.", cancel: "Cancelling.", fail: "Action failed. Refresh and try again.", forbidden: "Only the requester can operate this ticket." },
 } as const;
 
 /**
@@ -709,12 +709,14 @@ function handleTicketIntakeAction(
       }
       if (sourceMessageId) {
         const notice = action === "confirm"
-          ? (locale === "zh-CN" ? `✅ 工单信息已确认，编号：${result.intake?.id ?? value.intake_id}` : `✅ Ticket details confirmed: ${result.intake?.id ?? value.intake_id}`)
+          ? (locale === "zh-CN" ? "✅ 已确认工单信息。" : "✅ Ticket details confirmed.")
           : action === "cancel"
-            ? (locale === "zh-CN" ? "已取消这份工单草稿。" : "Ticket draft cancelled.")
+            ? (locale === "zh-CN" ? "已取消提交工单。" : "Ticket submission cancelled.")
             : action === "continue"
               ? copy.continue
-              : copy.start;
+              : (locale === "zh-CN"
+                  ? "好的，我来帮你提交工单。请继续发送问题背景、影响范围和期望结果。"
+                  : "Okay, I'll help you submit a ticket. Send the issue context, impact scope, and expected result.");
         await replyToLark(larkClient, sourceMessageId, notice);
       }
     } catch (err) {

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -662,6 +662,44 @@ describe("handleDelegationEvents", () => {
     expect(delivered).toHaveLength(0);
     expect(frontend.calls).toHaveLength(0);
   });
+
+  it("forwards ticket draft updates to Portal after enforcing session and agent ownership", async () => {
+    sessionRegistry.remember("ticket-session", "user-1", "agent-1");
+    frontend.responses.set("channel.updateTicketIntakeDraft", { success: true });
+    const res = new FakeRes();
+    const draft = {
+      classification: "incident_candidate", summary: "Login fails", impact: "Tenant A",
+      actual_behavior: "500", expected_behavior: "success", attempted_actions: [], source_refs: [],
+      open_questions: [], ready_for_review: true,
+    };
+    await handleDelegationEvents(
+      asReq(new FakeReq(JSON.stringify({
+        type: "channel.ticket_intake_draft",
+        intake: { sessionId: "ticket-session", intakeId: "intake-1", expectedRevision: 2, draft, fromAgentId: "agent-1" },
+      }))),
+      asRes(res), identity, frontend as unknown as FrontendWsClient,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ ok: true });
+    expect(frontend.calls[0]).toEqual({
+      method: "channel.updateTicketIntakeDraft",
+      params: { session_id: "ticket-session", intake_id: "intake-1", expected_revision: 2, draft },
+    });
+  });
+
+  it("rejects ticket draft updates from another agent identity", async () => {
+    sessionRegistry.remember("ticket-session", "user-1", "agent-1");
+    const res = new FakeRes();
+    await handleDelegationEvents(
+      asReq(new FakeReq(JSON.stringify({
+        type: "channel.ticket_intake_draft",
+        intake: { sessionId: "ticket-session", intakeId: "intake-1", expectedRevision: 1, draft: {}, fromAgentId: "agent-2" },
+      }))),
+      asRes(res), identity, frontend as unknown as FrontendWsClient,
+    );
+    expect(res.statusCode).toBe(403);
+    expect(frontend.calls).toHaveLength(0);
+  });
 });
 
 // ── handleMetricsFlush (module 5) ─────────────────────────

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -134,6 +134,11 @@ async function validateDelegationEventActor(
       if (!(await sessionBelongsToIdentity(event.message.sessionId, identity))) return { status: 403, error: "channel session mismatch" };
       return null;
     }
+    case "channel.ticket_intake_draft": {
+      if (!agentMatchesIdentity(event.intake.fromAgentId, identity)) return { status: 403, error: "ticket intake source agent mismatch" };
+      if (!(await sessionBelongsToIdentity(event.intake.sessionId, identity))) return { status: 403, error: "ticket intake session mismatch" };
+      return null;
+    }
     default:
       return null;
   }
@@ -676,6 +681,16 @@ export async function handleDelegationEvents(
       }
       case "channel.deliver_message": {
         response = { ok: await deliverChannelVisibleMessage(event.message) };
+        break;
+      }
+      case "channel.ticket_intake_draft": {
+        const result = await frontendClient.request("channel.updateTicketIntakeDraft", {
+          session_id: event.intake.sessionId,
+          intake_id: event.intake.intakeId,
+          expected_revision: event.intake.expectedRevision,
+          draft: event.intake.draft,
+        });
+        response = { ok: result?.success === true };
         break;
       }
       default: {

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -2377,9 +2377,9 @@ describe("metrics.auditDetail", () => {
 // ================================================================
 
 describe("buildAdapterRpcHandlers", () => {
-  it("registers exactly 59 handlers", () => {
+  it("registers exactly 63 handlers", () => {
     const handlers = buildAdapterRpcHandlers();
-    expect(handlers.size).toBe(59);
+    expect(handlers.size).toBe(63);
   });
 
   it("all expected handler names are registered", () => {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -25,6 +25,7 @@ import { normalizeChatSessionPreview, normalizeChatSessionTitle } from "./chat-s
 import { safeParseSkillFiles } from "../shared/skill-package.js";
 import { walkJumpChainRows, chainHopFromRow } from "./host-api.js";
 import { resolveAgentModelRouting } from "./model-routing-config.js";
+import { beginTicketIntake, getActiveTicketIntake, transitionTicketIntake, updateTicketIntakeDraft } from "./ticket-intake-store.js";
 
 function requireInternalAuth(req: http.IncomingMessage, internalSecret: string): boolean {
   const token = req.headers["x-auth-token"] as string | undefined;
@@ -3197,6 +3198,11 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     const db = getDb();
     return updateChannelBindingContextMode(db, params.channel_id, params.route_key, params.mode);
   });
+
+  handlers.set("channel.beginTicketIntake", async (params) => beginTicketIntake(getDb(), params));
+  handlers.set("channel.getActiveTicketIntake", async (params) => getActiveTicketIntake(getDb(), params));
+  handlers.set("channel.updateTicketIntakeDraft", async (params) => updateTicketIntakeDraft(getDb(), params));
+  handlers.set("channel.transitionTicketIntake", async (params) => transitionTicketIntake(getDb(), params));
 
   handlers.set("channel.resolvePersonalBinding", async (params) => {
     const db = getDb();

--- a/src/portal/migrate-sqlite.test.ts
+++ b/src/portal/migrate-sqlite.test.ts
@@ -11,7 +11,7 @@ describe("runPortalMigrations on SQLite :memory:", () => {
     await closeDb();
   });
 
-  it("creates all 34 tables without error", async () => {
+  it("creates all 36 tables without error", async () => {
     await runPortalMigrations();
     const db = getDb();
     const [rows] = await db.query<Array<{ name: string }>>(
@@ -53,6 +53,7 @@ describe("runPortalMigrations on SQLite :memory:", () => {
       "skill_versions",
       "skills",
       "system_config",
+      "ticket_intakes",
       "tracing_exporters",
     ];
     for (const name of expected) {
@@ -92,6 +93,7 @@ describe("runPortalMigrations on SQLite :memory:", () => {
       "idx_kpe_created",
       "idx_kpe_repo",
       "idx_message_feedback_session",
+      "idx_ticket_intakes_active",
       "idx_skills_overlay",
       "idx_skills_org_name",
       "idx_hosts_jump",

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -372,6 +372,26 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     CONSTRAINT fk_message_feedback_session FOREIGN KEY (session_id) REFERENCES chat_sessions(id) ON DELETE CASCADE
   )`,
 
+  // User-started support intake. The Agent may revise draft_json, but only a
+  // requester-authenticated card action can freeze submission_payload.
+  `CREATE TABLE IF NOT EXISTS ticket_intakes (
+    id CHAR(36) PRIMARY KEY,
+    request_key CHAR(64) NOT NULL UNIQUE,
+    session_id CHAR(36) NOT NULL,
+    channel_id VARCHAR(128) NOT NULL,
+    requester_external_id VARCHAR(128) NOT NULL,
+    source_message_id VARCHAR(128) NOT NULL,
+    state VARCHAR(32) NOT NULL DEFAULT 'collecting',
+    draft_json TEXT NOT NULL,
+    revision INT NOT NULL DEFAULT 1,
+    submission_payload TEXT DEFAULT NULL,
+    confirmed_at TIMESTAMP NULL DEFAULT NULL,
+    cancelled_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_ticket_intakes_session FOREIGN KEY (session_id) REFERENCES chat_sessions(id) ON DELETE CASCADE
+  )`,
+
   // A2A task projection. This is protocol state for external agent clients,
   // not an AgentBox/pi-agent checkpoint.
   `CREATE TABLE IF NOT EXISTS a2a_tasks (
@@ -568,6 +588,7 @@ async function createIndexes(): Promise<void> {
   await ensureIndex(db, "chat_messages", "idx_chat_messages_delegation", "delegation_id");
   // message_feedback — Metrics aggregates by session.
   await ensureIndex(db, "message_feedback", "idx_message_feedback_session", "session_id, created_at");
+  await ensureIndex(db, "ticket_intakes", "idx_ticket_intakes_active", "session_id, requester_external_id, state, updated_at");
   await ensureIndex(db, "chat_messages", "idx_chat_messages_trace", "trace_id");
   // a2a_tasks — every A2A query is scoped by (agent_id, api_key_id), so lead the composite
   // indexes with that prefix. #340 already created idx_a2a_tasks_agent/_context (older column

--- a/src/portal/siclaw-api.personal-bot.test.ts
+++ b/src/portal/siclaw-api.personal-bot.test.ts
@@ -126,6 +126,7 @@ describe("agent personal-bot routes", () => {
         app_id: "cli_xxx",
         access_mode: "open",
         group_auto_bind: true,
+        ticket_intake_enabled: false,
         status: "active",
       });
       expect(JSON.stringify(body)).not.toContain("s3cret");
@@ -172,7 +173,7 @@ describe("agent personal-bot routes", () => {
       const { status } = await runRoute(router, fakeReq({
         url: "/api/v1/siclaw/agents/agent-1/personal-bot", method: "PUT",
         headers: { authorization: `Bearer ${ADMIN_TOKEN}` },
-        body: { app_id: "cli_new", app_secret: "sec", domain: "feishu", group_auto_bind: false },
+        body: { app_id: "cli_new", app_secret: "sec", domain: "feishu", group_auto_bind: false, ticket_intake_enabled: true },
       }));
       expect(status).toBe(200);
       const insert = query.mock.calls[2];
@@ -180,6 +181,7 @@ describe("agent personal-bot routes", () => {
       const cfg = JSON.parse(insert[1][2]);
       expect(cfg.app_id).toBe("cli_new");
       expect(cfg.app_secret).toBe("sec");
+      expect(cfg.ticket_intake_enabled).toBe(true);
       expect(cfg.personal_bot).toEqual({
         agent_id: "agent-1",
         access_mode: "open",

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2829,6 +2829,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
         app_id: row.config.app_id ?? "",
         access_mode: "open",
         group_auto_bind: row.config.personal_bot?.group_auto_bind !== false,
+        ticket_intake_enabled: row.config.ticket_intake_enabled === true,
         status: row.status,
       },
     });
@@ -2840,7 +2841,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (!auth) { sendJson(res, 403, { error: "Admin only" }); return; }
 
     const body = await parseBody<{
-      domain?: string; app_id?: string; app_secret?: string; group_auto_bind?: boolean;
+      domain?: string; app_id?: string; app_secret?: string; group_auto_bind?: boolean; ticket_intake_enabled?: boolean;
     }>(req);
     const appId = typeof body.app_id === "string" ? body.app_id.trim() : "";
     if (!appId) { sendJson(res, 400, { error: "app_id is required" }); return; }
@@ -2868,6 +2869,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       domain: body.domain === "lark" ? "lark" : "feishu",
       app_id: appId,
       app_secret: effectiveSecret,
+      ticket_intake_enabled: body.ticket_intake_enabled === true,
       personal_bot: {
         ...(existing?.config.personal_bot ?? {}),
         agent_id: params.id,

--- a/src/portal/ticket-intake-store.test.ts
+++ b/src/portal/ticket-intake-store.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb, initDb } from "../gateway/db.js";
+import { runPortalMigrations } from "./migrate.js";
+import { beginTicketIntake, getActiveTicketIntake, transitionTicketIntake, updateTicketIntakeDraft } from "./ticket-intake-store.js";
+
+describe("ticket intake state machine", () => {
+  beforeEach(async () => {
+    initDb("sqlite::memory:");
+    await runPortalMigrations();
+    await getDb().query(
+      "INSERT INTO chat_sessions (id, agent_id, user_id, origin) VALUES (?, ?, ?, 'channel')",
+      ["session-1", "agent-1", "owner-1"],
+    );
+  });
+
+  afterEach(closeDb);
+
+  it("requires a user-started draft, optimistic revisions, and requester confirmation", async () => {
+    const created = await beginTicketIntake(getDb(), {
+      session_id: "session-1",
+      channel_id: "lark-channel-1",
+      requester_external_id: "ou_requester",
+      source_message_id: "om_source",
+    });
+    expect(created.success).toBe(true);
+    expect(created.intake?.state).toBe("collecting");
+    expect(created.intake?.revision).toBe(1);
+
+    const duplicate = await beginTicketIntake(getDb(), {
+      session_id: "session-1", channel_id: "lark-channel-1",
+      requester_external_id: "ou_requester", source_message_id: "om_source",
+    });
+    expect(duplicate.intake?.id).toBe(created.intake?.id);
+
+    const incomplete = await updateTicketIntakeDraft(getDb(), {
+      session_id: "session-1", intake_id: created.intake!.id, expected_revision: 1,
+      draft: {
+        classification: "needs_clarification", summary: "Login fails",
+        attempted_actions: [], source_refs: [], open_questions: ["Which tenant?"], ready_for_review: true,
+      },
+    });
+    expect(incomplete).toEqual({ success: true });
+    expect((await getActiveTicketIntake(getDb(), { session_id: "session-1", requester_external_id: "ou_requester" })).intake)
+      .toMatchObject({ state: "collecting", revision: 2 });
+
+    const stale = await updateTicketIntakeDraft(getDb(), {
+      session_id: "session-1", intake_id: created.intake!.id, expected_revision: 1,
+      draft: { classification: "incident_candidate", summary: "stale" },
+    });
+    expect(stale.success).toBe(false);
+
+    const completeDraft = {
+      classification: "incident_candidate",
+      summary: "Users cannot log in",
+      product: "Siclaw",
+      category: "Authentication",
+      impact: "All users in tenant A",
+      affected_object: "tenant A",
+      actual_behavior: "Login returns 500",
+      expected_behavior: "Login succeeds",
+      attempted_actions: ["Retried once"],
+      source_refs: ["Feishu message om_source"],
+      open_questions: [],
+      ready_for_review: true,
+    };
+    expect(await updateTicketIntakeDraft(getDb(), {
+      session_id: "session-1", intake_id: created.intake!.id, expected_revision: 2, draft: completeDraft,
+    })).toEqual({ success: true });
+    const review = (await getActiveTicketIntake(getDb(), {
+      session_id: "session-1", requester_external_id: "ou_requester",
+    })).intake!;
+    expect(review).toMatchObject({ state: "review", revision: 3, draft: completeDraft });
+
+    const forbidden = await transitionTicketIntake(getDb(), {
+      intake_id: review.id, requester_external_id: "ou_someone_else", expected_revision: 3, action: "confirm",
+    });
+    expect(forbidden.success).toBe(false);
+
+    const confirmed = await transitionTicketIntake(getDb(), {
+      intake_id: review.id, requester_external_id: "ou_requester", expected_revision: 3, action: "confirm",
+    });
+    expect(confirmed.success).toBe(true);
+    expect(confirmed.payload).toMatchObject({
+      schema_version: "siclaw.ticket_intake.v1",
+      intake_id: review.id,
+      session_id: "session-1",
+      channel: { type: "lark", requester_external_id: "ou_requester", source_message_id: "om_source" },
+      draft: completeDraft,
+    });
+    expect((await getActiveTicketIntake(getDb(), {
+      session_id: "session-1", requester_external_id: "ou_requester",
+    })).intake).toBeNull();
+
+    const retry = await transitionTicketIntake(getDb(), {
+      intake_id: review.id, requester_external_id: "ou_requester", expected_revision: 3, action: "confirm",
+    });
+    expect(retry.payload).toEqual(confirmed.payload);
+  });
+});

--- a/src/portal/ticket-intake-store.ts
+++ b/src/portal/ticket-intake-store.ts
@@ -1,0 +1,155 @@
+import crypto from "node:crypto";
+import type { Db } from "../gateway/db.js";
+import { insertIgnorePrefix, safeParseJson, toSqlTimestamp } from "../gateway/dialect-helpers.js";
+import {
+  isTicketIntakeReviewable,
+  normalizeTicketIntakeDraft,
+  type TicketIntakeRecord,
+  type TicketIntakeSubmissionPayload,
+} from "../shared/ticket-intake.js";
+
+interface IntakeRow {
+  id: string;
+  session_id: string;
+  channel_id: string;
+  requester_external_id: string;
+  source_message_id: string;
+  state: TicketIntakeRecord["state"];
+  draft_json: string;
+  revision: number;
+  submission_payload?: string | null;
+}
+
+function toRecord(row: IntakeRow): TicketIntakeRecord {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    channelId: row.channel_id,
+    requesterExternalId: row.requester_external_id,
+    sourceMessageId: row.source_message_id,
+    state: row.state,
+    draft: normalizeTicketIntakeDraft(safeParseJson(row.draft_json, {})),
+    revision: Number(row.revision),
+    submissionPayload: row.submission_payload
+      ? safeParseJson<TicketIntakeSubmissionPayload | null>(row.submission_payload, null)
+      : null,
+  };
+}
+
+async function selectById(db: Db, id: string, requester: string): Promise<TicketIntakeRecord | null> {
+  const [rows] = await db.query<IntakeRow[]>(
+    "SELECT * FROM ticket_intakes WHERE id = ? AND requester_external_id = ? LIMIT 1",
+    [id, requester],
+  );
+  return rows.length ? toRecord(rows[0]) : null;
+}
+
+export async function beginTicketIntake(db: Db, params: Record<string, unknown>) {
+  const sessionId = typeof params.session_id === "string" ? params.session_id.trim() : "";
+  const channelId = typeof params.channel_id === "string" ? params.channel_id.trim().slice(0, 128) : "";
+  const requester = typeof params.requester_external_id === "string" ? params.requester_external_id.trim().slice(0, 128) : "";
+  const sourceMessageId = typeof params.source_message_id === "string" ? params.source_message_id.trim().slice(0, 128) : "";
+  if (!sessionId || !channelId || !requester || !sourceMessageId) {
+    return { success: false, error: "session_id, channel_id, requester_external_id and source_message_id are required" };
+  }
+  const active = await getActiveTicketIntake(db, { session_id: sessionId, requester_external_id: requester });
+  if (active.intake) return { success: true, intake: active.intake };
+  const requestKey = crypto.createHash("sha256").update(`${channelId}\0${sessionId}\0${requester}\0${sourceMessageId}`).digest("hex");
+  const id = crypto.randomUUID();
+  const draft = normalizeTicketIntakeDraft({ classification: "needs_clarification", attempted_actions: [], source_refs: [], open_questions: [], ready_for_review: false });
+  await db.query(
+    `${insertIgnorePrefix(db)} INTO ticket_intakes
+      (id, request_key, session_id, channel_id, requester_external_id, source_message_id, state, draft_json, revision)
+     VALUES (?, ?, ?, ?, ?, ?, 'collecting', ?, 1)`,
+    [id, requestKey, sessionId, channelId, requester, sourceMessageId, JSON.stringify(draft)],
+  );
+  const [rows] = await db.query<IntakeRow[]>("SELECT * FROM ticket_intakes WHERE request_key = ? LIMIT 1", [requestKey]);
+  return rows.length ? { success: true, intake: toRecord(rows[0]) } : { success: false, error: "Failed to create ticket intake" };
+}
+
+export async function getActiveTicketIntake(db: Db, params: Record<string, unknown>) {
+  const sessionId = typeof params.session_id === "string" ? params.session_id.trim() : "";
+  const requester = typeof params.requester_external_id === "string" ? params.requester_external_id.trim() : "";
+  if (!sessionId || !requester) return { intake: null };
+  const [rows] = await db.query<IntakeRow[]>(
+    `SELECT * FROM ticket_intakes
+     WHERE session_id = ? AND requester_external_id = ? AND state IN ('collecting', 'review')
+     ORDER BY updated_at DESC LIMIT 1`,
+    [sessionId, requester],
+  );
+  return { intake: rows.length ? toRecord(rows[0]) : null };
+}
+
+export async function updateTicketIntakeDraft(db: Db, params: Record<string, unknown>) {
+  const sessionId = typeof params.session_id === "string" ? params.session_id.trim() : "";
+  const id = typeof params.intake_id === "string" ? params.intake_id.trim() : "";
+  const revision = Number(params.expected_revision);
+  if (!sessionId || !id || !Number.isInteger(revision)) return { success: false, error: "session_id, intake_id and expected_revision are required" };
+  const draft = normalizeTicketIntakeDraft(params.draft);
+  const state = isTicketIntakeReviewable(draft) && draft.open_questions.length === 0 ? "review" : "collecting";
+  const [result] = await db.query(
+    `UPDATE ticket_intakes SET draft_json = ?, state = ?, revision = revision + 1, updated_at = CURRENT_TIMESTAMP
+     WHERE id = ? AND session_id = ? AND revision = ? AND state IN ('collecting', 'review')`,
+    [JSON.stringify(draft), state, id, sessionId, revision],
+  ) as any;
+  return Number(result?.affectedRows ?? 0) > 0
+    ? { success: true }
+    : { success: false, error: "No active user-started ticket intake" };
+}
+
+export async function transitionTicketIntake(db: Db, params: Record<string, unknown>) {
+  const id = typeof params.intake_id === "string" ? params.intake_id.trim() : "";
+  const requester = typeof params.requester_external_id === "string" ? params.requester_external_id.trim() : "";
+  const revision = Number(params.expected_revision);
+  const action = params.action;
+  if (!id || !requester || !Number.isInteger(revision) || !["confirm", "continue", "cancel"].includes(String(action))) {
+    return { success: false, error: "intake_id, requester_external_id, expected_revision and a valid action are required" };
+  }
+  const current = await selectById(db, id, requester);
+  if (!current) return { success: false, error: "Ticket intake not found" };
+  if (action === "confirm" && current.state === "confirmed" && current.submissionPayload) {
+    return { success: true, intake: current, payload: current.submissionPayload };
+  }
+  if (current.revision !== revision) return { success: false, error: "Ticket intake changed; review the latest version" };
+  if (current.state === "confirmed" || current.state === "cancelled") return { success: false, error: "Ticket intake is already closed" };
+
+  let payload: TicketIntakeSubmissionPayload | undefined;
+  let nextState: TicketIntakeRecord["state"];
+  if (action === "confirm") {
+    if (current.state !== "review" || !isTicketIntakeReviewable(current.draft) || current.draft.open_questions.length) {
+      return { success: false, error: "Ticket intake is not ready for confirmation" };
+    }
+    const confirmedAt = new Date();
+    payload = {
+      schema_version: "siclaw.ticket_intake.v1",
+      intake_id: current.id,
+      session_id: current.sessionId,
+      channel: {
+        type: "lark",
+        channel_id: current.channelId,
+        requester_external_id: current.requesterExternalId,
+        source_message_id: current.sourceMessageId,
+      },
+      draft: current.draft,
+      confirmed_at: confirmedAt.toISOString(),
+    };
+    const [result] = await db.query(
+      `UPDATE ticket_intakes SET state = 'confirmed', submission_payload = ?, confirmed_at = ?, revision = revision + 1, updated_at = CURRENT_TIMESTAMP
+       WHERE id = ? AND requester_external_id = ? AND revision = ? AND state = 'review'`,
+      [JSON.stringify(payload), toSqlTimestamp(confirmedAt), id, requester, revision],
+    ) as any;
+    if (!Number(result?.affectedRows ?? 0)) return { success: false, error: "Ticket intake changed; review the latest version" };
+    nextState = "confirmed";
+  } else {
+    nextState = action === "cancel" ? "cancelled" : "collecting";
+    const [result] = await db.query(
+      `UPDATE ticket_intakes SET state = ?, revision = revision + 1,
+       cancelled_at = ${action === "cancel" ? "CURRENT_TIMESTAMP" : "NULL"}, updated_at = CURRENT_TIMESTAMP
+       WHERE id = ? AND requester_external_id = ? AND revision = ? AND state IN ('collecting', 'review')`,
+      [nextState, id, requester, revision],
+    ) as any;
+    if (!Number(result?.affectedRows ?? 0)) return { success: false, error: "Ticket intake changed; review the latest version" };
+  }
+  const updated = await selectById(db, id, requester);
+  return { success: true, intake: updated ?? { ...current, state: nextState, revision: revision + 1 }, ...(payload ? { payload } : {}) };
+}

--- a/src/shared/delegation-persistence.ts
+++ b/src/shared/delegation-persistence.ts
@@ -2,6 +2,7 @@
 // and tool-registry does not import shared → no cycle). Keeps the group item-status snapshot
 // precisely typed on the wire.
 import type { GroupItemStatus } from "../core/tool-registry.js";
+import type { TicketIntakeDraft } from "./ticket-intake.js";
 
 export interface DelegationLineagePayload {
   parentSessionId?: string | null;
@@ -85,6 +86,14 @@ export interface ChannelDeliverMessagePayload {
   fromAgentId?: string | null;
 }
 
+export interface ChannelTicketIntakeDraftPayload {
+  sessionId: string;
+  intakeId: string;
+  expectedRevision: number;
+  draft: TicketIntakeDraft;
+  fromAgentId?: string | null;
+}
+
 export type DelegationPersistenceEvent =
   | {
       type: "delegation.ensure_session";
@@ -101,7 +110,8 @@ export type DelegationPersistenceEvent =
   | { type: "delegation.update_tool_message"; message: DelegationToolUpdatePayload }
   | { type: "delegation.append_event"; event: DelegationEventPayload }
   | { type: "delegation.emit_chat_event"; sessionId: string; event: Record<string, unknown> }
-  | { type: "channel.deliver_message"; message: ChannelDeliverMessagePayload };
+  | { type: "channel.deliver_message"; message: ChannelDeliverMessagePayload }
+  | { type: "channel.ticket_intake_draft"; intake: ChannelTicketIntakeDraftPayload };
 
 export interface DelegationPersistenceResponse {
   ok: boolean;

--- a/src/shared/ticket-intake.ts
+++ b/src/shared/ticket-intake.ts
@@ -1,0 +1,103 @@
+export const TICKET_INTAKE_ACTION_KIND = "siclaw_ticket_intake" as const;
+
+export type TicketIntakeState = "collecting" | "review" | "confirmed" | "cancelled";
+
+export type TicketIntakeClassification =
+  | "answerable_consultation"
+  | "needs_clarification"
+  | "incident_candidate"
+  | "service_request";
+
+export interface TicketIntakeDraft {
+  classification: TicketIntakeClassification;
+  summary: string;
+  product?: string;
+  category?: string;
+  impact?: string;
+  affected_object?: string;
+  occurred_at?: string;
+  actual_behavior?: string;
+  expected_behavior?: string;
+  attempted_actions: string[];
+  source_refs: string[];
+  open_questions: string[];
+  ready_for_review: boolean;
+}
+
+export interface TicketIntakeRecord {
+  id: string;
+  sessionId: string;
+  channelId: string;
+  requesterExternalId: string;
+  sourceMessageId: string;
+  state: TicketIntakeState;
+  draft: TicketIntakeDraft;
+  revision: number;
+  submissionPayload?: TicketIntakeSubmissionPayload | null;
+}
+
+export interface TicketIntakeSubmissionPayload {
+  schema_version: "siclaw.ticket_intake.v1";
+  intake_id: string;
+  session_id: string;
+  channel: { type: "lark"; channel_id: string; requester_external_id: string; source_message_id: string };
+  draft: TicketIntakeDraft;
+  confirmed_at: string;
+}
+
+const CLASSIFICATIONS = new Set<TicketIntakeClassification>([
+  "answerable_consultation",
+  "needs_clarification",
+  "incident_candidate",
+  "service_request",
+]);
+
+function text(value: unknown, max = 4000): string {
+  return typeof value === "string" ? value.trim().slice(0, max) : "";
+}
+
+function texts(value: unknown, maxItems = 20): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => text(item, 1000)).filter(Boolean).slice(0, maxItems);
+}
+
+export function normalizeTicketIntakeDraft(value: unknown): TicketIntakeDraft {
+  const raw = value && typeof value === "object" ? value as Record<string, unknown> : {};
+  const classification = CLASSIFICATIONS.has(raw.classification as TicketIntakeClassification)
+    ? raw.classification as TicketIntakeClassification
+    : "needs_clarification";
+  return {
+    classification,
+    summary: text(raw.summary),
+    ...(text(raw.product, 200) ? { product: text(raw.product, 200) } : {}),
+    ...(text(raw.category, 200) ? { category: text(raw.category, 200) } : {}),
+    ...(text(raw.impact) ? { impact: text(raw.impact) } : {}),
+    ...(text(raw.affected_object) ? { affected_object: text(raw.affected_object) } : {}),
+    ...(text(raw.occurred_at, 200) ? { occurred_at: text(raw.occurred_at, 200) } : {}),
+    ...(text(raw.actual_behavior) ? { actual_behavior: text(raw.actual_behavior) } : {}),
+    ...(text(raw.expected_behavior) ? { expected_behavior: text(raw.expected_behavior) } : {}),
+    attempted_actions: texts(raw.attempted_actions),
+    source_refs: texts(raw.source_refs),
+    open_questions: texts(raw.open_questions),
+    ready_for_review: raw.ready_for_review === true,
+  };
+}
+
+export function isTicketIntakeReviewable(draft: TicketIntakeDraft): boolean {
+  return draft.ready_for_review && Boolean(
+    draft.summary && draft.classification && draft.impact && draft.actual_behavior && draft.expected_behavior,
+  );
+}
+
+export function buildTicketIntakeAgentContext(record: TicketIntakeRecord): string {
+  return [
+    "<siclaw_ticket_intake>",
+    "The user explicitly started a ticket-intake flow. Continue answering product questions from bound knowledge first.",
+    "Do not inspect or operate clusters, production systems, hosts, or credentials. Do not claim a ticket was submitted.",
+    "Collect only missing user facts, then call ticket_intake_draft with the full latest draft on every turn.",
+    "Set ready_for_review=true only when summary, classification, impact, actual_behavior, and expected_behavior are complete and open_questions is empty.",
+    "When ready, present a concise review summary and ask the user to use the Feishu confirmation button. The tool cannot confirm.",
+    `Current intake: ${JSON.stringify({ id: record.id, revision: record.revision, state: record.state, draft: record.draft })}`,
+    "</siclaw_ticket_intake>",
+  ].join("\n");
+}

--- a/src/tools/all-entries.ts
+++ b/src/tools/all-entries.ts
@@ -34,6 +34,7 @@ import { registration as manageSchedule } from "./workflow/manage-schedule.js";
 import { registration as taskReport } from "./workflow/task-report.js";
 import { registration as skillPreview } from "./workflow/skill-preview.js";
 import { registration as channelUpdate } from "./workflow/channel-update.js";
+import { registration as ticketIntakeDraft } from "./workflow/ticket-intake-draft.js";
 import { registration as reportFindings } from "./workflow/report-findings.js";
 import { registration as requestInput } from "./workflow/request-input.js";
 import { registration as delegateToAgent } from "./workflow/delegate-to-agent.js";
@@ -55,7 +56,7 @@ export const allToolEntries: ToolEntry[] = [
   memorySearch, memoryGet,
   // ── workflow ──
   saveFeedback, manageSchedule, taskReport, skillPreview,
-  channelUpdate, reportFindings, requestInput,
+  channelUpdate, ticketIntakeDraft, reportFindings, requestInput,
   taskCreateRegistration, taskUpdateRegistration, taskListRegistration, taskGetRegistration,
   spawnSubagent, jobStop, taskOutput,
   delegateToAgent, listDelegates,

--- a/src/tools/workflow/ticket-intake-draft.test.ts
+++ b/src/tools/workflow/ticket-intake-draft.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ToolRefs } from "../../core/tool-registry.js";
+import { createTicketIntakeDraftTool, registration } from "./ticket-intake-draft.js";
+
+function refs(executor: ToolRefs["ticketIntakeDraftExecutor"]): ToolRefs {
+  return {
+    kubeconfigRef: {} as any, userId: "user-1", agentId: "agent-1",
+    sessionIdRef: { current: "session-1" }, taskListId: "tasks-1",
+    memoryRef: {} as any, dpStateRef: {} as any, ticketIntakeDraftExecutor: executor,
+  };
+}
+
+describe("ticket_intake_draft tool", () => {
+  it("is channel-only, executor-gated, and unavailable to delegated workers", () => {
+    expect(registration.modes).toEqual(["channel"]);
+    expect(registration.available?.(refs(undefined))).toBe(false);
+    expect(registration.available?.(refs(vi.fn() as any))).toBe(true);
+    expect(registration.available?.({ ...refs(vi.fn() as any), delegation: { delegationId: "d1", readOnly: true } })).toBe(false);
+  });
+
+  it("updates only an opaque intake id and expected revision; it has no submit action", async () => {
+    const executor = vi.fn().mockResolvedValue({ accepted: true, message: "saved" });
+    const tool = createTicketIntakeDraftTool(refs(executor));
+    const result = await tool.execute("call-1", {
+      intake_id: "intake-1", expected_revision: 4,
+      classification: "incident_candidate", summary: "Login fails", impact: "Tenant A",
+      actual_behavior: "500", expected_behavior: "Login succeeds",
+      attempted_actions: ["retry"], source_refs: [], open_questions: [], ready_for_review: true,
+    });
+    expect(executor).toHaveBeenCalledWith({
+      sessionId: "session-1", intakeId: "intake-1", expectedRevision: 4,
+      draft: expect.objectContaining({ summary: "Login fails", ready_for_review: true }),
+    });
+    expect((result.content[0] as any).text).toBe("saved");
+    expect(JSON.stringify(tool.parameters)).not.toContain("submit");
+    expect(JSON.stringify(tool.parameters)).not.toContain("confirm");
+  });
+});

--- a/src/tools/workflow/ticket-intake-draft.ts
+++ b/src/tools/workflow/ticket-intake-draft.ts
@@ -1,0 +1,60 @@
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { renderTextResult } from "../infra/tool-render.js";
+import type { ToolEntry, ToolRefs } from "../../core/tool-registry.js";
+import { normalizeTicketIntakeDraft } from "../../shared/ticket-intake.js";
+
+export function createTicketIntakeDraftTool(refs: ToolRefs): ToolDefinition {
+  return {
+    name: "ticket_intake_draft",
+    label: "Ticket Intake Draft",
+    renderCall: (_a, theme) => new Text(theme.fg("toolTitle", theme.bold("ticket_intake_draft")), 0, 0),
+    renderResult: renderTextResult,
+    description:
+      "Update the full structured draft for a ticket-intake flow that the user explicitly started in the IM channel. " +
+      "This tool only saves a draft. It cannot confirm, submit, inspect infrastructure, or create a ticket. " +
+      "Keep open_questions precise and set ready_for_review only after all required facts are complete.",
+    parameters: Type.Object({
+      intake_id: Type.String({ minLength: 1, description: "Opaque intake id from the platform context." }),
+      expected_revision: Type.Integer({ minimum: 1, description: "Current revision from the platform context." }),
+      classification: Type.Union([
+        Type.Literal("answerable_consultation"),
+        Type.Literal("needs_clarification"),
+        Type.Literal("incident_candidate"),
+        Type.Literal("service_request"),
+      ]),
+      summary: Type.String({ minLength: 1 }),
+      product: Type.Optional(Type.String()),
+      category: Type.Optional(Type.String()),
+      impact: Type.Optional(Type.String()),
+      affected_object: Type.Optional(Type.String()),
+      occurred_at: Type.Optional(Type.String()),
+      actual_behavior: Type.Optional(Type.String()),
+      expected_behavior: Type.Optional(Type.String()),
+      attempted_actions: Type.Array(Type.String(), { maxItems: 20 }),
+      source_refs: Type.Array(Type.String(), { maxItems: 20 }),
+      open_questions: Type.Array(Type.String(), { maxItems: 20 }),
+      ready_for_review: Type.Boolean(),
+    }),
+    async execute(_toolCallId, rawParams) {
+      if (!refs.ticketIntakeDraftExecutor) {
+        return { content: [{ type: "text", text: "No user-started ticket intake is active." }], details: { accepted: false } };
+      }
+      const response = await refs.ticketIntakeDraftExecutor({
+        sessionId: refs.sessionIdRef.current,
+        intakeId: String((rawParams as any).intake_id),
+        expectedRevision: Number((rawParams as any).expected_revision),
+        draft: normalizeTicketIntakeDraft(rawParams),
+      });
+      return { content: [{ type: "text", text: response.message }], details: { accepted: response.accepted } };
+    },
+  };
+}
+
+export const registration: ToolEntry = {
+  category: "workflow",
+  create: createTicketIntakeDraftTool,
+  modes: ["channel"],
+  available: (refs) => Boolean(refs.ticketIntakeDraftExecutor && !refs.delegation),
+};


### PR DESCRIPTION
## Summary

- add an opt-in Lark/Feishu support intake flow: prepare, collect, review, continue/cancel, and requester-confirmed handoff
- persist revisioned intake drafts and freeze a versioned `siclaw.ticket_intake.v1` payload at confirmation
- add a draft-only Agent tool and dedicated capability group; the Agent cannot confirm or submit
- expose enablement controls for shared and per-agent Lark bots, disabled by default

## Safety boundary

- no cluster, host, VM, credential, or production access is added
- only the original Lark requester can transition their draft
- optimistic revisions reject stale card/tool updates
- this phase freezes the handoff payload; it does not claim that a remote ticket was created

## Validation

- `npm run build`
- `npm test` (245 files, 5028 passed, 2 skipped)
- `portal-web: npm run build`
- `portal-web: npm test` (23 files, 225 passed)

## Integration note

Standalone Portal implements the four channel RPCs. Any upstream control plane must implement the same contract before enabling `ticket_intake_enabled` in that environment. No environment was deployed or changed.