### PR TITLE
fix(gateway): correlate supervisor terminal events

### DIFF
--- a/src/gateway/server-shutdown-turns.test.ts
+++ b/src/gateway/server-shutdown-turns.test.ts
@@ -96,6 +96,12 @@ function chatEvents(client: any, sessionId: string): Array<Record<string, unknow
     .map(([, payload]: [string, any]) => payload.event);
 }
 
+function chatEventPayloads(client: any, sessionId: string): Array<Record<string, unknown>> {
+  return client.emitEvent.mock.calls
+    .filter(([channel, payload]: [string, any]) => channel === "chat.event" && payload?.sessionId === sessionId)
+    .map(([, payload]: [string, any]) => payload);
+}
+
 afterEach(() => {
   capturedSignal = undefined;
   vi.clearAllMocks();
@@ -107,7 +113,10 @@ describe("startRuntime — shutdown ends in-flight turns", () => {
     const server = await bootRuntime(client);
     const send = server.rpcMethods.get("chat.send")!;
 
-    await send({ agentId: "a", userId: "u", text: "hi", sessionId: "S" }, { sendEvent: vi.fn() });
+    const ack = await send(
+      { agentId: "a", userId: "u", text: "hi", sessionId: "S" },
+      { sendEvent: vi.fn() },
+    ) as { turnId: string };
     await waitFor(() => capturedSignal !== undefined);
     expect(capturedSignal!.aborted).toBe(false);
 
@@ -121,6 +130,10 @@ describe("startRuntime — shutdown ends in-flight turns", () => {
     // Additive fields: a consumer that reads them names the cause instead of showing a
     // generic connection failure; one that does not still sees the terminal it handles.
     expect(events[1]).toMatchObject({ type: "prompt_done", aborted: true, reason: "runtime_restart" });
+    expect(chatEventPayloads(client, "S")).toEqual([
+      expect.objectContaining({ turnId: ack.turnId, event: expect.objectContaining({ type: "stream_error" }) }),
+      expect.objectContaining({ turnId: ack.turnId, event: expect.objectContaining({ type: "prompt_done" }) }),
+    ]);
     // The consumer is broken too, so its own finalization runs (partial text persisted,
     // running tool rows closed) instead of the turn ending only when the box hangs up.
     expect(capturedSignal!.aborted).toBe(true);

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -573,20 +573,27 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       // tracked.
       const unreported = sessionTurns.filter((id) => !supervisorEndedTurns.has(id));
       for (const id of sessionTurns) supervisorEndedTurns.add(id);
-      const ownsTheReport = sessionTurns.length === 0 || unreported.length > 0;
-      if (ownsTheReport) {
+      // A known turn gets its own terminal envelope so strict consumers can
+      // correlate the interruption. Keep the session-only fallback for the
+      // cold-start window where no turn id has been allocated yet.
+      const turnsToReport: Array<string | undefined> = sessionTurns.length === 0
+        ? [undefined]
+        : unreported;
+      for (const turnId of turnsToReport) {
+        const envelope = (event: Record<string, unknown>) => ({
+          sessionId,
+          ...(turnId ? { turnId } : {}),
+          event,
+        });
         try {
-          frontendClient.emitEvent("chat.event", { sessionId, event: { type: "stream_error", error: detail } });
+          frontendClient.emitEvent("chat.event", envelope({ type: "stream_error", error: detail }));
           // `aborted`/`reason` are additive: a consumer that does not read them sees the
           // plain terminal it already handles, one that does can name the cause instead of
           // rendering a generic connection failure.
-          frontendClient.emitEvent("chat.event", {
-            sessionId,
-            event: { type: "prompt_done", aborted: true, reason },
-          });
+          frontendClient.emitEvent("chat.event", envelope({ type: "prompt_done", aborted: true, reason }));
         } catch (err) {
           // Best effort: a consumer that already went away must not stop what caused this.
-          console.warn(`[runtime] could not report interrupted turn session=${sessionId}:`, err);
+          console.warn(`[runtime] could not report interrupted turn session=${sessionId} turn=${turnId ?? "pending"}:`, err);
         }
       }
       // A delegated turn's caller is a machine that will otherwise wait out its idle


### PR DESCRIPTION
## Summary

Follow up #502 by preserving `turnId` when the Runtime supervisor terminates live turns during shutdown or AgentBox replacement. Strict `/run` consumers now receive the real interruption for the affected turn instead of misclassifying it as an unsupported protocol.

### Solution

Emit one terminal pair per unreported live turn, carrying that turn ID. Keep the existing session-only fallback for the cold-start window before a turn ID exists.

## Test Plan

- [x] `npm test` — 250 files, 5209 passed, 2 skipped
- [x] `npm run build`
- [x] focused gateway shutdown/abort and MCP transport tests — 52 passed