### PR TITLE
chore: replace internal hostnames and registry references with neutral placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Renamed the KB compile box so operators can tell it apart from chat agentboxes a
 - **Pod-name prefix**: compile boxes now spawn as `kbc-box-<id>` instead of `agentbox-<id>`, declared on the BoxProfile (`podNamePrefix`) for the `kb-compile` / `kb-compile-codex` profiles. Derived resources (cert Secret, hostname) follow the prefix. Chat agentboxes and the read-only `kb-test` box keep the `agentbox-` prefix.
 - **Upgrade behavior**: on the first compile spawn after upgrade, the spawner reaps any pod left under the old `agentbox-<id>` name for that agent (guarded to compile boxes only — a chat box under the same name is never touched), so the old and new pods do not coexist.
 - **Transition double-push**: `make push-kbc` republishes the same image digest under the legacy name `kbc-compile-box` for one release cycle so runtimes still pinned to the old name keep resolving. Remove the legacy tag/push next release.
-- **DevOps action required**: the registry replication rule (ap-southeast → cn-shanghai) must gain an entry for `siclaw-kbc-box` (the old `kbc-compile-box` was not in the rule and had to be pushed manually). Until the rule is added, push `siclaw-kbc-box` to cn-shanghai manually for production.
+- **DevOps action required**: the internal registry replication rule must gain an entry for `siclaw-kbc-box` (the old `kbc-compile-box` was not in the rule and had to be pushed manually). Until the rule is added, push `siclaw-kbc-box` to the production registry manually.
 
 ### Added
 

--- a/kbc/platform/pod/redblue.py
+++ b/kbc/platform/pod/redblue.py
@@ -88,7 +88,7 @@ def _t(locale: str | None, en: str, zh: str) -> str:
 
 
 # ── prompts (calibrated offline via the CLI before production wiring; schemas
-#    mirror siflow-kb/.claude/workflows/redblue-pk.js, proven on real data).
+#    mirror an internal red/blue PK workflow, proven on real data).
 #    en/zh pairs. STORED TOKENS DON'T FORK: score / failure_category /
 #    difficulty / flag / angle values persist to PK_RESULT.json and
 #    PK_SURVEY_CACHE.json and are compared in code (PASS_SCORES), so the en

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -787,7 +787,7 @@ def test_charset_corruption_detection():
     """U+FFFD (the lossy-UTF-8-decode marker) anywhere in a page — path OR body
     prose — must block state=passed. Body-prose corruption is INVISIBLE to the
     coverage ledger (it only diffs paths), so this lint is the only guard against
-    silently shipping a \ufffd in published text (siflow-test 2026-07-07: 需/础/成 got
+    silently shipping a \ufffd in published text (real incident 2026-07-07: 需/础/成 got
     mangled to 3× U+FFFD by an upstream stream chunk-boundary split)."""
     with tempfile.TemporaryDirectory() as td:
         base = Path(td)

--- a/services/ocr-backend/README.md
+++ b/services/ocr-backend/README.md
@@ -127,7 +127,7 @@ Build from the repository root:
 docker buildx build \
   --platform linux/amd64 \
   -f Dockerfile.ocr \
-  -t registry-cn-shanghai.siflow.cn/k8s/siclaw-ocr:<tag> \
+  -t <your-registry>/siclaw-ocr:<tag> \
   --push \
   .
 ```

--- a/src/core/brain-session.test.ts
+++ b/src/core/brain-session.test.ts
@@ -126,7 +126,7 @@ describe("modelNeedsRebind", () => {
 
   it.each([
     ["id", { id: "claude-opus-4-8" }],
-    ["provider", { provider: "siflow" }],
+    ["provider", { provider: "other-provider" }],
     ["reasoning", { reasoning: false }],
     ["contextWindow", { contextWindow: 200000 }],
     ["maxTokens", { maxTokens: 8192 }],

--- a/src/gateway/agentbox/client.test.ts
+++ b/src/gateway/agentbox/client.test.ts
@@ -590,11 +590,11 @@ describe("AgentBoxClient — prompt image URL resolution (vision-gated)", () => 
   afterAll(async () => { await srv.close(); });
 
   beforeEach(() => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     realFetch = globalThis.fetch.bind(globalThis);
     // Host-split: image URLs are stubbed; the agentbox POST is forwarded to the real local server.
     vi.stubGlobal("fetch", vi.fn(async (url: any, init: any) => {
-      if (String(url).includes("oss.siflow.cn")) return imageResponse(PNG);
+      if (String(url).includes("oss.example.org")) return imageResponse(PNG);
       return realFetch(url, init);
     }));
   });
@@ -605,29 +605,29 @@ describe("AgentBoxClient — prompt image URL resolution (vision-gated)", () => 
 
   it("vision model: resolves an allowlisted URL into images; URL stays in text", async () => {
     await client.prompt({
-      text: "see https://oss.siflow.cn/a.png",
+      text: "see https://oss.example.org/a.png",
       modelProvider: "openai", modelId: "gpt-4o", modelConfig: mkModelConfig(["text", "image"], "gpt-4o"),
     });
     const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
     const body = JSON.parse(req.body);
     expect(body.images).toEqual([{ mimeType: "image/png", data: PNG.toString("base64") }]);
-    expect(body.text).toContain("oss.siflow.cn/a.png"); // original URL left in text
+    expect(body.text).toContain("oss.example.org/a.png"); // original URL left in text
   });
 
   it("non-vision model: does NOT resolve; no images, URL stays as plain text", async () => {
     await client.prompt({
-      text: "see https://oss.siflow.cn/a.png",
+      text: "see https://oss.example.org/a.png",
       modelProvider: "deepseek", modelId: "deepseek-chat", modelConfig: mkModelConfig(["text"], "deepseek-chat"),
     });
     const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
     const body = JSON.parse(req.body);
     expect(body.images).toBeUndefined();
-    expect(body.text).toContain("oss.siflow.cn/a.png");
+    expect(body.text).toContain("oss.example.org/a.png");
   });
 
   it("vision routing candidate (no single-model fields): still resolves", async () => {
     await client.prompt({
-      text: "see https://oss.siflow.cn/a.png",
+      text: "see https://oss.example.org/a.png",
       modelRouting: {
         enabled: true,
         candidates: [{ provider: "openai", modelId: "gpt-4o", modelConfig: mkModelConfig(["text", "image"], "gpt-4o") }],
@@ -639,12 +639,12 @@ describe("AgentBoxClient — prompt image URL resolution (vision-gated)", () => 
 
   it("redacts signed-URL credentials from the forwarded text (fetch still used the full URL)", async () => {
     await client.prompt({
-      text: "see https://oss.siflow.cn/a.png?Signature=secret&AccessKeyId=key",
+      text: "see https://oss.example.org/a.png?Signature=secret&AccessKeyId=key",
       modelProvider: "openai", modelId: "gpt-4o", modelConfig: mkModelConfig(["text", "image"], "gpt-4o"),
     });
     const req = srv.captures.filter((c) => c.url === "/api/prompt").pop()!;
     const body = JSON.parse(req.body);
-    expect(body.text).toContain("oss.siflow.cn/a.png");
+    expect(body.text).toContain("oss.example.org/a.png");
     expect(body.text).not.toContain("Signature"); // creds stripped from model/history text
     expect(body.text).not.toContain("secret");
     expect(body.images).toHaveLength(1); // ...but the image was still resolved (full URL fetched)

--- a/src/gateway/agentbox/image-url-ingest.test.ts
+++ b/src/gateway/agentbox/image-url-ingest.test.ts
@@ -62,11 +62,11 @@ describe("sniffImageMime", () => {
 // ── extractImageUrls ────────────────────────────────────────────────────────
 describe("extractImageUrls", () => {
   it("extracts image URLs incl. OSS signed (ext before query)", () => {
-    const text = "see https://oss.siflow.cn/a/b.jpg?OSSAccessKeyId=x&Signature=y here";
-    expect(extractImageUrls(text)).toEqual(["https://oss.siflow.cn/a/b.jpg?OSSAccessKeyId=x&Signature=y"]);
+    const text = "see https://oss.example.org/a/b.jpg?OSSAccessKeyId=x&Signature=y here";
+    expect(extractImageUrls(text)).toEqual(["https://oss.example.org/a/b.jpg?OSSAccessKeyId=x&Signature=y"]);
   });
   it("dedups repeats and matches png/jpeg/webp", () => {
-    const url = "https://oss.siflow.cn/x.png";
+    const url = "https://oss.example.org/x.png";
     expect(extractImageUrls(`${url} ${url}`)).toEqual([url]);
     expect(extractImageUrls("https://h.cn/a.webp https://h.cn/b.jpeg")).toHaveLength(2);
   });
@@ -79,27 +79,27 @@ describe("extractImageUrls", () => {
 // ── assertAllowedImageUrl (SSRF guard) ──────────────────────────────────────
 describe("assertAllowedImageUrl", () => {
   it("is fail-closed when no allowlist configured", () => {
-    expect(() => assertAllowedImageUrl("https://oss.siflow.cn/a.jpg")).toThrow(/fail-closed/);
+    expect(() => assertAllowedImageUrl("https://oss.example.org/a.jpg")).toThrow(/fail-closed/);
   });
   it("allows exact and wildcard allowlist hosts", () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "oss.siflow.cn, *.example.com";
-    expect(() => assertAllowedImageUrl("https://oss.siflow.cn/a.jpg")).not.toThrow();
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "oss.example.org, *.example.com";
+    expect(() => assertAllowedImageUrl("https://oss.example.org/a.jpg")).not.toThrow();
     expect(() => assertAllowedImageUrl("https://img.example.com/a.jpg")).not.toThrow();
   });
   it("rejects hosts outside the allowlist", () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     expect(() => assertAllowedImageUrl("https://evil.com/a.jpg")).toThrow(/not in allowlist/);
-    // apex is not a subdomain of *.siflow.cn
-    expect(() => assertAllowedImageUrl("https://siflow.cn/a.jpg")).toThrow(/not in allowlist/);
+    // apex is not a subdomain of *.example.org
+    expect(() => assertAllowedImageUrl("https://example.org/a.jpg")).toThrow(/not in allowlist/);
   });
   it("rejects http by default, allows it only when opted in", () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "oss.siflow.cn";
-    expect(() => assertAllowedImageUrl("http://oss.siflow.cn/a.jpg")).toThrow(/protocol/);
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "oss.example.org";
+    expect(() => assertAllowedImageUrl("http://oss.example.org/a.jpg")).toThrow(/protocol/);
     process.env.SICLAW_IMAGE_URL_ALLOW_HTTP = "true";
-    expect(() => assertAllowedImageUrl("http://oss.siflow.cn/a.jpg")).not.toThrow();
+    expect(() => assertAllowedImageUrl("http://oss.example.org/a.jpg")).not.toThrow();
   });
   it("rejects private/metadata hosts (not on allowlist)", () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     expect(() => assertAllowedImageUrl("https://169.254.169.254/latest/meta-data")).toThrow(/not in allowlist/);
     expect(() => assertAllowedImageUrl("https://127.0.0.1/a.jpg")).toThrow(/not in allowlist/);
   });
@@ -115,39 +115,39 @@ describe("enrichImagesFromText", () => {
   });
 
   it("fetches an allowlisted url image", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     vi.stubGlobal("fetch", vi.fn(async () => imageResponse(PNG, "image/png")));
-    const out = await enrichImagesFromText("look https://oss.siflow.cn/a.png", []);
+    const out = await enrichImagesFromText("look https://oss.example.org/a.png", []);
     expect(out).toEqual([{ mimeType: "image/png", data: PNG.toString("base64") }]);
   });
 
   it("skips a url rejected by the SSRF guard (no allowlist)", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    const out = await enrichImagesFromText("https://oss.example.org/a.png", []);
     expect(out).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled(); // guard throws before fetch
   });
 
   it("skips a non-image content-type", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     vi.stubGlobal("fetch", vi.fn(async () => imageResponse(NOT_IMAGE, "text/html")));
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    const out = await enrichImagesFromText("https://oss.example.org/a.png", []);
     expect(out).toEqual([]);
   });
 
   it("skips an oversize image (declared content-length)", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => imageResponse(PNG, "image/png", { "content-length": String(50 * 1024 * 1024) })),
     );
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    const out = await enrichImagesFromText("https://oss.example.org/a.png", []);
     expect(out).toEqual([]);
   });
 
   it("skips an oversize url image even with no/lying content-length (streamed)", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     const huge = Buffer.alloc(7 * 1024 * 1024, 0x89); // > 6MiB raw cap
     vi.stubGlobal(
       "fetch",
@@ -158,42 +158,42 @@ describe("enrichImagesFromText", () => {
         body: Readable.from([huge]),
       }) as unknown as Response),
     );
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    const out = await enrichImagesFromText("https://oss.example.org/a.png", []);
     expect(out).toEqual([]);
   });
 
   it("re-validates the allowlist on redirect (rejects off-allowlist hop)", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     const fetchMock = vi.fn(async () => ({
       status: 302,
       ok: false,
       headers: new Headers({ location: "https://evil.com/a.png" }),
     }) as unknown as Response);
     vi.stubGlobal("fetch", fetchMock);
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png", []);
+    const out = await enrichImagesFromText("https://oss.example.org/a.png", []);
     expect(out).toEqual([]); // off-allowlist redirect target rejected on next hop
   });
 
   it("appends url images AFTER existing, sharing the 4-image budget", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     vi.stubGlobal("fetch", vi.fn(async () => imageResponse(JPEG, "image/jpeg")));
     const existing: InboundImage[] = [{ mimeType: "image/png", data: PNG.toString("base64") }];
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.jpeg", existing);
+    const out = await enrichImagesFromText("https://oss.example.org/a.jpeg", existing);
     expect(out.map((i) => i.mimeType)).toEqual(["image/png", "image/jpeg"]);
   });
 
   it("does not exceed 4 images when existing already fills the budget", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     const fetchMock = vi.fn(async () => imageResponse(JPEG, "image/jpeg"));
     vi.stubGlobal("fetch", fetchMock);
     const existing: InboundImage[] = Array.from({ length: 4 }, () => ({ mimeType: "image/png", data: "x" }));
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.jpeg", existing);
+    const out = await enrichImagesFromText("https://oss.example.org/a.jpeg", existing);
     expect(out).toHaveLength(4);
     expect(fetchMock).not.toHaveBeenCalled(); // budget full → never fetches
   });
 
   it("bounds the whole step by a total timeout and fetches in parallel (hanging host doesn't stall)", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     process.env.SICLAW_IMAGE_URL_TOTAL_TIMEOUT_MS = "100";
     // fetch that honours the abort signal but otherwise never resolves
     const fetchMock = vi.fn((_url: any, init: any) => new Promise((_res, reject) => {
@@ -201,7 +201,7 @@ describe("enrichImagesFromText", () => {
     }));
     vi.stubGlobal("fetch", fetchMock);
     const start = Date.now();
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png https://oss.siflow.cn/b.png", []);
+    const out = await enrichImagesFromText("https://oss.example.org/a.png https://oss.example.org/b.png", []);
     expect(out).toEqual([]);
     expect(fetchMock).toHaveBeenCalledTimes(2); // both fired in parallel, not gated one-by-one
     // bounded by the ~100ms total budget, NOT 2×(per-hop 5s) run sequentially
@@ -209,21 +209,21 @@ describe("enrichImagesFromText", () => {
   });
 
   it("bounds the parallel fan-out to the media budget (does not fetch every URL)", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     const fetchMock = vi.fn(async () => imageResponse(PNG));
     vi.stubGlobal("fetch", fetchMock);
-    const manyUrls = Array.from({ length: 50 }, (_, i) => `https://oss.siflow.cn/img${i}.png`).join(" ");
+    const manyUrls = Array.from({ length: 50 }, (_, i) => `https://oss.example.org/img${i}.png`).join(" ");
     const out = await enrichImagesFromText(manyUrls, []);
     expect(out).toHaveLength(4); // capped at MAX_INBOUND_IMAGES
     expect(fetchMock).toHaveBeenCalledTimes(4); // only 4 fetches fired, not 50 — bounded BEFORE fan-out
   });
 
   it("bounds the fan-out by the remaining budget when existing images are present", async () => {
-    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.siflow.cn";
+    process.env.SICLAW_IMAGE_URL_ALLOWLIST = "*.example.org";
     const fetchMock = vi.fn(async () => imageResponse(PNG));
     vi.stubGlobal("fetch", fetchMock);
     const existing: InboundImage[] = [{ mimeType: "image/png", data: "x" }, { mimeType: "image/png", data: "y" }];
-    const out = await enrichImagesFromText("https://oss.siflow.cn/a.png https://oss.siflow.cn/b.png https://oss.siflow.cn/c.png", existing);
+    const out = await enrichImagesFromText("https://oss.example.org/a.png https://oss.example.org/b.png https://oss.example.org/c.png", existing);
     expect(out).toHaveLength(4);
     expect(fetchMock).toHaveBeenCalledTimes(2); // 4 - 2 existing = 2 slots → only 2 fetches
   });
@@ -232,8 +232,8 @@ describe("enrichImagesFromText", () => {
 describe("redactImageUrlsInText", () => {
   it("strips signed-URL query (Signature/AccessKeyId) but keeps host+path", () => {
     expect(
-      redactImageUrlsInText("see https://oss.siflow.cn/a.jpg?Signature=secret&AccessKeyId=key here"),
-    ).toBe("see https://oss.siflow.cn/a.jpg here");
+      redactImageUrlsInText("see https://oss.example.org/a.jpg?Signature=secret&AccessKeyId=key here"),
+    ).toBe("see https://oss.example.org/a.jpg here");
   });
   it("redacts multiple image URLs and leaves other text intact", () => {
     expect(

--- a/src/gateway/agentbox/image-url-ingest.ts
+++ b/src/gateway/agentbox/image-url-ingest.ts
@@ -107,7 +107,7 @@ function imageUrlAllowlist(): string[] {
 function hostMatchesAllowlist(host: string, allowlist: string[]): boolean {
   return allowlist.some((entry) => {
     if (entry.startsWith("*.")) {
-      // "*.siflow.cn" → any subdomain (mirrors dingtalk.ts isAllowedWebhookHost).
+      // "*.example.org" → any subdomain (mirrors dingtalk.ts isAllowedWebhookHost).
       return host.endsWith(entry.slice(1));
     }
     return host === entry;

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -3474,7 +3474,7 @@ describe("handleLarkMessage — inbound images", () => {
     streamEventsMock.mockImplementation(async function* () { /* empty */ });
 
     await handleLarkMessage(
-      makeTextEvent("check this https://oss.siflow.cn/x.png"),
+      makeTextEvent("check this https://oss.example.org/x.png"),
       makeLarkClient(),
       "lark",
       makeAgentBoxManager("a1") as any,
@@ -3487,7 +3487,7 @@ describe("handleLarkMessage — inbound images", () => {
     // are attached here, and the URL survives in the prompt text.
     const arg = promptMock.mock.calls[0][0];
     expect(arg).not.toHaveProperty("images");
-    expect(arg.text).toContain("https://oss.siflow.cn/x.png");
+    expect(arg.text).toContain("https://oss.example.org/x.png");
   });
 
   it("persists the user row with signed-URL credentials stripped (prompt keeps the full URL)", async () => {
@@ -3496,7 +3496,7 @@ describe("handleLarkMessage — inbound images", () => {
     streamEventsMock.mockImplementation(async function* () { /* empty */ });
 
     await handleLarkMessage(
-      makeTextEvent("look https://oss.siflow.cn/x.png?Signature=secret"),
+      makeTextEvent("look https://oss.example.org/x.png?Signature=secret"),
       makeLarkClient(),
       "lark",
       makeAgentBoxManager("a1") as any,
@@ -3505,7 +3505,7 @@ describe("handleLarkMessage — inbound images", () => {
     );
 
     const userRow = appendMessageMock.mock.calls.find((c) => c[0].role === "user")?.[0];
-    expect(userRow.content).toContain("oss.siflow.cn/x.png");
+    expect(userRow.content).toContain("oss.example.org/x.png");
     expect(userRow.content).not.toContain("Signature"); // creds stripped from the persisted row
     // the prompt forwarded to AgentBoxClient keeps the full signed URL (client.prompt fetches it)
     expect(promptMock.mock.calls[0][0].text).toContain("Signature=secret");
@@ -3531,13 +3531,13 @@ describe("extractInbound — post receive shapes", () => {
       message_type: "post",
       content: JSON.stringify({
         title: "Report",
-        content: [[{ tag: "a", text: "see", href: "https://oss.siflow.cn/x.png" }]],
+        content: [[{ tag: "a", text: "see", href: "https://oss.example.org/x.png" }]],
       }),
     };
     const { text } = extractInbound(message);
     expect(text).toContain("Report");
     expect(text).toContain("see");
-    expect(text).toContain("https://oss.siflow.cn/x.png"); // href surfaced for the unified URL resolver
+    expect(text).toContain("https://oss.example.org/x.png"); // href surfaced for the unified URL resolver
   });
 });
 


### PR DESCRIPTION
## Summary

Scrub internal infrastructure references from the codebase ahead of community open-sourcing: test fixtures now use reserved `example.org`/`example.com` domains, docs use a `<your-registry>` placeholder, and code comments reference generic incident notes instead of internal project names.

### Solution

- Test fixtures (`image-url-ingest.test.ts`, `client.test.ts`, `lark.test.ts`): internal OSS hostnames → `example.org` family. Fixture semantics preserved — the mixed allowlist test keeps two distinct entries, and the apex-vs-wildcard case still exercises the subdomain boundary.
- `brain-session.test.ts`: provider patch value → `"other-provider"` (still differs from the base fixture, so the rebind assertion is unchanged).
- `image-url-ingest.ts`: comment example domain only.
- `services/ocr-backend/README.md`: internal registry in the build command → `<your-registry>` placeholder.
- `kbc/platform/pod/{redblue,test_selfcheck}.py`: comments now describe the incident/workflow generically instead of naming internal projects.
- `CHANGELOG.md`: registry replication note genericized (drops internal region/registry naming).

Fixture/comment/doc-only — no runtime behavior change.

## Test Plan

- `git grep` over tracked files confirms the scrubbed strings are gone
- Full `npm test`: 249 files, 5144 passed / 2 skipped / 0 failed