### PR TITLE
fix(kbc): make compile recovery checkpointed and reconnect-safe

### DIFF
--- a/kbc/design/compiler-agent-environment.md
+++ b/kbc/design/compiler-agent-environment.md
@@ -78,7 +78,8 @@ It is not a page per file and not a line-by-line code reference.
   is explicitly prohibited from starting a second full compilation.
 - All access remains read-only, path-confined, bounded, and covered by regression
   tests.
-- Default planning uses the discovered 1M context window but targets no more
-  than 500K estimated tokens per turn. Actual per-batch usage and high-water
-  context are stamped in the checkpoint for later tuning.
+- The compiler keeps the selected model's 1M context window and uses an internal
+  500K planning target per turn; neither number is a Helm value or environment
+  variable. Actual per-batch usage and high-water context are stamped in the
+  checkpoint for later tuning.
 - A persisted commit-phase checkpoint can finish with no new model session.

--- a/kbc/design/compiler-agent-environment.md
+++ b/kbc/design/compiler-agent-environment.md
@@ -40,6 +40,17 @@ It is not a page per file and not a line-by-line code reference.
 7. **Gates produce actionable truth.** Deterministic checks protect confinement,
    provenance, coverage, and output shape. They do not reward deleting citations
    or bulk-excluding ordinary code merely to make a score green.
+8. **Handoff is durable and globally scoped.** Each stateless batch starts from
+   `authoring/COMPILATION_STATE.json`, which names the phase, full Candidate page
+   set, source-to-page map, tree hash, full Raw inventory, and Candidate index.
+   The assigned batch limits responsibility, not what the agent may discover.
+9. **Delivery is its own resumable phase.** After final review the compiler
+   checkpoints `phase=commit` before emitting provenance commit input. A relay
+   failure at this point replays only delivery; it never repeats map, reduce, or
+   final semantic work.
+10. **Checkpoints prove their identity.** Every persisted `BATCH_PLAN.json`
+    carries a monotonically advancing revision, update time, and SHA-256 digest.
+    Corruption pauses with `plan_integrity`; it never looks like an absent plan.
 
 ## Phase access matrix
 
@@ -67,3 +78,7 @@ It is not a page per file and not a line-by-line code reference.
   is explicitly prohibited from starting a second full compilation.
 - All access remains read-only, path-confined, bounded, and covered by regression
   tests.
+- Default planning uses the discovered 1M context window but targets no more
+  than 500K estimated tokens per turn. Actual per-batch usage and high-water
+  context are stamped in the checkpoint for later tuning.
+- A persisted commit-phase checkpoint can finish with no new model session.

--- a/kbc/design/compiler-agent-environment.md
+++ b/kbc/design/compiler-agent-environment.md
@@ -51,6 +51,11 @@ It is not a page per file and not a line-by-line code reference.
 10. **Checkpoints prove their identity.** Every persisted `BATCH_PLAN.json`
     carries a monotonically advancing revision, update time, and SHA-256 digest.
     Corruption pauses with `plan_integrity`; it never looks like an absent plan.
+11. **A batch boundary is a durability barrier.** Candidate bytes,
+    `BATCH_PLAN.json`, and `COMPILATION_STATE.json` enter the consumer in one
+    transaction. The orchestrator starts the next batch only after the consumer
+    acknowledges that transaction; browser, WebSocket, Runtime, and Box states
+    are not permission to continue or evidence that a batch landed.
 
 ## Phase access matrix
 
@@ -83,3 +88,5 @@ It is not a page per file and not a line-by-line code reference.
   variable. Actual per-batch usage and high-water context are stamped in the
   checkpoint for later tuning.
 - A persisted commit-phase checkpoint can finish with no new model session.
+- Killing the Runtime or Box after an acknowledged batch rehydrates the same
+  Candidate/task checkpoint and starts at the first unsealed batch.

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -27,6 +27,7 @@ import os
 import re
 import shutil
 import subprocess
+from datetime import datetime, timezone
 import unicodedata
 from pathlib import Path
 from typing import Any
@@ -50,12 +51,10 @@ from source_kinds import (
 # batch while the very-large route had already been raised, so the route a
 # corpus happened to take decided how much its sessions saw.
 #
-# 1MB ≈ 350K tokens at this corpus's ~3 bytes/token (CJK prose 3.5-5; record
-# dumps with long opaque IDs 2.5-3.5). Against a 1M window whose agreed SAFE
-# ceiling is 750K, that is the source side sitting near a third, leaving ample
-# room for the system prompt and BRIEF/INTENT/index (~36K measured) plus
-# everything a session accumulates — pages read and written, grep results, its
-# own reasoning.
+# 1.25MiB is estimated conservatively at ~437K tokens using the lower end of
+# this corpus's observed bytes/token range. Against a 1M window the source plus
+# measured fixed context (~36K) stays below the agreed 500K target, leaving room
+# for pages read and written, grep results, tool output, and model reasoning.
 #
 # The previous 512KB was half this, and the frugality was not free: a smaller
 # budget forces more families through the splitting paths, and splitting a
@@ -64,14 +63,17 @@ from source_kinds import (
 # is the expensive one; spending the former to avoid exercising fragile code is
 # the right trade. _record_turn_usage measures where a session actually lands,
 # so the next move on this number is arithmetic rather than judgement.
-DEFAULT_BATCH_THRESHOLD_BYTES = 1024 * 1024
-DEFAULT_BATCH_BUDGET_BYTES = 1024 * 1024
+DEFAULT_BATCH_THRESHOLD_BYTES = 1280 * 1024
+DEFAULT_BATCH_BUDGET_BYTES = 1280 * 1024
 DEFAULT_HIERARCHICAL_THRESHOLD_BYTES = 8 * 1024 * 1024
-DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES = 1024 * 1024
-DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 1024 * 1024
-DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES = 1024 * 1024
+DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES = 1280 * 1024
+DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 1280 * 1024
+DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES = 1280 * 1024
 DEFAULT_HIERARCHICAL_PDF_SLICE_PAGES = 20
-DEFAULT_REDUCTION_BUDGET_BYTES = 1024 * 1024
+DEFAULT_REDUCTION_BUDGET_BYTES = 1280 * 1024
+DEFAULT_CONTEXT_WINDOW_TOKENS = 1_000_000
+DEFAULT_CONTEXT_TARGET_TOKENS = 500_000
+ESTIMATED_FIXED_CONTEXT_TOKENS = 36_000
 
 # ── effective-size weighting ─────────────────────────────────────────────────
 # Raw bytes are a terrible proxy for context cost on non-text sources: a 168KB
@@ -385,26 +387,18 @@ def should_hierarchical(
     return corpus_effective_bytes(inventory) > limit
 
 
-# A batch that is still nearly empty must not be flushed just because the next
-# family sits under a different top-level directory. Sections and the pages
-# NAMED after them interleave in path order (`X-2d66.md` sorts before `X/…`),
-# so a 19-byte section placeholder would open a batch, meet the very next
-# family under `X/`, and be flushed alone — a whole model session, spawned pod
-# and all, to read one heading. Topical coherence is worth a flush; it is not
-# worth one per placeholder, and a batch this far below budget has no coherence
-# to protect yet.
-# Deliberately a SCRAP, not a fraction of the budget: at a 512KB budget a plain
-# 10% would be 51KB, and a batch holding 40KB of real content would start
-# swallowing the next section. Coherence is cheap to protect once a batch holds
-# anything substantial; it is only the near-empty case that is not worth a
-# session of its own.
-BATCH_COHERENCE_FLUSH_FLOOR_RATIO = 0.05
-BATCH_COHERENCE_FLUSH_FLOOR_CAP = 32 * 1024
+# Crossing a top-level section is a preference, not a reason to spend an almost
+# empty Agent session. Production completed 125 map sessions with a measured
+# 118K-token maximum in a 1M window: the old 32KB flush floor was preserving
+# directory purity while using only a small fraction of the agreed 500K target.
+# Fill at least half the deterministic source budget before a section boundary
+# may flush. Families remain indivisible and the hard effective/text budgets
+# still win, so this changes efficiency, not safety or provenance.
+BATCH_COHERENCE_MIN_FILL_RATIO = 0.5
 
 
 def _too_small_to_flush(current_bytes: int, budget: int) -> bool:
-    floor = min(int(budget * BATCH_COHERENCE_FLUSH_FLOOR_RATIO),
-                BATCH_COHERENCE_FLUSH_FLOOR_CAP)
+    floor = int(budget * BATCH_COHERENCE_MIN_FILL_RATIO)
     return current_bytes < floor
 
 
@@ -419,9 +413,9 @@ def pack_batches(
 ) -> list[dict[str, Any]]:
     """Deterministic baseline: group by top-level directory (natural topical
     grouping in practice), greedy-pack in path order within the budget. A batch
-    never mixes top-level directories unless a directory itself is tiny —
-    deliberate: cross-dir mixing buys packing efficiency but costs topical
-    coherence, and coherence is the goal function (效果好/细节覆盖).
+    may mix small top-level directories until it reaches half its source budget;
+    whole-snapshot read/search and the durable Candidate handoff preserve the
+    global/topic context that directory-pure micro-batches were trying to buy.
 
     Packs document FAMILIES, never bare files: a document and the attachments
     its body embeds always land in the same batch, so no session is ever handed
@@ -881,6 +875,21 @@ def build_plan(
     mode = "hierarchical" if planner == "hierarchical-code" else "flat"
     has_text_slices = any(batch.get("source_ranges") for batch in batches)
     has_pdf_slices = any(batch.get("source_page_ranges") for batch in batches)
+    resolved_budget = budget if budget is not None else batch_budget_bytes()
+    resolved_text_budget = (
+        text_budget if text_budget is not None
+        else hierarchical_text_budget_bytes() if mode == "hierarchical"
+        else None
+    )
+    context_window = max(1, int(os.environ.get(
+        "KBC_CONTEXT_WINDOW_TOKENS", str(DEFAULT_CONTEXT_WINDOW_TOKENS))))
+    context_target = min(
+        context_window // 2,
+        max(1, int(os.environ.get(
+            "KBC_CONTEXT_TARGET_TOKENS", str(DEFAULT_CONTEXT_TARGET_TOKENS)))),
+    )
+    batch_sizes = sorted(int(batch.get("bytes") or 0) for batch in batches)
+    estimated_source_bytes = resolved_text_budget or resolved_budget
     return {
         "version": (
             4 if mode == "hierarchical" and has_pdf_slices
@@ -896,14 +905,20 @@ def build_plan(
             else hierarchical_threshold_bytes() if mode == "hierarchical"
             else batch_threshold_bytes()
         ),
-        "budget": budget if budget is not None else batch_budget_bytes(),
-        "text_budget": (
-            text_budget if text_budget is not None
-            else hierarchical_text_budget_bytes() if mode == "hierarchical"
-            else None
+        "budget": resolved_budget,
+        "text_budget": resolved_text_budget,
+        "context_window_tokens": context_window,
+        "context_target_tokens": context_target,
+        # Planning estimate only. Actual high-water usage is stamped per batch.
+        "estimated_context_tokens": (
+            ESTIMATED_FIXED_CONTEXT_TOKENS + estimated_source_bytes // 3
         ),
         "total_bytes": corpus_bytes(inventory),
         "total_effective_bytes": corpus_effective_bytes(inventory),
+        "source_count": len(inventory),
+        "batch_count": len(batches),
+        "batch_effective_bytes_min": batch_sizes[0] if batch_sizes else 0,
+        "batch_effective_bytes_max": batch_sizes[-1] if batch_sizes else 0,
         "batches": batches,
     }
 
@@ -1299,7 +1314,8 @@ def stamp_reduction_done(plan: dict[str, Any], reduction_id: str) -> dict[str, A
 
 
 def stamp_done(plan: dict[str, Any], batch_id: str,
-               usage: dict[str, int] | None = None) -> dict[str, Any]:
+               usage: dict[str, int] | None = None,
+               tree_hash: str | None = None) -> dict[str, Any]:
     """Mark a batch finished, and record what its session actually cost.
 
     The usage rides the plan because the plan is the durable, resumable record
@@ -1309,8 +1325,11 @@ def stamp_done(plan: dict[str, Any], batch_id: str,
     for b in plan.get("batches", []):
         if b.get("id") == batch_id:
             b["status"] = "done"
+            b["completed_at"] = datetime.now(timezone.utc).isoformat()
             if usage:
                 b["usage"] = dict(usage)
+            if tree_hash:
+                b["candidate_tree_hash"] = tree_hash
     return plan
 
 
@@ -1350,6 +1369,53 @@ def prune_missing_sources(plan: dict[str, Any], known: set[str]) -> list[str]:
 
 def dump_json(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+
+
+def checkpoint_digest(plan: dict[str, Any]) -> str:
+    """Digest the complete resumable execution checkpoint.
+
+    The digest field itself is excluded; phase, batch stamps, usage, candidate
+    hashes and the plan assignment are all included. This makes a persisted
+    BATCH_PLAN one verifiable checkpoint instead of a bag of loosely related
+    flags. Older plans without a digest remain readable for rolling upgrades.
+    """
+    payload = {key: value for key, value in plan.items() if key != "checkpoint_digest"}
+    encoded = json.dumps(
+        payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def seal_checkpoint(plan: dict[str, Any]) -> dict[str, Any]:
+    """Advance and sign a BATCH_PLAN checkpoint before durable persistence."""
+    plan["checkpoint_revision"] = max(0, int(plan.get("checkpoint_revision") or 0)) + 1
+    plan["checkpoint_updated_at"] = datetime.now(timezone.utc).isoformat()
+    plan["checkpoint_digest"] = checkpoint_digest(plan)
+    return plan
+
+
+def checkpoint_is_valid(plan: dict[str, Any]) -> bool:
+    """Verify a sealed checkpoint; digest-less legacy plans are compatible."""
+    expected = plan.get("checkpoint_digest")
+    return not expected or (
+        isinstance(expected, str) and expected == checkpoint_digest(plan)
+    )
+
+
+def checkpoint_state_errors(plan: dict[str, Any]) -> list[str]:
+    """Cross-field state-machine invariants for a resumable checkpoint."""
+    errors: list[str] = []
+    phase = str(plan.get("phase") or "map")
+    if phase not in {"map", "reduce", "final", "commit", "complete"}:
+        errors.append("unknown checkpoint phase")
+        return errors
+    unfinished_batches = pending_batches(plan)
+    if phase in {"reduce", "final", "commit", "complete"} and unfinished_batches:
+        errors.append(f"checkpoint phase {phase} has unfinished map batches")
+    unfinished_reductions = pending_reductions(plan)
+    if phase in {"final", "commit", "complete"} and unfinished_reductions:
+        errors.append(f"checkpoint phase {phase} has unfinished reductions")
+    return errors
 
 
 def plan_too_fragmented(model_batches: list[dict[str, Any]], baseline_batches: list[dict[str, Any]]) -> bool:

--- a/kbc/platform/pod/batching.py
+++ b/kbc/platform/pod/batching.py
@@ -51,10 +51,12 @@ from source_kinds import (
 # batch while the very-large route had already been raised, so the route a
 # corpus happened to take decided how much its sessions saw.
 #
-# 1.25MiB is estimated conservatively at ~437K tokens using the lower end of
-# this corpus's observed bytes/token range. Against a 1M window the source plus
-# measured fixed context (~36K) stays below the agreed 500K target, leaving room
-# for pages read and written, grep results, tool output, and model reasoning.
+# Keep the existing 1MiB deployment defaults. It is estimated conservatively at
+# ~350K tokens using the lower end of this corpus's observed bytes/token range;
+# with measured fixed context (~36K), it stays below the internal 500K planning
+# target and leaves room for Candidate reads, tool output, and reasoning. Batch
+# reduction comes from filling small cross-section batches more efficiently,
+# not from introducing or changing deployment configuration.
 #
 # The previous 512KB was half this, and the frugality was not free: a smaller
 # budget forces more families through the splitting paths, and splitting a
@@ -63,14 +65,14 @@ from source_kinds import (
 # is the expensive one; spending the former to avoid exercising fragile code is
 # the right trade. _record_turn_usage measures where a session actually lands,
 # so the next move on this number is arithmetic rather than judgement.
-DEFAULT_BATCH_THRESHOLD_BYTES = 1280 * 1024
-DEFAULT_BATCH_BUDGET_BYTES = 1280 * 1024
+DEFAULT_BATCH_THRESHOLD_BYTES = 1024 * 1024
+DEFAULT_BATCH_BUDGET_BYTES = 1024 * 1024
 DEFAULT_HIERARCHICAL_THRESHOLD_BYTES = 8 * 1024 * 1024
-DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES = 1280 * 1024
-DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 1280 * 1024
-DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES = 1280 * 1024
+DEFAULT_HIERARCHICAL_BATCH_BUDGET_BYTES = 1024 * 1024
+DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES = 1024 * 1024
+DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES = 1024 * 1024
 DEFAULT_HIERARCHICAL_PDF_SLICE_PAGES = 20
-DEFAULT_REDUCTION_BUDGET_BYTES = 1280 * 1024
+DEFAULT_REDUCTION_BUDGET_BYTES = 1024 * 1024
 DEFAULT_CONTEXT_WINDOW_TOKENS = 1_000_000
 DEFAULT_CONTEXT_TARGET_TOKENS = 500_000
 ESTIMATED_FIXED_CONTEXT_TOKENS = 36_000
@@ -881,13 +883,11 @@ def build_plan(
         else hierarchical_text_budget_bytes() if mode == "hierarchical"
         else None
     )
-    context_window = max(1, int(os.environ.get(
-        "KBC_CONTEXT_WINDOW_TOKENS", str(DEFAULT_CONTEXT_WINDOW_TOKENS))))
-    context_target = min(
-        context_window // 2,
-        max(1, int(os.environ.get(
-            "KBC_CONTEXT_TARGET_TOKENS", str(DEFAULT_CONTEXT_TARGET_TOKENS)))),
-    )
+    # These are compiler-internal planning facts, not deployment knobs. The
+    # selected Claude model has a 1M window; we deliberately plan each session
+    # around half of it so retrieval and reasoning have headroom.
+    context_window = DEFAULT_CONTEXT_WINDOW_TOKENS
+    context_target = DEFAULT_CONTEXT_TARGET_TOKENS
     batch_sizes = sorted(int(batch.get("bytes") or 0) for batch in batches)
     estimated_source_bytes = resolved_text_budget or resolved_budget
     return {

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -411,8 +411,13 @@ def _print_compile_lifecycle(label: str, run: "CompileRun", extra: str = "") -> 
     source paths or provider response fragments, and pod stdout is
     operator-visible. The full message belongs on the OWNER-facing SSE events
     (run.emit error/summary), which the owner owns."""
+    context = ""
+    command_context = getattr(run, "_command_context", None)
+    if command_context is not None:
+        operation_id, generation = command_context
+        context = f" operation={operation_id} generation={generation}"
     tail = f" {extra}" if extra else ""
-    print(f"[compile_box] {label} run={run.run_id} round={run.round}{tail}", flush=True)
+    print(f"[compile_box] {label} run={run.run_id} round={run.round}{context}{tail}", flush=True)
 
 
 def _error_event(
@@ -3741,9 +3746,16 @@ def _load_batch_plan(run: "CompileRun") -> dict | None:
         return None
     try:
         plan = json.loads(p.read_text())
-        return plan if isinstance(plan, dict) and isinstance(plan.get("batches"), list) else None
-    except Exception:
-        return None
+    except Exception as error:
+        raise PlanIntegrityError("the durable batch checkpoint is unreadable; reset or restore it") from error
+    if not isinstance(plan, dict) or not isinstance(plan.get("batches"), list):
+        raise PlanIntegrityError("the durable batch checkpoint has an invalid shape; reset or restore it")
+    if not batching.checkpoint_is_valid(plan):
+        raise PlanIntegrityError("the durable batch checkpoint digest does not match; reset or restore it")
+    state_errors = batching.checkpoint_state_errors(plan)
+    if state_errors:
+        raise PlanIntegrityError("the durable batch checkpoint state is inconsistent; reset or restore it")
+    return plan
 
 
 def _batch_resume_point(plan: dict | None) -> tuple[int, int] | None:
@@ -3770,13 +3782,15 @@ def _batch_plan_resumable(plan: dict | None) -> bool:
     """
     return plan is not None and (
         len(batching.pending_batches(plan)) > 0
-        or plan.get("phase") in {"map", "reduce", "final"}
+        or plan.get("phase") in {"map", "reduce", "final", "commit"}
     )
 
 
 def _write_batch_file(run: "CompileRun", rel: str, value) -> None:
     p = Path(run.workdir) / rel
     p.parent.mkdir(parents=True, exist_ok=True)
+    if rel == batching.BATCH_PLAN_PATH and isinstance(value, dict):
+        batching.seal_checkpoint(value)
     p.write_text(batching.dump_json(value))
 
 
@@ -4311,7 +4325,9 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
         return (
             f"[Batch compile · batch {k}/{n} · {batch['id']}] Compile ONLY the sources below "
             f"(see the batching discipline in the system prompt):\n{listing}\n"
-            "First read authoring/BRIEF.json, authoring/INTENT.md and candidate/index.md to stay consistent "
+            "First read authoring/BRIEF.json, authoring/INTENT.md, authoring/COMPILATION_STATE.json and "
+            "candidate/index.md to inherit the complete task, Raw inventory, completed-batch ownership, "
+            "and current Wiki shape; the entire frozen Raw snapshot and Candidate tree remain readable/searchable. "
             "in voice and structure; then read every source in this batch closely and fold its content fully "
             "into candidate/ pages (create new pages or merge into existing ones; each page's frontmatter "
             "sources[].resource must list the sources it was actually compiled from); update the matching "
@@ -4324,7 +4340,8 @@ def _compose_batch_directive(batch: dict, k: int, n: int, notes: str,
         )
     return (
         f"【分批编译 · 批 {k}/{n} · {batch['id']}】只编译下列源(见系统提示的分批纪律):\n{listing}\n"
-        "先读 authoring/BRIEF.json、authoring/INTENT.md 和 candidate/index.md 保持口径与结构一致;"
+        "先读 authoring/BRIEF.json、authoring/INTENT.md、authoring/COMPILATION_STATE.json 和 candidate/index.md,"
+        "继承完整任务、Raw 总清单、已完成批次归属和当前 Wiki 结构;冻结 Raw 全量与 Candidate 全树始终可读可搜索;"
         "然后精读本批每个源,按定调把内容完整编入 candidate/ 页(可新建页或并入既有页,页 frontmatter 的 "
         "sources[].resource 必须列出实际编自的源);更新 candidate/index.md 的相应条目;矛盾照常 best-guess+⚠️存疑+落工单,绝不停。"
         "清单是你的**交付责任面**,不是你的视野边界:需要交叉印证时(某个附件被谁引用、邻近文档同一件事怎么表述、"
@@ -4664,6 +4681,98 @@ async def _run_ledger_repairs(run: "CompileRun", replies: list[str]) -> None:
         run._ledger_forced = False
 
 
+def _candidate_checkpoint_hash(workdir: str) -> str:
+    pages = incremental.page_hashes(workdir)
+    return hashlib.sha256(json.dumps(
+        pages, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")).hexdigest()
+
+
+def _write_compilation_state(run: "CompileRun", plan: dict) -> None:
+    """Persist the complete machine hand-off between stateless batch sessions.
+
+    Responsibility remains per batch, but global visibility does not: every
+    successor gets the full Raw inventory, every Candidate page name, the full
+    source-to-page ownership map, and the current tree hash. Content remains in
+    Raw/Candidate and is available through read/search tools instead of being
+    duplicated into this bounded control artifact.
+    """
+    try:
+        pages = selfcheck.candidate_pages(run.workdir)
+    except Exception:
+        pages = {}
+    source_to_pages: dict[str, list[str]] = {}
+    for page, info in sorted(pages.items()):
+        for entry in info.get("sources") or []:
+            source = selfcheck._strip_source_prefix(str(entry))
+            source_to_pages.setdefault(source, []).append(page)
+    batches = plan.get("batches") or []
+    state = {
+        "version": 1,
+        "phase": plan.get("phase") or "map",
+        "planner": plan.get("planner") or "",
+        "checkpoint_revision": plan.get("checkpoint_revision") or 0,
+        "checkpoint_digest": plan.get("checkpoint_digest") or "",
+        "checkpoint_updated_at": plan.get("checkpoint_updated_at") or "",
+        "batches_done": sum(1 for batch in batches if batch.get("status") in {"done", "skipped"}),
+        "batches_total": len(batches),
+        "candidate_tree_hash": _candidate_checkpoint_hash(run.workdir),
+        "candidate_pages": sorted(pages),
+        "source_to_pages": source_to_pages,
+        "raw_inventory": batching.SOURCES_INVENTORY_PATH,
+        "candidate_index": "candidate/index.md",
+        "visibility": "complete_frozen_raw_and_candidate_tree",
+    }
+    _write_batch_file(run, "authoring/COMPILATION_STATE.json", state)
+
+
+async def _commit_batch_compile(run: "CompileRun", plan: dict, replies: list[str]) -> None:
+    """Commit an already-reviewed Candidate without replaying model work.
+
+    The content-only `commit` checkpoint is emitted before the provenance commit.
+    If the relay persists only the first event, a successor resumes here and
+    emits `commit_input` again; map/reduce/final are never repeated.
+    """
+    sent = getattr(run, "_sync_sent", None)
+    already_commit = plan.get("phase") == "commit"
+    plan["phase"] = "commit"
+    _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+    _write_compilation_state(run, plan)
+    _print_compile_lifecycle(
+        "batch.phase", run,
+        extra=(f"phase=commit done={len(plan.get('batches') or [])}/{len(plan.get('batches') or [])} "
+               f"checkpoint={str(plan.get('checkpoint_digest') or '')[:12]} "
+               f"revision={plan.get('checkpoint_revision', 0)}"))
+    if sent is not None:
+        try:
+            if not already_commit:
+                await _sync_workspace(run, sent)
+                _print_compile_lifecycle("batch.commit.checkpoint", run)
+            await _sync_workspace(run, sent, commit_input=True)
+            _print_compile_lifecycle("batch.commit.emit", run)
+        except Exception as error:
+            _print_compile_lifecycle(
+                "batch.commit.failed", run, extra=f"class={type(error).__name__}")
+            # Keep the local/replay state at commit. Never demote to final: the
+            # expensive semantic work is complete and only delivery is pending.
+            plan["phase"] = "commit"
+            _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+            raise
+    plan["phase"] = "complete"
+    _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+    _print_compile_lifecycle(
+        "batch.complete", run, extra=f"peak_context={run._peak_context_tokens}")
+    if run._peak_context_tokens > 0:
+        peak_k = run._peak_context_tokens // 1000
+        await run.emit({"type": "summary", "text": _loc(run,
+            f"Heaviest batch held about {peak_k}K tokens of context "
+            f"(per-batch detail in authoring/BATCH_PLAN.json).",
+            f"最重的一批约占用 {peak_k}K tokens 上下文"
+            f"(逐批明细见 authoring/BATCH_PLAN.json)。")})
+    await run.emit({"type": "turn_done", "text": "\n\n".join(replies).strip()
+                    or _loc(run, "Batch compile complete.", "分批编译完成。")})
+
+
 async def _run_batch_compile(run: "CompileRun", trigger_text: str):
     """The batch orchestrator: ONE logical turn to the consumer (single turn_done at
     the end), many bounded sessions inside. Crash-resumable across map, optional
@@ -4726,6 +4835,8 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                                              f"断点续批:{len(dropped)} 个源已不在 raw/ 中或已被豁免,已从待编批次剔除:")
                                         + ", ".join(sorted(dropped)[:5])
                                         + ("…" if len(dropped) > 5 else "")})
+        entry_phase = str(plan.get("phase") or "map")
+        _write_compilation_state(run, plan)
         slice_failures = _materialize_batch_slices(run, plan)
         if slice_failures:
             n_all = len(plan["batches"])
@@ -4757,7 +4868,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 f"{len(slice_failures)} 个批次的读界视图无法构建,已跳过;未记账的源已自动豁免并写明理由,"
                 f"列车继续。")})
         n = len(plan["batches"])
-        pending = batching.pending_batches(plan)
+        pending = batching.pending_batches(plan) if entry_phase == "map" else []
         if plan.get("mode") == "hierarchical":
             run._model_idle_timeout_s = max(
                 _MODEL_IDLE_TIMEOUT_S, _HIERARCHICAL_MODEL_IDLE_TIMEOUT_S)
@@ -4782,6 +4893,18 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                           f"继续分批编译:剩余 {len(pending)}/{n} 批。") if resuming
                      else _loc(run, plan_summary_en, plan_summary_zh)),
         })
+        _print_compile_lifecycle(
+            "batch.plan", run,
+            extra=(f"planner={plan.get('planner')} mode={plan.get('mode')} phase={entry_phase} "
+                   f"sources={plan.get('source_count', len(inventory))} batches={n} pending={len(pending)} "
+                   f"budget={plan.get('budget', 0)} text_budget={plan.get('text_budget', 0) or 0} "
+                   f"target_context={plan.get('context_target_tokens', 0)} "
+                   f"estimated_context={plan.get('estimated_context_tokens', 0)} "
+                   f"checkpoint={str(plan.get('checkpoint_digest') or '')[:12]} "
+                   f"revision={plan.get('checkpoint_revision', 0)}"))
+        if entry_phase == "commit":
+            await _commit_batch_compile(run, plan, replies)
+            return
         bounded = plan_bounded_sources(plan)
         for batch in list(pending):
             k = next(i + 1 for i, b in enumerate(plan["batches"]) if b["id"] == batch["id"])
@@ -4908,9 +5031,12 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                     f"Batch {k}/{n} could not complete ({e}); its unaccounted sources were auto-excluded "
                     f"with a reason and the train continues.",
                     f"批 {k}/{n} 无法完成({e});未记账的源已自动豁免并写明理由,列车继续。")})
-            batching.stamp_done(plan, batch["id"], usage=run._turn_usage)
+            batching.stamp_done(
+                plan, batch["id"], usage=run._turn_usage,
+                tree_hash=_candidate_checkpoint_hash(run.workdir))
             run._turn_usage = None
             _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+            _write_compilation_state(run, plan)
             # Push the done-stamp (and the batch's pages) to the durable store
             # NOW: if it only rode the next periodic sync, a crash in that window
             # would re-run an already-done batch on resume.
@@ -4923,12 +5049,13 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
             _print_compile_lifecycle("batch.done", run, extra=_lifecycle_batch_ref(batch, k, n))
             await run.emit({"type": "summary", "text": _loc(run,
                 f"Batch {k}/{n} done — landed in the store.", f"批 {k}/{n} 完成,已落库。")})
-        if plan.get("mode") == "hierarchical":
+        if plan.get("mode") == "hierarchical" and entry_phase in {"map", "reduce"}:
             if "reductions" not in plan:
                 plan["reductions"] = batching.pack_section_reductions(
                     selfcheck.candidate_pages(run.workdir))
             plan["phase"] = "reduce"
             _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+            _write_compilation_state(run, plan)
             reductions = plan.get("reductions", [])
             reduction_count = len(reductions)
             pending_reductions = batching.pending_reductions(plan)
@@ -4951,6 +5078,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 if len(reduction["pages"]) < 2:
                     batching.stamp_reduction_done(plan, reduction["id"])
                     _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+                    _write_compilation_state(run, plan)
                     continue
                 k = next(
                     i + 1 for i, item in enumerate(reductions)
@@ -4971,6 +5099,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                         f"【分区归并 {k}/{reduction_count}】{reply}"))
                 batching.stamp_reduction_done(plan, reduction["id"])
                 _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+                _write_compilation_state(run, plan)
                 sent = getattr(run, "_sync_sent", None)
                 if sent is not None:
                     try:
@@ -4979,6 +5108,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                         pass
         plan["phase"] = "final"
         _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+        _write_compilation_state(run, plan)
         final_reply = await _drive_batch_session(
             run, _compose_final_directive(run.workdir, n, _drain_batch_notes(run), locale=getattr(run, "locale", None)),
             _loc(run, "final review", "终审"),
@@ -5084,33 +5214,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
             if notes_reply:
                 replies.append(_loc(run, f"[Note digest] {notes_reply}", f"【留言消化】{notes_reply}"))
             await _run_ledger_repairs(run, replies)  # the digest may have touched pages
-        sent = getattr(run, "_sync_sent", None)
-        plan["phase"] = "complete"
-        _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
-        if sent is not None:
-            # Successful batch completion is one full-compile provenance commit.
-            # Content and input revision must land atomically before turn_done.
-            try:
-                await _sync_workspace(run, sent, commit_input=True)
-            except Exception:
-                # The durable commit did not happen. Keep the plan resumable at
-                # final close-out rather than falsely claiming completion.
-                plan["phase"] = "final"
-                _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
-                raise
-        _print_compile_lifecycle(
-            "batch.complete", run, extra=f"peak_context={run._peak_context_tokens}")
-        if run._peak_context_tokens > 0:
-            # The owner tuning a budget should not have to read pod logs for the
-            # one number that says whether it was right.
-            peak_k = run._peak_context_tokens // 1000
-            await run.emit({"type": "summary", "text": _loc(run,
-                f"Heaviest batch held about {peak_k}K tokens of context "
-                f"(per-batch detail in authoring/BATCH_PLAN.json).",
-                f"最重的一批约占用 {peak_k}K tokens 上下文"
-                f"(逐批明细见 authoring/BATCH_PLAN.json)。")})
-        await run.emit({"type": "turn_done", "text": "\n\n".join(replies).strip()
-                        or _loc(run, "Batch compile complete.", "分批编译完成。")})
+        await _commit_batch_compile(run, plan, replies)
     except Exception as e:
         # stdout stays whitelisted: exception class + a machine-routable code.
         # The MESSAGE (which can carry raw source paths / provider response

--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -794,6 +794,14 @@ class CompileRun:
         # machine; Sicore's operation and the runtime run remain authoritative.
         self._accepted_commands: dict[str, str] = {}
         self._command_context: tuple[str, int] | None = None
+        # A sealed batch checkpoint is not durable when it merely entered this
+        # process's SSE queue. New runtimes advertise artifact ACK support and
+        # acknowledge only after Sicore commits the whole syncArtifacts batch.
+        # The orchestrator waits on that ACK before starting the next batch.
+        self._artifact_ack_required = False
+        self._sync_lock = asyncio.Lock()
+        self._pending_sync_acks: dict[str, asyncio.Future] = {}
+        self._pending_sync_events: dict[str, dict] = {}
 
     async def emit(self, ev: dict):
         await self.events.put(ev)
@@ -950,6 +958,8 @@ _pack_candidates_to_wiki = selfcheck.pack_candidates_to_wiki
 WORKSPACE_SYNC_DIRS = ("authoring", "candidate", "eval", "release")
 SYNC_INTERVAL_SECS = int(os.environ.get("KBC_SYNC_INTERVAL_SECS", "20"))
 MAX_SYNC_FILE_BYTES = int(os.environ.get("KBC_MAX_SYNC_FILE_BYTES", str(1024 * 1024)))
+ARTIFACT_ACK_TIMEOUT_SECS = 10 * 60
+RECOVERY_RESET_PATH = "authoring/RECOVERY_RESET.json"
 # SDK stdio JSON reader buffer. The SDK default is 1MB, and one oversized tool
 # result (a Read of a big source file) kills the whole session with a fatal
 # "exceeded maximum buffer size" — seen live on a 139-source compile (2026-07-06).
@@ -1034,58 +1044,92 @@ def _workspace_sync_cursor(workdir: str) -> dict[str, str]:
     }
 
 
-async def _sync_workspace(run: CompileRun, sent: dict, *, commit_input: bool = False) -> int:
+async def _sync_workspace(
+    run: CompileRun,
+    sent: dict,
+    *,
+    commit_input: bool = False,
+    durable_barrier: bool = False,
+) -> int:
     """Emit a syncArtifacts event for workspace files changed since `sent`
     (path → content sha), plus TOMBSTONES ({path, deleted: true}) for
     previously-synced files that no longer exist on disk. Updates `sent` after
     enqueue and retains tombstone markers for reconnect replay;
     returns the number of changed entries."""
-    if commit_input and not (Path(run.workdir) / "candidate" / "index.md").is_file():
-        raise FileNotFoundError("cannot commit compile input without candidate/index.md")
-    blocked_paths = _blocked_provenance_paths(run)
-    if commit_input and blocked_paths:
-        raise selfcheck.ProvenanceStampError(
-            "cannot commit compile input while candidate provenance stamping is blocked")
-    changed = []
-    next_sent = dict(sent)
-    # Blocked pages still exist. Treat them as collected so durability sync
-    # preserves the last good consumer copy instead of emitting a tombstone.
-    collected = set(blocked_paths)
-    for art in _collect_workspace_artifacts_for_sync(run):
-        collected.add(art["path"])
-        sha = hashlib.sha256(art["content"].encode("utf-8")).hexdigest()
-        if sent.get(art["path"]) == sha:
-            continue
-        next_sent[art["path"]] = sha
-        changed.append(art)
-    # Tombstones: a previously-synced file the agent deleted (page merge, rename,
-    # restructure) must be deleted from the consumer's store too — otherwise the
-    # orphan row gets published and the next respawn's workspace rehydration puts
-    # the file back on disk, silently undoing the deletion. Judged by is_file(),
-    # NOT by absence from the collection: a file that merely became oversized or
-    # binary is skipped by the collector but still exists, and must keep its
-    # last-synced row. `sent` scopes the sweep to paths this box life actually
-    # synced, so a store row that never materialized here can't be tombstoned.
-    wd = Path(run.workdir)
-    for path in [p for p in sent if p not in collected]:
-        if (wd / path).is_file():
-            continue  # still on disk, just not collectable — keep the row
-        if sent.get(path) != _SYNC_TOMBSTONE:
-            next_sent[path] = _SYNC_TOMBSTONE
-            changed.append({"path": path, "deleted": True})
-    if changed or commit_input:
-        event = {"type": "syncArtifacts", "artifacts": changed}
-        if commit_input:
-            event["commit_input"] = True
-        await run.emit(event)
-        # Advance the dedup cursor only after the event is queued. Tombstone
-        # markers are retained so an SSE re-attach can replay deletions too.
-        if changed:
-            sent.clear()
-            sent.update(next_sent)
-        if commit_input:
-            run._commit_input_replay = True
-    return len(changed)
+    async with run._sync_lock:
+        if commit_input and not (Path(run.workdir) / "candidate" / "index.md").is_file():
+            raise FileNotFoundError("cannot commit compile input without candidate/index.md")
+        blocked_paths = _blocked_provenance_paths(run)
+        if commit_input and blocked_paths:
+            raise selfcheck.ProvenanceStampError(
+                "cannot commit compile input while candidate provenance stamping is blocked")
+        changed = []
+        next_sent = dict(sent)
+        # Blocked pages still exist. Treat them as collected so durability sync
+        # preserves the last good consumer copy instead of emitting a tombstone.
+        collected = set(blocked_paths)
+        for art in _collect_workspace_artifacts_for_sync(run):
+            collected.add(art["path"])
+            sha = hashlib.sha256(art["content"].encode("utf-8")).hexdigest()
+            if sent.get(art["path"]) == sha:
+                continue
+            next_sent[art["path"]] = sha
+            changed.append(art)
+        # Tombstones: a previously-synced file the agent deleted (page merge, rename,
+        # restructure) must be deleted from the consumer's store too — otherwise the
+        # orphan row gets published and the next respawn's workspace rehydration puts
+        # the file back on disk, silently undoing the deletion. Judged by is_file(),
+        # NOT by absence from the collection: a file that merely became oversized or
+        # binary is skipped by the collector but still exists, and must keep its
+        # last-synced row. `sent` scopes the sweep to paths this box life actually
+        # synced, so a store row that never materialized here can't be tombstoned.
+        wd = Path(run.workdir)
+        for path in [p for p in sent if p not in collected]:
+            if (wd / path).is_file():
+                continue  # still on disk, just not collectable — keep the row
+            if sent.get(path) != _SYNC_TOMBSTONE:
+                next_sent[path] = _SYNC_TOMBSTONE
+                changed.append({"path": path, "deleted": True})
+        if changed or commit_input:
+            event = {"type": "syncArtifacts", "artifacts": changed}
+            if commit_input:
+                event["commit_input"] = True
+            ack = None
+            sync_id = ""
+            if durable_barrier and run._artifact_ack_required:
+                sync_id = str(uuid.uuid4())
+                event["sync_id"] = sync_id
+                ack = asyncio.get_running_loop().create_future()
+                run._pending_sync_acks[sync_id] = ack
+                run._pending_sync_events[sync_id] = event
+            await run.emit(event)
+            if ack is not None:
+                _print_compile_lifecycle(
+                    "checkpoint.await_ack", run,
+                    extra=f"sync={sync_id} artifacts={len(changed)} commit={str(commit_input).lower()}",
+                )
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(ack), timeout=ARTIFACT_ACK_TIMEOUT_SECS)
+                except asyncio.TimeoutError as error:
+                    _print_compile_lifecycle(
+                        "checkpoint.ack_timeout", run, extra=f"sync={sync_id}")
+                    raise TimeoutError(
+                        f"consumer did not acknowledge artifact checkpoint {sync_id}"
+                    ) from error
+                _print_compile_lifecycle(
+                    "checkpoint.acked", run,
+                    extra=f"sync={sync_id} artifacts={len(changed)} commit={str(commit_input).lower()}",
+                )
+            # ACK-capable barriers advance only after the consumer transaction
+            # committed. Legacy/non-barrier sync keeps its established enqueue
+            # cursor and remains replayable on relay re-attach.
+            if changed:
+                sent.clear()
+                sent.update(next_sent)
+            if commit_input:
+                run._commit_input_replay = True
+        return len(changed)
 
 
 def _workspace_replay_artifacts(run: CompileRun, sent: dict) -> list[dict]:
@@ -1124,6 +1168,11 @@ async def _sync_loop(run: CompileRun, sent: dict):
     while True:
         try:
             await asyncio.sleep(SYNC_INTERVAL_SECS)
+            # Batch Candidate bytes and their task ledger form one sealed fact.
+            # Never leak a half-written current batch through the periodic path;
+            # the orchestrator persists the whole tree at its batch boundary.
+            if getattr(run, "_batch_active", False):
+                continue
             await _sync_workspace(run, sent)
         except asyncio.CancelledError:
             return
@@ -1696,7 +1745,8 @@ def _prepare_command(run: "CompileRun", command: dict) -> None:
         raise CommandRejected("no structured source changes are available for incremental compile", 409)
     if action == "compile.resume":
         plan = _load_batch_plan(run)
-        if not _batch_plan_resumable(plan):
+        reset_marker = (Path(run.workdir) / RECOVERY_RESET_PATH).is_file()
+        if not _batch_plan_resumable(plan) and not reset_marker:
             raise CommandRejected("no interrupted batch plan is available to resume", 409)
     if action == "compile.refresh_domain":
         index = Path(run.workdir) / "candidate" / "index.md"
@@ -3016,12 +3066,9 @@ async def _emit_message(run: CompileRun, msg) -> None:
                 ]
                 _record_provenance_stamp_result(run, resolved, failures)
             run._turn_page_hashes = None
-            sent = getattr(run, "_sync_sent", None)
-            if sent is not None:
-                try:
-                    await _sync_workspace(run, sent)
-                except Exception:
-                    pass
+            # Do not persist an internal batch session independently. Candidate
+            # bytes and the orchestrator's done stamp must enter the consumer in
+            # one atomic syncArtifacts transaction at the batch boundary.
             return
         # Layer-1 self-check BEFORE the sync so SELFCHECK.json rides the same
         # pre-turn_done sync. Fail-open: a self-check crash must not kill the
@@ -4746,9 +4793,9 @@ async def _commit_batch_compile(run: "CompileRun", plan: dict, replies: list[str
     if sent is not None:
         try:
             if not already_commit:
-                await _sync_workspace(run, sent)
+                await _sync_workspace(run, sent, durable_barrier=True)
                 _print_compile_lifecycle("batch.commit.checkpoint", run)
-            await _sync_workspace(run, sent, commit_input=True)
+            await _sync_workspace(run, sent, commit_input=True, durable_barrier=True)
             _print_compile_lifecycle("batch.commit.emit", run)
         except Exception as error:
             _print_compile_lifecycle(
@@ -4820,6 +4867,10 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 f"语料 {total_kb}KB 超过单会话阈值,启用分批编译。")})
             plan = await _plan_batches(run, [i for i in inventory if i["path"] in plannable])
             _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+            # An explicit plan-integrity reset preserves Candidate but revokes
+            # the corrupt controller checkpoint. Seal the replacement plan and
+            # the reset-marker tombstone in the same batch-zero transaction.
+            (Path(run.workdir) / RECOVERY_RESET_PATH).unlink(missing_ok=True)
         else:
             # The pinned plan predates this run; a source deleted from raw/ in
             # between would leave a batch directive pointing at a missing file,
@@ -4837,6 +4888,12 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                                         + ("…" if len(dropped) > 5 else "")})
         entry_phase = str(plan.get("phase") or "map")
         _write_compilation_state(run, plan)
+        # Seal the task/handoff before batch 1. A provider/Box failure with zero
+        # completed pages is still an autonomously recoverable compile when the
+        # exact plan and input identity are durable.
+        sent = getattr(run, "_sync_sent", None)
+        if sent is not None:
+            await _sync_workspace(run, sent, durable_barrier=True)
         slice_failures = _materialize_batch_slices(run, plan)
         if slice_failures:
             n_all = len(plan["batches"])
@@ -5042,10 +5099,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
             # would re-run an already-done batch on resume.
             sent = getattr(run, "_sync_sent", None)
             if sent is not None:
-                try:
-                    await _sync_workspace(run, sent)
-                except Exception:
-                    pass  # periodic sync will retry; the local stamp is already on disk
+                await _sync_workspace(run, sent, durable_barrier=True)
             _print_compile_lifecycle("batch.done", run, extra=_lifecycle_batch_ref(batch, k, n))
             await run.emit({"type": "summary", "text": _loc(run,
                 f"Batch {k}/{n} done — landed in the store.", f"批 {k}/{n} 完成,已落库。")})
@@ -5102,10 +5156,7 @@ async def _run_batch_compile(run: "CompileRun", trigger_text: str):
                 _write_compilation_state(run, plan)
                 sent = getattr(run, "_sync_sent", None)
                 if sent is not None:
-                    try:
-                        await _sync_workspace(run, sent)
-                    except Exception:
-                        pass
+                    await _sync_workspace(run, sent, durable_barrier=True)
         plan["phase"] = "final"
         _write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
         _write_compilation_state(run, plan)
@@ -7107,6 +7158,7 @@ async def handle_session(request: web.Request):
     # persistent session, batch sessions, PK and media-verify all inherit them.
     _apply_session_config(body)
     run = CompileRun(run_id, body.get("workdir", "/work"), int(body.get("round", 1)), body.get("instruction", ""))
+    run._artifact_ack_required = body.get("artifact_ack") is True
     # Tool whitelist from the runtime BoxProfile (None/absent → driver default).
     run.allowed_tools = body.get("allowed_tools")
     run.locale = body.get("locale")
@@ -7469,6 +7521,30 @@ async def handle_command(request: web.Request):
         return web.json_response({"error": str(exc)}, status=exc.status)
 
 
+async def handle_artifacts_ack(request: web.Request):
+    """Acknowledge one syncArtifacts transaction after consumer commit.
+
+    The endpoint is idempotent: a retried ACK for an already-released barrier is
+    still successful. Unknown runs remain a 404 so a runtime never mistakes a
+    different/reaped box for the owner of the checkpoint.
+    """
+    run = RUNS.get(request.match_info["run_id"])
+    if not run:
+        return web.json_response({"error": "unknown run"}, status=404)
+    try:
+        body = await request.json() if request.body_exists else {}
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+        return web.json_response({"error": "request body must be valid JSON"}, status=400)
+    sync_id = str(body.get("sync_id") or "").strip()
+    if not sync_id or len(sync_id) > 128:
+        return web.json_response({"error": "sync_id is required"}, status=400)
+    future = run._pending_sync_acks.pop(sync_id, None)
+    run._pending_sync_events.pop(sync_id, None)
+    if future is not None and not future.done():
+        future.set_result(True)
+    return web.json_response({"ok": True, "sync_id": sync_id, "accepted": future is not None})
+
+
 async def handle_events(request: web.Request):
     run = RUNS.get(request.match_info["run_id"])
     if not run:
@@ -7485,8 +7561,12 @@ async def handle_events(request: web.Request):
         # a previous runtime dequeued a sync event but died before persisting it;
         # it also works when the run already queued its terminal `end` frame.
         wants_replay = request.query.get("replay") == "1"
+        pending_syncs = (list(getattr(run, "_pending_sync_events", {}).values())
+                         if wants_replay else [])
+        for ev in pending_syncs:
+            await resp.write(("data: " + json.dumps(ev, ensure_ascii=False) + "\n\n").encode())
         replay = (_workspace_replay_artifacts(run, getattr(run, "_sync_sent", {}))
-                  if wants_replay else [])
+                  if wants_replay and not pending_syncs else [])
         replay_commit = wants_replay and getattr(run, "_commit_input_replay", False)
         if replay or replay_commit:
             ev = {"type": "syncArtifacts", "artifacts": replay}
@@ -7886,6 +7966,11 @@ async def _flush_on_shutdown(_app) -> None:
     Best-effort — a store that never acks still loses it; F1 is the durable fix."""
     runs = [r for r in RUNS.values() if getattr(r, "_sync_sent", None) is not None]
     for run in runs:
+        # A durability barrier already owns the sync lock and its exact event is
+        # queued/replayable. Waiting up to the ACK timeout inside aiohttp shutdown
+        # would consume the pod's termination grace without adding evidence.
+        if getattr(run, "_sync_lock", None) is not None and run._sync_lock.locked():
+            continue
         try:
             n = await _sync_workspace(run, run._sync_sent)
             if n:
@@ -7936,6 +8021,7 @@ def build_app() -> web.Application:
         web.post("/session/{run_id}", handle_session),
         web.post("/message/{run_id}", handle_message),
         web.post("/command/{run_id}", handle_command),
+        web.post("/artifacts/ack/{run_id}", handle_artifacts_ack),
         web.get("/events/{run_id}", handle_events),
         # Test session: read-only consumer session over a pinned draft snapshot.
         web.post("/test-session/{run_id}", handle_open_test),

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -113,6 +113,18 @@ def test_context_budget_defaults_leave_room_for_the_working_set(tmp_path):
     assert 280_000 <= slice_tokens <= 450_000, slice_tokens
     assert (slice_tokens + bt.ESTIMATED_FIXED_CONTEXT_TOKENS
             <= bt.DEFAULT_CONTEXT_TARGET_TOKENS)
+    # Same question, same answer: a file is sliced only when it truly does not
+    # fit one session. These are compiler facts, not environment configuration.
+    assert (bt.DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES
+            == bt.DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES)
+    plan = bt.build_plan([], [], planner="hierarchical-code")
+    assert plan["context_window_tokens"] == 1_000_000
+    assert plan["context_target_tokens"] == 500_000
+    assert plan["estimated_context_tokens"] <= plan["context_target_tokens"]
+    # An image is ~1.5-2.5K vision tokens. Pricing it like a document is what
+    # produced batches of nothing but screenshots.
+    assert bt._image_cost() <= 12 * 1024
+    assert bt._image_cost() <= bt._hierarchical_image_cost() <= 4 * bt._image_cost()
 
 
 def test_checkpoint_digest_covers_progress_and_detects_tampering(tmp_path):
@@ -139,18 +151,6 @@ def test_checkpoint_state_machine_rejects_late_phases_with_pending_work(tmp_path
     plan["phase"] = "final"
     plan["reductions"] = [{"id": "r001", "status": "pending"}]
     assert "unfinished reductions" in " ".join(bt.checkpoint_state_errors(plan))
-    # Same question, same answer: a file is sliced only when it truly does not
-    # fit one session.
-    assert (bt.DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES
-            == bt.DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES)
-    plan = bt.build_plan([], [], planner="hierarchical-code")
-    assert plan["context_window_tokens"] == 1_000_000
-    assert plan["context_target_tokens"] == 500_000
-    assert plan["estimated_context_tokens"] <= plan["context_target_tokens"]
-    # An image is ~1.5-2.5K vision tokens. Pricing it like a document is what
-    # produced batches of nothing but screenshots.
-    assert bt._image_cost() <= 12 * 1024
-    assert bt._image_cost() <= bt._hierarchical_image_cost() <= 4 * bt._image_cost()
 
 
 def test_a_section_placeholder_never_costs_its_own_session(tmp_path):
@@ -239,12 +239,16 @@ def test_pack_groups_by_top_dir_and_budget(tmp_path):
 
 def test_many_small_sections_fill_the_context_budget_instead_of_spawning_one_session_each(tmp_path):
     raw = _mk(tmp_path, {
-        f"section-{i:03d}/page.md": 100 for i in range(20)
+        f"section-{i:03d}/page.md": 200 for i in range(125)
     })
     inv = bt.scan_sources(raw)
     batches = bt.pack_hierarchical_batches(inv, budget=1_000, text_budget=1_000)
-    assert len(batches) == 4, batches
-    assert all(500 <= b["bytes"] <= 1_000 for b in batches), batches
+    # The old section-boundary flush emitted 125 sessions here. Filling to half
+    # the existing budget reduces the same shape to roughly the requested 50
+    # without enlarging any deployment-configured budget.
+    assert len(batches) == 42, batches
+    assert all(500 <= b["bytes"] <= 1_000 for b in batches[:-1]), batches
+    assert batches[-1]["bytes"] <= 1_000
     assert sorted(p for b in batches for p in b["sources"]) == sorted(i["path"] for i in inv)
 
 

--- a/kbc/platform/pod/test_batching.py
+++ b/kbc/platform/pod/test_batching.py
@@ -83,7 +83,7 @@ def test_partial_slices_are_still_rejected_for_ordinary_documents(tmp_path):
     stops short of the last line is incomplete, and there is no longer any
     exemption from that — nothing in this planner may decide the model has
     seen enough."""
-    body = "".join(f"operational note line {i:05d}\n" for i in range(40_000))
+    body = "".join(f"operational note line {i:05d}\n" for i in range(60_000))
     raw = _mk_text(tmp_path, {"ops/manual.md": body})
     inv = bt.scan_sources(raw)
     item = next(i for i in inv if i["path"] == "ops/manual.md")
@@ -101,9 +101,9 @@ def test_partial_slices_are_still_rejected_for_ordinary_documents(tmp_path):
 def test_context_budget_defaults_leave_room_for_the_working_set(tmp_path):
     """The numbers themselves, in one place. A batch spends its slice PLUS a
     working set (system prompt, BRIEF, INTENT, index, the pages it appends to,
-    every accumulated tool result). The agreed SAFE ceiling for one session is
-    750K of a 1M window, so at ~3 bytes/token for this corpus the slice should
-    sit near a third of the window — leaving the rest for the working set.
+    every accumulated tool result). The owner target is at most 500K of a 1M
+    window. At ~3 bytes/token the configured source slice plus the measured
+    fixed overhead must remain below that target.
 
     The band moved up from 120-220K when the old 512KB budget was found to be
     costly rather than cautious: a smaller budget pushes more families into the
@@ -111,11 +111,42 @@ def test_context_budget_defaults_leave_room_for_the_working_set(tmp_path):
     Context is the cheap resource; stability is the expensive one."""
     slice_tokens = bt.DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES / 3
     assert 280_000 <= slice_tokens <= 450_000, slice_tokens
-    assert slice_tokens < 750_000, "must stay under the agreed safe ceiling"
+    assert (slice_tokens + bt.ESTIMATED_FIXED_CONTEXT_TOKENS
+            <= bt.DEFAULT_CONTEXT_TARGET_TOKENS)
+
+
+def test_checkpoint_digest_covers_progress_and_detects_tampering(tmp_path):
+    plan = bt.build_plan([], [], planner="hierarchical-code")
+    plan["batches"] = [{"id": "b01", "sources": ["one.md"], "status": "pending"}]
+    bt.seal_checkpoint(plan)
+    first = plan["checkpoint_digest"]
+    assert bt.checkpoint_is_valid(plan)
+    plan["batches"][0]["status"] = "done"
+    assert not bt.checkpoint_is_valid(plan)
+    bt.seal_checkpoint(plan)
+    assert bt.checkpoint_is_valid(plan)
+    assert plan["checkpoint_digest"] != first
+
+
+def test_checkpoint_state_machine_rejects_late_phases_with_pending_work(tmp_path):
+    plan = {"phase": "complete", "batches": [
+        {"id": "b01", "sources": ["one.md"], "status": "pending"}
+    ]}
+    assert "unfinished map" in " ".join(bt.checkpoint_state_errors(plan))
+    plan["phase"] = "map"
+    assert bt.checkpoint_state_errors(plan) == []
+    plan["batches"][0]["status"] = "done"
+    plan["phase"] = "final"
+    plan["reductions"] = [{"id": "r001", "status": "pending"}]
+    assert "unfinished reductions" in " ".join(bt.checkpoint_state_errors(plan))
     # Same question, same answer: a file is sliced only when it truly does not
     # fit one session.
     assert (bt.DEFAULT_HIERARCHICAL_TEXT_SLICE_BYTES
             == bt.DEFAULT_HIERARCHICAL_TEXT_BUDGET_BYTES)
+    plan = bt.build_plan([], [], planner="hierarchical-code")
+    assert plan["context_window_tokens"] == 1_000_000
+    assert plan["context_target_tokens"] == 500_000
+    assert plan["estimated_context_tokens"] <= plan["context_target_tokens"]
     # An image is ~1.5-2.5K vision tokens. Pricing it like a document is what
     # produced batches of nothing but screenshots.
     assert bt._image_cost() <= 12 * 1024
@@ -199,14 +230,22 @@ def test_pack_groups_by_top_dir_and_budget(tmp_path):
     )
     inv = bt.scan_sources(raw)
     batches = bt.pack_batches(inv, budget=200)
-    # ops/, root(""), sdk/ in sorted path order; sdk splits at the budget.
     by_sources = [b["sources"] for b in batches]
-    assert ["ops/d.md"] in by_sources
-    assert ["root.md"] in by_sources
-    sdk_batches = [b for b in by_sources if b and b[0].startswith("sdk/")]
-    assert len(sdk_batches) == 2  # 90+90 then 90
+    assert len(by_sources) == 2, by_sources
+    assert all(b["bytes"] <= 200 for b in batches)
     flat = [p for b in by_sources for p in b]
     assert sorted(flat) == sorted(i["path"] for i in inv)  # exactly once
+
+
+def test_many_small_sections_fill_the_context_budget_instead_of_spawning_one_session_each(tmp_path):
+    raw = _mk(tmp_path, {
+        f"section-{i:03d}/page.md": 100 for i in range(20)
+    })
+    inv = bt.scan_sources(raw)
+    batches = bt.pack_hierarchical_batches(inv, budget=1_000, text_budget=1_000)
+    assert len(batches) == 4, batches
+    assert all(500 <= b["bytes"] <= 1_000 for b in batches), batches
+    assert sorted(p for b in batches for p in b["sources"]) == sorted(i["path"] for i in inv)
 
 
 def test_pack_oversized_single_file_gets_own_batch(tmp_path):
@@ -906,11 +945,14 @@ def main():
         test_every_text_format_can_be_sliced_not_only_markdown,
         test_partial_slices_are_still_rejected_for_ordinary_documents,
         test_context_budget_defaults_leave_room_for_the_working_set,
+        test_checkpoint_digest_covers_progress_and_detects_tampering,
+        test_checkpoint_state_machine_rejects_late_phases_with_pending_work,
         test_a_section_placeholder_never_costs_its_own_session,
         test_scan_skips_hidden_and_empty,
         test_threshold_gate_small_kb_never_batches,
         test_tiered_gate_keeps_small_and_medium_routes_stable,
         test_pack_groups_by_top_dir_and_budget,
+        test_many_small_sections_fill_the_context_budget_instead_of_spawning_one_session_each,
         test_pack_oversized_single_file_gets_own_batch,
         test_hierarchical_pack_keeps_document_assets_together,
         test_hierarchical_family_links_exact_original_attachment_and_sidecar,

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3899,6 +3899,29 @@ async def test_batch_orchestrator_routing_and_resume():
         note = compile_box._drain_batch_notes(run)
         assert "注意保密条款" in note and compile_box._drain_batch_notes(run) == ""
         run._batch_active = False
+
+        # Explicit control reset: a corrupt plan is revoked, but Candidate and
+        # Raw remain. The trusted resume command rebuilds a plan in-place and
+        # consumes the reset marker instead of requiring a fresh generation.
+        (wd / batching.BATCH_PLAN_PATH).unlink()
+        reset_marker = wd / compile_box.RECOVERY_RESET_PATH
+        reset_marker.write_text(
+            '{"version":1,"reason":"explicit_control_reset","candidate_preserved":true}',
+            "utf-8",
+        )
+        compile_box._prepare_command(
+            run, {"action": "compile.resume", "parameters": {}})
+        driven.clear()
+        compile_box._drive_batch_session = fake_drive
+        compile_box._unaccounted_batch_sources = lambda run_, sources: []
+        try:
+            await compile_box._run_batch_compile(run, "ignored localized text")
+        finally:
+            compile_box._drive_batch_session = real_drive
+            compile_box._unaccounted_batch_sources = real_accounted
+        assert len(driven) == 3, driven
+        assert not reset_marker.exists(), "reset marker survived replacement-plan seal"
+        assert (wd / batching.BATCH_PLAN_PATH).is_file()
         del os.environ["KBC_BATCH_THRESHOLD_BYTES"]
         del os.environ["KBC_BATCH_BUDGET_BYTES"]
     print("\u2713 batch orchestrator: gate/stamps/single turn_done/resume/notes")
@@ -6255,6 +6278,57 @@ async def test_workspace_sync_invalidates_verification_before_cross_process_resu
     print("✓ workspace sync invalidates old verified before cross-process resume")
 
 
+async def test_durable_workspace_sync_waits_for_consumer_ack():
+    """A sealed batch is not complete until Sicore commits and ACKs it."""
+    compile_box.RUNS.clear()
+    with tempfile.TemporaryDirectory() as td:
+        candidate = Path(td) / "candidate"
+        authoring = Path(td) / "authoring"
+        candidate.mkdir()
+        authoring.mkdir()
+        (candidate / "index.md").write_text("# Index\n", "utf-8")
+        (candidate / "topic.md").write_text("# Topic\n", "utf-8")
+        (authoring / "BATCH_PLAN.json").write_text(
+            json.dumps({"phase": "map", "batches": [{"id": "b01", "status": "done"}]}),
+            "utf-8",
+        )
+        run = compile_box.CompileRun("ack-run", td, 1)
+        run._artifact_ack_required = True
+        compile_box.RUNS[run.run_id] = run
+        sent = {}
+
+        pending = asyncio.create_task(
+            compile_box._sync_workspace(run, sent, durable_barrier=True))
+        event = await asyncio.wait_for(run.events.get(), timeout=1)
+        run.events.task_done()
+        assert event["type"] == "syncArtifacts", event
+        sync_id = event.get("sync_id")
+        assert sync_id and not pending.done(), "batch advanced before durable ACK"
+        assert run._pending_sync_events[sync_id] == event
+
+        client = TestClient(TestServer(compile_box.build_app()))
+        await client.start_server()
+        try:
+            response = await client.post(
+                f"/artifacts/ack/{run.run_id}", json={"sync_id": sync_id})
+            assert response.status == 200, await response.text()
+            body = await response.json()
+            assert body["accepted"] is True, body
+            changed = await asyncio.wait_for(pending, timeout=1)
+            assert changed >= 3, changed
+            assert sent, "dedupe cursor advances only after ACK"
+
+            # Lost ACK responses are harmless: runtime retries idempotently.
+            response = await client.post(
+                f"/artifacts/ack/{run.run_id}", json={"sync_id": sync_id})
+            body = await response.json()
+            assert response.status == 200 and body["accepted"] is False, body
+        finally:
+            await client.close()
+            compile_box.RUNS.clear()
+    print("✓ durable workspace sync waits for atomic consumer ACK")
+
+
 async def test_batch_stamp_blocker_is_repairable_without_syncing_stale_trust():
     """Unsafe YAML is a repair finding, not a retry poison or trust leak."""
     class ResultMessage:
@@ -6887,6 +6961,7 @@ async def main():
     await test_batch_rebuild_exhaustion_raises_resumable()
     test_batch_retry_preserves_first_attempt_page_baseline()
     await test_workspace_sync_invalidates_verification_before_cross_process_resume()
+    await test_durable_workspace_sync_waits_for_consumer_ack()
     await test_batch_stamp_blocker_is_repairable_without_syncing_stale_trust()
     await test_resumed_batch_phase_is_watchdog_armed()
     await test_run_wrapper_closes_turn_on_driver_crash()

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -3879,7 +3879,8 @@ async def test_batch_orchestrator_routing_and_resume():
         # resume: mark one batch pending again → next trigger routes to batch even
         # under a huge threshold, and only the pending batch (+终审) re-runs
         plan["batches"][1]["status"] = "pending"
-        (wd / batching.BATCH_PLAN_PATH).write_text(json.dumps(plan))
+        plan["phase"] = "map"
+        compile_box._write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
         os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100000"
         assert compile_box._should_route_to_batch(run, "直接开始编译")
         driven.clear()
@@ -4818,6 +4819,10 @@ def test_batch_relay_brief_hands_off_progress_and_prior_pages():
     with tempfile.TemporaryDirectory() as td:
         base = Path(td)
         (base / "raw" / "ops").mkdir(parents=True)
+        (base / "raw" / "other").mkdir(parents=True)
+        (base / "raw" / "ops" / "big.md").write_text("# big", encoding="utf-8")
+        (base / "raw" / "ops" / "sibling.md").write_text("# sibling", encoding="utf-8")
+        (base / "raw" / "other" / "far.md").write_text("# far", encoding="utf-8")
         (base / "candidate").mkdir()
         (base / "authoring").mkdir()
         (base / "candidate" / "tickets.md").write_text(
@@ -4850,12 +4855,50 @@ def test_batch_relay_brief_hands_off_progress_and_prior_pages():
         assert "candidate/tickets.md" in directive, directive
         assert "not your field of view" in directive, directive
 
+        # The durable hand-off names the ENTIRE Candidate tree and source map;
+        # responsibility is bounded, visibility is not.
+        compile_box._write_compilation_state(run, plan)
+        state = json.loads((base / "authoring" / "COMPILATION_STATE.json").read_text())
+        assert state["visibility"] == "complete_frozen_raw_and_candidate_tree", state
+        assert state["candidate_pages"] == [
+            "elsewhere.md", "neighbour.md", "tickets.md"
+        ], state
+        assert state["source_to_pages"]["ops/big.md"] == ["tickets.md"], state
+        assert len(state["candidate_tree_hash"]) == 64, state
+
         # No prior work \u2192 a hand-off that is still honest, never fabricated.
         fresh = compile_box._batch_relay_brief(
             run, plan, {"id": "h003", "sources": ["new/area.md"]}, 1, 2, locale="en")
         assert "Candidate pages so far: 3" in fresh, fresh
         assert "candidate/tickets.md" not in fresh, fresh
     print("\u2713 batch relay brief: machine-computed hand-off between sessions")
+
+
+def test_batch_checkpoint_digest_is_verified_before_resume():
+    """A damaged checkpoint must pause for explicit reset/restore, never look
+    like no checkpoint and silently restart an expensive semantic compile."""
+    import batching
+
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        run = compile_box.CompileRun("checkpoint-integrity", str(wd), 1)
+        plan = {"phase": "map", "batches": [
+            {"id": "b01", "sources": ["one.md"], "status": "pending"}
+        ]}
+        compile_box._write_batch_file(run, batching.BATCH_PLAN_PATH, plan)
+        assert compile_box._load_batch_plan(run)["checkpoint_digest"]
+
+        stored = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+        stored["batches"][0]["status"] = "done"
+        (wd / batching.BATCH_PLAN_PATH).write_text(batching.dump_json(stored))
+        try:
+            compile_box._load_batch_plan(run)
+        except compile_box.PlanIntegrityError as error:
+            assert "digest" in str(error)
+            assert compile_box._batch_error_code(error) == "plan_integrity"
+        else:
+            raise AssertionError("tampered checkpoint was accepted")
+    print("\u2713 batch checkpoint: digest mismatch pauses instead of replanning")
 
 
 def test_hierarchical_resume_state_contract():
@@ -4875,7 +4918,7 @@ def test_hierarchical_resume_state_contract():
             "reductions": [],
         }
 
-        for phase in ("map", "reduce", "final"):
+        for phase in ("map", "reduce", "final", "commit"):
             plan["phase"] = phase
             (wd / batching.BATCH_PLAN_PATH).write_text(batching.dump_json(plan))
             assert compile_box._batch_plan_resumable(plan), phase
@@ -4894,7 +4937,7 @@ def test_hierarchical_resume_state_contract():
             assert "no interrupted batch plan" in str(error)
         else:
             raise AssertionError("complete batch plan must not be resumable")
-    print("\u2713 hierarchical resume: typed command covers map/reduce/final only")
+    print("\u2713 hierarchical resume: typed command covers map/reduce/final/commit only")
 
 
 def test_hierarchical_pdf_page_directive():
@@ -5154,12 +5197,22 @@ async def test_hierarchical_batch_plan_and_section_reduce():
             # replay the expensive map or reduce train, even if raw has since
             # shrunk below the ordinary batch threshold.
             saved["phase"] = "final"
-            (wd / batching.BATCH_PLAN_PATH).write_text(json.dumps(saved))
+            compile_box._write_batch_file(run, batching.BATCH_PLAN_PATH, saved)
             os.environ["KBC_BATCH_THRESHOLD_BYTES"] = "100000"
             assert compile_box._should_route_to_batch(run, "直接开始编译")
             driven.clear()
             await compile_box._run_batch_compile(run, "直接开始编译")
             assert len(driven) == 1 and driven[0].startswith("final review"), driven
+
+            # A crash after semantic finalization but before the durable commit
+            # retries delivery only. No model session is replayed.
+            committed = json.loads((wd / batching.BATCH_PLAN_PATH).read_text())
+            committed["phase"] = "commit"
+            compile_box._write_batch_file(run, batching.BATCH_PLAN_PATH, committed)
+            driven.clear()
+            await compile_box._run_batch_compile(run, "直接开始编译")
+            assert driven == [], driven
+            assert json.loads((wd / batching.BATCH_PLAN_PATH).read_text())["phase"] == "complete"
     finally:
         compile_box._drive_batch_session = real_drive
         compile_box._run_ledger_repairs = real_repairs
@@ -6813,6 +6866,7 @@ async def main():
     test_small_kb_batch_gate_skips_poppler_metadata()
     test_hierarchical_text_slice_materialization_and_directive()
     test_batch_relay_brief_hands_off_progress_and_prior_pages()
+    test_batch_checkpoint_digest_is_verified_before_resume()
     test_hierarchical_resume_state_contract()
     test_hierarchical_pdf_page_directive()
     await test_codex_batch_scope_and_pdf_page_tool()

--- a/src/gateway/capability/session-driver.test.ts
+++ b/src/gateway/capability/session-driver.test.ts
@@ -272,6 +272,10 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     const artifactCalls = fe.request.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_PERSIST_ARTIFACTS);
     expect(artifactCalls).toHaveLength(3);
     expect(artifactCalls[0][1]).toEqual(artifactCalls[2][1]);
+    // A consumer persistence retry is not evidence that the Box is alive. If it
+    // refreshes the Box heartbeat, a dead Box can stay "running" for the full
+    // data-stale window while only this local retry loop is making progress.
+    expect(mgr.touchHeartbeat).not.toHaveBeenCalled();
   }, 10_000);
 
   it("stops retrying when the run is cancelled or reaped", async () => {

--- a/src/gateway/capability/session-driver.test.ts
+++ b/src/gateway/capability/session-driver.test.ts
@@ -96,6 +96,39 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     });
   });
 
+  it("ACKs a sealed checkpoint only after the consumer transaction commits", async () => {
+    const order: string[] = [];
+    const fe = fakeFrontend();
+    fe.request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === CAPABILITY_PERSIST_ARTIFACTS) order.push("persist");
+      return { ok: true };
+    });
+    const client = {
+      async *streamPath() {
+        yield {
+          type: "syncArtifacts",
+          sync_id: "sync-1",
+          artifacts: [{ path: "candidate/a.md", content: "# A" }],
+        };
+      },
+      postJson: vi.fn().mockImplementation(async () => {
+        order.push("ack");
+        return { ok: true };
+      }),
+    } as any;
+    const mgr = fakeManager();
+    mgr.get.mockReturnValue({ runId: "r1", status: "running", inputRevision: "manifest-1" });
+
+    await driveCapabilitySession({ client, runId: "r1", frontendClient: fe, manager: mgr });
+
+    expect(order).toEqual(["persist", "ack"]);
+    expect(client.postJson).toHaveBeenCalledWith(
+      "/artifacts/ack/r1",
+      { sync_id: "sync-1" },
+      10_000,
+    );
+  });
+
   it("persists an explicit input commit even when no files changed", async () => {
     const fe = fakeFrontend();
     const mgr = fakeManager();

--- a/src/gateway/capability/session-driver.ts
+++ b/src/gateway/capability/session-driver.ts
@@ -178,7 +178,6 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
                 `[capability] run=${runId} persistArtifacts failed; retrying in ${delayMs}ms:`,
                 err instanceof Error ? err.message : String(err),
               );
-              manager.touchHeartbeat(runId);
               await new Promise((resolve) => setTimeout(resolve, delayMs));
               delayMs = Math.min(delayMs * 2, 5000);
             }

--- a/src/gateway/capability/session-driver.ts
+++ b/src/gateway/capability/session-driver.ts
@@ -46,6 +46,8 @@ interface BoxEvent {
   artifacts?: Array<{ path: string; content?: string; deleted?: boolean }>;
   /** Explicit full-compile commit. Replayed file presence alone is not a commit. */
   commit_input?: boolean;
+  /** KBC durability barrier identity; ACK only after consumer commit succeeds. */
+  sync_id?: string;
   code?: string;
   stage?: string;
   attempts?: number;
@@ -180,6 +182,35 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
               );
               await new Promise((resolve) => setTimeout(resolve, delayMs));
               delayMs = Math.min(delayMs * 2, 5000);
+            }
+          }
+          if (evt.sync_id !== undefined) {
+            if (typeof evt.sync_id !== "string" || !evt.sync_id || evt.sync_id.length > 128) {
+              throw new Error(`invalid artifact sync id for run ${runId}`);
+            }
+            // Persistence acknowledgement is a second, idempotent hop back to
+            // KBC. Until it lands, the box must not start the next batch. A WS
+            // reconnect may replay the same sync_id; Sicore upserts atomically
+            // and this endpoint accepts duplicate ACKs.
+            let ackDelayMs = 250;
+            for (;;) {
+              try {
+                await client.postJson(`/artifacts/ack/${runId}`, { sync_id: evt.sync_id }, 10_000);
+                break;
+              } catch (err) {
+                const rec = manager.get(runId);
+                if (!rec || isTerminalCapabilityStatus(rec.status)) {
+                  throw new Error(
+                    `artifact acknowledgement aborted because run ${runId} is no longer active: ${err instanceof Error ? err.message : String(err)}`,
+                  );
+                }
+                console.error(
+                  `[capability] run=${runId} artifact ACK failed; retrying in ${ackDelayMs}ms:`,
+                  err instanceof Error ? err.message : String(err),
+                );
+                await new Promise((resolve) => setTimeout(resolve, ackDelayMs));
+                ackDelayMs = Math.min(ackDelayMs * 2, 5000);
+              }
             }
           }
         }

--- a/src/gateway/frontend-ws-client.test.ts
+++ b/src/gateway/frontend-ws-client.test.ts
@@ -611,6 +611,25 @@ describe("FrontendWsClient", () => {
     client.close();
   });
 
+  it("notifies lifecycle observers after both initial connect and reconnect", async () => {
+    const client = await createClient();
+    const connected = vi.fn();
+    const unsubscribe = client.onConnected(connected);
+
+    const connectPromise = client.connect();
+    const ws1 = openLatestWs();
+    await connectPromise;
+    expect(connected).toHaveBeenCalledTimes(1);
+
+    ws1.emit("close");
+    await vi.advanceTimersByTimeAsync(3100);
+    openLatestWs();
+    expect(connected).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    client.close();
+  });
+
   it("survives an 'unknown method' ack from an older consumer (best-effort)", async () => {
     const client = await createClient({ capabilities: { compile: true } });
     const connectPromise = client.connect();

--- a/src/gateway/frontend-ws-client.ts
+++ b/src/gateway/frontend-ws-client.ts
@@ -44,6 +44,7 @@ interface PendingRpc {
 
 type CommandHandler = (method: string, params: any) => Promise<any>;
 type EventHandler = (data: unknown) => boolean | void;
+type ConnectedHandler = () => void | Promise<void>;
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -61,6 +62,7 @@ export class FrontendWsClient {
   private pending = new Map<string, PendingRpc>();
   private commandHandler: CommandHandler | null = null;
   private eventHandlers = new Map<string, Set<EventHandler>>();
+  private connectedHandlers = new Set<ConnectedHandler>();
   private activeSessionsProvider?: () => string[];
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -82,6 +84,17 @@ export class FrontendWsClient {
   /** Whether the WS connection is currently open. */
   get connected(): boolean {
     return this._connected;
+  }
+
+  /**
+   * Observe every successful transport connection, including reconnects. The
+   * callback is deliberately lifecycle-only: callers re-read their durable
+   * state instead of trusting anything cached before the disconnect.
+   */
+  onConnected(handler: ConnectedHandler): () => void {
+    this.connectedHandlers.add(handler);
+    if (this._connected) queueMicrotask(() => this.notifyConnected(handler));
+    return () => this.connectedHandlers.delete(handler);
   }
 
   /**
@@ -271,6 +284,7 @@ export class FrontendWsClient {
       // Advertise capabilities on every (re)connect so the consumer's routing
       // reflects the current connection, not a stale record.
       this.advertiseCapabilities();
+      for (const handler of this.connectedHandlers) this.notifyConnected(handler);
     });
 
     ws.on("message", (raw: WebSocket.Data) => {
@@ -343,6 +357,16 @@ export class FrontendWsClient {
     // Inbound command (Portal → Runtime request)
     if (msg.type === "req" && typeof msg.id === "string" && typeof msg.method === "string") {
       this.handleInboundCommand(msg.id, msg.method, msg.params);
+    }
+  }
+
+  private notifyConnected(handler: ConnectedHandler): void {
+    try {
+      void Promise.resolve(handler()).catch((err) => {
+        console.warn(`[frontend-ws] connected observer failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    } catch (err) {
+      console.warn(`[frontend-ws] connected observer failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/src/gateway/server-capability-setup-failure.test.ts
+++ b/src/gateway/server-capability-setup-failure.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 const materializeMock = vi.hoisted(() => vi.fn());
 const postJsonMock = vi.hoisted(() => vi.fn());
+const streamPathMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
@@ -32,7 +33,7 @@ vi.mock("./agentbox/client.js", () => ({
     postJson = postJsonMock;
     getJson = vi.fn(async () => ({}));
     streamEvents = async function* () {};
-    streamPath = async function* () {};
+    streamPath = async function* (path: string) { streamPathMock(path); };
   },
 }));
 
@@ -45,8 +46,14 @@ const { startRuntime } = await import("./server.js");
 const { CapabilityMaterializationError } = await import("./capability/materialize.js");
 const { federationSelfRegistry } = await import("./federation-self-metrics.js");
 
-function fakeFrontendClient() {
-  return { request: vi.fn(async () => ({})), onCommand: vi.fn(), emitEvent: vi.fn(), close: vi.fn() } as any;
+function fakeFrontendClient(activeRuns: Array<Record<string, unknown>> = []) {
+  return {
+    request: vi.fn(async (method: string) => method === "capability.listActiveRuns" ? { runs: activeRuns } : {}),
+    onCommand: vi.fn(),
+    onConnected: vi.fn(),
+    emitEvent: vi.fn(),
+    close: vi.fn(),
+  } as any;
 }
 
 function fakeAgentBoxManager(created = true) {
@@ -72,6 +79,7 @@ beforeEach(() => {
   federationSelfRegistry.resetMetrics();
   materializeMock.mockReset();
   postJsonMock.mockReset().mockResolvedValue({ ok: true });
+  streamPathMock.mockReset();
 });
 afterEach(async () => {
   if (server) await server.close();
@@ -81,6 +89,54 @@ afterEach(async () => {
 });
 
 describe("startRuntime — capability session setup", () => {
+  it("re-attaches a recovered live Box with workspace replay even when materialization reports no conflict", async () => {
+    materializeMock.mockResolvedValueOnce({
+      reattached: false,
+      locale: undefined,
+      llm: undefined,
+      settings: undefined,
+    });
+    const frontend = fakeFrontendClient([{
+      id: "recovered-run",
+      profile: "kb-compile",
+      org_id: "org-1",
+      correlation_id: "attempt-1",
+      status: "running",
+    }]);
+    const manager = fakeAgentBoxManager(false);
+    manager.getAsync.mockResolvedValue({
+      boxId: "kbc-box-recovered-run",
+      endpoint: "https://10.0.0.9:3000",
+      agentId: "recovered-run",
+    });
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: manager,
+      frontendClient: frontend,
+      credentialService: {} as any,
+    });
+
+    await vi.waitFor(() => expect(streamPathMock).toHaveBeenCalled());
+    expect(streamPathMock).toHaveBeenCalledWith("/events/recovered-run?replay=1");
+  });
+
+  it("registers a connection observer that reconciles runs immediately after WS reconnect", async () => {
+    materializeMock.mockResolvedValue({ locale: undefined, llm: undefined, settings: undefined });
+    const frontend = fakeFrontendClient();
+    server = await startRuntime({
+      config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+      agentBoxManager: fakeAgentBoxManager(),
+      frontendClient: frontend,
+      credentialService: {} as any,
+    });
+
+    expect(frontend.onConnected).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(frontend.request).toHaveBeenCalledWith("capability.listActiveRuns", {}));
+    frontend.request.mockClear();
+    await frontend.onConnected.mock.calls[0][0]();
+    await vi.waitFor(() => expect(frontend.request).toHaveBeenCalledWith("capability.listActiveRuns", {}));
+  });
+
   it("stops the just-spawned box when session setup fails (no leak until the sweep)", async () => {
     materializeMock.mockResolvedValueOnce({ locale: undefined, llm: undefined, settings: undefined });
     postJsonMock.mockRejectedValueOnce(new Error("box unreachable during setup"));

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1232,6 +1232,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             instruction: instruction ?? "",
             allowed_tools: allowedTools,
             locale: materialized.locale,
+            // Enables KBC's per-batch durability barrier. Mixed-version safe:
+            // an older box ignores the field, while a newer box only waits for
+            // ACKs when a runtime explicitly advertises this support.
+            artifact_ack: true,
             // Whole-block authority: consumer LLM config wins as-is; only an
             // absent block uses Runtime's Helm env. The box applies it before
             // its SDK connects. Never logged here; token stays out of PodSpec.

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1175,7 +1175,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         try {
           const alive = await agentBoxManager.getAsync(rec.runId, rec.profile);
           if (!alive) return;
-          await ensureCapabilitySession(rec.runId, rec.profile, rec.orgId || undefined, undefined);
+          await ensureCapabilitySession(
+            rec.runId,
+            rec.profile,
+            rec.orgId || undefined,
+            undefined,
+            { replayWorkspace: true },
+          );
           console.log(`[capability] re-attached relay to live box for recovered run ${rec.runId}`);
         } catch (err) {
           console.warn(`[capability] relay re-attach for ${rec.runId} skipped:`, err instanceof Error ? err.message : String(err));
@@ -1189,7 +1195,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   // run record minted at capability.start — the box shape + tool/trust envelope
   // is fixed for the run's lifetime, never re-negotiated per message.
   const capabilitySessions = new Map<string, Promise<{ client: AgentBoxClient }>>();
-  const ensureCapabilitySession = (runId: string, profile: string, orgId: string | undefined, instruction: string | undefined) => {
+  const ensureCapabilitySession = (
+    runId: string,
+    profile: string,
+    orgId: string | undefined,
+    instruction: string | undefined,
+    opts: { replayWorkspace?: boolean } = {},
+  ) => {
     // An empty profile would silently resolve to the all-tools default agent
     // profile (getBoxProfile("") → AGENT) — the wrong shape AND a trust
     // escalation. Runs minted via capability.start always carry one; refuse
@@ -1199,7 +1211,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     if (!pending) {
       pending = (async () => {
         const { client, created } = await capabilityBoxClient(runId, profile, orgId);
-        let replayWorkspace = false;
+        let replayWorkspace = opts.replayWorkspace === true;
         try {
           // Raw sources + (fresh box only) the durable authoring workspace, both
           // from the consumer's store. Best-effort — see materializeCapabilityInputs.
@@ -1211,7 +1223,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             runId,
             inputRevision: capabilityRunManager.get(runId)?.inputRevision,
           });
-          replayWorkspace = materialized.reattached === true;
+          replayWorkspace = replayWorkspace || materialized.reattached === true;
           if (materialized.inputRevision) {
             await capabilityRunManager.setInputRevision(runId, materialized.inputRevision);
           }
@@ -1289,6 +1301,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   };
 
   // Recover AFTER ensureCapabilitySession exists — onAdopt re-attaches through it.
+  const unsubscribeCapabilityReconnect = frontendClient.onConnected?.(() => capabilityRunManager.reconcile());
   void capabilityRunManager.recover();
   capabilityRunManager.startWatchdog();
   // Capability-box orphan GC: a box is live iff its run is tracked and
@@ -2433,6 +2446,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     credentialService,
     async close() {
       metricsAggregator?.destroy();
+      unsubscribeCapabilityReconnect?.();
       // Before frontendClient.close(): the acknowledged terminal for a delegated turn
       // travels over that same connection.
       await endInFlightTurns();


### PR DESCRIPTION
## Summary
- treat Raw Head and Stable Wiki Head as content heads, while each sealed Candidate + task ledger is durable compilation progress
- require a Runtime-to-KBC acknowledgement after the durable backend atomically persists every batch checkpoint; the next batch cannot start before that ACK
- replay the exact unacknowledged sync across Runtime reconnects and make ACK delivery idempotent
- prevent periodic sync from leaking a half-written current batch
- seal a batch-zero plan/handoff checkpoint so a failure before batch 1 can recover autonomously
- keep full frozen Raw + current Candidate visible to each batch and preserve complete handoff metadata
- reduce the representative 125-section shape to 42 batches while retaining the 1M Claude context window and an internal 500K planning target
- add checkpoint ACK lifecycle logs without adding Helm values, environment variables, or resource changes

## Verification
- KBC compile-box full protocol suite: passed, including atomic ACK barrier and reset/replan preservation
- Runtime focused Vitest: 24 passed
- representative batching case: 125 sections -> 42 batches
- Python byte compilation and git diff check: passed
- broad npm run build remains blocked by pre-existing pi-coding-agent type drift outside this diff; GitHub Type Check is green