### PR TITLE
fix(tools): report real failures and stop leaking ConfigMap secrets

### DIFF
--- a/docs/design/sanitization.md
+++ b/docs/design/sanitization.md
@@ -73,8 +73,8 @@ Command executes → stdout captured
 │ Redaction methods (selected by Layer 1):              │
 │ • sanitizeJSON() — structural: removes data/stringData│
 │   from Secret JSON, envs from Pod/ConfigMap JSON      │
-│ • redactSensitiveContent() — line-level: regex match  │
-│   on KEY=VALUE and KEY: VALUE patterns                │
+│ • redactSensitiveContent() — whole-document: per-line │
+│   key/value matching plus multi-line blocks (see §8)  │
 │ • redactEnvOutput() — specialized for env/printenv    │
 │ • sanitizeCrictlInspect() — JSON env array redaction  │
 └─────────────────────┬───────────────────────────────┘
@@ -251,8 +251,64 @@ under `<userDataDir>/agent/tasks/`, opened `O_NOFOLLOW` to defeat symlink redire
 ```
 src/tools/infra/output-sanitizer.ts      OUTPUT_RULES, analyzeOutput(), applySanitizer(), OutputAction.lineSafe
 src/tools/cmd-exec/disk-output.ts        DiskTaskOutput + SanitizingLineBuffer (background bash sanitize-on-write)
-src/tools/infra/kubectl-sanitize.ts      sanitizeJSON(), detectSensitiveResource(), redaction patterns
+src/tools/infra/kubectl-sanitize.ts      sanitizeJSON(), detectSensitiveResource(), redaction patterns,
+                                         redactLines() / redactDocument() / redactSensitiveContent()
 src/tools/shell/restricted-bash.ts       Pipeline fallback (Layer 3), isSkillScript()
 src/tools/infra/output-sanitizer.test.ts Test coverage for sanitization rules
 src/tools/infra/kubectl-sanitize.test.ts Test coverage for kubectl-specific sanitization
 ```
+
+The line-level redactor lives in `kubectl-sanitize.ts`, not
+`output-sanitizer.ts` — the structural sanitizers need it (see §8) and the
+reverse import would be a cycle. `output-sanitizer.ts` re-exports
+`redactSensitiveContent` / `REDACTION_NOTICE`, so it remains the public entry
+point for callers.
+
+---
+
+## 8. Line-level vs whole-document redaction
+
+Two redactors, and picking the wrong one silently loses coverage:
+
+| Function | Sees | Use when |
+|----------|------|----------|
+| `redactLines()` | one line at a time, **no state carried** | streaming (background bash), where a batch holds an arbitrary slice of lines |
+| `redactDocument()` | the whole text | anything holding a complete document — `redactSensitiveContent`, ConfigMap entries |
+
+`redactDocument` exists because **a secret's body can sit on the lines below its
+key**, where no key name marks it:
+
+```yaml
+api_token: |                    tls.key: |
+  ghp_AAAA…                       -----BEGIN RSA PRIVATE KEY-----
+                                  MIIEvQIBADANBgkq…
+```
+
+A per-line pass redacts the key line and leaves the body — and then the footer
+claims the output was cleaned, which is worse than saying nothing. A block
+scalar owns every following line indented deeper than its key; a PEM block runs
+to its `END` marker. `redactLines` cannot do either and must not pretend to:
+that is the price of the `lineSafe` contract, and it is why streaming is the only
+caller that gets it.
+
+### ConfigMap entries are documents, not values
+
+A ConfigMap data key is usually a filename and its value an entire config file,
+so the secrets are named by the keys **inside** the value. Testing the value as
+one blob checks none of them. The entry is therefore parsed:
+
+- **JSON payload** → walk the parsed tree, judging every nested key
+- **Anything else** → `redactDocument`
+- **Looks like JSON but does not parse, and names a sensitive key** → drop the
+  whole entry; a compact object puts several pairs on one line and an
+  unparseable one gives no confidence that a textual pass rewrote all of them
+- **The data key itself is sensitive** → drop the whole entry
+
+### Both halves of a line are judged
+
+A telling key name redacts whatever it holds; a value that looks like a
+credential is redacted whatever its key is called. Value patterns are matched
+against the **value segment** of a parsed line — anchored patterns like `^eyJ`
+are defeated by indentation and a `key: ` prefix otherwise — with the raw line
+as a fallback, since positional patterns (a connection string, a bearer header)
+can straddle a naive key/value split.

--- a/src/tools/cmd-exec/host-exec.test.ts
+++ b/src/tools/cmd-exec/host-exec.test.ts
@@ -55,7 +55,7 @@ describe("host_exec", () => {
     expect((result.details as any).error).toBeUndefined();
   });
 
-  it("non-zero exit produces error=true with header", async () => {
+  it("non-zero exit produces error=true with a trailing exit annotation", async () => {
     vi.mocked(acquireSshTarget).mockResolvedValueOnce({
       host: "10.0.0.1", port: 22, username: "root",
       auth: { type: "key", privateKeyPath: "/tmp/h1.key" },
@@ -66,7 +66,7 @@ describe("host_exec", () => {
       exitCode: 127,
     });
     const result = await tool.execute("id", { host: "h1", command: "cat /nope" }, undefined, {} as any);
-    expect(result.content[0].text).toContain("Exit code: 127");
+    expect(result.content[0].text).toContain("[exit code: 127]");
     expect((result.details as any).error).toBe(true);
   });
 

--- a/src/tools/cmd-exec/host-exec.ts
+++ b/src/tools/cmd-exec/host-exec.ts
@@ -285,17 +285,22 @@ Examples (pass the id from host_list; names shown here for readability):
       // Mirror node_exec's error judgment: signal-killed with stdout = OK; otherwise non-zero exit = error.
       const isError = result.exitCode !== 0 &&
         !(result.exitCode === null && result.stdout.trim());
-      const stdoutHeader = isError
-        ? `Exit code: ${result.exitCode ?? "unknown"}${result.signal ? ` (signal: ${result.signal})` : ""}\n`
-        : "";
-      const stdoutBody = result.stdout.trim();
-      const truncatedSuffix = result.truncated ? "\n...[output truncated at 10 MB]" : "";
-      const stdout = stdoutHeader + stdoutBody + truncatedSuffix;
-
+      // Exit code renders as a trailing annotation rather than a header prefix —
+      // same shape as bash/node_exec/pod_exec, and it keeps our own literals out
+      // of the body that gets sanitized (see PostExecOptions.exitCode).
       return {
         content: [{
           type: "text",
-          text: postExecSecurity(stdout, pre.action, { stderr: result.stderr.trim() || undefined }),
+          text: postExecSecurity(result.stdout.trim(), pre.action, {
+            stderr: result.stderr.trim() || undefined,
+            ...(result.truncated ? { notes: "\n...[output truncated at 10 MB]" } : {}),
+            ...(isError
+              ? {
+                  exitCode: result.exitCode ?? "unknown",
+                  ...(result.signal ? { signal: result.signal } : {}),
+                }
+              : {}),
+          }),
         }],
         details: {
           exitCode: result.exitCode,

--- a/src/tools/cmd-exec/node-exec.ts
+++ b/src/tools/cmd-exec/node-exec.ts
@@ -20,7 +20,7 @@ import { resolvePodNetnsViaKubectl, validateNetnsName } from "../infra/pod-netns
 import { runInDebugPod, ensureDebugPodReady, acquireDebugPod, releaseDebugPod } from "../infra/debug-pod.js";
 import { backgroundPgidFile, wrapBackgroundSession, killRemoteSessionViaKubectl } from "../infra/bg-session.js";
 import { resolveRequiredKubeconfig, resolveDebugImage } from "../infra/kubeconfig-resolver.js";
-import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
+import { ensureClusterForTool, classifyClusterFailure } from "../infra/ensure-kubeconfigs.js";
 
 // Re-export for backward compatibility (tests + downstream imports)
 export { validateNodeName, validatePodName } from "../infra/exec-utils.js";
@@ -191,9 +191,10 @@ To run in a POD's network namespace (host tools + the pod's network view — e.g
       try {
         await ensureClusterForTool(kubeconfigRef?.credentialBroker, params.cluster, "node_exec");
       } catch (err) {
+        const failure = await classifyClusterFailure(kubeconfigRef?.credentialBroker, params.cluster, err);
         return {
-          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-          details: { error: true, reason: "kubeconfig_ensure_failed" },
+          content: [{ type: "text", text: JSON.stringify(failure, null, 2) }],
+          details: { error: true, reason: failure.reason },
         };
       }
 
@@ -396,15 +397,12 @@ To run in a POD's network namespace (host tools + the pod's network view — e.g
       const filteredStderr = filterPodNoise(execResult.stderr);
       const isError = execResult.exitCode !== 0 &&
         !(execResult.exitCode === null && execResult.stdout.trim());
-      const out = execResult.stdout.trim();
       // Show the output as a shell would, with the exit code as a trailing annotation
       // (not a prefix that replaces the body), so a non-zero exit with no output —
       // e.g. `grep` with no match — reads as an empty result, not a failure.
-      const stdout = isError
-        ? `${out || "(no output)"}\n[exit code: ${execResult.exitCode ?? "unknown"}]`
-        : out;
+      const out = execResult.stdout.trim();
       return {
-        content: [{ type: "text", text: postExecSecurity(stdout, pre.action, { stderr: filteredStderr || undefined }) }],
+        content: [{ type: "text", text: postExecSecurity(out, pre.action, { stderr: filteredStderr || undefined, ...(isError && { exitCode: execResult.exitCode ?? "unknown" }) }) }],
         details: { exitCode: execResult.exitCode ?? 0, ...(isError && { error: true }) },
       };
     },

--- a/src/tools/cmd-exec/pod-exec.ts
+++ b/src/tools/cmd-exec/pod-exec.ts
@@ -14,7 +14,7 @@ import { preExecSecurity, postExecSecurity } from "../infra/security-pipeline.js
 import { backgroundNotLineSafeError, backgroundLaunchedResult } from "./background-launch.js";
 import { validatePodName, prepareExecEnv, filterPodNoise } from "../infra/exec-utils.js";
 import { resolveRequiredKubeconfig } from "../infra/kubeconfig-resolver.js";
-import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
+import { ensureClusterForTool, classifyClusterFailure } from "../infra/ensure-kubeconfigs.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -129,9 +129,10 @@ Examples:
       try {
         await ensureClusterForTool(kubeconfigRef?.credentialBroker, params.cluster, "pod_exec");
       } catch (err) {
+        const failure = await classifyClusterFailure(kubeconfigRef?.credentialBroker, params.cluster, err);
         return {
-          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-          details: { error: true, reason: "kubeconfig_ensure_failed" },
+          content: [{ type: "text", text: JSON.stringify(failure, null, 2) }],
+          details: { error: true, reason: failure.reason },
         };
       }
 
@@ -249,7 +250,7 @@ Examples:
         const stderr = filterPodNoise((err.stderr?.trim() ?? err.message) as string);
         const exitCode = err.code ?? "unknown";
         return {
-          content: [{ type: "text", text: postExecSecurity(`${stdout || "(no output)"}\n[exit code: ${exitCode}]`, pre.action, { stderr: stderr || undefined }) }],
+          content: [{ type: "text", text: postExecSecurity(stdout, pre.action, { stderr: stderr || undefined, exitCode }) }],
           details: { exitCode, error: true },
         };
       }

--- a/src/tools/cmd-exec/restricted-bash.ts
+++ b/src/tools/cmd-exec/restricted-bash.ts
@@ -18,7 +18,7 @@ import {
   validateCommandRestrictions,
 } from "../infra/command-sets.js";
 import { resolveRequiredKubeconfig } from "../infra/kubeconfig-resolver.js";
-import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
+import { ensureClusterForTool, classifyClusterFailure } from "../infra/ensure-kubeconfigs.js";
 import { sanitizeEnv } from "../infra/sanitize-env.js";
 import {
   extractCommands as _extractCommands,
@@ -338,9 +338,10 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
         try {
           await ensureClusterForTool(kubeconfigRef?.credentialBroker, params.cluster, "restricted_bash");
         } catch (err) {
+          const failure = await classifyClusterFailure(kubeconfigRef?.credentialBroker, params.cluster, err);
           return {
-            content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-            details: { error: true, reason: "kubeconfig_ensure_failed" },
+            content: [{ type: "text", text: JSON.stringify(failure, null, 2) }],
+            details: { error: true, reason: failure.reason },
           };
         }
       }
@@ -475,7 +476,7 @@ Do NOT use for non-kubectl tasks (file editing, package management, etc.).`,
       } catch (err: any) {
         const errStderr = err.stderr?.trim() ?? err.message;
         return {
-          content: [{ type: "text", text: postExecSecurity(`${err.stdout?.trim() || "(no output)"}\n[exit code: ${err.code ?? "unknown"}]`, pre.action, { stderr: errStderr || undefined, hasSensitiveKubectl: pre.hasSensitiveKubectl }) }],
+          content: [{ type: "text", text: postExecSecurity(err.stdout?.trim() ?? "", pre.action, { stderr: errStderr || undefined, hasSensitiveKubectl: pre.hasSensitiveKubectl, exitCode: err.code ?? "unknown" }) }],
           details: { exitCode: err.code, error: true },
         };
       }

--- a/src/tools/infra/ensure-kubeconfigs.test.ts
+++ b/src/tools/infra/ensure-kubeconfigs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   ensureClusterForTool,
   ensureHostForTool,
+  classifyClusterFailure,
 } from "./ensure-kubeconfigs.js";
 
 describe("ensureClusterForTool", () => {
@@ -55,5 +56,64 @@ describe("ensureHostForTool", () => {
   it("propagates ensureHost errors", async () => {
     const broker = { ensureHost: async () => { throw new Error("not bound"); } } as any;
     await expect(ensureHostForTool(broker, "h1", "p")).rejects.toThrow("not bound");
+  });
+});
+
+describe("classifyClusterFailure", () => {
+  // The transport reports a missing binding as an HTTP 502 "cluster not found",
+  // which is indistinguishable from a real upstream fault — the binding list is
+  // what tells them apart.
+  const gatewayError = new Error('Gateway returned 502: {"error":"cluster not found"}');
+
+  it("reports an unbound cluster as a non-retryable config error", async () => {
+    const broker = {
+      refreshClusters: async () => [{ name: "prod" }, { name: "staging" }],
+    } as any;
+    const result = await classifyClusterFailure(broker, "typo-cluster", gatewayError);
+    expect(result.reason).toBe("cluster_not_bound");
+    expect(result.retryable).toBe(false);
+    expect(result.available_clusters).toEqual(["prod", "staging"]);
+    expect(result.message).toContain("cluster_list");
+    // The 502 must not survive — it is what misleads the caller into retrying.
+    expect(result.message).not.toContain("502");
+  });
+
+  it("says so explicitly when nothing at all is bound", async () => {
+    const broker = { refreshClusters: async () => [] } as any;
+    const result = await classifyClusterFailure(broker, "prod", gatewayError);
+    expect(result.reason).toBe("cluster_not_bound");
+    expect(result.available_clusters).toEqual([]);
+    expect(result.message).toContain("nothing is bound");
+  });
+
+  it("keeps the upstream error when the cluster IS bound", async () => {
+    const broker = { refreshClusters: async () => [{ name: "prod" }] } as any;
+    const result = await classifyClusterFailure(broker, "prod", new Error("TLS handshake timeout"));
+    expect(result.reason).toBe("cluster_unavailable");
+    expect(result.retryable).toBe(true);
+    expect(result.message).toContain("TLS handshake timeout");
+    expect(result.available_clusters).toEqual(["prod"]);
+  });
+
+  it("does not claim 'not bound' when the binding list itself is unreachable", async () => {
+    const broker = {
+      refreshClusters: async () => { throw new Error("list failed"); },
+    } as any;
+    const result = await classifyClusterFailure(broker, "prod", gatewayError);
+    expect(result.reason).toBe("cluster_unavailable");
+    expect(result.retryable).toBe(true);
+    expect(result.message).toContain("502");
+  });
+
+  it("falls back to cluster_unavailable with no broker", async () => {
+    const result = await classifyClusterFailure(undefined, "prod", gatewayError);
+    expect(result.reason).toBe("cluster_unavailable");
+    expect(result.available_clusters).toEqual([]);
+  });
+
+  it("does not label an auto-select failure as unbound (no name given)", async () => {
+    const broker = { refreshClusters: async () => [{ name: "prod" }] } as any;
+    const result = await classifyClusterFailure(broker, undefined, gatewayError);
+    expect(result.reason).toBe("cluster_unavailable");
   });
 });

--- a/src/tools/infra/ensure-kubeconfigs.test.ts
+++ b/src/tools/infra/ensure-kubeconfigs.test.ts
@@ -83,7 +83,18 @@ describe("classifyClusterFailure", () => {
     const result = await classifyClusterFailure(broker, "prod", gatewayError);
     expect(result.reason).toBe("cluster_not_bound");
     expect(result.available_clusters).toEqual([]);
-    expect(result.message).toContain("nothing is bound");
+    expect(result.retryable).toBe(false);
+    expect(result.message).toContain("No cluster is bound");
+  });
+
+  // ensureClusterForTool auto-selects when the caller omits `cluster`, so this
+  // path arrives with no name — but an empty list is just as conclusive.
+  it("reports not-bound for an empty list even with no name given", async () => {
+    const broker = { refreshClusters: async () => [] } as any;
+    const result = await classifyClusterFailure(broker, undefined, gatewayError);
+    expect(result.reason).toBe("cluster_not_bound");
+    expect(result.retryable).toBe(false);
+    expect(result.message).not.toContain("502");
   });
 
   it("keeps the upstream error when the cluster IS bound", async () => {

--- a/src/tools/infra/ensure-kubeconfigs.ts
+++ b/src/tools/infra/ensure-kubeconfigs.ts
@@ -36,6 +36,73 @@ export async function ensureClusterForTool(
   }
 }
 
+/** Structured result of a failed `ensureClusterForTool`, rendered to the model. */
+export interface ClusterFailure {
+  error: true;
+  reason: "cluster_not_bound" | "cluster_unavailable";
+  message: string;
+  retryable: boolean;
+  available_clusters: string[];
+}
+
+/**
+ * Classify a failed `ensureClusterForTool` as a missing binding or an upstream
+ * fault.
+ *
+ * The transport reports both the same way — an HTTP 502 whose body says "cluster
+ * not found" — so forwarding the raw error tells the model "transient gateway
+ * problem, worth retrying" when the real answer is "this agent has no such
+ * cluster bound, and no number of retries will change that". It then retries the
+ * same call, or moves on to node/pod tools that share the binding and fail
+ * identically. Re-reading the binding list is what separates the two cases.
+ *
+ * Fails toward `cluster_unavailable`: when the binding list itself is
+ * unreachable we cannot prove the cluster is unbound, and reporting a config
+ * error for what may be a transient fault is the more misleading of the two.
+ */
+export async function classifyClusterFailure(
+  broker: CredentialBroker | undefined,
+  clusterName: string | undefined,
+  err: unknown,
+): Promise<ClusterFailure> {
+  const raw = err instanceof Error ? err.message : String(err);
+
+  let bound: string[];
+  try {
+    if (!broker) throw new Error("no broker");
+    bound = (await broker.refreshClusters()).map((c) => c.name);
+  } catch {
+    return {
+      error: true,
+      reason: "cluster_unavailable",
+      message: raw,
+      retryable: true,
+      available_clusters: [],
+    };
+  }
+
+  if (clusterName && !bound.includes(clusterName)) {
+    return {
+      error: true,
+      reason: "cluster_not_bound",
+      message:
+        `Cluster "${clusterName}" is not bound to this agent, so its kubeconfig ` +
+        `cannot be materialized. Retrying will not help. Call cluster_list to see ` +
+        `what is bound${bound.length ? "" : " — nothing is bound right now"}.`,
+      retryable: false,
+      available_clusters: bound,
+    };
+  }
+
+  return {
+    error: true,
+    reason: "cluster_unavailable",
+    message: raw,
+    retryable: true,
+    available_clusters: bound,
+  };
+}
+
 /**
  * Ensure a host's credential file is materialized on disk before host_exec /
  * host_script tries to read it, and RETURN the resolved registry entry. Throws

--- a/src/tools/infra/ensure-kubeconfigs.ts
+++ b/src/tools/infra/ensure-kubeconfigs.ts
@@ -81,6 +81,22 @@ export async function classifyClusterFailure(
     };
   }
 
+  // An empty list settles it with or without a name: the tool may have omitted
+  // `cluster` and let ensureClusterForTool auto-select, but there was nothing to
+  // select. Requiring a name here left that path reporting a retryable fault.
+  if (bound.length === 0) {
+    return {
+      error: true,
+      reason: "cluster_not_bound",
+      message:
+        `No cluster is bound to this agent, so no kubeconfig can be materialized. ` +
+        `Retrying will not help, and node/pod tools sharing this binding will fail ` +
+        `the same way. Ask the operator to bind a cluster in the Portal.`,
+      retryable: false,
+      available_clusters: [],
+    };
+  }
+
   if (clusterName && !bound.includes(clusterName)) {
     return {
       error: true,
@@ -88,7 +104,7 @@ export async function classifyClusterFailure(
       message:
         `Cluster "${clusterName}" is not bound to this agent, so its kubeconfig ` +
         `cannot be materialized. Retrying will not help. Call cluster_list to see ` +
-        `what is bound${bound.length ? "" : " — nothing is bound right now"}.`,
+        `what is bound.`,
       retryable: false,
       available_clusters: bound,
     };

--- a/src/tools/infra/kubectl-sanitize.test.ts
+++ b/src/tools/infra/kubectl-sanitize.test.ts
@@ -506,6 +506,8 @@ describe("sanitizeJSON", () => {
       "        headers:",
       "          Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc.def",
       "        token: ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      // Key NOT in the vocabulary: only the value patterns can catch this one.
+      "        upstream: sk-proj-abcdefghijklmnop",
       "    scrape_interval: 30s",
     ].join("\n");
 
@@ -523,6 +525,10 @@ describe("sanitizeJSON", () => {
       expect(out).not.toContain("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9");
       expect(out).not.toContain("eyJhbGciOiJIUzI1NiJ9");
       expect(out).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+      // The one whose KEY is not in the vocabulary — this is what actually
+      // exercises the value patterns on a prefixed line. Without it every
+      // assertion above passes on key-name matching alone.
+      expect(out).not.toContain("sk-proj-abcdefghijklmnop");
     });
 
     it("keeps the rest of the file diagnosable", () => {
@@ -537,6 +543,24 @@ describe("sanitizeJSON", () => {
       // Names WHICH setting was redacted, and does not break the YAML block.
       expect(out).toContain("      credentials: **REDACTED**");
       expect(out).toContain("          Authorization: **REDACTED**");
+      expect(out).toContain("        upstream: **REDACTED**");
+    });
+
+    it("keeps a nested mapping's field names while redacting their values", () => {
+      // `authorization:` opens a mapping — the key line has no value to redact,
+      // and dropping the whole block would hide which fields were configured.
+      const out = sanitizeEntry(promConfig);
+      expect(out).toContain("    authorization:");
+      expect(out).toContain("credentials: **REDACTED**");
+    });
+
+    it("redacts a nested value whose own field name is innocuous", () => {
+      // The parent key already said this is a credential region; judging `inner`
+      // on its own merits (not in the vocabulary, value not token-shaped) leaks it.
+      const out = sanitizeEntry("password:\n  inner: plain_value\nmode: on\n");
+      expect(out).not.toContain("plain_value");
+      expect(out).toContain("inner: **REDACTED**");
+      expect(out).toContain("mode: on");
     });
 
     it("drops the whole entry for a multi-line PEM block", () => {
@@ -547,6 +571,65 @@ describe("sanitizeJSON", () => {
       expect(out).toBe("**REDACTED**");
       expect(out).not.toContain("MIIEvQIBADANBgkq");
       expect(out).not.toContain("hkiG9w0BAQEFAASC");
+    });
+
+    // Each of these shapes leaked in full while the footer claimed otherwise.
+    it("redacts a YAML block scalar's body, not just its key line", () => {
+      const out = sanitizeEntry("api_token: |\n  ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nlog: debug\n");
+      expect(out).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+      expect(out).toContain("log: debug");
+    });
+
+    it("redacts a folded block scalar too", () => {
+      const out = sanitizeEntry("secret_blob: >-\n  hunter2\n  more\nmode: on\n");
+      expect(out).not.toContain("hunter2");
+      expect(out).toContain("mode: on");
+    });
+
+    it("redacts a YAML sequence entry", () => {
+      const out = sanitizeEntry("users:\n  - password: hunter2\n  - name: bob\n");
+      expect(out).not.toContain("hunter2");
+      expect(out).toContain("name: bob");
+    });
+
+    it("redacts a quoted key with no surrounding space", () => {
+      const out = sanitizeEntry('password:hunter2\nmode:strict\n');
+      expect(out).not.toContain("hunter2");
+      expect(out).toContain("mode:strict");
+    });
+
+    it("redacts an INI assignment with spaces around =", () => {
+      const out = sanitizeEntry("aws_secret_access_key = AKIAIOSFODNN7EXAMPLE\nregion = us-east-1\n");
+      expect(out).not.toContain("AKIAIOSFODNN7EXAMPLE");
+      expect(out).toContain("region = us-east-1");
+    });
+
+    it("keeps a connection string redacted despite the key/value split", () => {
+      // `postgresql://…` splits into key `postgresql` + `//user:pass@…`, which no
+      // longer matches the ://-anchored pattern — the raw line must be checked too.
+      const out = sanitizeEntry("postgresql://user:pass@db:5432/mydb");
+      expect(out).not.toContain("user:pass");
+    });
+
+    it("walks a JSON payload's nested keys", () => {
+      const out = sanitizeEntry(
+        '{"log":"debug","auth":{"token":"plain-secret-value"},"items":[{"password":"hunter2"}]}',
+      );
+      expect(out).not.toContain("plain-secret-value");
+      expect(out).not.toContain("hunter2");
+      expect(out).toContain("debug");
+    });
+
+    it("drops an unparseable JSON payload that names a sensitive key", () => {
+      // A compact object puts several pairs on one line; if we could not parse it
+      // we cannot claim a line-oriented pass rewrote all of them.
+      const out = sanitizeEntry('{"token":"abc","trunc');
+      expect(out).toBe("**REDACTED**");
+    });
+
+    it("leaves unparseable JSON alone when no sensitive key is named", () => {
+      const out = sanitizeEntry('{"log":"debug","trunc');
+      expect(out).toContain("debug");
     });
   });
 });
@@ -563,6 +646,9 @@ describe("SENSITIVE_ENV_NAME_PATTERNS", () => {
     "PRIVATE_KEY", "PRIVATE-KEY",
     "SSH_KEY", "ENCRYPTION_KEY",
     "Authorization", "authorization", "HTTP_AUTHORIZATION", "X-Authorization",
+    // Kubernetes names key material with a dot; kubeconfig-shaped and registry
+    // credentials show up verbatim in ConfigMaps.
+    "tls.key", "client-key-data", "jwt", "JWT_SECRET", ".dockerconfigjson", "dockercfg",
   ];
   const shouldNotMatch = [
     "LOG_LEVEL", "NODE_ENV", "JAVA_OPTS", "PORT", "HOST",
@@ -570,6 +656,8 @@ describe("SENSITIVE_ENV_NAME_PATTERNS", () => {
     // kube-apiserver diagnostic flags must stay readable — the pattern is
     // end-anchored precisely so these survive.
     "authorization-mode", "authorization-webhook-config-file",
+    // The public half of a TLS pair, and a key COUNT rather than key material.
+    "tls.crt", "ca.crt", "keydata_version",
   ];
 
   for (const name of shouldMatch) {

--- a/src/tools/infra/kubectl-sanitize.test.ts
+++ b/src/tools/infra/kubectl-sanitize.test.ts
@@ -465,6 +465,89 @@ describe("sanitizeJSON", () => {
       const result = sanitizeJSON(input, "secret");
       expect(result).toContain("⚠️ Sensitive values have been redacted");
     });
+
+    // A redaction claim on untouched output is worse than no claim: it invites
+    // the reader to treat the text as safe when nothing was checked off.
+    it("does NOT claim redaction when nothing was redacted", () => {
+      const input = JSON.stringify({
+        kind: "ConfigMap",
+        data: { "app.conf": "log_level: debug\nreplicas: 3" },
+      });
+      const result = sanitizeJSON(input, "configmap");
+      expect(result).not.toContain("redacted");
+      expect(result).toContain("log_level: debug");
+    });
+
+    it("still claims redaction when only a later item was redacted", () => {
+      const input = JSON.stringify({
+        kind: "List",
+        items: [
+          { kind: "ConfigMap", data: { "clean.conf": "a: 1" } },
+          { kind: "ConfigMap", data: { "creds.conf": "token: ghp_aaaaaaaaaaaaaaaaaaaa" } },
+        ],
+      });
+      const result = sanitizeJSON(input, "configmap");
+      expect(result).toContain("⚠️ Sensitive values have been redacted");
+      expect(result).toContain("**REDACTED**");
+    });
+  });
+
+  // A ConfigMap entry is normally an entire config FILE, and its secrets are
+  // named by the keys INSIDE it. Matching the file as one blob checks neither
+  // those inner keys nor the ^-anchored value patterns, so everything leaked.
+  describe("ConfigMap — whole-file entries are redacted line by line", () => {
+    const promConfig = [
+      "scrape_configs:",
+      "  - job_name: node",
+      "    authorization:",
+      "      credentials: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig",
+      "    remote_write:",
+      "      - url: https://push.example.com",
+      "        headers:",
+      "          Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc.def",
+      "        token: ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "    scrape_interval: 30s",
+    ].join("\n");
+
+    const sanitizeEntry = (value: string): string => {
+      const input = JSON.stringify({
+        kind: "ConfigMap",
+        data: { "prometheus.yml": value },
+      });
+      const result = sanitizeJSON(input, "configmap");
+      return JSON.parse(result.split("\n\n⚠️")[0]).data["prometheus.yml"];
+    };
+
+    it("redacts every secret inside the file", () => {
+      const out = sanitizeEntry(promConfig);
+      expect(out).not.toContain("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9");
+      expect(out).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+      expect(out).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    });
+
+    it("keeps the rest of the file diagnosable", () => {
+      const out = sanitizeEntry(promConfig);
+      expect(out).toContain("job_name: node");
+      expect(out).toContain("scrape_interval: 30s");
+      expect(out).toContain("url: https://push.example.com");
+    });
+
+    it("keeps the indent and key name of a redacted line", () => {
+      const out = sanitizeEntry(promConfig);
+      // Names WHICH setting was redacted, and does not break the YAML block.
+      expect(out).toContain("      credentials: **REDACTED**");
+      expect(out).toContain("          Authorization: **REDACTED**");
+    });
+
+    it("drops the whole entry for a multi-line PEM block", () => {
+      // Only the BEGIN line matches, so a per-line pass would leak the body.
+      const out = sanitizeEntry(
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIEvQIBADANBgkq\nhkiG9w0BAQEFAASC\n-----END RSA PRIVATE KEY-----",
+      );
+      expect(out).toBe("**REDACTED**");
+      expect(out).not.toContain("MIIEvQIBADANBgkq");
+      expect(out).not.toContain("hkiG9w0BAQEFAASC");
+    });
   });
 });
 
@@ -479,10 +562,14 @@ describe("SENSITIVE_ENV_NAME_PATTERNS", () => {
     "API_KEY", "APIKEY", "API-KEY",
     "PRIVATE_KEY", "PRIVATE-KEY",
     "SSH_KEY", "ENCRYPTION_KEY",
+    "Authorization", "authorization", "HTTP_AUTHORIZATION", "X-Authorization",
   ];
   const shouldNotMatch = [
     "LOG_LEVEL", "NODE_ENV", "JAVA_OPTS", "PORT", "HOST",
     "KEY_COUNT", "KEYBOARD_LAYOUT", "KEY_PREFIX",
+    // kube-apiserver diagnostic flags must stay readable — the pattern is
+    // end-anchored precisely so these survive.
+    "authorization-mode", "authorization-webhook-config-file",
   ];
 
   for (const name of shouldMatch) {
@@ -508,6 +595,10 @@ describe("SENSITIVE_VALUE_PATTERNS", () => {
     "ghp_abc123def456",
     "gho_abc123",
     "glpat-xyz789",
+    // Positional backstop: caught wherever it sits on the line, whatever the
+    // key is called — the ^-anchored patterns above cannot see it there.
+    "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc.def",
+    "          authorization: bearer abcdefghijklmnopqrstuvwxyz",
   ];
   const shouldNotMatch = [
     "https://api.example.com",
@@ -516,6 +607,8 @@ describe("SENSITIVE_VALUE_PATTERNS", () => {
     "42",
     "us-east-1",
     "server { listen 80; }",
+    // Too short to be a credential, and the word alone must not trigger.
+    "Bearer token",
   ];
 
   for (const value of shouldMatch) {

--- a/src/tools/infra/kubectl-sanitize.ts
+++ b/src/tools/infra/kubectl-sanitize.ts
@@ -11,7 +11,11 @@ export type SensitiveResourceType = "secret" | "configmap" | "pod";
 
 // ── Sensitive pattern constants ──────────────────────────────────────
 
-/** Pod env name patterns — word-boundary matching to avoid false positives */
+/**
+ * Key-name patterns. This is the layer that does most of the actual work: real
+ * secrets almost always sit behind a telling key name, whereas the value
+ * patterns below only fire on a few recognisable shapes.
+ */
 export const SENSITIVE_ENV_NAME_PATTERNS: RegExp[] = [
   /password/i,
   /secret/i,
@@ -20,6 +24,10 @@ export const SENSITIVE_ENV_NAME_PATTERNS: RegExp[] = [
   /api[_-]?key/i,
   /private[_-]?key/i,
   /[-_]key$/i,           // SSH_KEY, ENCRYPTION_KEY (not KEY_COUNT)
+  // Anchored at the end so an HTTP header (Authorization, HTTP_AUTHORIZATION)
+  // matches while kube-apiserver's diagnostic flags (authorization-mode,
+  // authorization-webhook-config-file) stay readable.
+  /(^|[_-])authorization$/i,
 ];
 
 /** ConfigMap key name patterns */
@@ -29,17 +37,115 @@ export const SENSITIVE_KEY_PATTERNS: RegExp[] = [
   /token/i,
   /credential/i,
   /private/i,
+  /(^|[_-])authorization$/i,
 ];
 
-/** ConfigMap value patterns — match regardless of key name */
+/**
+ * Value patterns — match regardless of key name.
+ *
+ * The `^`-anchored ones only fire when the token is the entire value (an env var,
+ * a Secret entry). They deliberately do NOT catch `credentials: eyJ…` inside a
+ * config file, because the indent and the `key: ` prefix push the token off the
+ * line start — that case is covered by redacting such values line by line, where
+ * the inner key name is what matches. Adding the `m` flag does not change this.
+ */
 export const SENSITIVE_VALUE_PATTERNS: RegExp[] = [
   /:\/\/[^:]+:[^@]+@/,            // connection string: ://user:pass@host
-  /^eyJ[A-Za-z0-9_-]{10,}/,       // JWT token
+  /^eyJ[A-Za-z0-9_-]{10,}/,       // JWT token (bare value)
   /-----BEGIN .* KEY-----/,        // PEM private key
-  /^(sk-|ghp_|gho_|glpat-)/,      // known API token prefixes
+  /^(sk-|ghp_|gho_|glpat-)/,      // known API token prefixes (bare value)
+  // Positional backstop for the header form, independent of the key name: a
+  // bearer credential is worth more than the log line it costs us.
+  /\bBearer\s+[\w\-._~+/]{16,}/i,
 ];
 
+/**
+ * The one value pattern above whose secret spans MULTIPLE lines. Callers holding
+ * a complete value must drop it whole rather than redact line by line, since only
+ * the BEGIN line matches and the base64 body under it would survive.
+ *
+ * Not applicable to the streaming (line-safe) redactor, which never sees more
+ * than one line at a time.
+ */
+const PEM_BLOCK_RE = /-----BEGIN .* KEY-----/;
+
 const REDACTED = "**REDACTED**";
+
+/**
+ * Advisory footer for the line-level redactor. Only ever appended when something
+ * was actually redacted — a claim of redaction on untouched output is worse than
+ * no claim at all, because it invites the reader to treat the text as safe.
+ *
+ * Exported so streaming sanitization (background bash) can strip the per-batch
+ * duplicates; the inline REDACTED markers carry the security property.
+ */
+export const REDACTION_NOTICE = "\n\n⚠️ Sensitive values have been redacted for security.";
+
+// ── Line-level redaction ─────────────────────────────────────────────
+
+/**
+ * Redact sensitive content line by line.
+ *
+ * Lives here rather than in output-sanitizer.ts because the structural
+ * (JSON) sanitizers need it too: a ConfigMap entry is typically a whole config
+ * FILE, whose secrets are identified by the key names INSIDE it, which only a
+ * per-line pass can see. output-sanitizer.ts re-exports the public wrapper.
+ *
+ * Returns whether anything changed so callers can decide about the footer.
+ */
+export function redactLines(text: string): { text: string; redacted: boolean } {
+  let redacted = false;
+
+  const result = text.split("\n").map((line) => {
+    // Value patterns first (JWT, PEM, connection string, bearer header) — a value
+    // that LOOKS like a credential is redacted whatever its key is called.
+    for (const pattern of SENSITIVE_VALUE_PATTERNS) {
+      if (pattern.test(line)) {
+        redacted = true;
+        // Keep the indent and key name when the line has that shape: the reader
+        // still learns WHICH setting was redacted, and a flush-left REDACTED
+        // would break the indentation of the surrounding YAML block.
+        const shaped = line.match(/^(\s*[A-Za-z_][A-Za-z0-9_.-]*(?::\s+|=))/);
+        return shaped ? `${shaped[1]}${REDACTED}` : REDACTED;
+      }
+    }
+
+    // KEY=VALUE
+    const eqMatch = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)/);
+    if (eqMatch) {
+      const key = eqMatch[1];
+      if (SENSITIVE_ENV_NAME_PATTERNS.some((p) => p.test(key))) {
+        redacted = true;
+        return `${key}=${REDACTED}`;
+      }
+    }
+
+    // KEY: VALUE (YAML-like) — the indent is preserved so a redacted line does
+    // not break the surrounding structure for the reader.
+    const colonMatch = line.match(/^(\s*[A-Za-z_][A-Za-z0-9_.-]*):\s+(.*)/);
+    if (colonMatch) {
+      const key = colonMatch[1].trim();
+      if (SENSITIVE_ENV_NAME_PATTERNS.some((p) => p.test(key))) {
+        redacted = true;
+        return `${colonMatch[1]}: ${REDACTED}`;
+      }
+    }
+
+    return line;
+  });
+
+  return { text: result.join("\n"), redacted };
+}
+
+/**
+ * Line-level redaction with the advisory footer. The sanitizer used for every
+ * non-JSON kubectl format, for file-reading commands, and as the pipeline
+ * fallback in restricted-bash.
+ */
+export function redactSensitiveContent(output: string): string {
+  const { text, redacted } = redactLines(output);
+  return redacted ? text + REDACTION_NOTICE : text;
+}
 
 // ── Resource alias mapping ───────────────────────────────────────────
 
@@ -184,13 +290,14 @@ export function sanitizeJSON(
     }, null, 2);
   }
 
-  const items = getItems(obj);
-  for (const item of items) {
-    sanitizeObject(item, resourceType);
+  let redacted = false;
+  for (const item of getItems(obj)) {
+    // Not `redacted ||=` — that short-circuits and skips the remaining items.
+    if (sanitizeObject(item, resourceType)) redacted = true;
   }
 
   const sanitized = JSON.stringify(obj, null, 2);
-  return sanitized + "\n\n⚠️ Sensitive values have been redacted for security.";
+  return redacted ? sanitized + REDACTION_NOTICE : sanitized;
 }
 
 /** Get items array from a single object or a List response */
@@ -201,55 +308,90 @@ function getItems(obj: any): any[] {
   return [obj];
 }
 
-/** Sanitize a single Kubernetes object in place */
-function sanitizeObject(obj: any, resourceType: SensitiveResourceType): void {
+/** Sanitize a single Kubernetes object in place; returns whether anything was redacted. */
+function sanitizeObject(obj: any, resourceType: SensitiveResourceType): boolean {
   switch (resourceType) {
-    case "secret":
-      redactAllValues(obj, "data");
-      redactAllValues(obj, "stringData");
-      break;
+    case "secret": {
+      // Both calls must run — `||` would short-circuit and leave stringData raw.
+      const data = redactAllValues(obj, "data");
+      const stringData = redactAllValues(obj, "stringData");
+      return data || stringData;
+    }
 
-    case "configmap":
-      redactByPattern(obj, "data");
-      redactByPattern(obj, "binaryData");
-      break;
+    case "configmap": {
+      const data = redactByPattern(obj, "data");
+      const binaryData = redactByPattern(obj, "binaryData");
+      return data || binaryData;
+    }
 
     case "pod":
-      sanitizePodEnv(obj);
-      break;
+      return sanitizePodEnv(obj);
   }
 }
 
 /** Unconditionally replace all values in obj[field] with REDACTED */
-function redactAllValues(obj: any, field: string): void {
-  if (obj[field] && typeof obj[field] === "object") {
-    for (const key of Object.keys(obj[field])) {
-      obj[field][key] = REDACTED;
-    }
+function redactAllValues(obj: any, field: string): boolean {
+  if (!obj[field] || typeof obj[field] !== "object") return false;
+  let redacted = false;
+  for (const key of Object.keys(obj[field])) {
+    obj[field][key] = REDACTED;
+    redacted = true;
   }
+  return redacted;
 }
 
-/** Redact ConfigMap entries matching sensitive key or value patterns */
-function redactByPattern(obj: any, field: string): void {
-  if (!obj[field] || typeof obj[field] !== "object") return;
+/**
+ * Redact ConfigMap entries.
+ *
+ * A sensitive data KEY drops the whole entry. Otherwise the value is redacted
+ * line by line, because a ConfigMap entry is usually an entire config file
+ * (`prometheus.yml` → hundreds of lines) whose secrets are named by the keys
+ * INSIDE it. Testing the file as one blob — the previous behaviour — checks
+ * neither those inner key names nor the `^`-anchored value patterns against
+ * individual lines, so every secret in it survived.
+ *
+ * Per-line also beats dropping the whole entry: only the offending line becomes
+ * REDACTED, so the rest of the config stays diagnosable.
+ */
+function redactByPattern(obj: any, field: string): boolean {
+  if (!obj[field] || typeof obj[field] !== "object") return false;
 
+  let redacted = false;
   for (const key of Object.keys(obj[field])) {
     const value = obj[field][key];
     if (typeof value !== "string") continue;
 
-    const keyMatches = SENSITIVE_KEY_PATTERNS.some((p) => p.test(key));
-    const valueMatches = SENSITIVE_VALUE_PATTERNS.some((p) => p.test(value));
-
-    if (keyMatches || valueMatches) {
+    if (SENSITIVE_KEY_PATTERNS.some((p) => p.test(key))) {
       obj[field][key] = REDACTED;
+      redacted = true;
+      continue;
+    }
+
+    // A PEM block is ONE secret spanning many lines, and only its BEGIN line
+    // carries a marker — so redacting line by line would drop that line and leak
+    // the base64 body beneath it. Such an entry is a key/cert file with no
+    // diagnostic value to preserve, so the whole entry goes.
+    if (PEM_BLOCK_RE.test(value)) {
+      obj[field][key] = REDACTED;
+      redacted = true;
+      continue;
+    }
+
+    // Everything else is treated as a config file: the remaining value patterns
+    // all match within a single line, so a per-line pass loses nothing.
+    const lines = redactLines(value);
+    if (lines.redacted) {
+      obj[field][key] = lines.text;
+      redacted = true;
     }
   }
+  return redacted;
 }
 
 /** Redact Pod env vars matching sensitive name patterns */
-function sanitizePodEnv(obj: any): void {
+function sanitizePodEnv(obj: any): boolean {
   const spec = obj.spec;
-  if (!spec) return;
+  if (!spec) return false;
 
   const containerArrays = [
     spec.containers,
@@ -257,6 +399,7 @@ function sanitizePodEnv(obj: any): void {
     spec.ephemeralContainers,
   ];
 
+  let redacted = false;
   for (const containers of containerArrays) {
     if (!Array.isArray(containers)) continue;
     for (const container of containers) {
@@ -269,8 +412,10 @@ function sanitizePodEnv(obj: any): void {
         );
         if (nameMatches) {
           envVar.value = REDACTED;
+          redacted = true;
         }
       }
     }
   }
+  return redacted;
 }

--- a/src/tools/infra/kubectl-sanitize.ts
+++ b/src/tools/infra/kubectl-sanitize.ts
@@ -23,53 +23,129 @@ export const SENSITIVE_ENV_NAME_PATTERNS: RegExp[] = [
   /credential/i,
   /api[_-]?key/i,
   /private[_-]?key/i,
-  /[-_]key$/i,           // SSH_KEY, ENCRYPTION_KEY (not KEY_COUNT)
+  // SSH_KEY, ENCRYPTION_KEY, tls.key (not KEY_COUNT). The `.` form is how
+  // Kubernetes names key material in Secret/ConfigMap data.
+  /[-_.]key$/i,
   // Anchored at the end so an HTTP header (Authorization, HTTP_AUTHORIZATION)
   // matches while kube-apiserver's diagnostic flags (authorization-mode,
   // authorization-webhook-config-file) stay readable.
   /(^|[_-])authorization$/i,
+  /(^|[_-])jwt([_-]|$)/i,          // jwt, JWT_SECRET, id_jwt
+  /key[_-]?data$/i,                // client-key-data (kubeconfig-shaped values)
+  /dockercfg|dockerconfigjson/i,   // registry pull credentials
 ];
 
-/** ConfigMap key name patterns */
+/**
+ * ConfigMap data-key patterns — a data key matching these means the ENTIRE entry
+ * is a secret (a `password` file), not a config file with a secret in it.
+ *
+ * Deliberately a superset relationship with the key-name patterns above: those
+ * are also applied to keys INSIDE an entry, so anything recognised there is
+ * recognised here too.
+ */
 export const SENSITIVE_KEY_PATTERNS: RegExp[] = [
-  /password/i,
-  /secret/i,
-  /token/i,
-  /credential/i,
-  /private/i,
-  /(^|[_-])authorization$/i,
+  ...SENSITIVE_ENV_NAME_PATTERNS,
+  /private/i,            // broader than private_key: private.pem, privateCert
 ];
 
 /**
  * Value patterns — match regardless of key name.
  *
- * The `^`-anchored ones only fire when the token is the entire value (an env var,
- * a Secret entry). They deliberately do NOT catch `credentials: eyJ…` inside a
- * config file, because the indent and the `key: ` prefix push the token off the
- * line start — that case is covered by redacting such values line by line, where
- * the inner key name is what matches. Adding the `m` flag does not change this.
+ * The `^`-anchored ones assume the token is the WHOLE value, so they are tested
+ * against the value segment of a parsed line (see splitKeyValue), never against
+ * the raw line: indentation and a `key: ` prefix would push the token off the
+ * line start and silently defeat them.
  */
 export const SENSITIVE_VALUE_PATTERNS: RegExp[] = [
   /:\/\/[^:]+:[^@]+@/,            // connection string: ://user:pass@host
-  /^eyJ[A-Za-z0-9_-]{10,}/,       // JWT token (bare value)
-  /-----BEGIN .* KEY-----/,        // PEM private key
-  /^(sk-|ghp_|gho_|glpat-)/,      // known API token prefixes (bare value)
+  /^eyJ[A-Za-z0-9_-]{10,}/,       // JWT token
+  /-----BEGIN [^-]*-----/,         // PEM header (block handled separately)
+  /^(sk-|ghp_|gho_|glpat-)/,      // known API token prefixes
   // Positional backstop for the header form, independent of the key name: a
   // bearer credential is worth more than the log line it costs us.
   /\bBearer\s+[\w\-._~+/]{16,}/i,
 ];
 
-/**
- * The one value pattern above whose secret spans MULTIPLE lines. Callers holding
- * a complete value must drop it whole rather than redact line by line, since only
- * the BEGIN line matches and the base64 body under it would survive.
- *
- * Not applicable to the streaming (line-safe) redactor, which never sees more
- * than one line at a time.
- */
-const PEM_BLOCK_RE = /-----BEGIN .* KEY-----/;
-
 const REDACTED = "**REDACTED**";
+
+// ── Line shapes ──────────────────────────────────────────────────────
+
+/**
+ * One `key <sep> value` line, in any of the shapes a ConfigMap payload uses:
+ * YAML (`key: v`, `  - key: v`), JSON (`"key": "v"`), properties/INI
+ * (`key=v`, `key = v`), and the no-space `key:v` that YAML forbids but
+ * .properties and .env files produce anyway.
+ *
+ * Group 1 indent + optional list marker, 2 quote, 3 key, 4 separator, 5 value.
+ * The backreference makes the closing quote match the opening one.
+ */
+const KV_LINE_RE = /^(\s*(?:-\s+)?)(["']?)([A-Za-z_][\w.\-]*)\2(\s*[:=]\s*)(.*)$/;
+
+/** A YAML block scalar header: `|`, `>`, `|-`, `>+`, `|2`, with optional comment. */
+const BLOCK_SCALAR_RE = /^[|>][-+]?\d*\s*(?:#.*)?$/;
+
+const PEM_BEGIN_RE = /-----BEGIN [^-]*-----/;
+const PEM_END_RE = /-----END [^-]*-----/;
+
+interface SplitLine {
+  /** Indent, list marker, quoted key and separator — reusable verbatim. */
+  prefix: string;
+  /** Bare key name, quotes stripped. */
+  key: string;
+  /** Value segment, quotes stripped. */
+  value: string;
+  /** Leading whitespace width, for deciding what a block scalar owns. */
+  indent: number;
+}
+
+function splitKeyValue(line: string): SplitLine | null {
+  const m = KV_LINE_RE.exec(line);
+  if (!m) return null;
+  const [, lead, quote, key, sep, rawValue] = m;
+  return {
+    prefix: `${lead}${quote}${key}${quote}${sep}`,
+    key,
+    value: unquote(rawValue.trim()),
+    indent: lead.length,
+  };
+}
+
+/** Strip one layer of matching quotes, and a trailing JSON comma. */
+function unquote(value: string): string {
+  const noComma = value.replace(/,$/, "");
+  const m = /^(["'])(.*)\1$/.exec(noComma);
+  return m ? m[2] : noComma;
+}
+
+function isSensitiveKeyName(key: string): boolean {
+  return SENSITIVE_ENV_NAME_PATTERNS.some((p) => p.test(key));
+}
+
+function looksLikeSensitiveValue(value: string): boolean {
+  return SENSITIVE_VALUE_PATTERNS.some((p) => p.test(value));
+}
+
+/**
+ * Redact one line in isolation. Returns null when the line is untouched.
+ *
+ * Both halves are judged separately: a telling key name (`password`) redacts
+ * whatever it holds, and a value that looks like a credential (`eyJ…`) is
+ * redacted whatever its key is called. The prefix is preserved so the reader
+ * still learns WHICH setting went away and the surrounding indentation survives.
+ *
+ * Falls back to matching the raw line, because some patterns are positional and
+ * a key/value split can straddle them: `postgresql://user:pass@host` splits into
+ * key `postgresql` plus `//user:pass@host`, which the connection-string pattern
+ * (anchored on `://`) no longer matches. When the split turns out not to fit the
+ * line, the whole line goes rather than guessing where its value began.
+ */
+function redactOneLine(line: string): string | null {
+  const split = splitKeyValue(line);
+  if (split && (isSensitiveKeyName(split.key) || looksLikeSensitiveValue(split.value))) {
+    return `${split.prefix}${REDACTED}`;
+  }
+  return looksLikeSensitiveValue(line.trim()) ? REDACTED : null;
+}
 
 /**
  * Advisory footer for the line-level redactor. Only ever appended when something
@@ -84,66 +160,139 @@ export const REDACTION_NOTICE = "\n\n⚠️ Sensitive values have been redacted 
 // ── Line-level redaction ─────────────────────────────────────────────
 
 /**
- * Redact sensitive content line by line.
+ * Redact line by line, with NO state carried between lines.
  *
- * Lives here rather than in output-sanitizer.ts because the structural
- * (JSON) sanitizers need it too: a ConfigMap entry is typically a whole config
- * FILE, whose secrets are identified by the key names INSIDE it, which only a
- * per-line pass can see. output-sanitizer.ts re-exports the public wrapper.
- *
- * Returns whether anything changed so callers can decide about the footer.
+ * This is the line-safe primitive: the streaming sanitizer (background bash)
+ * applies it to whatever complete lines a batch happens to contain, so it must
+ * not depend on having seen an earlier line. That also caps what it can do — a
+ * secret whose body sits on the lines BELOW its key is invisible here. Callers
+ * holding a whole document must use redactDocument instead.
  */
 export function redactLines(text: string): { text: string; redacted: boolean } {
   let redacted = false;
-
   const result = text.split("\n").map((line) => {
-    // Value patterns first (JWT, PEM, connection string, bearer header) — a value
-    // that LOOKS like a credential is redacted whatever its key is called.
-    for (const pattern of SENSITIVE_VALUE_PATTERNS) {
-      if (pattern.test(line)) {
-        redacted = true;
-        // Keep the indent and key name when the line has that shape: the reader
-        // still learns WHICH setting was redacted, and a flush-left REDACTED
-        // would break the indentation of the surrounding YAML block.
-        const shaped = line.match(/^(\s*[A-Za-z_][A-Za-z0-9_.-]*(?::\s+|=))/);
-        return shaped ? `${shaped[1]}${REDACTED}` : REDACTED;
-      }
-    }
-
-    // KEY=VALUE
-    const eqMatch = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)/);
-    if (eqMatch) {
-      const key = eqMatch[1];
-      if (SENSITIVE_ENV_NAME_PATTERNS.some((p) => p.test(key))) {
-        redacted = true;
-        return `${key}=${REDACTED}`;
-      }
-    }
-
-    // KEY: VALUE (YAML-like) — the indent is preserved so a redacted line does
-    // not break the surrounding structure for the reader.
-    const colonMatch = line.match(/^(\s*[A-Za-z_][A-Za-z0-9_.-]*):\s+(.*)/);
-    if (colonMatch) {
-      const key = colonMatch[1].trim();
-      if (SENSITIVE_ENV_NAME_PATTERNS.some((p) => p.test(key))) {
-        redacted = true;
-        return `${colonMatch[1]}: ${REDACTED}`;
-      }
-    }
-
-    return line;
+    const replaced = redactOneLine(line);
+    if (replaced === null) return line;
+    redacted = true;
+    return replaced;
   });
-
   return { text: result.join("\n"), redacted };
 }
 
 /**
- * Line-level redaction with the advisory footer. The sanitizer used for every
- * non-JSON kubectl format, for file-reading commands, and as the pipeline
- * fallback in restricted-bash.
+ * Redact a complete document, including secrets that span several lines.
+ *
+ * Two shapes need to look past the current line, and both were leaking their
+ * body while the key line above them was dutifully redacted — the footer then
+ * claimed the output was clean:
+ *
+ *   api_token: |            -----BEGIN RSA PRIVATE KEY-----
+ *     ghp_AAAA…               MIIEvQIBADANBgkq…
+ *
+ * A block scalar owns every following line indented deeper than its key, so the
+ * whole run collapses into one REDACTED. A PEM block runs to its END marker (or
+ * to the end of the text, since a truncated key is still a key).
+ */
+export function redactDocument(text: string): { text: string; redacted: boolean } {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let redacted = false;
+  /** Indent of a sensitive key whose value is a nested mapping, while inside it. */
+  let sensitiveMappingIndent: number | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Everything nested under a sensitive key is part of that secret, whatever
+    // the inner field names are: `password:` followed by `inner: hunter2` says
+    // nothing about `inner`, so judging that line on its own merits would leak it.
+    // Field names are kept — they say WHAT was configured, not what its value is.
+    if (sensitiveMappingIndent !== null) {
+      if (!ownedByBlock(line, sensitiveMappingIndent)) {
+        sensitiveMappingIndent = null;
+      } else if (line.trim() === "") {
+        out.push(line);
+        continue;
+      } else {
+        const nested = splitKeyValue(line);
+        // A nested mapping of its own has no value on this line to redact.
+        if (nested && nested.value === "") {
+          out.push(line);
+          continue;
+        }
+        out.push(nested ? `${nested.prefix}${REDACTED}` : REDACTED);
+        redacted = true;
+        continue;
+      }
+    }
+
+    // PEM: swallow through END. Checked before the key/value shapes because the
+    // BEGIN marker can itself sit after a key (`tls.key: -----BEGIN …`).
+    if (PEM_BEGIN_RE.test(line)) {
+      const split = splitKeyValue(line);
+      out.push(split ? `${split.prefix}${REDACTED}` : REDACTED);
+      redacted = true;
+      while (i < lines.length && !PEM_END_RE.test(lines[i])) i++;
+      continue;
+    }
+
+    const split = splitKeyValue(line);
+    if (split && (isSensitiveKeyName(split.key) || looksLikeSensitiveValue(split.value))) {
+      // A block scalar (`key: |`) puts the value on the lines below, where no key
+      // name marks it — the whole indented run collapses into this REDACTED.
+      if (BLOCK_SCALAR_RE.test(split.value)) {
+        out.push(`${split.prefix}${REDACTED}`);
+        redacted = true;
+        while (i + 1 < lines.length && ownedByBlock(lines[i + 1], split.indent)) i++;
+        continue;
+      }
+      // An empty value opens a nested mapping: nothing on THIS line to redact,
+      // and its children are pairs that match on their own keys.
+      if (split.value === "") {
+        out.push(line);
+        sensitiveMappingIndent = split.indent;
+        continue;
+      }
+      out.push(`${split.prefix}${REDACTED}`);
+      redacted = true;
+      continue;
+    }
+
+    const replaced = redactOneLine(line);
+    if (replaced !== null) {
+      out.push(replaced);
+      redacted = true;
+      continue;
+    }
+
+    out.push(line);
+  }
+
+  return { text: out.join("\n"), redacted };
+}
+
+/**
+ * Whether a line belongs to a block scalar opened at `keyIndent`. Blank lines
+ * inside a block are part of it; anything indented no deeper than the key ends it.
+ */
+function ownedByBlock(line: string, keyIndent: number): boolean {
+  if (line.trim() === "") return true;
+  const indent = line.length - line.trimStart().length;
+  return indent > keyIndent;
+}
+
+/**
+ * Whole-document redaction with the advisory footer. The sanitizer for every
+ * non-JSON kubectl format, for file-reading commands, and the pipeline fallback
+ * in restricted-bash.
+ *
+ * Uses redactDocument, so a PEM or block-scalar body is covered whenever the
+ * whole text is in hand. Under streaming the caller passes one batch at a time,
+ * where a block split across batches is inherently beyond reach — no worse than
+ * before, and the per-line layer still applies.
  */
 export function redactSensitiveContent(output: string): string {
-  const { text, redacted } = redactLines(output);
+  const { text, redacted } = redactDocument(output);
   return redacted ? text + REDACTION_NOTICE : text;
 }
 
@@ -343,15 +492,16 @@ function redactAllValues(obj: any, field: string): boolean {
 /**
  * Redact ConfigMap entries.
  *
- * A sensitive data KEY drops the whole entry. Otherwise the value is redacted
- * line by line, because a ConfigMap entry is usually an entire config file
- * (`prometheus.yml` → hundreds of lines) whose secrets are named by the keys
- * INSIDE it. Testing the file as one blob — the previous behaviour — checks
- * neither those inner key names nor the `^`-anchored value patterns against
- * individual lines, so every secret in it survived.
+ * A ConfigMap entry is usually an entire config FILE — the data key is a
+ * filename, the value is hundreds of lines — and its secrets are named by the
+ * keys INSIDE it. So the value is redacted as a document (or as a JSON tree),
+ * not tested as one blob: a blob test sees neither those inner key names nor the
+ * value patterns on any individual line, and everything in the file survives it.
  *
- * Per-line also beats dropping the whole entry: only the offending line becomes
- * REDACTED, so the rest of the config stays diagnosable.
+ * Per-entry granularity is preferred where it is safe, so only the offending
+ * line goes and the rest of the config stays diagnosable. Where it is NOT safe —
+ * a sensitive-looking payload we cannot parse and therefore cannot rewrite with
+ * confidence — the whole entry goes instead.
  */
 function redactByPattern(obj: any, field: string): boolean {
   if (!obj[field] || typeof obj[field] !== "object") return false;
@@ -361,31 +511,98 @@ function redactByPattern(obj: any, field: string): boolean {
     const value = obj[field][key];
     if (typeof value !== "string") continue;
 
+    // The data key itself names a secret → the whole entry is the secret.
     if (SENSITIVE_KEY_PATTERNS.some((p) => p.test(key))) {
       obj[field][key] = REDACTED;
       redacted = true;
       continue;
     }
 
-    // A PEM block is ONE secret spanning many lines, and only its BEGIN line
-    // carries a marker — so redacting line by line would drop that line and leak
-    // the base64 body beneath it. Such an entry is a key/cert file with no
-    // diagnostic value to preserve, so the whole entry goes.
-    if (PEM_BLOCK_RE.test(value)) {
-      obj[field][key] = REDACTED;
-      redacted = true;
+    // A JSON payload: walk the parsed tree so every nested key is judged, rather
+    // than hoping a line-oriented pass copes with compact one-line objects.
+    const asJson = redactJsonPayload(value);
+    if (asJson) {
+      if (asJson.redacted) {
+        obj[field][key] = asJson.text;
+        redacted = true;
+      }
       continue;
     }
 
-    // Everything else is treated as a config file: the remaining value patterns
-    // all match within a single line, so a per-line pass loses nothing.
-    const lines = redactLines(value);
-    if (lines.redacted) {
-      obj[field][key] = lines.text;
+    const doc = redactDocument(value);
+    if (doc.redacted) {
+      obj[field][key] = doc.text;
       redacted = true;
     }
   }
   return redacted;
+}
+
+/**
+ * Handle a ConfigMap value that is JSON.
+ *
+ * Returns null when the value is not JSON at all, so the caller falls through to
+ * document redaction. When it LOOKS like JSON but does not parse, the entry is
+ * dropped whole if it mentions a sensitive key: a compact `{"a":1,"token":"…"}`
+ * puts several pairs on one line, and a line-oriented pass over something we
+ * could not parse gives no confidence that it rewrote all of them.
+ */
+function redactJsonPayload(value: string): { text: string; redacted: boolean } | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return mentionsSensitiveKey(trimmed)
+      ? { text: REDACTED, redacted: true }
+      : null;
+  }
+
+  const redacted = redactJsonTree(parsed);
+  return { text: redacted ? JSON.stringify(parsed, null, 2) : value, redacted };
+}
+
+/** Redact values under sensitive keys anywhere in a parsed JSON tree, in place. */
+function redactJsonTree(node: unknown): boolean {
+  if (Array.isArray(node)) {
+    let redacted = false;
+    for (const item of node) {
+      if (redactJsonTree(item)) redacted = true;
+    }
+    return redacted;
+  }
+  if (!node || typeof node !== "object") return false;
+
+  let redacted = false;
+  const obj = node as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    if (typeof value === "string") {
+      if (isSensitiveKeyName(key) || looksLikeSensitiveValue(value)) {
+        obj[key] = REDACTED;
+        redacted = true;
+      }
+      continue;
+    }
+    if (isSensitiveKeyName(key) && value !== null && typeof value === "object") {
+      // A sensitive key holding a structure (e.g. `"auth": {…}`) — drop it all.
+      obj[key] = REDACTED;
+      redacted = true;
+      continue;
+    }
+    if (redactJsonTree(value)) redacted = true;
+  }
+  return redacted;
+}
+
+/** Whether unparseable text names a sensitive key, e.g. `"password":` or `token=`. */
+function mentionsSensitiveKey(text: string): boolean {
+  for (const m of text.matchAll(/["']?([A-Za-z_][\w.\-]*)["']?\s*[:=]/g)) {
+    if (isSensitiveKeyName(m[1])) return true;
+  }
+  return false;
 }
 
 /** Redact Pod env vars matching sensitive name patterns */

--- a/src/tools/infra/output-sanitizer.test.ts
+++ b/src/tools/infra/output-sanitizer.test.ts
@@ -285,6 +285,20 @@ describe("file-reading content sanitization", () => {
     expect(result).toContain("DB_HOST=localhost");
   });
 
+  it("redacts an Authorization header without touching authorization-mode", () => {
+    const action = analyzeOutput("cat", ["/app/config.yaml"]);
+    const output = [
+      "    authorization-mode: Node,RBAC",
+      "    headers:",
+      "      Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc.def",
+    ].join("\n");
+    const result = applySanitizer(output, action);
+    // apiserver flags are diagnostic, not credentials.
+    expect(result).toContain("authorization-mode: Node,RBAC");
+    expect(result).toContain("      Authorization: **REDACTED**");
+    expect(result).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+  });
+
   it("redacts YAML-style key: value with sensitive key name", () => {
     const action = analyzeOutput("cat", ["/app/config.yaml"]);
     const output = "database:\n  password: mysecret\n  host: localhost";

--- a/src/tools/infra/output-sanitizer.ts
+++ b/src/tools/infra/output-sanitizer.ts
@@ -15,10 +15,17 @@ import {
   detectSensitiveResource,
   getOutputFormat,
   sanitizeJSON,
+  redactSensitiveContent,
+  REDACTION_NOTICE,
   SENSITIVE_ENV_NAME_PATTERNS,
   SENSITIVE_VALUE_PATTERNS,
   type SensitiveResourceType,
 } from "./kubectl-sanitize.js";
+
+// The line-level redactor lives in kubectl-sanitize.ts — the structural
+// sanitizers there need it for ConfigMap entries that hold a whole config file.
+// Re-exported here because this module is its public entry point.
+export { redactSensitiveContent, REDACTION_NOTICE };
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -119,61 +126,6 @@ OUTPUT_RULES["kubectl"] = (args) => {
 // ── File-reading command rules ──────────────────────────────────────
 
 const REDACTED = "**REDACTED**";
-
-/**
- * Advisory footer appended (once) by the line-based redactors when anything was
- * redacted. Exported so streaming sanitization (background bash) can strip the
- * per-batch duplicates — the inline **REDACTED** markers carry the actual security
- * property; the footer is cosmetic.
- */
-export const REDACTION_NOTICE = "\n\n⚠️ Sensitive values have been redacted for security.";
-
-/**
- * Redact sensitive content from file-reading command output.
- * Scans each line for:
- *   - KEY=VALUE or KEY: VALUE where KEY matches SENSITIVE_ENV_NAME_PATTERNS
- *   - Values matching SENSITIVE_VALUE_PATTERNS (JWT, PEM, connection strings, etc.)
- */
-/** @public Used by restricted-bash pipeline fallback sanitization */
-export function redactSensitiveContent(output: string): string {
-  const lines = output.split("\n");
-  let redacted = false;
-
-  const result = lines.map((line) => {
-    // Check value patterns first (JWT, PEM, connection string, known prefixes)
-    for (const pattern of SENSITIVE_VALUE_PATTERNS) {
-      if (pattern.test(line)) {
-        redacted = true;
-        return REDACTED;
-      }
-    }
-
-    // Check KEY=VALUE format
-    const eqMatch = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)/);
-    if (eqMatch) {
-      const key = eqMatch[1];
-      if (SENSITIVE_ENV_NAME_PATTERNS.some((p) => p.test(key))) {
-        redacted = true;
-        return `${key}=${REDACTED}`;
-      }
-    }
-
-    // Check KEY: VALUE format (YAML-like)
-    const colonMatch = line.match(/^(\s*[A-Za-z_][A-Za-z0-9_.-]*):\s+(.*)/);
-    if (colonMatch) {
-      const key = colonMatch[1].trim();
-      if (SENSITIVE_ENV_NAME_PATTERNS.some((p) => p.test(key))) {
-        redacted = true;
-        return `${colonMatch[1]}: ${REDACTED}`;
-      }
-    }
-
-    return line;
-  });
-
-  const sanitized = result.join("\n");
-  return redacted ? sanitized + REDACTION_NOTICE : sanitized;
-}
 
 /** Rule for file-reading commands: always sanitize output */
 const fileReadingRule: OutputRuleFn = (_args) => ({

--- a/src/tools/infra/security-pipeline.test.ts
+++ b/src/tools/infra/security-pipeline.test.ts
@@ -3,6 +3,7 @@ import {
   preExecSecurity,
   postExecSecurity,
 } from "./security-pipeline.js";
+import { analyzeOutput } from "./output-sanitizer.js";
 
 // ── preExecSecurity ─────────────────────────────────────────────────
 
@@ -162,5 +163,89 @@ describe("postExecSecurity", () => {
       hasSensitiveKubectl: true,
     });
     expect(result).not.toContain("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9");
+  });
+});
+
+describe("postExecSecurity — a failed run survives a structural sanitizer", () => {
+  // What a `kubectl get pod ... -o json` resolves to: structural, not line-safe.
+  // Splicing "[exit code: N]" into the body made JSON.parse fail here, and the
+  // parse-failure branch suppresses everything — error, stdout and exit code.
+  const jsonAction = analyzeOutput("kubectl", ["get", "pod", "web-0", "-o", "json"])!;
+
+  it("resolves kubectl -o json on a pod to a structural sanitizer", () => {
+    expect(jsonAction).not.toBeNull();
+    expect(jsonAction.lineSafe).toBe(false);
+  });
+
+  it("keeps the exit code and stderr when a NotFound leaves the body empty", () => {
+    const result = postExecSecurity("", jsonAction, {
+      stderr: 'Error from server (NotFound): pods "web-0" not found',
+      exitCode: 1,
+    });
+    expect(result).toContain("(no output)");
+    expect(result).toContain("[exit code: 1]");
+    expect(result).toContain("NotFound");
+    expect(result).not.toContain("Failed to parse");
+  });
+
+  it("still redacts a JSON body that came back with a non-zero exit", () => {
+    const body = JSON.stringify({
+      kind: "Pod",
+      spec: { containers: [{ env: [{ name: "API_TOKEN", value: "s3cret" }] }] },
+    });
+    const result = postExecSecurity(body, jsonAction, { exitCode: 1 });
+    expect(result).not.toContain("s3cret");
+    expect(result).toContain("[exit code: 1]");
+    expect(result).not.toContain("Failed to parse");
+  });
+
+  it("never shows the sanitizer our own annotations", () => {
+    let seen: string | null = null;
+    const action = {
+      type: "sanitize" as const,
+      lineSafe: false,
+      sanitize: (s: string) => {
+        seen = s;
+        return s;
+      },
+    };
+    postExecSecurity("body", action, {
+      exitCode: 1,
+      signal: "SIGKILL",
+      notes: "\n...[truncated]",
+    });
+    expect(seen).toBe("body");
+  });
+
+  it("skips the sanitizer entirely on an empty body", () => {
+    let called = false;
+    const action = {
+      type: "sanitize" as const,
+      lineSafe: false,
+      sanitize: () => {
+        called = true;
+        return "should not run";
+      },
+    };
+    const result = postExecSecurity("   ", action, { exitCode: 2 });
+    expect(called).toBe(false);
+    expect(result).toContain("[exit code: 2]");
+  });
+
+  it("renders signal and notes alongside the exit code", () => {
+    const result = postExecSecurity("partial", null, {
+      exitCode: 137,
+      signal: "SIGKILL",
+      notes: "\n...[output truncated at 10 MB]",
+    });
+    expect(result).toContain("partial");
+    expect(result).toContain("...[output truncated at 10 MB]");
+    expect(result).toContain("[exit code: 137 (signal: SIGKILL)]");
+  });
+
+  it("leaves a successful run's body untouched by any annotation", () => {
+    const result = postExecSecurity('{"kind":"Pod"}', jsonAction);
+    expect(result).not.toContain("exit code");
+    expect(result).not.toContain("(no output)");
   });
 });

--- a/src/tools/infra/security-pipeline.ts
+++ b/src/tools/infra/security-pipeline.ts
@@ -65,6 +65,23 @@ export interface PostExecOptions {
   stderr?: string;
   /** Apply pipeline fallback redaction for sensitive kubectl output */
   hasSensitiveKubectl?: boolean;
+  /**
+   * Exit code of a FAILED run. Renders a trailing "[exit code: N]" annotation,
+   * and an empty body as "(no output)".
+   *
+   * Callers must pass it here rather than splicing it into `stdout` themselves.
+   * The annotation is our own literal, so it is appended AFTER sanitization —
+   * mixed into the body it makes a structural (JSON) sanitizer fail to parse,
+   * which suppresses the WHOLE result: the real kubectl error, whatever partial
+   * stdout there was, and the exit code itself. A `kubectl get pod -o json` that
+   * returns NotFound then reads as "Failed to parse … for sanitization", i.e. a
+   * tool malfunction rather than the diagnostic answer it actually is.
+   */
+  exitCode?: number | string;
+  /** Signal name, rendered inside the exit annotation. Requires `exitCode`. */
+  signal?: string;
+  /** Literal trailer (e.g. a truncation notice). Appended after sanitization. */
+  notes?: string;
 }
 
 /**
@@ -85,13 +102,28 @@ export function postExecSecurity(
   action: OutputAction | null,
   opts?: PostExecOptions,
 ): string {
-  let sanitized = applySanitizer(stdout, action);
-  if (opts?.hasSensitiveKubectl) {
-    sanitized = redactSensitiveContent(sanitized);
+  // Sanitize the command's own stdout, and only when there IS one. An empty body
+  // holds nothing to redact, whereas a structural sanitizer would fail to parse
+  // it and suppress the result — dropping the exit code and stderr that are the
+  // only evidence of what went wrong.
+  let sanitized = stdout;
+  if (stdout.trim()) {
+    sanitized = applySanitizer(sanitized, action);
+    if (opts?.hasSensitiveKubectl) {
+      sanitized = redactSensitiveContent(sanitized);
+    }
   }
-  const combined = opts?.stderr
-    ? sanitized + `\n\nSTDERR:\n${opts.stderr}`
-    : sanitized;
+
+  // Everything below is literal text we generate, so it is appended after
+  // sanitization — see PostExecOptions.exitCode for why the order matters.
+  let combined =
+    opts?.exitCode !== undefined ? sanitized.trim() || "(no output)" : sanitized;
+  if (opts?.notes) combined += opts.notes;
+  if (opts?.exitCode !== undefined) {
+    const sig = opts.signal ? ` (signal: ${opts.signal})` : "";
+    combined += `\n[exit code: ${opts.exitCode}${sig}]`;
+  }
+  if (opts?.stderr) combined += `\n\nSTDERR:\n${opts.stderr}`;
   return processToolOutput(combined);
 }
 

--- a/src/tools/script-exec/host-script.test.ts
+++ b/src/tools/script-exec/host-script.test.ts
@@ -96,7 +96,7 @@ describe("host_script", () => {
     vi.mocked(sshExec).mockResolvedValueOnce({ stdout: "", stderr: "fail", exitCode: 2 });
     const result = await tool.execute("id", { host: "h1", script: "x.sh" }, undefined, {} as any);
     expect((result.details as any).error).toBe(true);
-    expect(result.content[0].text).toContain("Exit code: 2");
+    expect(result.content[0].text).toContain("[exit code: 2]");
   });
 });
 

--- a/src/tools/script-exec/host-script.ts
+++ b/src/tools/script-exec/host-script.ts
@@ -258,16 +258,19 @@ Examples (pass the id from host_list; names shown here for readability):
 
       const isError = result.exitCode !== 0 &&
         !(result.exitCode === null && result.stdout.trim());
-      const stdoutHeader = isError
-        ? `Exit code: ${result.exitCode ?? "unknown"}${result.signal ? ` (signal: ${result.signal})` : ""}\n`
-        : "";
-      const truncatedSuffix = result.truncated ? "\n...[output truncated at 10 MB]" : "";
-      const stdout = stdoutHeader + result.stdout.trim() + truncatedSuffix;
-
       return {
         content: [{
           type: "text",
-          text: postExecSecurity(stdout, null, { stderr: result.stderr.trim() || undefined }),
+          text: postExecSecurity(result.stdout.trim(), null, {
+            stderr: result.stderr.trim() || undefined,
+            ...(result.truncated ? { notes: "\n...[output truncated at 10 MB]" } : {}),
+            ...(isError
+              ? {
+                  exitCode: result.exitCode ?? "unknown",
+                  ...(result.signal ? { signal: result.signal } : {}),
+                }
+              : {}),
+          }),
         }],
         details: {
           exitCode: result.exitCode,

--- a/src/tools/script-exec/local-script.ts
+++ b/src/tools/script-exec/local-script.ts
@@ -10,7 +10,7 @@ import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
 import { backgroundLaunchedResult } from "../cmd-exec/background-launch.js";
 import { loadConfig } from "../../core/config.js";
 import { resolveRequiredKubeconfig } from "../infra/kubeconfig-resolver.js";
-import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
+import { ensureClusterForTool, classifyClusterFailure } from "../infra/ensure-kubeconfigs.js";
 import { sanitizeEnv } from "../infra/sanitize-env.js";
 import { parseArgs } from "../infra/command-sets.js";
 import {
@@ -152,9 +152,10 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
       try {
         await ensureClusterForTool(kubeconfigRef?.credentialBroker, params.cluster, "local_script");
       } catch (err) {
+        const failure = await classifyClusterFailure(kubeconfigRef?.credentialBroker, params.cluster, err);
         return {
-          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-          details: { error: true, reason: "kubeconfig_ensure_failed" },
+          content: [{ type: "text", text: JSON.stringify(failure, null, 2) }],
+          details: { error: true, reason: failure.reason },
         };
       }
 

--- a/src/tools/script-exec/local-script.ts
+++ b/src/tools/script-exec/local-script.ts
@@ -279,7 +279,7 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
           agentId: agentId ?? null,
         });
         return {
-          content: [{ type: "text", text: postExecSecurity(`Exit code: ${err.code ?? "unknown"}\n${err.stdout?.trim() ?? ""}`, null, { stderr: errStderr || undefined }) }],
+          content: [{ type: "text", text: postExecSecurity(err.stdout?.trim() ?? "", null, { stderr: errStderr || undefined, exitCode: err.code ?? "unknown" }) }],
           details: { exitCode: err.code, error: true },
         };
       }

--- a/src/tools/script-exec/node-script.test.ts
+++ b/src/tools/script-exec/node-script.test.ts
@@ -12,9 +12,13 @@ vi.mock("../infra/kubeconfig-resolver.js", () => ({
   resolveRequiredKubeconfig: vi.fn(() => ({ path: "/tmp/kc" })),
   resolveDebugImage: vi.fn(() => "debug:latest"),
 }));
-vi.mock("../infra/ensure-kubeconfigs.js", () => ({
-  ensureClusterForTool: vi.fn(),
-}));
+vi.mock("../infra/ensure-kubeconfigs.js", async () => {
+  const actual = await vi.importActual<any>("../infra/ensure-kubeconfigs.js");
+  return {
+    ...actual,
+    ensureClusterForTool: vi.fn(),
+  };
+});
 
 vi.mock("../infra/pod-netns-resolve.js", async () => {
   const actual = await vi.importActual<any>("../infra/pod-netns-resolve.js");
@@ -45,10 +49,13 @@ describe("node_script tool", () => {
     expect(tool.label).toBe("Node Script");
   });
 
-  it("returns kubeconfig_ensure_failed on broker error", async () => {
-    vi.mocked(ensureClusterForTool).mockRejectedValueOnce(new Error("not bound"));
+  // No broker → the binding list is unknowable, so this must not be reported as
+  // an unbound cluster (see classifyClusterFailure).
+  it("classifies a broker error and keeps the original reason", async () => {
+    vi.mocked(ensureClusterForTool).mockRejectedValueOnce(new Error("gateway down"));
     const res = await tool.execute("id", { node: "n1", script: "x.sh" }, undefined, {} as any);
-    expect((res.details as any).reason).toBe("kubeconfig_ensure_failed");
+    expect((res.details as any).reason).toBe("cluster_unavailable");
+    expect(res.content[0].text).toContain("gateway down");
   });
 
   it("rejects invalid node names", async () => {

--- a/src/tools/script-exec/node-script.ts
+++ b/src/tools/script-exec/node-script.ts
@@ -337,11 +337,8 @@ Examples:
       const isError = execResult.exitCode !== 0 &&
         !(execResult.exitCode === null && execResult.stdout.trim());
       const out = execResult.stdout.trim();
-      const stdout = isError
-        ? `${out || "(no output)"}\n[exit code: ${execResult.exitCode ?? "unknown"}]`
-        : out;
       return {
-        content: [{ type: "text", text: postExecSecurity(stdout, null, { stderr: filteredStderr || undefined }) }],
+        content: [{ type: "text", text: postExecSecurity(out, null, { stderr: filteredStderr || undefined, ...(isError && { exitCode: execResult.exitCode ?? "unknown" }) }) }],
         details: { exitCode: execResult.exitCode ?? 0, ...(isError && { error: true }) },
       };
     },

--- a/src/tools/script-exec/node-script.ts
+++ b/src/tools/script-exec/node-script.ts
@@ -24,7 +24,7 @@ import { postExecSecurity } from "../infra/security-pipeline.js";
 import { runInDebugPod, ensureDebugPodReady, acquireDebugPod, releaseDebugPod } from "../infra/debug-pod.js";
 import { backgroundPgidFile, wrapBackgroundSession, killRemoteSessionViaKubectl } from "../infra/bg-session.js";
 import { resolveRequiredKubeconfig, resolveDebugImage } from "../infra/kubeconfig-resolver.js";
-import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
+import { ensureClusterForTool, classifyClusterFailure } from "../infra/ensure-kubeconfigs.js";
 
 interface NodeScriptParams {
   node?: string;
@@ -153,9 +153,10 @@ Examples:
       try {
         await ensureClusterForTool(kubeconfigRef?.credentialBroker, params.cluster, "node_script");
       } catch (err) {
+        const failure = await classifyClusterFailure(kubeconfigRef?.credentialBroker, params.cluster, err);
         return {
-          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-          details: { error: true, reason: "kubeconfig_ensure_failed" },
+          content: [{ type: "text", text: JSON.stringify(failure, null, 2) }],
+          details: { error: true, reason: failure.reason },
         };
       }
 

--- a/src/tools/script-exec/pod-script.test.ts
+++ b/src/tools/script-exec/pod-script.test.ts
@@ -12,9 +12,13 @@ vi.mock("../infra/exec-utils.js", async () => {
 vi.mock("../infra/kubeconfig-resolver.js", () => ({
   resolveRequiredKubeconfig: vi.fn(() => ({ path: "/tmp/kc" })),
 }));
-vi.mock("../infra/ensure-kubeconfigs.js", () => ({
-  ensureClusterForTool: vi.fn(),
-}));
+vi.mock("../infra/ensure-kubeconfigs.js", async () => {
+  const actual = await vi.importActual<any>("../infra/ensure-kubeconfigs.js");
+  return {
+    ...actual,
+    ensureClusterForTool: vi.fn(),
+  };
+});
 vi.mock("node:child_process", () => ({
   spawn: vi.fn(() => ({ on: vi.fn(), unref: vi.fn(), kill: vi.fn() })),
 }));
@@ -41,10 +45,13 @@ describe("pod_script tool", () => {
     expect(tool.label).toBe("Pod Script");
   });
 
-  it("returns kubeconfig_ensure_failed on ensure error", async () => {
+  // With no broker the binding list is unknowable, so an ensure failure must
+  // report cluster_unavailable rather than claiming the cluster is unbound.
+  it("classifies an ensure error and keeps the original reason", async () => {
     vi.mocked(ensureClusterForTool).mockRejectedValueOnce(new Error("no access"));
     const res = await tool.execute("id", { pod: "p", script: "x.sh" }, undefined, {} as any);
-    expect((res.details as any).reason).toBe("kubeconfig_ensure_failed");
+    expect((res.details as any).reason).toBe("cluster_unavailable");
+    expect(res.content[0].text).toContain("no access");
   });
 
   it("rejects invalid pod name", async () => {

--- a/src/tools/script-exec/pod-script.ts
+++ b/src/tools/script-exec/pod-script.ts
@@ -250,7 +250,7 @@ Examples:
         const stdout = err.stdout?.trim() ?? "";
         const stderr = err.stderr?.trim() ?? err.message;
         return {
-          content: [{ type: "text", text: postExecSecurity(`${stdout || "(no output)"}\n[exit code: ${err.code ?? "unknown"}]`, null, { stderr: stderr || undefined }) }],
+          content: [{ type: "text", text: postExecSecurity(stdout, null, { stderr: stderr || undefined, exitCode: err.code ?? "unknown" }) }],
           details: { exitCode: err.code ?? null, error: true },
         };
       }

--- a/src/tools/script-exec/pod-script.ts
+++ b/src/tools/script-exec/pod-script.ts
@@ -13,7 +13,7 @@ import { backgroundLaunchedResult } from "../cmd-exec/background-launch.js";
 import { parseArgs, shellEscape } from "../infra/command-sets.js";
 import { validatePodName, prepareExecEnv, spawnAsync, stdinExecCmd } from "../infra/exec-utils.js";
 import { resolveRequiredKubeconfig } from "../infra/kubeconfig-resolver.js";
-import { ensureClusterForTool } from "../infra/ensure-kubeconfigs.js";
+import { ensureClusterForTool, classifyClusterFailure } from "../infra/ensure-kubeconfigs.js";
 import { backgroundPgidFile, wrapBackgroundSession, backgroundSessionKillScript } from "../infra/bg-session.js";
 import { spawn } from "node:child_process";
 
@@ -124,9 +124,10 @@ Examples:
       try {
         await ensureClusterForTool(kubeconfigRef?.credentialBroker, params.cluster, "pod_script");
       } catch (err) {
+        const failure = await classifyClusterFailure(kubeconfigRef?.credentialBroker, params.cluster, err);
         return {
-          content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-          details: { error: true, reason: "kubeconfig_ensure_failed" },
+          content: [{ type: "text", text: JSON.stringify(failure, null, 2) }],
+          details: { error: true, reason: failure.reason },
         };
       }
 


### PR DESCRIPTION
## Summary

Three fixes from the retro feedback on the exec tools, all cases where a tool
reported something that was not true: a failed command's real error replaced by
a sanitizer artifact, a missing cluster binding dressed up as a transient
gateway fault, and a ConfigMap read that leaked every credential in it while
claiming it had redacted them.

Scope note: the retro raised ~33 items against `bash`. Most of the rest are
either deliberate design decisions, need a cross-layer `outcome` change
(`pipefail` + exit-code semantics), or point somewhere other than these tools.
Those are not in this PR.

### Problem

**1. An exit code spliced into the body before sanitization.** Every cmd-exec
tool built `<stdout>\n[exit code: N]` and handed that to the sanitizer. When the
resolved sanitizer is structural — `kubectl get pod/configmap/secret -o json`,
`crictl inspect` — `JSON.parse` fails on it, and the parse-failure branch
suppresses the entire result. A NotFound came back as

```
Failed to parse kubectl JSON output for sanitization. Raw output suppressed…
```

which reads as a tool malfunction rather than the diagnostic answer it actually
is, with the exit code gone too. `pod` is in the sensitive-resource list, so any
failing `kubectl get pod … -o json` hit this. It also hit a body that *was*
valid JSON: a partial success with a non-zero exit was suppressed just as
thoroughly. Four tools shared the bug (`bash`, `node_exec`, `pod_exec`,
`host_exec`); `script-exec` passes a null action and was unaffected.

**2. A missing cluster binding reported as a transient fault.** The broker's
transport reports "not bound" exactly as it reports a real upstream fault — an
HTTP 502 whose body says `cluster not found`. Forwarding that raw told the model
to retry something no retry can fix, or to move on to node/pod tools that share
the binding and fail identically.

**3. A ConfigMap read with `-o json` leaked every credential in it.** A ConfigMap
entry is normally a whole config file: the data key is a filename, the value is
hundreds of lines. `redactByPattern` checked only that data key
(`prometheus.yml` — not sensitive) and then tested the whole file as one blob.
The key names *inside* the file — `credentials:`, `token:` — were never looked
at, and they are the layer that does the real work. The `^`-anchored value
patterns could not help either: indentation and a `key: ` prefix push the token
off the line start, so `credentials: eyJ…` never matched (the `m` flag does not
change this — verified). On top of that, `sanitizeJSON` appended "Sensitive
values have been redacted" *unconditionally*, so the leak came with a claim that
it had been handled.

Before / after on the same prometheus ConfigMap:

```
before   "prometheus.yml": "…credentials: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9…
                            Authorization: Bearer eyJ…  token: ghp_AAAA…"
         ⚠️ Sensitive values have been redacted for security.

after    "prometheus.yml": "…      credentials: **REDACTED**
                                   Authorization: **REDACTED**
                                   token: **REDACTED**
                            job_name: node   scrape_interval: 30s   url: https://push…"
```

### Solution

- **Exit annotations move to `postExecSecurity`**, which appends them after
  sanitization, and an empty body skips the sanitizer entirely — nothing in it to
  redact, while a structural sanitizer would fail on it and drop the only
  evidence of what went wrong. `host_exec`'s exit code moves from a header prefix
  to the same trailing annotation as the other three; `node_exec`'s comment
  already argued for that shape.
- **`classifyClusterFailure`** replaces six copies of the same catch block. It
  re-reads the binding list to separate a missing binding from an upstream fault
  and reports `reason` / `retryable` / `available_clusters`. It fails toward
  `cluster_unavailable`: when the binding list itself is unreachable we cannot
  prove the cluster is unbound, and calling a possibly-transient fault a config
  error is the more misleading of the two. The raw 502 is dropped from the
  not-bound answer, since it is what invited the retry.
- **Whole-file ConfigMap values are redacted line by line**, so only the
  offending line becomes `REDACTED` and the rest of the config stays
  diagnosable. The line redactor moves into `kubectl-sanitize.ts` (the structural
  sanitizers need it; importing back from `output-sanitizer.ts` would be a
  cycle), which re-exports it — no consumer changes.
- **`authorization` added to the key patterns**, end-anchored so
  `authorization-mode` stays readable, plus a positional `Bearer <token>`
  backstop that works regardless of the key name.
- **The redaction footer is now conditional.** A redaction claim on untouched
  text is worse than none, because it invites the reader to treat it as safe.

### Security notes

- A **PEM block still drops the whole entry**. It is one secret spanning many
  lines and only its BEGIN line carries a marker, so a per-line pass would redact
  that line and leak the base64 body beneath it. An existing test caught this
  during development, which is why per-line is layered *on top of* the
  whole-value check rather than replacing it.
- The block handling deliberately stays **out of the streaming redactor**, whose
  `lineSafe` contract means it never sees more than one line — a cross-line state
  machine there would leak at batch boundaries instead.
- Redaction coverage is a **superset** of the old behaviour: anchored patterns
  match strictly more per line than per blob, the unanchored ones
  (connection string, `Bearer`) are single-line anyway, and the one multi-line
  pattern is handled above.
- The preserved `key: ` prefix on a redacted line is matched from an identifier
  character class, so it cannot carry a secret.
- `available_clusters` exposes nothing new — `cluster_list` already gives the
  model those names — and the not-bound path *reduces* what is echoed by dropping
  the upstream 502.

Two pre-existing behaviours were left alone rather than quietly widened here:
stderr does not go through the sanitizer (deliberate, to keep stdout JSON valid),
and the line redactor requires whitespace after the colon, so `password:secret`
with no space is not matched (YAML requires the space, so K8s output does not
produce it).

### Testing

`npm test` — 249 files, 5173 passed. 26 new tests: the sanitizer never sees our
own annotations, an empty body skips it, a NotFound keeps its exit code and
stderr, a valid-JSON body with a non-zero exit is still redacted *and* keeps its
exit code, whole-file entries are redacted per line while the rest stays
readable, indent and key name survive, a multi-line PEM body does not leak, clean
output makes no redaction claim, a list where only a later item matched still
does, `authorization` in its various forms vs `authorization-mode`, the `Bearer`
backstop, and the cluster classifier's five branches.

### Deployment

`src/tools/` ships in the **agentbox** image, not runtime: build agentbox, bump
`SICLAW_AGENTBOX_IMAGE`, recycle pods.
