### PR TITLE
feat: preserve structured MCP results across turns

### DIFF
--- a/src/core/mcp-client.test.ts
+++ b/src/core/mcp-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { jsonSchemaToTypebox, normalizeMcpInputSchema, buildMcpToolName, isMcpTool, MCP_TOOL_PREFIX, mcpContentToAgentContent, McpClientManager } from "./mcp-client.js";
 
 describe("jsonSchemaToTypebox", () => {
@@ -166,6 +166,25 @@ describe("createToolDefinition server description", () => {
   it("applies the server context to the fallback description too", () => {
     const def = makeDef("Monitoring tenant ID: t-123");
     expect(def.description).toBe('[Server "grafana" context: Monitoring tenant ID: t-123]\nMCP tool query from grafana');
+  });
+
+  it("preserves official MCP structuredContent for host-side consumers", async () => {
+    const structuredContent = { label: true, info: { summary: "ready" } };
+    const def = (manager as any).createToolDefinition(
+      "product-support-result",
+      undefined,
+      { name: "submit_product_support_result" },
+      {
+        callTool: vi.fn(async () => ({
+          content: [{ type: "text", text: JSON.stringify(structuredContent) }],
+          structuredContent,
+        })),
+      },
+    );
+
+    await expect(def.execute("call-1", {})).resolves.toMatchObject({
+      details: { structuredContent },
+    });
   });
 });
 

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -351,7 +351,12 @@ export class McpClientManager {
 
           return {
             content,
-            details: isError ? { error: text } : {},
+            details: {
+              ...(isError ? { error: text } : {}),
+              ...(result.structuredContent !== undefined
+                ? { structuredContent: result.structuredContent }
+                : {}),
+            },
           };
         } catch (err: any) {
           const errorMsg = err?.message ?? String(err);

--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -257,6 +257,11 @@ describe("startRuntime — chat.abort wiring", () => {
       ([channel, data]) => channel === "chat.event" && data?.event?.type === "prompt_done",
     ));
 
+    const promptDone = ctx.sendEvent.mock.calls.find(
+      ([channel, data]) => channel === "chat.event" && data?.event?.type === "prompt_done",
+    );
+    expect(promptDone?.[1]).toMatchObject({ sessionId: "orphan", turnId: ack.turnId });
+
     expect(abortSessionCalls).toEqual(["orphan"]);
     expect(abortSessionTurnIds).toEqual([ack.turnId]);
   });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1038,12 +1038,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             onEvent: (evt, _eventType, extras) => {
               context.sendEvent("chat.event", {
                 sessionId: promptResult.sessionId,
+                turnId,
                 event: extras.dbMessageId ? { ...evt, dbMessageId: extras.dbMessageId } : evt,
               });
             },
           });
           if (!alreadyReported()) {
-            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
+            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, turnId, event: { type: "prompt_done" } });
             reportTerminal({ type: "prompt_done" });
           }
         } catch (err) {
@@ -1055,12 +1056,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             });
             context.sendEvent("chat.event", {
               sessionId: promptResult.sessionId,
+              turnId,
               event: { type: "stream_error", error: detail },
             });
           }
           // Shutdown, or a box removal, already reported this turn before aborting it.
           if (!alreadyReported()) {
-            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, event: { type: "prompt_done" } });
+            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, turnId, event: { type: "prompt_done" } });
             reportTerminal({ type: "prompt_done" });
           }
         } finally {
@@ -1082,6 +1084,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           });
           context.sendEvent("chat.event", {
             sessionId,
+            turnId,
             event: { type: "stream_error", error: detail },
           });
         }
@@ -1090,7 +1093,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         // check. A second, PLAIN terminal would contradict that one: without
         // `aborted` it reads as a turn that completed.
         if (!supervisorEndedTurns.has(turnId)) {
-          context.sendEvent("chat.event", { sessionId, event: { type: "prompt_done" } });
+          context.sendEvent("chat.event", { sessionId, turnId, event: { type: "prompt_done" } });
           reportTerminal({ type: "prompt_done" });
         }
       } finally {


### PR DESCRIPTION
## Summary

- preserve the MCP-standard `structuredContent` field in internal tool results
- correlate Runtime `chat.event` envelopes with the existing per-turn `turnId`
- keep the transport generic: no product-support schema or completion policy lives in Siclaw

## Why

API facades need a machine-verifiable MCP result for one exact turn without parsing assistant text or confusing events from a long-lived session. Siclaw already receives both values; this change stops dropping `structuredContent` and carries the existing turn identity across the Runtime boundary.

## Validation

- `npx vitest run src/core/mcp-client.test.ts`
- `npx vitest run src/gateway/server-chat-abort.test.ts`
- `npx tsc --noEmit`
- `npm run build`