### PR TITLE
fix(runtime): apply release models at turn boundaries

### DIFF
--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -559,3 +559,50 @@ than profile) must not be evicted while it is still running.
   the old (richer) payload by ignoring the extra fields.
 
 **Files**: `src/gateway/metrics-aggregator.ts`, `src/shared/metrics-types.ts`, `src/agentbox/http-server.ts`, `src/gateway/server.ts`, `src/portal/siclaw-api.ts`, `portal-web/src/hooks/useMetrics.ts`
+
+---
+
+## ADR-015: Agent Type Releases Apply at Turn Boundaries
+
+**Status**: Active
+
+**Context**:
+An external management server can move an Agent Type's production Release while
+existing AgentBoxes and sessions are warm. Skills, MCP, knowledge, prompt, and
+model configuration belong to one immutable Release, but replacing a model in
+the middle of an in-flight turn would make one turn span two configurations.
+Treating a generic reload ACK as proof that a particular model was prepared also
+allows stale or unrelated Release notifications to report success.
+
+**Decision**:
+Release application is identity-bound and happens at a turn boundary:
+
+- A release reload carries the expected `releaseId` and `modelFingerprint`.
+- Runtime resolves the current binding from the management server and rejects a
+  notification whose observed identity does not match the expected identity.
+- `model` is a reload type whose AgentBox action invalidates warm sessions. The
+  existing invalidation fence lets an in-flight turn finish and rebuilds the
+  session before its next prompt.
+- The next prompt remains the only carrier of provider credentials and model
+  configuration. Reload notifications carry identity, never secrets.
+- Runtime reports the observed Release identity and number of reached boxes.
+  Zero boxes means cold-start convergence, not runtime model verification.
+- A reload ACK proves preparation only. AgentBox records an observed release
+  and model fingerprint after a real turn completes successfully; only that
+  observed inventory can satisfy management-server runtime verification.
+
+**Consequences**:
+
+- ✅ Existing Agents switch models without a Pod restart on their next turn.
+- ✅ A turn never mixes model configurations.
+- ✅ Reload events are safe to retry and stale Release ACKs are detectable.
+- ✅ Provider credentials stay on the established prompt/config channel.
+- ⚠️ "Published" and "applied to an online box" are distinct states.
+- ⚠️ "Prepared for next turn" and "successfully ran a turn" are distinct
+  states; promotion gates consume only the latter.
+- ⚠️ Management servers predating this contract must keep model deliveries
+  pending while an older Runtime is deployed; rolling upgrades should deploy
+  Runtime support before relying on verified model delivery.
+
+**Files**: `src/shared/gateway-sync.ts`, `src/gateway/server.ts`,
+`src/gateway/agent-model-binding.ts`, `src/agentbox/sync-handlers.ts`

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -577,15 +577,18 @@ allows stale or unrelated Release notifications to report success.
 **Decision**:
 Release application is identity-bound and happens at a turn boundary:
 
-- A release reload carries the expected `releaseId` and `modelFingerprint`.
-- Runtime resolves the current binding from the management server and rejects a
-  notification whose observed identity does not match the expected identity.
+- Identity-bound callers send the expected `releaseId` and `modelFingerprint`.
+  Runtime resolves the current binding from the management server and rejects a
+  notification whose prepared identity does not match either supplied value.
+  Legacy callers may omit the expected identity; that compatibility path reports
+  what was prepared but cannot reject a stale notification.
 - `model` is a reload type whose AgentBox action invalidates warm sessions. The
   existing invalidation fence lets an in-flight turn finish and rebuilds the
   session before its next prompt.
 - The next prompt remains the only carrier of provider credentials and model
   configuration. Reload notifications carry identity, never secrets.
-- Runtime reports the observed Release identity and number of reached boxes.
+- The reload response reports the prepared Release identity and number of
+  reached boxes as `preparedReleaseId` and `preparedModelFingerprint`.
   Zero boxes means cold-start convergence, not runtime model verification.
 - A reload ACK proves preparation only. AgentBox records an observed release
   and model fingerprint after a real turn completes successfully; only that
@@ -601,8 +604,12 @@ Release application is identity-bound and happens at a turn boundary:
 - ⚠️ "Prepared for next turn" and "successfully ran a turn" are distinct
   states; promotion gates consume only the latter.
 - ⚠️ Management servers predating this contract must keep model deliveries
-  pending while an older Runtime is deployed; rolling upgrades should deploy
-  Runtime support before relying on verified model delivery.
+  pending while an older Runtime is deployed. Roll out Runtime support first,
+  then publish an AgentBox image containing observed-model reporting, update
+  `SICLAW_AGENTBOX_IMAGE`, and recycle existing AgentBox Pods before enabling
+  verified model delivery. Subsequent Release model changes use the turn-boundary
+  session fence and do not require another Pod restart.
 
 **Files**: `src/shared/gateway-sync.ts`, `src/gateway/server.ts`,
-`src/gateway/agent-model-binding.ts`, `src/agentbox/sync-handlers.ts`
+`src/gateway/agent-model-binding.ts`, `src/agentbox/sync-handlers.ts`,
+`src/agentbox/http-server.ts`

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -359,6 +359,7 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
         },
         skills: { names: ["k8s-debug"] },
         mcp: { names: ["incidents"] },
+        model: null,
       });
     } finally {
       mockConfigState.knowledgeDir = "knowledge";
@@ -366,6 +367,63 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
       mockConfigState.mcpServers = {};
       fs.rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("reports a release model only after a successful turn completes", async () => {
+    const session = await sm.getOrCreate("observed-model");
+    session.brain.prompt.mockImplementation(async () => {
+      session.brain.emitter.emit("event", {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+      });
+    });
+
+    const before = await getJson(port, "/api/sync-status");
+    expect(before.data.model).toBeNull();
+
+    const prompt = await getJson(port, "/api/prompt", "POST", {
+      text: "hi",
+      sessionId: "observed-model",
+      modelProvider: "openai",
+      modelId: "gpt-4",
+      releaseId: "release-2",
+      modelFingerprint: "fingerprint-2",
+    });
+    expect(prompt.status).toBe(200);
+    await flushAsync();
+
+    const after = await getJson(port, "/api/sync-status");
+    expect(after.data.model).toMatchObject({
+      releaseId: "release-2",
+      modelFingerprint: "fingerprint-2",
+    });
+    expect(new Date(after.data.model.observedAt).toString()).not.toBe("Invalid Date");
+  });
+
+  it("does not verify the release model when a fallback answered the turn", async () => {
+    const session = await sm.getOrCreate("observed-fallback");
+    session.brain.prompt.mockImplementation(async () => {
+      session.brain.emitter.emit("event", {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+      });
+    });
+    const prompt = await getJson(port, "/api/prompt", "POST", {
+      text: "hi", sessionId: "observed-fallback",
+      modelProvider: "missing-provider", modelId: "missing-model",
+      modelConfig: modelConfigWithInput(["text"]),
+      releaseId: "release-2", modelFingerprint: "fingerprint-2",
+      modelRouting: {
+        enabled: true, strategy: "ordered_fallback",
+        candidates: [
+          { provider: "missing-provider", modelId: "missing-model", modelConfig: modelConfigWithInput(["text"]) },
+          { provider: "anthropic", modelId: "claude" },
+        ],
+      },
+    });
+    expect(prompt.status).toBe(200);
+    await flushAsync();
+    expect((await getJson(port, "/api/sync-status")).data.model).toBeNull();
   });
 
   it("GET /api/internal/box-status reports drained when the box holds nothing", async () => {

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -426,6 +426,22 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
     expect((await getJson(port, "/api/sync-status")).data.model).toBeNull();
   });
 
+  it("does not verify the release model when the successful turn has no observed candidate", async () => {
+    const session = await sm.getOrCreate("unidentified-model");
+    session.brain.getModel.mockReturnValue(undefined);
+
+    const prompt = await getJson(port, "/api/prompt", "POST", {
+      text: "hi",
+      sessionId: "unidentified-model",
+      releaseId: "release-2",
+      modelFingerprint: "fingerprint-2",
+    });
+    expect(prompt.status).toBe(200);
+    await flushAsync();
+
+    expect((await getJson(port, "/api/sync-status")).data.model).toBeNull();
+  });
+
   it("GET /api/internal/box-status reports drained when the box holds nothing", async () => {
     // The Runtime routes on this: `drained` must come FROM the box, because a session can
     // have no in-flight turn while a background sub-agent still runs under it.

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -1221,7 +1221,8 @@ export function createHttpServer(
         const intendedCandidate = body.modelProvider && body.modelId
           ? candidateKey({ provider: body.modelProvider, modelId: body.modelId })
           : undefined;
-        const ranIntendedModel = !result?.activeCandidateKey || result.activeCandidateKey === intendedCandidate;
+        const ranIntendedModel = intendedCandidate !== undefined
+          && result?.activeCandidateKey === intendedCandidate;
         if (ranIntendedModel && body.releaseId && body.modelFingerprint) {
           observedModel = {
             releaseId: body.releaseId,

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -35,6 +35,7 @@ import { detectLanguage } from "../shared/detect-language.js";
 import { stripLanguageDirective } from "../shared/strip-language-directive.js";
 import {
   candidateSupportsPromptMedia,
+  candidateKey,
   clearModelRouteUserSelectionIfDifferent,
   filterCandidatesForPromptMedia,
   markModelRouteUserSelection,
@@ -78,6 +79,8 @@ interface PromptRequestBody {
   delegation?: DelegationContext;
   modelProvider?: string;
   modelId?: string;
+  releaseId?: string;
+  modelFingerprint?: string;
   systemPromptTemplate?: string;
   modelConfig?: Record<string, unknown>;
   modelRouting?: ModelRoutePolicy;
@@ -612,6 +615,10 @@ export function createHttpServer(
   // request routing would silently pick the wrong broker. We instead bind
   // these handlers per-httpServer and hand them to the route loop below.
   const perServerHandlers: Partial<Record<GatewaySyncType, AgentBoxSyncHandler<any>>> = {};
+  // Updated only after a turn completes successfully. A reload ACK means the
+  // next turn is prepared; this state is the stronger evidence that a box has
+  // actually run with the published model binding.
+  let observedModel: { releaseId: string; modelFingerprint: string; observedAt: string } | null = null;
   if (sessionManager.credentialBroker) {
     perServerHandlers.cluster = createClusterHandler(sessionManager.credentialBroker);
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
@@ -745,10 +752,13 @@ export function createHttpServer(
    * intended to send.
    */
   addRoute("GET", "/api/sync-status", async (_req, res) => {
-    sendJson(res, 200, readBoxSyncStatus({
-      knowledgeDir: sessionManager.knowledgeDir,
-      knowledgeHandler: perServerKnowledgeHandler,
-    }));
+    sendJson(res, 200, {
+      ...readBoxSyncStatus({
+        knowledgeDir: sessionManager.knowledgeDir,
+        knowledgeHandler: perServerKnowledgeHandler,
+      }),
+      model: observedModel,
+    });
   });
 
   /**
@@ -1208,6 +1218,17 @@ export function createHttpServer(
       } else {
         console.log(`[agentbox-http] Prompt completed for session ${managed.id}`);
         promptOutcome = "completed";
+        const intendedCandidate = body.modelProvider && body.modelId
+          ? candidateKey({ provider: body.modelProvider, modelId: body.modelId })
+          : undefined;
+        const ranIntendedModel = !result?.activeCandidateKey || result.activeCandidateKey === intendedCandidate;
+        if (ranIntendedModel && body.releaseId && body.modelFingerprint) {
+          observedModel = {
+            releaseId: body.releaseId,
+            modelFingerprint: body.modelFingerprint,
+            observedAt: new Date().toISOString(),
+          };
+        }
       }
       onPromptFinish();
     }).catch((err) => {

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -10,6 +10,7 @@ import {
   createToolsHandler,
   knowledgeHandler,
   mcpHandler,
+  modelHandler,
   promptHandler,
   readBoxSyncStatus,
   skillsHandler,
@@ -289,6 +290,20 @@ describe("promptHandler.postReload", () => {
     await expect(promptHandler.fetch(null)).resolves.toBeNull();
     await expect(promptHandler.materialize(null)).resolves.toBe(0);
     await promptHandler.postReload!({
+      sessions: [{ id: "s1", brain: dummyBrain, invalidate }],
+    });
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+});
+
+describe("modelHandler.postReload", () => {
+  const dummyBrain = { reload: async () => {} };
+
+  it("invalidates warm sessions without fetching secrets or local state", async () => {
+    const invalidate = vi.fn();
+    await expect(modelHandler.fetch(null)).resolves.toBeNull();
+    await expect(modelHandler.materialize(null)).resolves.toBe(0);
+    await modelHandler.postReload!({
       sessions: [{ id: "s1", brain: dummyBrain, invalidate }],
     });
     expect(invalidate).toHaveBeenCalledOnce();

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -106,6 +106,27 @@ export const promptHandler: AgentBoxSyncHandler<null> = {
   },
 };
 
+// ── Model handler ────────────────────────────────────────────────────
+
+/**
+ * Model bindings are resolved by the Gateway for every prompt. Invalidating
+ * the warm brain makes the next turn rebuild with the just-published Release,
+ * including provider configuration and credentials. Session invalidation is
+ * turn-safe: a currently running prompt completes on the old Release.
+ */
+export const modelHandler: AgentBoxSyncHandler<null> = {
+  type: "model",
+  async fetch(): Promise<null> {
+    return null;
+  },
+  async materialize(): Promise<number> {
+    return 0;
+  },
+  async postReload(context: ReloadContext): Promise<void> {
+    invalidateSessions(context);
+  },
+};
+
 // ── Skills helpers ────────────────────────────────────────────────────
 
 /** Write a single skill (specs + scripts) into the resolved directory */
@@ -718,11 +739,12 @@ const handlers = new Map<GatewaySyncType, AgentBoxSyncHandler<any>>([
   ["skills", skillsHandler],
   ["knowledge", knowledgeHandler],
   ["prompt", promptHandler],
+  ["model", modelHandler],
 ]);
 
 /**
- * Look up the static handler for a given sync type. MCP, skills, knowledge and
- * prompt are process-global and carry no per-box broker state.
+ * Look up the static handler for a given sync type. MCP, skills, knowledge,
+ * prompt and model are process-global and carry no per-box broker state.
  *
  * cluster/host handlers are NOT registered in this map: each AgentBox
  * httpServer constructs its own factory-bound instance (closing over

--- a/src/gateway/agent-model-binding.ts
+++ b/src/gateway/agent-model-binding.ts
@@ -9,6 +9,10 @@ import type { FrontendWsClient } from "./frontend-ws-client.js";
 import type { ModelRoutePolicy } from "../core/model-routing.js";
 
 export interface ResolvedModelBinding {
+  /** Effective Agent Type Release selected by the control plane. */
+  releaseId?: string;
+  /** Digest of the immutable model snapshot in that Release. */
+  modelFingerprint?: string;
   modelProvider: string;
   modelId: string;
   modelConfig: {

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -43,6 +43,10 @@ export interface PromptOptions {
   modelProvider?: string;
   /** Model ID to use for this prompt */
   modelId?: string;
+  /** Effective immutable release identity for runtime observation. */
+  releaseId?: string;
+  /** Fingerprint of the release model snapshot for runtime observation. */
+  modelFingerprint?: string;
   /** Agent ID (for logging/context) */
   agentId?: string;
   /** Custom system prompt template from agent settings */

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -365,6 +365,8 @@ export async function handleDingTalkMessage(
     sessionId,
     modelProvider: modelBinding?.modelProvider,
     modelId: modelBinding?.modelId,
+    releaseId: modelBinding?.releaseId,
+    modelFingerprint: modelBinding?.modelFingerprint,
     modelConfig: modelBinding?.modelConfig,
     modelRouting: modelBinding?.modelRouting,
     systemPromptTemplate,

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1860,6 +1860,8 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     sessionId,
     modelProvider: modelBinding?.modelProvider,
     modelId: modelBinding?.modelId,
+    releaseId: modelBinding?.releaseId,
+    modelFingerprint: modelBinding?.modelFingerprint,
     modelConfig: modelBinding?.modelConfig,
     modelRouting: modelBinding?.modelRouting,
     systemPromptTemplate: modelBinding?.systemPrompt?.trim() || undefined,

--- a/src/gateway/delegate-api.ts
+++ b/src/gateway/delegate-api.ts
@@ -693,6 +693,8 @@ export async function handleDelegate(
       agentId: peerAgentId,
       modelProvider: binding.modelProvider,
       modelId: binding.modelId,
+      releaseId: binding.releaseId,
+      modelFingerprint: binding.modelFingerprint,
       modelConfig: binding.modelConfig,
       modelRouting: binding.modelRouting,
       systemPromptTemplate: binding.systemPrompt ?? undefined,

--- a/src/gateway/server-agent-release-reload.test.ts
+++ b/src/gateway/server-agent-release-reload.test.ts
@@ -61,9 +61,11 @@ describe("agent.reload release model identity", () => {
     expect(reloadCalls).toEqual(["model"]);
     expect(result).toMatchObject({
       ok: true, boxes: 1,
-      observedReleaseId: "release-2",
-      observedModelFingerprint: "fingerprint-2",
+      preparedReleaseId: "release-2",
+      preparedModelFingerprint: "fingerprint-2",
     });
+    expect(result).not.toHaveProperty("observedReleaseId");
+    expect(result).not.toHaveProperty("observedModelFingerprint");
   });
 
   it("rejects a stale delivery before touching a box", async () => {
@@ -81,7 +83,7 @@ describe("agent.reload release model identity", () => {
       agentId: "agent-1", resources: ["model"],
       releaseId: "release-2", modelFingerprint: "fingerprint-2",
     }) as any;
-    expect(result).toMatchObject({ boxes: 0, observedReleaseId: "release-2" });
+    expect(result).toMatchObject({ boxes: 0, preparedReleaseId: "release-2" });
     expect(reloadCalls).toEqual([]);
   });
 });

--- a/src/gateway/server-agent-release-reload.test.ts
+++ b/src/gateway/server-agent-release-reload.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const reloadCalls: string[] = [];
+vi.mock("./agentbox/client.js", () => ({
+  AgentBoxClient: class {
+    constructor(_endpoint: string) {}
+    reloadResource = vi.fn(async (type: string) => { reloadCalls.push(type); });
+  },
+}));
+
+const { startRuntime } = await import("./server.js");
+
+const binding = {
+  releaseId: "release-2",
+  modelFingerprint: "fingerprint-2",
+  modelProvider: "openai",
+  modelId: "gpt-4",
+  modelConfig: { name: "openai", baseUrl: "", apiKey: "", api: "openai-responses", authHeader: true, models: [] },
+};
+
+function fakeFrontendClient() {
+  return {
+    request: vi.fn(async (method: string) => method === "config.getModelBinding" ? { binding } : null),
+    onCommand: vi.fn(), emitEvent: vi.fn(), close: vi.fn(),
+  } as any;
+}
+
+function fakeAgentBoxManager(running = true) {
+  return {
+    setCertManager: vi.fn(), setSpawnEnvResolver: vi.fn(), setPersistenceResolver: vi.fn(),
+    list: vi.fn(async () => running ? [{ agentId: "agent-1", boxId: "box-1", endpoint: "http://box", status: "running" }] : []),
+    cleanup: vi.fn(async () => {}),
+  } as any;
+}
+
+let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+  reloadCalls.length = 0;
+});
+
+async function boot(running = true) {
+  server = await startRuntime({
+    config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+    agentBoxManager: fakeAgentBoxManager(running),
+    frontendClient: fakeFrontendClient(),
+    credentialService: {} as any,
+  });
+  return server.rpcMethods.get("agent.reload")!;
+}
+
+describe("agent.reload release model identity", () => {
+  it("invalidates model sessions and returns the exact prepared release", async () => {
+    const reload = await boot();
+    const result = await reload({
+      agentId: "agent-1", resources: ["model"],
+      releaseId: "release-2", modelFingerprint: "fingerprint-2",
+    }) as any;
+
+    expect(reloadCalls).toEqual(["model"]);
+    expect(result).toMatchObject({
+      ok: true, boxes: 1,
+      observedReleaseId: "release-2",
+      observedModelFingerprint: "fingerprint-2",
+    });
+  });
+
+  it("rejects a stale delivery before touching a box", async () => {
+    const reload = await boot();
+    await expect(reload({
+      agentId: "agent-1", resources: ["model"],
+      releaseId: "release-1", modelFingerprint: "fingerprint-1",
+    })).rejects.toThrow(/does not match expected release-1/);
+    expect(reloadCalls).toEqual([]);
+  });
+
+  it("reports cold-start preparation without claiming a running box", async () => {
+    const reload = await boot(false);
+    const result = await reload({
+      agentId: "agent-1", resources: ["model"],
+      releaseId: "release-2", modelFingerprint: "fingerprint-2",
+    }) as any;
+    expect(result).toMatchObject({ boxes: 0, observedReleaseId: "release-2" });
+    expect(reloadCalls).toEqual([]);
+  });
+});

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -138,6 +138,7 @@ describe("agent.syncStatus RPC", () => {
       },
       skills: { names: ["k8s-debug"] },
       mcp: { names: [] },
+      model: null,
     });
     expect(getJsonCalls).toEqual([{ endpoint: "https://b1", path: "/api/sync-status" }]);
     expect(clientCalls).toEqual([{

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -788,6 +788,8 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       agentId,
       modelProvider: params.modelProvider as string | undefined,
       modelId: params.modelId as string | undefined,
+      releaseId: params.releaseId as string | undefined,
+      modelFingerprint: params.modelFingerprint as string | undefined,
       systemPromptTemplate: params.systemPrompt as string | undefined,
       mode: params.mode as string | undefined,
       origin: origin as PromptOptions["origin"],
@@ -2029,6 +2031,23 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // omits `resources` for its legacy all-bindings refresh; including prompt
     // here would rebuild every warm brain for unrelated binding changes.
     const resourceTypes = (params.resources as string[] | undefined) ?? ["skills", "mcp", "cluster", "host", "knowledge"];
+    const wantsModel = resourceTypes.includes("model");
+    const expectedReleaseId = params.releaseId as string | undefined;
+    const expectedModelFingerprint = params.modelFingerprint as string | undefined;
+    let preparedReleaseId = "";
+    let preparedModelFingerprint = "";
+    if (wantsModel) {
+      const binding = await resolveAgentModelBinding(agentId, frontendClient);
+      if (!binding) throw new Error(`model binding unavailable for agent ${agentId}`);
+      preparedReleaseId = binding.releaseId ?? "";
+      preparedModelFingerprint = binding.modelFingerprint ?? "";
+      if (expectedReleaseId && preparedReleaseId !== expectedReleaseId) {
+        throw new Error(`model binding release ${preparedReleaseId || "<empty>"} does not match expected ${expectedReleaseId}`);
+      }
+      if (expectedModelFingerprint && preparedModelFingerprint !== expectedModelFingerprint) {
+        throw new Error(`model binding fingerprint ${preparedModelFingerprint || "<empty>"} does not match expected ${expectedModelFingerprint}`);
+      }
+    }
 
     const boxes = await agentBoxManager.list();
     // Only "running" boxes are reachable — Pending/Terminating/Succeeded/Failed
@@ -2039,7 +2058,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
 
     if (targets.length === 0) {
       console.log(`[rpc] agent.reload: no active boxes for agent=${agentId}, skipping`);
-      return { ok: true, reloaded: [], skipped: resourceTypes, boxes: 0 };
+      return {
+        ok: true, reloaded: [], skipped: resourceTypes, boxes: 0,
+        observedReleaseId: preparedReleaseId, observedModelFingerprint: preparedModelFingerprint,
+      };
     }
 
     // Fan out across boxes AND resource types concurrently so one slow box
@@ -2067,7 +2089,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const reloaded = Array.from(reloadedSet);
     const failed = Array.from(failedSet);
     console.log(`[rpc] agent.reload: agent=${agentId} boxes=${targets.length} reloaded=[${reloaded}] failed=[${failed}]`);
-    return { ok: true, reloaded, failed, boxes: targets.length };
+    return {
+      ok: true, reloaded, failed, boxes: targets.length,
+      observedReleaseId: preparedReleaseId, observedModelFingerprint: preparedModelFingerprint,
+    };
   });
 
   // agent.syncStatus — read the box's observed inventory. Reload ACK only
@@ -2095,6 +2120,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           knowledge: status.knowledge ?? { syncedAt: null, repos: [] },
           skills: status.skills ?? { names: [] },
           mcp: status.mcp ?? { names: [] },
+          model: status.model ?? null,
         };
       } catch (err: any) {
         const message = String(err?.message ?? err);

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -2060,7 +2060,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       console.log(`[rpc] agent.reload: no active boxes for agent=${agentId}, skipping`);
       return {
         ok: true, reloaded: [], skipped: resourceTypes, boxes: 0,
-        observedReleaseId: preparedReleaseId, observedModelFingerprint: preparedModelFingerprint,
+        preparedReleaseId, preparedModelFingerprint,
       };
     }
 
@@ -2091,7 +2091,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     console.log(`[rpc] agent.reload: agent=${agentId} boxes=${targets.length} reloaded=[${reloaded}] failed=[${failed}]`);
     return {
       ok: true, reloaded, failed, boxes: targets.length,
-      observedReleaseId: preparedReleaseId, observedModelFingerprint: preparedModelFingerprint,
+      preparedReleaseId, preparedModelFingerprint,
     };
   });
 

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -287,6 +287,8 @@ export class TaskCoordinator {
         agentId,
         modelProvider: binding.modelProvider,
         modelId: binding.modelId,
+        releaseId: binding.releaseId,
+        modelFingerprint: binding.modelFingerprint,
         modelConfig: binding.modelConfig,
         modelRouting: binding.modelRouting,
         systemPromptTemplate: binding.systemPrompt ?? undefined,

--- a/src/shared/__tests__/gateway-sync.test.ts
+++ b/src/shared/__tests__/gateway-sync.test.ts
@@ -14,9 +14,10 @@ describe("GATEWAY_SYNC_DESCRIPTORS", () => {
     "knowledge",
     "tools",
     "prompt",
+    "model",
   ];
 
-  it("contains exactly the seven expected syncable types", () => {
+  it("contains exactly the eight expected syncable types", () => {
     const actual = Object.keys(GATEWAY_SYNC_DESCRIPTORS).sort();
     expect(actual).toEqual([...expectedTypes].sort());
   });
@@ -100,6 +101,14 @@ describe("GATEWAY_SYNC_DESCRIPTORS", () => {
     expect(d.initialSync).toBe(false);
     expect(d.gatewayPath).toBe("");
     expect(d.reloadPath).toBe("/api/reload-prompt");
+  });
+
+  it("model: rebuilds sessions without transporting credentials", () => {
+    const d = GATEWAY_SYNC_DESCRIPTORS.model;
+    expect(d.requiresGatewayClient).toBe(false);
+    expect(d.initialSync).toBe(false);
+    expect(d.gatewayPath).toBe("");
+    expect(d.reloadPath).toBe("/api/reload-model");
   });
 
   it("all reload paths are unique", () => {

--- a/src/shared/agentbox-sync-status.ts
+++ b/src/shared/agentbox-sync-status.ts
@@ -20,4 +20,10 @@ export interface BoxSyncStatus {
   };
   skills: { names: string[] };
   mcp: { names: string[] };
+  /** Last release model that completed a successful turn in this box. */
+  model?: {
+    releaseId: string;
+    modelFingerprint: string;
+    observedAt: string;
+  } | null;
 }

--- a/src/shared/gateway-sync.ts
+++ b/src/shared/gateway-sync.ts
@@ -15,7 +15,7 @@
 // ── Scalar types ──────────────────────────────────────────────────────
 
 /** Every syncable type is identified by a well-known key. */
-export type GatewaySyncType = "mcp" | "skills" | "cluster" | "host" | "knowledge" | "tools" | "prompt";
+export type GatewaySyncType = "mcp" | "skills" | "cluster" | "host" | "knowledge" | "tools" | "prompt" | "model";
 
 // ── Config / descriptor interfaces ────────────────────────────────────
 
@@ -193,6 +193,17 @@ export const GATEWAY_SYNC_DESCRIPTORS: Record<GatewaySyncType, GatewaySyncDescri
     // There is no prompt payload to sync at startup. Each message already
     // resolves the latest prompt through config.getAgent; reload only evicts
     // warm sessions so the next turn rebuilds immediately.
+    initialSync: false,
+  },
+  model: {
+    type: "model",
+    gatewayPath: "",
+    reloadPath: "/api/reload-model",
+    retry: { maxRetries: 1, baseDelayMs: 1000 },
+    requiresGatewayClient: false,
+    // Model credentials and provider config continue to resolve per message.
+    // Reload is an identity-bound session invalidation, not a secret-bearing
+    // payload sync.
     initialSync: false,
   },
 };


### PR DESCRIPTION
## Summary

Apply Agent Type Release model changes to existing AgentBoxes at a turn boundary, and expose evidence only after the intended release model completes a successful turn.

### Problem

The management server could publish a new Release while warm AgentBox sessions kept the previous model. The reload protocol also had no release identity, so an acknowledgement could not distinguish preparation from actual model execution.

### Solution

- Add identity-bound `model` reloads that invalidate warm sessions without transporting credentials.
- Reject stale release/fingerprint notifications before touching AgentBoxes.
- Name reload response identities `preparedReleaseId` / `preparedModelFingerprint` so an ACK cannot be mistaken for runtime evidence.
- Carry release identity on every prompt path and record it only when the intended model, not a fallback, successfully completes the turn.
- Fail closed when a completed turn does not report which model candidate actually ran.
- Return that observed identity through `/api/sync-status` for the management server's promotion gate.
- Document the turn-boundary and prepared-vs-verified contract in ADR-015.

## Test Plan

- [x] `npm run build` passes with lockfile dependencies
- [x] Full Vitest suite passes: 273 files / 6176 tests passed, 2 skipped
- [x] Focused reload/observation suites pass: 4 files / 151 tests
- [x] Model observation tests cover successful primary turns and reject fallback or unidentified turns as verification
- [x] Reload tests cover online invalidation, stale delivery rejection, and zero-box cold start

## Architecture Checklist

- [x] **Deployment mode**: The reload descriptor/handler is shared by local and K8s AgentBox HTTP servers; both keep model configuration on the established prompt channel.
- [x] **Security model**: Reload notifications contain release identity only, never provider credentials.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included
