### PR TITLE
docs(agents): add Cursor Cloud environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,3 +93,36 @@ Directive: <future warning>
 Tested: <what was verified>
 Not-tested: <known gaps>
 ```
+
+## Cursor Cloud specific instructions
+
+Dependencies (`npm ci` at root and in `portal-web/`) are installed by the
+startup update script; no manual install is needed.
+
+- **Node version is load-bearing.** The project requires Node `>=22.19.0`
+  because the memory DB uses `node:sqlite`'s FTS5 module, which the VM's default
+  `/exec-daemon/node` (22.14.0) does NOT include — under it, all `src/memory/**`
+  tests fail with `no such module: fts5` and the memory feature is broken. Setup
+  added a `~/.bashrc` line preferring nvm's Node 22.22.2 (which has FTS5), so
+  interactive agent shells resolve `node` to 22.22.2 automatically. If `node
+  --version` ever shows 22.14.0, run `source ~/.bashrc` (or
+  `nvm use 22.22.2`). `npm ci` itself works on either version.
+- **Build before running the local server.** `siclaw local` (via `siclaw.mjs`)
+  imports from `dist/`, so run `npm run build` first, and `npm run build:web`
+  (or `make build-portal-web`) so Portal can serve `portal-web/dist/`. The
+  update script intentionally does not build.
+- **Running the product.** `node siclaw.mjs local` starts Portal + Runtime +
+  in-process AgentBox + SQLite in one process (Portal `:3000`, Runtime `:3001`,
+  internal `:3002`). Health check: `curl http://127.0.0.1:3000/api/health`. It
+  seeds a bootstrap admin `admin` / `admin` and auto-creates the DB at
+  `.siclaw/data/portal.db` and secrets at `.siclaw/local-secrets.json`. On Node
+  < 24, `node:sqlite` needs `--experimental-sqlite`, which `siclaw.mjs`
+  re-execs automatically. `scripts/dev-local.sh` wraps rebuild+restart (add
+  `--web` to also rebuild the frontend, `--wipe` to reset DB/secrets).
+- **LLM provider is required for actual investigations.** The agent core cannot
+  answer without a configured LLM provider (API key). Configuring providers,
+  agents, clusters, skills, etc. through the web UI works fully offline, but
+  running a chat/investigation needs a real provider key set in the Models page.
+- **Lint/test/build commands:** lint == typecheck (`npx tsc --noEmit` or
+  `make typecheck`; no ESLint/Prettier). Backend tests: `npm test`. Frontend
+  tests: `cd portal-web && npm run test`. Full check: `make test`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Siclaw development environment for Cursor Cloud agents and documents the non-obvious gotchas discovered during setup. The only repository change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`; dependency refresh is handled by the environment update script (`npm ci` + `npm ci --prefix portal-web`).

### Problem

A fresh cloud VM defaults to `/exec-daemon/node` (v22.14.0), but the project requires Node `>=22.19.0`. The default Node's bundled SQLite lacks the FTS5 module used by the memory DB (`src/memory/**`), so 67 tests fail with `no such module: fts5` and the memory feature is broken. This, plus the build-before-run requirement of `siclaw local`, wasn't documented for future agents.

### Solution

- Made nvm's Node 22.22.2 (which includes FTS5) the preferred `node` for interactive agent shells via a one-time `~/.bashrc` PATH prepend (persisted in the VM snapshot; not part of the update script).
- Configured the startup update script to install dependencies only: `npm ci` and `npm ci --prefix portal-web`.
- Documented durable, non-obvious learnings in `AGENTS.md`: the Node/FTS5 requirement, build-before-run for `siclaw local`, how to run the local server (ports, bootstrap `admin`/`admin`, SQLite/secrets locations), the LLM-provider requirement for real investigations, and the lint/test commands.

## Test Plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes — 251 files, 5257 passed / 2 skipped (with Node 22.22.2)
- [x] `cd portal-web && npm run test` passes — 23 files, 229 passed
- [x] `npm run build` (backend tsc) and `npm run build:web` (vite) succeed
- [x] Manual verification: started `node siclaw.mjs local`, confirmed `GET /api/health` → `{"status":"ok"}`, logged into the web UI as `admin`/`admin`, and created a Model provider (OpenAI) + model (gpt-4o) through the UI; verified persistence via the REST API.

## Architecture Checklist

- [x] **Deployment mode**: No resource sync / skills / filesystem-write changes (docs only).
- [x] **Security model**: No new shell execution paths.
- [x] **DB parity**: No schema changes.
- [x] **Tool protocol**: No new tools.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included

## Demo

Login + configure a Model provider and model end-to-end through the web UI:

[siclaw_login_and_configure_model_provider.mp4](https://cursor.com/agents/bc-d9d01a94-e73d-48ff-bf49-7872897b32bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsiclaw_login_and_configure_model_provider.mp4)

Final configured state:

[Models page with OpenAI provider and gpt-4o model configured](https://cursor.com/agents/bc-d9d01a94-e73d-48ff-bf49-7872897b32bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsiclaw_models_configured.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9d01a94-e73d-48ff-bf49-7872897b32bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9d01a94-e73d-48ff-bf49-7872897b32bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

