### PR TITLE
Expose AgentBox observed inventory through sync-status

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -294,9 +294,10 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
     expect(r.data.sessions).toEqual([]);
   });
 
-  it("GET /api/sync-status reports the observed inventory", async () => {
+  it("GET /api/sync-status uses the box's agent-scoped knowledge directory", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "http-sync-status-"));
     const knowledgeDir = path.join(root, "knowledge");
+    const sharedKnowledgeDir = path.join(root, "shared-knowledge");
     const skillsDir = path.join(root, "skills");
     fs.mkdirSync(path.join(skillsDir, "resolved", "k8s-debug"), { recursive: true });
     fs.mkdirSync(knowledgeDir, { recursive: true });
@@ -304,10 +305,15 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
       syncedAt: "2026-08-18T08:00:00.000Z",
       repos: [{ id: "kb-1", name: "hardware", version: 2, sha256: "abc", fileCount: 12 }],
     }));
-    mockConfigState.knowledgeDir = knowledgeDir;
+    mockConfigState.knowledgeDir = sharedKnowledgeDir;
     mockConfigState.skillsDir = skillsDir;
     mockConfigState.mcpServers = { incidents: { transport: "http" } };
     try {
+      await new Promise<void>((resolve) => (server as http.Server).close(() => resolve()));
+      (sm as any).knowledgeDir = knowledgeDir;
+      server = createHttpServer(sm as any);
+      port = await startServer(server);
+
       const r = await getJson(port, "/api/sync-status");
       expect(r.status).toBe(200);
       expect(r.data).toEqual({

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -77,6 +77,11 @@ vi.mock("./sync-handlers.js", () => ({
     },
     postReload: async () => {},
   }),
+  readBoxSyncStatus: () => ({
+    knowledge: { syncedAt: null, repos: [] },
+    skills: { names: [] },
+    mcp: { names: [] },
+  }),
 }));
 
 vi.mock("./credential-broker.js", () => ({
@@ -284,6 +289,16 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
     const r = await getJson(port, "/api/sessions");
     expect(r.status).toBe(200);
     expect(r.data.sessions).toEqual([]);
+  });
+
+  it("GET /api/sync-status reports the observed inventory", async () => {
+    const r = await getJson(port, "/api/sync-status");
+    expect(r.status).toBe(200);
+    expect(r.data).toEqual({
+      knowledge: { syncedAt: null, repos: [] },
+      skills: { names: [] },
+      mcp: { names: [] },
+    });
   });
 
   it("GET /api/internal/box-status reports drained when the box holds nothing", async () => {

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { AddressInfo } from "node:net";
 import type http from "node:http";
 import type https from "node:https";
@@ -17,6 +20,9 @@ import type https from "node:https";
 const mockConfigState = vi.hoisted(() => ({
   modelRouting: undefined as unknown,
   memoryEnabled: true,
+  skillsDir: "skills",
+  knowledgeDir: "knowledge",
+  mcpServers: {} as Record<string, unknown>,
 }));
 
 // Silence metrics auth side effects.
@@ -43,8 +49,8 @@ vi.mock("../core/config.js", () => ({
   loadConfig: () => ({
     paths: {
       userDataDir: "/tmp/siclaw-test-user-data",
-      skillsDir: "skills",
-      knowledgeDir: "knowledge",
+      skillsDir: mockConfigState.skillsDir,
+      knowledgeDir: mockConfigState.knowledgeDir,
       credentialsDir: ".siclaw/credentials",
     },
     providers: {
@@ -53,12 +59,14 @@ vi.mock("../core/config.js", () => ({
       },
     },
     modelRouting: mockConfigState.modelRouting,
+    mcpServers: mockConfigState.mcpServers,
   }),
   isMemoryEnabled: () => mockConfigState.memoryEnabled,
 }));
 
 // Make sync-handlers a no-op registry.
-vi.mock("./sync-handlers.js", () => ({
+vi.mock("./sync-handlers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./sync-handlers.js")>()),
   getSyncHandler: () => undefined,
   createClusterHandler: () => ({ type: "cluster", fetch: async () => 0, materialize: async (n: number) => n }),
   createHostHandler: () => ({ type: "host", fetch: async () => 0, materialize: async (n: number) => n }),
@@ -76,11 +84,6 @@ vi.mock("./sync-handlers.js", () => ({
       return target.allowedToolsState ? target.allowedToolsState.length : 0;
     },
     postReload: async () => {},
-  }),
-  readBoxSyncStatus: () => ({
-    knowledge: { syncedAt: null, repos: [] },
-    skills: { names: [] },
-    mcp: { names: [] },
   }),
 }));
 
@@ -292,13 +295,35 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
   });
 
   it("GET /api/sync-status reports the observed inventory", async () => {
-    const r = await getJson(port, "/api/sync-status");
-    expect(r.status).toBe(200);
-    expect(r.data).toEqual({
-      knowledge: { syncedAt: null, repos: [] },
-      skills: { names: [] },
-      mcp: { names: [] },
-    });
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "http-sync-status-"));
+    const knowledgeDir = path.join(root, "knowledge");
+    const skillsDir = path.join(root, "skills");
+    fs.mkdirSync(path.join(skillsDir, "resolved", "k8s-debug"), { recursive: true });
+    fs.mkdirSync(knowledgeDir, { recursive: true });
+    fs.writeFileSync(path.join(knowledgeDir, ".sync-manifest.json"), JSON.stringify({
+      syncedAt: "2026-08-18T08:00:00.000Z",
+      repos: [{ id: "kb-1", name: "hardware", version: 2, sha256: "abc", fileCount: 12 }],
+    }));
+    mockConfigState.knowledgeDir = knowledgeDir;
+    mockConfigState.skillsDir = skillsDir;
+    mockConfigState.mcpServers = { incidents: { transport: "http" } };
+    try {
+      const r = await getJson(port, "/api/sync-status");
+      expect(r.status).toBe(200);
+      expect(r.data).toEqual({
+        knowledge: {
+          syncedAt: "2026-08-18T08:00:00.000Z",
+          repos: [{ id: "kb-1", name: "hardware", version: 2, sha256: "abc", fileCount: 12 }],
+        },
+        skills: { names: ["k8s-debug"] },
+        mcp: { names: ["incidents"] },
+      });
+    } finally {
+      mockConfigState.knowledgeDir = "knowledge";
+      mockConfigState.skillsDir = "skills";
+      mockConfigState.mcpServers = {};
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("GET /api/internal/box-status reports drained when the box holds nothing", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -27,6 +27,7 @@ import {
   createHostHandler,
   createKnowledgeHandler,
   createToolsHandler,
+  readBoxSyncStatus,
   type KnowledgeSyncHandler,
 } from "./sync-handlers.js";
 import { GATEWAY_SYNC_DESCRIPTORS, type AgentBoxSyncHandler, type GatewaySyncType } from "../shared/gateway-sync.js";
@@ -525,9 +526,12 @@ export function createHttpServer(
     perServerHandlers.cluster = createClusterHandler(sessionManager.credentialBroker);
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
   }
-  if (sessionManager.knowledgeDir) {
-    perServerHandlers.knowledge = options.knowledgeHandler
-      ?? createKnowledgeHandler({ knowledgeDir: sessionManager.knowledgeDir });
+  const perServerKnowledgeHandler = sessionManager.knowledgeDir
+    ? options.knowledgeHandler
+      ?? createKnowledgeHandler({ knowledgeDir: sessionManager.knowledgeDir })
+    : undefined;
+  if (perServerKnowledgeHandler) {
+    perServerHandlers.knowledge = perServerKnowledgeHandler;
   }
   // tools handler — same per-box rationale as cluster/host. It writes the
   // resolved allowedTools into THIS box's sessionManager and fetches with THIS
@@ -640,6 +644,21 @@ export function createHttpServer(
       // See MetricsFlushPayload: a claim, authorized against the mTLS cert on arrival.
       ...(process.env.SICLAW_POD_NAME ? { boxId: process.env.SICLAW_POD_NAME } : {}),
     });
+  });
+
+  /**
+   * GET /api/sync-status — observed inventory after materialize.
+   *
+   * Kept next to box-status because both expose box-observed state. This list
+   * is what a developer console can show after a test deploy: which knowledge
+   * libraries, skills, and MCP servers are actually on disk, not what Sicore
+   * intended to send.
+   */
+  addRoute("GET", "/api/sync-status", async (_req, res) => {
+    sendJson(res, 200, readBoxSyncStatus({
+      knowledgeDir: sessionManager.knowledgeDir,
+      knowledgeHandler: perServerKnowledgeHandler,
+    }));
   });
 
   /**

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -11,6 +11,7 @@ import {
   knowledgeHandler,
   mcpHandler,
   promptHandler,
+  readBoxSyncStatus,
   skillsHandler,
 } from "./sync-handlers.js";
 import { knowledgeRepoDirName } from "../shared/knowledge-package.js";
@@ -1167,5 +1168,112 @@ describe("knowledgeHandler multi-repo identity", () => {
     expect(entries[0]).toContain("平台知识");
     expect(entries[0]).toContain("权威运维库");
     expect(entries[0].split("\n")).toHaveLength(1);
+  });
+});
+
+describe("readBoxSyncStatus", () => {
+  let knowledgeTmpDir: string;
+  let skillsTmpDir: string;
+  let syncStatusHandler: ReturnType<typeof createKnowledgeHandler>;
+
+  function packageBase64(title: string): string {
+    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "sync-status-package-"));
+    const archive = path.join(os.tmpdir(), `sync-status-package-${process.pid}-${Date.now()}.tar.gz`);
+    try {
+      fs.writeFileSync(path.join(sourceDir, "index.md"), `# ${title}\n`);
+      execFileSync("tar", ["-czf", archive, "-C", sourceDir, "index.md"]);
+      return fs.readFileSync(archive).toString("base64");
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+      fs.rmSync(archive, { force: true });
+    }
+  }
+
+  beforeEach(() => {
+    knowledgeTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sync-status-knowledge-"));
+    skillsTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sync-status-skills-"));
+    _mockKnowledgeDir = knowledgeTmpDir;
+    _mockSkillsDir = skillsTmpDir;
+    syncStatusHandler = createKnowledgeHandler({ knowledgeDir: knowledgeTmpDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(knowledgeTmpDir, { recursive: true, force: true });
+    fs.rmSync(skillsTmpDir, { recursive: true, force: true });
+  });
+
+  it("prefers the in-memory inventory written by materialize", async () => {
+    const repos = [
+      { id: "repo-a", name: "硬件设施", version: 2, sizeBytes: 10, dataBase64: packageBase64("a") },
+    ];
+    await syncStatusHandler.materialize({ version: "v1", repos });
+
+    const status = readBoxSyncStatus({
+      knowledgeDir: knowledgeTmpDir,
+      knowledgeHandler: syncStatusHandler,
+    });
+    expect(status.knowledge.repos).toEqual([
+      expect.objectContaining({ id: "repo-a", name: "硬件设施", version: 2 }),
+    ]);
+    expect(status.knowledge.syncedAt).toBeTruthy();
+    expect(status.knowledge.repos[0].sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("falls back to .sync-manifest.json after a process restart", () => {
+    fs.writeFileSync(
+      path.join(knowledgeTmpDir, ".sync-manifest.json"),
+      JSON.stringify({
+        syncedAt: "2026-08-18T08:00:00.000Z",
+        version: "1",
+        repos: [{ id: "repo-b", name: "磁盘清单", version: 3, sha256: "abc", fileCount: 12, sizeBytes: 9 }],
+      }) + "\n",
+    );
+
+    const restartedHandler = createKnowledgeHandler({ knowledgeDir: knowledgeTmpDir });
+    const status = readBoxSyncStatus({
+      knowledgeDir: knowledgeTmpDir,
+      knowledgeHandler: restartedHandler,
+    });
+    expect(status.knowledge).toEqual({
+      syncedAt: "2026-08-18T08:00:00.000Z",
+      repos: [{ id: "repo-b", name: "磁盘清单", version: 3, sha256: "abc", fileCount: 12 }],
+    });
+  });
+
+  it("lists materialized skill directories", () => {
+    fs.mkdirSync(path.join(skillsTmpDir, "resolved", "k8s-debug"), { recursive: true });
+    fs.mkdirSync(path.join(skillsTmpDir, "resolved", "ticket-ops"), { recursive: true });
+    fs.writeFileSync(path.join(skillsTmpDir, "resolved", "notes.md"), "not a skill");
+
+    expect(readBoxSyncStatus({
+      knowledgeDir: knowledgeTmpDir,
+      knowledgeHandler: syncStatusHandler,
+    }).skills.names).toEqual(["k8s-debug", "ticket-ops"]);
+  });
+
+  it("keeps in-memory inventory isolated between local box handlers", async () => {
+    const otherKnowledgeDir = fs.mkdtempSync(path.join(os.tmpdir(), "sync-status-other-"));
+    const otherHandler = createKnowledgeHandler({ knowledgeDir: otherKnowledgeDir });
+    try {
+      await syncStatusHandler.materialize({
+        version: "v1",
+        repos: [{ id: "repo-a", name: "A", version: 1, sizeBytes: 10, dataBase64: packageBase64("a") }],
+      });
+      await otherHandler.materialize({
+        version: "v1",
+        repos: [{ id: "repo-b", name: "B", version: 1, sizeBytes: 10, dataBase64: packageBase64("b") }],
+      });
+
+      expect(readBoxSyncStatus({
+        knowledgeDir: knowledgeTmpDir,
+        knowledgeHandler: syncStatusHandler,
+      }).knowledge.repos.map((repo) => repo.id)).toEqual(["repo-a"]);
+      expect(readBoxSyncStatus({
+        knowledgeDir: otherKnowledgeDir,
+        knowledgeHandler: otherHandler,
+      }).knowledge.repos.map((repo) => repo.id)).toEqual(["repo-b"]);
+    } finally {
+      fs.rmSync(otherKnowledgeDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -24,6 +24,7 @@ import type {
   ReloadContext,
 } from "../shared/gateway-sync.js";
 import { GATEWAY_SYNC_DESCRIPTORS } from "../shared/gateway-sync.js";
+import type { BoxSyncStatus, ObservedKnowledgeRepo } from "../shared/agentbox-sync-status.js";
 import { resolveUnderDir } from "../shared/path-utils.js";
 import { decodeSkillFileContent, normalizeSkillFiles, type SkillPackageFile } from "../shared/skill-package.js";
 
@@ -342,23 +343,6 @@ export interface KnowledgeSyncStatus {
 
 export interface KnowledgeSyncHandler extends AgentBoxSyncHandler<KnowledgeBundlePayload> {
   getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null;
-}
-
-export interface ObservedKnowledgeRepo {
-  id: string;
-  name: string;
-  version: number;
-  sha256: string;
-  fileCount?: number | null;
-}
-
-export interface BoxSyncStatus {
-  knowledge: {
-    syncedAt: string | null;
-    repos: ObservedKnowledgeRepo[];
-  };
-  skills: { names: string[] };
-  mcp: { names: string[] };
 }
 
 function observedRepo(repo: KnowledgeSyncStatus["repos"][number]): ObservedKnowledgeRepo {

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -344,6 +344,99 @@ export interface KnowledgeSyncHandler extends AgentBoxSyncHandler<KnowledgeBundl
   getLastKnowledgeSyncStatus(): KnowledgeSyncStatus | null;
 }
 
+export interface ObservedKnowledgeRepo {
+  id: string;
+  name: string;
+  version: number;
+  sha256: string;
+  fileCount?: number | null;
+}
+
+export interface BoxSyncStatus {
+  knowledge: {
+    syncedAt: string | null;
+    repos: ObservedKnowledgeRepo[];
+  };
+  skills: { names: string[] };
+  mcp: { names: string[] };
+}
+
+function observedRepo(repo: KnowledgeSyncStatus["repos"][number]): ObservedKnowledgeRepo {
+  return {
+    id: repo.id,
+    name: repo.name,
+    version: repo.version,
+    sha256: repo.sha256,
+    fileCount: repo.fileCount,
+  };
+}
+
+function readKnowledgeInventoryFromDisk(knowledgeDir: string): BoxSyncStatus["knowledge"] {
+  const manifestPath = path.join(knowledgeDir, ".sync-manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    return { syncedAt: null, repos: [] };
+  }
+  try {
+    const raw = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+      syncedAt?: string;
+      repos?: KnowledgeSyncStatus["repos"];
+    };
+    return {
+      syncedAt: typeof raw.syncedAt === "string" ? raw.syncedAt : null,
+      repos: Array.isArray(raw.repos) ? raw.repos.map(observedRepo) : [],
+    };
+  } catch {
+    return { syncedAt: null, repos: [] };
+  }
+}
+
+function listSkillNames(skillsDir: string): string[] {
+  const resolvedDir = path.join(skillsDir, "resolved");
+  if (!fs.existsSync(resolvedDir)) return [];
+  return fs.readdirSync(resolvedDir).filter((name) => {
+    try {
+      return fs.statSync(path.join(resolvedDir, name)).isDirectory();
+    } catch {
+      return false;
+    }
+  }).sort();
+}
+
+export interface ReadBoxSyncStatusOptions {
+  /** Exact directory mounted for this logical box. */
+  knowledgeDir?: string;
+  /** Handler that materializes knowledge for this logical box. */
+  knowledgeHandler?: KnowledgeSyncHandler;
+}
+
+/**
+ * What this box has actually materialized. Memory is fresher than disk after
+ * the latest reload; `.sync-manifest.json` survives a process restart. Local
+ * boxes must pass their agent-scoped handler and directory to avoid cross-talk.
+ */
+export function readBoxSyncStatus(
+  options: ReadBoxSyncStatusOptions = {},
+): BoxSyncStatus {
+  const config = loadConfig();
+  const knowledgeDir = options.knowledgeDir
+    ? path.resolve(options.knowledgeDir)
+    : path.resolve(process.cwd(), config.paths.knowledgeDir);
+  const skillsDir = path.resolve(process.cwd(), config.paths.skillsDir);
+  const lastKnowledgeSyncStatus = (options.knowledgeHandler ?? knowledgeHandler)
+    .getLastKnowledgeSyncStatus();
+  const knowledge = lastKnowledgeSyncStatus
+    ? {
+        syncedAt: lastKnowledgeSyncStatus.syncedAt,
+        repos: lastKnowledgeSyncStatus.repos.map(observedRepo),
+      }
+    : readKnowledgeInventoryFromDisk(knowledgeDir);
+  return {
+    knowledge,
+    skills: { names: listSkillNames(skillsDir) },
+    mcp: { names: Object.keys(config.mcpServers ?? {}).sort() },
+  };
+}
+
 export function createKnowledgeHandler(
   options: { knowledgeDir?: string } = {},
 ): KnowledgeSyncHandler {

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -99,6 +99,22 @@ describe("agent.syncStatus RPC", () => {
       ok: true,
       available: false,
       reason: "no_running_box",
+      boxes: 1,
+    });
+    expect(getJsonCalls).toEqual([]);
+  });
+
+  it("reports zero boxes when the agent has no box at all", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "other", status: "running", endpoint: "https://b1" },
+    ];
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      ok: true,
+      available: false,
+      reason: "no_running_box",
       boxes: 0,
     });
     expect(getJsonCalls).toEqual([]);
@@ -107,6 +123,7 @@ describe("agent.syncStatus RPC", () => {
   it("reads /api/sync-status from the running box", async () => {
     listReturns = [
       { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "pending", endpoint: "https://b2" },
     ];
     server = await bootRuntime();
     const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
@@ -114,7 +131,7 @@ describe("agent.syncStatus RPC", () => {
     await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
       ok: true,
       available: true,
-      boxes: 1,
+      boxes: 2,
       knowledge: {
         syncedAt: "2026-08-18T08:00:00.000Z",
         repos: [{ id: "kb-1", name: "硬件", version: 2, sha256: "abc" }],

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -5,6 +5,7 @@
  * running box so the developer console can show what actually landed.
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
+import type { BoxSyncStatus } from "../shared/agentbox-sync-status.js";
 
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
@@ -14,23 +15,29 @@ vi.mock("./chat-repo.js", () => ({
   incrementMessageCount: vi.fn(async () => {}),
 }));
 
+const clientCalls: Array<{ endpoint: string; timeoutMs: number; tlsOptions: unknown }> = [];
 const getJsonCalls: Array<{ endpoint: string; path: string }> = [];
 const getJsonByEndpoint = new Map<string, () => Promise<unknown>>();
+const defaultSyncStatus = {
+  knowledge: {
+    syncedAt: "2026-08-18T08:00:00.000Z",
+    repos: [{ id: "kb-1", name: "硬件", version: 2, sha256: "abc" }],
+  },
+  skills: { names: ["k8s-debug"] },
+  mcp: { names: [] },
+} satisfies BoxSyncStatus;
 vi.mock("./agentbox/client.js", () => ({
   AgentBoxClient: class {
     endpoint: string;
-    constructor(endpoint: string) {
+    constructor(endpoint: string, timeoutMs = 30_000, tlsOptions?: unknown) {
       this.endpoint = endpoint;
+      clientCalls.push({ endpoint, timeoutMs, tlsOptions });
     }
     getJson = vi.fn(async (path: string) => {
       getJsonCalls.push({ endpoint: this.endpoint, path });
       const impl = getJsonByEndpoint.get(this.endpoint);
       if (impl) return impl();
-      return {
-        knowledge: { syncedAt: "2026-08-18T08:00:00.000Z", repos: [{ id: "kb-1", name: "硬件", version: 2 }] },
-        skills: { names: ["k8s-debug"] },
-        mcp: { names: [] },
-      };
+      return defaultSyncStatus;
     });
   },
 }));
@@ -72,6 +79,7 @@ let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
 afterEach(async () => {
   if (server) await server.close();
   server = undefined;
+  clientCalls.length = 0;
   getJsonCalls.length = 0;
   getJsonByEndpoint.clear();
   listReturns = [];
@@ -107,11 +115,19 @@ describe("agent.syncStatus RPC", () => {
       ok: true,
       available: true,
       boxes: 1,
-      knowledge: { syncedAt: "2026-08-18T08:00:00.000Z", repos: [{ id: "kb-1", name: "硬件", version: 2 }] },
+      knowledge: {
+        syncedAt: "2026-08-18T08:00:00.000Z",
+        repos: [{ id: "kb-1", name: "硬件", version: 2, sha256: "abc" }],
+      },
       skills: { names: ["k8s-debug"] },
       mcp: { names: [] },
     });
     expect(getJsonCalls).toEqual([{ endpoint: "https://b1", path: "/api/sync-status" }]);
+    expect(clientCalls).toEqual([{
+      endpoint: "https://b1",
+      timeoutMs: 8_000,
+      tlsOptions: server.agentBoxTlsOptions,
+    }]);
   });
 
   it("marks an old box image as unsupported", async () => {
@@ -130,5 +146,31 @@ describe("agent.syncStatus RPC", () => {
       reason: "unsupported",
       boxes: 1,
     });
+  });
+
+  it("keeps the actionable unsupported reason when every running box fails", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://old" },
+      { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://broken" },
+    ];
+    getJsonByEndpoint.set("https://old", async () => {
+      throw new Error("GET /api/sync-status failed: 404");
+    });
+    getJsonByEndpoint.set("https://broken", async () => {
+      throw new Error("connect ETIMEDOUT");
+    });
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      ok: true,
+      available: false,
+      reason: "unsupported",
+      boxes: 2,
+    });
+    expect(getJsonCalls).toEqual([
+      { endpoint: "https://old", path: "/api/sync-status" },
+      { endpoint: "https://broken", path: "/api/sync-status" },
+    ]);
   });
 });

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -1,0 +1,134 @@
+/**
+ * agent.syncStatus RPC — read the running box's observed inventory.
+ *
+ * Reload ACK only proves the RPC ran. This path GETs /api/sync-status from a
+ * running box so the developer console can show what actually landed.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+vi.mock("./chat-repo.js", () => ({
+  ensureChatSession: vi.fn(async () => {}),
+  appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
+  incrementMessageCount: vi.fn(async () => {}),
+}));
+
+const getJsonCalls: Array<{ endpoint: string; path: string }> = [];
+const getJsonByEndpoint = new Map<string, () => Promise<unknown>>();
+vi.mock("./agentbox/client.js", () => ({
+  AgentBoxClient: class {
+    endpoint: string;
+    constructor(endpoint: string) {
+      this.endpoint = endpoint;
+    }
+    getJson = vi.fn(async (path: string) => {
+      getJsonCalls.push({ endpoint: this.endpoint, path });
+      const impl = getJsonByEndpoint.get(this.endpoint);
+      if (impl) return impl();
+      return {
+        knowledge: { syncedAt: "2026-08-18T08:00:00.000Z", repos: [{ id: "kb-1", name: "硬件", version: 2 }] },
+        skills: { names: ["k8s-debug"] },
+        mcp: { names: [] },
+      };
+    });
+  },
+}));
+
+const { startRuntime } = await import("./server.js");
+
+function fakeFrontendClient() {
+  return {
+    request: vi.fn(async () => ({})),
+    onCommand: vi.fn(),
+    emitEvent: vi.fn(),
+    close: vi.fn(),
+  } as any;
+}
+
+let listReturns: Array<{ boxId: string; agentId: string; status: string; endpoint: string }> = [];
+function fakeAgentBoxManager() {
+  return {
+    setCertManager: vi.fn(),
+    setSpawnEnvResolver: vi.fn(),
+    setPersistenceResolver: vi.fn(),
+    getAsync: vi.fn(async () => ({ endpoint: "https://fake.internal" })),
+    getOrCreate: vi.fn(async () => ({ endpoint: "https://fake.internal" })),
+    list: vi.fn(async () => listReturns),
+    cleanup: vi.fn(async () => {}),
+  } as any;
+}
+
+async function bootRuntime() {
+  return startRuntime({
+    config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+    agentBoxManager: fakeAgentBoxManager(),
+    frontendClient: fakeFrontendClient(),
+    credentialService: {} as any,
+  });
+}
+
+let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+  getJsonCalls.length = 0;
+  getJsonByEndpoint.clear();
+  listReturns = [];
+  vi.clearAllMocks();
+});
+
+describe("agent.syncStatus RPC", () => {
+  it("returns no_running_box when the agent has no running pod", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "other", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "pending", endpoint: "https://b2" },
+    ];
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      ok: true,
+      available: false,
+      reason: "no_running_box",
+      boxes: 0,
+    });
+    expect(getJsonCalls).toEqual([]);
+  });
+
+  it("reads /api/sync-status from the running box", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+    ];
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      ok: true,
+      available: true,
+      boxes: 1,
+      knowledge: { syncedAt: "2026-08-18T08:00:00.000Z", repos: [{ id: "kb-1", name: "硬件", version: 2 }] },
+      skills: { names: ["k8s-debug"] },
+      mcp: { names: [] },
+    });
+    expect(getJsonCalls).toEqual([{ endpoint: "https://b1", path: "/api/sync-status" }]);
+  });
+
+  it("marks an old box image as unsupported", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://old" },
+    ];
+    getJsonByEndpoint.set("https://old", async () => {
+      throw new Error("GET /api/sync-status failed: 404");
+    });
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      ok: true,
+      available: false,
+      reason: "unsupported",
+      boxes: 1,
+    });
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -2042,6 +2042,52 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     return { ok: true, reloaded, failed, boxes: targets.length };
   });
 
+  // agent.syncStatus — read the box's observed inventory. Reload ACK only
+  // proves the RPC ran; this is what actually landed on disk.
+  rpcMethods.set("agent.syncStatus", async (params) => {
+    const agentId = params.agentId as string;
+    if (!agentId) throw new Error("agentId required");
+
+    const boxes = await agentBoxManager.list();
+    const targets = boxes.filter((b) => b.agentId === agentId && b.status === "running");
+    if (targets.length === 0) {
+      return { ok: true, available: false, reason: "no_running_box", boxes: 0 };
+    }
+
+    for (const box of targets) {
+      try {
+        const client = new AgentBoxClient(box.endpoint, 8_000, agentBoxTlsOptions);
+        const status = await client.getJson<{
+          knowledge?: { syncedAt?: string | null; repos?: unknown[] };
+          skills?: { names?: string[] };
+          mcp?: { names?: string[] };
+        }>("/api/sync-status");
+        return {
+          ok: true,
+          available: true,
+          boxes: targets.length,
+          knowledge: status.knowledge ?? { syncedAt: null, repos: [] },
+          skills: status.skills ?? { names: [] },
+          mcp: status.mcp ?? { names: [] },
+        };
+      } catch (err: any) {
+        const message = String(err?.message ?? err);
+        console.warn(`[rpc] agent.syncStatus: box=${box.boxId} failed: ${message}`);
+        if (targets[targets.length - 1] === box) {
+          const unsupported = /\b404\b/.test(message) || /not found/i.test(message);
+          return {
+            ok: true,
+            available: false,
+            reason: unsupported ? "unsupported" : "query_failed",
+            boxes: targets.length,
+          };
+        }
+      }
+    }
+
+    return { ok: true, available: false, reason: "query_failed", boxes: targets.length };
+  });
+
   // tracing.reloadAll — GLOBAL tracing hot-reload. Unlike agent.reload, tracing
   // is a single fan-out set shared by every agent, so this enumerates ALL
   // running boxes (no agentId filter) and POSTs /api/reload-tracing to each.

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -72,6 +72,7 @@ import type { FrontendWsClient } from "./frontend-ws-client.js";
 import { createMtlsMiddleware } from "./security/mtls-middleware.js";
 import type { BoxSpawner } from "./agentbox/spawner.js";
 import { checkMetricsAuth } from "../shared/metrics.js";
+import type { BoxSyncStatus } from "../shared/agentbox-sync-status.js";
 import { clearAgentMemory } from "./memory-cleanup.js";
 import {
   handleSettings,
@@ -2054,14 +2055,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       return { ok: true, available: false, reason: "no_running_box", boxes: 0 };
     }
 
+    let sawUnsupported = false;
     for (const box of targets) {
       try {
         const client = new AgentBoxClient(box.endpoint, 8_000, agentBoxTlsOptions);
-        const status = await client.getJson<{
-          knowledge?: { syncedAt?: string | null; repos?: unknown[] };
-          skills?: { names?: string[] };
-          mcp?: { names?: string[] };
-        }>("/api/sync-status");
+        const status = await client.getJson<BoxSyncStatus>("/api/sync-status");
         return {
           ok: true,
           available: true,
@@ -2073,19 +2071,16 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       } catch (err: any) {
         const message = String(err?.message ?? err);
         console.warn(`[rpc] agent.syncStatus: box=${box.boxId} failed: ${message}`);
-        if (targets[targets.length - 1] === box) {
-          const unsupported = /\b404\b/.test(message) || /not found/i.test(message);
-          return {
-            ok: true,
-            available: false,
-            reason: unsupported ? "unsupported" : "query_failed",
-            boxes: targets.length,
-          };
-        }
+        sawUnsupported ||= /\b404\b/.test(message) || /not found/i.test(message);
       }
     }
 
-    return { ok: true, available: false, reason: "query_failed", boxes: targets.length };
+    return {
+      ok: true,
+      available: false,
+      reason: sawUnsupported ? "unsupported" : "query_failed",
+      boxes: targets.length,
+    };
   });
 
   // tracing.reloadAll — GLOBAL tracing hot-reload. Unlike agent.reload, tracing

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -2050,9 +2050,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     if (!agentId) throw new Error("agentId required");
 
     const boxes = await agentBoxManager.list();
-    const targets = boxes.filter((b) => b.agentId === agentId && b.status === "running");
+    const agentBoxes = boxes.filter((b) => b.agentId === agentId);
+    const targets = agentBoxes.filter((b) => b.status === "running");
     if (targets.length === 0) {
-      return { ok: true, available: false, reason: "no_running_box", boxes: 0 };
+      return { ok: true, available: false, reason: "no_running_box", boxes: agentBoxes.length };
     }
 
     let sawUnsupported = false;
@@ -2063,7 +2064,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         return {
           ok: true,
           available: true,
-          boxes: targets.length,
+          boxes: agentBoxes.length,
           knowledge: status.knowledge ?? { syncedAt: null, repos: [] },
           skills: status.skills ?? { names: [] },
           mcp: status.mcp ?? { names: [] },
@@ -2079,7 +2080,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       ok: true,
       available: false,
       reason: sawUnsupported ? "unsupported" : "query_failed",
-      boxes: targets.length,
+      boxes: agentBoxes.length,
     };
   });
 

--- a/src/shared/agentbox-sync-status.ts
+++ b/src/shared/agentbox-sync-status.ts
@@ -1,0 +1,23 @@
+/**
+ * Cross-process contract for the inventory an AgentBox has materialized.
+ *
+ * AgentBox serves this payload and Runtime relays it, so both processes must
+ * compile against one shape even though their images can be released
+ * independently.
+ */
+export interface ObservedKnowledgeRepo {
+  id: string;
+  name: string;
+  version: number;
+  sha256: string;
+  fileCount?: number | null;
+}
+
+export interface BoxSyncStatus {
+  knowledge: {
+    syncedAt: string | null;
+    repos: ObservedKnowledgeRepo[];
+  };
+  skills: { names: string[] };
+  mcp: { names: string[] };
+}


### PR DESCRIPTION
## Summary
- AgentBox now serves `GET /api/sync-status` from the materialized knowledge manifest, skill directories, and MCP config.
- Runtime `agent.syncStatus` reads that list from a running box so Sicore can show what the test box actually loaded.

## Test plan
- [ ] `npx vitest run src/agentbox/sync-handlers.test.ts src/agentbox/http-server.test.ts src/gateway/server-sync-status.test.ts`
- [ ] With a running box, `GET /api/sync-status` returns the knowledge repos on disk
- [ ] Pair with the Sicore developer-console MR that displays this on test deploy


Made with [Cursor](https://cursor.com)