### PR TITLE
feat(lark): add topic-scoped group conversations

### DIFF
--- a/docs/design/2026-08-26-feishu-topic-closed-loop.md
+++ b/docs/design/2026-08-26-feishu-topic-closed-loop.md
@@ -1,0 +1,59 @@
+# Feishu Topic Closed Loop
+
+## Goal
+
+Let a Feishu group use one Siclaw Agent as a natural, shared conversation inside
+one Topic: the first message mentions the bot, then authorized participants can
+continue in that Topic without mentioning it again. The main group and other
+Topics must remain unaffected.
+
+This is a third context mode. It does not change the existing Team or Personal
+contracts.
+
+## Modes
+
+| Mode | Session key | Follow-up without `@bot` | Reply surface |
+| --- | --- | --- | --- |
+| Team (`shared`) | `chat:<chat_id>` | Main-group chatter may be buffered; Topic follow-ups do not run the Agent | Main group |
+| Personal (`per_user`) | `<participant>:lark_thread:<root_id>` | Only the same participant can reuse their Topic session | Topic |
+| Topic (`topic`) | `lark_thread:<root_id>` | Any authorized participant can reuse a claimed Topic | Topic |
+
+## Claim and isolation rules
+
+1. An explicit `@bot` message is allowed to create the Topic session.
+2. An unmentioned Topic follow-up is resolved with `conversation_existing_only`.
+   It can reuse an existing Topic session, but cannot create one.
+3. The Topic root ID is the complete session scope in Topic mode. Sender IDs are
+   deliberately excluded so authorized participants share one context.
+4. A different Topic root produces a different key. If it has not been claimed,
+   the runtime receives no binding and stays silent.
+5. Main-group messages without `@bot` do not enter Topic sessions.
+6. `/new` resets only the current Topic session. It never resets another Topic
+   or the whole group.
+
+## Authorization boundary
+
+Session sharing does not bypass access control. Sicore resolves every incoming
+turn with the current sender identity before returning the Topic session. An
+unauthorized sender receives no reusable binding for an unmentioned follow-up;
+an explicit mention follows the normal access-denied flow.
+
+Standalone Siclaw supports the same session-key and existing-only rules for its
+open group bots. Gated, platform-authorized groups remain a Sicore capability.
+
+## Product controls
+
+Topic mode is available from:
+
+- the Sicore channel-binding selector;
+- the standalone Siclaw Agent settings selector; and
+- the Feishu `/mode` card.
+
+New group bindings still default to Team mode. Existing legacy or unknown mode
+values still fail closed to Personal mode; they are never inferred as shared.
+
+## Feishu prerequisite
+
+The app must receive group messages without a bot mention
+(`im:message.group_msg`). Without that permission, Feishu does not deliver the
+follow-up event, so no runtime implementation can continue the Topic naturally.

--- a/docs/features/channels.mdx
+++ b/docs/features/channels.mdx
@@ -79,6 +79,10 @@ is no separate Topic switch or deployment setting.
   streaming card inside it. Follow-ups in that topic reuse that user's Agent
   session without another mention. Unrelated topics and another user's
   unmentioned replies do not create or inherit the private session.
+- **Topic (thread-shared)**: a root `@bot` message claims that Feishu Topic.
+  Every authorized participant can then continue inside it without another
+  mention, and all of them reuse the same Agent session. The main group and
+  every other unclaimed Topic remain silent and context-isolated.
 - **Team (shared)**: users continue to `@bot` in the main group and the bot
   replies on the existing main-group path. The whole group keeps one shared
   Agent session; Feishu topics do not split it into separate sessions.
@@ -100,7 +104,7 @@ Use these application-identity scopes for a complete Siclaw Agent test bot:
 | Send and reply to messages | `im:message` | Plain-text replies, CardKit card replies, topic replies, mode-switch announcements, and downloading images attached to received messages |
 | Receive direct messages | `im:message.p2p_msg:readonly` | Required separately even when `im:message` is enabled |
 | Receive group `@bot` messages | `im:message.group_at_msg:readonly` | Starts an investigation from a group root message |
-| Receive group messages without a mention | `im:message.group_msg` | Required for natural follow-ups inside an existing personal-mode bot topic and for passive shared-group discussion context; this is a sensitive permission, so restrict the app's availability for pilots |
+| Receive group messages without a mention | `im:message.group_msg` | Required for natural follow-ups inside an existing Personal- or Topic-mode bot Topic and for passive shared-group discussion context; this is a sensitive permission, so restrict the app's availability for pilots |
 | Read group metadata | `im:chat:readonly` | Resolves the group title shown in Siclaw |
 | Create and stream cards | `cardkit:card:write` | Creates the thinking card, streams milestones, finalizes the answer, and updates feedback controls |
 | Upload reply images and files | `im:resource` | Uploads charts and other Agent-generated message resources; received-message downloads are covered by `im:message` |
@@ -132,6 +136,12 @@ Acceptance should cover each permission unit independently:
   confirm the first reply opens a topic.
 - Personal-mode continuity: reply inside that topic without another mention and
   confirm the same Siclaw session is reused.
+- Topic-mode root: select **Topic**, send `@bot` with a unique text, and confirm
+  the first reply opens a Topic.
+- Topic-mode continuity: have another authorized member reply in that Topic
+  without another mention and confirm both turns reuse the same session.
+- Topic-mode isolation: reply without a mention in another Topic and confirm the
+  bot stays silent and creates no session there.
 - Team-mode root: select **Team**, send `@bot` with a unique text, and confirm
   the bot replies in the main group without opening a topic.
 - Team-mode continuity: have another member `@bot` and confirm both turns reuse

--- a/portal-web/src/components/AgentSettings.tsx
+++ b/portal-web/src/components/AgentSettings.tsx
@@ -1120,13 +1120,19 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
     } catch (err: any) { toast.error(err.message) }
   }
 
-  const handleSetContextMode = async (bindingId: string, mode: "shared" | "per_user") => {
+  const handleSetContextMode = async (bindingId: string, mode: "shared" | "per_user" | "topic") => {
     try {
       await api(`/siclaw/agents/${agentId}/channel-bindings/${bindingId}/context-mode`, {
         method: "PUT", body: { mode },
       })
       setBindings(prev => prev.map(b => (b.id === bindingId ? { ...b, context_mode: mode } : b)))
-      toast.success(mode === "shared" ? "Switched to Team (shared) mode" : "Switched to Personal (per-user) mode")
+      toast.success(
+        mode === "shared"
+          ? "Switched to Team (shared) mode"
+          : mode === "topic"
+            ? "Switched to Topic (thread-shared) mode"
+            : "Switched to Personal (per-user) mode",
+      )
     } catch (err: any) { toast.error(err.message) }
   }
 
@@ -1234,13 +1240,14 @@ function ChannelsTab({ agentId, selectedChannelIds, setSelectedChannelIds }: {
                 <div className="flex shrink-0 items-center gap-1.5">
                   {b.route_type === "group" && (
                     <select
-                      value={b.context_mode === "shared" ? "shared" : "per_user"}
-                      onChange={e => handleSetContextMode(b.id, e.target.value as "shared" | "per_user")}
-                      title="Context mode: Team shares one conversation; Personal gives each member their own"
+                      value={b.context_mode === "shared" ? "shared" : b.context_mode === "topic" ? "topic" : "per_user"}
+                      onChange={e => handleSetContextMode(b.id, e.target.value as "shared" | "per_user" | "topic")}
+                      title="Context mode: Team shares the group; Personal isolates members; Topic shares only a claimed thread"
                       className="rounded-md border border-border/50 bg-secondary/30 px-1.5 py-1 text-[10px] text-muted-foreground hover:bg-secondary/50 focus:outline-none"
                     >
                       <option value="shared">Team (shared)</option>
                       <option value="per_user">Personal (per-user)</option>
+                      <option value="topic">Topic (thread-shared)</option>
                     </select>
                   )}
                   <button onClick={() => handleUnbind(b.id)} title="Unbind" className="p-1 rounded-md hover:bg-destructive/20 text-muted-foreground hover:text-red-400">

--- a/src/gateway/channel-manager.ts
+++ b/src/gateway/channel-manager.ts
@@ -42,8 +42,10 @@ export interface ResolvedChannelBinding {
   /**
    * Group context sharing mode, chosen server-side from the binding row.
    * `"shared"` → the whole group shares one session and non-@ chatter is
-   * buffered into it. `"per_user"` → each sender gets an isolated session and
-   * non-@ chatter is dropped. A NEW group defaults to `"shared"` (written at
+   * buffered into it. `"per_user"` → each sender gets an isolated Topic
+   * session. `"topic"` → everyone authorized for the bot shares one session
+   * inside a claimed Topic; unrelated Topics remain silent. A NEW group
+   * defaults to `"shared"` (written at
    * pair/auto-bind time), but the server resolves NULL/legacy rows to
    * `"per_user"` (grandfathering — never merges an existing group's contexts),
    * so an ABSENT field here is treated as `"per_user"` by the runtime: never
@@ -51,7 +53,7 @@ export interface ResolvedChannelBinding {
    * `sessionKey` as opaque; this field is the explicit signal for the non-@
    * ingestion gate — never infer the mode from the key shape.
    */
-  contextMode?: "shared" | "per_user";
+  contextMode?: "shared" | "per_user" | "topic";
 }
 
 /**
@@ -155,7 +157,7 @@ export async function resolveBinding(
 }
 
 /**
- * Set a group binding's context mode (shared|per_user) via the generic
+ * Set a group binding's context mode (shared|per_user|topic) via the generic
  * `channel.setContextMode` RPC. Backs the in-group /mode switch card; the
  * console selector calls the same RPC. Best-effort — returns the portal's
  * `{success}` shape, or a failure object if there is no frontend client.
@@ -163,7 +165,7 @@ export async function resolveBinding(
 export async function setChannelContextMode(
   channelId: string,
   routeKey: string,
-  mode: "shared" | "per_user",
+  mode: "shared" | "per_user" | "topic",
   frontendClient?: FrontendWsClient,
 ): Promise<{ success: boolean; mode?: string; error?: string }> {
   if (!frontendClient) return { success: false, error: "No frontend client for setContextMode" };

--- a/src/gateway/channels/lark-card.test.ts
+++ b/src/gateway/channels/lark-card.test.ts
@@ -512,9 +512,9 @@ describe("buildModeCard", () => {
     return cols.map((c: any) => c.elements[0]);
   }
 
-  it("renders two self-contained mode buttons and marks the current one primary", () => {
+  it("renders three self-contained mode buttons and marks the current one primary", () => {
     const card = buildModeCard("shared", "ch1", "oc_group1", "zh-CN") as any;
-    const [sharedBtn, perUserBtn] = buttons(card);
+    const [sharedBtn, perUserBtn, topicBtn] = buttons(card);
 
     expect(sharedBtn.behaviors[0].value).toEqual({
       kind: MODE_ACTION_KIND, channel_id: "ch1", route_key: "oc_group1", mode: "shared", locale: "zh-CN",
@@ -522,9 +522,13 @@ describe("buildModeCard", () => {
     expect(perUserBtn.behaviors[0].value).toEqual({
       kind: MODE_ACTION_KIND, channel_id: "ch1", route_key: "oc_group1", mode: "per_user", locale: "zh-CN",
     });
+    expect(topicBtn.behaviors[0].value).toEqual({
+      kind: MODE_ACTION_KIND, channel_id: "ch1", route_key: "oc_group1", mode: "topic", locale: "zh-CN",
+    });
     // Current mode (shared) is highlighted; the other is default.
     expect(sharedBtn.type).toBe("primary");
     expect(perUserBtn.type).toBe("default");
+    expect(topicBtn.type).toBe("default");
     expect(sharedBtn.text.content).toContain("✓");
   });
 
@@ -532,5 +536,12 @@ describe("buildModeCard", () => {
     const [sharedBtn, perUserBtn] = buttons(buildModeCard("per_user", "ch1", "g", "en-US") as any);
     expect(perUserBtn.type).toBe("primary");
     expect(sharedBtn.type).toBe("default");
+  });
+
+  it("highlights topic when it is the current mode", () => {
+    const [sharedBtn, perUserBtn, topicBtn] = buttons(buildModeCard("topic", "ch1", "g", "en-US") as any);
+    expect(topicBtn.type).toBe("primary");
+    expect(sharedBtn.type).toBe("default");
+    expect(perUserBtn.type).toBe("default");
   });
 });

--- a/src/gateway/channels/lark-card.ts
+++ b/src/gateway/channels/lark-card.ts
@@ -212,7 +212,7 @@ export function resetFeedbackEchoForTest(): void {
 
 // ── Group context-mode switch card ───────────────────────────────
 
-export type GroupContextMode = "shared" | "per_user";
+export type GroupContextMode = "shared" | "per_user" | "topic";
 
 export const MODE_ACTION_KIND = "siclaw_ctx_mode";
 
@@ -231,22 +231,25 @@ const MODE_CARD_COPY: Record<LarkLocale, {
   hint: string;
   shared: string;
   perUser: string;
+  topic: string;
 }> = {
   "zh-CN": {
-    title: (m) => `**本群上下文模式:当前为「${m === "shared" ? "团队模式" : "个人模式"}」**`,
-    hint: "团队模式:全群共用一个对话,机器人跟进全群讨论(故障/支持群)。\n个人模式:每个人各自独立对话,互不影响(大群/混合群)。\n切换后是一段新对话。",
+    title: (m) => `**本群上下文模式:当前为「${m === "shared" ? "团队模式" : m === "topic" ? "话题模式" : "个人模式"}」**`,
+    hint: "团队模式:全群共用一个对话,机器人跟进全群讨论(故障/支持群)。\n个人模式:每个人各自独立对话,互不影响(大群/混合群)。\n话题模式:每个由机器人认领的话题单独闭环,话题内已授权成员共享上下文且无需再次 @。\n切换后是一段新对话。",
     shared: "团队模式",
     perUser: "个人模式",
+    topic: "话题模式",
   },
   "en-US": {
-    title: (m) => `**Group context mode: currently ${m === "shared" ? "Team (shared)" : "Personal (per-user)"}**`,
-    hint: "Team: everyone shares one conversation; the bot follows the whole group (incident / support rooms).\nPersonal: each person talks to the bot privately (large / mixed groups).\nSwitching starts a fresh conversation.",
+    title: (m) => `**Group context mode: currently ${m === "shared" ? "Team (shared)" : m === "topic" ? "Topic (thread-shared)" : "Personal (per-user)"}**`,
+    hint: "Team: everyone shares one conversation; the bot follows the whole group (incident / support rooms).\nPersonal: each person talks to the bot privately (large / mixed groups).\nTopic: each bot-claimed Topic is a closed conversation shared by its authorized participants; no repeated mention is needed inside it.\nSwitching starts a fresh conversation.",
     shared: "Team (shared)",
     perUser: "Personal (per-user)",
+    topic: "Topic (thread-shared)",
   },
 };
 
-/** Schema-2.0 card: current mode + two callback buttons (current one primary). */
+/** Schema-2.0 card: current mode + three callback buttons (current one primary). */
 export function buildModeCard(
   currentMode: GroupContextMode,
   channelId: string,
@@ -276,6 +279,7 @@ export function buildModeCard(
           columns: [
             { tag: "column", width: "auto", elements: [button("shared", copy.shared)] },
             { tag: "column", width: "auto", elements: [button("per_user", copy.perUser)] },
+            { tag: "column", width: "auto", elements: [button("topic", copy.topic)] },
           ],
         },
       ],

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1216,6 +1216,69 @@ describe("handleLarkMessage — routing to AgentBox", () => {
     await Promise.all([first, second]);
   });
 
+  it("queues different participants in the same Topic behind one shared session", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      sessionId: "shared-topic-session",
+      sessionKey: "lark_thread:mid-topic-root",
+      contextMode: "topic",
+    }));
+    let releaseFirst!: () => void;
+    promptMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseFirst = () => resolve({ sessionId: "shared-topic-session" });
+      }))
+      .mockResolvedValueOnce({ sessionId: "shared-topic-session" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    const mgr = makeAgentBoxManager("a1");
+    const botOpenId = "ou_bot_self";
+    const config = { app_id: "x", app_secret: "y" } as const;
+
+    const first = handleLarkMessage(
+      makeTextEvent("@_user_1 first", {
+        message_id: "mid-topic-root",
+        chat_type: "group",
+        mentions: [{ key: "@_user_1", id: { open_id: botOpenId } }],
+      }, "ou_user_1"),
+      makeLarkClient(),
+      "lark",
+      mgr as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      botOpenId,
+    );
+    await waitForExpect(() => expect(promptMock).toHaveBeenCalledTimes(1));
+
+    const second = handleLarkMessage(
+      makeTextEvent("second", {
+        message_id: "mid-topic-followup",
+        chat_type: "group",
+        root_id: "mid-topic-root",
+        thread_id: "omt-topic-1",
+        mentions: [],
+      }, "ou_user_2"),
+      makeLarkClient(),
+      "lark",
+      mgr as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      botOpenId,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(promptMock).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    await waitForExpect(() => expect(promptMock).toHaveBeenCalledTimes(2));
+    await Promise.all([first, second]);
+    expect(promptMock.mock.calls.map((call) => call[0].sessionId)).toEqual([
+      "shared-topic-session",
+      "shared-topic-session",
+    ]);
+  });
+
   it("replies with a queue-full notice when one binding already has 20 pending messages", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ sessionId: "full-session" }));
     let releaseFirst!: () => void;

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -1408,6 +1408,19 @@ describe("handleLarkCardAction — /mode context switch", () => {
     const result = handleLarkCardAction(modeAction("shared"), modeClient(), { request: vi.fn() } as any);
     expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("团队模式") } });
   });
+
+  it("accepts Topic mode and announces the closed Topic behavior", async () => {
+    setChannelContextModeMock.mockResolvedValue({ success: true, mode: "topic" });
+    const client = modeClient();
+    const result = handleLarkCardAction(modeAction("topic"), client, { request: vi.fn() } as any);
+    expect(result).toEqual({ toast: { type: "success", content: expect.stringContaining("话题模式") } });
+
+    await flush();
+    expect(setChannelContextModeMock).toHaveBeenCalledWith("ch1", "oc_group1", "topic", expect.anything());
+    const announce = JSON.parse(client.im.message.create.mock.calls[0][0].data.content).text;
+    expect(announce).toContain("话题内");
+    expect(announce).toContain("无需再次 @");
+  });
 });
 
 describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => {
@@ -1538,6 +1551,36 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
   });
 
+  it("/mode inside an unclaimed Topic stays silent and cannot claim it", async () => {
+    resolveBindingMock.mockResolvedValue(null);
+    const data = makeTextEvent("/mode", {
+      message_id: "mid-unclaimed-mode",
+      chat_type: "group",
+      mentions: [],
+      root_id: "mid-unclaimed-root",
+      thread_id: "omt-unclaimed",
+    });
+    const lark = makeLarkClient();
+
+    await handleLarkMessage(
+      data, lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(resolveBindingMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "open_id:ou_user_1",
+      "ou_user_1",
+      "lark_thread:mid-unclaimed-root",
+      true,
+      undefined,
+    );
+    expect(lark.im.message.reply).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
   it("/mode at the group root stays on the main-group path", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "per_user" }));
     const data = botSenderEvent("/mode", [{ key: "@_user_1", id: { open_id: BOT } }]);
@@ -1545,6 +1588,16 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     await handleLarkMessage(data, lark, "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
     expect(resolveBindingMock).toHaveBeenCalled();
     expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBeUndefined();
+  });
+
+  it("/mode reports Topic mode as Topic instead of degrading it to Personal", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const data = botSenderEvent("/mode", [{ key: "@_user_1", id: { open_id: BOT } }]);
+    const lark = makeLarkClient();
+    await handleLarkMessage(data, lark, "lark", makeAgentBoxManager() as any, undefined, undefined, "zh-CN", {} as any, BOT);
+
+    const replyText = JSON.parse(lark.im.message.reply.mock.calls[0][0].data.content).text;
+    expect(replyText).toContain("话题模式");
   });
 
   it("IGNORES @所有人 announcements (key @_all, not the bot's open_id)", async () => {
@@ -1680,6 +1733,112 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         threadId: "omt-topic-1",
       }),
     }));
+  });
+
+  it("Topic mode shares one claimed Topic across participants and ignores another Topic", async () => {
+    resolveBindingMock.mockImplementation(async (
+      _channelId: string,
+      _routeKey: string,
+      _frontend: unknown,
+      _sessionKey: string,
+      _senderOpenId: string,
+      conversationKey?: string,
+      conversationExistingOnly?: boolean,
+    ) => {
+      if (conversationKey === "lark_thread:mid-other" && conversationExistingOnly) return null;
+      return makeBinding({
+        sessionId: "shared-topic-session",
+        sessionKey: "lark_thread:mid-1",
+        contextMode: "topic",
+      });
+    });
+    promptMock.mockResolvedValue({ sessionId: "shared-topic-session" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "topic answer" }] },
+      };
+    });
+    const config = { app_id: "x", app_secret: "y" } as const;
+
+    const rootClient = makeLarkClient();
+    await handleLarkMessage(
+      groupEvent("@_user_1 查一下集群", [{ key: "@_user_1", id: { open_id: BOT } }]),
+      rootClient,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    const followupClient = makeLarkClient();
+    await handleLarkMessage(
+      makeTextEvent("再看一下其他节点", {
+        message_id: "mid-followup",
+        chat_type: "group",
+        root_id: "mid-1",
+        thread_id: "omt-topic-1",
+        mentions: [],
+      }, "ou_user_2"),
+      followupClient,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    const unrelatedClient = makeLarkClient();
+    await handleLarkMessage(
+      makeTextEvent("这个话题也问一下", {
+        message_id: "mid-unrelated-followup",
+        chat_type: "group",
+        root_id: "mid-other",
+        thread_id: "omt-topic-other",
+        mentions: [],
+      }, "ou_user_2"),
+      unrelatedClient,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      config,
+      BOT,
+    );
+
+    expect(promptMock.mock.calls.map((call) => call[0].sessionId)).toEqual([
+      "shared-topic-session",
+      "shared-topic-session",
+    ]);
+    expect(resolveBindingMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "open_id:ou_user_2",
+      "ou_user_2",
+      "lark_thread:mid-1",
+      true,
+      undefined,
+    );
+    expect(resolveBindingMock).toHaveBeenCalledWith(
+      "lark",
+      "oc_abc123",
+      expect.anything(),
+      "open_id:ou_user_2",
+      "ou_user_2",
+      "lark_thread:mid-other",
+      true,
+      undefined,
+    );
+    expect(rootClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+    expect(followupClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+    expect(unrelatedClient.im.message.reply).not.toHaveBeenCalled();
   });
 
   it("never enables Topic delivery for an unknown chat type", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -558,17 +558,25 @@ function backfillBindingDisplayName(
 }
 
 const MODE_LABEL_BY_LOCALE: Record<LarkLocale, Record<GroupContextMode, string>> = {
-  "zh-CN": { shared: "团队模式(全群共享上下文)", per_user: "个人模式(各自独立上下文)" },
-  "en-US": { shared: "Team mode (shared context)", per_user: "Personal mode (per-user context)" },
+  "zh-CN": {
+    shared: "团队模式(全群共享上下文)",
+    per_user: "个人模式(各自独立上下文)",
+    topic: "话题模式(每个话题独立闭环)",
+  },
+  "en-US": {
+    shared: "Team mode (shared context)",
+    per_user: "Personal mode (per-user context)",
+    topic: "Topic mode (thread-shared context)",
+  },
 };
 
 const MODE_TOAST_BY_LOCALE: Record<LarkLocale, { ok: (m: GroupContextMode) => string; fail: string }> = {
   "zh-CN": {
-    ok: (m) => `已切换为${m === "shared" ? "团队模式" : "个人模式"}`,
+    ok: (m) => `已切换为${m === "shared" ? "团队模式" : m === "topic" ? "话题模式" : "个人模式"}`,
     fail: "切换失败,请重试。",
   },
   "en-US": {
-    ok: (m) => `Switched to ${m === "shared" ? "Team" : "Personal"} mode`,
+    ok: (m) => `Switched to ${m === "shared" ? "Team" : m === "topic" ? "Topic" : "Personal"} mode`,
     fail: "Couldn't switch mode. Please try again.",
   },
 };
@@ -577,11 +585,15 @@ const MODE_ANNOUNCE_BY_LOCALE: Record<LarkLocale, (m: GroupContextMode) => strin
   "zh-CN": (m) =>
     m === "shared"
       ? `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].shared};之后大家的消息按全群共享处理。`
-      : `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].per_user};之后每个人各自独立对话。`,
+      : m === "topic"
+        ? `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].topic};首次 @ 机器人会认领一个话题,之后已授权成员在该话题内无需再次 @,其他话题不受影响。`
+        : `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].per_user};之后每个人各自独立对话。`,
   "en-US": (m) =>
     m === "shared"
       ? `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].shared}; messages are handled as one shared conversation.`
-      : `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].per_user}; each person now talks to the bot separately.`,
+      : m === "topic"
+        ? `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].topic}; the first @bot message claims a Topic, then authorized participants can continue there without another mention while other Topics stay separate.`
+        : `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].per_user}; each person now talks to the bot separately.`,
 };
 
 const MODE_UNBOUND_NOTICE_BY_LOCALE: Record<LarkLocale, string> = {
@@ -700,7 +712,7 @@ function handleModeSwitchAction(
   const locale: LarkLocale = value.locale === "en-US" ? "en-US" : "zh-CN";
   const toasts = MODE_TOAST_BY_LOCALE[locale];
   const mode: GroupContextMode | null =
-    value.mode === "shared" ? "shared" : value.mode === "per_user" ? "per_user" : null;
+    value.mode === "shared" ? "shared" : value.mode === "per_user" ? "per_user" : value.mode === "topic" ? "topic" : null;
   if (!mode || !value.channel_id || !value.route_key) {
     console.warn(`[lark] Dropping malformed mode action channel=${value.channel_id ?? "?"} mode=${value.mode ?? "?"}`);
     return { toast: { type: "error", content: toasts.fail } };
@@ -843,7 +855,7 @@ function firstLocalePost(raw: any): any {
   return undefined;
 }
 
-// ── Group context mode (shared vs per_user) ──────────────────────
+// ── Group context mode (shared vs per_user vs topic) ─────────────
 //
 // The server (portal adapter) owns the shared-vs-isolated decision and encodes
 // it in the session key it returns; the runtime only needs the mode to decide
@@ -901,6 +913,16 @@ function cachedGroupMode(channelId: string, chatId: string): GroupContextMode | 
     return undefined;
   }
   return entry.mode;
+}
+
+/**
+ * Preserve every mode this runtime understands while keeping the historical
+ * fail-closed behavior for absent or future values: an unknown mode must never
+ * make unrelated group chatter enter a shared session.
+ */
+function normalizeGroupContextMode(value: unknown): GroupContextMode {
+  if (value === "shared" || value === "topic") return value;
+  return "per_user";
 }
 
 /** Drop cached mode + any buffered chatter for a group (used on a /mode switch). */
@@ -1016,8 +1038,9 @@ export async function handleLarkMessage(
   const senderType = getLarkSenderType(data);
   const sessionKey = buildLarkSessionKey(senderOpenId, chatId);
   // Every group message carries a provider-native Topic candidate. The
-  // server-authoritative contextMode decides the product behavior after binding
-  // resolution: per_user uses the Topic; shared stays on the main-group path.
+  // Server-authoritative contextMode decides the product behavior after binding
+  // resolution: personal and topic modes use the Topic; shared stays on the
+  // main-group path.
   const isGroupMessage = chatType === "group";
   const eventRootMessageId = typeof message.root_id === "string" && message.root_id.trim()
     ? message.root_id.trim()
@@ -1396,28 +1419,34 @@ export async function handleLarkMessage(
   // (thread follow-ups are allowed through) and reach the model as a prompt.
   // PAIR stays exempt: it carries its own one-time code.
   if (/^\/mode$/i.test(text.trim()) && (botMentioned || isThreadFollowup)) {
+    // A no-mention command inherits the same claim boundary as ordinary Topic
+    // follow-ups: it may reuse an established bot Topic but must never create
+    // state or answer inside an unrelated Topic.
+    const modeExistingOnly = isThreadFollowup && !botMentioned;
     const modeBinding = await resolveBinding(
       groupChannelId,
       chatId,
       frontendClient!,
       sessionKey,
       senderOpenId ?? undefined,
-      undefined,
-      false,
+      modeExistingOnly ? topicConversationKey : undefined,
+      modeExistingOnly,
       senderType ?? undefined,
     );
     if (isChannelAccessDenied(modeBinding)) {
+      if (modeExistingOnly) return;
       await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(modeBinding, locale, dmCanResolveAccess(personalBot)));
       return;
     }
     if (!modeBinding) {
+      if (modeExistingOnly) return;
       await replyToLark(larkClient, messageId, MODE_UNBOUND_NOTICE_BY_LOCALE[locale]);
       return;
     }
-    const current: GroupContextMode = modeBinding.contextMode === "shared" ? "shared" : "per_user";
+    const current = normalizeGroupContextMode(modeBinding.contextMode);
     // /mode changes the whole group. Keep a root invocation visible on the
     // main-group path; only retain the card inside an already-established Topic.
-    const modeReplyInThread = isThreadFollowup && current === "per_user";
+    const modeReplyInThread = isThreadFollowup && current !== "shared";
     rememberGroupMode(groupChannelId, chatId, current);
     const sent = await sendModeCard(larkClient, messageId, current, groupChannelId, chatId, locale, modeReplyInThread);
     if (!sent) {
@@ -1427,7 +1456,7 @@ export async function handleLarkMessage(
   }
 
   // Only respond when THIS bot is individually @-mentioned, except inside a
-  // topic that personal mode already scoped to a root message. Feishu also
+  // Topic that Personal or Topic mode already scoped to a root message. Feishu also
   // delivers "@所有人" to an @bot-scoped app (it mentions everyone, the bot
   // included), so an @所有人 announcement arrives looking just like a real
   // @bot — without this gate the bot replies to group-wide announcements that
@@ -1439,7 +1468,7 @@ export async function handleLarkMessage(
     // Non-@ group message. In a group KNOWN to be shared, retain it as passive
     // discussion context for the next @-turn — WITHOUT running the agent or
     // touching the AgentBox (idle pods must not be woken by group chatter).
-    // In a per_user group, or one whose mode we haven't confirmed shared,
+    // In a personal/topic group, or one whose mode we haven't confirmed shared,
     // drop it immediately: privacy discipline — only a confirmed-shared group
     // may retain chatter (the receive-all-messages scope is app-level, so the
     // bot sees chatter from groups it must not buffer).
@@ -1491,6 +1520,7 @@ export async function handleLarkMessage(
   //   - open group     → open_id:<sender>  (per-sender: concurrent + isolated)
   //   - authorized group → platform_user:<id> (per-user)
   //   - personal topic → <participant-key>:lark_thread:<root message>
+  //   - shared Topic → lark_thread:<root message>
   //   - shared group → chat:<route-key> (topic candidates are ignored)
   //   - legacy single binding session → "" (binding-level queue + /new reset)
   // /new then resets the right session, and same-session senders serialize.
@@ -1498,7 +1528,7 @@ export async function handleLarkMessage(
   // retain chatter without an RPC per message. Only an explicit "shared" is
   // shared; an absent field (e.g. an older portal) is treated as per_user so we
   // never buffer chatter for a group we can't confirm is shared (privacy-safe).
-  const contextMode: GroupContextMode = binding.contextMode === "shared" ? "shared" : "per_user";
+  const contextMode = normalizeGroupContextMode(binding.contextMode);
   // If the mode changed out of band (a console switch, or another actor) since
   // we last cached it, drop any buffered chatter — it belonged to the previous
   // mode and must not resurface (e.g. after a per_user detour back to shared).
@@ -1506,7 +1536,7 @@ export async function handleLarkMessage(
   if (cachedMode && cachedMode !== contextMode) forgetGroupState(groupChannelId, chatId);
   rememberGroupMode(groupChannelId, chatId, contextMode);
 
-  // A no-@ message inside a Feishu topic is a continuation only in personal
+  // A no-@ message inside a Feishu Topic is a continuation in Personal or Topic
   // mode. Team mode deliberately stays on the old main-group path; an
   // unrelated/manual topic must not wake the shared Agent session.
   if (isThreadFollowup && !botMentioned && contextMode === "shared") {
@@ -1517,9 +1547,9 @@ export async function handleLarkMessage(
     return;
   }
 
-  const personalTopicMode = isGroupMessage && contextMode === "per_user";
-  const conversationKey = personalTopicMode ? topicConversationKey : undefined;
-  const replyInThread = personalTopicMode;
+  const topicScopedMode = isGroupMessage && contextMode !== "shared";
+  const conversationKey = topicScopedMode ? topicConversationKey : undefined;
+  const replyInThread = topicScopedMode;
   const effectiveSessionKey = binding.sessionKey ?? "";
   const queueKey = `${binding.bindingId}:${binding.sessionKey ?? "__binding__"}`;
   const queued = enqueueBindingTask(queueKey, () => processQueuedLarkMessage({
@@ -1563,7 +1593,8 @@ interface QueuedLarkMessageContext {
   channelId: string;
   route: "group" | "personal";
   /** Group route only: "shared" drains the discussion buffer into the prompt
-   *  and attributes the asker; absent/"per_user" behaves as an isolated chat. */
+   * and attributes the asker. `per_user` isolates each participant within a
+   * Topic; `topic` shares the claimed Topic among authorized participants. */
   contextMode?: GroupContextMode;
   /** Provider-native conversation scope. For Feishu topics this is rooted at
    *  the root message id and remains stable before/after thread_id exists. */
@@ -1608,7 +1639,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   if (/^\/new$/i.test(text)) {
     // A shared group has ONE group-level session, so a single member's /new
     // would clear everyone's context — reject it instead of resetting. (A
-    // confirmation-gated "reset the whole room" is deferred.) per_user groups
+    // confirmation-gated "reset the whole room" is deferred.) Topic-scoped groups
     // and personal chats reset the caller's own session as before.
     if (contextMode === "shared" && !conversationKey) {
       await replyToLark(larkClient, messageId, SHARED_NEW_REJECTED_NOTICE_BY_LOCALE[locale], replyInThread);

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -1865,6 +1865,62 @@ describe("channel.resolveBinding", () => {
     expect(result.binding.sessionKey).toBe("open_id:ou_1:lark_thread:mid-root");
   });
 
+  it("topic mode shares the claimed Feishu Topic across participants", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "topic", created_by: "u1" }],
+      [],
+      [],
+      [{ session_id: "shared-topic-session" }],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      {
+        channel_id: "ch1",
+        route_key: "group-123",
+        session_key: "open_id:ou_2",
+        conversation_key: "lark_thread:mid-root",
+      },
+      "a1",
+    );
+
+    expect(query.mock.calls[2][1]).toEqual([
+      expect.any(String),
+      "b1",
+      "lark_thread:mid-root",
+      expect.any(String),
+    ]);
+    expect(result.binding).toEqual(expect.objectContaining({
+      sessionId: "shared-topic-session",
+      sessionKey: "lark_thread:mid-root",
+      contextMode: "topic",
+    }));
+  });
+
+  it("topic mode only reuses an already claimed Topic for an unmentioned follow-up", async () => {
+    const query = mockQuery(
+      [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "topic", created_by: "u1" }],
+      [{ session_id: "shared-topic-session" }],
+    );
+
+    const result = await getHandler("channel.resolveBinding")(
+      {
+        channel_id: "ch1",
+        route_key: "group-123",
+        session_key: "open_id:ou_2",
+        conversation_key: "lark_thread:mid-root",
+        conversation_existing_only: true,
+      },
+      "a1",
+    );
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(result.binding).toEqual(expect.objectContaining({
+      sessionId: "shared-topic-session",
+      sessionKey: "lark_thread:mid-root",
+      contextMode: "topic",
+    }));
+  });
+
   it("does not create a session for an unmentioned unrelated topic", async () => {
     const query = mockQuery(
       [{ id: "b1", agent_id: "a1", session_id: "legacy", route_type: "group", context_mode: "shared", created_by: "u1" }],
@@ -2113,11 +2169,11 @@ describe("channel.setContextMode", () => {
     const query = mockQuery({ affectedRows: 1 } as any);
 
     const result = await getHandler("channel.setContextMode")(
-      { channel_id: "ch1", route_key: "group-1", mode: "per_user" }, "a1",
+      { channel_id: "ch1", route_key: "group-1", mode: "topic" }, "a1",
     );
-    expect(result).toEqual({ success: true, mode: "per_user" });
+    expect(result).toEqual({ success: true, mode: "topic" });
     expect(query.mock.calls[0][0]).toContain("UPDATE channel_bindings SET context_mode");
-    expect(query.mock.calls[0][1]).toEqual(["per_user", "ch1", "group-1"]);
+    expect(query.mock.calls[0][1]).toEqual(["topic", "ch1", "group-1"]);
   });
 
   it("rejects an unknown mode without touching the DB", async () => {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -49,17 +49,18 @@ interface ChannelBindingRow {
   channel_created_by?: string | null;
 }
 
-type ContextMode = "shared" | "per_user";
+type ContextMode = "shared" | "per_user" | "topic";
 
 /**
- * Only an explicit "shared" is shared; NULL / anything unrecognised
+ * Only explicit known values are preserved; NULL / anything unrecognised
  * grandfathers to "per_user". Existing group bindings pre-date this column and
  * behaved per-sender, so a NULL must NOT silently merge their contexts on
  * upgrade. New bindings are written "shared" at pair time (the product default
  * for a fresh group), so the NULL branch only ever hits legacy rows.
  */
 function normalizeContextMode(value: unknown): ContextMode {
-  return value === "shared" ? "shared" : "per_user";
+  if (value === "shared" || value === "topic") return value;
+  return "per_user";
 }
 
 interface ResolvedChannelBinding {
@@ -120,7 +121,8 @@ async function resolveChannelBinding(
   // queue, so this one choice drives shared-vs-isolated end to end):
   //   shared   → chat:{route_key}  — the whole group shares one session,
   //              overriding whatever per-sender key the runtime guessed.
-  //   per_user → the per-sender key the runtime passed (open_id:{sender}).
+  //   per_user → participant + Topic, keeping every sender isolated.
+  //   topic    → Topic root only, shared by authorized participants.
   // Non-group (1:1 user) routes ignore the mode — they are single-user by
   // nature — and keep the legacy passed-key-or-binding-session behavior.
   const effectiveSessionKey = routeType === "group"
@@ -159,6 +161,7 @@ function buildGroupSessionKey(
   if (contextMode === "shared") return `chat:${routeKey}`;
 
   const conversation = conversationKey?.trim();
+  if (contextMode === "topic" && conversation) return conversation;
   if (conversation) {
     if (!participant || participant === conversation || participant.endsWith(`:${conversation}`)) {
       return participant ?? conversation;
@@ -427,7 +430,7 @@ async function updateChannelName(
 /**
  * Set a group's context sharing mode. The generic switch endpoint behind both
  * the console selector and the in-group /mode card. Rejects anything but the
- * two known modes so a bad client can't write a value that NULL-defaults to
+ * known modes so a bad client can't write a value that NULL-defaults to
  * shared silently.
  */
 async function updateChannelBindingContextMode(
@@ -436,8 +439,8 @@ async function updateChannelBindingContextMode(
   routeKey: string,
   mode: unknown,
 ): Promise<{ success: boolean; mode?: ContextMode; error?: string }> {
-  if (mode !== "shared" && mode !== "per_user") {
-    return { success: false, error: "mode must be 'shared' or 'per_user'" };
+  if (mode !== "shared" && mode !== "per_user" && mode !== "topic") {
+    return { success: false, error: "mode must be 'shared', 'per_user', or 'topic'" };
   }
   const [result] = await db.query(
     "UPDATE channel_bindings SET context_mode = ? WHERE channel_id = ? AND route_key = ?",

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -335,6 +335,35 @@ describe("siclaw-api misc routes", () => {
     });
   });
 
+  describe("PUT /api/v1/siclaw/agents/:id/channel-bindings/:bindingId/context-mode", () => {
+    it("accepts Topic mode and persists it on an owned binding", async () => {
+      query
+        .mockResolvedValueOnce([[{ id: "b1" }], []])
+        .mockResolvedValueOnce([{ affectedRows: 1 }, []]);
+
+      const { status, body } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/channel-bindings/b1/context-mode",
+        method: "PUT",
+        body: { mode: "topic" },
+      }));
+
+      expect(status).toBe(200);
+      expect(body).toEqual({ ok: true, mode: "topic" });
+      expect(query.mock.calls[1][1]).toEqual(["topic", "b1"]);
+    });
+
+    it("rejects an unknown mode before querying the database", async () => {
+      const { status } = await runRoute(router, fakeReq({
+        url: "/api/v1/siclaw/agents/a1/channel-bindings/b1/context-mode",
+        method: "PUT",
+        body: { mode: "bogus" },
+      }));
+
+      expect(status).toBe(400);
+      expect(query).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Diagnostics ──────────────────────────────────────────
   describe("GET /api/v1/siclaw/agents/:id/diagnostics", () => {
     it("returns diagnostics list", async () => {

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -2785,7 +2785,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     sendJson(res, 200, { ok: true });
   });
 
-  // Set a group binding's context mode (shared|per_user) — admin any, user own.
+  // Set a group binding's context mode (shared|per_user|topic) — admin any, user own.
   // The runtime picks up the change on its mode cache's TTL (or the next @-turn
   // resolve); the in-group /mode card is the low-latency path.
   router.put(`${P}/agents/:id/channel-bindings/:bindingId/context-mode`, async (req, res, params) => {
@@ -2793,8 +2793,8 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     if (!auth) { sendJson(res, 401, { error: "Unauthorized" }); return; }
 
     const body = await parseBody<{ mode?: string }>(req);
-    if (body.mode !== "shared" && body.mode !== "per_user") {
-      sendJson(res, 400, { error: "mode must be 'shared' or 'per_user'" });
+    if (body.mode !== "shared" && body.mode !== "per_user" && body.mode !== "topic") {
+      sendJson(res, 400, { error: "mode must be 'shared', 'per_user', or 'topic'" });
       return;
     }
 


### PR DESCRIPTION
## Summary
- add a Topic context mode that shares one claimed Feishu Topic across authorized participants
- keep the main group and unrelated Topics silent and isolated
- expose Topic mode in the Feishu mode card and standalone Portal
- document the claim, authorization, and reset contracts

## Validation
- 493 focused Vitest tests passed
- TypeScript build passed
- standalone Portal production build passed
- full Vitest suite: 6225 passed, 2 skipped; one unrelated timing test timed out under parallel load and passed alone