### PR TITLE
fix(knowledge): wipe agentbox disk when the next release has no libraries

### DIFF
--- a/docs/design/invariants.md
+++ b/docs/design/invariants.md
@@ -38,9 +38,10 @@ TUI has two sub-modes: **standalone** (no Portal in the cwd) and **Portal-paired
 - Any code that writes/deletes files in `./skills/` affects ALL users simultaneously
 - `skillsHandler.materialize()` is **NOT safe** in local mode — it wipes `skills/global/`, `skills/skillset/`, and `skills/user/` subdirectories (not `core/`), which in a shared filesystem destroys ALL users' personal skills. This is designed for K8s pods with isolated filesystems.
 - Per-user skill sync in local mode must write only to `skills/user/<userId>/` without touching `skills/core/` (global + personal skills from the bundle are both written into the user's directory)
+- Knowledge sync in local mode must materialize and read from an agent-scoped directory (`.siclaw/knowledge/<agentId>/`). Empty and non-empty bundles both replace their target, so pointing the canonical handler at the shared knowledge root would let one agent erase another agent's libraries.
 - Local SQLite (via `node:sqlite`) uses WAL mode with a shared process — local mode is single-process by design; production K8s uses MySQL and has no such constraint
 
-**Source**: `src/gateway/agentbox/local-spawner.ts`, `src/agentbox/resource-handlers.ts:82-97`
+**Source**: `src/gateway/agentbox/local-spawner.ts`, `src/agentbox/sync-handlers.ts`, `src/agentbox/session.ts`, `src/core/agent-factory.ts`
 
 ### 1.3 K8s Pod Isolation
 
@@ -316,6 +317,7 @@ postReload(context)  Notify active sessions to pick up changes
 |---------|----------------------|------------------|-------|
 | `mcpHandler.materialize()` | ✅ Yes | ✅ Yes | Merges, does not wipe |
 | `skillsHandler.materialize()` | ❌ No | ✅ Yes | Wipes `global/` + `skillset/` + `user/` subdirs (not `core/`) |
+| `knowledgeHandler.materialize()` | ✅ With agent-scoped target | ✅ Yes | Replaces its whole target; LocalSpawner binds `.siclaw/knowledge/<agentId>/` |
 
 For local mode skills sync, write directly to `skills/user/<userId>/` without delegating to `skillsHandler.materialize()`. Global and personal skills from the bundle are both placed under the user's directory.
 

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -62,6 +62,7 @@ vi.mock("./sync-handlers.js", () => ({
   getSyncHandler: () => undefined,
   createClusterHandler: () => ({ type: "cluster", fetch: async () => 0, materialize: async (n: number) => n }),
   createHostHandler: () => ({ type: "host", fetch: async () => 0, materialize: async (n: number) => n }),
+  createKnowledgeHandler: () => ({ type: "knowledge", fetch: async () => ({ repos: [] }), materialize: async () => 0 }),
   createToolsHandler: (target: { allowedToolsState: string[] | null }) => ({
     type: "tools",
     fetch: async () => ({ allowedTools: null }),

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -62,7 +62,12 @@ vi.mock("./sync-handlers.js", () => ({
   getSyncHandler: () => undefined,
   createClusterHandler: () => ({ type: "cluster", fetch: async () => 0, materialize: async (n: number) => n }),
   createHostHandler: () => ({ type: "host", fetch: async () => 0, materialize: async (n: number) => n }),
-  createKnowledgeHandler: () => ({ type: "knowledge", fetch: async () => ({ repos: [] }), materialize: async () => 0 }),
+  createKnowledgeHandler: () => ({
+    type: "knowledge",
+    fetch: async () => ({ repos: [] }),
+    materialize: async () => 0,
+    getLastKnowledgeSyncStatus: () => null,
+  }),
   createToolsHandler: (target: { allowedToolsState: string[] | null }) => ({
     type: "tools",
     fetch: async () => ({ allowedTools: null }),

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -27,6 +27,7 @@ import {
   createHostHandler,
   createKnowledgeHandler,
   createToolsHandler,
+  type KnowledgeSyncHandler,
 } from "./sync-handlers.js";
 import { GATEWAY_SYNC_DESCRIPTORS, type AgentBoxSyncHandler, type GatewaySyncType } from "../shared/gateway-sync.js";
 import { detectLanguage } from "../shared/detect-language.js";
@@ -456,6 +457,13 @@ async function abortBrainForHttp(
 
 export interface CreateHttpServerOptions {
   /**
+   * Knowledge handler already bound to this box's target directory. LocalSpawner
+   * supplies the same instance used by its initial sync so status and reloads
+   * share one per-box lifecycle. Other entrypoints create their handler here.
+   */
+  knowledgeHandler?: KnowledgeSyncHandler;
+
+  /**
    * If true, skip the idle self-destruct entirely. Intended for LocalSpawner,
    * which runs AgentBox in-process with the Portal — shutting down from
    * the idle timer would take the whole `siclaw local` process down with it.
@@ -518,9 +526,8 @@ export function createHttpServer(
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
   }
   if (sessionManager.knowledgeDir) {
-    perServerHandlers.knowledge = createKnowledgeHandler({
-      knowledgeDir: sessionManager.knowledgeDir,
-    });
+    perServerHandlers.knowledge = options.knowledgeHandler
+      ?? createKnowledgeHandler({ knowledgeDir: sessionManager.knowledgeDir });
   }
   // tools handler — same per-box rationale as cluster/host. It writes the
   // resolved allowedTools into THIS box's sessionManager and fetches with THIS

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -21,7 +21,13 @@ import { checkMetricsAuth } from "../shared/metrics.js"; // also registers metri
 import { GatewayClient } from "./gateway-client.js";
 import { CredentialBroker } from "./credential-broker.js";
 import { HttpTransport } from "./credential-transport.js";
-import { getSyncHandler, createClusterHandler, createHostHandler, createToolsHandler } from "./sync-handlers.js";
+import {
+  getSyncHandler,
+  createClusterHandler,
+  createHostHandler,
+  createKnowledgeHandler,
+  createToolsHandler,
+} from "./sync-handlers.js";
 import { GATEWAY_SYNC_DESCRIPTORS, type AgentBoxSyncHandler, type GatewaySyncType } from "../shared/gateway-sync.js";
 import { detectLanguage } from "../shared/detect-language.js";
 import { stripLanguageDirective } from "../shared/strip-language-directive.js";
@@ -510,6 +516,11 @@ export function createHttpServer(
   if (sessionManager.credentialBroker) {
     perServerHandlers.cluster = createClusterHandler(sessionManager.credentialBroker);
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
+  }
+  if (sessionManager.knowledgeDir) {
+    perServerHandlers.knowledge = createKnowledgeHandler({
+      knowledgeDir: sessionManager.knowledgeDir,
+    });
   }
   // tools handler — same per-box rationale as cluster/host. It writes the
   // resolved allowedTools into THIS box's sessionManager and fetches with THIS

--- a/src/agentbox/resource-sync.test.ts
+++ b/src/agentbox/resource-sync.test.ts
@@ -127,6 +127,7 @@ describe("syncResource — error paths", () => {
     expect(result.message).toBe("boom");
     // mcp descriptor says maxRetries=3
     expect(handler.fetch).toHaveBeenCalledTimes(3);
+    expect(handler.materialize).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -350,6 +350,13 @@ export class AgentBoxSessionManager {
   credentialsDir?: string;
 
   /**
+   * Optional directory containing this AgentBox's materialized knowledge.
+   * LocalSpawner sets an agent-scoped path because every local box shares one
+   * process and cwd. K8s leaves this unset and uses the pod-local config path.
+   */
+  knowledgeDir?: string;
+
+  /**
    * Per-agent tool capability whitelist — the resolved `allowedTools` list for
    * this AgentBox's agent (see core/tool-capabilities.ts).
    *
@@ -2138,6 +2145,7 @@ export class AgentBoxSessionManager {
       memoryIndexer: this._sharedMemoryIndexer ?? undefined,
       userId: this.userId,
       agentId,
+      knowledgeDir: this.knowledgeDir,
       // A spawned sub-agent must never be broader than its parent: inherit the
       // parent's per-agent tool whitelist. Without this, a restricted agent that
       // has the `spawn_subagents` capability could escalate by spawning a child
@@ -2697,6 +2705,7 @@ export class AgentBoxSessionManager {
       memoryIndexer: this._sharedMemoryIndexer ?? undefined,
       userId: this.userId,
       agentId: this.agentId ?? null,
+      knowledgeDir: this.knowledgeDir,
       // Per-agent tool capability whitelist. null = unrestricted (falls back to
       // global config.allowedTools in agent-factory — today's behaviour for any
       // agent that never set tool_capabilities).

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -940,10 +940,10 @@ describe("skill directory resolution", () => {
 });
 
 // ---------------------------------------------------------------------------
-// knowledgeHandler — empty-bundle preservation guard (symmetric to skills)
+// knowledgeHandler — empty-bundle wipe (successful empty fetch = unbound)
 // ---------------------------------------------------------------------------
 
-describe("knowledgeHandler empty-bundle guard", () => {
+describe("knowledgeHandler empty-bundle wipe", () => {
   let knowledgeTmpDir: string;
 
   beforeEach(() => {
@@ -961,21 +961,17 @@ describe("knowledgeHandler empty-bundle guard", () => {
     expect(fs.readdirSync(knowledgeTmpDir)).toEqual([]);
   });
 
-  it("preserves knowledgeDir contents when empty bundle arrives but content already materialized", async () => {
-    // Seed the dir as if a previous successful sync had happened.
+  it("wipes previously materialized knowledge when an empty bundle arrives", async () => {
+    // Previous successful sync left A on disk; next release unbound every library.
     fs.writeFileSync(path.join(knowledgeTmpDir, "index.md"), "# Seeded");
     fs.mkdirSync(path.join(knowledgeTmpDir, "repos", "alpha"), { recursive: true });
     fs.writeFileSync(path.join(knowledgeTmpDir, "repos", "alpha", "index.md"), "# alpha");
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const count = await knowledgeHandler.materialize({ version: "v2", repos: [] });
 
-    // Reports what it kept (top-level entries: index.md + repos/)
-    expect(count).toBe(2);
-    expect(fs.existsSync(path.join(knowledgeTmpDir, "index.md"))).toBe(true);
-    expect(fs.existsSync(path.join(knowledgeTmpDir, "repos", "alpha", "index.md"))).toBe(true);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("skipping wipe"));
-    warnSpy.mockRestore();
+    expect(count).toBe(0);
+    expect(fs.existsSync(path.join(knowledgeTmpDir, "index.md"))).toBe(false);
+    expect(fs.existsSync(path.join(knowledgeTmpDir, "repos", "alpha", "index.md"))).toBe(false);
   });
 
   it("ignores stale .sync-staging-* leftovers when deciding whether to preserve", async () => {

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -990,6 +990,28 @@ describe("knowledgeHandler empty-bundle wipe", () => {
     expect(fs.existsSync(path.join(agentBDir, "index.md"))).toBe(false);
   });
 
+  it("keeps the last sync status isolated per knowledge handler", async () => {
+    const agentADir = path.join(knowledgeTmpDir, "agent-a");
+    const agentBDir = path.join(knowledgeTmpDir, "agent-b");
+    const agentAHandler = createKnowledgeHandler({ knowledgeDir: agentADir });
+    const agentBHandler = createKnowledgeHandler({ knowledgeDir: agentBDir });
+
+    expect(agentAHandler.getLastKnowledgeSyncStatus()).toBeNull();
+    expect(agentBHandler.getLastKnowledgeSyncStatus()).toBeNull();
+
+    await agentAHandler.materialize({ version: "v1", repos: [] });
+    expect(agentAHandler.getLastKnowledgeSyncStatus()).toMatchObject({
+      targetDir: agentADir,
+      repoCount: 0,
+      repos: [],
+    });
+    expect(agentBHandler.getLastKnowledgeSyncStatus()).toBeNull();
+
+    await agentBHandler.materialize({ version: "v1", repos: [] });
+    expect(agentAHandler.getLastKnowledgeSyncStatus()).toMatchObject({ targetDir: agentADir });
+    expect(agentBHandler.getLastKnowledgeSyncStatus()).toMatchObject({ targetDir: agentBDir });
+  });
+
   it("ignores stale .sync-staging-* leftovers when deciding whether to preserve", async () => {
     // Only a leftover staging dir — not meaningful content.
     fs.mkdirSync(path.join(knowledgeTmpDir, ".sync-staging-9999-99"), { recursive: true });

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   createClusterHandler,
   createHostHandler,
+  createKnowledgeHandler,
   createToolsHandler,
   knowledgeHandler,
   mcpHandler,
@@ -972,6 +973,21 @@ describe("knowledgeHandler empty-bundle wipe", () => {
     expect(count).toBe(0);
     expect(fs.existsSync(path.join(knowledgeTmpDir, "index.md"))).toBe(false);
     expect(fs.existsSync(path.join(knowledgeTmpDir, "repos", "alpha", "index.md"))).toBe(false);
+  });
+
+  it("wipes only the explicitly targeted agent directory", async () => {
+    const agentADir = path.join(knowledgeTmpDir, "agent-a");
+    const agentBDir = path.join(knowledgeTmpDir, "agent-b");
+    fs.mkdirSync(agentADir, { recursive: true });
+    fs.mkdirSync(agentBDir, { recursive: true });
+    fs.writeFileSync(path.join(agentADir, "index.md"), "# A");
+    fs.writeFileSync(path.join(agentBDir, "index.md"), "# B");
+
+    const agentBHandler = createKnowledgeHandler({ knowledgeDir: agentBDir });
+    await agentBHandler.materialize({ version: "v2", repos: [] });
+
+    expect(fs.readFileSync(path.join(agentADir, "index.md"), "utf8")).toBe("# A");
+    expect(fs.existsSync(path.join(agentBDir, "index.md"))).toBe(false);
   });
 
   it("ignores stale .sync-staging-* leftovers when deciding whether to preserve", async () => {

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -359,28 +359,10 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
     const syncedAt = new Date().toISOString();
 
     if (repos.length === 0) {
-      // Defense against empty-bundle erasure (belt-and-suspenders; the primary
-      // fix is Gateway-side so empty-bundles only arrive when the agent is
-      // genuinely unbound). If an empty payload arrives but we already have
-      // knowledge materialized, keep what we have and let the next reload retry.
-      // Legitimate "unbind-all" admin operations can force a fresh wipe by
-      // restarting the pod — which is cheap and explicit.
-      if (fs.existsSync(knowledgeDir)) {
-        const existing = fs.readdirSync(knowledgeDir).filter((name) => {
-          if (name.startsWith(".sync-staging")) return false;
-          try { return fs.statSync(path.join(knowledgeDir, name)).isDirectory() || fs.statSync(path.join(knowledgeDir, name)).isFile(); }
-          catch { return false; }
-        });
-        if (existing.length > 0) {
-          console.warn(
-            `[sync-handlers.knowledge] Empty bundle received but knowledgeDir has ` +
-            `${existing.length} entr${existing.length === 1 ? "y" : "ies"}; skipping wipe to preserve state. ` +
-            `Next non-empty reload will refresh normally.`,
-          );
-          return existing.length;
-        }
-      }
-      // Clear knowledge directory — agent has no bound repos AND nothing on disk worth keeping
+      // A successful empty fetch is authoritative: the type release unbound
+      // every library. Fetch failures never reach materialize (http-server
+      // catches them), so "keep the last disk copy" here made a deliberate
+      // empty publish look like the previous library. Wipe.
       if (fs.existsSync(knowledgeDir)) {
         for (const entry of fs.readdirSync(knowledgeDir)) {
           if (entry.startsWith(".sync-staging")) continue;

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -329,7 +329,7 @@ function catalogNameLine(raw: string | null | undefined): string {
   return catalogOneLine(raw, KNOWLEDGE_CATALOG_NAME_MAX_CHARS) || "library";
 }
 
-interface KnowledgeSyncStatus {
+export interface KnowledgeSyncStatus {
   syncedAt: string;
   targetDir: string;
   repoCount: number;
@@ -339,14 +339,21 @@ interface KnowledgeSyncStatus {
   }>;
 }
 
-let lastKnowledgeSyncStatus: KnowledgeSyncStatus | null = null;
-export function getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null { return lastKnowledgeSyncStatus; }
+export interface KnowledgeSyncHandler extends AgentBoxSyncHandler<KnowledgeBundlePayload> {
+  getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null;
+}
 
 export function createKnowledgeHandler(
   options: { knowledgeDir?: string } = {},
-): AgentBoxSyncHandler<KnowledgeBundlePayload> {
+): KnowledgeSyncHandler {
+  let lastKnowledgeSyncStatus: KnowledgeSyncStatus | null = null;
+
   return {
     type: "knowledge",
+
+    getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null {
+      return lastKnowledgeSyncStatus;
+    },
 
     async fetch(client: GatewaySyncClientLike | null): Promise<KnowledgeBundlePayload> {
       if (!client) throw new Error("[knowledge] GatewaySyncClientLike required but missing");
@@ -494,6 +501,11 @@ export function createKnowledgeHandler(
 }
 
 export const knowledgeHandler = createKnowledgeHandler();
+
+/** Backwards-compatible status accessor for the process-global default handler. */
+export function getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null {
+  return knowledgeHandler.getLastKnowledgeSyncStatus();
+}
 
 // ── Cluster / Host handlers (factory, broker-dependent) ───────────────
 

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -342,27 +342,32 @@ interface KnowledgeSyncStatus {
 let lastKnowledgeSyncStatus: KnowledgeSyncStatus | null = null;
 export function getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null { return lastKnowledgeSyncStatus; }
 
-export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
-  type: "knowledge",
+export function createKnowledgeHandler(
+  options: { knowledgeDir?: string } = {},
+): AgentBoxSyncHandler<KnowledgeBundlePayload> {
+  return {
+    type: "knowledge",
 
-  async fetch(client: GatewaySyncClientLike | null): Promise<KnowledgeBundlePayload> {
-    if (!client) throw new Error("[knowledge] GatewaySyncClientLike required but missing");
-    const descriptor = GATEWAY_SYNC_DESCRIPTORS.knowledge;
-    const data = await client.request(descriptor.gatewayPath, "GET");
-    return data as KnowledgeBundlePayload;
-  },
+    async fetch(client: GatewaySyncClientLike | null): Promise<KnowledgeBundlePayload> {
+      if (!client) throw new Error("[knowledge] GatewaySyncClientLike required but missing");
+      const descriptor = GATEWAY_SYNC_DESCRIPTORS.knowledge;
+      const data = await client.request(descriptor.gatewayPath, "GET");
+      return data as KnowledgeBundlePayload;
+    },
 
-  async materialize(payload: KnowledgeBundlePayload): Promise<number> {
-    const repos = payload?.repos ?? [];
-    const config = loadConfig();
-    const knowledgeDir = path.resolve(process.cwd(), config.paths.knowledgeDir);
-    const syncedAt = new Date().toISOString();
+    async materialize(payload: KnowledgeBundlePayload): Promise<number> {
+      const repos = payload?.repos ?? [];
+      const config = loadConfig();
+      const knowledgeDir = options.knowledgeDir
+        ? path.resolve(options.knowledgeDir)
+        : path.resolve(process.cwd(), config.paths.knowledgeDir);
+      const syncedAt = new Date().toISOString();
 
     if (repos.length === 0) {
-      // A successful empty fetch is authoritative: the type release unbound
-      // every library. Fetch failures never reach materialize (http-server
-      // catches them), so "keep the last disk copy" here made a deliberate
-      // empty publish look like the previous library. Wipe.
+      // A successful empty fetch is authoritative for this isolated target: the
+      // type release unbound every library. Both reload entrypoints call
+      // materialize only after fetch resolves, so thrown fetch failures preserve
+      // the disk copy. Keeping it here made a deliberate empty publish stale.
       if (fs.existsSync(knowledgeDir)) {
         for (const entry of fs.readdirSync(knowledgeDir)) {
           if (entry.startsWith(".sync-staging")) continue;
@@ -471,21 +476,24 @@ export const knowledgeHandler: AgentBoxSyncHandler<KnowledgeBundlePayload> = {
       fs.rmSync(stagingDir, { recursive: true, force: true });
       throw err;
     }
-  },
+    },
 
-  async postReload(context: ReloadContext): Promise<void> {
-    if (!context.sessions?.length) return;
-    for (const session of context.sessions) {
-      try {
-        await session.brain.reload();
-        console.log(`[resource-sync] Knowledge reloaded for session ${session.id}`);
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(`[resource-sync] Failed to reload knowledge for session ${session.id}: ${msg}`);
+    async postReload(context: ReloadContext): Promise<void> {
+      if (!context.sessions?.length) return;
+      for (const session of context.sessions) {
+        try {
+          await session.brain.reload();
+          console.log(`[resource-sync] Knowledge reloaded for session ${session.id}`);
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(`[resource-sync] Failed to reload knowledge for session ${session.id}: ${msg}`);
+        }
       }
-    }
-  },
-};
+    },
+  };
+}
+
+export const knowledgeHandler = createKnowledgeHandler();
 
 // ── Cluster / Host handlers (factory, broker-dependent) ───────────────
 

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -84,6 +84,12 @@ export interface CreateSiclawSessionOpts {
   /** Agent ID — used for metrics labeling (tool_call / skill_call events). Null if no agent context (TUI/CLI). */
   agentId?: string | null;
   /**
+   * Absolute knowledge directory override for an AgentBox. LocalSpawner uses
+   * this to isolate agents that otherwise share one cwd. Unset keeps the
+   * config-driven pod/TUI path.
+   */
+  knowledgeDir?: string;
+  /**
    * Absolute path to a directory that a local Portal snapshot has materialized
    * skills into. CLI mode only: when set, the agent session loads builtin
    * skills from here INSTEAD of `./skills/`, making Portal the source of
@@ -492,9 +498,10 @@ export async function createSiclawSession(
   const reposDir = path.resolve(cwd, config.paths.reposDir);
   const docsDir = path.resolve(cwd, config.paths.docsDir);
   const tracesDir = path.resolve(cwd, ".siclaw", "traces");
-  const knowledgeDir = opts?.portalKnowledgeDir && fs.existsSync(opts.portalKnowledgeDir)
-    ? opts.portalKnowledgeDir
-    : path.resolve(cwd, config.paths.knowledgeDir);
+  const knowledgeDir = opts?.knowledgeDir
+    ?? (opts?.portalKnowledgeDir && fs.existsSync(opts.portalKnowledgeDir)
+      ? opts.portalKnowledgeDir
+      : path.resolve(cwd, config.paths.knowledgeDir));
   const readAllowedDirs = [
     builtinSkillsRoot, skillsBase, userDataDir, reportsDir, tracesDir, reposDir, docsDir, knowledgeDir,
     os.tmpdir(),

--- a/src/gateway/agentbox/local-spawner.test.ts
+++ b/src/gateway/agentbox/local-spawner.test.ts
@@ -39,6 +39,15 @@ vi.mock("../../agentbox/http-server.js", () => ({
   }),
 }));
 
+const syncResourceMock = vi.hoisted(() => vi.fn(async () => 0));
+vi.mock("../../agentbox/resource-sync.js", () => ({
+  syncResource: syncResourceMock,
+}));
+
+vi.mock("../../core/config.js", () => ({
+  loadConfig: () => ({ paths: { knowledgeDir: ".siclaw/knowledge" } }),
+}));
+
 const sessionManagerShutdownCalls: string[] = [];
 
 vi.mock("../../agentbox/session.js", () => ({
@@ -46,6 +55,7 @@ vi.mock("../../agentbox/session.js", () => ({
     userId?: string;
     agentId?: string;
     credentialsDir?: string;
+    knowledgeDir?: string;
     allowedToolsState: string[] | null = null;
     agentTypeState = "custom";
     credentialBroker = { dispose: () => { sessionManagerShutdownCalls.push("broker.dispose"); } };
@@ -80,6 +90,7 @@ beforeEach(() => {
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
   sessionManagerShutdownCalls.length = 0;
+  syncResourceMock.mockClear();
   // Default: agent has no tool_capabilities row value → unrestricted.
   dbQueryImpl = async () => [[{ tool_capabilities: null }], undefined];
 
@@ -119,6 +130,29 @@ describe("LocalSpawner — spawn (happy path)", () => {
     // ENV propagated for http-server / GatewayClient to pick up
     expect(process.env.SICLAW_GATEWAY_URL).toBe("https://127.0.0.1:3002");
     expect(process.env.SICLAW_CERT_PATH).toBe(certDir);
+  });
+
+  it("isolates knowledge materialization by agent", async () => {
+    const spawner = new LocalSpawner(new FakeCertManager() as any, "https://127.0.0.1:3002", 5000);
+    await spawner.spawn({ agentId: "a1" });
+    await spawner.spawn({ agentId: "a2" });
+
+    const boxA = (spawner as any).boxes.get("local-a1");
+    const boxB = (spawner as any).boxes.get("local-a2");
+    expect(boxA.sessionManager.knowledgeDir).toBe(path.join(tmpDir, ".siclaw", "knowledge", "a1"));
+    expect(boxB.sessionManager.knowledgeDir).toBe(path.join(tmpDir, ".siclaw", "knowledge", "a2"));
+
+    await vi.waitFor(() => expect(syncResourceMock).toHaveBeenCalledTimes(2));
+    const agentBHandler = syncResourceMock.mock.calls[1][2];
+
+    fs.mkdirSync(boxA.sessionManager.knowledgeDir, { recursive: true });
+    fs.mkdirSync(boxB.sessionManager.knowledgeDir, { recursive: true });
+    fs.writeFileSync(path.join(boxA.sessionManager.knowledgeDir, "index.md"), "# A");
+    fs.writeFileSync(path.join(boxB.sessionManager.knowledgeDir, "index.md"), "# B");
+    await agentBHandler.materialize({ version: "v2", repos: [] });
+
+    expect(fs.readFileSync(path.join(boxA.sessionManager.knowledgeDir, "index.md"), "utf8")).toBe("# A");
+    expect(fs.existsSync(path.join(boxB.sessionManager.knowledgeDir, "index.md"))).toBe(false);
   });
 
   it("returns the existing handle on a second spawn for the same agent (idempotent)", async () => {

--- a/src/gateway/agentbox/local-spawner.test.ts
+++ b/src/gateway/agentbox/local-spawner.test.ts
@@ -20,23 +20,9 @@ import path from "node:path";
 
 // ── Mocks (hoisted by vi.mock) ────────────────────────────────────────
 
+const createHttpServerMock = vi.hoisted(() => vi.fn());
 vi.mock("../../agentbox/http-server.js", () => ({
-  createHttpServer: vi.fn(() => {
-    // Return a fake http.Server that listen()/close() cleanly.
-    const handlers: Record<string, ((...args: any[]) => void)[]> = {};
-    const server: any = {
-      listen: (_port: number, _host: string, cb: () => void) => {
-        setImmediate(cb);
-        return server;
-      },
-      on: (ev: string, cb: any) => {
-        (handlers[ev] ||= []).push(cb);
-        return server;
-      },
-      close: vi.fn((cb?: () => void) => { cb?.(); }),
-    };
-    return server;
-  }),
+  createHttpServer: createHttpServerMock,
 }));
 
 const syncResourceMock = vi.hoisted(() => vi.fn(async () => 0));
@@ -86,11 +72,28 @@ class FakeCertManager {
 let origCwd: string;
 let tmpDir: string;
 
+function createFakeHttpServer() {
+  const handlers: Record<string, ((...args: any[]) => void)[]> = {};
+  const server: any = {
+    listen: (_port: number, _host: string, cb: () => void) => {
+      setImmediate(cb);
+      return server;
+    },
+    on: (ev: string, cb: any) => {
+      (handlers[ev] ||= []).push(cb);
+      return server;
+    },
+    close: vi.fn((cb?: () => void) => { cb?.(); }),
+  };
+  return server;
+}
+
 beforeEach(() => {
   vi.spyOn(console, "log").mockImplementation(() => {});
   vi.spyOn(console, "warn").mockImplementation(() => {});
   sessionManagerShutdownCalls.length = 0;
   syncResourceMock.mockClear();
+  createHttpServerMock.mockReset().mockImplementation(createFakeHttpServer);
   // Default: agent has no tool_capabilities row value → unrestricted.
   dbQueryImpl = async () => [[{ tool_capabilities: null }], undefined];
 
@@ -153,6 +156,21 @@ describe("LocalSpawner — spawn (happy path)", () => {
 
     expect(fs.readFileSync(path.join(boxA.sessionManager.knowledgeDir, "index.md"), "utf8")).toBe("# A");
     expect(fs.existsSync(path.join(boxB.sessionManager.knowledgeDir, "index.md"))).toBe(false);
+  });
+
+  it("shares one knowledge handler between initial sync and HTTP reloads", async () => {
+    const spawner = new LocalSpawner(new FakeCertManager() as any, "https://127.0.0.1:3002", 5000);
+    await spawner.spawn({ agentId: "a1" });
+
+    await vi.waitFor(() => expect(syncResourceMock).toHaveBeenCalledTimes(1));
+    const initialSyncHandler = syncResourceMock.mock.calls[0][2];
+    expect(createHttpServerMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        disableIdleShutdown: true,
+        knowledgeHandler: initialSyncHandler,
+      }),
+    );
   });
 
   it("returns the existing handle on a second spawn for the same agent (idempotent)", async () => {

--- a/src/gateway/agentbox/local-spawner.ts
+++ b/src/gateway/agentbox/local-spawner.ts
@@ -15,11 +15,14 @@ import { createHttpServer } from "../../agentbox/http-server.js";
 import { AgentBoxSessionManager } from "../../agentbox/session.js";
 import { GatewayClient } from "../../agentbox/gateway-client.js";
 import { syncResource } from "../../agentbox/resource-sync.js";
+import { createKnowledgeHandler } from "../../agentbox/sync-handlers.js";
 import type { CertificateManager } from "../security/cert-manager.js";
 import { getDb } from "../db.js";
 import { safeParseJson } from "../dialect-helpers.js";
 import { resolveCapabilities } from "../../core/tool-capabilities.js";
 import { normalizeAgentType, effectiveCapabilityKeys } from "../../core/agent-types.js";
+import { loadConfig } from "../../core/config.js";
+import { resolveUnderDir } from "../../shared/path-utils.js";
 
 interface LocalBox {
   agentId: string;
@@ -89,6 +92,11 @@ export class LocalSpawner implements BoxSpawner {
       ".siclaw/credentials",
       agentId,
     );
+    const knowledgeRoot = path.resolve(process.cwd(), loadConfig().paths.knowledgeDir);
+    sessionManager.knowledgeDir = resolveUnderDir(knowledgeRoot, agentId);
+    const knowledgeHandler = createKnowledgeHandler({
+      knowledgeDir: sessionManager.knowledgeDir,
+    });
 
     // Inject the resolved tool whitelist AND the locked agent-type policy at spawn
     // time. The tools sync type is initialSync:false, so the framework's
@@ -152,7 +160,7 @@ export class LocalSpawner implements BoxSpawner {
           gatewayUrl: this.gatewayInternalUrl,
           certPath: certDir,
         });
-        await syncResource("knowledge", gatewayClient.toClientLike());
+        await syncResource("knowledge", gatewayClient.toClientLike(), knowledgeHandler);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(`[local-spawner] Initial knowledge sync failed for agent=${agentId}: ${msg}`);

--- a/src/gateway/agentbox/local-spawner.ts
+++ b/src/gateway/agentbox/local-spawner.ts
@@ -135,7 +135,10 @@ export class LocalSpawner implements BoxSpawner {
     // disableIdleShutdown: LocalSpawner runs AgentBox in the same process as
     // the Portal — the 5-min idle timer's `process.exit(0)` would take the
     // whole `siclaw local` down and strand the web UI.
-    const httpServer = createHttpServer(sessionManager, { disableIdleShutdown: true });
+    const httpServer = createHttpServer(sessionManager, {
+      disableIdleShutdown: true,
+      knowledgeHandler,
+    });
 
     await new Promise<void>((resolve, reject) => {
       httpServer.listen(port, "127.0.0.1", () => {


### PR DESCRIPTION
## Summary

A successful empty `config.getKnowledgeBundle` means the type unbound every library. AgentBox used to keep the previous on-disk wiki when `repos: []` arrived, so a delete-and-republish left library A visible.

Fetch failures never reach `materialize` (the reload handler returns 500 first), so the old preserve guard was protecting the wrong case.

## Test plan

- [x] `npx vitest run src/agentbox/sync-handlers.test.ts` (57 passed)
- [ ] After merge: publish a type with knowledge A, then publish again with knowledge unbound; a new tenant session must not see A

Made with [Cursor](https://cursor.com)