### PR TITLE
fix(coordinator): locate resources before clarification

### DIFF
--- a/docs/design/coordinator-routing.md
+++ b/docs/design/coordinator-routing.md
@@ -61,6 +61,32 @@ still missing — rather than the internal rule that produced it.
   The roster remains the authorization source; a routing helper never grants
   coverage.
 
+## Unknown-cluster resource location
+
+When the request names a concrete resource but omits its owning cluster, an
+explicitly attached read-only resource-locator skill may establish the routing
+identity before the coordinator asks the user. Typical inputs are a Pod, Job,
+Node, reservation, entry ID, or IP address.
+
+The locator is bounded to identity discovery. It must not diagnose the resource,
+read logs or events, refresh remote state, or recommend remediation. Its result
+must distinguish:
+
+- one unambiguous resource match and one confirmed canonical Siclaw binding
+  name;
+- multiple or ambiguous matches; or
+- no match.
+
+Only the first outcome proceeds to `list_delegates`, with the confirmed binding
+name and `binding_name_confirmed=true`. A locator-specific cluster id, display
+name, region, or alias is not interchangeable with a Siclaw binding name. The
+other outcomes ask for only the detail needed to disambiguate, such as cluster,
+region, namespace, or resource kind.
+
+Resource location is optional: a coordinator without an attached locator asks
+for the missing routing detail. In every case, `list_delegates` remains the
+authorization boundary and the specialist remains the owner of diagnosis.
+
 ## Optional alias resolution
 
 When the first lookup misses and the target may be a cluster alias, the

--- a/src/core/agent-types.test.ts
+++ b/src/core/agent-types.test.ts
@@ -45,6 +45,20 @@ describe("agent-types", () => {
     expect(AGENT_TYPES.coordinator.defaultPrompt).not.toContain("search_memory");
   });
 
+  it("coordinator locates concrete resources before asking for a missing cluster", () => {
+    const prompt = AGENT_TYPES.coordinator.defaultPrompt;
+    expect(prompt).toBeTruthy();
+    expect(prompt).toContain("read-only resource-locator");
+    expect(prompt).toContain("only to establish routing identity, never to diagnose");
+    expect(prompt).toContain("one confirmed canonical Siclaw binding name");
+    expect(prompt).toContain("Pass `binding_name_confirmed=true` when the target came from the locator");
+
+    const locate = prompt!.indexOf("consult an attached read-only resource-locator");
+    const ask = prompt!.indexOf("ASK THE USER for the minimum detail");
+    expect(locate).toBeGreaterThanOrEqual(0);
+    expect(ask).toBeGreaterThan(locate);
+  });
+
   it("normalizeAgentType defaults unknown/absent to custom", () => {
     expect(normalizeAgentType("sre")).toBe("sre");
     expect(normalizeAgentType("coordinator")).toBe("coordinator");

--- a/src/core/agent-types.ts
+++ b/src/core/agent-types.ts
@@ -58,17 +58,22 @@ export const COORDINATOR_DEFAULT_PROMPT =
   "OUTCOME the user needs (e.g. the specialist covering that cluster could not be reached, or which detail " +
   "you still need) rather than explaining your own rules. " +
   "To ROUTE: (1) determine the TARGET resource (cluster / " +
-  "host / node) from the user's request; (2) call `list_delegates` first with query=<that target exactly as " +
-  "established> to find WHICH " +
+  "host / node) from the user's request. If the request gives a concrete resource (Pod, Job, Node, " +
+  "reservation, entry ID, or IP) but not its owning cluster, consult an attached read-only resource-locator " +
+  "skill, if any, BEFORE asking the user. Use it only to establish routing identity, never to diagnose the " +
+  "resource. Continue only when it yields one confirmed canonical Siclaw binding name; if no locator is " +
+  "attached or its result is empty, ambiguous, or unresolved, ASK THE USER for the minimum detail needed to " +
+  "disambiguate. (2) call `list_delegates` with query=<that target exactly as established> to find WHICH " +
   "delegate is bound to it — this authoritative coverage lookup (NOT your own cluster_list, which is YOUR " +
-  "bindings) is how you confirm who covers the target. If it returns no exact binding match and the target " +
-  "may be a cluster alias, consult a routing-helper skill you were given, if any. Only when the helper confirms " +
+  "bindings) is how you confirm who covers the target. Pass `binding_name_confirmed=true` when the target " +
+  "came from the locator. If an unconfirmed user-supplied cluster name returns no exact binding match and may " +
+  "be an alias, consult a routing-helper skill you were given, if any. Only when the helper confirms " +
   "one canonical Siclaw binding name, retry `list_delegates` once with that name and " +
   "`binding_name_confirmed=true`; do not guess from an ambiguous or unresolved result. If no helper is " +
   "attached, it cannot confirm one name, or the confirmed retry also misses, tell the user that no authorized " +
   "agent covers the name and that it may be an alias. (3) delegate to the matching agent via " +
-  "`delegate_to_agent`. If you CANNOT determine the target from the request — it is missing, ambiguous, or a " +
-  "node/pod is named without its cluster — ASK THE USER to supply the missing detail. Do NOT guess, do NOT " +
+  "`delegate_to_agent`. If you CANNOT determine any concrete target from the request, ASK THE USER to supply " +
+  "the missing detail. Do NOT guess, do NOT " +
   "browse the whole delegate list hoping to infer it, and do NOT pick the closest match. EXCEPTION — a " +
   "follow-up WITHIN an investigation already in progress: INHERIT the target resource and the specialist from " +
   "the ongoing thread. A pronoun-only or elliptical follow-up that does not restate the target still refers " +


### PR DESCRIPTION
## Summary
- let coordinators consult an attached read-only resource locator when a concrete resource lacks its owning cluster
- require a confirmed canonical Siclaw binding before coverage lookup
- keep resource diagnosis and authorization outside the locator

## Validation
- `npx vitest run src/core/agent-types.test.ts`
- `npm run build`

## Integration
The concrete Navix locator is delivered separately in `siclaw-inner`; this PR defines only the generic open-source coordinator contract. Coordinator prompts are persisted configuration after creation, so existing agents still require an explicit prompt refresh. Control planes that mirror this default must update their mirror separately.