### PR TITLE
fix(lark): allow no-mention turns in claimed two-party Topics

### DIFF
--- a/docs/design/2026-07-11-lark-group-context-mode.md
+++ b/docs/design/2026-07-11-lark-group-context-mode.md
@@ -71,6 +71,18 @@ no user-facing choice, and non-@ group messages are dropped unconditionally
    messages never arrive; `shared` degrades to "shared @-turns only" (multiple
    senders share one session but the agent doesn't hear the chatter). This is
    functional, not an error.
+8. **No-mention activation is a two-party Topic exception**: the parent group
+   roster does not define Topic participation. Only `topic` mode may invoke the
+   agent without `@bot`, and only inside an already-claimed Topic whose root
+   message plus every paginated reply contain exactly one human sender and this
+   Siclaw app. The current event sender is added explicitly to cover Feishu
+   history-list eventual consistency. Two humans or another app in that Topic
+   require an explicit mention on every Agent turn, including turns from the
+   original asker. Personal and Team modes never run the Agent from an
+   unmentioned message. Missing/malformed root/history data, incomplete or
+   cyclic pagination, unknown sender identities, and lookup failures all fail
+   closed to "mention required". The positive result is revalidated before
+   every unmentioned turn so a new participant takes effect immediately.
 
 ## Feishu permission matrix
 
@@ -91,20 +103,27 @@ group message arrives
  ├─ @bot        → resolveBinding (existing path) → enqueue agent turn on the
  │                returned sessionKey; in shared mode, prepend the drained
  │                discussion buffer to the prompt
- └─ no mention  → look up the group's context_mode (short-TTL cache, no RPC
-                  per message)
-                   ├─ shared   → append {sender, text, ts} to the session's
-                   │             discussion buffer; no agent run
-                   └─ per_user → drop immediately (today's behavior)
+ └─ no mention  → known shared → append passive discussion
+                   otherwise require a real thread_id and human sender
+                   → resolveBinding(existing Topic only)
+                     ├─ topic → fetch root + paginate Topic replies
+                     │          ├─ one human + this app → enqueue Agent turn
+                     │          └─ other / unknown → drop immediately
+                     ├─ shared → append passive discussion
+                     └─ per_user / unclaimed → drop immediately
 ```
 
 Feishu Topic placement is derived directly from the resolved group mode; it is
 not a separate runtime or deployment setting:
 
-- `per_user`: each root `@bot` message starts a Topic-scoped session, and
-  follow-ups in that Topic reuse it without another mention.
+- `per_user`: each explicitly mentioned root message starts a Topic-scoped
+  session, and explicitly mentioned follow-ups in that Topic reuse it.
 - `shared`: replies and the shared session stay on the main-group path; provider
   Topic identifiers never split the group session.
+- `topic`: each accepted root claims a Topic-scoped session shared by its
+  authorized participants. Only a one-human/this-bot Topic may omit mentions;
+  the containing group may be large, but once another human or app participates
+  in that Topic, every Agent turn requires `@bot`.
 - Existing pre-Topic `per_user` session history is not migrated into a new
   Topic root. Each new root intentionally starts its own scoped conversation.
 

--- a/docs/design/2026-08-26-feishu-topic-closed-loop.md
+++ b/docs/design/2026-08-26-feishu-topic-closed-loop.md
@@ -3,9 +3,10 @@
 ## Goal
 
 Let a Feishu group use one Siclaw Agent as a natural, shared conversation inside
-one Topic: the first message mentions the bot, then authorized participants can
-continue in that Topic without mentioning it again. The main group and other
-Topics must remain unaffected.
+one Topic: the first message mentions the bot, then its sole human participant
+can continue there without mentioning it again. Once another human or another
+app joins that Topic, every Agent invocation requires an explicit mention. The
+main group and other Topics must remain unaffected.
 
 This is a third context mode. It does not change the existing Team or Personal
 contracts.
@@ -16,19 +17,23 @@ contracts.
 | --- | --- | --- | --- |
 | Team (`shared`) | `chat:<chat_id>` | Main-group chatter may be buffered; Topic follow-ups do not run the Agent | Main group |
 | Personal (`per_user`) | `<participant>:lark_thread:<root_id>` | Only the same participant can reuse their Topic session | Topic |
-| Topic (`topic`) | `lark_thread:<root_id>` | Any authorized participant can reuse a claimed Topic | Topic |
+| Topic (`topic`) | `lark_thread:<root_id>` | Authorized participants share a claimed Topic; only a one-human/this-bot Topic may omit `@bot` | Topic |
 
 ## Claim and isolation rules
 
 1. An explicit `@bot` message is allowed to create the Topic session.
 2. An unmentioned Topic follow-up is resolved with `conversation_existing_only`.
    It can reuse an existing Topic session, but cannot create one.
-3. The Topic root ID is the complete session scope in Topic mode. Sender IDs are
+3. Before accepting that unmentioned follow-up, Runtime reads the root message
+   separately and paginates every Topic reply. It accepts only when the complete
+   sender set contains exactly one human and no app other than this Siclaw bot.
+   Missing or malformed history fails closed and requires `@bot`.
+4. The Topic root ID is the complete session scope in Topic mode. Sender IDs are
    deliberately excluded so authorized participants share one context.
-4. A different Topic root produces a different key. If it has not been claimed,
+5. A different Topic root produces a different key. If it has not been claimed,
    the runtime receives no binding and stays silent.
-5. Main-group messages without `@bot` do not enter Topic sessions.
-6. `/new` resets only the current Topic session. It never resets another Topic
+6. Main-group messages without `@bot` do not enter Topic sessions.
+7. `/new` resets only the current Topic session. It never resets another Topic
    or the whole group.
 
 ## Authorization boundary

--- a/docs/features/channels.mdx
+++ b/docs/features/channels.mdx
@@ -75,20 +75,33 @@ Create a Lark bot app, enable message event subscriptions, then configure it in 
 The existing group context selector determines Topic behavior directly; there
 is no separate Topic switch or deployment setting.
 
-- **Personal (per-user)**: a root `@bot` message opens a Feishu topic with the
-  streaming card inside it. Follow-ups in that topic reuse that user's Agent
-  session without another mention. Unrelated topics and another user's
-  unmentioned replies do not create or inherit the private session.
-- **Topic (thread-shared)**: a root `@bot` message claims that Feishu Topic.
-  Every authorized participant can then continue inside it without another
-  mention, and all of them reuse the same Agent session. The main group and
-  every other unclaimed Topic remain silent and context-isolated.
-- **Team (shared)**: users continue to `@bot` in the main group and the bot
-  replies on the existing main-group path. The whole group keeps one shared
-  Agent session; Feishu topics do not split it into separate sessions.
+The mention rule is intentionally narrow:
 
-No additional Topic switch is required in the UI. Follow-ups without another
-`@bot` require the app's group-message event permission.
+- Only **Topic** mode may omit `@bot`, and only inside an already-claimed Topic
+  whose complete message history contains exactly one human and this Siclaw
+  app. The parent group's roster is irrelevant: a large group can still have a
+  two-party Topic.
+- The Runtime reads the Topic root separately and paginates every Topic reply,
+  up to 100 pages of 50 replies. A longer Topic fails closed and requires
+  `@bot`. A second human or another app also makes every Agent turn require
+  `@bot`, including turns from the original asker, so human-to-human discussion
+  cannot wake the Agent.
+- Personal and Team modes never run the Agent from an unmentioned message.
+  Missing/malformed root or Topic history, pagination anomalies, unknown sender
+  identities, and lookup failures all require `@bot`.
+
+- **Personal (per-user)**: each accepted root message opens a Feishu topic with
+  the streaming card inside it. Accepted follow-ups reuse that user's Agent
+  session, but this mode never gets the no-mention exception.
+- **Topic (thread-shared)**: an accepted root message claims that Feishu Topic.
+  Every authorized participant then reuses the same Agent session inside it.
+  The main group and every other unclaimed Topic remain context-isolated.
+- **Team (shared)**: accepted turns use the existing main-group reply path and
+  the whole group keeps one shared Agent session; Feishu topics do not split it
+  into separate sessions.
+
+No additional Topic switch is required in the UI. The one-human/one-bot Topic
+path without `@bot` requires the app's group-message event permission.
 
 ### Feishu test-bot capability checklist
 
@@ -101,11 +114,11 @@ Use these application-identity scopes for a complete Siclaw Agent test bot:
 
 | Capability unit | Scope | Why Siclaw needs it |
 |---|---|---|
-| Send and reply to messages | `im:message` | Plain-text replies, CardKit card replies, topic replies, mode-switch announcements, and downloading images attached to received messages |
+| Send, reply, and read messages | `im:message` | Plain-text replies, CardKit card replies, topic replies, mode-switch announcements, reading the Topic root/history for the mention gate, and downloading images attached to received messages |
 | Receive direct messages | `im:message.p2p_msg:readonly` | Required separately even when `im:message` is enabled |
 | Receive group `@bot` messages | `im:message.group_at_msg:readonly` | Starts an investigation from a group root message |
-| Receive group messages without a mention | `im:message.group_msg` | Required for natural follow-ups inside an existing Personal- or Topic-mode bot Topic and for passive shared-group discussion context; this is a sensitive permission, so restrict the app's availability for pilots |
-| Read group metadata | `im:chat:readonly` | Resolves the group title shown in Siclaw |
+| Receive group messages without a mention | `im:message.group_msg` | Required for the one-human/one-bot Topic path and for passive shared-group discussion context; this is a sensitive permission, so restrict the app's availability for pilots |
+| Read group metadata | `im:chat:readonly` | Resolves the group title shown for the binding; group roster counts are not used by the Topic mention gate |
 | Create and stream cards | `cardkit:card:write` | Creates the thinking card, streams milestones, finalizes the answer, and updates feedback controls |
 | Upload reply images and files | `im:resource` | Uploads charts and other Agent-generated message resources; received-message downloads are covered by `im:message` |
 | Read bot metadata (recommended) | `application:bot.basic_info:read` | Keeps the bot name and identity lookup explicit in the app configuration |
@@ -132,14 +145,19 @@ The matching platform configuration is:
 Acceptance should cover each permission unit independently:
 
 - Direct message: send a unique text and confirm the bot replies.
-- Personal-mode root: select **Personal**, send `@bot` with a unique text, and
+- Topic mention gate: in **Topic** mode, send a unique root with `@bot`, then a
+  follow-up without `@bot`; confirm both reply even if the parent group has many
+  members. Add a second human to that Topic and confirm every unmentioned
+  follow-up stays silent; the same turns should work when `@bot` is explicit.
+- Personal-mode root: select **Personal**, send an accepted unique message, and
   confirm the first reply opens a topic.
-- Personal-mode continuity: reply inside that topic without another mention and
-  confirm the same Siclaw session is reused.
-- Topic-mode root: select **Topic**, send `@bot` with a unique text, and confirm
-  the first reply opens a Topic.
-- Topic-mode continuity: have another authorized member reply in that Topic
-  without another mention and confirm both turns reuse the same session.
+- Personal-mode gate: even with one human and one bot, omit `@bot` and confirm
+  the Agent stays silent; then mention it and confirm the same user's session
+  is reused.
+- Topic-mode root: select **Topic**, send an accepted unique message, and
+  confirm the first reply opens a Topic.
+- Topic-mode continuity: have another authorized member explicitly `@bot` in
+  that Topic and confirm both turns reuse the same session.
 - Topic-mode isolation: reply without a mention in another Topic and confirm the
   bot stays silent and creates no session there.
 - Team-mode root: select **Team**, send `@bot` with a unique text, and confirm

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -119,14 +119,47 @@ describe("createLarkHandler — fallback when SDK is missing", () => {
  * message, otherwise the original "Feishu silent drop" bug comes back.
  */
 
-function makeLarkClient() {
-  return {
+function makeLarkClient(
+  threadMessages?: any[],
+  rootMessage?: any,
+) {
+  const client: any = {
     im: {
       message: {
         reply: vi.fn().mockResolvedValue({}),
+        ...(rootMessage ? {
+          get: vi.fn().mockResolvedValue({
+            data: { items: [rootMessage] },
+          }),
+        } : {}),
+        ...(threadMessages ? {
+          list: vi.fn().mockResolvedValue({
+            data: { items: threadMessages, has_more: false },
+          }),
+        } : {}),
       },
     },
   };
+  return client;
+}
+
+function makeTopicLarkClient(
+  humanIds: string[] = ["ou_user_1"],
+  appIds: string[] = ["x"],
+) {
+  return makeLarkClient([
+    ...humanIds.slice(1).map((id, index) => ({
+      message_id: `mid-human-reply-${index}`,
+      sender: { id, sender_type: "user" },
+    })),
+    ...appIds.map((id, index) => ({
+      message_id: `mid-app-${index}`,
+      sender: { id, sender_type: "app" },
+    })),
+  ], {
+    message_id: "mid-root",
+    sender: { id: humanIds[0], sender_type: "user" },
+  });
 }
 
 function makeAgentBoxManager(agentId = "agent-7") {
@@ -139,13 +172,19 @@ function makeAgentBoxManager(agentId = "agent-7") {
   };
 }
 
-function makeTextEvent(text: string, overrides: Record<string, unknown> = {}, senderOpenId = "ou_user_1") {
+function makeTextEvent(
+  text: string,
+  overrides: Record<string, unknown> = {},
+  senderOpenId = "ou_user_1",
+  senderType?: string,
+) {
   return {
     // EventDispatcher has already spread event.* onto the top level here.
     sender: {
       sender_id: {
         open_id: senderOpenId,
       },
+      ...(senderType ? { sender_type: senderType } : {}),
     },
     message: {
       message_id: "mid-1",
@@ -1256,8 +1295,8 @@ describe("handleLarkMessage — routing to AgentBox", () => {
         chat_type: "group",
         root_id: "mid-topic-root",
         thread_id: "omt-topic-1",
-        mentions: [],
-      }, "ou_user_2"),
+        mentions: [{ key: "@_user_1", id: { open_id: botOpenId } }],
+      }, "ou_user_2", "user"),
       makeLarkClient(),
       "lark",
       mgr as any,
@@ -1481,8 +1520,9 @@ describe("handleLarkCardAction — /mode context switch", () => {
     await flush();
     expect(setChannelContextModeMock).toHaveBeenCalledWith("ch1", "oc_group1", "topic", expect.anything());
     const announce = JSON.parse(client.im.message.create.mock.calls[0][0].data.content).text;
-    expect(announce).toContain("话题内");
-    expect(announce).toContain("无需再次 @");
+    expect(announce).toContain("该话题");
+    expect(announce).toContain("仅有一名真人");
+    expect(announce).toContain("每次调用都需要 @");
   });
 });
 
@@ -1504,11 +1544,11 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
   });
 
   // ── @-ed BY ANOTHER BOT ────────────────────────────────────────────
-  // Nothing in the pipeline inspects sender_type, so an app-sent message takes
-  // the same path as a human's. What differs is the SENDER IDENTITY: Feishu
-  // describes an app sender as sender_type:"app", and when it carries no
-  // sender_id.open_id every downstream identity decision sees an empty sender.
-  // These pin what we actually do in both payload shapes.
+  // An explicit @ mention does not use sender_type as an activation gate, so an
+  // app-sent message takes the same route as a human's. What differs is the
+  // SENDER IDENTITY: Feishu describes an app sender as sender_type:"app", and
+  // when it carries no sender_id.open_id every downstream identity decision
+  // sees an empty sender. These pin what we do in both payload shapes.
 
   /** App/bot sender WITHOUT sender_id.open_id — the shape that loses identity. */
   function botSenderEvent(text: string, mentions: any[]) {
@@ -1592,19 +1632,16 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(resolveBindingMock).not.toHaveBeenCalled();
   });
 
-  it("/mode inside an established topic works without a mention, and never reaches the model", async () => {
-    // Inside a topic people stop @-ing, and thread follow-ups are let through the
-    // @-gate — so requiring a mention here would not merely ignore /mode, it
-    // would forward the literal text to the model as a prompt.
-    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "per_user" }));
+  it("/mode inside an established one-human/one-bot Topic works without a mention, and never reaches the model", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
     const data = makeTextEvent("/mode", {
       message_id: "mid-topic-mode",
       chat_type: "group",
       mentions: [],
       root_id: "mid-root",
       thread_id: "omt-1",
-    });
-    const lark = makeLarkClient();
+    }, "ou_user_1", "user");
+    const lark = makeTopicLarkClient();
     await handleLarkMessage(
       data, lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any,
       "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
@@ -1612,6 +1649,28 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(resolveBindingMock).toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();   // handled as a command, not a prompt
     expect(lark.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+  });
+
+  it("/mode inside a two-human/one-bot Topic requires a mention", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const data = makeTextEvent("/mode", {
+      message_id: "mid-topic-mode-large-group",
+      chat_type: "group",
+      mentions: [],
+      root_id: "mid-root",
+      thread_id: "omt-1",
+    }, "ou_user_1", "user");
+    const lark = makeTopicLarkClient(["ou_user_1", "ou_user_2"]);
+
+    await handleLarkMessage(
+      data, lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(resolveBindingMock).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.list).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.reply).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
   });
 
   it("/mode inside an unclaimed Topic stays silent and cannot claim it", async () => {
@@ -1622,7 +1681,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       mentions: [],
       root_id: "mid-unclaimed-root",
       thread_id: "omt-unclaimed",
-    });
+    }, "ou_user_1", "user");
     const lark = makeLarkClient();
 
     await handleLarkMessage(
@@ -1638,7 +1697,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       "ou_user_1",
       "lark_thread:mid-unclaimed-root",
       true,
-      undefined,
+      "user",
     );
     expect(lark.im.message.reply).not.toHaveBeenCalled();
     expect(promptMock).not.toHaveBeenCalled();
@@ -1688,6 +1747,321 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     expect(resolveBindingMock).not.toHaveBeenCalled();
   });
 
+  it("does not treat an unmentioned group root as a two-party Topic", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      contextMode: "topic",
+      sessionKey: "lark_thread:mid-1",
+    }));
+    const lark = makeTopicLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("你好", { chat_type: "group", mentions: [] }, "ou_user_1", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+    expect(lark.im.message.list).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a one-human/one-bot Topic follow-up even when the containing group has many members", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      contextMode: "topic",
+      sessionKey: "lark_thread:mid-live-root",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    // Live Feishu shape from the failing 12:15 Topic: the group roster is not
+    // usable, while the Topic history contains exactly the asker and this app.
+    const lark = makeLarkClient([
+      { message_id: "mid-bot-card", sender: { id: "cli_siclaw", sender_type: "app" } },
+      { message_id: "mid-live-followup", sender: { id: "ou_user_1", sender_type: "user" } },
+    ], {
+      message_id: "mid-live-root",
+      sender: { id: "ou_user_1", sender_type: "user" },
+    });
+
+    await handleLarkMessage(
+      makeTextEvent("你好", {
+        message_id: "mid-live-followup",
+        chat_type: "group",
+        mentions: [],
+        root_id: "mid-live-root",
+        thread_id: "omt-live-topic",
+      }, "ou_user_1", "user"),
+      lark,
+      "lark",
+      makeAgentBoxManager() as any,
+      undefined,
+      {} as any,
+      "zh-CN",
+      { app_id: "cli_siclaw", app_secret: "secret" },
+      BOT,
+    );
+
+    expect(lark.im.message.list).toHaveBeenCalledWith({
+      params: expect.objectContaining({
+        container_id_type: "thread",
+        container_id: "omt-live-topic",
+      }),
+    });
+    expect(lark.im.message.get).toHaveBeenCalledWith({
+      path: { message_id: "mid-live-root" },
+    });
+    expect(promptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats @all in a claimed one-human/one-bot Topic as an unmentioned human follow-up", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      contextMode: "topic",
+      sessionKey: "lark_thread:mid-root",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    const lark = makeTopicLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("@_all 继续", {
+        message_id: "mid-topic-at-all",
+        chat_type: "group",
+        mentions: [{ key: "@_all", id: {} }],
+        root_id: "mid-root",
+        thread_id: "omt-topic",
+      }, "ou_user_1", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(lark.im.message.get).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.list).toHaveBeenCalledTimes(1);
+    expect(promptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("revalidates Topic participants before every unmentioned turn", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({
+      contextMode: "topic",
+      sessionKey: "lark_thread:mid-1",
+    }));
+    promptMock.mockResolvedValue({ sessionId: "session-fixed" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    const lark = makeTopicLarkClient();
+    lark.im.message.list
+      .mockResolvedValueOnce({ data: { items: [
+        { sender: { id: "ou_user_1", sender_type: "user" } },
+        { sender: { id: "x", sender_type: "app" } },
+      ], has_more: false } })
+      .mockResolvedValueOnce({ data: { items: [
+        { sender: { id: "ou_user_1", sender_type: "user" } },
+        { sender: { id: "ou_user_2", sender_type: "user" } },
+        { sender: { id: "x", sender_type: "app" } },
+      ], has_more: false } });
+
+    await handleLarkMessage(
+      makeTextEvent("第一条", {
+        message_id: "mid-followup-1", chat_type: "group", mentions: [],
+        root_id: "mid-1", thread_id: "omt-topic-1",
+      }, "ou_user_1", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+    await handleLarkMessage(
+      makeTextEvent("第二个人加入后的下一条", {
+        message_id: "mid-followup-2", chat_type: "group", mentions: [],
+        root_id: "mid-1", thread_id: "omt-topic-1",
+      }, "ou_user_1", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(lark.im.message.list).toHaveBeenCalledTimes(2);
+    expect(promptMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when Topic history is unavailable", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const lark = makeLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("你好", {
+        message_id: "mid-followup", chat_type: "group", mentions: [],
+        root_id: "mid-root", thread_id: "omt-topic",
+      }, "ou_user_1", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(resolveBindingMock).toHaveBeenCalledTimes(1);
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps Personal mode mention-gated inside a one-human/one-bot Topic", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "per_user" }));
+    const manager = makeAgentBoxManager();
+    const data = makeTextEvent("你好", {
+      message_id: "mid-followup",
+      chat_type: "group",
+      mentions: [],
+      root_id: "mid-root",
+      thread_id: "omt-topic",
+    }, "ou_user_1", "user");
+    const lark = makeTopicLarkClient();
+
+    await handleLarkMessage(data, lark, "lark", manager as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT);
+
+    expect(resolveBindingMock).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.list).not.toHaveBeenCalled();
+    expect(manager.getOrCreate).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps Team mode passive inside a one-human/one-bot Topic", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "shared" }));
+    const manager = makeAgentBoxManager();
+    const data = makeTextEvent("你好", {
+      message_id: "mid-followup",
+      chat_type: "group",
+      mentions: [],
+      root_id: "mid-root",
+      thread_id: "omt-topic",
+    }, "ou_user_1", "user");
+    const lark = makeTopicLarkClient();
+
+    await handleLarkMessage(data, lark, "lark", manager as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT);
+
+    expect(resolveBindingMock).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.list).not.toHaveBeenCalled();
+    expect(manager.getOrCreate).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("requires @ when Topic history contains two humans and this bot", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const data = makeTextEvent("继续", {
+      message_id: "mid-topic-followup",
+      chat_type: "group",
+      root_id: "mid-root",
+      thread_id: "omt-topic",
+      mentions: [],
+    }, "ou_user_1", "user");
+
+    const lark = makeTopicLarkClient(["ou_user_1", "ou_user_2"]);
+    await handleLarkMessage(data, lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT);
+
+    expect(resolveBindingMock).toHaveBeenCalledTimes(1);
+    expect(lark.im.message.list).toHaveBeenCalledTimes(1);
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("requires @ on the first reply from a second human even though thread history omits the root", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const lark = makeTopicLarkClient(["ou_user_1"]);
+
+    await handleLarkMessage(
+      makeTextEvent("我也问一句", {
+        message_id: "mid-user-2", chat_type: "group", mentions: [],
+        root_id: "mid-root", thread_id: "omt-topic",
+      }, "ou_user_2", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(lark.im.message.get).toHaveBeenCalledTimes(1);
+    // currentSenderOpenId + root sender already proves two humans, so no reply
+    // page is needed to fail closed.
+    expect(lark.im.message.list).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("requires @ when another app has participated in the Topic", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const lark = makeTopicLarkClient(["ou_user_1"], ["x", "cli_other_bot"]);
+
+    await handleLarkMessage(
+      makeTextEvent("继续", {
+        message_id: "mid-followup", chat_type: "group", mentions: [],
+        root_id: "mid-root", thread_id: "omt-topic",
+      }, "ou_user_1", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(lark.im.message.list).toHaveBeenCalledTimes(1);
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("scans every Topic-history page before allowing a no-mention turn", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const lark = makeTopicLarkClient();
+    lark.im.message.list
+      .mockResolvedValueOnce({ data: {
+        items: [{ sender: { id: "x", sender_type: "app" } }],
+        has_more: true,
+        page_token: "page-2",
+      } })
+      .mockResolvedValueOnce({ data: {
+        items: [{ sender: { id: "ou_user_2", sender_type: "user" } }],
+        has_more: false,
+      } });
+
+    await handleLarkMessage(
+      makeTextEvent("继续", {
+        message_id: "mid-followup", chat_type: "group", mentions: [],
+        root_id: "mid-root", thread_id: "omt-topic",
+      }, "ou_user_1", "user"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(lark.im.message.list).toHaveBeenCalledTimes(2);
+    expect(lark.im.message.list.mock.calls[1][0].params.page_token).toBe("page-2");
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("never lets an unmentioned app sender wake the Topic agent", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const lark = makeTopicLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("bot chatter", {
+        message_id: "mid-other-app", chat_type: "group", mentions: [],
+        root_id: "mid-root", thread_id: "omt-topic",
+      }, "ou_other_bot", "app"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+    expect(lark.im.message.get).not.toHaveBeenCalled();
+    expect(lark.im.message.list).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it("requires @ when an unmentioned Topic event omits sender_type", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding({ contextMode: "topic" }));
+    const lark = makeTopicLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("继续", {
+        message_id: "mid-missing-sender-type",
+        chat_type: "group",
+        mentions: [],
+        root_id: "mid-root",
+        thread_id: "omt-topic",
+      }, "ou_user_1"),
+      lark, "lark", makeAgentBoxManager() as any, undefined, {} as any,
+      "zh-CN", { app_id: "x", app_secret: "y" }, BOT,
+    );
+
+    expect(resolveBindingMock).not.toHaveBeenCalled();
+    expect(lark.im.message.get).not.toHaveBeenCalled();
+    expect(lark.im.message.list).not.toHaveBeenCalled();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
   it("/mode resolves only the group mode and does not allocate a topic session", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "shared-session",
@@ -1720,7 +2094,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
     );
   });
 
-  it("personal mode always creates a topic reply and accepts an unmentioned follow-up in the same root", async () => {
+  it("Personal mode creates a Topic reply but still requires @ on follow-ups", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding({
       sessionId: "thread-session",
       sessionKey: "open_id:ou_user_1:lark_thread:mid-1",
@@ -1756,7 +2130,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         root_id: "mid-1",
         thread_id: "omt-topic-1",
         mentions: [],
-      }),
+      }, "ou_user_1", "user"),
       followupClient,
       "lark",
       makeAgentBoxManager("a1") as any,
@@ -1767,12 +2141,8 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       BOT,
     );
 
-    expect(promptMock.mock.calls.map((call) => call[0].sessionId)).toEqual([
-      "thread-session",
-      "thread-session",
-    ]);
+    expect(promptMock.mock.calls.map((call) => call[0].sessionId)).toEqual(["thread-session"]);
     expect(resolveBindingMock.mock.calls.map((call) => call[5])).toEqual([
-      "lark_thread:mid-1",
       "lark_thread:mid-1",
       "lark_thread:mid-1",
       "lark_thread:mid-1",
@@ -1781,19 +2151,13 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       false,
       false,
       true,
-      true,
     ]);
     expect(rootClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
-    expect(followupClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
+    expect(followupClient.im.message.reply).not.toHaveBeenCalled();
     expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({
       metadata: expect.objectContaining({
         conversationKey: "lark_thread:mid-1",
         rootMessageId: "mid-1",
-      }),
-    }));
-    expect(appendMessageMock).toHaveBeenCalledWith(expect.objectContaining({
-      metadata: expect.objectContaining({
-        threadId: "omt-topic-1",
       }),
     }));
   });
@@ -1844,8 +2208,8 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         chat_type: "group",
         root_id: "mid-1",
         thread_id: "omt-topic-1",
-        mentions: [],
-      }, "ou_user_2"),
+        mentions: [{ key: "@_user_1", id: { open_id: BOT } }],
+      }, "ou_user_2", "user"),
       followupClient,
       "lark",
       makeAgentBoxManager("a1") as any,
@@ -1864,7 +2228,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         root_id: "mid-other",
         thread_id: "omt-topic-other",
         mentions: [],
-      }, "ou_user_2"),
+      }, "ou_user_2", "user"),
       unrelatedClient,
       "lark",
       makeAgentBoxManager("a1") as any,
@@ -1886,8 +2250,8 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       "open_id:ou_user_2",
       "ou_user_2",
       "lark_thread:mid-1",
-      true,
-      undefined,
+      false,
+      "user",
     );
     expect(resolveBindingMock).toHaveBeenCalledWith(
       "lark",
@@ -1897,7 +2261,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       "ou_user_2",
       "lark_thread:mid-other",
       true,
-      undefined,
+      "user",
     );
     expect(rootClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
     expect(followupClient.im.message.reply.mock.calls[0][0].data.reply_in_thread).toBe(true);
@@ -2066,7 +2430,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
         root_id: "mid-unrelated-root",
         thread_id: "omt-unrelated",
         mentions: [],
-      }),
+      }, "ou_user_1", "user"),
       lark,
       "lark",
       makeAgentBoxManager("a1") as any,
@@ -2085,7 +2449,7 @@ describe("handleLarkMessage — group @-mention gating (@所有人 bug)", () => 
       "ou_user_1",
       "lark_thread:mid-unrelated-root",
       true,
-      undefined,   // sender_type — absent on a plain user event
+      "user",
     );
     expect(promptMock).not.toHaveBeenCalled();
     expect(lark.im.message.reply).not.toHaveBeenCalled();
@@ -3735,6 +4099,26 @@ describe("handleLarkMessage — inbound images", () => {
 });
 
 describe("extractInbound — post receive shapes", () => {
+  it("parses a Feishu code_block post instead of silently dropping the turn", () => {
+    const message = {
+      message_type: "post",
+      content: JSON.stringify({
+        content: [[{ tag: "code_block", language: "PLAIN_TEXT", text: "你好-验收-adba021f\n" }]],
+      }),
+    };
+    const { text, imageRefs } = extractInbound(message);
+    expect(text).toBe("你好-验收-adba021f");
+    expect(imageRefs).toEqual([]);
+  });
+
+  it("parses a standalone md node in a Feishu post", () => {
+    const message = {
+      message_type: "post",
+      content: JSON.stringify({ content: [[{ tag: "md", text: "**hello**" }]] }),
+    };
+    expect(extractInbound(message).text).toBe("**hello**");
+  });
+
   it("parses locale-nested post content instead of silently dropping it", () => {
     const message = {
       message_type: "post",

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -264,6 +264,8 @@ const PERSONAL_DENIAL_MESSAGE_MAX_CHARS = 1000;
 // to keep memory flat if an agent over-emits.
 const MILESTONE_CAP = 20;
 const MAX_LARK_BINDING_QUEUE = 20;
+const TOPIC_PARTICIPANT_PAGE_SIZE = 50;
+const TOPIC_PARTICIPANT_MAX_PAGES = 100;
 
 interface QueuedLarkTask {
   run: () => Promise<void>;
@@ -486,9 +488,10 @@ function getLarkSenderOpenId(data: any): string | null {
  * control the vocabulary, and a value we have not seen before must reach the
  * Portal intact instead of being flattened into "not a user".
  *
- * Nothing in this file branches on it. It exists so the Portal can tell a bot
- * from a person at all — until now it received only an open_id, which an app
- * sender may not even have, leaving "a bot wrote this" and "we could not
+ * No-mention Topic activation additionally requires the exact value "user";
+ * missing or unknown values fail closed. Other routes pass the value through
+ * so the Portal can distinguish a bot from a person — an app sender may not
+ * even have an open_id, otherwise leaving "a bot wrote this" and "we could not
  * identify the writer" indistinguishable.
  */
 function getLarkSenderType(data: any): string | null {
@@ -517,6 +520,100 @@ async function fetchLarkChatName(larkClient: any, chatId: string): Promise<strin
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[lark] Could not fetch chat name for chat=${chatId}: ${msg}`);
     return null;
+  }
+}
+
+/**
+ * Verify the participants of one Feishu Topic, not the roster of its parent
+ * group. An established Topic may omit @ only while its complete history shows
+ * one human sender and no app other than this Siclaw app. The current event is
+ * added explicitly because the history API can be briefly eventually
+ * consistent immediately after delivery.
+ *
+ * Every malformed, incomplete, overlong, or failed lookup requires @. The
+ * positive result is deliberately not cached: a second participant must take
+ * effect on the very next turn.
+ */
+async function topicHasOneHumanAndThisBot(
+  larkClient: any,
+  threadId: string,
+  rootMessageId: string,
+  currentSenderOpenId: string,
+  siclawAppId: string,
+): Promise<boolean> {
+  const humanIds = new Set<string>([currentSenderOpenId]);
+  const appIds = new Set<string>();
+  let pageToken: string | undefined;
+  const seenPageTokens = new Set<string>();
+
+  try {
+    const addSender = (item: any): boolean => {
+      const senderId = item?.sender?.id;
+      const senderType = item?.sender?.sender_type;
+      if (typeof senderId !== "string" || !senderId.trim()
+        || typeof senderType !== "string" || !senderType.trim()) {
+        throw new Error("message sender identity unavailable");
+      }
+      if (senderType === "user") humanIds.add(senderId);
+      else if (senderType === "app") appIds.add(senderId);
+      else throw new Error(`unsupported sender_type=${senderType}`);
+      return humanIds.size <= 1 && [...appIds].every((id) => id === siclawAppId);
+    };
+
+    // Feishu's thread container contains replies only. Fetch the root message
+    // separately or a Topic started by user A and first answered by user B
+    // would look like a one-human Topic and be incorrectly activated.
+    const rootResp: any = await larkClient.im.message.get({
+      path: { message_id: rootMessageId },
+    });
+    if (typeof rootResp?.code === "number" && rootResp.code !== 0) {
+      throw new Error(`Feishu root code=${rootResp.code} msg=${rootResp?.msg ?? "unknown"}`);
+    }
+    const rootItems = rootResp?.data?.items;
+    if (!Array.isArray(rootItems) || rootItems.length !== 1) {
+      throw new Error("root message unavailable");
+    }
+    if (!addSender(rootItems[0])) {
+      console.log(`[lark] Topic participant gate requires @bot thread=${threadId} humans=${humanIds.size} apps=${appIds.size}`);
+      return false;
+    }
+
+    for (let page = 0; page < TOPIC_PARTICIPANT_MAX_PAGES; page += 1) {
+      const resp: any = await larkClient.im.message.list({
+        params: {
+          container_id_type: "thread",
+          container_id: threadId,
+          sort_type: "ByCreateTimeAsc",
+          page_size: TOPIC_PARTICIPANT_PAGE_SIZE,
+          ...(pageToken ? { page_token: pageToken } : {}),
+        },
+      });
+      if (typeof resp?.code === "number" && resp.code !== 0) {
+        throw new Error(`Feishu code=${resp.code} msg=${resp?.msg ?? "unknown"}`);
+      }
+      const items = resp?.data?.items;
+      if (!Array.isArray(items)) throw new Error("missing data.items");
+
+      for (const item of items) {
+        if (!addSender(item)) {
+          console.log(`[lark] Topic participant gate requires @bot thread=${threadId} humans=${humanIds.size} apps=${appIds.size}`);
+          return false;
+        }
+      }
+
+      if (!resp?.data?.has_more) return humanIds.size === 1;
+      const next = resp?.data?.page_token;
+      if (typeof next !== "string" || !next.trim() || seenPageTokens.has(next)) {
+        throw new Error("invalid pagination state");
+      }
+      seenPageTokens.add(next);
+      pageToken = next;
+    }
+    throw new Error(`topic history exceeds ${TOPIC_PARTICIPANT_MAX_PAGES} pages`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[lark] Could not verify Topic participants thread=${threadId}; requiring @bot: ${msg}`);
+    return false;
   }
 }
 
@@ -586,13 +683,13 @@ const MODE_ANNOUNCE_BY_LOCALE: Record<LarkLocale, (m: GroupContextMode) => strin
     m === "shared"
       ? `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].shared};之后大家的消息按全群共享处理。`
       : m === "topic"
-        ? `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].topic};首次 @ 机器人会认领一个话题,之后已授权成员在该话题内无需再次 @,其他话题不受影响。`
+        ? `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].topic};首次 @ 机器人会认领一个话题。该话题仅有一名真人和本机器人时可直接续聊;出现其他真人或机器人后,每次调用都需要 @。`
         : `本群已切换为${MODE_LABEL_BY_LOCALE["zh-CN"].per_user};之后每个人各自独立对话。`,
   "en-US": (m) =>
     m === "shared"
       ? `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].shared}; messages are handled as one shared conversation.`
       : m === "topic"
-        ? `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].topic}; the first @bot message claims a Topic, then authorized participants can continue there without another mention while other Topics stay separate.`
+        ? `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].topic}; the first @bot message claims a Topic. Follow-ups may omit @ only while that Topic contains one human and this bot; once another human or bot participates, every Agent turn requires @.`
         : `This group is now in ${MODE_LABEL_BY_LOCALE["en-US"].per_user}; each person now talks to the bot separately.`,
 };
 
@@ -790,7 +887,8 @@ const IMAGE_ONLY_PLACEHOLDER = "[image]";
  *   - text  → `content.text`
  *   - image → `content.image_key`
  *   - post  → rich text whose `content` is a `Node[][]` (array of paragraphs of
- *             nodes); flatten and split by `tag`: img → image_key, text → text.
+ *             nodes); flatten and split by `tag`: img → image_key,
+ *             text/link/markdown/code block → text.
  *
  * Unknown types yield empty text + no refs (caller drops them).
  */
@@ -826,7 +924,9 @@ export function extractInbound(message: any): { text: string; imageRefs: LarkIma
     for (const node of paragraphs.flat()) {
       if (node?.tag === "img" && typeof node?.image_key === "string") {
         imageRefs.push({ imageKey: node.image_key });
-      } else if ((node?.tag === "text" || node?.tag === "a") && typeof node?.text === "string") {
+      } else if ((node?.tag === "text" || node?.tag === "a"
+        || node?.tag === "md" || node?.tag === "code_block")
+        && typeof node?.text === "string") {
         textParts.push(node.text);
       }
       // A hyperlink's href may itself be an image URL — surface it so the unified
@@ -1407,22 +1507,20 @@ export async function handleLarkMessage(
   const isThreadFollowup = isGroupMessage && threadId !== null && rootMessageId !== messageId;
 
   // /mode — summon the context-mode switch card. Command words are exact, and
-  // the bot must be @-mentioned: this switches the mode for the WHOLE group, and
-  // nothing in the pipeline checks who the sender is (Feishu reports app senders
-  // the same way it reports people, sometimes without any id at all). Handling it
-  // before the @-gate meant any group member — or any other BOT in the room —
-  // could reconfigure the group by typing two words at nobody in particular.
-  // Requiring that costs the sender four characters and makes the change an act
-  // aimed at us. A follow-up inside a topic WE opened counts too — it is already
-  // scoped to a conversation the bot owns, and inside a topic people rightly stop
-  // @-ing. Without that second arm, `/mode` in a topic would fall past the @-gate
-  // (thread follow-ups are allowed through) and reach the model as a prompt.
+  // the message must pass the same explicit-mention/two-party Topic gate as an
+  // ordinary turn: this switches the mode for the WHOLE group and must not be
+  // triggered by ambient discussion. Handling it before mention gating meant
+  // any group member — or any other BOT in the room — could reconfigure the
+  // group by typing two words at nobody in particular. Only a follow-up inside
+  // an already-claimed Topic with one human and this app may omit @.
   // PAIR stays exempt: it carries its own one-time code.
-  if (/^\/mode$/i.test(text.trim()) && (botMentioned || isThreadFollowup)) {
+  if (/^\/mode$/i.test(text.trim())) {
+    if (!botMentioned && (!isThreadFollowup || senderType !== "user"
+      || !senderOpenId || !threadId || !channelConfig?.app_id)) return;
     // A no-mention command inherits the same claim boundary as ordinary Topic
     // follow-ups: it may reuse an established bot Topic but must never create
     // state or answer inside an unrelated Topic.
-    const modeExistingOnly = isThreadFollowup && !botMentioned;
+    const modeExistingOnly = !botMentioned;
     const modeBinding = await resolveBinding(
       groupChannelId,
       chatId,
@@ -1444,6 +1542,14 @@ export async function handleLarkMessage(
       return;
     }
     const current = normalizeGroupContextMode(modeBinding.contextMode);
+    if (!botMentioned && current !== "topic") return;
+    if (!botMentioned && !await topicHasOneHumanAndThisBot(
+      larkClient,
+      threadId!,
+      rootMessageId,
+      senderOpenId!,
+      channelConfig!.app_id,
+    )) return;
     // /mode changes the whole group. Keep a root invocation visible on the
     // main-group path; only retain the card inside an already-established Topic.
     const modeReplyInThread = isThreadFollowup && current !== "shared";
@@ -1455,16 +1561,17 @@ export async function handleLarkMessage(
     return;
   }
 
-  // Only respond when THIS bot is individually @-mentioned, except inside a
-  // Topic that Personal or Topic mode already scoped to a root message. Feishu also
-  // delivers "@所有人" to an @bot-scoped app (it mentions everyone, the bot
-  // included), so an @所有人 announcement arrives looking just like a real
-  // @bot — without this gate the bot replies to group-wide announcements that
-  // were never aimed at it. Skips "@所有人" and "@someone-else"; PAIR above is
-  // exempt (explicit command). Gated on chat_type==="group" so the binding/
-  // access checks below stay reachable only for messages aimed at the bot.
-  const conversationExistingOnly = isThreadFollowup && !botMentioned;
-  if (chatType === "group" && !botMentioned) {
+  // Only Topic mode may omit @, and only when Feishu currently proves the
+  // Topic history consists of one human plus this app. The containing GROUP's
+  // roster is irrelevant: a large group can still have a two-party Topic.
+  // Personal/Team modes still require @ to run the agent. Larger/unknown Topics
+  // require @ on every turn.
+  // Feishu also delivers "@所有人" to an @bot-scoped app, so the individual-
+  // mention check remains necessary. PAIR above stays exempt.
+  const unmentionedGroupMessage = chatType === "group" && !botMentioned;
+  const conversationExistingOnly = unmentionedGroupMessage && isThreadFollowup;
+  let binding: ResolvedChannelBinding | ChannelAccessDenied | null | undefined;
+  if (unmentionedGroupMessage) {
     // Non-@ group message. In a group KNOWN to be shared, retain it as passive
     // discussion context for the next @-turn — WITHOUT running the agent or
     // touching the AgentBox (idle pods must not be woken by group chatter).
@@ -1477,15 +1584,51 @@ export async function handleLarkMessage(
       console.log(`[lark] Buffered non-@ discussion for shared group chat=${chatId}`);
       return;
     }
-    if (!isThreadFollowup) {
-      console.log(`[lark] Group message not directed at bot (chat=${chatId}) — ignoring (@所有人 / @others / no @bot)`);
+    // No-@ activation is strictly a human follow-up in a real Feishu Topic.
+    // Root messages, quote replies (root_id without thread_id), app senders,
+    // and events with missing identities stay silent.
+    if (!isThreadFollowup || senderType !== "user" || !senderOpenId
+      || !threadId || !channelConfig?.app_id) {
+      console.log(`[lark] Group message not directed at bot (chat=${chatId}) — ignoring (@ required outside a claimed two-party Topic)`);
       return;
     }
+
+    // Resolve BEFORE reading Topic history. The server-authoritative binding
+    // proves that this provider Topic was already claimed by the bot and that
+    // its current mode is Topic; unrelated Topics remain silent and incur no
+    // history scan beyond this existing-only lookup.
+    binding = await resolveBinding(
+      groupChannelId,
+      chatId,
+      frontendClient!,
+      sessionKey,
+      senderOpenId ?? undefined,
+      topicConversationKey,
+      conversationExistingOnly,
+      senderType ?? undefined,
+    );
+    if (isChannelAccessDenied(binding) || !binding) return;
+    const candidateMode = normalizeGroupContextMode(binding.contextMode);
+    if (candidateMode !== "topic") {
+      rememberGroupMode(groupChannelId, chatId, candidateMode);
+      if (candidateMode === "shared" && text.length > 0) {
+        appendDiscussion(groupChannelId, chatId, senderLabel(senderOpenId), text);
+        console.log(`[lark] Buffered non-@ discussion after resolving shared group chat=${chatId}`);
+      }
+      return;
+    }
+    if (!await topicHasOneHumanAndThisBot(
+      larkClient,
+      threadId,
+      rootMessageId,
+      senderOpenId,
+      channelConfig.app_id,
+    )) return;
   }
 
   // Look up binding for this chat. Pass sender_open_id so the Portal can
   // auto-bind / per-sender resolve group bots and pick the session key.
-  const binding = await resolveBinding(
+  binding ??= await resolveBinding(
     groupChannelId,
     chatId,
     frontendClient!,
@@ -1499,7 +1642,7 @@ export async function handleLarkMessage(
     // A no-@ Topic/quote follow-up is never an authorization prompt. If the
     // server cannot reuse an existing authorized topic session, stay silent;
     // explicit @ messages still receive the normal access hint.
-    if (conversationExistingOnly) return;
+    if (unmentionedGroupMessage) return;
     // Gated group: this sender isn't allowed. The message is either an explicit @ or a follow-up
     // in a previously established bot topic, so a single short hint is appropriate.
     await replyToLark(larkClient, messageId, formatGroupAccessDeniedReply(binding, locale, dmCanResolveAccess(personalBot)));
@@ -1535,17 +1678,6 @@ export async function handleLarkMessage(
   const cachedMode = cachedGroupMode(groupChannelId, chatId);
   if (cachedMode && cachedMode !== contextMode) forgetGroupState(groupChannelId, chatId);
   rememberGroupMode(groupChannelId, chatId, contextMode);
-
-  // A no-@ message inside a Feishu Topic is a continuation in Personal or Topic
-  // mode. Team mode deliberately stays on the old main-group path; an
-  // unrelated/manual topic must not wake the shared Agent session.
-  if (isThreadFollowup && !botMentioned && contextMode === "shared") {
-    if (text.length > 0) {
-      appendDiscussion(groupChannelId, chatId, senderLabel(senderOpenId), text);
-      console.log(`[lark] Buffered no-@ topic discussion after resolving shared group chat=${chatId}`);
-    }
-    return;
-  }
 
   const topicScopedMode = isGroupMessage && contextMode !== "shared";
   const conversationKey = topicScopedMode ? topicConversationKey : undefined;


### PR DESCRIPTION
## Summary
- allow an unmentioned human follow-up only in Topic mode and only inside an already-claimed Feishu Topic
- verify the Topic participant set from its root plus every paginated reply; allow only exactly one human and this Siclaw app, regardless of the parent group roster
- require an explicit bot mention when another human or app participates, sender identity is unknown, history is malformed or unavailable, pagination is invalid, or the Topic exceeds 100 pages of 50 replies
- keep Personal and Team Agent turns mention-gated, apply the same Topic gate to `/mode`, and treat `@all` as an unmentioned human follow-up inside an otherwise eligible Topic
- preserve rich-post Markdown and code-block content while parsing Feishu messages

## Validation
- `npx vitest run src/gateway/channels/lark.test.ts` (238 passed)
- `npm run build`
- `git diff --check`
- GitHub CI