### PR TITLE
feat(knowledge): bind citations to exact evidence

### DIFF
--- a/docs/design/okf-evidence-citations.md
+++ b/docs/design/okf-evidence-citations.md
@@ -1,0 +1,87 @@
+---
+title: "OKF Evidence Citations"
+sidebarTitle: "OKF Evidence Citations"
+description: "Canonical marker grammar and fail-closed source binding for knowledge_cite."
+---
+
+# OKF Evidence Citations
+
+Compiled wiki pages may bind one answerable section to declared source ids.
+`knowledge_cite` then re-derives the original URL from the frozen citation
+manifest. The marker is input; the manifest is authority.
+
+Three implementations must agree on the grammar:
+
+- compile box: `selfcheck.py` in `SICLAW_COMPILE_BOX_IMAGE`
+- agentbox: `knowledge-citation-tool.ts` in `SICLAW_AGENTBOX_IMAGE`
+- Sicore import: `okf_citations.go` (`okfEvidenceMarker` / `okfEvidenceMarkerStart`)
+
+Shared recognition cases live in `okf-evidence-marker-fixtures.json` and are
+exercised by both `test_selfcheck.py` and `knowledge-citation-tool.test.ts`.
+The Go importer must use the same start regex (`\b` after `okf:evidence`),
+scan only the post-frontmatter body, and ignore fenced / inline code.
+
+## Marker grammar
+
+A marker is a single HTML comment on one line. Only space and tab are
+whitespace. Newlines, NBSP, and other `\\s` characters are not.
+
+```
+<!--[ \t]*okf:evidence[ \t]+({[^\r\n]*})[ \t]*-->
+```
+
+The JSON object has exactly two keys: `id` and `sources`. `id` and each
+source id match `^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`. `sources` has 1 to
+`MAX_EVIDENCE_SOURCES_PER_MARKER` (8) unique declared frontmatter source ids.
+
+Pretty-printed or newline-broken comments are not markers. Markers inside
+fenced code or inline code spans are also not markers — they are examples.
+
+## Binding
+
+For `page.md#evidence-id`:
+
+1. The page was Read this turn. Cite uses the exact bytes from that Read,
+   not a later disk reread or knowledge reload.
+2. Read captures a mount receipt, then reads the page, then checks the
+   receipt again. Register only when both match: those bytes plus that
+   manifest. A raced Read whose receipt does not match drops earlier
+   snapshots and invalidates the pin. A later consistent Read on a new
+   mount also drops earlier snapshots and re-pins, so the model can
+   re-read and cite in this turn.
+3. The evidence id parses from a canonical marker in the snapshot prose.
+4. Each source id appears in the page frontmatter `sources`.
+5. The same source id appears in the pinned manifest.
+6. `normalizedResource` agrees. It strips a leading `raw/` or `drop/` and
+   does not strip a leading `/`, matching `selfcheck._norm_source_entry`.
+
+A page cannot claim a source it does not declare. A marker cannot re-point a
+manifest entry at a different original.
+
+## Fail-closed matrix
+
+- One malformed marker does not invalidate other markers on the same page.
+  Only the refs that do not resolve fail.
+- Any unresolved `evidence_refs` entry registers zero citations for that
+  call. Retry once with only the remaining valid refs.
+- `evidence_refs` and `pages` may be passed together. Marked pages must use
+  `evidence_refs`; `pages` is only for pages with no parsed evidence marker.
+- One call never emits more than `MAX_KNOWLEDGE_CITATIONS` (8) originals.
+  Crossing the cap fails closed; it does not truncate. Gateway rendering
+  (`appendKnowledgeSourceCitations`) uses the same cap.
+- A mount that has any `sourceId` in the manifest offers evidence guidance.
+  Mixed answers are expressed in one call, not by flipping modes.
+
+## Deploy
+
+The 3→8 render cap lives in `src/shared/knowledge-citations.ts` and is used
+by AgentBox *and* Gateway (SSE consumer and Lark). Shipping only a new
+agentbox image leaves Feishu / SSE rendering on the old 3-link ceiling.
+
+- Agentbox (`SICLAW_AGENTBOX_IMAGE`): grammar, snapshots, mixed call.
+- Gateway / Runtime image: the shared render cap.
+- Compile box (`SICLAW_COMPILE_BOX_IMAGE`): `selfcheck.py` marker scan.
+- Sicore apiserver: `okf_citations.go` import gate. A compile-green page
+  can still fail package import if Go's start regex or scan range differs.
+
+Live sessions keep the box they already have.

--- a/docs/design/okf-evidence-marker-fixtures.json
+++ b/docs/design/okf-evidence-marker-fixtures.json
@@ -1,0 +1,72 @@
+{
+  "pattern": "<!--[ \\t]*okf:evidence[ \\t]+(\\{[^\\r\\n]*\\})[ \\t]*-->",
+  "start_pattern": "<!--[ \\t]*okf:evidence\\b",
+  "max_sources": 8,
+  "cases": [
+    {
+      "id": "canonical-single-line",
+      "body": "<!-- okf:evidence {\"id\":\"e1\",\"sources\":[\"src-1\"]} -->",
+      "recognized": true
+    },
+    {
+      "id": "leading-trailing-spaces",
+      "body": "<!--  okf:evidence {\"id\":\"e1\",\"sources\":[\"src-1\"]}  -->",
+      "recognized": true
+    },
+    {
+      "id": "tab-separated",
+      "body": "<!--\tokf:evidence\t{\"id\":\"e1\",\"sources\":[\"src-1\"]}\t-->",
+      "recognized": true
+    },
+    {
+      "id": "pretty-printed-multiline",
+      "body": "<!--\nokf:evidence {\"id\":\"e1\",\"sources\":[\"src-1\"]}\n-->",
+      "recognized": false
+    },
+    {
+      "id": "newline-after-open",
+      "body": "<!--\nokf:evidence NOT-JSON -->",
+      "recognized": false
+    },
+    {
+      "id": "nbsp-before-name",
+      "body": "<!-- okf:evidence {\"id\":\"e1\",\"sources\":[\"src-1\"]} -->",
+      "recognized": false
+    },
+    {
+      "id": "fenced-code-example",
+      "body": "```\n<!-- okf:evidence {\"id\":\"e1\",\"sources\":[\"src-1\"]} -->\n```",
+      "recognized": false
+    },
+    {
+      "id": "language-tagged-fence-then-prose",
+      "body": "```markdown\n<!-- okf:evidence {\"id\":\"hidden\",\"sources\":[\"src-1\"]} -->\n```\n<!-- okf:evidence {\"id\":\"visible\",\"sources\":[\"src-1\"]} -->",
+      "recognized": true
+    },
+    {
+      "id": "tilde-fence-then-prose",
+      "body": "~~~markdown\n<!-- okf:evidence {\"id\":\"hidden\",\"sources\":[\"src-1\"]} -->\n~~~\n<!-- okf:evidence {\"id\":\"visible\",\"sources\":[\"src-1\"]} -->",
+      "recognized": true
+    },
+    {
+      "id": "four-backtick-short-run-not-close",
+      "body": "````markdown\n```\n<!-- okf:evidence {\"id\":\"hidden\",\"sources\":[\"src-1\"]} -->\n````\n<!-- okf:evidence {\"id\":\"visible\",\"sources\":[\"src-1\"]} -->",
+      "recognized": true
+    },
+    {
+      "id": "three-space-indented-fence-then-prose",
+      "body": "   ```text\n<!-- okf:evidence {\"id\":\"hidden\",\"sources\":[\"src-1\"]} -->\n   ```\n<!-- okf:evidence {\"id\":\"visible\",\"sources\":[\"src-1\"]} -->",
+      "recognized": true
+    },
+    {
+      "id": "unclosed-fence-to-eof",
+      "body": "```text\n<!-- okf:evidence {\"id\":\"hidden\",\"sources\":[\"src-1\"]} -->",
+      "recognized": false
+    },
+    {
+      "id": "multi-backtick-inline-then-prose",
+      "body": "Example: ``<!-- okf:evidence {\"id\":\"hidden\",\"sources\":[\"src-1\"]} -->``\n<!-- okf:evidence {\"id\":\"visible\",\"sources\":[\"src-1\"]} -->",
+      "recognized": true
+    }
+  ]
+}

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -60,6 +60,10 @@ MEDIA_ASSET_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".
 EXCLUSIONS_PATH = "authoring/EXCLUSIONS.json"
 SELFCHECK_PATH = "authoring/SELFCHECK.json"
 SUPPORTED_OKF_VERSION = "0.2"
+_EVIDENCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_EVIDENCE_MARKER_RE = re.compile(r"<!--[ \t]*okf:evidence[ \t]+(\{[^\r\n]*\})[ \t]*-->")
+_EVIDENCE_MARKER_START_RE = re.compile(r"<!--[ \t]*okf:evidence\b")
+_MAX_EVIDENCE_SOURCES = 8
 
 # TEST_ROLE = the standing identity of a read-only knowledge CONSUMER over a
 # pinned wiki snapshot. Single-sourced in the locale prompt packs
@@ -826,6 +830,8 @@ def _okf_v02_metadata_violations(rel: str, fm: dict, body: str) -> list[dict]:
         violations.append({"page": rel, "kind": "okf_usage_window",
                            "detail": "usage_window 必须包含合法且有序的 YYYY-MM-DD from/to 日期"})
 
+    violations.extend(_okf_evidence_violations(rel, fm, body))
+
     if "generated" in fm:
         generated = fm.get("generated")
         if not isinstance(generated, dict) or not _valid_okf_actor(generated.get("by")):
@@ -883,6 +889,73 @@ def _okf_v02_metadata_violations(rel: str, fm: dict, body: str) -> list[dict]:
         if "attester" in fm and not _valid_resource_mapping(fm.get("attester")):
             violations.append({"page": rel, "kind": "okf_attested_computation",
                                "detail": "attester 必须包含非空 resource"})
+    return violations
+
+
+def _okf_evidence_violations(rel: str, fm: dict, body: str) -> list[dict]:
+    """Evidence markers bind one answerable section to declared source ids.
+
+    The marker is single-line JSON so both the compiler and Runtime can parse
+    the same deterministic shape without interpreting surrounding prose.
+    """
+    violations: list[dict] = []
+    declared = {
+        source.get("id").strip()
+        for source in fm.get("sources", [])
+        if isinstance(source, dict)
+        and isinstance(source.get("id"), str)
+        and source.get("id").strip()
+    }
+    scan = _markdown_prose(body)
+    matches = list(_EVIDENCE_MARKER_RE.finditer(scan))
+    if len(matches) != len(_EVIDENCE_MARKER_START_RE.findall(scan)):
+        violations.append({
+            "page": rel,
+            "kind": "okf_evidence",
+            "detail": "okf:evidence 必须是单行 JSON: {\"id\":...,\"sources\":[...]}",
+        })
+    seen: set[str] = set()
+    for match in matches:
+        try:
+            marker = json.loads(match.group(1))
+        except json.JSONDecodeError as exc:
+            violations.append({"page": rel, "kind": "okf_evidence",
+                               "detail": f"okf:evidence JSON 无效: {exc}"})
+            continue
+        if not isinstance(marker, dict) or set(marker) != {"id", "sources"}:
+            violations.append({"page": rel, "kind": "okf_evidence",
+                               "detail": "okf:evidence 只允许 id 与 sources"})
+            continue
+        evidence_id = marker.get("id")
+        if not isinstance(evidence_id, str) or not _EVIDENCE_ID_RE.fullmatch(evidence_id.strip()):
+            violations.append({"page": rel, "kind": "okf_evidence",
+                               "detail": f"evidence id 无效: {evidence_id!r}"})
+            continue
+        evidence_id = evidence_id.strip()
+        if evidence_id in seen:
+            violations.append({"page": rel, "kind": "okf_evidence",
+                               "detail": f"evidence id 重复: {evidence_id}"})
+        seen.add(evidence_id)
+        source_ids = marker.get("sources")
+        if (not isinstance(source_ids, list) or not source_ids
+                or len(source_ids) > _MAX_EVIDENCE_SOURCES):
+            violations.append({"page": rel, "kind": "okf_evidence",
+                               "detail": f"evidence {evidence_id} 必须声明 1-{_MAX_EVIDENCE_SOURCES} 个 sources"})
+            continue
+        marker_seen: set[str] = set()
+        for source_id in source_ids:
+            if not isinstance(source_id, str) or not _EVIDENCE_ID_RE.fullmatch(source_id.strip()):
+                violations.append({"page": rel, "kind": "okf_evidence",
+                                   "detail": f"evidence {evidence_id} source id 无效: {source_id!r}"})
+                continue
+            source_id = source_id.strip()
+            if source_id in marker_seen:
+                violations.append({"page": rel, "kind": "okf_evidence",
+                                   "detail": f"evidence {evidence_id} source 重复: {source_id}"})
+            marker_seen.add(source_id)
+            if source_id not in declared:
+                violations.append({"page": rel, "kind": "okf_evidence",
+                                   "detail": f"evidence {evidence_id} 引用了未在页面 sources 声明的 {source_id}"})
     return violations
 
 

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -189,6 +189,68 @@ def test_okf_v02_conformance():
     print("OK  OKF v0.2 core conformance + Siclaw portable-output profile")
 
 
+def test_okf_evidence_markers_bind_only_declared_source_ids():
+    valid = {"gb300.md": {
+        "text": '''---
+type: Concept
+sources:
+  - id: src-asus-sales-kit
+    resource: raw/specs/asus.md
+---
+<!-- okf:evidence {"id":"ev.gb300.asus.power","sources":["src-asus-sales-kit"]} -->
+# GB300
+''',
+    }}
+    assert selfcheck.okf_v02_violations(valid) == []
+
+    unmapped = {"gb300.md": {
+        "text": '''---
+type: Concept
+sources:
+  - id: src-asus-sales-kit
+    resource: raw/specs/asus.md
+---
+<!-- okf:evidence {"id":"ev.gb300.asus.power","sources":["src-other"]} -->
+# GB300
+''',
+    }}
+    violations = selfcheck.okf_v02_violations(unmapped)
+    assert any(v["kind"] == "okf_evidence" and "src-other" in v["detail"] for v in violations), violations
+
+    malformed = {"gb300.md": {
+        "text": '''---
+type: Concept
+sources:
+  - id: src-asus-sales-kit
+    resource: raw/specs/asus.md
+---
+<!-- okf:evidence not-json -->
+# GB300
+''',
+    }}
+    assert any(v["kind"] == "okf_evidence" for v in selfcheck.okf_v02_violations(malformed))
+    print("OK  OKF evidence markers bind declared source ids")
+
+
+def test_okf_evidence_marker_grammar_matches_runtime_fixtures():
+    """Compiler and runtime must agree on which comments are markers."""
+    fixtures_path = Path(__file__).resolve().parents[3] / "docs/design/okf-evidence-marker-fixtures.json"
+    fixtures = json.loads(fixtures_path.read_text(encoding="utf-8"))
+    assert selfcheck._EVIDENCE_MARKER_RE.pattern == fixtures["pattern"]
+    assert selfcheck._EVIDENCE_MARKER_START_RE.pattern == fixtures["start_pattern"]
+    assert selfcheck._MAX_EVIDENCE_SOURCES == fixtures["max_sources"]
+    for case in fixtures["cases"]:
+        scan = selfcheck._markdown_prose(case["body"])
+        start = len(selfcheck._EVIDENCE_MARKER_START_RE.findall(scan))
+        full = len(selfcheck._EVIDENCE_MARKER_RE.findall(scan))
+        expected = 1 if case["recognized"] else 0
+        assert start == expected == full, (case["id"], start, full)
+        if not case["recognized"]:
+            page = {"page.md": {"text": f"---\ntype: Concept\nsources:\n  - id: src-1\n    resource: raw/a.md\n---\n{case['body']}\n"}}
+            assert not any(v["kind"] == "okf_evidence" for v in selfcheck.okf_v02_violations(page)), case["id"]
+    print("OK  OKF evidence marker grammar matches runtime fixtures")
+
+
 def test_okf_import_profile():
     """Direct import validates structure without rewriting external semantics."""
     external = {
@@ -2503,6 +2565,8 @@ def main():
     os.environ.setdefault("KBC_PK_MODE", "off")  # PK never fires in unrelated wiring tests
     test_parse_okf_sources()
     test_okf_v02_conformance()
+    test_okf_evidence_markers_bind_only_declared_source_ids()
+    test_okf_evidence_marker_grammar_matches_runtime_fixtures()
     test_okf_import_profile()
     test_stamp_siclaw_generated_metadata()
     test_frontmatter_delimiters_and_stamp_preserve_yaml_scalar_and_comments()

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -1227,7 +1227,7 @@ describe("knowledgeHandler multi-repo identity", () => {
   it("materializes server-owned citation metadata beside the exact repo roots", async () => {
     const repos = [
       { id: "repo-a", name: "A", version: 1, sizeBytes: 10, dataBase64: packageBase64("a"),
-        citationSources: [{ resource: "feishu/a.md", title: "A 原文", url: "https://docs.feishu.cn/wiki/a" }] },
+        citationSources: [{ sourceId: "source-a", resource: "feishu/a.md", title: "A 原文", url: "https://docs.feishu.cn/wiki/a" }] },
       { id: "repo-b", name: "B", version: 1, sizeBytes: 10, dataBase64: packageBase64("b"), citationSources: [] },
     ];
     await knowledgeHandler.materialize({ version: "v1", repos });

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -403,7 +403,7 @@ interface KnowledgeBundlePayload {
     sha256?: string | null;
     sizeBytes: number;
     fileCount?: number | null;
-    citationSources?: Array<{ resource: string; title: string; url: string }>;
+    citationSources?: Array<{ sourceId?: string; resource: string; title: string; url: string }>;
     dataBase64: string;
   }>;
 }

--- a/src/core/agent-factory.test.ts
+++ b/src/core/agent-factory.test.ts
@@ -29,6 +29,8 @@ describe("agent-factory", () => {
     expect(source).toMatch(/const knowledgeDir = opts\?\.knowledgeDir\s*\?\?/);
     expect(source).toMatch(/createKnowledgeCitationSupport\(\{\s*knowledgeDir,/);
     expect(source).toContain("buildKnowledgeCitationSystemPrompt(knowledgeDir)");
+    expect(source).toMatch(/captureMount\(\)[\s\S]*?fsReadFile\(p\)[\s\S]*?noteRead\(p,/);
+    expect(source).not.toMatch(/citationSupport\?\.noteRead\(p\);/);
   });
 
   it("keeps configured MCP as a resolved resource axis, not a built-in capability name filter", () => {

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -618,8 +618,11 @@ export async function createSiclawSession(
       operations: {
         readFile: async (p) => {
           assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir);
+          const start = citationSupport?.captureMount();
           const content = await fsReadFile(p);
-          citationSupport?.noteRead(p);
+          if (citationSupport && start !== undefined) {
+            citationSupport.noteRead(p, typeof content === "string" ? content : content.toString("utf8"), start);
+          }
           return content;
         },
         access: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir); return fsAccess(p, fs.constants.R_OK); },

--- a/src/core/knowledge-citation-tool.test.ts
+++ b/src/core/knowledge-citation-tool.test.ts
@@ -5,12 +5,31 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   buildKnowledgeCitationSystemPrompt,
   createKnowledgeCitationSupport,
+  EVIDENCE_MARKER,
+  EVIDENCE_MARKER_START,
   KNOWLEDGE_CITATION_MANIFEST,
+  maskMarkdownCode,
+  normalizedResource,
 } from "./knowledge-citation-tool.js";
+import {
+  MAX_EVIDENCE_SOURCES_PER_MARKER,
+  MAX_KNOWLEDGE_CITATIONS,
+} from "../shared/knowledge-citations.js";
 
 describe("knowledge_cite", () => {
   const dirs: string[] = [];
   afterEach(() => dirs.splice(0).forEach((dir) => fs.rmSync(dir, { recursive: true, force: true })));
+
+  function readPage(
+    support: {
+      captureMount: () => { readonly json: string };
+      noteRead: (pagePath: string, content: string, start: { readonly json: string }) => void;
+    },
+    page: string,
+    content = fs.readFileSync(page, "utf8"),
+  ) {
+    support.noteRead(page, content, support.captureMount());
+  }
 
   function fixture() {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-"));
@@ -31,7 +50,7 @@ describe("knowledge_cite", () => {
     const events: Record<string, unknown>[] = [];
     const turnRef = { current: 1 };
     const support = createKnowledgeCitationSupport({ knowledgeDir: dir, turnRef, sessionEventEmitter: (e) => events.push(e) });
-    support.noteRead(page);
+    readPage(support, page);
     const output = await support.tool.execute("call", { pages: [page] } as never);
     expect(output.details).toEqual({ cited: 1 });
     expect(events).toEqual([{ type: "knowledge_sources", sources: [{
@@ -42,6 +61,135 @@ describe("knowledge_cite", () => {
     const unread = await support.tool.execute("call", { pages: [page] } as never);
     expect(unread.details).toEqual({ cited: 0 });
     expect(events).toHaveLength(1);
+  });
+
+  it("resolves evidence refs to the exact source used instead of the first page source", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-evidence-"));
+    dirs.push(dir);
+    const page = path.join(dir, "entities", "GB-supernode.md");
+    fs.mkdirSync(path.dirname(page), { recursive: true });
+    fs.writeFileSync(page, `---
+sources:
+  - id: src-gb300-performance
+    resource: raw/benchmarks/gb300-performance.md
+  - id: src-asus-sales-kit
+    resource: raw/specs/GB3XX-ASUS-sales-kit.md
+---
+# GB300
+
+<!-- okf:evidence {"id":"ev.gb300.asus.rack-power-ports","sources":["src-asus-sales-kit"]} -->
+
+## ASUS rack
+
+The rack power budget and port inventory come from the ASUS sales kit.
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [
+        {
+          sourceId: "src-gb300-performance",
+          resource: "benchmarks/gb300-performance.md",
+          title: "GB300 performance report",
+          url: "https://docs.feishu.cn/wiki/performance",
+        },
+        {
+          sourceId: "src-asus-sales-kit",
+          resource: "specs/GB3XX-ASUS-sales-kit.md",
+          title: "GB3XX-ASUS product manual 2",
+          url: "https://acnizrso7ikb.feishu.cn/wiki/NMWWw0WEOiyXcekQh3hcCQTVnff",
+        },
+      ] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["entities/GB-supernode.md#ev.gb300.asus.rack-power-ports"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 1, unresolved: [] },
+    });
+    expect(events).toEqual([{ type: "knowledge_sources", sources: [{
+      title: "GB3XX-ASUS product manual 2",
+      url: "https://acnizrso7ikb.feishu.cn/wiki/NMWWw0WEOiyXcekQh3hcCQTVnff",
+      resource: "specs/GB3XX-ASUS-sales-kit.md",
+      sourceId: "src-asus-sales-kit",
+      page: "entities/GB-supernode.md",
+      evidence: "ev.gb300.asus.rack-power-ports",
+    }] }]);
+  });
+
+  it("fails closed when an evidence source has no frozen original mapping", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-unresolved-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    fs.writeFileSync(page, `---
+sources:
+  - id: src-missing
+    resource: raw/missing.md
+---
+<!-- okf:evidence {"id":"ev.missing","sources":["src-missing"]} -->
+# Guide
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#ev.missing"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 0, unresolved: ["guide.md#ev.missing"] },
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("fails closed on malformed or over-specified evidence markers", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-malformed-evidence-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    fs.writeFileSync(page, `---
+sources:
+  - id: src-runbook
+    resource: raw/runbook.md
+---
+<!-- okf:evidence {"id":"ev.runbook","sources":["src-runbook"],"unexpected":true} -->
+# Guide
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-runbook",
+        resource: "runbook.md",
+        title: "Runbook",
+        url: "https://docs.feishu.cn/wiki/Runbook",
+      }] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#ev.runbook"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 0, unresolved: ["guide.md#ev.runbook"] },
+    });
+    expect(events).toEqual([]);
   });
 
   it("switches prompt guidance when a manifest appears on a warm session reload", () => {
@@ -58,7 +206,7 @@ describe("knowledge_cite", () => {
     );
   });
 
-  it("degrades to no citations when a previously read page disappears", async () => {
+  it("cites the Read snapshot after the page file is deleted", async () => {
     const { dir, page } = fixture();
     const events: Record<string, unknown>[] = [];
     const support = createKnowledgeCitationSupport({
@@ -66,16 +214,16 @@ describe("knowledge_cite", () => {
       turnRef: { current: 1 },
       sessionEventEmitter: (event) => events.push(event),
     });
-    support.noteRead(page);
+    readPage(support, page);
     fs.rmSync(page);
 
     await expect(support.tool.execute("call", { pages: [page] } as never)).resolves.toMatchObject({
-      details: { cited: 0 },
+      details: { cited: 1 },
     });
-    expect(events).toEqual([]);
+    expect(events).toHaveLength(1);
   });
 
-  it("degrades to no citations when page frontmatter is malformed", async () => {
+  it("ignores a later disk rewrite of a page that was already Read", async () => {
     const { dir, page } = fixture();
     const events: Record<string, unknown>[] = [];
     const support = createKnowledgeCitationSupport({
@@ -83,13 +231,13 @@ describe("knowledge_cite", () => {
       turnRef: { current: 1 },
       sessionEventEmitter: (event) => events.push(event),
     });
-    support.noteRead(page);
+    readPage(support, page);
     fs.writeFileSync(page, "---\nsources: [\n---\n# Broken\n");
 
     await expect(support.tool.execute("call", { pages: [page] } as never)).resolves.toMatchObject({
-      details: { cited: 0 },
+      details: { cited: 1 },
     });
-    expect(events).toEqual([]);
+    expect(events).toHaveLength(1);
   });
 
   it("uses the most specific repository root when manifests overlap", async () => {
@@ -115,7 +263,7 @@ describe("knowledge_cite", () => {
       turnRef: { current: 1 },
       sessionEventEmitter: (event) => events.push(event),
     });
-    support.noteRead(page);
+    readPage(support, page);
 
     await expect(support.tool.execute("call", { pages: [page] } as never)).resolves.toMatchObject({
       details: { cited: 1 },
@@ -126,5 +274,540 @@ describe("knowledge_cite", () => {
       resource: "runbook.md",
       page: "repos/specific/guide.md",
     }] }]);
+  });
+
+  it("keeps the compiler and runtime on one marker grammar", () => {
+    const fixtures = JSON.parse(fs.readFileSync(
+      path.join(import.meta.dirname, "../../docs/design/okf-evidence-marker-fixtures.json"),
+      "utf8",
+    )) as {
+      pattern: string;
+      start_pattern: string;
+      max_sources: number;
+      cases: Array<{ id: string; body: string; recognized: boolean }>;
+    };
+    expect(EVIDENCE_MARKER.source).toBe(fixtures.pattern);
+    expect(EVIDENCE_MARKER_START.source).toBe(fixtures.start_pattern);
+    expect(MAX_EVIDENCE_SOURCES_PER_MARKER).toBe(fixtures.max_sources);
+    expect(fs.readFileSync(path.join(import.meta.dirname, "../../kbc/platform/pod/selfcheck.py"), "utf8"))
+      .toContain(`_MAX_EVIDENCE_SOURCES = ${fixtures.max_sources}`);
+
+    for (const fixture of fixtures.cases) {
+      EVIDENCE_MARKER.lastIndex = 0;
+      EVIDENCE_MARKER_START.lastIndex = 0;
+      const scan = maskMarkdownCode(fixture.body);
+      const start = scan.match(EVIDENCE_MARKER_START)?.length ?? 0;
+      const full = [...scan.matchAll(EVIDENCE_MARKER)].length;
+      expect({ id: fixture.id, start, full }, fixture.id).toEqual({
+        id: fixture.id,
+        start: fixture.recognized ? 1 : 0,
+        full: fixture.recognized ? 1 : 0,
+      });
+    }
+  });
+
+  it("cites a good marker even when the same page has a newline-broken comment", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-newline-junk-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    fs.writeFileSync(page, `---
+sources:
+  - id: src-runbook
+    resource: raw/runbook.md
+---
+<!-- okf:evidence {"id":"good","sources":["src-runbook"]} -->
+<!--
+okf:evidence NOT-JSON
+-->
+# Guide
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-runbook",
+        resource: "runbook.md",
+        title: "Runbook",
+        url: "https://docs.feishu.cn/wiki/Runbook",
+      }] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#good"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 1, unresolved: [] },
+    });
+    expect(events).toHaveLength(1);
+  });
+
+  it("merges evidence refs and unmarked pages in one call", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-mixed-"));
+    dirs.push(dir);
+    const marked = path.join(dir, "guide.md");
+    const legacy = path.join(dir, "legacy.md");
+    fs.writeFileSync(marked, `---
+sources:
+  - id: src-runbook
+    resource: raw/runbook.md
+---
+<!-- okf:evidence {"id":"good","sources":["src-runbook"]} -->
+# Guide
+`);
+    fs.writeFileSync(legacy, "---\nsources:\n  - resource: raw/policy.md\n---\n# Policy\n");
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [
+        {
+          sourceId: "src-runbook",
+          resource: "runbook.md",
+          title: "Runbook",
+          url: "https://docs.feishu.cn/wiki/Runbook",
+        },
+        {
+          resource: "policy.md",
+          title: "Policy",
+          url: "https://docs.feishu.cn/wiki/Policy",
+        },
+      ] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, marked);
+    readPage(support, legacy);
+
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#good"],
+      pages: ["legacy.md"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 2, unresolved: [] },
+    });
+    expect(events[0]).toMatchObject({
+      type: "knowledge_sources",
+      sources: [
+        { title: "Runbook", evidence: "good" },
+        { title: "Policy", page: "legacy.md" },
+      ],
+    });
+    expect(buildKnowledgeCitationSystemPrompt(dir)).toContain("pass those as `pages` in the same call");
+  });
+
+  it("rejects citing a marked page through the legacy pages parameter", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-marked-via-pages-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    fs.writeFileSync(page, `---
+sources:
+  - id: src-runbook
+    resource: raw/runbook.md
+---
+<!-- okf:evidence {"id":"good","sources":["src-runbook"]} -->
+# Guide
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-runbook",
+        resource: "runbook.md",
+        title: "Runbook",
+        url: "https://docs.feishu.cn/wiki/Runbook",
+      }] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+
+    await expect(support.tool.execute("call", {
+      pages: ["guide.md"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 0 },
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("deduplicates two source ids inside one marker that share a URL", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-dup-url-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    fs.writeFileSync(page, `---
+sources:
+  - id: src-a
+    resource: raw/a.md
+  - id: src-b
+    resource: raw/b.md
+---
+<!-- okf:evidence {"id":"both","sources":["src-a","src-b"]} -->
+# Guide
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [
+        { sourceId: "src-a", resource: "a.md", title: "A", url: "https://docs.feishu.cn/wiki/same" },
+        { sourceId: "src-b", resource: "b.md", title: "B", url: "https://docs.feishu.cn/wiki/same" },
+      ] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#both"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 1, unresolved: [] },
+    });
+    expect((events[0] as { sources: unknown[] }).sources).toHaveLength(1);
+  });
+
+  it("keeps the transport ceiling separate from the per-marker source cap", () => {
+    expect(MAX_KNOWLEDGE_CITATIONS).toBe(8);
+    expect(MAX_EVIDENCE_SOURCES_PER_MARKER).toBe(8);
+  });
+
+  it("fails closed when mixed pages would add a ninth original source", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-cap-"));
+    dirs.push(dir);
+    const sources = Array.from({ length: 8 }, (_, index) => ({
+      id: `src-${index + 1}`,
+      resource: `raw/s${index + 1}.md`,
+    }));
+    const sourceIds = sources.map((source) => source.id);
+    const marked = path.join(dir, "guide.md");
+    const legacy = path.join(dir, "legacy.md");
+    fs.writeFileSync(marked, `---
+sources:
+${sources.map((source) => `  - id: ${source.id}\n    resource: ${source.resource}`).join("\n")}
+---
+<!-- okf:evidence {"id":"all","sources":${JSON.stringify(sourceIds)}} -->
+# Guide
+`);
+    fs.writeFileSync(legacy, "---\nsources:\n  - resource: raw/extra.md\n---\n# Extra\n");
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [
+        ...sources.map((source, index) => ({
+          sourceId: source.id,
+          resource: `s${index + 1}.md`,
+          title: `S${index + 1}`,
+          url: `https://docs.feishu.cn/wiki/s${index + 1}`,
+        })),
+        { resource: "extra.md", title: "Extra", url: "https://docs.feishu.cn/wiki/extra" },
+      ] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, marked);
+    readPage(support, legacy);
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#all"],
+      pages: ["legacy.md"],
+    } as never)).resolves.toMatchObject({
+      content: [{
+        type: "text",
+        text: "Evidence resolves to more than 8 original sources; split the answer instead of truncating citations.",
+      }],
+      details: { cited: 0, unresolved: ["guide.md#all"] },
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("does not treat a fenced example marker as citable evidence", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-fence-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    fs.writeFileSync(page, [
+      "---",
+      "sources:",
+      "  - id: src-runbook",
+      "    resource: raw/runbook.md",
+      "---",
+      "```",
+      "<!-- okf:evidence {\"id\":\"example\",\"sources\":[\"src-runbook\"]} -->",
+      "```",
+      "# Guide",
+      "",
+    ].join("\n"));
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-runbook",
+        resource: "runbook.md",
+        title: "Runbook",
+        url: "https://docs.feishu.cn/wiki/Runbook",
+      }] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#example"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 0, unresolved: ["guide.md#example"] },
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("cites the Read-time source after a mid-turn knowledge reload", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-reload-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    const writePage = (sourceId: string, resource: string) => {
+      fs.writeFileSync(page, `---
+sources:
+  - id: ${sourceId}
+    resource: ${resource}
+---
+<!-- okf:evidence {"id":"claim","sources":["${sourceId}"]} -->
+# Guide
+`);
+    };
+    const writeManifest = (sourceId: string, resource: string, title: string, url: string) => {
+      fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+        version: 1,
+        repos: [{ id: "repo", root: "", sources: [{ sourceId, resource, title, url }] }],
+      }));
+    };
+    writePage("src-a", "raw/a.md");
+    writeManifest("src-a", "a.md", "Source A", "https://docs.feishu.cn/wiki/a");
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page);
+    writePage("src-b", "raw/b.md");
+    writeManifest("src-b", "b.md", "Source B", "https://docs.feishu.cn/wiki/b");
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#claim"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 1, unresolved: [] },
+    });
+    expect(events[0]).toMatchObject({
+      sources: [{ title: "Source A", url: "https://docs.feishu.cn/wiki/a", sourceId: "src-a" }],
+    });
+  });
+
+  it("cites the bytes passed to noteRead even when disk already shows another page", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-passed-bytes-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    const pageA = `---
+sources:
+  - id: src-a
+    resource: raw/a.md
+---
+<!-- okf:evidence {"id":"claim","sources":["src-a"]} -->
+# Guide
+`;
+    const pageB = `---
+sources:
+  - id: src-b
+    resource: raw/b.md
+---
+<!-- okf:evidence {"id":"claim","sources":["src-b"]} -->
+# Guide
+`;
+    fs.writeFileSync(page, pageB);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-a", resource: "a.md", title: "Source A", url: "https://docs.feishu.cn/wiki/a",
+      }] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page, pageA);
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#claim"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 1, unresolved: [] },
+    });
+    expect(events[0]).toMatchObject({
+      sources: [{ title: "Source A", url: "https://docs.feishu.cn/wiki/a", sourceId: "src-a" }],
+    });
+  });
+
+  it("does not pair Read bytes with a remount that landed during the Read", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-read-race-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    const pageA = `---
+sources:
+  - id: src-1
+    resource: raw/doc.md
+---
+<!-- okf:evidence {"id":"claim","sources":["src-1"]} -->
+# Guide
+`;
+    fs.writeFileSync(page, pageA);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-1", resource: "doc.md", title: "Source A", url: "https://docs.feishu.cn/wiki/a",
+      }] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    const startA = support.captureMount();
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-1", resource: "doc.md", title: "Source B", url: "https://docs.feishu.cn/wiki/b",
+      }] }],
+    }));
+    support.noteRead(page, pageA, startA);
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#claim"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 0, unresolved: ["guide.md#claim"] },
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("drops a prior snapshot when a later Read of the same page races the remount", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-stale-after-race-"));
+    dirs.push(dir);
+    const page = path.join(dir, "guide.md");
+    const writePage = (sourceId: string, resource: string) => `---
+sources:
+  - id: ${sourceId}
+    resource: ${resource}
+---
+<!-- okf:evidence {"id":"claim","sources":["${sourceId}"]} -->
+# Guide
+`;
+    const writeManifest = (title: string, url: string) => {
+      fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+        version: 1,
+        repos: [{ id: "repo", root: "", sources: [{
+          sourceId: "src-1", resource: "doc.md", title, url,
+        }] }],
+      }));
+    };
+    const pageA = writePage("src-1", "raw/doc.md");
+    const pageB = writePage("src-1", "raw/doc.md");
+    fs.writeFileSync(page, pageA);
+    writeManifest("Source A", "https://docs.feishu.cn/wiki/a");
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, page, pageA);
+    const startA = support.captureMount();
+    writeManifest("Source B", "https://docs.feishu.cn/wiki/b");
+    fs.writeFileSync(page, pageB);
+    support.noteRead(page, pageB, startA);
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#claim"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 0, unresolved: ["guide.md#claim"] },
+    });
+    expect(events).toEqual([]);
+    readPage(support, page, pageB);
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["guide.md#claim"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 1, unresolved: [] },
+    });
+    expect(events[0]).toMatchObject({
+      sources: [{ title: "Source B", url: "https://docs.feishu.cn/wiki/b", sourceId: "src-1" }],
+    });
+  });
+
+  it("re-pins on a later consistent Read so the model can cite in the same turn", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-cite-repin-"));
+    dirs.push(dir);
+    const first = path.join(dir, "first.md");
+    const second = path.join(dir, "second.md");
+    fs.writeFileSync(first, `---
+sources:
+  - id: src-a
+    resource: raw/a.md
+---
+<!-- okf:evidence {"id":"claim","sources":["src-a"]} -->
+# First
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-a", resource: "a.md", title: "Source A", url: "https://docs.feishu.cn/wiki/a",
+      }] }],
+    }));
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({
+      knowledgeDir: dir,
+      turnRef: { current: 1 },
+      sessionEventEmitter: (event) => events.push(event),
+    });
+    readPage(support, first);
+    fs.writeFileSync(second, `---
+sources:
+  - id: src-b
+    resource: raw/b.md
+---
+<!-- okf:evidence {"id":"claim","sources":["src-b"]} -->
+# Second
+`);
+    fs.writeFileSync(path.join(dir, KNOWLEDGE_CITATION_MANIFEST), JSON.stringify({
+      version: 1,
+      repos: [{ id: "repo", root: "", sources: [{
+        sourceId: "src-b", resource: "b.md", title: "Source B", url: "https://docs.feishu.cn/wiki/b",
+      }] }],
+    }));
+    readPage(support, second);
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["first.md#claim"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 0, unresolved: ["first.md#claim"] },
+    });
+    await expect(support.tool.execute("call", {
+      evidence_refs: ["second.md#claim"],
+    } as never)).resolves.toMatchObject({
+      details: { cited: 1, unresolved: [] },
+    });
+    expect(events[0]).toMatchObject({
+      sources: [{ title: "Source B", url: "https://docs.feishu.cn/wiki/b", sourceId: "src-b" }],
+    });
+  });
+
+  it("normalizes drop/ and keeps a leading slash from matching a relative path", () => {
+    expect(normalizedResource("drop/foo.md")).toBe("foo.md");
+    expect(normalizedResource("raw/foo.md")).toBe("foo.md");
+    expect(normalizedResource("/foo.md")).toBe("/foo.md");
   });
 });

--- a/src/core/knowledge-citation-tool.ts
+++ b/src/core/knowledge-citation-tool.ts
@@ -7,23 +7,111 @@ import { Text } from "@earendil-works/pi-tui";
 import { renderTextResult } from "../tools/infra/tool-render.js";
 import type { SessionEventEmitter } from "./tool-registry.js";
 import {
+  MAX_EVIDENCE_SOURCES_PER_MARKER,
   MAX_KNOWLEDGE_CITATIONS,
   type KnowledgeSourceCitation,
 } from "../shared/knowledge-citations.js";
 
 export const KNOWLEDGE_CITATION_MANIFEST = ".citation-manifest.json";
 
-interface CitationManifestSource { resource: string; title: string; url: string }
+interface CitationManifestSource { sourceId?: string; resource: string; title: string; url: string }
 interface CitationManifestRepo { id: string; root: string; sources: CitationManifestSource[] }
 interface CitationManifest { version: 1; repos: CitationManifestRepo[] }
 
-function result(text: string, cited: number) {
-  return { content: [{ type: "text" as const, text }], details: { cited } };
+interface PageSource { sourceId?: string; resource: string }
+interface PageEvidence { id: string; sourceIds: string[] }
+interface PageProvenance { sources: PageSource[]; evidence: Map<string, PageEvidence> }
+
+const EVIDENCE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+/** Canonical grammar: space/tab only. Must stay identical to selfcheck.py and Sicore. */
+export const EVIDENCE_MARKER_START = /<!--[ \t]*okf:evidence\b/g;
+export const EVIDENCE_MARKER = /<!--[ \t]*okf:evidence[ \t]+(\{[^\r\n]*\})[ \t]*-->/g;
+
+function result(text: string, cited: number, unresolved?: string[]) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details: unresolved ? { cited, unresolved } : { cited },
+  };
 }
 
-function normalizedResource(value: string): string {
-  const clean = path.posix.normalize(value.replaceAll("\\", "/").replace(/^\.\//, "")).replace(/^\/+/, "");
-  return clean.startsWith("raw/") ? clean.slice(4) : clean;
+/** Match selfcheck._norm_source_entry: strip raw/ or drop/, keep a leading slash. */
+export function normalizedResource(value: string): string {
+  let entry = path.posix.normalize(value.trim().replaceAll("\\", "/"));
+  for (const prefix of ["raw/", "drop/"] as const) {
+    if (entry.startsWith(prefix)) {
+      entry = entry.slice(prefix.length);
+      break;
+    }
+  }
+  entry = path.posix.normalize(entry);
+  return entry === "." ? "" : entry;
+}
+
+function maskSpan(text: string): string {
+  return text.replace(/[^\n]/g, " ");
+}
+
+/**
+ * Mask fenced blocks and inline code the same way selfcheck._markdown_prose
+ * does, so an example marker in a code fence is not evidence.
+ */
+export function maskMarkdownCode(body: string): string {
+  const maskedLines: string[] = [];
+  let fenceChar: string | null = null;
+  let fenceLen = 0;
+  for (const line of body.match(/.*(?:\r?\n|$)/g) ?? []) {
+    if (!line) continue;
+    const raw = line.replace(/\r?\n$/, "");
+    if (fenceChar !== null) {
+      const close = /^[ ]{0,3}([`~]+)[ \t]*$/.exec(raw);
+      maskedLines.push(maskSpan(line));
+      if (close && close[1][0] === fenceChar && close[1].length >= fenceLen) {
+        fenceChar = null;
+        fenceLen = 0;
+      }
+      continue;
+    }
+    const opened = /^[ ]{0,3}(`{3,}|~{3,})(?:[^\r\n]*)$/.exec(raw);
+    if (opened) {
+      fenceChar = opened[1][0];
+      fenceLen = opened[1].length;
+      maskedLines.push(maskSpan(line));
+    } else {
+      maskedLines.push(line);
+    }
+  }
+  const text = maskedLines.join("");
+  const chars = text.split("");
+  let pos = 0;
+  while (true) {
+    const start = text.indexOf("`", pos);
+    if (start < 0) break;
+    let endRun = start;
+    while (endRun < text.length && text[endRun] === "`") endRun += 1;
+    const ticks = endRun - start;
+    let close = endRun;
+    let found = -1;
+    while (true) {
+      close = text.indexOf("`", close);
+      if (close < 0) break;
+      let closeEnd = close;
+      while (closeEnd < text.length && text[closeEnd] === "`") closeEnd += 1;
+      if (closeEnd - close === ticks) {
+        found = closeEnd;
+        break;
+      }
+      close = closeEnd;
+    }
+    if (found < 0) {
+      pos = endRun;
+      continue;
+    }
+    for (let i = start; i < found; i += 1) {
+      if (chars[i] !== "\n") chars[i] = " ";
+    }
+    pos = found;
+  }
+  return chars.join("");
 }
 
 function readManifest(knowledgeDir: string): CitationManifest | null {
@@ -35,28 +123,73 @@ function readManifest(knowledgeDir: string): CitationManifest | null {
   }
 }
 
-function pageResources(pagePath: string): string[] {
+function sameManifest(left: CitationManifest | null, right: CitationManifest | null): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/** Opaque before/after receipt for one Read. Compare by JSON, not identity. */
+export type KnowledgeMountReceipt = { readonly json: string };
+
+function mountReceipt(manifest: CitationManifest | null): KnowledgeMountReceipt {
+  return { json: JSON.stringify(manifest) };
+}
+
+export function pageProvenanceFromBody(body: string): PageProvenance | null {
   try {
-    const body = fs.readFileSync(pagePath, "utf8");
-    if (!body.startsWith("---\n")) return [];
+    if (!body.startsWith("---\n")) return null;
     const end = body.indexOf("\n---", 4);
-    if (end < 0 || end > 64 * 1024) return [];
+    if (end < 0 || end > 64 * 1024) return null;
     const frontmatter = yaml.load(body.slice(4, end)) as Record<string, unknown> | null;
-    if (!frontmatter || !Array.isArray(frontmatter.sources)) return [];
-    return frontmatter.sources.flatMap((source) => {
+    if (!frontmatter || !Array.isArray(frontmatter.sources)) return null;
+    const sources = frontmatter.sources.flatMap((source): PageSource[] => {
       if (!source || typeof source !== "object") return [];
-      const resource = (source as Record<string, unknown>).resource;
-      return typeof resource === "string" && resource.trim() ? [normalizedResource(resource)] : [];
+      const row = source as Record<string, unknown>;
+      const resource = row.resource;
+      if (typeof resource !== "string" || !resource.trim()) return [];
+      const sourceId = typeof row.id === "string" && EVIDENCE_ID.test(row.id.trim())
+        ? row.id.trim()
+        : undefined;
+      return [{ sourceId, resource: normalizedResource(resource) }];
     });
+
+    const evidence = new Map<string, PageEvidence>();
+    const pageBody = maskMarkdownCode(body.slice(end + 4));
+    EVIDENCE_MARKER.lastIndex = 0;
+    for (const match of pageBody.matchAll(EVIDENCE_MARKER)) {
+      try {
+        const parsed = JSON.parse(match[1]) as unknown;
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) ||
+          Object.keys(parsed).sort().join(",") !== "id,sources") {
+          continue;
+        }
+        const row = parsed as Record<string, unknown>;
+        const id = typeof row.id === "string" ? row.id.trim() : "";
+        const sourceIds = Array.isArray(row.sources)
+          ? row.sources.map((value) => typeof value === "string" ? value.trim() : "")
+          : [];
+        if (!EVIDENCE_ID.test(id) || sourceIds.length === 0 || sourceIds.length > MAX_EVIDENCE_SOURCES_PER_MARKER ||
+          sourceIds.some((sourceId) => !EVIDENCE_ID.test(sourceId)) ||
+          new Set(sourceIds).size !== sourceIds.length || evidence.has(id)) {
+          continue;
+        }
+        evidence.set(id, { id, sourceIds });
+      } catch {
+        continue;
+      }
+    }
+    return { sources, evidence };
   } catch {
-    // A resource reload can replace the page after Read recorded it, and a
-    // malformed page must not turn an optional citation miss into a failed turn.
-    return [];
+    return null;
   }
 }
 
 export function hasKnowledgeCitationManifest(knowledgeDir: string): boolean {
   return readManifest(knowledgeDir)?.repos.some((repo) => repo.sources.length > 0) ?? false;
+}
+
+function hasEvidenceCitationManifest(knowledgeDir: string): boolean {
+  return readManifest(knowledgeDir)?.repos.some((repo) =>
+    repo.sources.some((source) => typeof source.sourceId === "string" && EVIDENCE_ID.test(source.sourceId))) ?? false;
 }
 
 /**
@@ -70,6 +203,12 @@ export function buildKnowledgeCitationSystemPrompt(knowledgeDir: string): string
 ## Knowledge source citations
 
 Trusted original-source metadata is not available for this knowledge mount. Do not call \`knowledge_cite\`; answer normally without a references section. This instruction may change after a knowledge reload.`;
+  }
+  if (hasEvidenceCitationManifest(knowledgeDir)) {
+    return `
+## Knowledge source citations
+
+When your final answer materially relies on mounted knowledge, call \`knowledge_cite\` once after research and immediately before the final answer. Prefer \`evidence_refs\` for sections that contain an \`okf:evidence\` marker: pass only refs you successfully Read and actually used, in \`page.md#evidence-id\` form. If the answer also uses unmarked pages, pass those as \`pages\` in the same call. The runtime resolves each evidence ref to its exact frozen original and fails closed if any evidence ref is unresolved — retry once with only the remaining valid refs; do not ship the answer after a failed cite. Never invent or manually copy source URLs.`;
   }
   return `
 ## Knowledge source citations
@@ -94,22 +233,51 @@ export function createKnowledgeCitationSupport(opts: {
   knowledgeDir: string;
   turnRef: { current: number };
   sessionEventEmitter: SessionEventEmitter;
-}): { noteRead: (pagePath: string) => void; tool: ToolDefinition } {
+}): {
+  captureMount: () => KnowledgeMountReceipt;
+  noteRead: (pagePath: string, content: string, start: KnowledgeMountReceipt) => void;
+  tool: ToolDefinition;
+} {
   let turn = -1;
-  const readPages = new Set<string>();
+  const readPages = new Map<string, string>();
+  let pinnedManifest: CitationManifest | null | undefined;
   const resetForTurn = () => {
     if (turn !== opts.turnRef.current) {
       turn = opts.turnRef.current;
       readPages.clear();
+      pinnedManifest = undefined;
     }
   };
-  const noteRead = (pagePath: string) => {
+  const pinManifest = () => {
+    if (pinnedManifest !== undefined) return;
+    pinnedManifest = readManifest(opts.knowledgeDir);
+  };
+  const captureMount = (): KnowledgeMountReceipt => mountReceipt(readManifest(opts.knowledgeDir));
+  const noteRead = (pagePath: string, content: string, start: KnowledgeMountReceipt) => {
     resetForTurn();
     const absolute = path.resolve(pagePath);
     const root = path.resolve(opts.knowledgeDir);
-    if (absolute.endsWith(".md") && (absolute === root || absolute.startsWith(root + path.sep))) {
-      readPages.add(absolute);
+    if (!absolute.endsWith(".md") || !(absolute === root || absolute.startsWith(root + path.sep))) {
+      return;
     }
+    const current = readManifest(opts.knowledgeDir);
+    if (start.json !== mountReceipt(current).json) {
+      // Remount landed between the pre-Read receipt and this check.
+      // The model already saw the new page bytes; drop earlier snapshots so
+      // cite cannot emit the old mount for a path the model just re-read.
+      readPages.clear();
+      pinnedManifest = undefined;
+      return;
+    }
+    if (pinnedManifest !== undefined && !sameManifest(pinnedManifest, current)) {
+      // A later consistent Read saw the new mount. Drop earlier snapshots so
+      // the model can re-read and cite in this same turn.
+      readPages.clear();
+      pinnedManifest = current;
+    } else if (pinnedManifest === undefined) {
+      pinnedManifest = current;
+    }
+    readPages.set(absolute, content);
   };
 
   const tool: ToolDefinition = {
@@ -119,54 +287,156 @@ export function createKnowledgeCitationSupport(opts: {
     renderResult: renderTextResult,
     description:
       "Use only when the current system prompt says knowledge source citations are available. " +
-      "Register the knowledge pages that materially support your final answer. Call once, immediately before the final answer, " +
-      "and include only pages you successfully Read in this turn and actually used. The runtime validates their published original-source metadata and appends trusted links; never invent or copy source URLs yourself.",
+      "Register the exact evidence refs that materially support your final answer, and unmarked pages if needed. " +
+      "Call once, immediately before the final answer. If the tool reports unresolved refs, retry once with only the remaining valid refs. " +
+      "The runtime validates frozen original-source metadata and appends trusted links; never invent or copy source URLs yourself.",
     parameters: Type.Object({
-      pages: Type.Array(Type.String({ minLength: 1 }), {
+      evidence_refs: Type.Optional(Type.Array(Type.String({ minLength: 3 }), {
         minItems: 1,
         maxItems: MAX_KNOWLEDGE_CITATIONS,
-        description: `Absolute paths, or paths relative to the mounted knowledge directory, of the 1-${MAX_KNOWLEDGE_CITATIONS} adopted knowledge pages.`,
-      }),
+        description: `Evidence refs from read knowledge sections, in page.md#evidence-id form (1-${MAX_KNOWLEDGE_CITATIONS}).`,
+      })),
+      pages: Type.Optional(Type.Array(Type.String({ minLength: 1 }), {
+        minItems: 1,
+        maxItems: MAX_KNOWLEDGE_CITATIONS,
+        description: `Unmarked knowledge pages actually used (1-${MAX_KNOWLEDGE_CITATIONS}). May be combined with evidence_refs.`,
+      })),
     }),
     async execute(_toolCallId, rawParams) {
       resetForTurn();
-      const manifest = readManifest(opts.knowledgeDir);
+      pinManifest();
+      const manifest = pinnedManifest ?? null;
       if (!manifest) return result("No trusted original-source metadata is available for this knowledge mount.", 0);
-      const rawPages = (rawParams as { pages?: unknown }).pages;
-      if (!Array.isArray(rawPages)) return result("knowledge_cite requires pages.", 0);
-      const selected = rawPages.map((raw) => {
-        const value = String(raw);
-        return path.resolve(path.isAbsolute(value) ? value : path.join(opts.knowledgeDir, value));
-      });
-      const unread = selected.find((page) => !readPages.has(page));
-      if (unread) return result(`Cannot cite unread knowledge page: ${unread}`, 0);
+      const params = rawParams as { evidence_refs?: unknown; pages?: unknown };
+      const refs = Array.isArray(params.evidence_refs) ? params.evidence_refs.map(String) : [];
+      const pageArgs = Array.isArray(params.pages) ? params.pages.map(String) : [];
+      if (refs.length === 0 && pageArgs.length === 0) {
+        return result("knowledge_cite requires evidence_refs and/or pages.", 0);
+      }
 
       const citations: KnowledgeSourceCitation[] = [];
       const seenURLs = new Set<string>();
-      for (const page of selected) {
+      const unresolved: string[] = [];
+
+      for (const ref of refs) {
+        const hash = ref.lastIndexOf("#");
+        const pageValue = hash > 0 ? ref.slice(0, hash) : "";
+        const evidenceId = hash > 0 ? ref.slice(hash + 1) : "";
+        const page = pageValue
+          ? path.resolve(path.isAbsolute(pageValue) ? pageValue : path.join(opts.knowledgeDir, pageValue))
+          : "";
+        const root = path.resolve(opts.knowledgeDir);
+        const snapshot = page ? readPages.get(page) : undefined;
+        if (!page || !snapshot || !EVIDENCE_ID.test(evidenceId) || !page.endsWith(".md") ||
+          !(page === root || page.startsWith(root + path.sep))) {
+          unresolved.push(ref);
+          continue;
+        }
         const rel = path.relative(opts.knowledgeDir, page).replaceAll(path.sep, "/");
         const repo = findCitationRepo(manifest, rel);
-        if (!repo) continue;
-        const sourceByResource = new Map(repo.sources.map((source) => [normalizedResource(source.resource), source]));
-        for (const resource of pageResources(page)) {
-          const source = sourceByResource.get(resource);
-          if (!source || seenURLs.has(source.url)) continue;
-          seenURLs.add(source.url);
-          citations.push({ title: source.title, url: source.url, resource: source.resource, page: rel });
-          if (citations.length >= MAX_KNOWLEDGE_CITATIONS) break;
+        const provenance = pageProvenanceFromBody(snapshot);
+        const evidence = provenance?.evidence.get(evidenceId);
+        if (!repo || !provenance || !evidence) {
+          unresolved.push(ref);
+          continue;
         }
-        if (citations.length >= MAX_KNOWLEDGE_CITATIONS) break;
+        const pageSourceById = new Map(
+          provenance.sources.filter((source) => source.sourceId).map((source) => [source.sourceId!, source]),
+        );
+        const manifestSourceById = new Map(
+          repo.sources.filter((source) => source.sourceId).map((source) => [source.sourceId!, source]),
+        );
+        let refResolved = true;
+        const refCitations: KnowledgeSourceCitation[] = [];
+        const refSeen = new Set<string>();
+        for (const sourceId of evidence.sourceIds) {
+          const pageSource = pageSourceById.get(sourceId);
+          const source = manifestSourceById.get(sourceId);
+          if (!pageSource || !source || normalizedResource(source.resource) !== pageSource.resource) {
+            refResolved = false;
+            break;
+          }
+          if (seenURLs.has(source.url) || refSeen.has(source.url)) continue;
+          refSeen.add(source.url);
+          refCitations.push({
+            title: source.title,
+            url: source.url,
+            resource: source.resource,
+            sourceId,
+            page: rel,
+            evidence: evidenceId,
+          });
+        }
+        if (!refResolved) {
+          unresolved.push(ref);
+          continue;
+        }
+        for (const citation of refCitations) {
+          seenURLs.add(citation.url);
+          citations.push(citation);
+        }
+      }
+      if (unresolved.length > 0 || citations.length > MAX_KNOWLEDGE_CITATIONS) {
+        const failed = unresolved.length > 0 ? unresolved : refs;
+        return result(
+          unresolved.length > 0
+            ? `Unresolved evidence refs: ${unresolved.join(", ")}. No citations were registered. Retry knowledge_cite once with only the remaining valid refs (and any unmarked pages).`
+            : `Evidence resolves to more than ${MAX_KNOWLEDGE_CITATIONS} original sources; split the answer instead of truncating citations.`,
+          0,
+          failed,
+        );
+      }
+
+      if (pageArgs.length > 0) {
+        const selected = pageArgs.map((raw) => {
+          const value = String(raw);
+          return path.resolve(path.isAbsolute(value) ? value : path.join(opts.knowledgeDir, value));
+        });
+        const unread = selected.find((page) => !readPages.has(page));
+        if (unread) return result(`Cannot cite unread knowledge page: ${unread}`, 0);
+        for (const page of selected) {
+          const snapshot = readPages.get(page);
+          if (!snapshot) return result(`Cannot cite unread knowledge page: ${page}`, 0);
+          const rel = path.relative(opts.knowledgeDir, page).replaceAll(path.sep, "/");
+          const provenance = pageProvenanceFromBody(snapshot);
+          if ((provenance?.evidence.size ?? 0) > 0) {
+            return result(
+              `Cannot cite ${rel} via pages; it has evidence markers. Use evidence_refs.`,
+              0,
+            );
+          }
+          const repo = findCitationRepo(manifest, rel);
+          if (!repo) continue;
+          const sourceByResource = new Map(repo.sources.map((source) => [normalizedResource(source.resource), source]));
+          for (const resource of provenance?.sources.map((source) => source.resource) ?? []) {
+            const source = sourceByResource.get(resource);
+            if (!source || seenURLs.has(source.url)) continue;
+            seenURLs.add(source.url);
+            citations.push({ title: source.title, url: source.url, resource: source.resource, page: rel });
+          }
+        }
+      }
+
+      if (citations.length > MAX_KNOWLEDGE_CITATIONS) {
+        return result(
+          `Evidence resolves to more than ${MAX_KNOWLEDGE_CITATIONS} original sources; split the answer instead of truncating citations.`,
+          0,
+          refs.length > 0 ? refs : undefined,
+        );
       }
       if (citations.length > 0) {
         opts.sessionEventEmitter({ type: "knowledge_sources", sources: citations });
       }
       return result(
         citations.length > 0
-          ? `Registered ${citations.length} trusted original source${citations.length === 1 ? "" : "s"}; links will be appended automatically.`
-          : "The selected pages have no trusted clickable original sources; answer normally without a references section.",
+          ? `Registered ${citations.length} ${refs.length > 0 ? "exact " : ""}trusted original source${citations.length === 1 ? "" : "s"}; links will be appended automatically.`
+          : refs.length > 0
+            ? "The evidence refs resolved but have no unique original-source links."
+            : "The selected pages have no trusted clickable original sources; answer normally without a references section.",
         citations.length,
+        refs.length > 0 ? [] : undefined,
       );
     },
   };
-  return { noteRead, tool };
+  return { captureMount, noteRead, tool };
 }

--- a/src/shared/knowledge-citations.test.ts
+++ b/src/shared/knowledge-citations.test.ts
@@ -29,4 +29,14 @@ describe("knowledge source citation rendering", () => {
       "- [Title](https://ok.example/%29[Login]%28https://evil.example/)",
     );
   });
+
+  it("does not silently discard a fourth resolved evidence source", () => {
+    const sources = Array.from({ length: 4 }, (_, index) => ({
+      title: `Source ${index + 1}`,
+      url: `https://docs.feishu.cn/wiki/source${index + 1}`,
+    }));
+
+    expect(normalizeKnowledgeSourceCitations(sources)).toHaveLength(4);
+    expect(appendKnowledgeSourceCitations("answer", sources)).toContain("Source 4");
+  });
 });

--- a/src/shared/knowledge-citations.ts
+++ b/src/shared/knowledge-citations.ts
@@ -2,10 +2,21 @@ export interface KnowledgeSourceCitation {
   title: string;
   url: string;
   resource?: string;
+  sourceId?: string;
   page?: string;
+  evidence?: string;
 }
 
-export const MAX_KNOWLEDGE_CITATIONS = 3;
+// Shared ceiling for one knowledge_cite result, the tool's evidence_refs /
+// pages maxItems, and the rendered references list (including Feishu cards).
+// The raise from 3 to 8 is intentional for both evidence and legacy paths:
+// a multi-source answer must not lose the fourth original after the runtime
+// already validated it. This is not the per-marker source cap — that is
+// MAX_EVIDENCE_SOURCES_PER_MARKER, mirrored by Python `_MAX_EVIDENCE_SOURCES`.
+export const MAX_KNOWLEDGE_CITATIONS = 8;
+
+/** Max `sources` inside one `okf:evidence` marker. Keep equal to selfcheck.py. */
+export const MAX_EVIDENCE_SOURCES_PER_MARKER = 8;
 
 export function normalizeKnowledgeSourceCitations(value: unknown): KnowledgeSourceCitation[] {
   if (!Array.isArray(value)) return [];
@@ -25,7 +36,9 @@ export function normalizeKnowledgeSourceCitations(value: unknown): KnowledgeSour
       title,
       url: parsed.href,
       resource: typeof row.resource === "string" ? row.resource : undefined,
+      sourceId: typeof row.sourceId === "string" ? row.sourceId : undefined,
       page: typeof row.page === "string" ? row.page : undefined,
+      evidence: typeof row.evidence === "string" ? row.evidence : undefined,
     });
     if (out.length >= MAX_KNOWLEDGE_CITATIONS) break;
   }


### PR DESCRIPTION
## Summary
- bind claim-level `evidence_refs` to stable source IDs; runtime re-derives the URL from the frozen manifest
- fail closed on malformed, missing, over-limit, or remount-raced evidence instead of substituting or pairing across generations
- accept `evidence_refs` and unmarked `pages` in one call; crossing 8 originals fails the whole call
- keep compiler and runtime on one `[space/tab]` marker grammar; one bad marker no longer wipes the page

## Binding
Read captures a mount receipt, then reads the page, then checks the receipt again. Register only those bytes plus that manifest. A raced Read drops earlier snapshots and invalidates the pin. A later consistent Read on a new mount re-pins so the model can re-read and cite in the same turn.

## Review follow-up
The original two blockers plus later remount/cap reviews:

1. TypeScript marker regexes match `selfcheck.py` (`[space/tab]`, not `\\s`). Shared cases live in `docs/design/okf-evidence-marker-fixtures.json`.
2. Mixed marked + unmarked answers are one `knowledge_cite` call. Marked pages cannot be cited through `pages`.
3. Mixed 8 evidence + 1 used legacy page fails closed (`cited: 0`); it does not truncate.
4. `noteRead` takes the exact Read bytes. Factory captures the mount before `fsReadFile` and passes that receipt in.
5. Receipt mismatch clears prior snapshots and the pin. Stable A → raced B → cite 0 → stable re-read B → cite B.
6. Contract is in `docs/design/okf-evidence-citations.md`. History is squashed to one commit.

## Deploy
- Agentbox (`SICLAW_AGENTBOX_IMAGE`): grammar, snapshots, mixed call.
- Gateway / Runtime image: the shared 3→8 render cap (Feishu / SSE).
- Compile box (`SICLAW_COMPILE_BOX_IMAGE`): `selfcheck.py` marker scan.
- Sicore apiserver: `okf_citations.go` import gate (companion MR to `develop`).

Live sessions keep the box they already have.

## Tests
- `npx vitest run src/core/knowledge-citation-tool.test.ts src/core/agent-factory.test.ts` (25 passed, 1 skipped)
- focused Python evidence selfcheck passed
- remote CI: Type Check, Test, Portal Web Test, AgentBox Build Graph, KBC Box Test
