### PR TITLE
fix(agent-types): give the SRE type the tools its own exec tools promise

### DIFF
--- a/portal-web/src/lib/agentTypes.ts
+++ b/portal-web/src/lib/agentTypes.ts
@@ -19,7 +19,7 @@ export const AGENT_TYPES: AgentTypeOption[] = [
     key: "sre",
     label: "SRE Agent",
     description: "Hands-on specialist: inspects, diagnoses and remediates within its authorized clusters/hosts.",
-    capabilities: ["inspect_infra", "run_commands", "run_scripts", "read_files", "search_memory", "plan_tasks", "session_output"],
+    capabilities: ["inspect_infra", "run_commands", "run_scripts", "read_files", "write_sandbox", "search_memory", "plan_tasks", "spawn_subagents", "session_output"],
     defaultNoSkills: false,
   },
   {

--- a/src/core/agent-types.ts
+++ b/src/core/agent-types.ts
@@ -5,7 +5,11 @@
  * system_prompt is the single editable identity/behaviour instruction.
  *
  *   - sre         — a specialist that operates hands-on within its authorized
- *                   clusters/hosts (full read + exec + scripts).
+ *                   clusters/hosts (full read + write + exec + scripts, plus
+ *                   sub-agent fan-out and the background-job read/stop pair its
+ *                   own exec tools hand out task ids for). It does NOT delegate:
+ *                   routing to peers is the coordinator's job, and an SRE agent
+ *                   is the delegation TARGET, not a router.
  *   - coordinator — answers knowledge questions from its skills/knowledge base and
  *                   routes hands-on work to specialists via delegate_to_agent.
  *                   No skills by default. Ships an editable default prompt.
@@ -105,7 +109,11 @@ export const AGENT_TYPES: Record<AgentType, AgentTypeDef> = {
   sre: {
     label: "SRE Agent",
     description: "Hands-on specialist: inspects, diagnoses and remediates within its authorized clusters/hosts.",
-    capabilities: ["inspect_infra", "run_commands", "run_scripts", "read_files", "search_memory", "plan_tasks", "session_output"],
+    // spawn_subagents is not optional polish: run_commands hands the model
+    // `run_in_background`, whose tool descriptions tell it to call task_output /
+    // job_stop — both of which live in this group. Without it an SRE agent can
+    // start a background capture it can neither read nor stop.
+    capabilities: ["inspect_infra", "run_commands", "run_scripts", "read_files", "write_sandbox", "search_memory", "plan_tasks", "spawn_subagents", "session_output"],
     defaultPrompt: SRE_DEFAULT_PROMPT,
     defaultNoSkills: false,
   },


### PR DESCRIPTION
## Problem

An SRE-type agent could start a background job it could neither read nor stop.

`run_commands` is in the SRE locked capability set, and the background mode of `bash` / `node_exec` / `pod_exec` is gated only on a compile-time constant plus an injected executor — **not** on `allowedTools` (`restricted-bash.ts:249`, `node-exec.ts:49`; both constants are `true`). So `run_in_background` stays in the tool schema for an SRE agent, and the tool descriptions actively tell the model to follow up:

> "open-ended capture; returns immediately — stop it later with `job_stop`, then `task_output(task_id)`" — `node-exec.ts:102`

Both `job_stop` and `task_output` live in the `spawn_subagents` group, which the SRE type did not have. The model launches a tcpdump or a perftest run, gets a task id back, and then has no way to read the output or stop the capture — exactly the workflows an SRE agent is for.

## Change

Add two groups to the SRE locked capability set:

- **`spawn_subagents`** — fixes the above (`task_output` + `job_stop`), and grants parallel fan-out across nodes/clusters.
- **`write_sandbox`** — lets the agent stage intermediate output and report drafts. Paths are already restricted to the skills / user-data / reports / traces / repos / docs / knowledge / tmpdir set; credentials and config remain unreachable.

SRE goes from 7 to 9 of the 11 capability groups.

## Deliberately still excluded

- **`delegate_agents`** — routing to peers is the coordinator's job. An SRE agent is the delegation *target*, not a router. This is the one line that keeps `sre` meaningfully narrower than an unrestricted `custom` agent.
- **`scheduling`** — `manage_schedule` self-describes as "ALL actions are AUTO-EXECUTED immediately — no user confirmation needed" (`manage-schedule.ts:28`) and carries no approval metadata. A diagnostic turn could mint (or `delete`) an autonomous cron task that then runs with this agent's full exec privileges. Schedules belong to an operator in the Portal.

`search_memory` stays even though memory is off by default fleet-wide (`config.ts:240`, `values.yaml:68`): the `available` guard runs *before* the `allowedTools` whitelist in `ToolRegistry.resolve()` (`tool-registry.ts:556`), so the entry costs nothing while memory is disabled and needs no code change if an environment turns it on.

## Notes for review / rollout

- The Portal mirror (`portal-web/src/lib/agentTypes.ts`) is updated in lockstep — the drift guard in `agent-types.test.ts` compares the two with `toEqual`, so element order matters.
- The locked set is resolved **gateway-side** (`internal-api.ts` → `effectiveCapabilityKeys` → `resolveCapabilities`), so this takes effect with a **runtime** image; the portal image only affects the chips shown in the Tools tab. AgentBox is unaffected (it only uses `agentType` for the prompt fallback).
- Existing agents already on the `sre` type will **not** pick this up automatically — `allowedToolsState` is cached per box. Recycle the pod (cold spawn refetches) or save the agent once in the Portal to trigger `agent.reload`.

## Testing

- `npx vitest run` (repo, excluding stale local worktrees): 245 files / 5115 tests passed
- `cd portal-web && npx vitest run`: 23 files / 225 tests passed
- `npx tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
