### PR TITLE
feat(skills): add http-log-stats — one-pass access log measurement

### DIFF
--- a/skills/core/http-log-stats/SKILL.md
+++ b/skills/core/http-log-stats/SKILL.md
@@ -44,10 +44,23 @@ This step costs one command and routinely saves the entire investigation.
 ## Tool
 
 ```
-local_script: skill="http-log-stats", script="http-log-stats.sh", args="<args>"
+local_script: cluster="<cluster>", skill="http-log-stats",
+              script="http-log-stats.sh", args="<args>"
 ```
 
 Runs `kubectl` from the agent's own context — no debug pod, no node access.
+
+**Set `cluster`** to the target cluster's credential name (from `cluster_list`).
+`local_script` resolves it to a kubeconfig and exports `KUBECONFIG` into the
+script's environment, so the `kubectl` calls inside the script pick it up
+automatically. You may omit it only when the agent is bound to exactly one
+cluster; with several bound, omitting it is an error listing the available
+names, not a silent default.
+
+Do **not** pass `--kubeconfig` or a `KUBECONFIG=` prefix in `args` — cluster
+selection goes through the tool parameter, and the script takes no such flag.
+If the name is wrong or the agent is not bound to that cluster, the call fails
+with the available names; it never silently talks to the wrong cluster.
 
 ## Parameters
 

--- a/skills/core/http-log-stats/SKILL.md
+++ b/skills/core/http-log-stats/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: http-log-stats
+description: >-
+  Count HTTP status codes and request-duration distribution from an ingress
+  controller's access log, over a fixed time window, in one pass.
+  Use when asked "how many 503s", "how many requests took over 60s", "what's the
+  status code / latency distribution" for a service — i.e. a MEASUREMENT question
+  about traffic, not a "why is it broken" diagnosis (for that use ingress-debug).
+  Run via local_script.
+---
+
+# HTTP Access Log Statistics
+
+Answers **measurement** questions about HTTP traffic: how many of each status
+code, how the request durations distribute, how many exceeded a threshold.
+
+This is deliberately separate from `ingress-debug`, which diagnoses *why*
+traffic fails (404 / 502 / TLS / no ADDRESS). Here nothing is broken
+necessarily — the user wants numbers.
+
+## Before you run it: identify the layer
+
+A request usually passes through several components that can each return a
+status code, and the user's word for the one they mean ("router", "gateway",
+"entry", "网关") rarely maps to exactly one of them. **Counting on the wrong
+layer produces a confident, wrong answer**, so establish the path first:
+
+```bash
+kubectl get ingress,svc,endpoints -n <ns> | grep <service>
+```
+
+- An Ingress in front → the user's "router 503" is almost certainly the
+  **ingress controller's** access log. Use this skill.
+- No Ingress, traffic reaches the Service directly → there is no access log to
+  count; the numbers must come from the application's own logs or metrics, and
+  the format is application-specific.
+- **Do not** grep the application pod's log for the string `503`. Application
+  logs contain the digits 503 in request bodies, upstream error text and
+  unrelated fields; that count is not the number of HTTP 503 responses the
+  entry layer returned.
+
+This step costs one command and routinely saves the entire investigation.
+
+## Tool
+
+```
+local_script: skill="http-log-stats", script="http-log-stats.sh", args="<args>"
+```
+
+Runs `kubectl` from the agent's own context — no debug pod, no node access.
+
+## Parameters
+
+Required:
+
+| Parameter | Description |
+|-----------|-------------|
+| `--since-time T` | Window start, RFC3339 UTC (`2026-08-17T12:02:06Z`). Absolute on purpose — see Notes. |
+
+Optional:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--until-time T` | now | Window end, RFC3339 UTC |
+| `-n, --namespace N` | `ingress-nginx` | Controller namespace |
+| `--selector S` | `app.kubernetes.io/name=ingress-nginx` | Pod label selector |
+| `--pod P[,P2]` | — | Explicit pod names; overrides `--selector` |
+| `--match S` | — | Only count lines containing this substring (ingress name, host, or path) |
+| `--buckets a,b,c` | `1,10,60` | Duration bucket edges in seconds |
+| `--preset P` | `nginx-ingress` | Access log format |
+
+## Output
+
+```
+window:    2026-08-17T12:02:06Z .. 2026-08-17T14:02:06Z
+source:    live cluster (kubectl logs), ns=ingress-nginx, 3 pod(s)
+coverage:  FULL  (earliest retained line 2026-08-17T11:47:33Z)
+match:     my-service
+parsed:    1007 lines (status 1007, request_time 1007)
+
+status codes:
+  200      1000   99.3%
+  499         7    0.7%
+
+request_time buckets (seconds):
+  <1        983   97.6%
+  1-10       17    1.7%
+  10-60       7    0.7%
+  >=60        0    0.0%
+```
+
+### `coverage` is part of the answer — always report it
+
+| Value | Meaning | What to tell the user |
+|-------|---------|-----------------------|
+| `FULL` | Live log reaches back past the window start | Report the numbers plainly |
+| `PARTIAL` | Log only reaches back to a later point | **Say so.** The counts cover only from that point on — they are a lower bound, not the window total |
+| `UNAVAILABLE` | No controller pod matched | There is no live source; do not report zero |
+| `UNKNOWN` | Earliest line unreadable | Treat as PARTIAL and say the bound is unverified |
+
+A count over a window the log no longer covers is not a smaller truth, it is a
+wrong number. Never present `PARTIAL` results as the window total.
+
+## Notes
+
+- **One pull per replica, all dimensions at once.** Every bucket and every
+  status code comes out of a single pass. Do not fall back to running
+  `kubectl logs | grep -c` once per number — on a busy controller each full
+  pull costs 30–90s, so a four-bucket distribution across three replicas
+  becomes twelve full pulls of the same data.
+- **Absolute window, not a rolling one.** `--since=2h` moves between
+  invocations, so two counts taken minutes apart cover different windows and
+  cannot be compared or summed. That is why `--since-time` is required.
+- **All replicas are summed.** An ingress controller usually runs several
+  replicas and any of them may have served the request; counting one replica
+  undercounts silently.
+- **Live cluster is the source.** This reads the running controllers, so it is
+  authoritative and current — no collection lag, no sampling, no field mapping
+  in between. When `coverage` is not `FULL`, that is the point at which a log
+  or metrics backend becomes the only option; note the switch explicitly when
+  you report, because that data has different freshness and completeness.
+- **Format assumption.** Parsing targets the nginx-ingress default
+  `log-format-upstream`: `$status` after the quoted request line, `$request_time`
+  immediately before the bracketed `$proxy_upstream_name`. If a cluster
+  customises `log-format`, the script reports that it parsed 0 values rather
+  than returning a silent zero — sample raw lines before trusting anything.
+
+## See also
+
+- `ingress-debug` — why traffic is failing (404 / 502 / TLS / no ADDRESS), as
+  opposed to how much of it there is
+- `service-debug` — backend Service has no healthy endpoints

--- a/skills/core/http-log-stats/SKILL.md
+++ b/skills/core/http-log-stats/SKILL.md
@@ -101,6 +101,21 @@ request_time buckets (seconds):
 A count over a window the log no longer covers is not a smaller truth, it is a
 wrong number. Never present `PARTIAL` results as the window total.
 
+## Safety
+
+Read-only, and it creates **no files** — not even a temporary one that is
+cleaned up afterwards.
+
+- Only two cluster verbs are ever issued: `kubectl get pods` and `kubectl logs`.
+  Nothing is created, patched, deleted, or exec'd; no debug pod is spawned.
+- No output redirection, no scratch file. Every log line is streamed through a
+  pipe into a single `awk` that keeps only counters in memory, so a
+  multi-gigabyte window costs a constant amount of RAM and zero disk.
+- Shell constructs that create a temp file behind your back are avoided on
+  purpose: no here-doc / here-string (bash backs those with a file in `$TMPDIR`
+  before 5.1 and beyond the pipe buffer) and no `sort` (spills to `/tmp` above
+  its memory threshold). `awk` formats the report itself.
+
 ## Notes
 
 - **One pull per replica, all dimensions at once.** Every bucket and every
@@ -119,6 +134,12 @@ wrong number. Never present `PARTIAL` results as the window total.
   in between. When `coverage` is not `FULL`, that is the point at which a log
   or metrics backend becomes the only option; note the switch explicitly when
   you report, because that data has different freshness and completeness.
+- **Buckets, not percentiles.** A single streaming pass can count how many
+  requests fell in a range, but it cannot produce an exact p95/p99 without
+  retaining every value. If the user asks for a percentile rather than "how
+  many exceeded N", use the controller's duration histogram
+  (`nginx_ingress_controller_request_duration_seconds`) — that is what
+  histograms are for.
 - **Format assumption.** Parsing targets the nginx-ingress default
   `log-format-upstream`: `$status` after the quoted request line, `$request_time`
   immediately before the bracketed `$proxy_upstream_name`. If a cluster

--- a/skills/core/http-log-stats/SKILL.md
+++ b/skills/core/http-log-stats/SKILL.md
@@ -147,6 +147,12 @@ cleaned up afterwards.
   in between. When `coverage` is not `FULL`, that is the point at which a log
   or metrics backend becomes the only option; note the switch explicitly when
   you report, because that data has different freshness and completeness.
+- **The access log is not necessarily every request.** nginx-ingress maps
+  `$request_uri` to a `$loggable` flag, so a cluster can switch logging off for
+  chosen paths (health checks are the usual case). What you get is the count of
+  *logged* requests. If a total looks implausibly low, check `log_format` /
+  `$loggable` in the controller's `nginx.conf` before concluding traffic is
+  missing.
 - **Buckets, not percentiles.** A single streaming pass can count how many
   requests fell in a range, but it cannot produce an exact p95/p99 without
   retaining every value. If the user asks for a percentile rather than "how

--- a/skills/core/http-log-stats/scripts/http-log-stats.sh
+++ b/skills/core/http-log-stats/scripts/http-log-stats.sh
@@ -25,30 +25,32 @@ UNTIL=""
 BUCKETS="1,10,60"
 PRESET="nginx-ingress"
 
+# printf, not a here-doc: bash backs here-documents and here-strings with a
+# temporary file (pre-5.1, and for anything past the pipe buffer). It is
+# unlinked immediately, but this script must not create a file at all — it runs
+# read-only against production clusters.
 usage() {
-  cat <<'EOF'
-Usage: http-log-stats.sh --since-time <RFC3339> [options]
-
-Required:
-  --since-time T     Window start, RFC3339 UTC (e.g. 2026-08-17T12:02:06Z)
-
-Options:
-  --until-time T     Window end, RFC3339 UTC. Default: now (open-ended).
-  -n, --namespace N  Ingress controller namespace. Default: ingress-nginx
-  --selector S       Pod label selector. Default: app.kubernetes.io/name=ingress-nginx
-  --pod P[,P2]       Explicit pod name(s), comma-separated. Overrides --selector.
-  --match S          Only count lines containing this substring (host, path,
-                     service or ingress name). Omit to count all traffic.
-  --buckets a,b,c    Duration bucket edges in seconds. Default: 1,10,60
-                     (yields <1, 1-10, 10-60, >=60)
-  --preset P         Access log format. Only "nginx-ingress" today.
-  -h, --help         Show this help
-
-Example:
-  http-log-stats.sh --since-time 2026-08-17T12:02:06Z \
-    --until-time 2026-08-17T14:02:06Z \
-    --match my-service --buckets 1,10,60
-EOF
+  printf '%s\n' \
+    'Usage: http-log-stats.sh --since-time <RFC3339> [options]' \
+    '' \
+    'Required:' \
+    '  --since-time T     Window start, RFC3339 UTC (e.g. 2026-08-17T12:02:06Z)' \
+    '' \
+    'Options:' \
+    '  --until-time T     Window end, RFC3339 UTC. Default: now (open-ended).' \
+    '  -n, --namespace N  Ingress controller namespace. Default: ingress-nginx' \
+    '  --selector S       Pod label selector. Default: app.kubernetes.io/name=ingress-nginx' \
+    '  --pod P[,P2]       Explicit pod name(s), comma-separated. Overrides --selector.' \
+    '  --match S          Only count lines containing this substring (host, path,' \
+    '                     service or ingress name). Omit to count all traffic.' \
+    '  --buckets a,b,c    Duration bucket edges in seconds. Default: 1,10,60' \
+    '                     (yields <1, 1-10, 10-60, >=60)' \
+    '  --preset P         Access log format. Only "nginx-ingress" today.' \
+    '  -h, --help         Show this help' \
+    '' \
+    'Example:' \
+    '  http-log-stats.sh --since-time 2026-08-17T12:02:06Z \' \
+    '    --until-time 2026-08-17T14:02:06Z --match my-service --buckets 1,10,60'
 }
 
 while [[ $# -gt 0 ]]; do
@@ -129,14 +131,24 @@ else
   COVERAGE_NOTE="(earliest retained line $EARLIEST)"
 fi
 
+# ── Report header ──────────────────────────────────────────────────────
+echo "window:    $SINCE .. ${UNTIL:-now}"
+echo "source:    live cluster (kubectl logs), ns=$NAMESPACE, $POD_COUNT pod(s)"
+echo "coverage:  $COVERAGE  $COVERAGE_NOTE"
+[[ -n "$MATCH" ]] && echo "match:     $MATCH"
+
 # ── Single full pull per replica, one awk pass over all of it ──────────
 # Every replica's stream is concatenated into ONE awk so cross-replica totals
 # come out already summed. Failures per replica are tolerated (a pod can be
 # restarting) — unreadable replicas are reported via the parsed/total counters.
-STATS=$(
-  for p in $POD_LIST; do
-    kubectl logs -n "$NAMESPACE" "$p" --timestamps --since-time="$SINCE" 2>/dev/null || true
-  done | awk -v until_t="$UNTIL" -v match_s="$MATCH" -v buckets="$BUCKETS" '
+#
+# awk formats the whole report itself. Piping its output through sort/read in
+# the shell would be the only remaining way this script could touch disk (sort
+# spills to /tmp above its memory threshold; read <<< is a here-string), and
+# status codes are naturally ordered by walking 100..599 instead.
+for p in $POD_LIST; do
+  kubectl logs -n "$NAMESPACE" "$p" --timestamps --since-time="$SINCE" 2>/dev/null || true
+done | awk -v until_t="$UNTIL" -v match_s="$MATCH" -v buckets="$BUCKETS" '
     BUCKET_INIT_ONCE == 0 {
       n = split(buckets, edge, ",")
       BUCKET_INIT_ONCE = 1
@@ -172,61 +184,41 @@ STATS=$(
       }
     }
     END {
-      printf "TOTAL %d %d %d\n", total, parsed_status, parsed_time
-      for (c in codes) printf "CODE %s %d\n", c, codes[c]
-      # "-" rather than an empty upper bound: an empty field would collapse into
-      # adjacent spaces and shift every later column when the shell reads it back.
+      printf "parsed:    %d lines (status %d, request_time %d)\n\n",
+             total, parsed_status, parsed_time
+
+      if (total == 0) {
+        print "No matching lines in the window."
+        print ""
+        print "Before reporting this as \"no traffic\": confirm --match matches how the"
+        print "access log names the target (ingress name / host / path, not the Deployment"
+        print "name), and that this controller is the one serving it. An empty result is"
+        print "bounded non-evidence for THIS command, not proof of zero requests."
+        exit 0
+      }
+
+      print "status codes:"
+      for (c = 100; c < 600; c++) {
+        if (codes[c] > 0)
+          printf "  %-5d %7d  %5.1f%%\n", c, codes[c], codes[c] * 100 / total
+      }
+
+      printf "\nrequest_time buckets (seconds):\n"
       for (i = 1; i <= n + 1; i++) {
-        lo = (i == 1) ? "0" : edge[i - 1]
-        hi = (i == n + 1) ? "-" : edge[i]
-        printf "BUCKET %s %s %d\n", lo, hi, hist[i] + 0
+        if (i == n + 1)   label = ">=" edge[n]
+        else if (i == 1)  label = "<" edge[1]
+        else              label = edge[i - 1] "-" edge[i]
+        printf "  %-9s %7d  %5.1f%%\n", label, hist[i] + 0,
+               parsed_time ? hist[i] * 100 / parsed_time : 0
+      }
+
+      # A parser that silently matched nothing would hand back a
+      # confident-looking zero. Say so instead — the format is probably custom.
+      if (parsed_status == 0 || parsed_time == 0) {
+        printf "\nWARNING: parsed 0 %s from %d matching lines. This controller'"'"'s\n",
+               (parsed_status == 0 ? "status codes" : "durations"), total
+        print "log_format is probably not the nginx-ingress default — the counts above are"
+        print "NOT trustworthy. Sample a few raw lines before drawing any conclusion."
       }
     }
   '
-)
-
-# ── Report ────────────────────────────────────────────────────────────
-read -r _ TOTAL PARSED_STATUS PARSED_TIME <<<"$(echo "$STATS" | grep '^TOTAL ' || echo 'TOTAL 0 0 0')"
-
-echo "window:    $SINCE .. ${UNTIL:-now}"
-echo "source:    live cluster (kubectl logs), ns=$NAMESPACE, $POD_COUNT pod(s)"
-echo "coverage:  $COVERAGE  $COVERAGE_NOTE"
-[[ -n "$MATCH" ]] && echo "match:     $MATCH"
-echo "parsed:    $TOTAL lines (status $PARSED_STATUS, request_time $PARSED_TIME)"
-echo
-
-if [[ "$TOTAL" -eq 0 ]]; then
-  echo "No matching lines in the window."
-  echo
-  echo "Before reporting this as \"no traffic\": confirm --match matches how the"
-  echo "access log names the target (ingress name / host / path, not the Deployment"
-  echo "name), and that this controller is the one serving it. An empty result is"
-  echo "bounded non-evidence for THIS command, not proof of zero requests."
-  exit 0
-fi
-
-echo "status codes:"
-echo "$STATS" | grep '^CODE ' | sort -k2,2 | while read -r _ code count; do
-  awk -v c="$code" -v n="$count" -v t="$TOTAL" \
-    'BEGIN { printf "  %-5s %7d  %5.1f%%\n", c, n, (t ? n * 100 / t : 0) }'
-done
-
-echo
-echo "request_time buckets (seconds):"
-echo "$STATS" | grep '^BUCKET ' | while read -r _ lo hi count; do
-  if [[ "$hi" == "-" ]]; then label=">=${lo}"
-  elif [[ "$lo" == "0" ]]; then label="<${hi}"
-  else label="${lo}-${hi}"; fi
-  awk -v l="$label" -v n="$count" -v t="$PARSED_TIME" \
-    'BEGIN { printf "  %-9s %7d  %5.1f%%\n", l, n, (t ? n * 100 / t : 0) }'
-done
-
-# A parser that silently matched nothing would hand back a confident-looking
-# zero. Say so instead — the format is probably customised.
-if [[ "$PARSED_STATUS" -eq 0 || "$PARSED_TIME" -eq 0 ]]; then
-  echo
-  echo "WARNING: parsed 0 $([[ "$PARSED_STATUS" -eq 0 ]] && echo 'status codes' || echo 'durations')"
-  echo "from $TOTAL matching lines. This controller's log_format is probably not the"
-  echo "nginx-ingress default — the counts above are NOT trustworthy. Sample a few raw"
-  echo "lines before drawing any conclusion."
-fi

--- a/skills/core/http-log-stats/scripts/http-log-stats.sh
+++ b/skills/core/http-log-stats/scripts/http-log-stats.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+set -euo pipefail
+
+# Aggregate HTTP status codes and request-duration buckets from an ingress
+# controller's access log — in ONE pass per replica.
+#
+# Why this exists: computing "how many 503s" and "how many took >=60s" by
+# running one `kubectl logs | grep -c` per question means re-streaming the whole
+# window from the API server for every number you want. On a busy ingress that
+# is 30-90s per call, and a four-bucket distribution across three replicas is
+# twelve full pulls. This script pulls each replica's log exactly once and lets
+# a single awk accumulate every dimension at the same time.
+#
+# It also reports COVERAGE. A statistic computed over a window the live log no
+# longer covers is not a smaller truth, it is a wrong number — so the earliest
+# retained line is compared against the requested window and the verdict is
+# printed with the result.
+
+NAMESPACE="ingress-nginx"
+SELECTOR="app.kubernetes.io/name=ingress-nginx"
+PODS=""
+MATCH=""
+SINCE=""
+UNTIL=""
+BUCKETS="1,10,60"
+PRESET="nginx-ingress"
+
+usage() {
+  cat <<'EOF'
+Usage: http-log-stats.sh --since-time <RFC3339> [options]
+
+Required:
+  --since-time T     Window start, RFC3339 UTC (e.g. 2026-08-17T12:02:06Z)
+
+Options:
+  --until-time T     Window end, RFC3339 UTC. Default: now (open-ended).
+  -n, --namespace N  Ingress controller namespace. Default: ingress-nginx
+  --selector S       Pod label selector. Default: app.kubernetes.io/name=ingress-nginx
+  --pod P[,P2]       Explicit pod name(s), comma-separated. Overrides --selector.
+  --match S          Only count lines containing this substring (host, path,
+                     service or ingress name). Omit to count all traffic.
+  --buckets a,b,c    Duration bucket edges in seconds. Default: 1,10,60
+                     (yields <1, 1-10, 10-60, >=60)
+  --preset P         Access log format. Only "nginx-ingress" today.
+  -h, --help         Show this help
+
+Example:
+  http-log-stats.sh --since-time 2026-08-17T12:02:06Z \
+    --until-time 2026-08-17T14:02:06Z \
+    --match my-service --buckets 1,10,60
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since-time)    SINCE="$2";     shift 2 ;;
+    --until-time)    UNTIL="$2";     shift 2 ;;
+    -n|--namespace)  NAMESPACE="$2"; shift 2 ;;
+    --selector)      SELECTOR="$2";  shift 2 ;;
+    --pod)           PODS="$2";      shift 2 ;;
+    --match)         MATCH="$2";     shift 2 ;;
+    --buckets)       BUCKETS="$2";   shift 2 ;;
+    --preset)        PRESET="$2";    shift 2 ;;
+    -h|--help)       usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$SINCE" ]]; then
+  echo "Error: --since-time is required. A rolling window (--since=2h) shifts between calls," >&2
+  echo "       which makes successive numbers incomparable — pin an absolute start." >&2
+  exit 1
+fi
+if [[ "$PRESET" != "nginx-ingress" ]]; then
+  echo "Error: unknown --preset '$PRESET' (supported: nginx-ingress)" >&2
+  exit 1
+fi
+
+# ── Resolve the replica set ────────────────────────────────────────────
+if [[ -n "$PODS" ]]; then
+  POD_LIST="${PODS//,/ }"
+else
+  POD_LIST=$(kubectl get pods -n "$NAMESPACE" -l "$SELECTOR" \
+               -o jsonpath='{range .items[*]}{.metadata.name} {end}' 2>/dev/null || true)
+fi
+POD_LIST=$(echo "$POD_LIST" | tr -s ' ' | sed 's/^ *//; s/ *$//')
+
+if [[ -z "$POD_LIST" ]]; then
+  echo "window:    $SINCE .. ${UNTIL:-now}"
+  echo "source:    live cluster (kubectl logs), ns=$NAMESPACE"
+  echo "coverage:  UNAVAILABLE  (no controller pod matched ns=$NAMESPACE selector=$SELECTOR)"
+  echo
+  echo "No live source to count. The controller may have been replaced, or the"
+  echo "namespace/selector is wrong. Verify with 'kubectl get pods -n $NAMESPACE',"
+  echo "and if the pods are genuinely gone, this window can only be answered from"
+  echo "a log/metrics backend — say so rather than reporting zero."
+  exit 0
+fi
+
+POD_COUNT=$(echo "$POD_LIST" | wc -w | tr -d ' ')
+
+# ── Coverage probe (cheap: first few KB per replica, not a full pull) ──
+# --limit-bytes truncates from the START, so the first line is the oldest one
+# still retained. Deliberately WITHOUT --since-time: we need to know how far
+# back the log actually reaches, not where the window begins.
+EARLIEST=""
+for p in $POD_LIST; do
+  first=$(kubectl logs -n "$NAMESPACE" "$p" --timestamps --limit-bytes=4096 2>/dev/null \
+            | head -1 | cut -d' ' -f1 || true)
+  [[ -z "$first" ]] && continue
+  # Keep the LATEST of the per-replica earliest lines: if any replica's history
+  # starts after the window opens, that replica's early traffic is missing, so
+  # the aggregate is partial.
+  if [[ -z "$EARLIEST" || "$first" > "$EARLIEST" ]]; then
+    EARLIEST="$first"
+  fi
+done
+
+COVERAGE="UNKNOWN"
+COVERAGE_NOTE=""
+if [[ -z "$EARLIEST" ]]; then
+  COVERAGE="UNKNOWN"
+  COVERAGE_NOTE="(could not read the earliest retained line)"
+elif [[ "${EARLIEST:0:19}" > "${SINCE:0:19}" ]]; then
+  COVERAGE="PARTIAL"
+  COVERAGE_NOTE="(live log only reaches back to $EARLIEST — traffic before that is NOT counted)"
+else
+  COVERAGE="FULL"
+  COVERAGE_NOTE="(earliest retained line $EARLIEST)"
+fi
+
+# ── Single full pull per replica, one awk pass over all of it ──────────
+# Every replica's stream is concatenated into ONE awk so cross-replica totals
+# come out already summed. Failures per replica are tolerated (a pod can be
+# restarting) — unreadable replicas are reported via the parsed/total counters.
+STATS=$(
+  for p in $POD_LIST; do
+    kubectl logs -n "$NAMESPACE" "$p" --timestamps --since-time="$SINCE" 2>/dev/null || true
+  done | awk -v until_t="$UNTIL" -v match_s="$MATCH" -v buckets="$BUCKETS" '
+    BUCKET_INIT_ONCE == 0 {
+      n = split(buckets, edge, ",")
+      BUCKET_INIT_ONCE = 1
+    }
+    {
+      # $1 is the RFC3339 stamp kubelet prepends via --timestamps. kubectl has
+      # no --until, so the upper bound is enforced here; substr to seconds so a
+      # fractional stamp cannot sort oddly against a whole-second bound.
+      if (until_t != "" && substr($1, 1, 19) > substr(until_t, 1, 19)) next
+      if (match_s != "" && index($0, match_s) == 0) next
+      total++
+
+      # $status sits right after the quoted request line ("GET /p HTTP/1.1" 200).
+      # Anchoring on HTTP/x.y" survives referer/user-agent fields that contain
+      # spaces, which makes positional field indexes unreliable.
+      if (match($0, /HTTP\/[0-9.]+" [0-9][0-9][0-9]/)) {
+        code = substr($0, RSTART + RLENGTH - 3, 3)
+        codes[code]++
+        parsed_status++
+      }
+
+      # $request_time is the fractional seconds immediately before the bracketed
+      # $proxy_upstream_name. $request_length precedes it but is an integer, so
+      # requiring a decimal point plus the trailing " [" pins the right field.
+      if (match($0, / [0-9]+\.[0-9]+ \[/)) {
+        rt = substr($0, RSTART + 1, RLENGTH - 3) + 0
+        parsed_time++
+        placed = 0
+        for (i = 1; i <= n; i++) {
+          if (rt < edge[i] + 0) { hist[i]++; placed = 1; break }
+        }
+        if (!placed) hist[n + 1]++
+      }
+    }
+    END {
+      printf "TOTAL %d %d %d\n", total, parsed_status, parsed_time
+      for (c in codes) printf "CODE %s %d\n", c, codes[c]
+      # "-" rather than an empty upper bound: an empty field would collapse into
+      # adjacent spaces and shift every later column when the shell reads it back.
+      for (i = 1; i <= n + 1; i++) {
+        lo = (i == 1) ? "0" : edge[i - 1]
+        hi = (i == n + 1) ? "-" : edge[i]
+        printf "BUCKET %s %s %d\n", lo, hi, hist[i] + 0
+      }
+    }
+  '
+)
+
+# ── Report ────────────────────────────────────────────────────────────
+read -r _ TOTAL PARSED_STATUS PARSED_TIME <<<"$(echo "$STATS" | grep '^TOTAL ' || echo 'TOTAL 0 0 0')"
+
+echo "window:    $SINCE .. ${UNTIL:-now}"
+echo "source:    live cluster (kubectl logs), ns=$NAMESPACE, $POD_COUNT pod(s)"
+echo "coverage:  $COVERAGE  $COVERAGE_NOTE"
+[[ -n "$MATCH" ]] && echo "match:     $MATCH"
+echo "parsed:    $TOTAL lines (status $PARSED_STATUS, request_time $PARSED_TIME)"
+echo
+
+if [[ "$TOTAL" -eq 0 ]]; then
+  echo "No matching lines in the window."
+  echo
+  echo "Before reporting this as \"no traffic\": confirm --match matches how the"
+  echo "access log names the target (ingress name / host / path, not the Deployment"
+  echo "name), and that this controller is the one serving it. An empty result is"
+  echo "bounded non-evidence for THIS command, not proof of zero requests."
+  exit 0
+fi
+
+echo "status codes:"
+echo "$STATS" | grep '^CODE ' | sort -k2,2 | while read -r _ code count; do
+  awk -v c="$code" -v n="$count" -v t="$TOTAL" \
+    'BEGIN { printf "  %-5s %7d  %5.1f%%\n", c, n, (t ? n * 100 / t : 0) }'
+done
+
+echo
+echo "request_time buckets (seconds):"
+echo "$STATS" | grep '^BUCKET ' | while read -r _ lo hi count; do
+  if [[ "$hi" == "-" ]]; then label=">=${lo}"
+  elif [[ "$lo" == "0" ]]; then label="<${hi}"
+  else label="${lo}-${hi}"; fi
+  awk -v l="$label" -v n="$count" -v t="$PARSED_TIME" \
+    'BEGIN { printf "  %-9s %7d  %5.1f%%\n", l, n, (t ? n * 100 / t : 0) }'
+done
+
+# A parser that silently matched nothing would hand back a confident-looking
+# zero. Say so instead — the format is probably customised.
+if [[ "$PARSED_STATUS" -eq 0 || "$PARSED_TIME" -eq 0 ]]; then
+  echo
+  echo "WARNING: parsed 0 $([[ "$PARSED_STATUS" -eq 0 ]] && echo 'status codes' || echo 'durations')"
+  echo "from $TOTAL matching lines. This controller's log_format is probably not the"
+  echo "nginx-ingress default — the counts above are NOT trustworthy. Sample a few raw"
+  echo "lines before drawing any conclusion."
+fi

--- a/skills/core/ingress-debug/SKILL.md
+++ b/skills/core/ingress-debug/SKILL.md
@@ -187,3 +187,8 @@ kubectl top pods -n <controller-ns> -l app.kubernetes.io/name=ingress-nginx
 - Ingress controller logs are the most useful source for debugging routing issues — always check them when the cause is unclear.
 - If the cluster uses multiple Ingress controllers, make sure the Ingress's `ingressClassName` matches the correct controller.
 - For cloud-managed Ingress (AWS ALB Ingress Controller, GCE Ingress), the controller creates cloud load balancers — check cloud provider console if the ADDRESS is stuck or the load balancer is unhealthy.
+
+## See also
+
+- `http-log-stats` — when the question is **how much** rather than **why**: counting status codes or request-duration distribution over a time window from the controller's access log. Use it instead of hand-rolling `kubectl logs | grep -c` per number.
+- `service-debug` — backend Service has no healthy endpoints.

--- a/skills/core/meta.json
+++ b/skills/core/meta.json
@@ -6,6 +6,7 @@
     "hpa-debug":                ["kubernetes", "general",  "diagnostic", "sre", "developer"],
     "image-pull-debug":         ["kubernetes", "general",  "diagnostic", "sre", "developer"],
     "ingress-debug":            ["kubernetes", "network",  "diagnostic", "sre", "developer"],
+    "http-log-stats":           ["kubernetes", "network",  "diagnostic", "sre", "developer"],
     "job-debug":                ["kubernetes", "general",  "diagnostic", "sre", "developer"],
     "networkpolicy-debug":      ["kubernetes", "network",  "diagnostic", "sre", "developer"],
     "node-health-check":        ["kubernetes", "general",  "diagnostic", "sre", "developer"],

--- a/src/tools/cmd-exec/restricted-bash.ts
+++ b/src/tools/cmd-exec/restricted-bash.ts
@@ -311,7 +311,10 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
                   "read (or any other tool) to check on it, and do NOT sleep or wait. You will be " +
                   "automatically notified when it completes; ONLY THEN call task_output(task_id). Polling " +
                   "the file before the notification just wastes turns (it will not be there yet). Use " +
-                  "for long-running work (perftest, follow logs, big collections). Output that needs " +
+                  "for long-running work (perftest, follow logs, big collections). ALSO use it when one " +
+                  "expensive collection has to answer SEVERAL questions (e.g. counting status codes AND " +
+                  "duration buckets in the same log): launch it once, then run your greps against the " +
+                  "output file, instead of re-running the collection per question. Output that needs " +
                   "structural (JSON) redaction cannot run in the background — use -o wide/name or run foreground.",
               })
             ),


### PR DESCRIPTION
## Problem

Answering "how many 503s did the router return, and how many took over 60s" from an ingress controller currently means one `kubectl logs … | grep -c` per number. Each full pull of a busy controller's window is a **30–90s stream** from the API server, per replica — so a four-bucket duration distribution across three replicas is **twelve pulls of byte-identical data**.

A real investigation spent 25 minutes doing exactly that, plus 4 more minutes grepping the *application* pod log for the string `503` before discovering an NGINX Ingress sat in front.

## What this adds

`skills/core/http-log-stats` — pulls each replica's access log **once** and lets a single `awk` accumulate every status code and every duration bucket in the same pass.

```
window:    2026-08-17T12:02:06Z .. 2026-08-17T14:02:06Z
source:    live cluster (kubectl logs), ns=ingress-nginx, 3 pod(s)
coverage:  FULL  (earliest retained line 2026-08-17T11:47:33Z)
parsed:    1007 lines (status 1007, request_time 1007)

status codes:
  200      1000   99.3%
  499         7    0.7%

request_time buckets (seconds):
  <1        983   97.6%
  1-10       17    1.7%
  10-60       7    0.7%
  >=60        0    0.0%
```

### Three things beyond counting

- **Reports `coverage`.** Container logs rotate and pods get replaced, so the earliest retained line is compared against the requested window and the verdict (`FULL` / `PARTIAL` / `UNAVAILABLE`) is printed alongside the numbers. A count over a window the log no longer covers is not a smaller truth, it is a wrong number. `UNAVAILABLE` output explicitly says *do not report this as zero*.
- **Requires an absolute window.** A rolling `--since=2h` shifts between invocations, so two counts taken minutes apart cover different spans and cannot be compared or summed — the earlier investigation had to recompute a whole round because of this.
- **Fails loudly on an unrecognised `log_format`** instead of returning a confident zero.

### Layer identification comes first

SKILL.md leads with `kubectl get ingress,svc,endpoints` before reading any log. "router 503" may mean the ingress controller, the Service, or the application, and grepping the app pod log for `503` counts request bodies and upstream error text rather than HTTP responses.

## Also in this PR

- `ingress-debug` gets a **See also** — it diagnoses *why* traffic fails; this counts *how much* there is.
- `run_in_background`'s description now covers the case where one expensive collection must answer several questions: launch once and grep the output file, rather than re-running the collection per question.

## Parsing notes

Targets the nginx-ingress default `log-format-upstream`. `$status` is anchored on `HTTP/x.y"` rather than a positional field index, because `$http_referer` / `$http_user_agent` can contain spaces; `$request_time` is pinned by the decimal point plus the trailing ` [` of `$proxy_upstream_name`, which distinguishes it from the integer `$request_length` in front of it. `--preset` exists so another format (Envoy, JSON) is a new branch rather than a new skill.

## Testing

- `npx vitest run` (excluding stale local worktrees): **245 files / 5115 tests passed**
- `npx tsc --noEmit`: clean; `bash -n` on the script: clean
- End-to-end against a **stubbed kubectl**: bucket boundaries (including the `>=N` tail bucket), cross-replica summing, `--until` filtering, `--match` filtering, and all three coverage verdicts. This caught a real bug pre-merge — an empty upper bound collapsed adjacent spaces and shifted the shell's column read, silently dropping the `>=60` count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
