### PR TITLE
fix(runtime): mark user-aborted chat terminals

### DIFF
--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -299,6 +299,12 @@ describe("startRuntime — chat.abort wiring", () => {
     await waitFor(() => ctx.sendEvent.mock.calls.some(
       ([channel, data]) => channel === "chat.event" && data?.event?.type === "prompt_done",
     ));
+    const firstTerminal = ctx.sendEvent.mock.calls.find(
+      ([channel, data]) => channel === "chat.event" && data?.turnId === first.turnId && data?.event?.type === "prompt_done",
+    );
+    expect(firstTerminal?.[1]).toMatchObject({
+      event: { type: "prompt_done", aborted: true, reason: "user_cancelled" },
+    });
     expect(promptCalls).toHaveLength(0);
 
     const second = await send({ agentId: "a", userId: "u", text: "try again", sessionId: "S" }, ctx) as { turnId?: string };
@@ -353,7 +359,7 @@ describe("startRuntime — chat.abort wiring", () => {
       delegationId: "d1",
       sessionId: "delegated",
       turnId: ack.turnId,
-      event: { type: "prompt_done" },
+      event: { type: "prompt_done", aborted: true, reason: "user_cancelled" },
     });
   });
 
@@ -398,6 +404,12 @@ describe("startRuntime — chat.abort wiring", () => {
     await waitFor(() => ctx.sendEvent.mock.calls.some(
       ([channel, data]) => channel === "chat.event" && data?.event?.type === "prompt_done",
     ));
+    const terminal = ctx.sendEvent.mock.calls.find(
+      ([channel, data]) => channel === "chat.event" && data?.event?.type === "prompt_done",
+    );
+    expect(terminal?.[1]).toMatchObject({
+      event: { type: "prompt_done", aborted: true, reason: "user_cancelled" },
+    });
 
     expect(frontendClient.request.mock.calls.some(([method]: any[]) => method === "delegation.terminal")).toBe(false);
   });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -839,6 +839,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // past the check above is already visible to the drain, instead of appearing after
     // it while it was still in the database.
     const turnAbort = new AbortController();
+    const promptDoneTerminal = (): Record<string, unknown> => turnAbort.signal.aborted
+      ? { type: "prompt_done", aborted: true, reason: "user_cancelled" }
+      : { type: "prompt_done" };
     registerPendingStart(sessionId, turnAbort);
     addLiveTurn(sessionId, turnId, turnAbort);
     if (delegation?.delegationId) delegatedTurns.set(turnId, { delegationId: delegation.delegationId, sessionId });
@@ -1072,8 +1075,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             },
           });
           if (!alreadyReported()) {
-            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, turnId, event: { type: "prompt_done" } });
-            reportTerminal({ type: "prompt_done" });
+            const terminal = promptDoneTerminal();
+            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, turnId, event: terminal });
+            reportTerminal(terminal);
           }
         } catch (err) {
           if (!abortCtrl.signal.aborted) {
@@ -1090,8 +1094,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           }
           // Shutdown, or a box removal, already reported this turn before aborting it.
           if (!alreadyReported()) {
-            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, turnId, event: { type: "prompt_done" } });
-            reportTerminal({ type: "prompt_done" });
+            const terminal = promptDoneTerminal();
+            context.sendEvent("chat.event", { sessionId: promptResult.sessionId, turnId, event: terminal });
+            reportTerminal(terminal);
           }
         } finally {
           // Only clear if still ours — a fast re-send for the same session would
@@ -1121,8 +1126,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         // check. A second, PLAIN terminal would contradict that one: without
         // `aborted` it reads as a turn that completed.
         if (!supervisorEndedTurns.has(turnId)) {
-          context.sendEvent("chat.event", { sessionId, turnId, event: { type: "prompt_done" } });
-          reportTerminal({ type: "prompt_done" });
+          const terminal = promptDoneTerminal();
+          context.sendEvent("chat.event", { sessionId, turnId, event: terminal });
+          reportTerminal(terminal);
         }
       } finally {
         // Anything still queued was never consumed — a steer the user sent into a turn


### PR DESCRIPTION
## Summary
- emit turn-correlated aborted prompt terminals when a user cancels an active or cold-starting chat turn
- preserve supervisor-owned shutdown and box-roll terminal reasons
- cover ordinary, delegated, and cold-start cancellation paths

## Why
Strict machine-facing run streams must distinguish a user cancellation from a completed turn that omitted its required structured result.

## Validation
- npm run build
- npm test -- --run src/gateway/server-chat-abort.test.ts (25 passed)
- npm test (5900 passed, 2 skipped; one unrelated 5s timeout under full-suite load)
- npm test -- --run src/gateway/server-capability-setup-failure.test.ts (6 passed on isolated rerun)