### PR TITLE
feat(agentbox): expose live child sessions for subagent groups

### DIFF
--- a/docs/design/2026-07-subagent-group.md
+++ b/docs/design/2026-07-subagent-group.md
@@ -167,6 +167,12 @@ one approval ─► tool layer: validateAndRenderGroupPlan (fail-fast) → rende
 - **`skipped` items are never persisted as a child event** (never started; `skipped` is not in
   the delegation status enum) — they exist only in the aggregate report and the batch terminal
   event's item detail.
+- **User identity is request-scoped in a shared AgentBox.** K8s AgentBoxes are shared per agent and
+  commonly have no process-level `USER_ID`; `/api/prompt.userId` is therefore passed into
+  `getOrCreate`, bound to the managed session, and used when building both the parent and spawned
+  child tool contexts. Reusing one resident session with a different non-empty user id is rejected
+  instead of silently attributing child sessions to the wrong user. This keeps child transcript
+  ownership aligned with the parent session and makes the read-only child messages API usable.
 
 ### Job model & notification
 
@@ -209,8 +215,10 @@ one approval ─► tool layer: validateAndRenderGroupPlan (fail-fast) → rende
   no-reduce call renders as the legacy **AgentWorkCard** (its collapse events are legacy-shaped,
   so this path is unchanged). The now-deleted `spawn_subagent_group` tool name is still
   recognised as the batch form so historical sessions keep rendering.
-- **Batch card:** progress bar + one status row per item (each row drills into its child
-  session) + the reduce summary + a drill-in to the reduce child. Children's `delegation_event`s
+- **Batch card:** progress bar + one expandable status row per item + an expandable reduce section.
+  Each expanded area reads its child session and renders the same inline execution component as a
+  single sub-agent (`SubagentSteps` + the shared tool card), refreshing persisted history while the
+  child runs. Children's `delegation_event`s
   are naturally hidden, so no per-child `AgentWorkCard`. It renders both a foreground batch's
   inline report (`item_results` in the tool result) and a background batch's folded metadata
   (`groupItems` from persisted events, `groupProgress` from the live event, `groupStatus`/reduce

--- a/docs/design/2026-07-subagent-group.md
+++ b/docs/design/2026-07-subagent-group.md
@@ -182,11 +182,19 @@ one approval ─► tool layer: validateAndRenderGroupPlan (fail-fast) → rende
 ### Progress (two paths that must not be confused)
 
 - **Foreground:** the tool's `onUpdate` carries either legacy per-child steps (collapse) or the
-  aggregate status array + phase (batch: map x/N → reduce). The executor emits a union of the two
-  progress shapes; the tool bridge and the frontend both dispatch by shape.
+  aggregate status array + phase (batch: map x/N → reduce). Batch updates use the same wire names
+  as background events: `child_session_id` and the latest `activity` per started item, plus
+  `reduce_child_session_id` once the reducer owns an execution slot. The executor emits a union of
+  the two progress shapes; the tool bridge and the frontend both dispatch by shape.
 - **Background:** `onUpdate` goes dead after `launched`, so live per-item progress rides a
   **`group_progress` chat event** (same `emit_chat_event` channel as `subagent_done`, throttled,
-  **live-only — never persisted**). It carries `job_id`, `phase`, and `[{index, status}]`.
+  **live-only — never persisted**). It carries `job_id`, `phase`, and
+  `[{index, status, child_session_id?, activity?}]` plus `reduce_child_session_id?` during the
+  reduce phase.
+  A child id is assigned only after the item acquires an execution slot, immediately before its
+  first `running` frame, and the same id is passed into `runSpawnedSubagent`; queued/skipped-never-
+  started items therefore expose no false drill-in. The reduce id follows the same rule and is
+  present from the first reduce frame.
   Correctness comes from the persisted per-child + terminal events: the card rebuilds from them
   on reload / refetch (per-child grouped by the `{groupId}#` prefix), so a dropped or coalesced
   progress frame costs immediacy, never correctness.

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -216,8 +216,15 @@ function makeFakeSessionManager() {
     markPendingAbort: vi.fn(),
     consumePendingAbort: vi.fn(() => false),
     discardPendingNotifications: vi.fn(),
-    getOrCreate: async (id?: string, _mode?: unknown, _systemPromptTemplate?: unknown, activeMode?: unknown) => {
-      getOrCreateCalls.push({ id, activeMode });
+    getOrCreate: async (
+      id?: string,
+      _mode?: unknown,
+      _systemPromptTemplate?: unknown,
+      activeMode?: unknown,
+      _delegation?: unknown,
+      userId?: string,
+    ) => {
+      getOrCreateCalls.push({ id, activeMode, userId });
       const key = id ?? "default";
       let s = sessions.get(key);
       if (!s) {
@@ -876,6 +883,17 @@ describe("http-server — prompt + session lifecycle", () => {
 
     await getJson(port, "/api/prompt", "POST", { text: "plain question", sessionId: "plain-a" });
     expect(lastMode()).toBe("normal");
+  });
+
+  it("passes the prompt user identity into session creation", async () => {
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "inspect the cluster",
+      sessionId: "owned-session",
+      userId: "user-42",
+    });
+
+    expect(r.status).toBe(200);
+    expect(sm.getOrCreateCalls.at(-1)?.userId).toBe("user-42");
   });
 
   it("POST /api/prompt rejects a second prompt while the session is still running", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -826,7 +826,14 @@ export function createHttpServer(
     // A delegated agent runs under its own configuration; delegation does not
     // downgrade it. readOnly is honored only when explicitly set true.
     const delegation = resolveDelegation(body.delegation, body.origin);
-    const managed = await sessionManager.getOrCreate(body.sessionId, body.mode, body.systemPromptTemplate, activeMode, delegation);
+    const managed = await sessionManager.getOrCreate(
+      body.sessionId,
+      body.mode,
+      body.systemPromptTemplate,
+      activeMode,
+      delegation,
+      body.userId,
+    );
     if (!managed._promptDone || managed._promptInflight) {
       // _promptInflight covers the synthetic-parent-prompt path that may
       // be holding the brain even when _promptDone has already flipped

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -981,9 +981,9 @@ describe("AgentBoxSessionManager — spawn_subagent batch (foreground)", () => {
     // and mock the child runner so no real child sessions spin up — we assert only trace threading.
     const ensureSpy = vi.spyOn(tracingRecorder, "ensureToolSpan").mockReturnValue(SC as any);
     vi.spyOn(tracingRecorder, "getRootTraceId").mockReturnValue(T1);
-    const runSpy = vi.spyOn(mgr, "runSpawnedSubagent").mockResolvedValue({
-      status: "done", summary: "ok", childSessionId: "c", toolCalls: 0, durationMs: 1,
-    });
+    const runSpy = vi.spyOn(mgr, "runSpawnedSubagent").mockImplementation(async (_request: any, opts: any) => ({
+      status: "done", summary: "ok", childSessionId: opts.childSessionId, toolCalls: 0, durationMs: 1,
+    }));
 
     await mgr.createSpawnSubagentExecutor()(baseReq({ reducePrompt: "Summarize" }), undefined, undefined);
 
@@ -998,7 +998,56 @@ describe("AgentBoxSessionManager — spawn_subagent batch (foreground)", () => {
     for (const call of runSpy.mock.calls) {
       expect(call[1]?.spawnSpanContext).toBe(SC);
       expect(call[1]?.mainTraceId).toBe(T1);
+      expect(call[1]?.childSessionId).toMatch(/^[0-9a-f-]{36}$/);
     }
+    expect(new Set(runSpy.mock.calls.map((call: any[]) => call[1]?.childSessionId)).size).toBe(4);
+  });
+
+  it("does not expose the reduce session until its execution slot is acquired", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    vi.spyOn(mgr, "runSpawnedSubagent").mockImplementation(async (request: any, opts: any, onProgress: any) => {
+      onProgress?.({
+        status: "running",
+        toolCalls: 1,
+        steps: [],
+        activity: `Running ${request.spawnId}`,
+      });
+      return { status: "done", summary: "ok", childSessionId: opts.childSessionId, toolCalls: 0, durationMs: 1 };
+    });
+
+    let releaseReduce: () => void = () => {};
+    const reduceGate = new Promise<void>((resolve) => { releaseReduce = resolve; });
+    let reduceQueuedResolve: () => void = () => {};
+    const reduceQueued = new Promise<void>((resolve) => { reduceQueuedResolve = resolve; });
+    let slotRequestCount = 0;
+    mgr.podSubagentLimiter = {
+      run: async (fn: () => Promise<unknown>) => {
+        slotRequestCount++;
+        if (slotRequestCount === 4) {
+          reduceQueuedResolve();
+          await reduceGate;
+        }
+        return fn();
+      },
+    };
+
+    const progress: any[] = [];
+    const pending = mgr.runSubagentGroup(
+      baseReq({ reducePrompt: "Summarize" }),
+      (frame: any) => progress.push(frame),
+    );
+
+    await reduceQueued;
+    expect(progress.some((frame) => frame.phase === "reduce")).toBe(false);
+    expect(progress.some((frame) => frame.items.some(
+      (item: any) => item.index === 0 && item.activity === "Running grp1#0",
+    ))).toBe(true);
+
+    releaseReduce();
+    const report = await pending;
+    const reduceFrame = progress.find((frame) => frame.phase === "reduce");
+    expect(reduceFrame?.reduceChildSessionId).toBe(report.reduceChildSessionId);
+    expect(reduceFrame?.reduceChildSessionId).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it("map partial + slow reduce: group timer disarmed before reduce, overall is partial not timed_out", async () => {
@@ -1599,13 +1648,18 @@ describe("AgentBoxSessionManager — spawn_subagent batch (background)", () => {
     await new Promise((r) => setTimeout(r, 120)); // let the group settle (before the 600ms coalesce)
 
     // group_progress is LIVE-ONLY (emit_chat_event, never append_event) and carries the groupId
-    // + per-item status array so the card animates without a full refetch.
+    // + per-item status/session array so the card animates and can open a running child's
+    // transcript without waiting for the terminal result/refetch.
     const progress = sent.filter(
       (e) => e.type === "delegation.emit_chat_event" && e.event?.type === "group_progress",
     );
     expect(progress.length).toBeGreaterThan(0);
     expect(progress[0].event.job_id).toBe("grpbg");
     expect(Array.isArray(progress[0].event.items)).toBe(true);
+    const liveRunningItems = progress.flatMap((e) => e.event.items)
+      .filter((item: any) => item.status === "running");
+    expect(liveRunningItems.length).toBeGreaterThan(0);
+    expect(liveRunningItems.every((item: any) => typeof item.child_session_id === "string" && item.child_session_id.length > 0)).toBe(true);
 
     // The completion notice reuses the subagent_done channel but flags is_group so the frontend
     // does an authoritative refetch (it can't fold full per-item detail from this event alone).
@@ -1629,9 +1683,19 @@ describe("AgentBoxSessionManager — spawn_subagent batch (background)", () => {
 
     const emitter = mgr.makeGroupProgressEmitter("p1", "grpX");
     // First emit flushes immediately (lastEmitAt=0 → elapsed ≫ throttle): an early "map, running" frame.
-    emitter.emit({ phase: "map", items: [{ index: 0, status: "running" }, { index: 1, status: "running" }] });
+    emitter.emit({
+      phase: "map",
+      items: [
+        { index: 0, status: "running", childSessionId: "child-0", activity: "Running kubectl…" },
+        { index: 1, status: "queued" },
+      ],
+    });
     // The terminal frame lands within the throttle window → held as the pending trailing frame.
-    emitter.emit({ phase: "reduce", items: [{ index: 0, status: "done" }, { index: 1, status: "failed" }] });
+    emitter.emit({
+      phase: "reduce",
+      items: [{ index: 0, status: "done" }, { index: 1, status: "failed" }],
+      reduceChildSessionId: "reduce-1",
+    });
     // Settle BEFORE the trailing timer fires: it must flush the pending terminal frame, not drop it.
     emitter.settle();
 
@@ -1641,8 +1705,16 @@ describe("AgentBoxSessionManager — spawn_subagent batch (background)", () => {
     // The last live frame the card sees is the terminal one: reduce phase, every item terminal.
     expect(last.event.job_id).toBe("grpX");
     expect(last.event.phase).toBe("reduce");
+    expect(last.event.reduce_child_session_id).toBe("reduce-1");
     expect(last.event.items.every((it: any) => it.status !== "running" && it.status !== "queued")).toBe(true);
     expect(last.event.items).toEqual([{ index: 0, status: "done" }, { index: 1, status: "failed" }]);
+
+    // The wire shape is explicit snake_case. Queued items without a real session must not expose
+    // a fake drill-in target.
+    expect(frames[0].event.items).toEqual([
+      { index: 0, status: "running", child_session_id: "child-0", activity: "Running kubectl…" },
+      { index: 1, status: "queued" },
+    ]);
 
     // Idempotent: a second settle finds no pending frame → no extra emit (matches the double
     // settle() in the .then + .finally of startBackgroundSubagentGroup).

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -255,6 +255,31 @@ describe("AgentBoxSessionManager — getOrCreate", () => {
     expect(opts.agentId).toBe("agent-a");
   });
 
+  it("prefers the request user identity when the shared AgentBox has no USER_ID", async () => {
+    const mgr = new AgentBoxSessionManager();
+
+    const session = await mgr.getOrCreate(
+      "sess-request-user",
+      "web",
+      undefined,
+      "normal",
+      undefined,
+      "user-from-prompt",
+    );
+
+    expect(session.userId).toBe("user-from-prompt");
+    expect(lastCreateSiclawSession.calls[0].userId).toBe("user-from-prompt");
+  });
+
+  it("rejects reusing one resident session for a different user", async () => {
+    const mgr = new AgentBoxSessionManager();
+    await mgr.getOrCreate("sess-owned", "web", undefined, "normal", undefined, "alice");
+
+    await expect(
+      mgr.getOrCreate("sess-owned", "web", undefined, "normal", undefined, "bob"),
+    ).rejects.toThrow(/different user/);
+  });
+
   it("uses the delegated read-only persona exclusively", async () => {
     const mgr = new AgentBoxSessionManager();
     mgr.agentTypeState = "sre";
@@ -881,6 +906,7 @@ describe("AgentBoxSessionManager — Stop / abort latches", () => {
       // precede startPrompt (else startPrompt takes the id-only branch, no span).
       expect(startSpy).toHaveBeenCalledWith("child-1", "do x", "u1", T1, SC);
       expect(attachSpy).toHaveBeenCalledWith("child-1", expect.anything(), expect.objectContaining({ userId: "u1" }));
+      expect(lastCreateSiclawSession.calls.at(-1)?.userId).toBe("u1");
       expect(attachSpy.mock.invocationCallOrder[0]).toBeLessThan(startSpy.mock.invocationCallOrder[0]);
       // done → completed; detach runs after endPrompt (finally safety net).
       expect(endSpy).toHaveBeenCalledWith("child-1", "completed");

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -806,14 +806,22 @@ export class AgentBoxSessionManager {
       status: "queued" | "running" | GroupItemStatus;
       summary: string;
       childSessionId: string;
+      activity?: string;
     };
     const states: ItemState[] = tasks.map(() => ({ status: "queued", summary: "", childSessionId: "" }));
+    let reduceChildSessionId: string | undefined;
     const breaker = new GroupCircuitBreaker();
 
     const emit = (phase: "map" | "reduce") =>
       onProgress?.({
         phase,
-        items: states.map((s, index) => ({ index, status: s.status })),
+        items: states.map((s, index) => ({
+          index,
+          status: s.status,
+          ...(s.childSessionId ? { childSessionId: s.childSessionId } : {}),
+          ...(s.activity ? { activity: s.activity } : {}),
+        })),
+        ...(reduceChildSessionId ? { reduceChildSessionId } : {}),
       });
 
     const skipReason = (): string =>
@@ -860,16 +868,33 @@ export class AgentBoxSessionManager {
             return undefined;
           }
           // Mark `running` + emit only once the slot is acquired — an item still waiting for a
-          // limiter slot must stay `queued`, not report as running.
+          // limiter slot must stay `queued`, not report as running. Pre-assign the exact session
+          // id runSpawnedSubagent will persist so the live UI can open the child transcript from
+          // the first running frame instead of waiting for the terminal result.
+          const childSessionId = randomUUID();
+          state.childSessionId = childSessionId;
           state.status = "running";
           emit("map");
-          return this.runSpawnedSubagent(childReq, { ...traceCtx }, undefined, mapAbort.signal);
+          return this.runSpawnedSubagent(
+            childReq,
+            { ...traceCtx, childSessionId },
+            (progress) => {
+              const activity = progress.activity?.trim();
+              if (!activity || activity === state.activity) return;
+              state.activity = activity;
+              emit("map");
+            },
+            mapAbort.signal,
+          );
         })));
       } catch (err) {
         res = {
           status: "failed",
           summary: `Sub-agent errored: ${err instanceof Error ? err.message : String(err)}`,
-          childSessionId: "",
+          // The id was already exposed in the running frame and may already own
+          // persisted rows. Keep it stable even if an unexpected exception
+          // escapes runSpawnedSubagent before it can return its normal envelope.
+          childSessionId: state.childSessionId,
           toolCalls: 0,
           durationMs: 0,
         };
@@ -929,7 +954,6 @@ export class AgentBoxSessionManager {
     const usableCount = states.filter((s) => s.status === "done" || s.status === "partial").length;
 
     let reduceSummary: string | undefined;
-    let reduceChildSessionId: string | undefined;
     let reduceTruncated = false;
     let reduceError: string | undefined;    // reduce ran but did not complete → drives status + groupSummary (kept off the report as its own key)
     let reduceSkippedForCancel = false;      // reduce requested but skipped because the user cancelled
@@ -945,7 +969,6 @@ export class AgentBoxSessionManager {
       if (userAbort.signal.aborted) {
         reduceSkippedForCancel = true;
       } else if (doneCount > 0 && !breaker.tripped) {
-        emit("reduce");
         const outcomes: GroupItemOutcome[] = states.map((s, i) => ({
           item: tasks[i].item,
           status: s.status as GroupItemStatus,
@@ -963,9 +986,19 @@ export class AgentBoxSessionManager {
           spawnId: `${groupId}#reduce`,
         };
         try {
-          const reduceRes = await this.podGroupLimiter.run(() => sessionLim.run(() => this.podSubagentLimiter.run(() =>
-            this.runSpawnedSubagent(reduceReq, { ...traceCtx }, undefined, userAbort.signal),
-          )));
+          const reduceRes = await this.podGroupLimiter.run(() => sessionLim.run(() => this.podSubagentLimiter.run(() => {
+            // Match map-item semantics: advertise the reduce child only after it owns
+            // an execution slot. Until then the batch remains in its completed map
+            // state instead of exposing a session that has not started yet.
+            reduceChildSessionId = randomUUID();
+            emit("reduce");
+            return this.runSpawnedSubagent(
+              reduceReq,
+              { ...traceCtx, childSessionId: reduceChildSessionId },
+              undefined,
+              userAbort.signal,
+            );
+          })));
           if (reduceRes.status === "done") {
             // Use the FULL reduce report, not the 1800-char capsule, before applying the group's
             // 6000-char budget (design decision #21): the capsule is already ≤1800, so truncating it
@@ -1227,10 +1260,24 @@ export class AgentBoxSessionManager {
       lastEmitAt = Date.now();
       const snapshot = latest;
       latest = null;
+      const items = snapshot.items.map(({ index, status, childSessionId, activity }) => ({
+        index,
+        status,
+        ...(childSessionId ? { child_session_id: childSessionId } : {}),
+        ...(activity ? { activity } : {}),
+      }));
       void this.persistDelegationEvent({
         type: "delegation.emit_chat_event",
         sessionId: parentSessionId,
-        event: { type: "group_progress", job_id: jobId, phase: snapshot.phase, items: snapshot.items },
+        event: {
+          type: "group_progress",
+          job_id: jobId,
+          phase: snapshot.phase,
+          items,
+          ...(snapshot.reduceChildSessionId
+            ? { reduce_child_session_id: snapshot.reduceChildSessionId }
+            : {}),
+        },
       }).catch((err) => {
         // Best-effort live update (never rethrow): correctness rebuilds from the persisted per-child
         // + terminal events on refetch. Log so a systematically failing progress channel is visible.

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -92,6 +92,8 @@ type SubagentTraceContext = { mainTraceId?: string; spawnSpanContext?: SpanConte
 
 export interface ManagedSession {
   id: string;
+  /** User identity bound to this conversation's tools and child-session persistence. */
+  userId?: string;
   brain: BrainSession;
   session: AgentSession;  // backward compat — only guaranteed for pi-agent brain
   createdAt: Date;
@@ -2222,7 +2224,7 @@ export class AgentBoxSessionManager {
       kubeconfigRef,
       mode: "web",
       memoryIndexer: this._sharedMemoryIndexer ?? undefined,
-      userId: this.userId,
+      userId: request.userId,
       agentId,
       knowledgeDir: this.knowledgeDir,
       // A spawned sub-agent must never be broader than its parent: inherit the
@@ -2552,12 +2554,18 @@ export class AgentBoxSessionManager {
     systemPromptTemplate?: string,
     activeMode: AgentMode = "normal",
     delegation?: DelegationContext,
+    requestUserId?: string,
   ): Promise<ManagedSession> {
     const id = sessionId || this.defaultSessionId;
+    const effectiveUserId = requestUserId?.trim() || this.userId;
 
     const existing = this.sessions.get(id);
     if (existing) {
       existing.lastActiveAt = new Date();
+      if (effectiveUserId && existing.userId && effectiveUserId !== existing.userId) {
+        throw new Error(`Session ${id} is already bound to a different user`);
+      }
+      const needsUserIdentityRebuild = Boolean(effectiveUserId && !existing.userId);
       // Config invalidation is stronger than the ordinary release timer:
       // even if the next message races the 0ms timer, an idle session must be
       // rebuilt so it cannot run one extra turn with stale prompt/tool state.
@@ -2610,11 +2618,15 @@ export class AgentBoxSessionManager {
           existing.delegation.parentSessionId = delegation.parentSessionId;
           existing.delegation.parentAgentId = delegation.parentAgentId;
         }
-        if ((existing.activeMode === activeMode && sameDelegation) || !existing._promptDone) {
+        if (
+          (existing.activeMode === activeMode && sameDelegation && !needsUserIdentityRebuild) ||
+          !existing._promptDone ||
+          existing._promptInflight
+        ) {
           return existing;
         }
         console.log(
-          `[agentbox-session] Rebuilding session ${id} for mode change ${existing.activeMode}/${delegationSignature(existing.delegation)} -> ${activeMode}/${delegationSignature(delegation)}`,
+          `[agentbox-session] Rebuilding session ${id} for context change ${existing.activeMode}/${delegationSignature(existing.delegation)}/${existing.userId ?? "anonymous"} -> ${activeMode}/${delegationSignature(delegation)}/${effectiveUserId ?? "anonymous"}`,
         );
         await this.releaseForRebuild(id, existing);
       }
@@ -2785,7 +2797,7 @@ export class AgentBoxSessionManager {
       mode: effectiveMode,
       activeMode,
       memoryIndexer: this._sharedMemoryIndexer ?? undefined,
-      userId: this.userId,
+      userId: effectiveUserId,
       agentId: this.agentId ?? null,
       knowledgeDir: this.knowledgeDir,
       // Per-agent tool capability whitelist. null = unrestricted (falls back to
@@ -2837,6 +2849,7 @@ export class AgentBoxSessionManager {
 
     const managed: ManagedSession = {
       id,
+      userId: effectiveUserId,
       brain: result.brain,
       session: result.session,
       createdAt: new Date(),
@@ -2891,7 +2904,7 @@ export class AgentBoxSessionManager {
     // routing, brain events + model_route_* events reach the recorder via
     // emitSessionExtraEvent → handleEvent instead.
     if (isTracingEnabled()) {
-      tracingRecorder.attach(id, result.brain, { userId: this.userId, agentId: this.agentId });
+      tracingRecorder.attach(id, result.brain, { userId: effectiveUserId, agentId: this.agentId });
       managed._tracingUnsub = result.brain.subscribe((event: any) => {
         if (managed._routeBrainEventsThroughExtra) return;
         tracingRecorder.handleEvent(id, event);
@@ -2934,7 +2947,7 @@ export class AgentBoxSessionManager {
           outcome: event.isError ? "error" : "success",
           // 0 used to mean both "instant" and "we could not pair this" — indistinguishable downstream.
           durationMs: entry ? Date.now() - entry.startMs : undefined,
-          userId: this.userId ?? "unknown",
+          userId: effectiveUserId ?? "unknown",
           agentId: this.agentId ?? null,
         });
       }

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -163,11 +163,17 @@ export interface SpawnSubagentGroupRequest {
 export interface GroupItemProgress {
   index: number;
   status: "queued" | "running" | GroupItemStatus;
+  /** Assigned once the item owns an execution slot; absent while it is still queued/skipped. */
+  childSessionId?: string;
+  /** Latest concise child activity suitable for the parent group card. */
+  activity?: string;
 }
 export interface SubagentGroupProgress {
   /** "map" while item children run; "reduce" while the summary child runs. */
   phase: "map" | "reduce";
   items: GroupItemProgress[];
+  /** Assigned immediately before the reduce child starts. */
+  reduceChildSessionId?: string;
 }
 
 /** One item's terminal record in the group report. */

--- a/src/tools/workflow/spawn-subagent.test.ts
+++ b/src/tools/workflow/spawn-subagent.test.ts
@@ -6,6 +6,7 @@ import type {
   ToolRefs,
   SpawnSubagentGroupRequest,
   SpawnSubagentResult,
+  SubagentGroupProgress,
   SubagentGroupResult,
 } from "../../core/tool-registry.js";
 
@@ -274,6 +275,64 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
     // details carries the full per-item drill-in data.
     expect((r.details as any).item_results[0].child_session_id).toBe("c1");
     expect((r.details as any).reduce_child_session_id).toBe("reduce-1");
+  });
+
+  it("forwards live foreground child session ids with the wire-format field names", async () => {
+    const executor = vi.fn(async (
+      _req: SpawnSubagentGroupRequest,
+      onProgress?: (progress: SubagentGroupProgress) => void,
+    ): Promise<SubagentGroupResult> => {
+      onProgress?.({
+        phase: "map",
+        items: [
+          { index: 0, status: "running", childSessionId: "child-0", activity: "Running kubectl…" },
+          { index: 1, status: "queued" },
+        ],
+      });
+      onProgress?.({
+        phase: "reduce",
+        items: [
+          { index: 0, status: "done", childSessionId: "child-0" },
+          { index: 1, status: "done", childSessionId: "child-1" },
+        ],
+        reduceChildSessionId: "reduce-1",
+      });
+      return {
+        status: "done",
+        durationMs: 10,
+        reduceSummary: "done",
+        reduceChildSessionId: "reduce-1",
+        itemResults: [
+          { item: "pod-a", status: "done", summary: "ok", childSessionId: "child-0" },
+          { item: "pod-b", status: "done", summary: "ok", childSessionId: "child-1" },
+        ],
+      };
+    });
+    const updates: any[] = [];
+    const tool = createSpawnSubagentTool(makeRefs(executor));
+
+    await tool.execute(
+      "g-live",
+      { description: "x", items: ["pod-a", "pod-b"], reduce_prompt: "summarize", run_in_background: false },
+      undefined,
+      (update) => updates.push(update),
+    );
+
+    expect(updates[0].details).toEqual({
+      phase: "map",
+      items: [
+        { index: 0, status: "running", child_session_id: "child-0", activity: "Running kubectl…" },
+        { index: 1, status: "queued" },
+      ],
+    });
+    expect(updates[1].details).toEqual({
+      phase: "reduce",
+      items: [
+        { index: 0, status: "done", child_session_id: "child-0" },
+        { index: 1, status: "done", child_session_id: "child-1" },
+      ],
+      reduce_child_session_id: "reduce-1",
+    });
   });
 
   it("exposes per-item capsules to the model when there is NO reduce stage", async () => {

--- a/src/tools/workflow/spawn-subagent.ts
+++ b/src/tools/workflow/spawn-subagent.ts
@@ -248,13 +248,25 @@ export function createSpawnSubagentTool(
               const done = progress.items.filter(
                 (i) => i.status !== "queued" && i.status !== "running",
               ).length;
+              const items = progress.items.map(({ index, status, childSessionId, activity: itemActivity }) => ({
+                index,
+                status,
+                ...(childSessionId ? { child_session_id: childSessionId } : {}),
+                ...(itemActivity ? { activity: itemActivity } : {}),
+              }));
               const activity =
                 progress.phase === "reduce"
                   ? "Summarizing results…"
                   : `Running sub-agents… ${done}/${total} done`;
               onUpdate({
                 content: [{ type: "text" as const, text: activity }],
-                details: { phase: progress.phase, items: progress.items },
+                details: {
+                  phase: progress.phase,
+                  items,
+                  ...(progress.reduceChildSessionId
+                    ? { reduce_child_session_id: progress.reduceChildSessionId }
+                    : {}),
+                },
               });
             } else {
               onUpdate({


### PR DESCRIPTION
## Summary

Expose each batch sub-agent's real session ID and latest activity from live progress, allowing clients to open and follow the persisted child transcript while execution is still in progress.

### Problem

Batch progress previously carried only item status. Clients had to wait for terminal persistence or session discovery before they could render the same live execution view used by a single sub-agent, and the group card could not show what each running child was currently doing.

### Solution

- Allocate map and reduce child IDs only after their execution slots are acquired.
- Pass those exact IDs into `runSpawnedSubagent`.
- Forward each map child's latest `activity` from `runSpawnedSubagent` into group progress.
- Publish `child_session_id`, `activity`, and `reduce_child_session_id` consistently through foreground updates and background `group_progress` events.
- Keep queued and never-started items free of false session IDs.

## Test Plan

- [x] `npm test` — 272 files, 6160 passed, 2 skipped
- [x] `npm run build`
- [x] Regression coverage for slot timing, per-item activity, and foreground/background wire shapes

No breaking changes or migration steps.
