### PR TITLE
feat(runtime): observe personal preview harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
 
+  agentbox-build-graph:
+    name: AgentBox Build Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build --target builder -f Dockerfile.agentbox .
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -22,7 +22,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
-# Copy backend source only (AgentBox runtime graph: agentbox-main + core + tools).
+# Copy backend source only (AgentBox runtime graph: agentbox-main + core + tools + knowledge).
 # Gateway code (spawners, security, db) is intentionally NOT built here — the
 # agentbox image runs only agentbox-main.ts, which never imports src/gateway/*.
 # Those modules are compiled in the runtime/portal images instead.
@@ -31,6 +31,7 @@ COPY src/agentbox-main.ts ./src/
 COPY src/agentbox/ ./src/agentbox/
 COPY src/core/ ./src/core/
 COPY src/cron/ ./src/cron/
+COPY src/knowledge/ ./src/knowledge/
 COPY src/memory/ ./src/memory/
 COPY src/shared/ ./src/shared/
 COPY src/tools/ ./src/tools/

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -83,7 +83,9 @@ Bundles contain **only global + skillset (dev only) + personal skills**. Core sk
 - ✅ Core skills are versioned with the code, not the database
 - ⚠️ `skillsHandler.materialize()` does NOT restore core skills — it only writes what's in the bundle
 - ⚠️ In local mode, only the scoped `createSkillsHandler()` may materialize a bundle, under `.siclaw/skills/agents/<agentId>/`; the process-global handler remains unsafe
-- ⚠️ If a user disables a core skill, the `disabledBuiltins` list in the bundle tells AgentBox which core skills to skip
+- ⚠️ The control plane resolves Agent Type inheritance, masks, and personal overlays before returning the effective bundle; materialized entries therefore remain available independently of the image-Built-in switch
+- ⚠️ A personal Preview can set `inheritBuiltins=false` to skip every image Built-in, or use `disabledBuiltins` to skip individual image-Built-in names; AgentBox applies that policy to both model-visible Skills and Skill scripts
+- ⚠️ LocalSpawner must inject the Agent-scoped Skill root into script tools; process-global script lookup would cross Agent boundaries even if model-visible Skills were filtered correctly
 - ⚠️ Skillset skills are dev-only — untested collaborative work cannot reach production without promotion to global
 
 ---

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -171,6 +171,10 @@ function makeFakeSession(id: string) {
   return {
     id,
     brain: makeFakeBrain(),
+    toolNames: ["bash", "preview_echo"],
+    skillNames: ["personal-probe", "skill-authoring"],
+    skillDigests: { "personal-probe": "abc", "skill-authoring": "def" },
+    getSkillSnapshot: undefined as (() => { skillNames: string[]; skillDigests: Record<string, string> }) | undefined,
     createdAt: new Date(),
     lastActiveAt: new Date(),
     _promptDoneCallbacks: new Set<() => void>(),
@@ -206,6 +210,7 @@ function makeFakeSessionManager() {
     getOrCreateCalls,
     userId: "u",
     agentId: "a",
+    agentTypeState: "sre",
     activeCount: () => sessions.size,
     // Resident is not the same as busy — box-status reports both.
     inFlightCount: () => Array.from(sessions.values()).filter((s) => !s._promptDone).length,
@@ -353,12 +358,14 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
       const r = await getJson(port, "/api/sync-status");
       expect(r.status).toBe(200);
       expect(r.data).toEqual({
+        schemaVersion: 2,
         knowledge: {
           syncedAt: "2026-08-18T08:00:00.000Z",
           repos: [{ id: "kb-1", name: "hardware", version: 2, sha256: "abc", fileCount: 12 }],
         },
         skills: { names: ["k8s-debug"] },
         mcp: { names: ["incidents"] },
+        harness: null,
         model: null,
       });
     } finally {
@@ -371,6 +378,10 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
 
   it("reports a release model only after a successful turn completes", async () => {
     const session = await sm.getOrCreate("observed-model");
+    session.getSkillSnapshot = vi.fn(() => ({
+      skillNames: ["personal-probe-v2", "skill-authoring"],
+      skillDigests: { "personal-probe-v2": "v2", "skill-authoring": "def" },
+    }));
     session.brain.prompt.mockImplementation(async () => {
       session.brain.emitter.emit("event", {
         type: "message_end",
@@ -380,6 +391,7 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
 
     const before = await getJson(port, "/api/sync-status");
     expect(before.data.model).toBeNull();
+    expect(before.data.harness).toBeNull();
 
     const prompt = await getJson(port, "/api/prompt", "POST", {
       text: "hi",
@@ -388,6 +400,7 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
       modelId: "gpt-4",
       releaseId: "release-2",
       modelFingerprint: "fingerprint-2",
+      systemPromptTemplate: "You are the personal preview.",
     });
     expect(prompt.status).toBe(200);
     await flushAsync();
@@ -398,6 +411,15 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
       modelFingerprint: "fingerprint-2",
     });
     expect(new Date(after.data.model.observedAt).toString()).not.toBe("Invalid Date");
+    expect(after.data.harness).toMatchObject({
+      agentType: "sre",
+      systemPromptTemplate: "You are the personal preview.",
+      skillNames: ["personal-probe-v2", "skill-authoring"],
+      skillDigests: { "personal-probe-v2": "v2", "skill-authoring": "def" },
+      toolNames: ["bash", "preview_echo"],
+    });
+    expect(session.getSkillSnapshot).toHaveBeenCalledOnce();
+    expect(new Date(after.data.harness.observedAt).toString()).not.toBe("Invalid Date");
   });
 
   it("does not verify the release model when a fallback answered the turn", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -625,6 +625,15 @@ export function createHttpServer(
   // next turn is prepared; this state is the stronger evidence that a box has
   // actually run with the published model binding.
   let observedModel: { releaseId: string; modelFingerprint: string; observedAt: string } | null = null;
+  let observedHarness: {
+    agentType: string;
+    /** Request-scoped Agent prompt; the resource loader adds platform instructions. */
+    systemPromptTemplate: string | null;
+    skillNames: string[];
+    skillDigests: Record<string, string>;
+    toolNames: string[];
+    observedAt: string;
+  } | null = null;
   if (sessionManager.credentialBroker) {
     perServerHandlers.cluster = createClusterHandler(sessionManager.credentialBroker);
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
@@ -784,6 +793,7 @@ export function createHttpServer(
         knowledgeHandler: perServerKnowledgeHandler,
       }),
       model: observedModel,
+      harness: observedHarness,
     });
   });
 
@@ -1244,6 +1254,21 @@ export function createHttpServer(
       } else {
         console.log(`[agentbox-http] Prompt completed for session ${managed.id}`);
         promptOutcome = "completed";
+        const latestSkills = managed.getSkillSnapshot?.();
+        if (latestSkills) {
+          managed.skillNames = [...latestSkills.skillNames].sort();
+          managed.skillDigests = { ...latestSkills.skillDigests };
+        }
+        observedHarness = {
+          agentType: sessionManager.agentTypeState,
+          // Preserve the configured Agent prompt that completed this turn. This
+          // is deliberately not labelled as the final compiled system prompt.
+          systemPromptTemplate: body.systemPromptTemplate ?? null,
+          skillNames: [...managed.skillNames],
+          skillDigests: { ...managed.skillDigests },
+          toolNames: [...managed.toolNames],
+          observedAt: new Date().toISOString(),
+        };
         const intendedCandidate = body.modelProvider && body.modelId
           ? candidateKey({ provider: body.modelProvider, modelId: body.modelId })
           : undefined;

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -97,6 +97,14 @@ export interface ManagedSession {
   userId?: string;
   brain: BrainSession;
   session: AgentSession;  // backward compat — only guaranteed for pi-agent brain
+  /** Exact function-schema names exposed when this in-memory brain was built. */
+  toolNames: string[];
+  /** Exact Skill names exposed after personal overlay and Built-in masks. */
+  skillNames: string[];
+  /** SHA-256 of the actual SKILL.md loaded for each visible Skill. */
+  skillDigests: Record<string, string>;
+  /** Re-read Skills after an in-session hot reload before recording evidence. */
+  getSkillSnapshot?: () => { skillNames: string[]; skillDigests: Record<string, string> };
   createdAt: Date;
   lastActiveAt: Date;
   /** Callbacks fired when the current prompt completes */
@@ -2902,6 +2910,10 @@ export class AgentBoxSessionManager {
       userId: effectiveUserId,
       brain: result.brain,
       session: result.session,
+      toolNames: (result.customTools ?? []).map((tool) => tool.name).sort(),
+      skillNames: [...(result.skillNames ?? [])].sort(),
+      skillDigests: { ...(result.skillDigests ?? {}) },
+      getSkillSnapshot: result.getSkillSnapshot,
       createdAt: new Date(),
       lastActiveAt: new Date(),
       _promptDoneCallbacks: new Set(),

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -454,6 +454,25 @@ describe("skillsHandler", () => {
     expect(fs.readFileSync(path.join(resolvedDir(), "packaged", "scripts", "run.sh"), "utf8")).toBe("echo ok");
   });
 
+  it("writes specs as SKILL.md when package files contain only Preview extras", async () => {
+    const specs = "---\nname: personal-preview\n---\n\n# Personal Preview\n";
+    await skillsHandler.materialize({
+      version: "preview-v1",
+      skills: [{
+        dirName: "personal-preview",
+        scope: "global" as const,
+        specs,
+        scripts: [],
+        files: [
+          { path: "evidence/version.txt", content: "V1\n", encoding: "utf8" as const, size: 3, sha256: "probe" },
+        ],
+      }],
+    });
+
+    expect(readResolved("personal-preview")).toBe(specs);
+    expect(fs.readFileSync(path.join(resolvedDir(), "personal-preview", "evidence", "version.txt"), "utf8")).toBe("V1\n");
+  });
+
   it("skips one invalid skill package instead of aborting the whole bundle", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
@@ -536,6 +555,31 @@ describe("skillsHandler", () => {
     expect(count).toBe(0);
     const entries = fs.readdirSync(resolvedDir());
     expect(entries).toEqual([]);
+  });
+
+  it("writes an authoritative Built-in mask and permits an explicit empty preview bundle", async () => {
+    await skillsHandler.materialize({
+      version: "v1",
+      inheritBuiltins: true,
+      disabledBuiltins: [],
+      skills: [{ dirName: "old", scope: "global", specs: "old", scripts: [] }],
+    });
+    expect(resolvedExists("old")).toBe(true);
+
+    const count = await skillsHandler.materialize({
+      version: "v2",
+      inheritBuiltins: false,
+      disabledBuiltins: ["manage-skill"],
+      skills: [],
+    });
+    expect(count).toBe(0);
+    expect(resolvedExists("old")).toBe(false);
+    expect(JSON.parse(fs.readFileSync(
+      path.join(skillsTmpDir, ".inherit-builtins.json"), "utf8",
+    ))).toBe(false);
+    expect(JSON.parse(fs.readFileSync(
+      path.join(skillsTmpDir, ".disabled-builtins.json"), "utf8",
+    ))).toEqual(["manage-skill"]);
   });
 
   // ── 5b. defense: empty payload does NOT wipe existing skills ─────
@@ -1304,6 +1348,7 @@ describe("readBoxSyncStatus", () => {
       knowledgeDir: knowledgeTmpDir,
       knowledgeHandler: syncStatusHandler,
     });
+    expect(status.schemaVersion).toBe(2);
     expect(status.knowledge.repos).toEqual([
       expect.objectContaining({ id: "repo-a", name: "硬件设施", version: 2 }),
     ]);

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -24,7 +24,11 @@ import type {
   ReloadContext,
 } from "../shared/gateway-sync.js";
 import { GATEWAY_SYNC_DESCRIPTORS } from "../shared/gateway-sync.js";
-import type { BoxSyncStatus, ObservedKnowledgeRepo } from "../shared/agentbox-sync-status.js";
+import {
+  AGENT_SYNC_STATUS_SCHEMA_VERSION,
+  type BoxSyncStatus,
+  type ObservedKnowledgeRepo,
+} from "../shared/agentbox-sync-status.js";
 import { resolveUnderDir } from "../shared/path-utils.js";
 import { decodeSkillFileContent, normalizeSkillFiles, type SkillPackageFile } from "../shared/skill-package.js";
 
@@ -178,13 +182,23 @@ function writeSkillToDir(
   const skillDir = resolveUnderDir(resolvedDir, skill.dirName);
   fs.mkdirSync(skillDir, { recursive: true });
   if (Array.isArray(skill.files) && skill.files.length > 0) {
-    for (const file of normalizeSkillFiles(skill.files)) {
+    const files = normalizeSkillFiles(skill.files);
+    let packageHasSkillMd = false;
+    for (const file of files) {
       const filePath = resolveUnderDir(skillDir, file.path);
       fs.mkdirSync(path.dirname(filePath), { recursive: true });
       fs.writeFileSync(filePath, file.encoding === "base64" ? Buffer.from(file.content, "base64") : decodeSkillFileContent(file));
+      packageHasSkillMd ||= file.path === "SKILL.md";
       if (file.executable || /^scripts\/[^/]+\.(sh|py)$/.test(file.path)) {
         try { fs.chmodSync(filePath, 0o755); } catch { /* non-POSIX */ }
       }
+    }
+    // Personal Preview uploads carry SKILL.md in `specs` and only additional
+    // package files in `files[]`. Published bundles may instead include
+    // SKILL.md in the complete file list. Support both without overwriting a
+    // package-authored SKILL.md or dropping the Preview Skill entirely.
+    if (!packageHasSkillMd && skill.specs) {
+      fs.writeFileSync(path.join(skillDir, "SKILL.md"), skill.specs);
     }
     return;
   }
@@ -212,8 +226,13 @@ function writeSkillToDir(
  */
 interface SkillBundlePayload {
   version: string;
+  /** Whether image Built-ins remain available to this preview instance. */
+  inheritBuiltins?: boolean;
+  /** Built-in image Skills explicitly masked by this preview instance. */
+  disabledBuiltins?: string[];
   skills: Array<{
     dirName: string;
+    /** "builtin" is accepted for legacy producers; image Built-ins are not bundled. */
     scope: "builtin" | "global";
     specs: string;
     scripts: Array<{ name: string; content: string }>;
@@ -249,8 +268,36 @@ export function createSkillsHandler(
     // Build a flat unified "resolved/" directory with priority-based merging:
     //   global > builtin
     // First dirName written wins; later duplicates are skipped.
-    // All scopes come from the bundle payload (including builtin, synced to DB at startup).
+    // The control plane sends an effective non-image bundle. Legacy producers
+    // may still label an entry "builtin"; that label affects collision order
+    // only and is not an image-Built-in inheritance signal.
     const resolvedDir = path.join(skillsDir, "resolved");
+
+    // Keep the image-Built-in policy next to the effective bundle. Both the
+    // model-visible loader and the Session-scoped script resolver read it.
+    // Absence means an older control plane and preserves the current file;
+    // presence (including []) is an authoritative preview snapshot.
+    const hasExplicitBuiltinPolicy = typeof payload?.inheritBuiltins === "boolean";
+    const hasExplicitBuiltinMask = Array.isArray(payload?.disabledBuiltins);
+    if (hasExplicitBuiltinPolicy) {
+      fs.mkdirSync(skillsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, ".inherit-builtins.json"),
+        JSON.stringify(payload.inheritBuiltins),
+        { mode: 0o600 },
+      );
+    }
+    if (hasExplicitBuiltinMask) {
+      const disabled = [...new Set(payload.disabledBuiltins!
+        .map((name) => String(name).trim())
+        .filter(Boolean))].sort();
+      fs.mkdirSync(skillsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillsDir, ".disabled-builtins.json"),
+        JSON.stringify(disabled),
+        { mode: 0o600 },
+      );
+    }
 
     // Defense against empty-bundle erasure (belt-and-suspenders; the primary
     // fix is Gateway-side so empty-bundles only arrive when the agent is
@@ -259,7 +306,11 @@ export function createSkillsHandler(
     // Legitimate "unbind-all" admin operations can force a fresh wipe by
     // restarting the pod — which is cheap and explicit.
     const incomingCount = Array.isArray(payload?.skills) ? payload.skills.length : 0;
-    if (options.preserveExistingOnEmpty !== false && incomingCount === 0 && fs.existsSync(resolvedDir)) {
+    if (options.preserveExistingOnEmpty !== false
+        && !hasExplicitBuiltinPolicy
+        && !hasExplicitBuiltinMask
+        && incomingCount === 0
+        && fs.existsSync(resolvedDir)) {
       const existing = fs.readdirSync(resolvedDir).filter((name) => {
         try { return fs.statSync(path.join(resolvedDir, name)).isDirectory(); }
         catch { return false; }
@@ -485,6 +536,7 @@ export function readBoxSyncStatus(
       }
     : readKnowledgeInventoryFromDisk(knowledgeDir);
   return {
+    schemaVersion: AGENT_SYNC_STATUS_SCHEMA_VERSION,
     knowledge,
     skills: { names: listSkillNames(skillsDir) },
     mcp: { names: Object.keys(config.mcpServers ?? {}).sort() },

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { buildKnowledgeOverview, buildKnowledgeWikiCatalog } from "../memory/overview-generator.js";
 import { readFile as fsReadFile, writeFile as fsWriteFile, access as fsAccess, mkdir as fsMkdir } from "node:fs/promises";
 import {
@@ -50,12 +50,14 @@ import { inspectModelEnvelope, type ModelEnvelopeManifest } from "./model-envelo
 import { McpClientManager } from "./mcp-client.js";
 import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryEnabled } from "./config.js";
 import { initExtraCommands } from "../tools/infra/extra-commands.js";
+import { filterHarnessSkills } from "./skill-overlay.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
 import {
   buildKnowledgeCitationSystemPrompt,
   createKnowledgeCitationSupport,
 } from "./knowledge-citation-tool.js";
 import { resolveSkillDirectories } from "./skill-directories.js";
+import { createSkillScriptResolver } from "../tools/infra/script-resolver.js";
 
 import type { SessionMode, KubeconfigRef, MemoryRef, DpStateRef, MutableDpStateRef, DelegationContext } from "./types.js";
 
@@ -170,6 +172,12 @@ export interface SiclawSessionResult {
   extensionsResult: LoadExtensionsResult;
   modelFallbackMessage?: string;
   customTools: ToolDefinition[];
+  /** Exact Skill names exposed by the resource loader after overlay/mask resolution. */
+  skillNames?: string[];
+  /** SHA-256 of each loaded SKILL.md, keyed by Skill name. */
+  skillDigests?: Record<string, string>;
+  /** Re-read the resource loader after a hot Skill reload. */
+  getSkillSnapshot?: () => { skillNames: string[]; skillDigests: Record<string, string> };
   kubeconfigRef: KubeconfigRef;
   /** Mutable skill dirs array — update contents + call session.reload() to switch */
   skillsDirs: string[];
@@ -404,6 +412,14 @@ export async function createSiclawSession(
   // Paths from settings.json (needed early for memoryIndexer init and tool resolution)
   const cwd = process.cwd();
   const skillsBase = path.resolve(cwd, config.paths.skillsDir);
+  const scriptSkillsBase = opts?.portalSkillsDir
+    ? path.dirname(path.resolve(opts.portalSkillsDir))
+    : skillsBase;
+  const scriptResolvedSkillsDir = path.resolve(opts?.portalSkillsDir ?? path.join(skillsBase, "resolved"));
+  const skillScriptResolver = createSkillScriptResolver({
+    skillsBaseDir: scriptSkillsBase,
+    resolvedSkillsDir: scriptResolvedSkillsDir,
+  });
   const userDataDir = path.resolve(cwd, config.paths.userDataDir);
   const memoryDir = path.join(userDataDir, "memory");
   const knowledgeDir = opts?.knowledgeDir
@@ -468,13 +484,14 @@ export async function createSiclawSession(
   if (!knowledgeIndexer) {
     let candidate: MemoryIndexer | undefined;
     try {
-      candidate = createKnowledgeIndexer(
+      const created = createKnowledgeIndexer(
         knowledgeDir,
         path.join(userDataDir, "knowledge-index"),
         resolveEmbeddingConfig(),
       );
-      await candidate.sync();
-      knowledgeIndexer = candidate;
+      candidate = created;
+      await created.sync();
+      knowledgeIndexer = created;
     } catch (err) {
       try { candidate?.close(); } catch { /* ignore cleanup failure */ }
       knowledgeIndexer = undefined;
@@ -497,6 +514,7 @@ export async function createSiclawSession(
       memoryRef, dpStateRef,
       memoryIndexer: memoryEnabled ? memoryIndexer : undefined,
       knowledgeIndexer,
+      skillScriptResolver,
       memoryDir: memoryEnabled ? memoryDir : undefined,
       sessionEventEmitter: opts?.sessionEventEmitter,
       knowledgeCitationTool: citationSupport?.tool,
@@ -693,6 +711,9 @@ export async function createSiclawSession(
     includePlatformSkills: compiledContext.harness.includePlatformSkills,
   });
 
+  const builtinPath = path.resolve(cwd, "skills", "core");
+  const extensionPath = path.resolve(cwd, "skills", "extension");
+  const platformPath = path.resolve(cwd, "skills", "platform");
   // A scoped Agent must not inherit pi's ambient ~/.pi/agent/skills discovery.
   // Keep standalone SRE/TUI compatibility only when there is no Portal/Gateway
   // scope and the harness explicitly permits bundled operational skills.
@@ -701,6 +722,12 @@ export async function createSiclawSession(
     fs.existsSync(resolvedSkillsDir) ||
     !compiledContext.harness.includeBundledSkills;
   const allowedSkillRoots = [...new Set(skillsDirs.map((dir) => path.resolve(dir)))];
+  // LocalSpawner materializes policy files beside its Agent-scoped resolved/
+  // tree; K8s keeps them in the process-wide skills root because one pod owns
+  // one Agent. Resolve both layouts from the authoritative directory above.
+  const overlayPolicyDir = opts?.portalSkillsDir
+    ? path.dirname(path.resolve(opts.portalSkillsDir))
+    : skillsBase;
 
   // Resolve credentials directory for tools and /setup extension
   // Credentials dir: Portal snapshot override > explicit kubeconfigRef > config default.
@@ -768,17 +795,27 @@ export async function createSiclawSession(
         (api) => setupExtension(api, credentialsDir, { portalUrl: opts?.portalUrl ?? null }),
         ...cliOnlyFactories,
       ],
-      // Scoped Agent sessions only expose skill roots selected above. This
-      // filters pi-coding-agent's ambient ~/.pi/agent/skills auto-discovery and
-      // makes the harness, rather than the host filesystem, the authority.
-      skillsOverride: filterSkillsToHarness
-        ? (base) => ({
-            skills: base.skills.filter((skill) =>
+      // First enforce the context compiler's authoritative roots, then apply
+      // the personal Preview's Built-in master switch / per-name mask. Both
+      // filters are required: one prevents ambient host Skill discovery, while
+      // the other lets a developer intentionally test without image Built-ins.
+      skillsOverride: (base) => {
+        const harnessSkills = filterSkillsToHarness
+          ? base.skills.filter((skill) =>
               Boolean(skill.filePath) &&
-              allowedSkillRoots.some((root) => isPathInsideDir(skill.filePath!, root))),
-            diagnostics: base.diagnostics,
-          })
-        : undefined,
+              allowedSkillRoots.some((root) => isPathInsideDir(skill.filePath!, root)))
+          : base.skills;
+        return {
+          skills: filterHarnessSkills(harnessSkills, {
+            resolvedDir: path.resolve(opts?.portalSkillsDir ?? resolvedSkillsDir),
+            builtinDirs: [builtinPath, extensionPath, platformPath],
+            inheritFile: path.join(overlayPolicyDir, ".inherit-builtins.json"),
+            disabledFile: path.join(overlayPolicyDir, ".disabled-builtins.json"),
+            portalDir: opts?.portalSkillsDir,
+          }),
+          diagnostics: base.diagnostics,
+        };
+      },
       additionalSkillPaths: skillsDirs,
     },
   });
@@ -869,5 +906,26 @@ export async function createSiclawSession(
   installGuardPipeline(guardRegistry, { agent: session.agent, sessionManager });
 
   const brain: BrainSession = new PiAgentBrain(session);
-  return { brain, session, services, extensionsResult, modelFallbackMessage, customTools, kubeconfigRef, skillsDirs, mode, mcpManager, memoryIndexer, knowledgeIndexer, sessionIdRef, turnRef, dpStateRef, contextManifest, modelEnvelopeManifestRef };
+  const getSkillSnapshot = () => {
+    const currentSkills = loader.getSkills().skills;
+    const skillNames = currentSkills.map((skill) => skill.name).sort();
+    const skillDigests: Record<string, string> = {};
+    for (const skill of currentSkills) {
+      if (!skill.filePath) continue;
+      try {
+        skillDigests[skill.name] = createHash("sha256").update(fs.readFileSync(skill.filePath)).digest("hex");
+      } catch {
+        // The resource loader already emitted its own diagnostic. Keep the
+        // loaded name and omit only the unverifiable digest.
+      }
+    }
+    return { skillNames, skillDigests };
+  };
+  const { skillNames, skillDigests } = getSkillSnapshot();
+  return {
+    brain, session, services, extensionsResult, modelFallbackMessage, customTools,
+    skillNames, skillDigests, getSkillSnapshot,
+    kubeconfigRef, skillsDirs, mode, mcpManager, memoryIndexer, knowledgeIndexer,
+    sessionIdRef, turnRef, dpStateRef, contextManifest, modelEnvelopeManifestRef,
+  };
 }

--- a/src/core/skill-overlay.test.ts
+++ b/src/core/skill-overlay.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { filterHarnessSkills } from "./skill-overlay.js";
+
+describe("personal preview Skill overlay", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function fixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "skill-overlay-"));
+    roots.push(root);
+    const resolvedDir = path.join(root, ".siclaw/skills/resolved");
+    const platformDir = path.join(root, "skills/platform");
+    const inheritFile = path.join(root, ".siclaw/skills/.inherit-builtins.json");
+    const disabledFile = path.join(root, ".siclaw/skills/.disabled-builtins.json");
+    fs.mkdirSync(path.dirname(disabledFile), { recursive: true });
+    return { root, resolvedDir, platformDir, inheritFile, disabledFile };
+  }
+
+  it("personal Skill wins over a same-named image Built-in", () => {
+    const f = fixture();
+    const got = filterHarnessSkills([
+      { name: "probe", filePath: path.join(f.platformDir, "probe/SKILL.md") },
+      { name: "probe", filePath: path.join(f.resolvedDir, "probe/SKILL.md") },
+      { name: "manage-skill", filePath: path.join(f.platformDir, "manage-skill/SKILL.md") },
+    ], { resolvedDir: f.resolvedDir, builtinDirs: [f.platformDir], inheritFile: f.inheritFile, disabledFile: f.disabledFile });
+    expect(got.map((skill) => skill.filePath)).toEqual([
+      path.join(f.resolvedDir, "probe/SKILL.md"),
+      path.join(f.platformDir, "manage-skill/SKILL.md"),
+    ]);
+  });
+
+  it("explicit mask removes only the Built-in", () => {
+    const f = fixture();
+    fs.writeFileSync(f.disabledFile, JSON.stringify(["manage-skill"]));
+    const got = filterHarnessSkills([
+      { name: "manage-skill", filePath: path.join(f.platformDir, "manage-skill/SKILL.md") },
+      { name: "probe", filePath: path.join(f.resolvedDir, "probe/SKILL.md") },
+    ], { resolvedDir: f.resolvedDir, builtinDirs: [f.platformDir], inheritFile: f.inheritFile, disabledFile: f.disabledFile });
+    expect(got.map((skill) => skill.name)).toEqual(["probe"]);
+  });
+
+  it("inheritance off removes every Built-in but keeps personal Skills", () => {
+    const f = fixture();
+    fs.writeFileSync(f.inheritFile, JSON.stringify(false));
+    const got = filterHarnessSkills([
+      { name: "manage-skill", filePath: path.join(f.platformDir, "manage-skill/SKILL.md") },
+      { name: "triage", filePath: path.join(f.platformDir, "triage/SKILL.md") },
+      { name: "probe", filePath: path.join(f.resolvedDir, "probe/SKILL.md") },
+    ], {
+      resolvedDir: f.resolvedDir,
+      builtinDirs: [f.platformDir],
+      inheritFile: f.inheritFile,
+      disabledFile: f.disabledFile,
+    });
+    expect(got.map((skill) => skill.name)).toEqual(["probe"]);
+  });
+
+  it("does not accept a sibling path that only shares an allowed prefix", () => {
+    const f = fixture();
+    const got = filterHarnessSkills([
+      { name: "forged", filePath: path.join(`${f.platformDir}-untrusted`, "forged/SKILL.md") },
+    ], {
+      resolvedDir: f.resolvedDir,
+      builtinDirs: [f.platformDir],
+      inheritFile: f.inheritFile,
+      disabledFile: f.disabledFile,
+      portalDir: f.resolvedDir,
+    });
+    expect(got).toEqual([]);
+  });
+});

--- a/src/core/skill-overlay.ts
+++ b/src/core/skill-overlay.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface DiscoveredSkill {
+  name: string;
+  filePath?: string;
+}
+
+export interface SkillOverlayFilterOptions {
+  resolvedDir: string;
+  builtinDirs: string[];
+  inheritFile: string;
+  disabledFile: string;
+  portalDir?: string;
+}
+
+function disabledNames(filePath: string): Set<string> {
+  try {
+    if (!fs.existsSync(filePath)) return new Set();
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    return new Set(Array.isArray(parsed) ? parsed.map(String) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function inheritsBuiltins(filePath: string): boolean {
+  try {
+    if (!fs.existsSync(filePath)) return true;
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) !== false;
+  } catch {
+    return true;
+  }
+}
+
+function isWithin(filePath: string, root: string): boolean {
+  const resolvedFile = path.resolve(filePath);
+  const resolvedRoot = path.resolve(root);
+  return resolvedFile === resolvedRoot || resolvedFile.startsWith(resolvedRoot + path.sep);
+}
+
+/** Apply the personal-preview precedence rule to model-visible Skills. */
+export function filterHarnessSkills<T extends DiscoveredSkill>(
+  skills: T[],
+  options: SkillOverlayFilterOptions,
+): T[] {
+  const scoped = skills.filter((skill) => {
+    if (!options.portalDir) return true;
+    if (!skill.filePath) return false;
+    return isWithin(skill.filePath, options.portalDir)
+      || options.builtinDirs.some((root) => isWithin(skill.filePath!, root));
+  });
+  const personalNames = new Set(scoped
+    .filter((skill) => skill.filePath && (
+      isWithin(skill.filePath, options.resolvedDir)
+      || Boolean(options.portalDir && isWithin(skill.filePath, options.portalDir))
+    ))
+    .map((skill) => skill.name));
+  const disabled = disabledNames(path.resolve(options.disabledFile));
+  const inherit = inheritsBuiltins(path.resolve(options.inheritFile));
+  return scoped.filter((skill) => {
+    const isBuiltin = Boolean(skill.filePath
+      && options.builtinDirs.some((root) => isWithin(skill.filePath!, root)));
+    if (!isBuiltin) return true;
+    return inherit && !disabled.has(skill.name) && !personalNames.has(skill.name);
+  });
+}

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types.js";
 import type { DelegateResponse, DelegateRosterMember } from "../shared/agent-delegate.js";
 import type { MemoryIndexer } from "../memory/indexer.js";
+import type { SkillScriptResolver } from "../tools/infra/script-resolver.js";
 
 export type { SessionMode };
 
@@ -410,6 +411,8 @@ export interface ToolRefs {
   memoryIndexer?: MemoryIndexer;
   /** Hybrid index over the knowledge pages mounted for this Agent. */
   knowledgeIndexer?: MemoryIndexer;
+  /** Session-scoped Skill script lookup. Required for LocalSpawner isolation. */
+  skillScriptResolver?: SkillScriptResolver;
   memoryDir?: string;
   /** See SessionEventEmitter. Undefined when running without a session SSE bus. */
   sessionEventEmitter?: SessionEventEmitter;

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -19,6 +19,7 @@ const clientCalls: Array<{ endpoint: string; timeoutMs: number; tlsOptions: unkn
 const getJsonCalls: Array<{ endpoint: string; path: string }> = [];
 const getJsonByEndpoint = new Map<string, () => Promise<unknown>>();
 const defaultSyncStatus = {
+  schemaVersion: 2,
   knowledge: {
     syncedAt: "2026-08-18T08:00:00.000Z",
     repos: [{ id: "kb-1", name: "硬件", version: 2, sha256: "abc" }],
@@ -96,10 +97,15 @@ describe("agent.syncStatus RPC", () => {
     const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
 
     await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      schemaVersion: 2,
       ok: true,
       available: false,
       reason: "no_running_box",
       boxes: 1,
+      runningBoxes: 0,
+      observedBoxes: 0,
+      consistent: false,
+      observations: [],
     });
     expect(getJsonCalls).toEqual([]);
   });
@@ -112,10 +118,15 @@ describe("agent.syncStatus RPC", () => {
     const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
 
     await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      schemaVersion: 2,
       ok: true,
       available: false,
       reason: "no_running_box",
       boxes: 0,
+      runningBoxes: 0,
+      observedBoxes: 0,
+      consistent: false,
+      observations: [],
     });
     expect(getJsonCalls).toEqual([]);
   });
@@ -129,15 +140,25 @@ describe("agent.syncStatus RPC", () => {
     const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
 
     await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      schemaVersion: 2,
       ok: true,
       available: true,
       boxes: 2,
+      runningBoxes: 1,
+      observedBoxes: 1,
+      consistent: true,
+      observations: [{
+        boxId: "b1",
+        available: true,
+        status: defaultSyncStatus,
+      }],
       knowledge: {
         syncedAt: "2026-08-18T08:00:00.000Z",
         repos: [{ id: "kb-1", name: "硬件", version: 2, sha256: "abc" }],
       },
       skills: { names: ["k8s-debug"] },
       mcp: { names: [] },
+      harness: null,
       model: null,
     });
     expect(getJsonCalls).toEqual([{ endpoint: "https://b1", path: "/api/sync-status" }]);
@@ -146,6 +167,142 @@ describe("agent.syncStatus RPC", () => {
       timeoutMs: 8_000,
       tlsOptions: server.agentBoxTlsOptions,
     }]);
+  });
+
+  it("returns a consistent observed Harness while ignoring evidence timestamps", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://b2" },
+    ];
+    const harness = {
+      agentType: "sre",
+      systemPromptTemplate: "personal prompt",
+      skillNames: ["personal-probe"],
+      skillDigests: { "personal-probe": "abc" },
+      toolNames: ["preview_echo"],
+    };
+    getJsonByEndpoint.set("https://b1", async () => ({
+      ...defaultSyncStatus,
+      harness: { ...harness, observedAt: "2026-08-26T08:00:00.000Z" },
+    }));
+    getJsonByEndpoint.set("https://b2", async () => ({
+      ...defaultSyncStatus,
+      harness: { ...harness, observedAt: "2026-08-26T08:01:00.000Z" },
+    }));
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toMatchObject({
+      available: true,
+      consistent: true,
+      harness: { ...harness, observedAt: "2026-08-26T08:00:00.000Z" },
+    });
+  });
+
+  it("normalizes a partial v1 wire payload without pretending it is v2", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://v1" },
+    ];
+    getJsonByEndpoint.set("https://v1", async () => ({
+      schemaVersion: 1,
+      knowledge: { repos: [] },
+    }));
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toMatchObject({
+      available: true,
+      consistent: true,
+      observations: [{
+        boxId: "b1",
+        available: true,
+        status: {
+          schemaVersion: 1,
+          knowledge: { syncedAt: null, repos: [] },
+          skills: { names: [] },
+          mcp: { names: [] },
+        },
+      }],
+    });
+  });
+
+  it("observes every running box and refuses a legacy model consensus when one box differs", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://b2" },
+    ];
+    getJsonByEndpoint.set("https://b1", async () => ({
+      ...defaultSyncStatus,
+      model: {
+        releaseId: "release-2",
+        modelFingerprint: "fingerprint-2",
+        observedAt: "2026-08-26T08:00:00.000Z",
+      },
+    }));
+    getJsonByEndpoint.set("https://b2", async () => ({
+      ...defaultSyncStatus,
+      model: {
+        releaseId: "release-1",
+        modelFingerprint: "fingerprint-1",
+        observedAt: "2026-08-26T08:01:00.000Z",
+      },
+    }));
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toMatchObject({
+      schemaVersion: 2,
+      available: true,
+      boxes: 2,
+      runningBoxes: 2,
+      observedBoxes: 2,
+      consistent: false,
+      model: null,
+      observations: [
+        {
+          boxId: "b1",
+          available: true,
+          status: { model: { releaseId: "release-2", modelFingerprint: "fingerprint-2" } },
+        },
+        {
+          boxId: "b2",
+          available: true,
+          status: { model: { releaseId: "release-1", modelFingerprint: "fingerprint-1" } },
+        },
+      ],
+    });
+    expect(getJsonCalls).toEqual([
+      { endpoint: "https://b1", path: "/api/sync-status" },
+      { endpoint: "https://b2", path: "/api/sync-status" },
+    ]);
+  });
+
+  it("returns partial per-box evidence without exposing transport errors", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://secret.internal" },
+    ];
+    getJsonByEndpoint.set("https://secret.internal", async () => {
+      throw new Error("connect ETIMEDOUT https://secret.internal?token=secret");
+    });
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+
+    const result = await syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any);
+    expect(result).toMatchObject({
+      schemaVersion: 2,
+      available: true,
+      runningBoxes: 2,
+      observedBoxes: 1,
+      consistent: false,
+      model: null,
+      observations: [
+        { boxId: "b1", available: true },
+        { boxId: "b2", available: false, reason: "query_failed" },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain("secret.internal");
+    expect(JSON.stringify(result)).not.toContain("token=secret");
   });
 
   it("marks an old box image as unsupported", async () => {
@@ -159,10 +316,15 @@ describe("agent.syncStatus RPC", () => {
     const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
 
     await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      schemaVersion: 2,
       ok: true,
       available: false,
       reason: "unsupported",
       boxes: 1,
+      runningBoxes: 1,
+      observedBoxes: 0,
+      consistent: false,
+      observations: [{ boxId: "b1", available: false, reason: "unsupported" }],
     });
   });
 
@@ -181,10 +343,18 @@ describe("agent.syncStatus RPC", () => {
     const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
 
     await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toEqual({
+      schemaVersion: 2,
       ok: true,
       available: false,
       reason: "unsupported",
       boxes: 2,
+      runningBoxes: 2,
+      observedBoxes: 0,
+      consistent: false,
+      observations: [
+        { boxId: "b1", available: false, reason: "unsupported" },
+        { boxId: "b2", available: false, reason: "query_failed" },
+      ],
     });
     expect(getJsonCalls).toEqual([
       { endpoint: "https://old", path: "/api/sync-status" },

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -72,7 +72,12 @@ import type { FrontendWsClient } from "./frontend-ws-client.js";
 import { createMtlsMiddleware } from "./security/mtls-middleware.js";
 import type { BoxSpawner } from "./agentbox/spawner.js";
 import { checkMetricsAuth } from "../shared/metrics.js";
-import type { BoxSyncStatus } from "../shared/agentbox-sync-status.js";
+import {
+  AGENT_SYNC_STATUS_SCHEMA_VERSION,
+  normalizeBoxSyncStatus,
+  type BoxSyncObservation,
+  type BoxSyncStatus,
+} from "../shared/agentbox-sync-status.js";
 import { clearAgentMemory } from "./memory-cleanup.js";
 import {
   handleSettings,
@@ -2105,35 +2110,99 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const agentBoxes = boxes.filter((b) => b.agentId === agentId);
     const targets = agentBoxes.filter((b) => b.status === "running");
     if (targets.length === 0) {
-      return { ok: true, available: false, reason: "no_running_box", boxes: agentBoxes.length };
+      return {
+        schemaVersion: AGENT_SYNC_STATUS_SCHEMA_VERSION,
+        ok: true,
+        available: false,
+        reason: "no_running_box",
+        boxes: agentBoxes.length,
+        runningBoxes: 0,
+        observedBoxes: 0,
+        consistent: false,
+        observations: [] as BoxSyncObservation[],
+      };
     }
 
-    let sawUnsupported = false;
-    for (const box of targets) {
+    // Observe every running replica concurrently. Returning the first reachable
+    // box made a partially updated deployment look healthy whenever that box
+    // happened to be queried first.
+    const observations: BoxSyncObservation[] = await Promise.all(targets.map(async (box) => {
       try {
         const client = new AgentBoxClient(box.endpoint, 8_000, agentBoxTlsOptions);
-        const status = await client.getJson<BoxSyncStatus>("/api/sync-status");
-        return {
-          ok: true,
-          available: true,
-          boxes: agentBoxes.length,
-          knowledge: status.knowledge ?? { syncedAt: null, repos: [] },
-          skills: status.skills ?? { names: [] },
-          mcp: status.mcp ?? { names: [] },
-          model: status.model ?? null,
-        };
+        const status = normalizeBoxSyncStatus(await client.getJson<unknown>("/api/sync-status"));
+        return { boxId: box.boxId, available: true, status };
       } catch (err: any) {
         const message = String(err?.message ?? err);
-        console.warn(`[rpc] agent.syncStatus: box=${box.boxId} failed: ${message}`);
-        sawUnsupported ||= /\b404\b/.test(message) || /not found/i.test(message);
+        const reason = /\b404\b/.test(message) || /not found/i.test(message)
+          ? "unsupported"
+          : "query_failed";
+        console.warn(`[rpc] agent.syncStatus: box=${box.boxId} failed: ${reason}`);
+        // Do not return the transport error: endpoints and headers can contain
+        // credentials. The per-box reason is enough for the control plane.
+        return { boxId: box.boxId, available: false, reason };
       }
+    }));
+
+    const observed = observations.filter(
+      (item): item is Extract<BoxSyncObservation, { available: true }> => item.available,
+    );
+    if (observed.length === 0) {
+      return {
+        schemaVersion: AGENT_SYNC_STATUS_SCHEMA_VERSION,
+        ok: true,
+        available: false,
+        reason: observations.some((item) => !item.available && item.reason === "unsupported")
+          ? "unsupported"
+          : "query_failed",
+        boxes: agentBoxes.length,
+        runningBoxes: targets.length,
+        observedBoxes: 0,
+        consistent: false,
+        observations,
+      };
     }
 
+    // Timestamps are evidence freshness, not harness identity. Ignore them when
+    // deciding whether replicas agree, while retaining content/version fields.
+    const identity = (status: BoxSyncStatus): string => JSON.stringify({
+      schemaVersion: status.schemaVersion ?? 0,
+      knowledge: [...(status.knowledge?.repos ?? [])].sort((a, b) => a.id.localeCompare(b.id)),
+      skills: [...(status.skills?.names ?? [])].sort(),
+      mcp: [...(status.mcp?.names ?? [])].sort(),
+      harness: status.harness ? {
+        agentType: status.harness.agentType,
+        systemPromptTemplate: status.harness.systemPromptTemplate,
+        skillNames: [...(status.harness.skillNames ?? [])].sort(),
+        skillDigests: Object.fromEntries(Object.entries(status.harness.skillDigests ?? {}).sort(([a], [b]) => a.localeCompare(b))),
+        toolNames: [...(status.harness.toolNames ?? [])].sort(),
+      } : null,
+      model: status.model ? {
+        releaseId: status.model.releaseId,
+        modelFingerprint: status.model.modelFingerprint,
+      } : null,
+    });
+    const first = observed[0].status;
+    const firstIdentity = identity(first);
+    const consistent = observed.length === targets.length &&
+      observed.every((item) => identity(item.status) === firstIdentity);
+
     return {
+      schemaVersion: AGENT_SYNC_STATUS_SCHEMA_VERSION,
       ok: true,
-      available: false,
-      reason: sawUnsupported ? "unsupported" : "query_failed",
+      available: true,
       boxes: agentBoxes.length,
+      runningBoxes: targets.length,
+      observedBoxes: observed.length,
+      consistent,
+      observations,
+      // Keep the legacy aggregate while old Sicore versions roll forward. A
+      // model is proof only when every running box agrees; otherwise null keeps
+      // the old verifier in sync_pending rather than producing a false success.
+      knowledge: first.knowledge ?? { syncedAt: null, repos: [] },
+      skills: first.skills ?? { names: [] },
+      mcp: first.mcp ?? { names: [] },
+      harness: consistent ? (first.harness ?? null) : null,
+      model: consistent ? (first.model ?? null) : null,
     };
   });
 

--- a/src/shared/agentbox-sync-status.ts
+++ b/src/shared/agentbox-sync-status.ts
@@ -13,13 +13,28 @@ export interface ObservedKnowledgeRepo {
   fileCount?: number | null;
 }
 
+/** Version of the AgentBox inventory and Runtime observation envelope. */
+export const AGENT_SYNC_STATUS_SCHEMA_VERSION = 2;
+
 export interface BoxSyncStatus {
+  /** Preserve the box-reported version during rolling upgrades. */
+  schemaVersion: number;
   knowledge: {
     syncedAt: string | null;
     repos: ObservedKnowledgeRepo[];
   };
   skills: { names: string[] };
   mcp: { names: string[] };
+  /** Harness configuration that completed the latest successful turn. */
+  harness?: {
+    agentType: string;
+    /** Configured Agent prompt/template, excluding stable platform instructions. */
+    systemPromptTemplate: string | null;
+    skillNames: string[];
+    skillDigests: Record<string, string>;
+    toolNames: string[];
+    observedAt: string;
+  } | null;
   /** Last release model that completed a successful turn in this box. */
   model?: {
     releaseId: string;
@@ -27,3 +42,91 @@ export interface BoxSyncStatus {
     observedAt: string;
   } | null;
 }
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function strings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+/** Normalize an independently released AgentBox's JSON before Runtime uses it. */
+export function normalizeBoxSyncStatus(value: unknown): BoxSyncStatus {
+  const root = record(value);
+  if (!root) throw new Error("invalid AgentBox sync status");
+
+  const knowledge = record(root.knowledge);
+  const repos = Array.isArray(knowledge?.repos)
+    ? knowledge.repos.flatMap((item): ObservedKnowledgeRepo[] => {
+        const repo = record(item);
+        if (!repo || typeof repo.id !== "string" || typeof repo.name !== "string" ||
+            typeof repo.version !== "number" || typeof repo.sha256 !== "string") return [];
+        return [{
+          id: repo.id,
+          name: repo.name,
+          version: repo.version,
+          sha256: repo.sha256,
+          ...(typeof repo.fileCount === "number" || repo.fileCount === null
+            ? { fileCount: repo.fileCount }
+            : {}),
+        }];
+      })
+    : [];
+
+  const harness = record(root.harness);
+  const skillDigests = record(harness?.skillDigests);
+  const normalizedDigests: Record<string, string> = {};
+  for (const [name, digest] of Object.entries(skillDigests ?? {})) {
+    if (typeof digest === "string") normalizedDigests[name] = digest;
+  }
+
+  const model = record(root.model);
+  return {
+    schemaVersion: typeof root.schemaVersion === "number" && Number.isFinite(root.schemaVersion)
+      ? root.schemaVersion
+      : 0,
+    knowledge: {
+      syncedAt: typeof knowledge?.syncedAt === "string" ? knowledge.syncedAt : null,
+      repos,
+    },
+    skills: { names: strings(record(root.skills)?.names) },
+    mcp: { names: strings(record(root.mcp)?.names) },
+    ...(harness && typeof harness.agentType === "string"
+      ? { harness: {
+          agentType: harness.agentType,
+          // This is the configured Agent prompt/template, not the final compiled
+          // platform prompt. Keep the wire name for backward compatibility.
+          systemPromptTemplate: typeof harness.systemPromptTemplate === "string"
+            ? harness.systemPromptTemplate
+            : null,
+          skillNames: strings(harness.skillNames),
+          skillDigests: normalizedDigests,
+          toolNames: strings(harness.toolNames),
+          observedAt: typeof harness.observedAt === "string" ? harness.observedAt : "",
+        } }
+      : root.harness === null ? { harness: null } : {}),
+    ...(model && typeof model.releaseId === "string" && typeof model.modelFingerprint === "string"
+      ? { model: {
+          releaseId: model.releaseId,
+          modelFingerprint: model.modelFingerprint,
+          observedAt: typeof model.observedAt === "string" ? model.observedAt : "",
+        } }
+      : root.model === null ? { model: null } : {}),
+  };
+}
+
+export type BoxSyncObservation =
+  | {
+      boxId: string;
+      available: true;
+      status: BoxSyncStatus;
+    }
+  | {
+      boxId: string;
+      available: false;
+      reason: "unsupported" | "query_failed";
+    };

--- a/src/tools/infra/script-resolver.test.ts
+++ b/src/tools/infra/script-resolver.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  createSkillScriptResolver,
   resolveScript,
   resolveSkillScript,
   listSkillScripts,
@@ -84,6 +85,32 @@ describe("resolveScript — validation", () => {
 });
 
 describe("resolveSkillScript — path search precedence", () => {
+  it("isolates two Agent-scoped resolved trees and Built-in policies in one process", () => {
+    const sharedBuiltins = path.join(tmpRoot, "skills/core");
+    const agentA = path.join(tmpRoot, ".siclaw/skills/agents/agent-a");
+    const agentB = path.join(tmpRoot, ".siclaw/skills/agents/agent-b");
+    mkFile(path.join(sharedBuiltins, "builtin-probe/scripts/run.sh"), "builtin");
+    mkFile(path.join(agentA, "resolved/personal-probe/scripts/run.sh"), "agent-a");
+    mkFile(path.join(agentB, "resolved/personal-probe/scripts/run.sh"), "agent-b");
+    fs.writeFileSync(path.join(agentA, ".inherit-builtins.json"), "false");
+
+    const resolverA = createSkillScriptResolver({
+      skillsBaseDir: agentA,
+      resolvedSkillsDir: path.join(agentA, "resolved"),
+      builtinDirs: [sharedBuiltins],
+    });
+    const resolverB = createSkillScriptResolver({
+      skillsBaseDir: agentB,
+      resolvedSkillsDir: path.join(agentB, "resolved"),
+      builtinDirs: [sharedBuiltins],
+    });
+
+    expect(resolverA.resolveSkillScript("personal-probe", "run.sh")?.content).toBe("agent-a");
+    expect(resolverB.resolveSkillScript("personal-probe", "run.sh")?.content).toBe("agent-b");
+    expect(resolverA.resolveSkillScript("builtin-probe", "run.sh")).toBeNull();
+    expect(resolverB.resolveSkillScript("builtin-probe", "run.sh")?.content).toBe("builtin");
+  });
+
   it("finds script in scope subdirectory (global)", () => {
     mkFile(path.join(tmpRoot, ".siclaw/skills/global/my-skill/scripts/run.sh"), "echo run");
     const res = resolveSkillScript("my-skill", "run.sh");
@@ -131,6 +158,22 @@ describe("resolveSkillScript — path search precedence", () => {
     );
     const res = resolveSkillScript("disabled-one", "a.sh");
     expect(res).toBeNull();
+  });
+
+  it("inheritance off blocks every builtin script but keeps personal scripts", () => {
+    mkFile(path.join(tmpRoot, "skills/core/builtin-one/scripts/a.sh"), "builtin");
+    mkFile(path.join(tmpRoot, ".siclaw/skills/extension/builtin-two/scripts/b.sh"), "extension");
+    mkFile(path.join(tmpRoot, ".siclaw/skills/global/personal/scripts/p.sh"), "personal");
+    fs.writeFileSync(
+      path.join(tmpRoot, ".siclaw/skills/.inherit-builtins.json"),
+      JSON.stringify(false),
+    );
+
+    expect(resolveSkillScript("builtin-one", "a.sh")).toBeNull();
+    expect(resolveSkillScript("builtin-two", "b.sh")).toBeNull();
+    expect(resolveSkillScript("personal", "p.sh")?.content).toBe("personal");
+    expect(skillExistsAsBuiltin("builtin-one")).toBe(false);
+    expect(listAllSkillsWithScripts().map((item) => item.skill)).toEqual(["personal"]);
   });
 
   it("returns null for unknown skill", () => {

--- a/src/tools/infra/script-resolver.ts
+++ b/src/tools/infra/script-resolver.ts
@@ -2,31 +2,64 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import { loadConfig } from "../../core/config.js";
 
-function skillsBase(): string {
+export interface SkillScriptResolverOptions {
+  /** Session-owned Skill root containing policy files and legacy scope dirs. */
+  skillsBaseDir?: string;
+  /** Exact materialized Skill directory. LocalSpawner passes <agent>/resolved. */
+  resolvedSkillsDir?: string;
+  /** Image Built-in roots. Primarily injectable for tests. */
+  builtinDirs?: string[];
+}
+
+export interface SkillScriptResolver {
+  resolveScript(params: { skill?: string; script: string }): ResolvedScript | { error: string };
+  resolveSkillScript(skill: string, script: string): ResolvedScript | null;
+  listSkillScripts(skill: string): string[];
+  listAllSkillsWithScripts(): Array<{ skill: string; scripts: string[] }>;
+  skillExistsInBundle(skillName: string): boolean;
+  skillExistsAsBuiltin(skillName: string): boolean;
+  readSkillMd(skill: string, maxChars?: number): string | null;
+  skillMdHint(skill: string): string;
+}
+
+function skillsBase(options: SkillScriptResolverOptions = {}): string {
+  if (options.skillsBaseDir) return path.resolve(options.skillsBaseDir);
   const config = loadConfig();
   return path.resolve(process.cwd(), config.paths.skillsDir);
+}
+
+function resolvedSkillsDir(options: SkillScriptResolverOptions = {}): string {
+  return path.resolve(options.resolvedSkillsDir ?? path.join(skillsBase(options), "resolved"));
 }
 
 /** Builtin skills directories (baked into Docker image at skills/core/ and skills/extension/) */
 const BUILTIN_TIERS = ["core", "extension"] as const;
 
-function builtinCoreDir(): string {
-  return path.resolve(process.cwd(), "skills", "core");
-}
-
-function builtinDirs(): string[] {
+function builtinDirs(options: SkillScriptResolverOptions = {}): string[] {
+  if (options.builtinDirs) return options.builtinDirs.map((dir) => path.resolve(dir));
   return BUILTIN_TIERS.map(t => path.resolve(process.cwd(), "skills", t));
 }
 
 /** Load disabled builtins list (written by agentbox startup from bundle API) */
-function loadDisabledBuiltins(): Set<string> {
+function loadDisabledBuiltins(options: SkillScriptResolverOptions = {}): Set<string> {
   try {
-    const filePath = path.join(skillsBase(), ".disabled-builtins.json");
+    const filePath = path.join(skillsBase(options), ".disabled-builtins.json");
     if (fs.existsSync(filePath)) {
       return new Set(JSON.parse(fs.readFileSync(filePath, "utf-8")) as string[]);
     }
   } catch { /* ignore malformed file */ }
   return new Set();
+}
+
+/** Default-on preview policy written beside the materialized Skill bundle. */
+function loadInheritBuiltins(options: SkillScriptResolverOptions = {}): boolean {
+  try {
+    const filePath = path.join(skillsBase(options), ".inherit-builtins.json");
+    if (fs.existsSync(filePath)) {
+      return JSON.parse(fs.readFileSync(filePath, "utf-8")) !== false;
+    }
+  } catch { /* keep the backward-compatible default */ }
+  return true;
 }
 
 /**
@@ -57,12 +90,14 @@ const SCOPE_MAP: Record<string, SkillScope> = {
  * 3. Scope subdirectories (extension > global > core)
  * 4. Builtin fallback (skills/core/) — unless disabled
  */
-function getSkillScriptDirs(skill: string): ScopeDir[] {
-  const base = skillsBase();
+function getSkillScriptDirs(skill: string, options: SkillScriptResolverOptions = {}): ScopeDir[] {
+  const base = skillsBase(options);
+  const inheritBuiltins = loadInheritBuiltins(options);
+  const disabled = loadDisabledBuiltins(options);
 
   // 1. Unified resolved/ directory (built by materialize with priority merging)
   // K8s mode: {base}/resolved/{skill}/scripts
-  const resolvedPath = path.join(base, "resolved", skill, "scripts");
+  const resolvedPath = path.join(resolvedSkillsDir(options), skill, "scripts");
   if (fs.existsSync(resolvedPath)) return [{ dir: resolvedPath, scope: "global" }];
 
   // 2. Legacy flat layout (bundle-materialized without scope subdirs)
@@ -72,15 +107,15 @@ function getSkillScriptDirs(skill: string): ScopeDir[] {
   // 3. Scope subdirectories (extension > global > core)
   const dirs: ScopeDir[] = [];
   for (const scopeName of SKILL_SCOPES) {
+    if (SCOPE_MAP[scopeName] === "builtin" && (!inheritBuiltins || disabled.has(skill))) continue;
     const dir = path.join(base, scopeName, skill, "scripts");
     if (fs.existsSync(dir)) dirs.push({ dir, scope: SCOPE_MAP[scopeName] });
   }
   if (dirs.length > 0) return dirs;
 
   // 4. Builtin fallback (skills/{core,extension}/) — for skills not in the bundle
-  const disabled = loadDisabledBuiltins();
-  if (!disabled.has(skill)) {
-    for (const bDir of builtinDirs()) {
+  if (inheritBuiltins && !disabled.has(skill)) {
+    for (const bDir of builtinDirs(options)) {
       const builtinPath = path.join(bDir, skill, "scripts");
       if (fs.existsSync(builtinPath)) return [{ dir: builtinPath, scope: "builtin" }];
     }
@@ -95,56 +130,63 @@ function getSkillScriptDirs(skill: string): ScopeDir[] {
  * Priority: global (bundle) > builtin (Docker image).
  * Uses seenSkills dedup in callers so first-wins = highest priority.
  */
-function getSkillBaseDirs(): string[] {
-  const base = skillsBase();
+function getSkillBaseDirs(options: SkillScriptResolverOptions = {}): string[] {
+  const base = skillsBase(options);
+  const inheritBuiltins = loadInheritBuiltins(options);
+  const resolvedDir = resolvedSkillsDir(options);
+
+  const dirs: string[] = [];
+  if (fs.existsSync(resolvedDir)) dirs.push(resolvedDir);
 
   // 1. Legacy flat layout (bundle-materialized without scope subdirs)
   const hasDirectSkills = fs.existsSync(base) && fs.readdirSync(base).some(
-    (entry) => !entry.startsWith(".") && !SKILL_SCOPES.includes(entry) &&
+    (entry) => entry !== path.basename(resolvedDir) && !entry.startsWith(".") && !SKILL_SCOPES.includes(entry) &&
       fs.statSync(path.join(base, entry)).isDirectory(),
   );
   if (hasDirectSkills) {
-    const dirs = [base];
-    for (const bDir of builtinDirs()) {
-      if (fs.existsSync(bDir)) dirs.push(bDir);
-    }
-    return dirs;
+    dirs.push(base);
   }
 
   // 2. Scope subdirectories (extension > global > core)
-  const dirs: string[] = [];
   for (const scope of SKILL_SCOPES) {
+    if (!inheritBuiltins && SCOPE_MAP[scope] === "builtin") continue;
     const dir = path.join(base, scope);
     if (fs.existsSync(dir)) dirs.push(dir);
   }
 
   // 3. Builtin fallback (skills/{core,extension}/ from Docker image)
-  for (const bDir of builtinDirs()) {
-    if (fs.existsSync(bDir) && !dirs.includes(bDir)) dirs.push(bDir);
+  if (inheritBuiltins) {
+    for (const bDir of builtinDirs(options)) {
+      if (fs.existsSync(bDir) && !dirs.includes(bDir)) dirs.push(bDir);
+    }
   }
 
   return dirs;
 }
 
 /** Check if a skill exists in the materialized bundle (global/builtin) */
-export function skillExistsInBundle(skillName: string): boolean {
-  const base = skillsBase();
+export function skillExistsInBundle(skillName: string, options: SkillScriptResolverOptions = {}): boolean {
+  const base = skillsBase(options);
+  const resolvedDir = path.join(resolvedSkillsDir(options), skillName);
+  if (fs.existsSync(resolvedDir) && fs.statSync(resolvedDir).isDirectory()) return true;
   // Legacy flat layout
   const directDir = path.join(base, skillName);
   if (fs.existsSync(directDir) && fs.statSync(directDir).isDirectory()) return true;
-  // Scope subdirectory layout
-  for (const scopeDir of ["extension", "global"]) {
-    const dir = path.join(base, scopeDir, skillName);
-    if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) return true;
-  }
+  // Personal/global scope remains available when inherited resources are off.
+  const globalDir = path.join(base, "global", skillName);
+  if (fs.existsSync(globalDir) && fs.statSync(globalDir).isDirectory()) return true;
+  if (!loadInheritBuiltins(options) || loadDisabledBuiltins(options).has(skillName)) return false;
+  const extensionDir = path.join(base, "extension", skillName);
+  if (fs.existsSync(extensionDir) && fs.statSync(extensionDir).isDirectory()) return true;
   return false;
 }
 
 /** Check if a skill exists as a non-disabled builtin (skills/{core,extension}/) */
-export function skillExistsAsBuiltin(skillName: string): boolean {
-  const disabled = loadDisabledBuiltins();
+export function skillExistsAsBuiltin(skillName: string, options: SkillScriptResolverOptions = {}): boolean {
+  if (!loadInheritBuiltins(options)) return false;
+  const disabled = loadDisabledBuiltins(options);
   if (disabled.has(skillName)) return false;
-  for (const bDir of builtinDirs()) {
+  for (const bDir of builtinDirs(options)) {
     const dir = path.join(bDir, skillName);
     if (fs.existsSync(dir) && fs.statSync(dir).isDirectory()) return true;
   }
@@ -167,8 +209,9 @@ export interface ResolvedScript {
 export function resolveSkillScript(
   skill: string,
   script: string,
+  options: SkillScriptResolverOptions = {},
 ): ResolvedScript | null {
-  for (const { dir, scope } of getSkillScriptDirs(skill)) {
+  for (const { dir, scope } of getSkillScriptDirs(skill, options)) {
     const scriptPath = path.join(dir, script);
     if (fs.existsSync(scriptPath)) {
       return {
@@ -185,9 +228,9 @@ export function resolveSkillScript(
 /**
  * List available scripts for a given skill.
  */
-export function listSkillScripts(skill: string): string[] {
+export function listSkillScripts(skill: string, options: SkillScriptResolverOptions = {}): string[] {
   const scripts = new Set<string>();
-  for (const { dir } of getSkillScriptDirs(skill)) {
+  for (const { dir } of getSkillScriptDirs(skill, options)) {
     try {
       for (const f of fs.readdirSync(dir)) {
         if (f.endsWith(".sh") || f.endsWith(".py")) scripts.add(f);
@@ -202,16 +245,21 @@ export function listSkillScripts(skill: string): string[] {
 /**
  * List all skills that have scripts.
  */
-export function listAllSkillsWithScripts(): Array<{
+export function listAllSkillsWithScripts(options: SkillScriptResolverOptions = {}): Array<{
   skill: string;
   scripts: string[];
 }> {
   const result: Array<{ skill: string; scripts: string[] }> = [];
   const seen = new Set<string>();
-  const disabled = loadDisabledBuiltins();
-  const builtinSet = new Set(builtinDirs());
+  const disabled = loadDisabledBuiltins(options);
+  const base = skillsBase(options);
+  const builtinSet = new Set([
+    ...builtinDirs(options),
+    path.join(base, "extension"),
+    path.join(base, "core"),
+  ]);
 
-  for (const base of getSkillBaseDirs()) {
+  for (const base of getSkillBaseDirs(options)) {
     const isBuiltinDir = builtinSet.has(base);
     try {
       for (const d of fs.readdirSync(base, { withFileTypes: true })) {
@@ -254,8 +302,12 @@ export function listAllSkillsWithScripts(): Array<{
  * instructions — exact script names + usage — instead of letting it guess again.
  * Returns null when the skill has no readable SKILL.md.
  */
-export function readSkillMd(skill: string, maxChars = 6000): string | null {
-  for (const { dir } of getSkillScriptDirs(skill)) {
+export function readSkillMd(
+  skill: string,
+  maxChars = 6000,
+  options: SkillScriptResolverOptions = {},
+): string | null {
+  for (const { dir } of getSkillScriptDirs(skill, options)) {
     try {
       const md = fs.readFileSync(path.join(path.dirname(dir), "SKILL.md"), "utf-8");
       return md.length > maxChars ? `${md.slice(0, maxChars)}\n…[SKILL.md truncated]` : md;
@@ -267,8 +319,8 @@ export function readSkillMd(skill: string, maxChars = 6000): string | null {
 }
 
 /** Suffix appended to a "script not found" error: the skill's SKILL.md, if any. */
-export function skillMdHint(skill: string): string {
-  const md = readSkillMd(skill);
+export function skillMdHint(skill: string, options: SkillScriptResolverOptions = {}): string {
+  const md = readSkillMd(skill, 6000, options);
   return md
     ? `\n\n--- SKILL.md for "${skill}" (use the exact script name and usage from here, do not guess) ---\n${md}`
     : "";
@@ -281,7 +333,7 @@ export function skillMdHint(skill: string): string {
 export function resolveScript(params: {
   skill?: string;
   script: string;
-}): ResolvedScript | { error: string } {
+}, options: SkillScriptResolverOptions = {}): ResolvedScript | { error: string } {
   const script = params.script?.trim();
   if (!script) {
     return { error: "Script name is required." };
@@ -306,15 +358,15 @@ export function resolveScript(params: {
     };
   }
 
-  const resolved = resolveSkillScript(skill, script);
+  const resolved = resolveSkillScript(skill, script, options);
   if (!resolved) {
-    const available = listSkillScripts(skill);
+    const available = listSkillScripts(skill, options);
     if (available.length > 0) {
       return {
-        error: `Script "${script}" not found in skill "${skill}". Available: ${available.join(", ")}${skillMdHint(skill)}`,
+        error: `Script "${script}" not found in skill "${skill}". Available: ${available.join(", ")}${skillMdHint(skill, options)}`,
       };
     }
-    const allSkills = listAllSkillsWithScripts();
+    const allSkills = listAllSkillsWithScripts(options);
     let hint = `Skill "${skill}" has no scripts directory.`;
     if (allSkills.length > 0) {
       hint += `\nSkills with scripts: ${allSkills.map((s) => `${s.skill} (${s.scripts.join(", ")})`).join("; ")}`;
@@ -322,4 +374,18 @@ export function resolveScript(params: {
     return { error: hint };
   }
   return resolved;
+}
+
+/** Bind script lookup to one Session's materialized Skill and policy roots. */
+export function createSkillScriptResolver(options: SkillScriptResolverOptions = {}): SkillScriptResolver {
+  return {
+    resolveScript: (params) => resolveScript(params, options),
+    resolveSkillScript: (skill, script) => resolveSkillScript(skill, script, options),
+    listSkillScripts: (skill) => listSkillScripts(skill, options),
+    listAllSkillsWithScripts: () => listAllSkillsWithScripts(options),
+    skillExistsInBundle: (skillName) => skillExistsInBundle(skillName, options),
+    skillExistsAsBuiltin: (skillName) => skillExistsAsBuiltin(skillName, options),
+    readSkillMd: (skill, maxChars) => readSkillMd(skill, maxChars, options),
+    skillMdHint: (skill) => skillMdHint(skill, options),
+  };
 }

--- a/src/tools/script-exec/host-script.ts
+++ b/src/tools/script-exec/host-script.ts
@@ -3,7 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import type { KubeconfigRef } from "../../core/types.js";
-import { resolveScript } from "../infra/script-resolver.js";
+import { resolveScript, type SkillScriptResolver } from "../infra/script-resolver.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { postExecSecurity } from "../infra/security-pipeline.js";
 import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
@@ -46,8 +46,10 @@ const HOST_BG_MAX_TTL = 3600;
 export function createHostScriptTool(
   kubeconfigRef?: KubeconfigRef,
   bg?: BackgroundExecWiring,
+  scriptResolver?: SkillScriptResolver,
 ): ToolDefinition {
   const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
+  const scripts = scriptResolver ?? { resolveScript };
   return {
     name: "host_script",
     label: "Host Script",
@@ -138,7 +140,7 @@ Examples (pass the id from host_list; names shown here for readability):
         };
       }
 
-      const resolved = resolveScript({
+      const resolved = scripts.resolveScript({
         skill: params.skill,
         script: params.script,
       });
@@ -290,5 +292,5 @@ export const registration: ToolEntry = {
     createHostScriptTool(refs.kubeconfigRef, {
       executor: refs.backgroundExecExecutor,
       sessionIdRef: refs.sessionIdRef,
-    }),
+    }, refs.skillScriptResolver),
 };

--- a/src/tools/script-exec/local-script.test.ts
+++ b/src/tools/script-exec/local-script.test.ts
@@ -44,4 +44,28 @@ describe("createLocalScriptTool", () => {
     const text = (result.content as any)[0].text;
     expect(text).toContain("path separator");
   });
+
+  it("uses the Session-scoped script resolver instead of process-global Skills", async () => {
+    const isolatedTool = createLocalScriptTool(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        resolveSkillScript: () => null,
+        listSkillScripts: () => ["agent-only.sh"],
+        listAllSkillsWithScripts: () => [],
+        skillMdHint: () => "",
+      } as any,
+    );
+
+    const result = await isolatedTool.execute(
+      "test-id",
+      { skill: "personal", script: "missing.sh" },
+      undefined,
+      {} as any,
+    );
+    expect((result.content as any)[0].text).toContain("agent-only.sh");
+  });
 });

--- a/src/tools/script-exec/local-script.ts
+++ b/src/tools/script-exec/local-script.ts
@@ -14,10 +14,11 @@ import { ensureClusterForTool, classifyClusterFailure } from "../infra/ensure-ku
 import { sanitizeEnv } from "../infra/sanitize-env.js";
 import { parseArgs } from "../infra/command-sets.js";
 import {
-  resolveSkillScript,
-  listSkillScripts,
   listAllSkillsWithScripts,
+  listSkillScripts,
+  resolveSkillScript,
   skillMdHint,
+  type SkillScriptResolver,
 } from "../infra/script-resolver.js";
 import { emitDiagnostic } from "../../shared/diagnostic-events.js";
 
@@ -36,8 +37,15 @@ export function createLocalScriptTool(
   userId?: string,
   agentId?: string | null,
   bg?: BackgroundExecWiring,
+  scriptResolver?: SkillScriptResolver,
 ): ToolDefinition {
   const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
+  const scripts = scriptResolver ?? {
+    resolveSkillScript,
+    listSkillScripts,
+    listAllSkillsWithScripts,
+    skillMdHint,
+  };
   return {
     name: "local_script",
     label: "Local Script",
@@ -129,15 +137,15 @@ Read the skill's SKILL.md first to understand required parameters and usage.`,
         };
       }
 
-      const resolved = resolveSkillScript(skill, script);
+      const resolved = scripts.resolveSkillScript(skill, script);
       if (!resolved) {
-        const available = listSkillScripts(skill);
+        const available = scripts.listSkillScripts(skill);
         let hint: string;
         if (available.length > 0) {
-          hint = `Available scripts for "${skill}": ${available.join(", ")}${skillMdHint(skill)}`;
+          hint = `Available scripts for "${skill}": ${available.join(", ")}${scripts.skillMdHint(skill)}`;
         } else {
           // List all skills that DO have scripts to help the LLM
-          const allSkillsWithScripts = listAllSkillsWithScripts();
+          const allSkillsWithScripts = scripts.listAllSkillsWithScripts();
           hint = `Skill "${skill}" has no scripts directory — follow its SKILL.md instructions using bash/other tools instead.`;
           if (allSkillsWithScripts.length > 0) {
             hint += `\n\nSkills with scripts: ${allSkillsWithScripts.map((s) => `${s.skill} (${s.scripts.join(", ")})`).join("; ")}`;
@@ -298,5 +306,5 @@ export const registration: ToolEntry = {
     createLocalScriptTool(refs.kubeconfigRef, refs.sessionIdRef, refs.userId, refs.agentId, {
       executor: refs.backgroundExecExecutor,
       sessionIdRef: refs.sessionIdRef,
-    }),
+    }, refs.skillScriptResolver),
 };

--- a/src/tools/script-exec/node-script.ts
+++ b/src/tools/script-exec/node-script.ts
@@ -6,7 +6,7 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import type { KubeconfigRef } from "../../core/types.js";
 import { checkNodeReady } from "../infra/k8s-checks.js";
-import { resolveScript } from "../infra/script-resolver.js";
+import { resolveScript, type SkillScriptResolver } from "../infra/script-resolver.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { loadConfig } from "../../core/config.js";
 import { BACKGROUND_BASH_ENABLED } from "../../core/subagent-registry.js";
@@ -46,8 +46,10 @@ export function createNodeScriptTool(
   kubeconfigRef?: KubeconfigRef,
   userId?: string,
   bg?: BackgroundExecWiring,
+  scriptResolver?: SkillScriptResolver,
 ): ToolDefinition {
   const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
+  const scripts = scriptResolver ?? { resolveScript };
   return {
     name: "node_script",
     label: "Node Script",
@@ -209,7 +211,7 @@ Examples:
       }
 
       // Resolve script
-      const resolved = resolveScript({
+      const resolved = scripts.resolveScript({
         skill: params.skill,
         script: params.script,
       });
@@ -353,5 +355,5 @@ export const registration: ToolEntry = {
     createNodeScriptTool(refs.kubeconfigRef, refs.userId, {
       executor: refs.backgroundExecExecutor,
       sessionIdRef: refs.sessionIdRef,
-    }),
+    }, refs.skillScriptResolver),
 };

--- a/src/tools/script-exec/pod-script.ts
+++ b/src/tools/script-exec/pod-script.ts
@@ -3,7 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import type { KubeconfigRef } from "../../core/types.js";
-import { resolveScript } from "../infra/script-resolver.js";
+import { resolveScript, type SkillScriptResolver } from "../infra/script-resolver.js";
 import { renderTextResult } from "../infra/tool-render.js";
 import { postExecSecurity } from "../infra/security-pipeline.js";
 import { checkPodRunning } from "../infra/k8s-checks.js";
@@ -32,8 +32,10 @@ interface PodScriptParams {
 export function createPodScriptTool(
   kubeconfigRef?: KubeconfigRef,
   bg?: BackgroundExecWiring,
+  scriptResolver?: SkillScriptResolver,
 ): ToolDefinition {
   const backgroundEnabled = BACKGROUND_BASH_ENABLED && Boolean(bg?.executor);
+  const scripts = scriptResolver ?? { resolveScript };
   return {
     name: "pod_script",
     label: "Pod Script",
@@ -155,7 +157,7 @@ Examples:
       }
 
       // Resolve script
-      const resolved = resolveScript({
+      const resolved = scripts.resolveScript({
         skill: params.skill,
         script: params.script,
       });
@@ -267,5 +269,5 @@ export const registration: ToolEntry = {
     createPodScriptTool(refs.kubeconfigRef, {
       executor: refs.backgroundExecExecutor,
       sessionIdRef: refs.sessionIdRef,
-    }),
+    }, refs.skillScriptResolver),
 };

--- a/tsconfig.agentbox.json
+++ b/tsconfig.agentbox.json
@@ -5,6 +5,7 @@
     "src/agentbox/**/*.ts",
     "src/core/**/*.ts",
     "src/cron/**/*.ts",
+    "src/knowledge/**/*.ts",
     "src/memory/**/*.ts",
     "src/shared/**/*.ts",
     "src/tools/**/*.ts"


### PR DESCRIPTION
## Summary
- version the AgentBox sync-status contract and query every running box
- materialize personal Preview Skill overlays and explicit image Built-in masks
- expose configured Agent prompt, loaded Skill names/digests and actual tool functions after a successful turn
- refresh Skill evidence after hot reload and require replica consensus for aggregate Harness/model evidence
- preserve per-box evidence while redacting transport failures
- bind Skill script lookup to each Agent session so LocalSpawner previews cannot share resolved resources or Built-in policy
- normalize older/partial AgentBox status payloads during Runtime/AgentBox rolling upgrades
- include the knowledge indexer in the isolated AgentBox image build and verify the builder stage in CI

## Contract boundary
Sicore sends the effective non-image Skill bundle after Agent Type inheritance, masks, and personal overlay resolution. Siclaw applies the accompanying policy only to image Built-ins. The observed prompt field is the configured Agent prompt/template, not the fully compiled platform prompt.

## Validation
- npm test: 278 files passed; 6233 passed, 2 skipped
- npx tsc --noEmit
- npx tsc -p tsconfig.agentbox.json --noEmit
- focused script resolver/tool tests: 69 passed
- gateway sync-status tests: 9 passed
- AgentBox builder-stage Docker build runs in CI