### PR TITLE
feat: cite original sources in knowledge answers

### DIFF
--- a/portal-web/src/components/CapabilityGroupSelector.test.tsx
+++ b/portal-web/src/components/CapabilityGroupSelector.test.tsx
@@ -38,16 +38,16 @@ describe("CapabilityGroupSelector — render contract", () => {
     const html = render(new Set(["read_files"]))
     expect(html).toContain("Restricted")
     expect(html).not.toContain("Unrestricted")
-    // read_files grants 4 tools; "1 group" must be singular.
-    expect(html).toContain("1 group · 4 tools")
+    // read_files grants 5 tools; "1 group" must be singular.
+    expect(html).toContain("1 group · 5 tools")
     expect(html).toContain("Capability groups (1 / 11)")
     expect(countChecked(html)).toBe(1)
   })
 
   it("pluralizes groups and sums the deduped tool count for a multi-group selection", () => {
     const html = render(new Set(["read_files", "run_commands"]))
-    // 4 + 4 distinct tools, plural "groups".
-    expect(html).toContain("2 groups · 8 tools")
+    // 5 + 4 distinct tools, plural "groups".
+    expect(html).toContain("2 groups · 9 tools")
     expect(html).toContain("Capability groups (2 / 11)")
     expect(countChecked(html)).toBe(2)
   })

--- a/portal-web/src/lib/toolCapabilities.test.ts
+++ b/portal-web/src/lib/toolCapabilities.test.ts
@@ -101,17 +101,17 @@ describe("countToolsForSelection", () => {
   })
 
   it("counts a single group's tools", () => {
-    expect(countToolsForSelection(new Set(["read_files"]))).toBe(4)
+    expect(countToolsForSelection(new Set(["read_files"]))).toBe(5)
     expect(countToolsForSelection(new Set(["scheduling"]))).toBe(1)
   })
 
   it("counts the deduped union across multiple groups", () => {
-    // read_files (4) + search_memory (2), no shared tools → 6 distinct.
-    expect(countToolsForSelection(new Set(["read_files", "search_memory"]))).toBe(6)
+    // read_files (5) + search_memory (2), no shared tools → 7 distinct.
+    expect(countToolsForSelection(new Set(["read_files", "search_memory"]))).toBe(7)
   })
 
   it("ignores unknown keys in the selection", () => {
-    expect(countToolsForSelection(new Set(["read_files", "ghost"]))).toBe(4)
+    expect(countToolsForSelection(new Set(["read_files", "ghost"]))).toBe(5)
     expect(countToolsForSelection(new Set(["ghost"]))).toBe(0)
   })
 

--- a/portal-web/src/lib/toolCapabilities.ts
+++ b/portal-web/src/lib/toolCapabilities.ts
@@ -18,7 +18,7 @@ export interface CapabilityGroup {
 }
 
 export const CAPABILITY_GROUPS: CapabilityGroup[] = [
-  { key: "read_files", name: "Read files", description: "Read & search files and knowledge pages", tools: ["read", "grep", "find", "ls"] },
+  { key: "read_files", name: "Read files", description: "Read & search files and knowledge pages", tools: ["read", "grep", "find", "ls", "knowledge_cite"] },
   { key: "write_sandbox", name: "Write & author skills", description: "Write/edit scratch files and author skills (sandboxed to user-data)", tools: ["write", "edit", "skill_preview"] },
   { key: "inspect_infra", name: "Inspect infrastructure", description: "Read-only discovery of bound clusters and hosts", tools: ["cluster_list", "host_list"] },
   { key: "run_commands", name: "Run commands", description: "Execute whitelisted shell commands (kubectl read-only)", tools: ["bash", "node_exec", "pod_exec", "host_exec"] },

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -1087,6 +1087,20 @@ describe("knowledgeHandler multi-repo identity", () => {
     expect(index).toContain(`[[repos/${knowledgeRepoDirName("平台知识", "repo-b")}/index]] - 平台知识 v1\n`);
   });
 
+  it("materializes server-owned citation metadata beside the exact repo roots", async () => {
+    const repos = [
+      { id: "repo-a", name: "A", version: 1, sizeBytes: 10, dataBase64: packageBase64("a"),
+        citationSources: [{ resource: "feishu/a.md", title: "A 原文", url: "https://docs.feishu.cn/wiki/a" }] },
+      { id: "repo-b", name: "B", version: 1, sizeBytes: 10, dataBase64: packageBase64("b"), citationSources: [] },
+    ];
+    await knowledgeHandler.materialize({ version: "v1", repos });
+    const manifest = JSON.parse(fs.readFileSync(path.join(knowledgeTmpDir, ".citation-manifest.json"), "utf8"));
+    expect(manifest).toEqual({ version: 1, repos: [
+      { id: "repo-a", root: `repos/${knowledgeRepoDirName("A", "repo-a")}`, sources: repos[0].citationSources },
+      { id: "repo-b", root: `repos/${knowledgeRepoDirName("B", "repo-b")}`, sources: [] },
+    ] });
+  });
+
   it("says the entries are libraries, since the prompt around it says pages", async () => {
     // The system prompt introduces this file as a page catalog — true when one
     // library unpacks at the root, false here. An agent reading these ten lines

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -281,6 +281,7 @@ interface KnowledgeBundlePayload {
     sha256?: string | null;
     sizeBytes: number;
     fileCount?: number | null;
+    citationSources?: Array<{ resource: string; title: string; url: string }>;
     dataBase64: string;
   }>;
 }
@@ -389,6 +390,11 @@ export function createKnowledgeHandler(
     const stagingDir = path.join(knowledgeDir, `.sync-staging-${Date.now()}-${process.pid}`);
     fs.mkdirSync(stagingDir, { recursive: true });
     const syncedRepos: KnowledgeSyncStatus["repos"] = [];
+    const citationRepos: Array<{
+      id: string;
+      root: string;
+      sources: Array<{ resource: string; title: string; url: string }>;
+    }> = [];
 
     try {
       if (repos.length === 1) {
@@ -404,6 +410,7 @@ export function createKnowledgeHandler(
         }
         syncedRepos.push({ id: repos[0].id, name: repos[0].name, version: repos[0].version,
           sha256: info.sha256, expectedSha256: repos[0].sha256 ?? null, fileCount: info.fileCount, sizeBytes: repos[0].sizeBytes });
+        citationRepos.push({ id: repos[0].id, root: "", sources: repos[0].citationSources ?? [] });
       } else {
         const repoRoot = path.join(stagingDir, "repos");
         fs.mkdirSync(repoRoot, { recursive: true });
@@ -445,6 +452,7 @@ export function createKnowledgeHandler(
           }
           syncedRepos.push({ id: repo.id, name: repo.name, version: repo.version,
             sha256: info.sha256, expectedSha256: repo.sha256 ?? null, fileCount: info.fileCount, sizeBytes: repo.sizeBytes });
+          citationRepos.push({ id: repo.id, root: `repos/${dirName}`, sources: repo.citationSources ?? [] });
           // This line is the whole of what the agent knows about a library
           // before deciding to open it: the catalog goes into the system prompt,
           // there is no search tool, and everything else costs a Read of that
@@ -476,6 +484,8 @@ export function createKnowledgeHandler(
 
       fs.writeFileSync(path.join(stagingDir, ".sync-manifest.json"),
         JSON.stringify({ syncedAt, version: payload.version ?? "1", repos: syncedRepos }, null, 2) + "\n");
+      fs.writeFileSync(path.join(stagingDir, ".citation-manifest.json"),
+        JSON.stringify({ version: 1, repos: citationRepos }, null, 2) + "\n");
       await replaceDirectoryContentsFromStaging(knowledgeDir, stagingDir);
       lastKnowledgeSyncStatus = { syncedAt, targetDir: knowledgeDir, repoCount: syncedRepos.length, repos: syncedRepos };
       return repos.length;

--- a/src/core/agent-factory.test.ts
+++ b/src/core/agent-factory.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { describe, it, expect } from "vitest";
 
 // NOTE: We deliberately do NOT import "./agent-factory.js" here.
@@ -17,5 +19,15 @@ describe("agent-factory", () => {
 
   it("placeholder remains present until integration coverage lands", () => {
     expect(true).toBe(true);
+  });
+
+  it("keeps the agent-scoped knowledge override as the one citation root", () => {
+    // Cross-PR regression guard for #489 + #490. This module cannot be imported
+    // in the unit workspace (see above), so pin the conflict-sensitive wiring
+    // structurally: a bad resolution that restores the shared root goes red.
+    const source = fs.readFileSync(path.resolve(__dirname, "agent-factory.ts"), "utf8");
+    expect(source).toMatch(/const knowledgeDir = opts\?\.knowledgeDir\s*\?\?/);
+    expect(source).toMatch(/createKnowledgeCitationSupport\(\{\s*knowledgeDir,/);
+    expect(source).toContain("buildKnowledgeCitationSystemPrompt(knowledgeDir)");
   });
 });

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -124,9 +124,9 @@ export interface CreateSiclawSessionOpts {
   portalUrl?: string;
   /**
    * Optional callback injected by agentbox. When present, tools may call it to
-   * push custom events into the parent session's SSE stream (used by
-   * `spawn_subagent` to forward child-agent events so the frontend can render
-   * them in a nested block).
+   * push custom events into the parent session's SSE stream (used by citation
+   * delivery and by `spawn_subagent` to forward child-agent events so the
+   * frontend can render them in a nested block).
    */
   sessionEventEmitter?: import("./tool-registry.js").SessionEventEmitter;
   /** Shared task-ledger id; sub-agents pass the parent's id to share its ledger. Default: fresh uuid. */
@@ -207,6 +207,7 @@ function truncateWithBudget(content: string, maxChars: number): string {
 function buildAppendSystemPrompt(
   memoryDir: string | null,
   knowledgeDir?: string,
+  knowledgeCitationsEnabled = false,
 ): string[] {
   const parts: string[] = [];
 
@@ -275,7 +276,7 @@ When the user does provide identifying info, IMMEDIATELY update \`${memoryDir}/P
   if (wikiCatalog) {
     parts.push(wikiCatalog);
   }
-  if (knowledgeDir && hasKnowledgeCitationManifest(knowledgeDir)) {
+  if (knowledgeCitationsEnabled && knowledgeDir && hasKnowledgeCitationManifest(knowledgeDir)) {
     parts.push(`
 ## Knowledge source citations
 
@@ -374,11 +375,13 @@ export async function createSiclawSession(
     ?? (opts?.portalKnowledgeDir && fs.existsSync(opts.portalKnowledgeDir)
       ? opts.portalKnowledgeDir
       : path.resolve(cwd, config.paths.knowledgeDir));
-  const citationSupport = createKnowledgeCitationSupport({
-    knowledgeDir,
-    turnRef,
-    sessionEventEmitter: opts?.sessionEventEmitter,
-  });
+  const citationSupport = opts?.sessionEventEmitter
+    ? createKnowledgeCitationSupport({
+        knowledgeDir,
+        turnRef,
+        sessionEventEmitter: opts.sessionEventEmitter,
+      })
+    : undefined;
 
   if (memoryEnabled) {
     // Ensure memoryDir and skeleton PROFILE.md exist before the memory indexer
@@ -440,7 +443,7 @@ export async function createSiclawSession(
       memoryIndexer: memoryEnabled ? memoryIndexer : undefined,
       memoryDir: memoryEnabled ? memoryDir : undefined,
       sessionEventEmitter: opts?.sessionEventEmitter,
-      knowledgeCitationTool: citationSupport.tool,
+      knowledgeCitationTool: citationSupport?.tool,
       spawnSubagentExecutor: opts?.spawnSubagentExecutor,
       // Force sub-agents foreground when a detached batch's conclusion would be
       // stranded because the caller blocks on the turn's own result and has no
@@ -535,7 +538,7 @@ export async function createSiclawSession(
         readFile: async (p) => {
           assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir);
           const content = await fsReadFile(p);
-          citationSupport.noteRead(p);
+          citationSupport?.noteRead(p);
           return content;
         },
         access: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir); return fsAccess(p, fs.constants.R_OK); },
@@ -588,9 +591,11 @@ export async function createSiclawSession(
   // Subject to allowedTools (same chokepoint as MCP append above): file tools are
   // created outside the registry, so the shared name-based whitelist is applied here.
   appendAllowedTools(customTools, restrictedFileTools, allowedTools);
-  // Citation registration is an intrinsic, side-effect-free companion to Read:
-  // capability groups need not know its name, and Agent Type never gates it.
-  if ((!Array.isArray(allowedTools) || allowedTools.includes("read")) &&
+  // Citation registration is an intrinsic, side-effect-free companion to Read,
+  // but it must have a delivery sink — otherwise the tool would promise that
+  // links are appended while CLI/child sessions silently drop the event.
+  if (citationSupport &&
+      (!Array.isArray(allowedTools) || allowedTools.includes("read")) &&
       !customTools.some((tool) => tool.name === citationSupport.tool.name)) {
     customTools.push(citationSupport.tool);
   }
@@ -698,7 +703,7 @@ export async function createSiclawSession(
       systemPromptOverride: () =>
         buildSreSystemPrompt(mode, opts?.systemPromptTemplate, opts?.systemPromptAppend),
       appendSystemPromptOverride: () =>
-        buildAppendSystemPrompt(memoryEnabled ? memoryDir : null, knowledgeDir),
+        buildAppendSystemPrompt(memoryEnabled ? memoryDir : null, knowledgeDir, Boolean(citationSupport)),
       // Extension registration order: compactionSafeguard handles session_before_compact.
       extensionFactories: [
         contextPruningExtension,

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -44,6 +44,7 @@ import { McpClientManager } from "./mcp-client.js";
 import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryEnabled } from "./config.js";
 import { initExtraCommands } from "../tools/infra/extra-commands.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
+import { createKnowledgeCitationSupport, hasKnowledgeCitationManifest } from "./knowledge-citation-tool.js";
 
 import type { SessionMode, KubeconfigRef, MemoryRef, DpStateRef, MutableDpStateRef, DelegationContext } from "./types.js";
 
@@ -274,6 +275,12 @@ When the user does provide identifying info, IMMEDIATELY update \`${memoryDir}/P
   if (wikiCatalog) {
     parts.push(wikiCatalog);
   }
+  if (knowledgeDir && hasKnowledgeCitationManifest(knowledgeDir)) {
+    parts.push(`
+## Knowledge source citations
+
+When your final answer materially relies on mounted knowledge, call \`knowledge_cite\` once after research and immediately before the final answer. Pass only the 1-3 knowledge pages you successfully Read this turn and actually used. Do not register an index, catalog, or a page you merely inspected. The runtime appends validated original links automatically; never invent or manually copy source URLs. If no trusted clickable source exists, answer normally without a references section.`);
+  }
 
   return parts;
 }
@@ -363,6 +370,15 @@ export async function createSiclawSession(
   const skillsBase = path.resolve(cwd, config.paths.skillsDir);
   const userDataDir = path.resolve(cwd, config.paths.userDataDir);
   const memoryDir = path.join(userDataDir, "memory");
+  const knowledgeDir = opts?.knowledgeDir
+    ?? (opts?.portalKnowledgeDir && fs.existsSync(opts.portalKnowledgeDir)
+      ? opts.portalKnowledgeDir
+      : path.resolve(cwd, config.paths.knowledgeDir));
+  const citationSupport = createKnowledgeCitationSupport({
+    knowledgeDir,
+    turnRef,
+    sessionEventEmitter: opts?.sessionEventEmitter,
+  });
 
   if (memoryEnabled) {
     // Ensure memoryDir and skeleton PROFILE.md exist before the memory indexer
@@ -424,6 +440,7 @@ export async function createSiclawSession(
       memoryIndexer: memoryEnabled ? memoryIndexer : undefined,
       memoryDir: memoryEnabled ? memoryDir : undefined,
       sessionEventEmitter: opts?.sessionEventEmitter,
+      knowledgeCitationTool: citationSupport.tool,
       spawnSubagentExecutor: opts?.spawnSubagentExecutor,
       // Force sub-agents foreground when a detached batch's conclusion would be
       // stranded because the caller blocks on the turn's own result and has no
@@ -498,10 +515,6 @@ export async function createSiclawSession(
   const reposDir = path.resolve(cwd, config.paths.reposDir);
   const docsDir = path.resolve(cwd, config.paths.docsDir);
   const tracesDir = path.resolve(cwd, ".siclaw", "traces");
-  const knowledgeDir = opts?.knowledgeDir
-    ?? (opts?.portalKnowledgeDir && fs.existsSync(opts.portalKnowledgeDir)
-      ? opts.portalKnowledgeDir
-      : path.resolve(cwd, config.paths.knowledgeDir));
   const readAllowedDirs = [
     builtinSkillsRoot, skillsBase, userDataDir, reportsDir, tracesDir, reposDir, docsDir, knowledgeDir,
     os.tmpdir(),
@@ -519,7 +532,12 @@ export async function createSiclawSession(
   const restrictedFileTools = [
     createReadTool(cwd, {
       operations: {
-        readFile: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir); return fsReadFile(p); },
+        readFile: async (p) => {
+          assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir);
+          const content = await fsReadFile(p);
+          citationSupport.noteRead(p);
+          return content;
+        },
         access: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir); return fsAccess(p, fs.constants.R_OK); },
       },
     }),
@@ -570,6 +588,12 @@ export async function createSiclawSession(
   // Subject to allowedTools (same chokepoint as MCP append above): file tools are
   // created outside the registry, so the shared name-based whitelist is applied here.
   appendAllowedTools(customTools, restrictedFileTools, allowedTools);
+  // Citation registration is an intrinsic, side-effect-free companion to Read:
+  // capability groups need not know its name, and Agent Type never gates it.
+  if ((!Array.isArray(allowedTools) || allowedTools.includes("read")) &&
+      !customTools.some((tool) => tool.name === citationSupport.tool.name)) {
+    customTools.push(citationSupport.tool);
+  }
 
   // Final model-visible tool set (registry-resolved + MCP + file tools, after the
   // whitelist is applied at every chokepoint). Logged by NAME when restricted so a

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -44,7 +44,10 @@ import { McpClientManager } from "./mcp-client.js";
 import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryEnabled } from "./config.js";
 import { initExtraCommands } from "../tools/infra/extra-commands.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
-import { createKnowledgeCitationSupport, hasKnowledgeCitationManifest } from "./knowledge-citation-tool.js";
+import {
+  buildKnowledgeCitationSystemPrompt,
+  createKnowledgeCitationSupport,
+} from "./knowledge-citation-tool.js";
 
 import type { SessionMode, KubeconfigRef, MemoryRef, DpStateRef, MutableDpStateRef, DelegationContext } from "./types.js";
 
@@ -276,11 +279,8 @@ When the user does provide identifying info, IMMEDIATELY update \`${memoryDir}/P
   if (wikiCatalog) {
     parts.push(wikiCatalog);
   }
-  if (knowledgeCitationsEnabled && knowledgeDir && hasKnowledgeCitationManifest(knowledgeDir)) {
-    parts.push(`
-## Knowledge source citations
-
-When your final answer materially relies on mounted knowledge, call \`knowledge_cite\` once after research and immediately before the final answer. Pass only the 1-3 knowledge pages you successfully Read this turn and actually used. Do not register an index, catalog, or a page you merely inspected. The runtime appends validated original links automatically; never invent or manually copy source URLs. If no trusted clickable source exists, answer normally without a references section.`);
+  if (knowledgeCitationsEnabled && knowledgeDir) {
+    parts.push(buildKnowledgeCitationSystemPrompt(knowledgeDir));
   }
 
   return parts;

--- a/src/core/knowledge-citation-tool.test.ts
+++ b/src/core/knowledge-citation-tool.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createKnowledgeCitationSupport, KNOWLEDGE_CITATION_MANIFEST } from "./knowledge-citation-tool.js";
+
+describe("knowledge_cite", () => {
+  const dirs: string[] = [];
+  afterEach(() => dirs.splice(0).forEach((dir) => fs.rmSync(dir, { recursive: true, force: true })));
+
+  function fixture() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    fs.writeFileSync(page, "---\nsources:\n  - resource: raw/feishu/runbook.md\n---\n# Guide\n");
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        resource: "feishu/runbook.md", title: "GPU Runbook", url: "https://docs.feishu.cn/wiki/abc",
+      }] }],
+    }));
+    return { dir, page };
+  }
+
+  it("emits only sources from pages successfully read in the current turn", async () => {
+    const { dir, page } = fixture();
+    const events: Record<string, unknown>[] = [];
+    const turnRef = { current: 1 };
+    const support = createKnowledgeCitationSupport({ knowledgeDir: dir, turnRef, sessionEventEmitter: (e) => events.push(e) });
+    support.noteRead(page);
+    const output = await support.tool.execute("call", { pages: [page] } as never);
+    expect(output.details).toEqual({ cited: 1 });
+    expect(events).toEqual([{ type: "knowledge_sources", sources: [{
+      title: "GPU Runbook", url: "https://docs.feishu.cn/wiki/abc", resource: "feishu/runbook.md", page: "guide.md",
+    }] }]);
+
+    turnRef.current = 2;
+    const unread = await support.tool.execute("call", { pages: [page] } as never);
+    expect(unread.details).toEqual({ cited: 0 });
+    expect(events).toHaveLength(1);
+  });
+});

--- a/src/core/knowledge-citation-tool.test.ts
+++ b/src/core/knowledge-citation-tool.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { createKnowledgeCitationSupport, KNOWLEDGE_CITATION_MANIFEST } from "./knowledge-citation-tool.js";
+import {
+  buildKnowledgeCitationSystemPrompt,
+  createKnowledgeCitationSupport,
+  KNOWLEDGE_CITATION_MANIFEST,
+} from "./knowledge-citation-tool.js";
 
 describe("knowledge_cite", () => {
   const dirs: string[] = [];
@@ -38,5 +42,89 @@ describe("knowledge_cite", () => {
     const unread = await support.tool.execute("call", { pages: [page] } as never);
     expect(unread.details).toEqual({ cited: 0 });
     expect(events).toHaveLength(1);
+  });
+
+  it("switches prompt guidance when a manifest appears on a warm session reload", () => {
+    const { dir } = fixture();
+    const manifestPath = path.join(dir, KNOWLEDGE_CITATION_MANIFEST);
+    const manifest = fs.readFileSync(manifestPath, "utf8");
+    fs.rmSync(manifestPath);
+
+    expect(buildKnowledgeCitationSystemPrompt(dir)).toContain("Do not call `knowledge_cite`");
+
+    fs.writeFileSync(manifestPath, manifest);
+    expect(buildKnowledgeCitationSystemPrompt(dir)).toContain(
+      "call `knowledge_cite` once after research",
+    );
+  });
+
+  it("degrades to no citations when a previously read page disappears", async () => {
+    const { dir, page } = fixture();
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    support.noteRead(page);
+    fs.rmSync(page);
+
+    await expect(support.tool.execute("call", { pages: [page] } as never)).resolves.toMatchObject({
+      details: { cited: 0 },
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("degrades to no citations when page frontmatter is malformed", async () => {
+    const { dir, page } = fixture();
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    support.noteRead(page);
+    fs.writeFileSync(page, "---\nsources: [\n---\n# Broken\n");
+
+    await expect(support.tool.execute("call", { pages: [page] } as never)).resolves.toMatchObject({
+      details: { cited: 0 },
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("uses the most specific repository root when manifests overlap", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-roots-"));
+    dirs.push(dir);
+    const page = path.join(dir, "repos", "specific", "guide.md");
+    fs.mkdirSync(path.dirname(page), { recursive: true });
+    fs.writeFileSync(page, "---\nsources:\n  - resource: raw/runbook.md\n---\n# Guide\n");
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [
+        { id: "fallback", root: "", sources: [
+          { resource: "runbook.md", title: "Wrong fallback", url: "https://example.com/wrong" },
+        ] },
+        { id: "specific", root: "repos/specific", sources: [
+          { resource: "runbook.md", title: "Specific", url: "https://example.com/specific" },
+        ] },
+      ],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    support.noteRead(page);
+
+    await expect(support.tool.execute("call", { pages: [page] } as never)).resolves.toMatchObject({
+      details: { cited: 1 },
+    });
+    expect(events).toEqual([{ type: "knowledge_sources", sources: [{
+      title: "Specific",
+      url: "https://example.com/specific",
+      resource: "runbook.md",
+      page: "repos/specific/guide.md",
+    }] }]);
   });
 });

--- a/src/core/knowledge-citation-tool.ts
+++ b/src/core/knowledge-citation-tool.ts
@@ -53,7 +53,7 @@ export function hasKnowledgeCitationManifest(knowledgeDir: string): boolean {
 export function createKnowledgeCitationSupport(opts: {
   knowledgeDir: string;
   turnRef: { current: number };
-  sessionEventEmitter?: SessionEventEmitter;
+  sessionEventEmitter: SessionEventEmitter;
 }): { noteRead: (pagePath: string) => void; tool: ToolDefinition } {
   let turn = -1;
   const readPages = new Set<string>();
@@ -120,7 +120,7 @@ export function createKnowledgeCitationSupport(opts: {
         if (citations.length >= 3) break;
       }
       if (citations.length > 0) {
-        opts.sessionEventEmitter?.({ type: "knowledge_sources", sources: citations });
+        opts.sessionEventEmitter({ type: "knowledge_sources", sources: citations });
       }
       return result(
         citations.length > 0

--- a/src/core/knowledge-citation-tool.ts
+++ b/src/core/knowledge-citation-tool.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { renderTextResult } from "../tools/infra/tool-render.js";
+import type { SessionEventEmitter } from "./tool-registry.js";
+import type { KnowledgeSourceCitation } from "../shared/knowledge-citations.js";
+
+export const KNOWLEDGE_CITATION_MANIFEST = ".citation-manifest.json";
+
+interface CitationManifestSource { resource: string; title: string; url: string }
+interface CitationManifestRepo { id: string; root: string; sources: CitationManifestSource[] }
+interface CitationManifest { version: 1; repos: CitationManifestRepo[] }
+
+function result(text: string, cited: number) {
+  return { content: [{ type: "text" as const, text }], details: { cited } };
+}
+
+function normalizedResource(value: string): string {
+  const clean = path.posix.normalize(value.replaceAll("\\", "/").replace(/^\.\//, "")).replace(/^\/+/, "");
+  return clean.startsWith("raw/") ? clean.slice(4) : clean;
+}
+
+function readManifest(knowledgeDir: string): CitationManifest | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(knowledgeDir, KNOWLEDGE_CITATION_MANIFEST), "utf8")) as CitationManifest;
+    return parsed?.version === 1 && Array.isArray(parsed.repos) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function pageResources(pagePath: string): string[] {
+  const body = fs.readFileSync(pagePath, "utf8");
+  if (!body.startsWith("---\n")) return [];
+  const end = body.indexOf("\n---", 4);
+  if (end < 0 || end > 64 * 1024) return [];
+  const frontmatter = yaml.load(body.slice(4, end)) as Record<string, unknown> | null;
+  if (!frontmatter || !Array.isArray(frontmatter.sources)) return [];
+  return frontmatter.sources.flatMap((source) => {
+    if (!source || typeof source !== "object") return [];
+    const resource = (source as Record<string, unknown>).resource;
+    return typeof resource === "string" && resource.trim() ? [normalizedResource(resource)] : [];
+  });
+}
+
+export function hasKnowledgeCitationManifest(knowledgeDir: string): boolean {
+  return readManifest(knowledgeDir)?.repos.some((repo) => repo.sources.length > 0) ?? false;
+}
+
+export function createKnowledgeCitationSupport(opts: {
+  knowledgeDir: string;
+  turnRef: { current: number };
+  sessionEventEmitter?: SessionEventEmitter;
+}): { noteRead: (pagePath: string) => void; tool: ToolDefinition } {
+  let turn = -1;
+  const readPages = new Set<string>();
+  const resetForTurn = () => {
+    if (turn !== opts.turnRef.current) {
+      turn = opts.turnRef.current;
+      readPages.clear();
+    }
+  };
+  const noteRead = (pagePath: string) => {
+    resetForTurn();
+    const absolute = path.resolve(pagePath);
+    const root = path.resolve(opts.knowledgeDir);
+    if (absolute.endsWith(".md") && (absolute === root || absolute.startsWith(root + path.sep))) {
+      readPages.add(absolute);
+    }
+  };
+
+  const tool: ToolDefinition = {
+    name: "knowledge_cite",
+    label: "Cite Knowledge Sources",
+    renderCall: (_a, theme) => new Text(theme.fg("toolTitle", theme.bold("knowledge_cite")), 0, 0),
+    renderResult: renderTextResult,
+    description:
+      "Register the knowledge pages that materially support your final answer. Call once, immediately before the final answer, " +
+      "and include only pages you successfully Read in this turn and actually used. The runtime validates their published original-source metadata and appends trusted links; never invent or copy source URLs yourself.",
+    parameters: Type.Object({
+      pages: Type.Array(Type.String({ minLength: 1 }), {
+        minItems: 1,
+        maxItems: 3,
+        description: "Absolute paths, or paths relative to the mounted knowledge directory, of the 1-3 adopted knowledge pages.",
+      }),
+    }),
+    async execute(_toolCallId, rawParams) {
+      resetForTurn();
+      const manifest = readManifest(opts.knowledgeDir);
+      if (!manifest) return result("No trusted original-source metadata is available for this knowledge mount.", 0);
+      const rawPages = (rawParams as { pages?: unknown }).pages;
+      if (!Array.isArray(rawPages)) return result("knowledge_cite requires pages.", 0);
+      const selected = rawPages.map((raw) => {
+        const value = String(raw);
+        return path.resolve(path.isAbsolute(value) ? value : path.join(opts.knowledgeDir, value));
+      });
+      const unread = selected.find((page) => !readPages.has(page));
+      if (unread) return result(`Cannot cite unread knowledge page: ${unread}`, 0);
+
+      const citations: KnowledgeSourceCitation[] = [];
+      const seenURLs = new Set<string>();
+      for (const page of selected) {
+        const rel = path.relative(opts.knowledgeDir, page).replaceAll(path.sep, "/");
+        const repo = manifest.repos.find((candidate) => {
+          const root = candidate.root.replace(/\/$/, "");
+          return root === "" || rel === root || rel.startsWith(root + "/");
+        });
+        if (!repo) continue;
+        const sourceByResource = new Map(repo.sources.map((source) => [normalizedResource(source.resource), source]));
+        for (const resource of pageResources(page)) {
+          const source = sourceByResource.get(resource);
+          if (!source || seenURLs.has(source.url)) continue;
+          seenURLs.add(source.url);
+          citations.push({ title: source.title, url: source.url, resource: source.resource, page: rel });
+          if (citations.length >= 3) break;
+        }
+        if (citations.length >= 3) break;
+      }
+      if (citations.length > 0) {
+        opts.sessionEventEmitter?.({ type: "knowledge_sources", sources: citations });
+      }
+      return result(
+        citations.length > 0
+          ? `Registered ${citations.length} trusted original source${citations.length === 1 ? "" : "s"}; links will be appended automatically.`
+          : "The selected pages have no trusted clickable original sources; answer normally without a references section.",
+        citations.length,
+      );
+    },
+  };
+  return { noteRead, tool };
+}

--- a/src/core/knowledge-citation-tool.ts
+++ b/src/core/knowledge-citation-tool.ts
@@ -6,7 +6,10 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { renderTextResult } from "../tools/infra/tool-render.js";
 import type { SessionEventEmitter } from "./tool-registry.js";
-import type { KnowledgeSourceCitation } from "../shared/knowledge-citations.js";
+import {
+  MAX_KNOWLEDGE_CITATIONS,
+  type KnowledgeSourceCitation,
+} from "../shared/knowledge-citations.js";
 
 export const KNOWLEDGE_CITATION_MANIFEST = ".citation-manifest.json";
 
@@ -33,21 +36,58 @@ function readManifest(knowledgeDir: string): CitationManifest | null {
 }
 
 function pageResources(pagePath: string): string[] {
-  const body = fs.readFileSync(pagePath, "utf8");
-  if (!body.startsWith("---\n")) return [];
-  const end = body.indexOf("\n---", 4);
-  if (end < 0 || end > 64 * 1024) return [];
-  const frontmatter = yaml.load(body.slice(4, end)) as Record<string, unknown> | null;
-  if (!frontmatter || !Array.isArray(frontmatter.sources)) return [];
-  return frontmatter.sources.flatMap((source) => {
-    if (!source || typeof source !== "object") return [];
-    const resource = (source as Record<string, unknown>).resource;
-    return typeof resource === "string" && resource.trim() ? [normalizedResource(resource)] : [];
-  });
+  try {
+    const body = fs.readFileSync(pagePath, "utf8");
+    if (!body.startsWith("---\n")) return [];
+    const end = body.indexOf("\n---", 4);
+    if (end < 0 || end > 64 * 1024) return [];
+    const frontmatter = yaml.load(body.slice(4, end)) as Record<string, unknown> | null;
+    if (!frontmatter || !Array.isArray(frontmatter.sources)) return [];
+    return frontmatter.sources.flatMap((source) => {
+      if (!source || typeof source !== "object") return [];
+      const resource = (source as Record<string, unknown>).resource;
+      return typeof resource === "string" && resource.trim() ? [normalizedResource(resource)] : [];
+    });
+  } catch {
+    // A resource reload can replace the page after Read recorded it, and a
+    // malformed page must not turn an optional citation miss into a failed turn.
+    return [];
+  }
 }
 
 export function hasKnowledgeCitationManifest(knowledgeDir: string): boolean {
   return readManifest(knowledgeDir)?.repos.some((repo) => repo.sources.length > 0) ?? false;
+}
+
+/**
+ * This text is rebuilt by session.reload(), while custom tools remain attached
+ * to the session. Keeping both states explicit lets a newly published manifest
+ * enable citations on a warm session without inviting calls before it exists.
+ */
+export function buildKnowledgeCitationSystemPrompt(knowledgeDir: string): string {
+  if (!hasKnowledgeCitationManifest(knowledgeDir)) {
+    return `
+## Knowledge source citations
+
+Trusted original-source metadata is not available for this knowledge mount. Do not call \`knowledge_cite\`; answer normally without a references section. This instruction may change after a knowledge reload.`;
+  }
+  return `
+## Knowledge source citations
+
+When your final answer materially relies on mounted knowledge, call \`knowledge_cite\` once after research and immediately before the final answer. Pass only the 1-${MAX_KNOWLEDGE_CITATIONS} knowledge pages you successfully Read this turn and actually used. Do not register an index, catalog, or a page you merely inspected. The runtime appends validated original links automatically; never invent or manually copy source URLs. If no trusted clickable source exists, answer normally without a references section.`;
+}
+
+function findCitationRepo(manifest: CitationManifest, rel: string): CitationManifestRepo | undefined {
+  let best: CitationManifestRepo | undefined;
+  let bestRootLength = -1;
+  for (const candidate of manifest.repos) {
+    const root = candidate.root.replace(/\/$/, "");
+    if ((root === "" || rel === root || rel.startsWith(root + "/")) && root.length > bestRootLength) {
+      best = candidate;
+      bestRootLength = root.length;
+    }
+  }
+  return best;
 }
 
 export function createKnowledgeCitationSupport(opts: {
@@ -78,13 +118,14 @@ export function createKnowledgeCitationSupport(opts: {
     renderCall: (_a, theme) => new Text(theme.fg("toolTitle", theme.bold("knowledge_cite")), 0, 0),
     renderResult: renderTextResult,
     description:
+      "Use only when the current system prompt says knowledge source citations are available. " +
       "Register the knowledge pages that materially support your final answer. Call once, immediately before the final answer, " +
       "and include only pages you successfully Read in this turn and actually used. The runtime validates their published original-source metadata and appends trusted links; never invent or copy source URLs yourself.",
     parameters: Type.Object({
       pages: Type.Array(Type.String({ minLength: 1 }), {
         minItems: 1,
-        maxItems: 3,
-        description: "Absolute paths, or paths relative to the mounted knowledge directory, of the 1-3 adopted knowledge pages.",
+        maxItems: MAX_KNOWLEDGE_CITATIONS,
+        description: `Absolute paths, or paths relative to the mounted knowledge directory, of the 1-${MAX_KNOWLEDGE_CITATIONS} adopted knowledge pages.`,
       }),
     }),
     async execute(_toolCallId, rawParams) {
@@ -104,10 +145,7 @@ export function createKnowledgeCitationSupport(opts: {
       const seenURLs = new Set<string>();
       for (const page of selected) {
         const rel = path.relative(opts.knowledgeDir, page).replaceAll(path.sep, "/");
-        const repo = manifest.repos.find((candidate) => {
-          const root = candidate.root.replace(/\/$/, "");
-          return root === "" || rel === root || rel.startsWith(root + "/");
-        });
+        const repo = findCitationRepo(manifest, rel);
         if (!repo) continue;
         const sourceByResource = new Map(repo.sources.map((source) => [normalizedResource(source.resource), source]));
         for (const resource of pageResources(page)) {
@@ -115,9 +153,9 @@ export function createKnowledgeCitationSupport(opts: {
           if (!source || seenURLs.has(source.url)) continue;
           seenURLs.add(source.url);
           citations.push({ title: source.title, url: source.url, resource: source.resource, page: rel });
-          if (citations.length >= 3) break;
+          if (citations.length >= MAX_KNOWLEDGE_CITATIONS) break;
         }
-        if (citations.length >= 3) break;
+        if (citations.length >= MAX_KNOWLEDGE_CITATIONS) break;
       }
       if (citations.length > 0) {
         opts.sessionEventEmitter({ type: "knowledge_sources", sources: citations });

--- a/src/core/tool-capabilities-coverage.test.ts
+++ b/src/core/tool-capabilities-coverage.test.ts
@@ -19,9 +19,15 @@ const INTENTIONALLY_UNGROUPED = new Set<string>([]);
 describe("capability-group registry coverage", () => {
   it("every registered tool belongs to some capability group", () => {
     const grouped = new Set(Object.values(CAPABILITY_GROUPS).flat());
-    // Minimal stub: tool factories read executor refs lazily inside execute(),
-    // not at construction, so an empty-ish refs object is enough to read .name.
-    const stubRefs = { sessionIdRef: { current: "coverage-probe" } } as unknown as ToolRefs;
+    // Minimal stub: most tool factories read executor refs lazily inside
+    // execute(). Dynamic per-session tools need a sentinel definition so this
+    // static catalog probe can still read their name without making them
+    // available in sessions that lack the real runtime dependency.
+    const stubRefs = {
+      sessionIdRef: { current: "coverage-probe" },
+      sessionEventEmitter: () => {},
+      knowledgeCitationTool: { name: "knowledge_cite" },
+    } as unknown as ToolRefs;
 
     const missing: string[] = [];
     for (const entry of allToolEntries) {

--- a/src/core/tool-capabilities.test.ts
+++ b/src/core/tool-capabilities.test.ts
@@ -23,13 +23,13 @@ describe("resolveCapabilities", () => {
   });
 
   it("a single group resolves to exactly that group's tools", () => {
-    expect(resolveCapabilities(["read_files"])).toEqual(["read", "grep", "find", "ls"]);
+    expect(resolveCapabilities(["read_files"])).toEqual(["read", "grep", "find", "ls", "knowledge_cite"]);
   });
 
   it("multiple groups resolve to the union of their tools", () => {
     const result = resolveCapabilities(["read_files", "search_memory"]);
     expect(new Set(result)).toEqual(
-      new Set(["read", "grep", "find", "ls", "memory_search", "memory_get"]),
+      new Set(["read", "grep", "find", "ls", "knowledge_cite", "memory_search", "memory_get"]),
     );
   });
 
@@ -37,14 +37,14 @@ describe("resolveCapabilities", () => {
     // Construct overlap synthetically would require shared tools; instead assert
     // no duplicates appear when the same group is listed twice.
     const result = resolveCapabilities(["read_files", "read_files"]);
-    expect(result).toEqual(["read", "grep", "find", "ls"]);
+    expect(result).toEqual(["read", "grep", "find", "ls", "knowledge_cite"]);
     expect(result!.length).toBe(new Set(result).size);
   });
 
   it("unknown group keys are warned + ignored, valid subset is used", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = resolveCapabilities(["read_files", "does_not_exist"]);
-    expect(result).toEqual(["read", "grep", "find", "ls"]);
+    expect(result).toEqual(["read", "grep", "find", "ls", "knowledge_cite"]);
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0][0]).toContain("does_not_exist");
   });
@@ -100,7 +100,7 @@ describe("encodeToolCapabilitiesForDb", () => {
     const encoded = encodeToolCapabilitiesForDb(["read_files"]);
     expect(encoded).not.toBeNull();
     const decoded = JSON.parse(encoded as string) as string[];
-    expect(resolveCapabilities(decoded)).toEqual(["read", "grep", "find", "ls"]);
+    expect(resolveCapabilities(decoded)).toEqual(["read", "grep", "find", "ls", "knowledge_cite"]);
   });
 
   it("rejects non-array, non-null/undefined values (HTTP 400 at the boundary)", () => {

--- a/src/core/tool-capabilities.ts
+++ b/src/core/tool-capabilities.ts
@@ -26,7 +26,7 @@
  * added/renamed without changing stored selections.
  */
 export const CAPABILITY_GROUPS: Record<string, string[]> = {
-  read_files:      ["read", "grep", "find", "ls"],
+  read_files:      ["read", "grep", "find", "ls", "knowledge_cite"],
   write_sandbox:   ["write", "edit", "skill_preview"],   // includes skill authoring
   inspect_infra:   ["cluster_list", "host_list"],   // read-only fleet discovery (registry)
   run_commands:    ["bash", "node_exec", "pod_exec", "host_exec"],

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -405,6 +405,8 @@ export interface ToolRefs {
   memoryDir?: string;
   /** See SessionEventEmitter. Undefined when running without a session SSE bus. */
   sessionEventEmitter?: SessionEventEmitter;
+  /** Per-session citation registrar sharing successful-read state with Read. */
+  knowledgeCitationTool?: ToolDefinition;
   /**
    * Optional spawn_subagent executor (design §6, v3 single-tool merge). Handles the whole
    * batch plan (1..N items + optional reduce), collapsing a single no-reduce task to a legacy

--- a/src/gateway/agentbox/local-spawner.test.ts
+++ b/src/gateway/agentbox/local-spawner.test.ts
@@ -257,7 +257,7 @@ describe("LocalSpawner — tool-capabilities injection", () => {
     const handle = await spawner.spawn({ agentId: "a1" });
     const box = (spawner as any).boxes.get(handle.boxId);
     expect(new Set(box.sessionManager.allowedToolsState)).toEqual(
-      new Set(["read", "grep", "find", "ls", "memory_search", "memory_get"]),
+      new Set(["read", "grep", "find", "ls", "knowledge_cite", "memory_search", "memory_get"]),
     );
   });
 
@@ -304,7 +304,9 @@ describe("LocalSpawner — locked agent-type policy (P1: parity with K8s)", () =
     const spawner = new LocalSpawner(new FakeCertManager() as any, "https://127.0.0.1:3002", 5000);
     const handle = await spawner.spawn({ agentId: "a1" });
     const box = (spawner as any).boxes.get(handle.boxId);
-    expect(new Set(box.sessionManager.allowedToolsState)).toEqual(new Set(["read", "grep", "find", "ls"]));
+    expect(new Set(box.sessionManager.allowedToolsState)).toEqual(
+      new Set(["read", "grep", "find", "ls", "knowledge_cite"]),
+    );
     expect(box.sessionManager.agentTypeState).toBe("custom");
   });
 });

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -3066,6 +3066,16 @@ describe("collectResponse — SSE event flattening", () => {
     expect(text).toBe("Hello! How can I help?");
   });
 
+  it("appends registered knowledge sources to a Feishu answer", async () => {
+    const events = [
+      { type: "knowledge_sources", sources: [{ title: "GPU Runbook", url: "https://docs.feishu.cn/wiki/a" }] },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "结论" }] } },
+    ];
+    const text = await collectResponse(fakeClient(events), "s-citations");
+    expect(text).toContain("### 参考原文");
+    expect(text).toContain("[GPU Runbook](https://docs.feishu.cn/wiki/a)");
+  });
+
   it("falls back to streamed content_block_delta when no message_end arrives", async () => {
     const events = [
       { type: "content_block_delta", delta: { text: "Hello" } },

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -3076,6 +3076,20 @@ describe("collectResponse — SSE event flattening", () => {
     expect(text).toContain("[GPU Runbook](https://docs.feishu.cn/wiki/a)");
   });
 
+  it("discards a failed primary's knowledge sources before rendering the fallback answer", async () => {
+    const events = [
+      { type: "model_route_start", candidateCount: 2 },
+      { type: "knowledge_sources", sources: [{ title: "Primary Runbook", url: "https://example.com/primary" }] },
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error", errorMessage: "429 rate limit" } },
+      { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-4", failureKind: "rate_limit" },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "answer from fallback" }], stopReason: "stop" } },
+      { type: "model_route_success", attempt: 2, candidateKey: "anthropic/claude", provider: "anthropic", modelId: "claude", isFallback: true, primaryCandidateKey: "openai/gpt-4" },
+    ];
+    const text = await collectResponse(fakeClient(events), "s-citations-fallback");
+    expect(text).toBe("answer from fallback");
+    expect(text).not.toContain("Primary Runbook");
+  });
+
   it("falls back to streamed content_block_delta when no message_end arrives", async () => {
     const events = [
       { type: "content_block_delta", delta: { text: "Hello" } },

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -62,6 +62,7 @@ import { replyImageToLark } from "./lark-image.js";
 import { collectInboundImages, type LarkImageRef } from "./inbound-image.js";
 import { modelOptionsSupportImageInput } from "../../core/model-routing.js";
 import { redactImageUrlsInText } from "../agentbox/image-url-ingest.js";
+import { appendKnowledgeSourceCitations } from "../../shared/knowledge-citations.js";
 import { registerBackgroundChannelDelivery } from "./background-delivery.js";
 
 const VISUAL_ONLY_NOTICE_BY_LOCALE = {
@@ -2908,6 +2909,7 @@ export async function collectChannelResponse(
   // for the user). pi-agent's agent_end signals the last turn is complete.
   let lastAssistantText = "";
   let lastAssistantMessageId: string | null = null;
+  let pendingKnowledgeSources: unknown = null;
 
   // ── Audit persistence (opt-in) ──────────────────────────────────────────
   // Mirrors the field mapping in sse-consumer.ts so a channel transcript looks
@@ -2936,6 +2938,10 @@ export async function collectChannelResponse(
   try {
     for await (const event of client.streamEvents(sessionId)) {
       const ev = event as Record<string, any>;
+
+      if (ev.type === "knowledge_sources") {
+        pendingKnowledgeSources = ev.sources;
+      }
 
       // Live tool progress → milestone. A FOREGROUND sub-agent batch blocks the parent inside one
       // tool call, so no intermediate assistant turn fires while it runs — without this the card
@@ -3008,7 +3014,11 @@ export async function collectChannelResponse(
       if (ev.type === "message_end" && ev.message?.role === "assistant") {
         const blocks = Array.isArray(ev.message.content) ? ev.message.content : [];
         if (options.includeImages) collectImageAttachments(blocks, images, seenImageKeys);
-        const turnText = contentBlocksToMarkdown(blocks);
+        let turnText = contentBlocksToMarkdown(blocks);
+        if (pendingKnowledgeSources && turnText.trim() && ev.message?.stopReason !== "error") {
+          turnText = appendKnowledgeSourceCitations(turnText, pendingKnowledgeSources);
+          pendingKnowledgeSources = null;
+        }
         if (turnText) {
           // A NEW assistant turn means the PREVIOUS one was an intermediate
           // step (the agent narrated, then called a tool) — surface its first

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -2939,6 +2939,9 @@ export async function collectChannelResponse(
     for await (const event of client.streamEvents(sessionId)) {
       const ev = event as Record<string, any>;
 
+      if (ev.type === "model_route_start" || ev.type === "model_route_rollback") {
+        pendingKnowledgeSources = null;
+      }
       if (ev.type === "knowledge_sources") {
         pendingKnowledgeSources = ev.sources;
       }

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -210,7 +210,7 @@ describe("handleToolCapabilities", () => {
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(new Set(body.allowedTools)).toEqual(
-      new Set(["read", "grep", "find", "ls", "memory_search", "memory_get"]),
+      new Set(["read", "grep", "find", "ls", "knowledge_cite", "memory_search", "memory_get"]),
     );
     // agentId comes from the cert identity, never the body.
     expect(frontend.calls[0]).toEqual({ method: "config.getAgent", params: { agentId: "agent-1" } });

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -79,6 +79,20 @@ describe("consumeAgentSse — type-less extra events", () => {
 });
 
 describe("consumeAgentSse — assistant message flow", () => {
+  it("appends registered knowledge sources to the final answer event and result", async () => {
+    const events = [
+      { type: "knowledge_sources", sources: [{ title: "GPU Runbook", url: "https://docs.feishu.cn/wiki/a" }] },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "结论" }] } },
+    ];
+    const seen: any[] = [];
+    const result = await consumeAgentSse({
+      client: mkClient(events), sessionId: "s", userId: "u", onEvent: (event) => seen.push(event),
+    });
+    expect(result.resultText).toContain("### 参考原文");
+    expect(result.resultText).toContain("https://docs.feishu.cn/wiki/a");
+    expect((seen[1].message.content[0].text as string)).toBe(result.resultText);
+  });
+
   it("accumulates text deltas across message_update events and returns the concatenated result", async () => {
     const events = [
       { type: "message_start" },

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -499,6 +499,20 @@ describe("consumeAgentSse — routed turn commit gating", () => {
     expect(result.errorMessage).toBe("");
   });
 
+  it("discards a failed primary's knowledge sources before rendering the fallback answer", async () => {
+    const events = [
+      { type: "model_route_start", candidateCount: 2 },
+      { type: "knowledge_sources", sources: [{ title: "Primary Runbook", url: "https://example.com/primary" }] },
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error", errorMessage: "429 rate limit" } },
+      { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-4", failureKind: "rate_limit" },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "answer from fallback" }], stopReason: "stop" } },
+      { type: "model_route_success", attempt: 2, candidateKey: "anthropic/claude", provider: "anthropic", modelId: "claude", isFallback: true, primaryCandidateKey: "openai/gpt-4" },
+    ];
+    const result = await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u" });
+    expect(result.resultText).toBe("answer from fallback");
+    expect(result.resultText).not.toContain("Primary Runbook");
+  });
+
   it("persists the error row when a routed turn is exhausted (no fallback succeeded)", async () => {
     const events = [
       { type: "model_route_start", candidateCount: 2 },

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -376,6 +376,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   // so they persist inline exactly as before.
   let isRoutingTurn = false;
   let routingCommitted = false;
+  let pendingKnowledgeSources: unknown = null;
   const pendingAssistantOps: Array<() => Promise<void>> = [];
   const pendingErrorOps: Array<() => Promise<void>> = [];
   const flushOps = async (ops: Array<() => Promise<void>>) => {
@@ -433,6 +434,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   const discardRoutedAttempt = () => {
     pendingAssistantOps.length = 0;
     pendingErrorOps.length = 0;
+    pendingKnowledgeSources = null;
     pendingStreamError = null;
     errorMessage = "";
     // The primary's deferred assistant op flipped firstAssistantPersisted when
@@ -491,8 +493,6 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   let capturedContextUsage: Record<string, unknown> | undefined;
   let latestModelRouteSwitch: Record<string, unknown> | null = null;
   let currentModelRouteMetadata: Record<string, unknown> | null = null;
-  let pendingKnowledgeSources: unknown = null;
-
   // try/finally, not a bare fall-through: the terminal error is BUFFERED
   // (last one wins), so a stream that dies mid-turn — pod recycled, transport
   // dropped — would otherwise take the operator's only explanation of the

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -15,6 +15,7 @@ import { ErrorCodes } from "../lib/error-envelope.js";
 import { AgentBoxClient } from "./agentbox/client.js";
 import { appendMessage, incrementMessageCount, updateMessage } from "./chat-repo.js";
 import { redactText, type RedactionConfig } from "./output-redactor.js";
+import { appendKnowledgeSourceCitations } from "../shared/knowledge-citations.js";
 
 // ── Public types ────────────────────────────────────
 
@@ -490,6 +491,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   let capturedContextUsage: Record<string, unknown> | undefined;
   let latestModelRouteSwitch: Record<string, unknown> | null = null;
   let currentModelRouteMetadata: Record<string, unknown> | null = null;
+  let pendingKnowledgeSources: unknown = null;
 
   // try/finally, not a bare fall-through: the terminal error is BUFFERED
   // (last one wins), so a stream that dies mid-turn — pod recycled, transport
@@ -505,6 +507,10 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       // undefined would throw and kill the whole SSE stream (STREAM_INTERRUPTED).
       const eventType = (evt.type as string | undefined) ?? "";
       eventCount++;
+
+      if (eventType === "knowledge_sources") {
+        pendingKnowledgeSources = (evt as Record<string, unknown>).sources;
+      }
 
       // Log lifecycle events
       if (
@@ -884,6 +890,18 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
               .filter((c) => c.type === "text")
               .map((c) => c.text ?? "")
               .join("");
+          }
+          if (pendingKnowledgeSources && message.stopReason !== "error") {
+            const base = extracted || currentMsgText || assistantContent;
+            if (base.trim()) {
+              const cited = appendKnowledgeSourceCitations(base, pendingKnowledgeSources);
+              if (cited !== base) {
+                extracted = cited;
+                assistantContent = cited;
+                message.content = [{ type: "text", text: cited }];
+              }
+              pendingKnowledgeSources = null;
+            }
           }
           resultText = extracted || currentMsgText || resultText;
 

--- a/src/portal/cli-snapshot-api.test.ts
+++ b/src/portal/cli-snapshot-api.test.ts
@@ -655,7 +655,7 @@ describe("GET /api/v1/cli-snapshot", () => {
 
     expect(status).toBe(200);
     expect(new Set(body.activeAgent.allowedTools)).toEqual(
-      new Set(["read", "grep", "find", "ls", "manage_schedule"]),
+      new Set(["read", "grep", "find", "ls", "knowledge_cite", "manage_schedule"]),
     );
   });
 

--- a/src/shared/knowledge-citations.test.ts
+++ b/src/shared/knowledge-citations.test.ts
@@ -17,4 +17,16 @@ describe("knowledge source citation rendering", () => {
   it("does not add a section without valid https citations", () => {
     expect(appendKnowledgeSourceCitations("answer", [{ title: "x", url: "javascript:alert(1)" }])).toBe("answer");
   });
+
+  it("keeps parentheses in an https URL inside one Markdown destination", () => {
+    const rendered = appendKnowledgeSourceCitations("answer", [{
+      title: "Title",
+      url: "https://ok.example/)[Login](https://evil.example/",
+    }]);
+
+    expect(rendered.match(/\]\(/g)).toHaveLength(1);
+    expect(rendered).toContain(
+      "- [Title](https://ok.example/%29[Login]%28https://evil.example/)",
+    );
+  });
 });

--- a/src/shared/knowledge-citations.test.ts
+++ b/src/shared/knowledge-citations.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { appendKnowledgeSourceCitations, normalizeKnowledgeSourceCitations } from "./knowledge-citations.js";
+
+describe("knowledge source citation rendering", () => {
+  it("deduplicates, caps and appends trusted source links", () => {
+    const sources = [
+      { title: "GPU Runbook", url: "https://docs.feishu.cn/wiki/a" },
+      { title: "duplicate", url: "https://docs.feishu.cn/wiki/a" },
+      { title: "Policy", url: "https://example.com/policy" },
+    ];
+    expect(normalizeKnowledgeSourceCitations(sources)).toHaveLength(2);
+    expect(appendKnowledgeSourceCitations("结论", sources)).toBe(
+      "结论\n\n### 参考原文\n\n- [GPU Runbook](https://docs.feishu.cn/wiki/a)\n- [Policy](https://example.com/policy)",
+    );
+  });
+
+  it("does not add a section without valid https citations", () => {
+    expect(appendKnowledgeSourceCitations("answer", [{ title: "x", url: "javascript:alert(1)" }])).toBe("answer");
+  });
+});

--- a/src/shared/knowledge-citations.ts
+++ b/src/shared/knowledge-citations.ts
@@ -1,0 +1,42 @@
+export interface KnowledgeSourceCitation {
+  title: string;
+  url: string;
+  resource?: string;
+  page?: string;
+}
+
+const MAX_KNOWLEDGE_CITATIONS = 3;
+
+export function normalizeKnowledgeSourceCitations(value: unknown): KnowledgeSourceCitation[] {
+  if (!Array.isArray(value)) return [];
+  const out: KnowledgeSourceCitation[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    const url = typeof row.url === "string" ? row.url.trim() : "";
+    let parsed: URL;
+    try { parsed = new URL(url); } catch { continue; }
+    if (parsed.protocol !== "https:" || seen.has(parsed.href)) continue;
+    const titleRaw = typeof row.title === "string" ? row.title : "";
+    const title = titleRaw.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim().slice(0, 160) || "原文";
+    seen.add(parsed.href);
+    out.push({
+      title,
+      url: parsed.href,
+      resource: typeof row.resource === "string" ? row.resource : undefined,
+      page: typeof row.page === "string" ? row.page : undefined,
+    });
+    if (out.length >= MAX_KNOWLEDGE_CITATIONS) break;
+  }
+  return out;
+}
+
+export function appendKnowledgeSourceCitations(text: string, value: unknown): string {
+  if (!text.trim()) return text;
+  const citations = normalizeKnowledgeSourceCitations(value);
+  if (citations.length === 0) return text;
+  const heading = /[\u3400-\u9fff]/u.test(text) ? "参考原文" : "Original sources";
+  const lines = citations.map((source) => `- [${source.title.replace(/[\[\]]/g, "")}](${source.url})`);
+  return `${text.trimEnd()}\n\n### ${heading}\n\n${lines.join("\n")}`;
+}

--- a/src/shared/knowledge-citations.ts
+++ b/src/shared/knowledge-citations.ts
@@ -5,7 +5,7 @@ export interface KnowledgeSourceCitation {
   page?: string;
 }
 
-const MAX_KNOWLEDGE_CITATIONS = 3;
+export const MAX_KNOWLEDGE_CITATIONS = 3;
 
 export function normalizeKnowledgeSourceCitations(value: unknown): KnowledgeSourceCitation[] {
   if (!Array.isArray(value)) return [];
@@ -37,6 +37,13 @@ export function appendKnowledgeSourceCitations(text: string, value: unknown): st
   const citations = normalizeKnowledgeSourceCitations(value);
   if (citations.length === 0) return text;
   const heading = /[\u3400-\u9fff]/u.test(text) ? "参考原文" : "Original sources";
-  const lines = citations.map((source) => `- [${source.title.replace(/[\[\]]/g, "")}](${source.url})`);
+  // WHATWG URL accepts literal parentheses in an https path. Left raw, `)`
+  // closes a Markdown destination early and the remaining path can be parsed as
+  // attacker-controlled document text. Percent-encoding preserves the URL while
+  // keeping the destination inside the one link we render.
+  const lines = citations.map((source) => {
+    const destination = source.url.replaceAll("(", "%28").replaceAll(")", "%29");
+    return `- [${source.title.replace(/[\[\]]/g, "")}](${destination})`;
+  });
   return `${text.trimEnd()}\n\n### ${heading}\n\n${lines.join("\n")}`;
 }

--- a/src/tools/all-entries.ts
+++ b/src/tools/all-entries.ts
@@ -25,6 +25,7 @@ import { registration as hostList } from "./query/host-list.js";
 // internally via pod= (shared pod-netns-resolve.ts); the standalone tool was redundant.
 import { registration as memorySearch } from "./query/memory-search.js";
 import { registration as memoryGet } from "./query/memory-get.js";
+import { registration as knowledgeCite } from "./query/knowledge-cite.js";
 // workflow — investigation_feedback / deep_search / propose_hypotheses /
 // end_investigation removed as part of the DP state-machine teardown
 // (see docs/design/2026-04-24-dp-mode-refactor-design.md §6.6).
@@ -52,7 +53,7 @@ export const allToolEntries: ToolEntry[] = [
   nodeScript, podScript, localScript, hostScript,
   // ── query ──
   clusterList, hostList,
-  memorySearch, memoryGet,
+  memorySearch, memoryGet, knowledgeCite,
   // ── workflow ──
   saveFeedback, manageSchedule, taskReport, skillPreview,
   channelUpdate, reportFindings, requestInput,

--- a/src/tools/query/knowledge-cite.test.ts
+++ b/src/tools/query/knowledge-cite.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { registration } from "./knowledge-cite.js";
+
+describe("knowledge_cite registration", () => {
+  const tool = { name: "knowledge_cite" } as any;
+
+  it("requires both the per-session tool and an event delivery sink", () => {
+    expect(registration.available?.({ knowledgeCitationTool: tool } as any)).toBe(false);
+    expect(registration.available?.({
+      knowledgeCitationTool: tool,
+      sessionEventEmitter: () => {},
+    } as any)).toBe(true);
+  });
+});

--- a/src/tools/query/knowledge-cite.ts
+++ b/src/tools/query/knowledge-cite.ts
@@ -1,15 +1,11 @@
 import type { ToolEntry } from "../../core/tool-registry.js";
-import { createKnowledgeCitationSupport } from "../../core/knowledge-citation-tool.js";
 
 // knowledge_cite is registered like every model-visible Siclaw tool, while its
 // per-session implementation is injected by agent-factory because it shares
 // state with the framework-owned Read tool.
 export const registration: ToolEntry = {
   category: "query",
-  create: (refs) => refs.knowledgeCitationTool ?? createKnowledgeCitationSupport({
-    knowledgeDir: "",
-    turnRef: { current: 0 },
-  }).tool,
-  available: (refs) => Boolean(refs.knowledgeCitationTool),
+  create: (refs) => refs.knowledgeCitationTool!,
+  available: (refs) => Boolean(refs.knowledgeCitationTool && refs.sessionEventEmitter),
   readOnlyDelegable: true,
 };

--- a/src/tools/query/knowledge-cite.ts
+++ b/src/tools/query/knowledge-cite.ts
@@ -1,0 +1,15 @@
+import type { ToolEntry } from "../../core/tool-registry.js";
+import { createKnowledgeCitationSupport } from "../../core/knowledge-citation-tool.js";
+
+// knowledge_cite is registered like every model-visible Siclaw tool, while its
+// per-session implementation is injected by agent-factory because it shares
+// state with the framework-owned Read tool.
+export const registration: ToolEntry = {
+  category: "query",
+  create: (refs) => refs.knowledgeCitationTool ?? createKnowledgeCitationSupport({
+    knowledgeDir: "",
+    turnRef: { current: 0 },
+  }).tool,
+  available: (refs) => Boolean(refs.knowledgeCitationTool),
+  readOnlyDelegable: true,
+};


### PR DESCRIPTION
## Summary

Knowledge-backed answers now append trusted original-source links only when the agent actually adopts pages it read. The capability follows `read_files`, is independent of Agent Type, and applies to web/API/A2A and Feishu delivery.

### Problem

Compiled knowledge did not carry a safe end-to-end contract for distinguishing pages merely inspected from evidence used in an answer. Asking the model to print URLs would allow invented or stale citations.

### Solution

- Materialize server-owned citation metadata beside the exact knowledge bundle.
- Track successful per-turn knowledge reads and register only adopted pages through `knowledge_cite`.
- Resolve OKF source references against trusted metadata, deduplicate and cap links, then append them at response boundaries.
- Include `knowledge_cite` in the `read_files` capability group, with no Agent Type gate.

Existing published bundles must be recompiled and published once because older frozen manifests contain no origin URL.

## Test Plan

- [x] `npm run build`
- [x] `npm test -- --reporter=dot` (247 files; 5121 passed, 2 skipped)
- [ ] Manual end-to-end verification after the paired server change is deployed

## Architecture Checklist

- [x] Deployment mode: citation metadata is materialized through the existing knowledge sync path.
- [x] Security model: URLs are server-owned, HTTPS-only metadata; the model cannot supply arbitrary URLs.
- [x] Database parity: no schema changes.
- [x] Tool protocol: registered through the Tool Registry with a TypeBox schema.

## General Checklist

- [x] Changes are focused and backward compatible.
- [x] Tests cover read/adopt validation, rendering, sync, tool capabilities, SSE, and Feishu output.
- [x] No new dependency was added.
