### PR TITLE
fix(agentbox): include knowledge indexer in image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
 
+  agentbox-build-graph:
+    name: AgentBox Build Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build --target builder -f Dockerfile.agentbox .
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -22,7 +22,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 
-# Copy backend source only (AgentBox runtime graph: agentbox-main + core + tools).
+# Copy backend source only (AgentBox runtime graph: agentbox-main + core + tools + knowledge).
 # Gateway code (spawners, security, db) is intentionally NOT built here — the
 # agentbox image runs only agentbox-main.ts, which never imports src/gateway/*.
 # Those modules are compiled in the runtime/portal images instead.
@@ -31,6 +31,7 @@ COPY src/agentbox-main.ts ./src/
 COPY src/agentbox/ ./src/agentbox/
 COPY src/core/ ./src/core/
 COPY src/cron/ ./src/cron/
+COPY src/knowledge/ ./src/knowledge/
 COPY src/memory/ ./src/memory/
 COPY src/shared/ ./src/shared/
 COPY src/tools/ ./src/tools/

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -468,13 +468,14 @@ export async function createSiclawSession(
   if (!knowledgeIndexer) {
     let candidate: MemoryIndexer | undefined;
     try {
-      candidate = createKnowledgeIndexer(
+      const created = createKnowledgeIndexer(
         knowledgeDir,
         path.join(userDataDir, "knowledge-index"),
         resolveEmbeddingConfig(),
       );
-      await candidate.sync();
-      knowledgeIndexer = candidate;
+      candidate = created;
+      await created.sync();
+      knowledgeIndexer = created;
     } catch (err) {
       try { candidate?.close(); } catch { /* ignore cleanup failure */ }
       knowledgeIndexer = undefined;

--- a/tsconfig.agentbox.json
+++ b/tsconfig.agentbox.json
@@ -5,6 +5,7 @@
     "src/agentbox/**/*.ts",
     "src/core/**/*.ts",
     "src/cron/**/*.ts",
+    "src/knowledge/**/*.ts",
     "src/memory/**/*.ts",
     "src/shared/**/*.ts",
     "src/tools/**/*.ts"


### PR DESCRIPTION
## Summary
- copy src/knowledge into the isolated AgentBox builder context
- include knowledge sources in the AgentBox TypeScript project
- make knowledge indexer initialization safe for cleanup on sync failure
- add CI that builds the AgentBox builder stage to catch missing source directories

## Validation
- npx tsc --noEmit
- npx tsc -p tsconfig.agentbox.json --noEmit
- AgentBox builder-stage Docker build runs in CI

## Relationship
This is an independently mergeable build hotfix extracted from PR #522. Merge this PR first; #522 keeps equivalent content until main contains the fix.