### PR TITLE
fix: three runtime failures found while testing a v0.3.4 rolling deploy

### DIFF
--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -527,6 +527,15 @@ loop. The agentbox `/api/internal/metrics-snapshot` pull and the SIGTERM
 `/api/internal/metrics-flush` push share one `MetricsFlushPayload { incarnation, prom }`.
 Per-message `ttft_ms` (still consumed by the chat timing badge) is kept.
 
+**Scope — which boxes are pulled**:
+Only boxes running the default `agent` profile serve `/api/internal/metrics-snapshot`.
+The pod list the loop reads is selected by the `app=agentbox` label, which every spawned
+box carries including the KB compile boxes (Python, a different HTTP contract), so
+pull-eligibility is judged by profile, not by the label. Liveness — what
+`retainInstances` grace-evicts against — deliberately stays the FULL box list: a box that
+reaches federation by some other route (the SIGTERM flush, keyed on cert identity rather
+than profile) must not be evicted while it is still running.
+
 **Consequences**:
 - ✅ One metrics path instead of two; no in-memory counter state on the gateway
 - ✅ External Grafana unaffected — every federated `siclaw_*` series is unchanged

--- a/src/agentbox-main.ts
+++ b/src/agentbox-main.ts
@@ -26,6 +26,38 @@ import { startCapacityMetrics } from "./shared/capacity-metrics.js";
 const config = loadConfig();
 const PORT = config.server.port;
 
+/**
+ * How long the gateway-dependent startup work gets before the box stops waiting on it.
+ *
+ * Everything before `listen()` — settings, resource bundles, the tool whitelist — is a
+ * round trip to the Runtime, and the moment they all happen at once is a rolling deploy:
+ * the Runtime is itself restarting while every box of every agent asks it for the same
+ * things. Whatever is not back by then, the box comes up without and picks up on the next
+ * push, because a box that answers no probe is judged crashed at 60s and replaced by
+ * another one that will queue behind the same slow gateway.
+ *
+ * Deliberately under that 60s so the box loses the sync, not its life.
+ */
+const STARTUP_DEADLINE_MS = 30_000;
+
+/** Run gateway-dependent startup work, giving up (loudly) rather than delaying `listen`. */
+async function withStartupDeadline<T>(label: string, work: () => Promise<T>): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out after ${STARTUP_DEADLINE_MS}ms`)), STARTUP_DEADLINE_MS);
+      }),
+    ]);
+  } catch (err) {
+    console.warn(`[agentbox] startup: ${label} did not finish (${err instanceof Error ? err.message : String(err)}); continuing without it`);
+    return undefined;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function main() {
   // If gatewayUrl is configured, fetch the latest settings.json from Gateway (with mTLS)
   if (config.server.gatewayUrl) {
@@ -34,27 +66,31 @@ async function main() {
     });
 
     // Step 1: Fetch and persist settings.json
-    try {
-      const remoteConfig = await gatewayClient.fetchSettings();
-      const configPath = getConfigPath();
-      const dir = path.dirname(configPath);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(configPath, JSON.stringify(remoteConfig, null, 2) + "\n");
-      reloadConfig();
-      console.log(`[agentbox] Fetched settings from Gateway via mTLS: ${config.server.gatewayUrl}`);
-    } catch (err) {
-      console.warn(`[agentbox] Failed to fetch settings from Gateway, using local config:`, err);
-    }
+    await withStartupDeadline("settings fetch", async () => {
+      try {
+        const remoteConfig = await gatewayClient.fetchSettings();
+        const configPath = getConfigPath();
+        const dir = path.dirname(configPath);
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(configPath, JSON.stringify(remoteConfig, null, 2) + "\n");
+        reloadConfig();
+        console.log(`[agentbox] Fetched settings from Gateway via mTLS: ${config.server.gatewayUrl}`);
+      } catch (err) {
+        console.warn(`[agentbox] Failed to fetch settings from Gateway, using local config:`, err);
+      }
+    });
 
     // Step 2: Sync resources (MCP, skills) — independent of settings fetch
-    try {
-      const { failed } = await syncAllResources(gatewayClient.toClientLike());
-      if (failed.length > 0) {
-        console.error(`[agentbox] Resource sync partial failure: [${failed.join(", ")}]`);
+    await withStartupDeadline("resource sync", async () => {
+      try {
+        const { failed } = await syncAllResources(gatewayClient.toClientLike());
+        if (failed.length > 0) {
+          console.error(`[agentbox] Resource sync partial failure: [${failed.join(", ")}]`);
+        }
+      } catch (err) {
+        console.error(`[agentbox] Resource sync failed:`, err);
       }
-    } catch (err) {
-      console.error(`[agentbox] Resource sync failed:`, err);
-    }
+    });
   }
 
   // Initialise OpenTelemetry agent-behaviour tracing. Placed in main() proper —
@@ -170,8 +206,11 @@ async function main() {
       // 3 attempts, 1s base) to shrink the fail-open window from a transient
       // gateway blip. Pass the per-box handler since `tools` is not in the
       // module-level registry that syncResource would otherwise look up.
-      const count = await syncResource("tools", boxClient, createToolsHandler(sessionManager, boxClient));
-      console.log(`[agentbox] Initial tool-capabilities synced: ${count === 0 ? "unrestricted" : `${count} tools`}`);
+      const count = await withStartupDeadline("tool-capabilities sync", () =>
+        syncResource("tools", boxClient, createToolsHandler(sessionManager, boxClient)));
+      if (count !== undefined) {
+        console.log(`[agentbox] Initial tool-capabilities synced: ${count === 0 ? "unrestricted" : `${count} tools`}`);
+      }
     } catch (err) {
       // Fail-open after all retries: a fresh box has no prior whitelist to fall
       // back to, and a failed fetch usually means broader gateway unreachability

--- a/src/cron/cron-scheduler.test.ts
+++ b/src/cron/cron-scheduler.test.ts
@@ -132,14 +132,103 @@ describe("CronScheduler", () => {
     s.stop();
   });
 
-  it("does not schedule a job with a bogus cron expression (logs error)", () => {
+  it("re-sending an unchanged active job keeps the SAME timer", () => {
+    const s = new CronScheduler(async () => {});
+    s.addOrUpdate(makeJob({ id: "a", schedule: "0 * * * *" }));
+    const armed = (s as any).timers.get("a");
+    // The reconcile loop re-sends every active row on a fixed interval; three passes over
+    // an unchanged job must leave the timer it already has alone.
+    for (let i = 0; i < 3; i++) s.addOrUpdate(makeJob({ id: "a", schedule: "0 * * * *" }));
+    expect((s as any).timers.get("a")).toBe(armed);
+    expect(s.jobCount).toBe(1);
+    s.stop();
+  });
+
+  it("re-arms with a NEW timer when the schedule changes", () => {
+    const s = new CronScheduler(async () => {});
+    s.addOrUpdate(makeJob({ id: "a", schedule: "0 * * * *" }));
+    const armed = (s as any).timers.get("a");
+    s.addOrUpdate(makeJob({ id: "a", schedule: "*/30 * * * *" }));
+    expect((s as any).timers.get("a")).not.toBe(armed);
+    expect(s.jobCount).toBe(1);
+    s.stop();
+  });
+
+  it("paused → active re-arms even though the timer was already gone", () => {
+    const s = new CronScheduler(async () => {});
+    s.addOrUpdate(makeJob({ id: "a", status: "paused" }));
+    expect(s.jobCount).toBe(0);
+    s.addOrUpdate(makeJob({ id: "a", status: "active" }));
+    expect(s.jobCount).toBe(1);
+    s.stop();
+  });
+
+  it("fires the row as it stands now, not the one captured when the timer was armed", async () => {
+    const fired: string[] = [];
+    const s = new CronScheduler(async (job) => { fired.push(job.name); });
+    s.addOrUpdate(makeJob({ id: "t", schedule: "* * * * *", name: "old-name" }));
+    // Same schedule → keeps its timer, so the captured row would otherwise go stale.
+    s.addOrUpdate(makeJob({ id: "t", schedule: "* * * * *", name: "new-name" }));
+
+    await vi.advanceTimersByTimeAsync(60_000 + 1000);
+    await Promise.resolve();
+
+    expect(fired[0]).toBe("new-name");
+    s.stop();
+  });
+
+  it("a schedule change mid-fire leaves no timer that stop() cannot reach", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    let fires = 0;
+    const s = new CronScheduler(async () => { fires++; await gate; });
+    s.addOrUpdate(makeJob({ id: "t", schedule: "* * * * *" }));
+
+    await vi.advanceTimersByTimeAsync(60_000 + 1000);
+    expect(fires).toBe(1); // in flight, blocked on the gate — no timer armed right now
+
+    // A reconcile pass delivers a changed schedule while the fire is still running, so
+    // it arms one; the fire's tail then arms its own. Only one may survive.
+    s.addOrUpdate(makeJob({ id: "t", schedule: "*/2 * * * *" }));
+    release();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    expect(s.jobCount).toBe(1);
+
+    const settled = fires;
+    s.stop();
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(fires).toBe(settled); // an untracked timer would have fired here
+  });
+
+  it("re-arms a job whose fire never settles, so a later pass puts it back on schedule", async () => {
+    let fires = 0;
+    const s = new CronScheduler(async () => { fires++; await new Promise<void>(() => {}); });
+    s.addOrUpdate(makeJob({ id: "h", schedule: "* * * * *" }));
+
+    await vi.advanceTimersByTimeAsync(60_000 + 1000);
+    expect(fires).toBe(1);
+    expect(s.jobCount).toBe(0); // mid-fire: the fire path deleted the timer and never returns
+
+    // Without this the job would never be scheduled again — the fire path's own re-arm
+    // is unreachable while onFire is stuck.
+    s.addOrUpdate(makeJob({ id: "h", schedule: "* * * * *" }));
+    expect(s.jobCount).toBe(1);
+    s.stop();
+  });
+
+  it("does not schedule a job with a bogus cron expression (logs error, claims nothing)", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const s = new CronScheduler(async () => {});
     s.addOrUpdate(makeJob({ id: "bad", schedule: "not a cron" }));
     // Internally jobs map has it, but timers map is empty because scheduleNext threw
     expect(s.jobCount).toBe(0);
     expect(errSpy).toHaveBeenCalled();
+    // ...so it must not also report the job as scheduled.
+    expect(logSpy.mock.calls.filter(c => String(c[0]).includes("Scheduled job bad"))).toHaveLength(0);
     s.stop();
     errSpy.mockRestore();
+    logSpy.mockRestore();
   });
 });

--- a/src/cron/cron-scheduler.ts
+++ b/src/cron/cron-scheduler.ts
@@ -39,30 +39,72 @@ export class CronScheduler {
     this.onFire = onFire;
   }
 
-  /** Add or update a job — cancels old timer and reschedules */
+  /**
+   * Add or update a job.
+   *
+   * Idempotent on purpose: the reconcile loop re-sends every active job on a fixed
+   * interval, almost always unchanged. Re-arming an identical timer each pass is churn
+   * that also drowned the log — two lines per job per pass, so a busy runtime's log was
+   * mostly this. An already-armed job whose scheduling inputs (`schedule`, `status`)
+   * did not change is left alone. The stored row is refreshed either way, and the fire
+   * path reads it back, so a changed prompt/agent still takes effect on the next fire
+   * without a re-arm.
+   *
+   * A job mid-fire has no timer — the fire path re-arms when it finishes — so a pass
+   * that lands there DOES arm one. That is deliberate: it is the only thing that gets a
+   * job whose fire never settles (a hang before the execution timeout is armed) back on
+   * a schedule. Arming is safe because {@link scheduleNext} replaces whatever timer the
+   * job already has instead of leaving a second one running.
+   */
   addOrUpdate(job: CronJobRow): void {
-    this.cancel(job.id);
+    const prev = this.jobs.get(job.id);
     this.jobs.set(job.id, job);
-    if (job.status === "active") {
-      this.scheduleNext(job);
+
+    if (job.status !== "active") {
+      this.clearTimer(job.id);
+      if (prev?.status !== job.status) {
+        console.log(`[cron-scheduler] Job ${job.id} (${job.name}) is paused, not scheduling`);
+      }
+      return;
+    }
+
+    const unchanged = prev?.schedule === job.schedule && prev?.status === job.status;
+    if (this.timers.has(job.id) && unchanged) return;
+
+    this.scheduleNext(job);
+    // Announce a real (re)schedule only. Nothing armed means scheduleNext rejected the
+    // expression and already said so; a mid-fire arm is a safety net, not news.
+    if (this.timers.has(job.id) && !this.executing.has(job.id)) {
       console.log(`[cron-scheduler] Scheduled job ${job.id} (${job.name})`);
-    } else {
-      console.log(`[cron-scheduler] Job ${job.id} (${job.name}) is paused, not scheduling`);
     }
   }
 
   /** Cancel a job's timer */
   cancel(jobId: string): void {
+    this.clearTimer(jobId);
+    this.jobs.delete(jobId);
+  }
+
+  /** Drop a job's timer without forgetting the job itself. */
+  private clearTimer(jobId: string): void {
     const timer = this.timers.get(jobId);
     if (timer) {
       clearTimeout(timer);
       this.timers.delete(jobId);
     }
-    this.jobs.delete(jobId);
   }
 
-  /** Schedule next fire for a job */
+  /**
+   * Schedule next fire for a job.
+   *
+   * Replaces the job's timer rather than adding one: both callers (a re-schedule and the
+   * fire path's tail) can reach a job that already has one armed, and `timers` holds a
+   * single handle per job — so setting without clearing would drop a live timer out of
+   * the map, where neither `cancel()` nor `stop()` can ever reach it and it fires the
+   * job a second time.
+   */
   private scheduleNext(job: CronJobRow): void {
+    this.clearTimer(job.id);
     try {
       const delay = getNextCronDelay(job.schedule);
       const nextTime = getNextCronTime(job.schedule);
@@ -74,12 +116,22 @@ export class CronScheduler {
       const timer = setTimeout(async () => {
         this.timers.delete(job.id);
 
-        if (this.executing.has(job.id)) return;
+        if (this.executing.has(job.id)) {
+          // The previous fire has not finished. Skipping this one is right — two runs of
+          // the same job must not overlap — but returning bare would leave the job with no
+          // timer at all until a reconcile pass noticed, and none is guaranteed to come.
+          this.scheduleNext(this.jobs.get(job.id) ?? job);
+          return;
+        }
         this.executing.add(job.id);
 
-        console.log(`[cron-scheduler] Firing job ${job.id} (${job.name})`);
+        // Fire the row as it stands now, not as it looked when the timer was armed —
+        // an unchanged schedule keeps its timer across reconciles, so the captured
+        // `job` can be several syncs stale (different prompt, agent, name).
+        const firing = this.jobs.get(job.id) ?? job;
+        console.log(`[cron-scheduler] Firing job ${firing.id} (${firing.name})`);
         try {
-          await this.onFire(job);
+          await this.onFire(firing);
         } catch (err) {
           console.error(`[cron-scheduler] Job ${job.id} fire error:`, err);
         } finally {

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -380,6 +380,28 @@ describe("K8sSpawner — spawn branches", () => {
     expect(container.livenessProbe.exec.command).toEqual(container.readinessProbe.exec.command);
     expect(container.readinessProbe.timeoutSeconds).toBe(3);
     expect(container.livenessProbe.timeoutSeconds).toBe(3);
+    // The startup gate has to speak the same dialect, or it is the one probe kubelet
+    // cannot run through the NetworkPolicy and the box never starts at all.
+    expect(container.startupProbe.httpGet).toBeUndefined();
+    expect(container.startupProbe.exec.command).toEqual(container.readinessProbe.exec.command);
+  });
+
+  it("gates a box's probes on a startup probe, so coming up is not reported as unhealthy", async () => {
+    // Readiness used to open fire 2s in, against a process still fetching settings — and,
+    // because instance names are reused, sometimes against a pod with no IP yet. Every
+    // rolled box published Warning events on the way up while nothing was wrong.
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+    readPodImpl.fn = async () => { throw Object.assign(new Error("nf"), { code: 404 }); };
+
+    await s.spawn({ agentId: "probe-gate" }).catch(() => {});
+    const container = calls.createNamespacedPod[0].body.spec.containers[0];
+    expect(container.startupProbe.httpGet).toMatchObject({ path: "/health", scheme: "HTTPS" });
+    // 30 x 2s: the same 60s the manager waits before calling a box crashed, so the two
+    // do not disagree about when a box has failed to come up.
+    expect(container.startupProbe.periodSeconds! * container.startupProbe.failureThreshold!).toBe(60);
+    expect(container.startupProbe.initialDelaySeconds).toBeUndefined();
   });
 
   it("refuses to forward secret-shaped names through the prefix glob (ops knobs only)", async () => {

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -118,6 +118,28 @@ export function clampRequestToLimit(request: string, limit: string, podName: str
   return request;
 }
 
+/**
+ * How kubelet asks a box whether it is up.
+ *
+ * Capability boxes run under a NetworkPolicy that admits only Runtime ingress, and kubelet
+ * probes originate outside that podSelector on several CNIs — so they self-check from
+ * inside the container instead. ONE declaration, shared by all three probes: a profile
+ * that got the wrong dialect for even one of them would fail the probe kubelet cannot
+ * route, and with a startup gate in place that means the box never becomes ready at all.
+ */
+function healthProbeFor(profileName: string): Record<string, unknown> {
+  const inContainer = profileName === "kb-compile" || profileName === "kb-compile-codex" || profileName === "kb-test";
+  return inContainer
+    ? {
+        exec: { command: [
+          "python", "-c",
+          "import ssl,urllib.request; urllib.request.urlopen('https://127.0.0.1:3000/health', context=ssl._create_unverified_context(), timeout=2).read()",
+        ] },
+        timeoutSeconds: 3,
+      }
+    : { httpGet: { path: "/health", port: 3000, scheme: "HTTPS" } };
+}
+
 export class K8sSpawner implements BoxSpawner {
   readonly name = "k8s";
 
@@ -268,6 +290,7 @@ export class K8sSpawner implements BoxSpawner {
     // capability like "kb-compile" declares its own image + writable /work etc.
     // All flavors reuse the same spawn/cert/mTLS/port machinery below.
     const profile = getBoxProfile(boxConfig.profile);
+    const healthProbe = healthProbeFor(profile.name);
     const needsBubblewrap = profile.nestedSandbox === "bubblewrap";
     const image = boxConfig.image ?? profile.image ?? this.config.image;
     const agentId = boxConfig.agentId;
@@ -762,36 +785,20 @@ export class K8sSpawner implements BoxSpawner {
             // Kubelet HTTP probes originate outside that podSelector on several
             // CNIs, so use an in-container HTTPS check for KB profiles. The
             // endpoint is deliberately the sole route that needs no client cert.
-            readinessProbe: profile.name === "kb-compile" || profile.name === "kb-compile-codex" || profile.name === "kb-test"
-              ? {
-                  exec: { command: [
-                    "python", "-c",
-                    "import ssl,urllib.request; urllib.request.urlopen('https://127.0.0.1:3000/health', context=ssl._create_unverified_context(), timeout=2).read()",
-                  ] },
-                  initialDelaySeconds: 2,
-                  periodSeconds: 2,
-                  timeoutSeconds: 3,
-                }
-              : {
-                  httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },
-                  initialDelaySeconds: 2,
-                  periodSeconds: 2,
-                },
-            livenessProbe: profile.name === "kb-compile" || profile.name === "kb-compile-codex" || profile.name === "kb-test"
-              ? {
-                  exec: { command: [
-                    "python", "-c",
-                    "import ssl,urllib.request; urllib.request.urlopen('https://127.0.0.1:3000/health', context=ssl._create_unverified_context(), timeout=2).read()",
-                  ] },
-                  initialDelaySeconds: 10,
-                  periodSeconds: 10,
-                  timeoutSeconds: 3,
-                }
-              : {
-                  httpGet: { path: "/health", port: 3000 as any, scheme: "HTTPS" },
-                  initialDelaySeconds: 10,
-                  periodSeconds: 10,
-                },
+            // Nothing is probed until the box answers once. Without this, readiness opens
+            // fire 2s in against a process still fetching settings and syncing skills —
+            // and, because instance names are reused, sometimes against a pod with no IP
+            // yet ("connect: invalid argument"). Every rolled box therefore published one
+            // or two Warning events on the way up, which is what a rolling upgrade looked
+            // like from the outside: a pool full of unhealthy boxes, none of them failing.
+            //
+            // 30 x 2s is the same 60s the manager waits before calling a box crashed, so
+            // the two do not disagree about when a box has failed to come up. Readiness
+            // and liveness carry no initialDelay: kubelet holds them until this passes,
+            // and a delay measured from container start would be spent by then anyway.
+            startupProbe: { ...healthProbe, periodSeconds: 2, failureThreshold: 30 },
+            readinessProbe: { ...healthProbe, periodSeconds: 2 },
+            livenessProbe: { ...healthProbe, periodSeconds: 10 },
           },
         ],
       },

--- a/src/gateway/agentbox/manager.test.ts
+++ b/src/gateway/agentbox/manager.test.ts
@@ -45,7 +45,11 @@ class FakeSpawner implements BoxSpawner {
       agentId: config.agentId,
     };
   }
-  async stop(boxId: string): Promise<void> { this.stopCalls.push(boxId); }
+  stopThrows = false;
+  async stop(boxId: string): Promise<void> {
+    this.stopCalls.push(boxId);
+    if (this.stopThrows) throw new Error("k8s API said no");
+  }
   async get(boxId: string): Promise<AgentBoxInfo | null> {
     return this.getReturns.get(boxId) ?? null;
   }
@@ -792,6 +796,69 @@ describe("AgentBoxManager — drain reaper", () => {
     });
     await (mgr as any).reapDrainedBoxes();
     expect(spawner.stopCalls).toHaveLength(0);
+  });
+
+  it("names the turns it cuts when the drain deadline forces a live box out", async () => {
+    // The streams break either way — the point is that the Runtime can say WHY, instead of
+    // the user seeing a bare connection error for a rolling upgrade.
+    const { mgr, spawner } = drainingManager({
+      "http://10.0.0.9:3000": { sessionIds: ["s-live", "s-other"], turnsInFlight: 1, drained: false },
+    });
+    const reported: Array<{ ids: string[]; reason: string }> = [];
+    mgr.setTurnTerminator((ids, reason) => reported.push({ ids, reason }));
+    // A box lists every session RESIDENT on it and never forgets one that moved away, so
+    // only the ones still bound HERE may be reported: s-other has since been placed on a
+    // healthy box, and cutting its turn would blame this removal for someone else's work.
+    (mgr as any).bindings.remember("agent-a", "s-live", "old-box");
+    (mgr as any).bindings.remember("agent-a", "s-other", "other-box");
+    // Past the grace period: the box is going regardless of what it still holds.
+    (mgr as any).draining.set("old-box", Date.now() - 10 * 60_000);
+
+    await (mgr as any).reapDrainedBoxes();
+
+    expect(spawner.stopCalls).toEqual(["old-box"]);
+    expect(reported).toEqual([{ ids: ["s-live"], reason: "box_rolled" }]);
+  });
+
+  it("does not report the same box's turns twice when the removal has to be retried", async () => {
+    const { mgr, spawner } = drainingManager({
+      "http://10.0.0.9:3000": { sessionIds: ["s-live"], turnsInFlight: 1, drained: false },
+    });
+    const reported: string[][] = [];
+    mgr.setTurnTerminator((ids) => reported.push(ids));
+    (mgr as any).bindings.remember("agent-a", "s-live", "old-box");
+    (mgr as any).draining.set("old-box", Date.now() - 10 * 60_000);
+    spawner.stopThrows = true;
+
+    await (mgr as any).reapDrainedBoxes();
+    spawner.stopThrows = false;
+    // The mark survives a failed stop, so the next tick sees the same box listing the same
+    // session — by then a retry may own that id, and cutting it would be someone else's turn.
+    await (mgr as any).reapDrainedBoxes();
+
+    expect(reported).toEqual([["s-live"]]);
+  });
+
+  it("does not report turns when the box left on its own terms", async () => {
+    const { mgr, spawner } = drainingManager({ "http://10.0.0.9:3000": { sessionIds: [], turnsInFlight: 0, drained: true } });
+    const reported: string[][] = [];
+    mgr.setTurnTerminator((ids) => reported.push(ids));
+    await (mgr as any).reapDrainedBoxes();
+    expect(spawner.stopCalls).toEqual(["old-box"]);
+    expect(reported).toEqual([]);
+  });
+
+  it("still removes an overdue box when it cannot be asked what it holds", async () => {
+    // A probe failure must not buy the box another lap: it is already past the deadline.
+    const { mgr, spawner } = drainingManager({}, true);
+    const reported: string[][] = [];
+    mgr.setTurnTerminator((ids) => reported.push(ids));
+    (mgr as any).draining.set("old-box", Date.now() - 10 * 60_000);
+
+    await (mgr as any).reapDrainedBoxes();
+
+    expect(spawner.stopCalls).toEqual(["old-box"]);
+    expect(reported).toEqual([]); // nothing to name, so nothing claimed
   });
 
   it("waits when the box cannot be asked at all", async () => {

--- a/src/gateway/agentbox/manager.ts
+++ b/src/gateway/agentbox/manager.ts
@@ -123,6 +123,9 @@ export class AgentBoxManager {
   private persistenceResolver?: (agentId: string) => Promise<boolean | undefined>;
   private replicasResolver?: (agentId: string) => Promise<number | undefined>;
   private boxStatusProbe?: (endpoint: string) => Promise<BoxStatusReport>;
+  private turnTerminator?: (sessionIds: string[], reason: "box_rolled") => void;
+  /** Boxes whose held turns were already reported, so a failed stop cannot report twice. */
+  private interruptReported = new Set<string>();
   /** Which box serves which session. Only consulted when an agent runs more than one. */
   private readonly bindings = new BoxBindings();
   /** boxId → when it was marked draining. In memory only; re-derived after a restart. */
@@ -214,6 +217,18 @@ export class AgentBoxManager {
    */
   setLegacySessionLister(fn: (endpoint: string) => Promise<string[]>): void {
     this.legacySessionLister = fn;
+  }
+
+  /**
+   * How to report turns that this manager is about to interrupt.
+   *
+   * Removing a box that still holds work does end those turns — their SSE streams break —
+   * but as an anonymous transport failure, indistinguishable from a network blip. Told
+   * first, the Runtime can name the cause, so a user sees "a rolling upgrade interrupted
+   * this, retry" instead of a bare connection error.
+   */
+  setTurnTerminator(fn: (sessionIds: string[], reason: "box_rolled") => void): void {
+    this.turnTerminator = fn;
   }
 
   setBoxStatusProbe(fn: (endpoint: string) => Promise<BoxStatusReport>): void {
@@ -1083,18 +1098,45 @@ export class AgentBoxManager {
       if (!info || info.status === "stopped") {
         this.draining.delete(boxId);
         this.statusCache.delete(boxId);
+        this.interruptReported.delete(boxId);
         this.probeFailures.delete(boxId);
         continue;
       }
       const overdue = Date.now() - markedAt >= DRAIN_DEADLINE_MS;
       let drained = false;
+      let held: string[] = [];
       if (!overdue && this.boxStatusProbe && info.endpoint) {
         try {
           drained = (await this.boxStatusProbe(info.endpoint)).drained;
         } catch { continue; } // can't tell → keep waiting rather than cut a live box
       }
       if (!drained && !overdue) continue;
+      if (overdue && !drained && this.boxStatusProbe && info.endpoint && !this.interruptReported.has(boxId)) {
+        // Only on the path that cuts a box still holding work: ask what it holds, so those
+        // turns can be reported as interrupted rather than dying as a broken stream. The
+        // box is going away regardless — a probe that fails just costs the better message.
+        try {
+          const status = await this.boxStatusProbe(info.endpoint);
+          // A box lists every session RESIDENT on it, including ones whose turns have since
+          // been placed elsewhere — it never forgets. Reporting those would cut a live turn
+          // on a healthy box and blame this removal for it, so keep only the sessions this
+          // box is still the bound holder of.
+          held = status.sessionIds.filter((id) => this.bindings.get(info!.agentId, id) === boxId);
+        } catch { /* keep the removal going; the streams still break and end the turns */ }
+      }
       console.log(`[agentbox-manager] Removing drained box ${boxId}${overdue ? " (deadline reached)" : ""}`);
+      if (held.length) {
+        // Marked before reporting: a stop that throws keeps the drain mark and retries next
+        // tick, and the box still lists those sessions — reporting again would cut whatever
+        // turn has since taken that session id.
+        this.interruptReported.add(boxId);
+        console.log(`[agentbox-manager] ${boxId} still held ${held.length} session(s); reporting them interrupted`);
+        try {
+          this.turnTerminator?.(held, "box_rolled");
+        } catch (err) {
+          console.warn(`[agentbox-manager] could not report interrupted turns for ${boxId}:`, err);
+        }
+      }
       try {
         await this.spawner.stop(boxId);
       } catch (err) {
@@ -1103,6 +1145,7 @@ export class AgentBoxManager {
       }
       this.draining.delete(boxId);
       this.statusCache.delete(boxId);
+      this.interruptReported.delete(boxId);
       // Indices — and therefore names — are reused. A leftover failure count would make
       // the replacement's first transient probe failure look like its fourth.
       this.probeFailures.delete(boxId);

--- a/src/gateway/frontend-ws-client.test.ts
+++ b/src/gateway/frontend-ws-client.test.ts
@@ -483,6 +483,68 @@ describe("FrontendWsClient", () => {
     client.close();
   });
 
+  it("reports the sessions it is streaming, read fresh on every connect", async () => {
+    // The list has to be true when the frame goes out: a consumer settles every in-flight
+    // turn NOT named here, so a stale list either strands a live turn or keeps a dead one.
+    let live: string[] = ["s1", "s2"];
+    const client = await createClient({ capabilities: { compile: true } });
+    client.setActiveSessionsProvider(() => live);
+
+    const connectPromise = client.connect();
+    const ws1 = openLatestWs();
+    await connectPromise;
+    expect(JSON.parse(ws1._sent[0]).params).toEqual({ capabilities: { compile: true }, activeSessions: ["s1", "s2"] });
+
+    live = [];
+    ws1.emit("close");
+    await vi.advanceTimersByTimeAsync(3100);
+    const ws2 = openLatestWs();
+    // Empty is a real answer, not a missing one: it tells the consumer to settle everything.
+    expect(JSON.parse(ws2._sent[0]).params).toEqual({ capabilities: { compile: true }, activeSessions: [] });
+
+    client.close();
+  });
+
+  it("stays silent when there is nothing to advertise", async () => {
+    // No capabilities and nothing streaming: the frame would carry no information, and
+    // against a consumer that predates `runtime.register` it costs a rejected RPC and a
+    // warning line on every reconnect.
+    const client = await createClient(); // no capabilities
+    client.setActiveSessionsProvider(() => []);
+    const connectPromise = client.connect();
+    const ws = openLatestWs();
+    await connectPromise;
+
+    expect(ws._sent).toHaveLength(0);
+    client.close();
+  });
+
+  it("advertises live sessions even with no capabilities", async () => {
+    const client = await createClient(); // no capabilities
+    client.setActiveSessionsProvider(() => ["s1"]);
+    const connectPromise = client.connect();
+    const ws = openLatestWs();
+    await connectPromise;
+
+    expect(JSON.parse(ws._sent[0]).params).toEqual({ capabilities: {}, activeSessions: ["s1"] });
+    client.close();
+  });
+
+  it("still connects when the session provider throws", async () => {
+    // advertiseCapabilities runs inside the socket "open" listener, where a throw is an
+    // uncaughtException — and the value it is fetching is advisory.
+    const client = await createClient({ capabilities: { compile: true } });
+    client.setActiveSessionsProvider(() => { throw new Error("registry unavailable"); });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const connectPromise = client.connect();
+    const ws = openLatestWs();
+    await expect(connectPromise).resolves.toBeUndefined();
+
+    expect(JSON.parse(ws._sent[0]).params).toEqual({ capabilities: { compile: true } });
+    client.close();
+    warn.mockRestore();
+  });
+
   it("re-advertises on every reconnect", async () => {
     const client = await createClient({ capabilities: { compile: true } });
     const connectPromise = client.connect();

--- a/src/gateway/frontend-ws-client.ts
+++ b/src/gateway/frontend-ws-client.ts
@@ -59,6 +59,7 @@ export class FrontendWsClient {
   private _connected = false;
   private pending = new Map<string, PendingRpc>();
   private commandHandler: CommandHandler | null = null;
+  private activeSessionsProvider?: () => string[];
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private closed = false;
@@ -128,6 +129,16 @@ export class FrontendWsClient {
   }
 
   /**
+   * Supply the sessions this Runtime is streaming, read on every (re)connect.
+   *
+   * A pull, not a stored list: the answer has to be true at the moment the register frame
+   * goes out, and a reconnect happens whenever the transport decides to.
+   */
+  setActiveSessionsProvider(fn: () => string[]): void {
+    this.activeSessionsProvider = fn;
+  }
+
+  /**
    * Emit an unsolicited event frame to Portal (e.g. chat.event stream).
    * Fire and forget — does nothing if not connected.
    */
@@ -177,8 +188,24 @@ export class FrontendWsClient {
    */
   private advertiseCapabilities(): void {
     const caps = this.opts.capabilities;
-    if (!caps || Object.keys(caps).length === 0) return;
-    this.request("runtime.register", { capabilities: caps }).catch((err: unknown) => {
+    let activeSessions: string[] | undefined;
+    try {
+      activeSessions = this.activeSessionsProvider?.();
+    } catch (err) {
+      // Advisory, like everything else here: this runs inside the socket's "open"
+      // listener, where a throw is an uncaughtException that takes the process down.
+      console.warn(`[frontend-ws] active session list unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    // Nothing to say — and saying it anyway costs a rejected RPC and a warning line on
+    // every reconnect against a consumer that predates `runtime.register`.
+    if ((!caps || Object.keys(caps).length === 0) && !activeSessions?.length) return;
+    // `activeSessions` is what THIS process is streaming right now — deliberately not
+    // "what the boxes hold". After a restart it is empty even though boxes still carry
+    // sessions from the dead process, and that is the point: those turns have no consumer
+    // left, so a consumer told they are active would keep waiting for them forever.
+    const params: Record<string, unknown> = { capabilities: caps ?? {} };
+    if (activeSessions) params.activeSessions = activeSessions;
+    this.request("runtime.register", params).catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[frontend-ws] capability advertise not acked (ok on older consumer): ${message}`);
     });

--- a/src/gateway/metrics-aggregator.test.ts
+++ b/src/gateway/metrics-aggregator.test.ts
@@ -15,7 +15,7 @@ describe("MetricsAggregator (K8s federation pull loop)", () => {
   let aggr: MetricsAggregator;
   let lister: PodLister;
   let fetcher: SnapshotFetcher;
-  let pods: Array<{ boxId: string; endpoint: string; status: string }>;
+  let pods: Array<{ boxId: string; endpoint: string; status: string; profile?: string }>;
   let fetchMap: Map<string, MetricsFlushPayload | null>;
 
   beforeEach(() => {
@@ -46,6 +46,32 @@ describe("MetricsAggregator (K8s federation pull loop)", () => {
     await Promise.resolve();
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledWith("https://p3");
+  });
+
+  it("skips boxes whose profile has no metrics route, and does not score them as pull failures", async () => {
+    const fetchSpy = vi.fn(async () => null);
+    const pullFailuresTotal = { inc: vi.fn() };
+    aggr.destroy();
+    fetcher = { fetch: fetchSpy };
+    const fed = new PromFederationAggregator();
+    aggr = new MetricsAggregator(lister, fetcher, fed, {
+      pullFailuresTotal,
+      pullDurationMs: { observe: vi.fn() },
+      lastSuccessTimestampSeconds: { set: vi.fn() },
+      trackedInstances: { set: vi.fn() },
+      seriesCount: { set: vi.fn() },
+    });
+    // All three carry the app=agentbox label the pod list selects on; only the first two
+    // run the Node agentbox that serves /api/internal/metrics-snapshot.
+    pods.push({ boxId: "a1", endpoint: "https://a1", status: "running" });                          // default profile
+    pods.push({ boxId: "a2", endpoint: "https://a2", status: "running", profile: "agent" });
+    pods.push({ boxId: "kb1", endpoint: "https://kb1", status: "running", profile: "kb-compile" }); // Python box, 404s
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await Promise.resolve();
+
+    expect(fetchSpy.mock.calls.flat()).toEqual(["https://a1", "https://a2"]);
+    expect(pullFailuresTotal.inc).not.toHaveBeenCalledWith({ box_id: "kb1" });
   });
 
   it("destroy clears the pull timer", async () => {

--- a/src/gateway/metrics-aggregator.ts
+++ b/src/gateway/metrics-aggregator.ts
@@ -14,10 +14,26 @@ import type {
   MetricsFlushPayload,
   PromSampleGroup,
 } from "../shared/metrics-types.js";
+import { AGENT_PROFILE } from "./agentbox/box-profile.js";
 
 /** Interface for pod listing (K8s mode only) */
 export interface PodLister {
-  list(): Promise<Array<{ boxId: string; endpoint: string; status: string }>>;
+  list(): Promise<Array<{ boxId: string; endpoint: string; status: string; profile?: string }>>;
+}
+
+/**
+ * Whether this box serves `/api/internal/metrics-snapshot`.
+ *
+ * The pod list is selected by the `app=agentbox` label, which every box carries —
+ * including the KB compile boxes, whose Python HTTP contract has no metrics route at
+ * all. Pulling them 404s on every tick: log noise, and worse, each 404 counted as a
+ * pull failure, so the federation's own health metric reported a permanent fault.
+ *
+ * A profile that is absent means the default (agent) profile, same as everywhere else
+ * that reads this field.
+ */
+function servesSnapshot(box: { profile?: string }): boolean {
+  return !box.profile || box.profile === AGENT_PROFILE.name;
 }
 
 /** Interface for making mTLS requests to AgentBox pods */
@@ -78,7 +94,10 @@ export class MetricsAggregator {
     if (!this.podLister || !this.snapshotFetcher) return;
     const startedAt = Date.now();
     const pods = await this.podLister.list();
-    const activePods = pods.filter((p) => p.status === "running" && p.endpoint);
+    // Pull-eligibility only. `pods` stays the full list on purpose: liveness (below)
+    // must keep meaning "every box K8s reports", or a box that federates by some other
+    // route than this pull would be grace-evicted while it is still running.
+    const activePods = pods.filter((p) => p.status === "running" && p.endpoint && servesSnapshot(p));
     // Keep the boxId paired with each fetch (even on failure) so federation can key on
     // (boxId, incarnation) and self-monitoring can attribute failures to a box.
     const results = await Promise.all(

--- a/src/gateway/server-shutdown-turns.test.ts
+++ b/src/gateway/server-shutdown-turns.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression test for turns left hanging by a Runtime restart.
+ *
+ * Bug: close() dropped the consumer WS without a word, so a turn that was
+ * streaming at that moment simply stopped. Termination is `prompt_done`
+ * (docs/design/2026-08-02-error-surfacing-contract.md), and no later event could
+ * ever arrive — the process that owned the turn was gone, and its replacement does
+ * not adopt turns it did not start. The chat sat at "still working" until reload,
+ * so every rolling deploy stranded whoever was mid-conversation.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+vi.mock("./chat-repo.js", () => ({
+  ensureChatSession: vi.fn(async () => {}),
+  appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
+  incrementMessageCount: vi.fn(async () => {}),
+}));
+
+vi.mock("./output-redactor.js", () => ({
+  buildRedactionConfigForModelConfig: vi.fn(() => ({})),
+}));
+
+// A turn that is mid-stream: it ends only when its abort signal fires.
+let capturedSignal: AbortSignal | undefined;
+vi.mock("./sse-consumer.js", () => ({
+  consumeAgentSse: vi.fn((opts: { signal?: AbortSignal }) => {
+    capturedSignal = opts.signal;
+    return new Promise((resolve) => {
+      const done = () =>
+        resolve({ resultText: "", taskReportText: "", errorMessage: "", eventCount: 0, durationMs: 0 });
+      if (opts.signal?.aborted) return done();
+      opts.signal?.addEventListener("abort", done, { once: true });
+    });
+  }),
+}));
+
+vi.mock("./agentbox/client.js", () => ({
+  AgentBoxClient: class {
+    constructor(public endpoint: string) {}
+    prompt = vi.fn(async (opts: { sessionId: string }) => ({
+      sessionId: opts.sessionId,
+      traceId: "0123456789abcdef0123456789abcdef",
+    }));
+    abortSession = vi.fn(async () => {});
+    steerSession = vi.fn(async () => ({ ok: true, traceId: "fedcba9876543210fedcba9876543210" }));
+    streamEvents = async function* () {};
+  },
+}));
+
+const { startRuntime } = await import("./server.js");
+
+function fakeFrontendClient() {
+  return {
+    request: vi.fn(async () => ({ found: false })),
+    onCommand: vi.fn(),
+    emitEvent: vi.fn(),
+    close: vi.fn(),
+  } as any;
+}
+
+/** Captures the terminator the Runtime hands the manager, so a test can fire it. */
+let terminateTurns: ((sessionIds: string[], reason: "box_rolled") => void) | undefined;
+
+async function bootRuntime(frontendClient: any) {
+  terminateTurns = undefined;
+  return startRuntime({
+    config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+    agentBoxManager: {
+      setCertManager: vi.fn(),
+      setSpawnEnvResolver: vi.fn(),
+      setPersistenceResolver: vi.fn(),
+      setTurnTerminator: vi.fn((fn: any) => { terminateTurns = fn; }),
+      getOrCreate: vi.fn(async () => ({ endpoint: "https://fake.internal" })),
+      list: vi.fn(() => []),
+      cleanup: vi.fn(async () => {}),
+    } as any,
+    frontendClient,
+    credentialService: {} as any,
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** chat.event payloads emitted for `sessionId`, in order. */
+function chatEvents(client: any, sessionId: string): Array<Record<string, unknown>> {
+  return client.emitEvent.mock.calls
+    .filter(([channel, payload]: [string, any]) => channel === "chat.event" && payload?.sessionId === sessionId)
+    .map(([, payload]: [string, any]) => payload.event);
+}
+
+afterEach(() => {
+  capturedSignal = undefined;
+  vi.clearAllMocks();
+});
+
+describe("startRuntime — shutdown ends in-flight turns", () => {
+  it("reports and terminates a streaming turn before the consumer WS closes", async () => {
+    const client = fakeFrontendClient();
+    const server = await bootRuntime(client);
+    const send = server.rpcMethods.get("chat.send")!;
+
+    await send({ agentId: "a", userId: "u", text: "hi", sessionId: "S" }, { sendEvent: vi.fn() });
+    await waitFor(() => capturedSignal !== undefined);
+    expect(capturedSignal!.aborted).toBe(false);
+
+    await server.close();
+
+    const events = chatEvents(client, "S");
+    const kinds = events.map((e) => e.type);
+    expect(kinds).toEqual(["stream_error", "prompt_done"]);
+    // Retriable, so a consumer can tell the user to resend rather than reporting a fault.
+    expect(events[0]).toMatchObject({ type: "stream_error", error: { retriable: true } });
+    // Additive fields: a consumer that reads them names the cause instead of showing a
+    // generic connection failure; one that does not still sees the terminal it handles.
+    expect(events[1]).toMatchObject({ type: "prompt_done", aborted: true, reason: "runtime_restart" });
+    // The consumer is broken too, so its own finalization runs (partial text persisted,
+    // running tool rows closed) instead of the turn ending only when the box hangs up.
+    expect(capturedSignal!.aborted).toBe(true);
+    // ...and the terminal goes out while the WS is still usable.
+    expect(client.emitEvent.mock.invocationCallOrder.at(-1)!)
+      .toBeLessThan(client.close.mock.invocationCallOrder[0]!);
+  });
+
+  it("reports each in-flight turn exactly once — the abort it causes must not double-report", async () => {
+    const client = fakeFrontendClient();
+    const server = await bootRuntime(client);
+    const send = server.rpcMethods.get("chat.send")!;
+
+    await send({ agentId: "a", userId: "u", text: "hi", sessionId: "S" }, { sendEvent: vi.fn() });
+    await waitFor(() => capturedSignal !== undefined);
+
+    await server.close();
+    // The aborted consumer settles asynchronously; give its catch/finally a turn to run.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(chatEvents(client, "S").filter((e) => e.type === "prompt_done")).toHaveLength(1);
+  });
+
+  it("names a turn cut by a box removal, and lets the broken stream report nothing more", async () => {
+    const client = fakeFrontendClient();
+    const server = await bootRuntime(client);
+    const send = server.rpcMethods.get("chat.send")!;
+
+    await send({ agentId: "a", userId: "u", text: "hi", sessionId: "S" }, { sendEvent: vi.fn() });
+    await waitFor(() => capturedSignal !== undefined);
+
+    // What the manager does when the drain deadline forces out a box still holding work.
+    terminateTurns!(["S", "not-streaming-here"], "box_rolled");
+    await new Promise((r) => setTimeout(r, 20)); // let the abort settle the consumer
+
+    const events = chatEvents(client, "S");
+    expect(events.map((e) => e.type)).toEqual(["stream_error", "prompt_done"]);
+    expect(events[1]).toMatchObject({ aborted: true, reason: "box_rolled" });
+    // A session this Runtime is not streaming has no turn to end.
+    expect(chatEvents(client, "not-streaming-here")).toEqual([]);
+    expect(capturedSignal!.aborted).toBe(true);
+
+    await server.close();
+    // Shutdown must not report it a second time — it was already ended and deregistered.
+    expect(chatEvents(client, "S")).toHaveLength(2);
+  });
+
+  it("does not report a turn that started too late to be registered", async () => {
+    // The hazard a blanket "we are shutting down" flag creates: this turn is not in the
+    // registry when close() runs, so shutdown cannot report it — and it must therefore be
+    // left free to report itself, or it is exactly the hang this file exists to prevent.
+    const client = fakeFrontendClient();
+    const server = await bootRuntime(client);
+    await server.close();
+    expect(chatEvents(client, "late-session")).toEqual([]);
+
+    const send = server.rpcMethods.get("chat.send")!;
+    await send({ agentId: "a", userId: "u", text: "hi", sessionId: "late-session" }, { sendEvent: vi.fn() });
+    await waitFor(() => capturedSignal !== undefined);
+    capturedSignal!.dispatchEvent?.(new Event("abort"));
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -115,6 +115,9 @@ function stablePayloadDigest(value: unknown): string {
   return crypto.createHash("sha256").update(JSON.stringify(canonicalize(value))).digest("hex");
 }
 
+/** Why a turn was cut short by the Runtime rather than by the model or the user. */
+export type InterruptionReason = "runtime_restart" | "box_rolled";
+
 export interface RuntimeServer {
   httpServer: http.Server;
   httpsServer: https.Server | null;
@@ -320,6 +323,78 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   // turn as still reasoning. Registered in chat.send, cleared on its settle.
   const activeStreamAborts = new Map<string, AbortController>();
 
+  /**
+   * Sessions whose terminal this Runtime already sent — on shutdown, or because the box
+   * running them was removed under them.
+   *
+   * Ending a turn also aborts its consumer, which makes that consumer take its own
+   * terminal path, so each id is consumed exactly once to drop the duplicate. Per-turn on
+   * purpose: a "we are shutting down" flag would also swallow the terminal of a turn that
+   * started too late to be reported here, which is the hang this whole path exists to fix.
+   */
+  const supervisorEndedTurns = new Set<string>();
+
+  const INTERRUPTION_MESSAGE: Record<InterruptionReason, string> = {
+    runtime_restart: "Runtime restarted; this turn was interrupted",
+    box_rolled: "The agentbox running this turn was replaced; the turn was interrupted",
+  };
+
+  /**
+   * End the named turns, while the WS to the consumer is still up.
+   *
+   * Termination is `prompt_done` (docs/design/2026-08-02-error-surfacing-contract.md):
+   * a consumer renders an error but keeps the turn open until that arrives. A turn whose
+   * stream simply stops therefore hangs forever — the process that owned it is gone and
+   * its replacement does not adopt turns it did not start, so no later event can come.
+   */
+  function endTurns(sessionIds: Iterable<string>, reason: InterruptionReason): void {
+    const detail = wrapError(new Error(INTERRUPTION_MESSAGE[reason]), {
+      code: ErrorCodes.STREAM_INTERRUPTED,
+      retriable: true,
+    });
+    for (const sessionId of sessionIds) {
+      const ctrl = activeStreamAborts.get(sessionId);
+      if (!ctrl) continue; // nothing of ours is streaming for it
+      supervisorEndedTurns.add(sessionId);
+      try {
+        frontendClient.emitEvent("chat.event", { sessionId, event: { type: "stream_error", error: detail } });
+        // `aborted`/`reason` are additive: a consumer that does not read them sees the
+        // plain terminal it already handles, one that does can name the cause instead of
+        // rendering a generic connection failure.
+        frontendClient.emitEvent("chat.event", {
+          sessionId,
+          event: { type: "prompt_done", aborted: true, reason },
+        });
+      } catch (err) {
+        // Best effort: a consumer that already went away must not stop what caused this.
+        console.warn(`[runtime] could not report interrupted turn session=${sessionId}:`, err);
+      }
+      // Abort AFTER reporting: it makes the consumer run its own finalization (partial
+      // text persisted, running tool rows closed) so a reload agrees with the screen.
+      ctrl.abort();
+      activeStreamAborts.delete(sessionId);
+    }
+  }
+
+  function endInFlightTurns(): void {
+    const sessionIds = [...activeStreamAborts.keys()];
+    if (sessionIds.length === 0) return;
+    // Say it happened. Reporting used to be silent on success, so the only way to tell
+    // whether a restart had ended its turns was to go ask the consumer — during an
+    // incident, from the outside. The failure path already logs; this is its other half.
+    console.log(`[runtime] shutdown interrupting ${sessionIds.length} in-flight turn(s): ${sessionIds.join(", ")}`);
+    endTurns(sessionIds, "runtime_restart");
+  }
+
+  // A box removed while it still holds turns breaks their SSE streams, which does end
+  // them — but as an anonymous transport failure. Reporting here instead names the cause.
+  agentBoxManager.setTurnTerminator?.(endTurns);
+
+  // Reported on every (re)connect so a consumer can settle the turns this Runtime is NOT
+  // streaming. After a restart the list is empty, which is the honest answer: the boxes
+  // still hold those sessions, but nothing is reading them any more.
+  frontendClient.setActiveSessionsProvider?.(() => [...activeStreamAborts.keys()]);
+
   rpcMethods.set("chat.send", async (params, context: RpcContext) => {
     const agentId = params.agentId as string;
     const userId = params.userId as string;
@@ -520,6 +595,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         // promptResult.sessionId — the same id chat.abort looks up.
         activeStreamAborts.set(promptResult.sessionId, abortCtrl);
 
+        /**
+         * Whether this turn's terminal was already sent by the supervisor (shutdown, or a
+         * box removed under it). One-shot: the id is consumed, so a later turn on the same
+         * session reports normally.
+         */
+        const alreadyReported = () => supervisorEndedTurns.delete(promptResult.sessionId);
+
         try {
           await consumeAgentSse({
             client,
@@ -546,7 +628,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
               });
             },
           });
-          context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
+          if (!alreadyReported()) context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
         } catch (err) {
           if (!abortCtrl.signal.aborted) {
             console.error(`[runtime] SSE stream error for session=${promptResult.sessionId}:`, err);
@@ -559,7 +641,8 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
               event: { type: "stream_error", error: detail },
             });
           }
-          context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
+          // Shutdown, or a box removal, already reported this turn before aborting it.
+          if (!alreadyReported()) context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
         } finally {
           // Only clear if still ours — a fast re-send for the same session would
           // have replaced the entry with a newer controller.
@@ -1808,6 +1891,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     credentialService,
     async close() {
       metricsAggregator?.destroy();
+      endInFlightTurns();
       frontendClient.close();
       // Older embedded test/adapter managers may only implement cleanup(); the
       // concrete manager's shutdown() preserves K8s boxes across Runtime rolls.


### PR DESCRIPTION
## Summary

Three independent fixes found while reading production logs and then testing a rolling deploy of v0.3.4 in a test environment. The first is a lost-work bug; the other two are log noise that had a correctness cost of its own — and that noise is why the first one went unnoticed for so long.

### 1. A Runtime restart strands every in-flight turn

**Problem.** Observed during a rolling deploy: a conversation was mid-turn, the pod was replaced, and the chat sat at "still working" until the user reloaded. Reproducible by construction, not a race — it happens to every turn that is streaming when the process exits.

`close()` dropped the consumer WS without a word. Termination is `prompt_done` (`docs/design/2026-08-02-error-surfacing-contract.md`): a consumer renders an error but keeps the turn open until that arrives. No later event can ever arrive — the process that owned the turn is gone, and its replacement does not adopt turns it did not start. Every other exit path from a turn already emits a terminal; only shutdown did not.

**Solution.** Report each turn in `activeStreamAborts` as a retriable `STREAM_INTERRUPTED`, then `prompt_done`, while the WS is still up; abort the consumer afterwards so its own finalization runs (partial text persisted, running tool rows closed) instead of leaving a row at "running" for a reload to re-paint as live. The abort makes the consumer take its own terminal path, so a `shuttingDown` flag suppresses that second report — exactly one terminal per turn.

This is the graceful half only. A Runtime that dies without running `close()` (OOM, eviction, kill -9) still needs the consumer to fail in-flight turns on disconnect; that belongs on the consumer side and is not in this change.

### 2. The federation pull loop 404s on every tick

The pod list it reads is selected by the `app=agentbox` label, which every spawned box carries — including the KB compile boxes, whose Python HTTP contract has no `/api/internal/metrics-snapshot` route. One 404 error line every 30s per compile box, forever, and each 404 scored as a pull failure, so the federation's own health counter reported a fault that never cleared.

Judge pull-eligibility by box profile — already on `AgentBoxInfo` from the `boxType` label. Filtering at the consumer rather than the pod-list layer is deliberate: the same list feeds pool reconciliation, drain and the orphan GC, all of which need every box. Liveness also keeps reading the full list — a box can reach federation by the SIGTERM flush, which keys on cert identity rather than profile, and evicting it while it runs would deflate cross-pod gauge sums. ADR-014 gains the scope rule.

### 3. The cron reconcile re-arms every job every 15s

`addOrUpdate` cancelled and re-armed each timer and logged two lines per job per pass. On a runtime with a handful of cron jobs that was the bulk of the log.

Leave an armed job alone when `schedule`/`status` did not change. Three consequences of no longer re-arming constantly, each handled:

- The fire path reads the row back from the registry instead of the one captured when the timer was armed, so a changed prompt/agent/name still takes effect.
- `scheduleNext` replaces the job's timer instead of adding one. Both callers can reach a job that already has a timer and `timers` holds one handle per job, so setting without clearing dropped a live timer out of the map — where neither `cancel()` nor `stop()` could reach it, and it fired the job a second time. Reachable before this change too, just rarer.
- A job mid-fire has no timer, so a reconcile pass arms one. That is what gets a job whose fire never settles back on a schedule.

A bogus cron expression also no longer reports `Scheduled job` — `scheduleNext` armed nothing and already said so.

## Test Plan

- [x] `npm test` — 245 files / 5061 passing; `npx tsc --noEmit` clean
- [x] Rolling deploy of v0.3.4 exercised end to end in a test environment: gateway replaced, agentbox pool drained and rebuilt one box at a time (5-replica pool never dropped below 4 accepting), zero old-image pods left, no errors in the new gateway log
- [x] Fix 1 found by that deploy interrupting a live turn; the two regression tests reproduce it
- [x] Every regression test confirmed to fail without its fix, not just pass with it: shutdown terminal + no-double-report, orphan timer reachable by `stop()`, hung-fire re-arm