### PR TITLE
build: remove legacy KBC image alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Renamed the KB compile box so operators can tell it apart from chat agentboxes a
 - **Image rename**: `kbc-compile-box` → `siclaw-kbc-box` (Makefile build/push targets, helm `siclaw.compileBoxImage` derivation, Dockerfile/README/docs). `agentbox.compileBoxImage` explicit-override semantics are unchanged.
 - **Pod-name prefix**: compile boxes now spawn as `kbc-box-<id>` instead of `agentbox-<id>`, declared on the BoxProfile (`podNamePrefix`) for the `kb-compile` / `kb-compile-codex` profiles. Derived resources (cert Secret, hostname) follow the prefix. Chat agentboxes and the read-only `kb-test` box keep the `agentbox-` prefix.
 - **Upgrade behavior**: on the first compile spawn after upgrade, the spawner reaps any pod left under the old `agentbox-<id>` name for that agent (guarded to compile boxes only — a chat box under the same name is never touched), so the old and new pods do not coexist.
-- **Transition double-push**: `make push-kbc` republishes the same image digest under the legacy name `kbc-compile-box` for one release cycle so runtimes still pinned to the old name keep resolving. Remove the legacy tag/push next release.
+- **Legacy alias removed**: the one-release compatibility window has ended, so `make push-kbc` now publishes only `siclaw-kbc-box`. Runtimes and deployment overrides must no longer reference `kbc-compile-box`.
 - **DevOps action required**: the internal registry replication rule must gain an entry for `siclaw-kbc-box` (the old `kbc-compile-box` was not in the rule and had to be pushed manually). Until the rule is added, push `siclaw-kbc-box` to the production registry manually.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Renamed the KB compile box so operators can tell it apart from chat agentboxes a
 - **Image rename**: `kbc-compile-box` → `siclaw-kbc-box` (Makefile build/push targets, helm `siclaw.compileBoxImage` derivation, Dockerfile/README/docs). `agentbox.compileBoxImage` explicit-override semantics are unchanged.
 - **Pod-name prefix**: compile boxes now spawn as `kbc-box-<id>` instead of `agentbox-<id>`, declared on the BoxProfile (`podNamePrefix`) for the `kb-compile` / `kb-compile-codex` profiles. Derived resources (cert Secret, hostname) follow the prefix. Chat agentboxes and the read-only `kb-test` box keep the `agentbox-` prefix.
 - **Upgrade behavior**: on the first compile spawn after upgrade, the spawner reaps any pod left under the old `agentbox-<id>` name for that agent (guarded to compile boxes only — a chat box under the same name is never touched), so the old and new pods do not coexist.
-- **Legacy alias removed**: the one-release compatibility window has ended, so `make push-kbc` now publishes only `siclaw-kbc-box`. Runtimes and deployment overrides must no longer reference `kbc-compile-box`.
+- **Legacy alias retirement**: releases `v0.2.8` through `v0.3.10` published the KBC image under both repository names. Starting with the next release, `make push-kbc` publishes only `siclaw-kbc-box`; update any explicit `agentbox.compileBoxImage` or `SICLAW_COMPILE_BOX_IMAGE` override before upgrading.
 - **DevOps action required**: the internal registry replication rule must gain an entry for `siclaw-kbc-box` (the old `kbc-compile-box` was not in the rule and had to be pushed manually). Until the rule is added, push `siclaw-kbc-box` to the production registry manually.
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,6 @@ AGENTBOX_IMAGE = $(REGISTRY)/siclaw-agentbox:$(TAG)
 PORTAL_IMAGE   = $(REGISTRY)/siclaw-portal:$(TAG)
 OCR_IMAGE      = $(REGISTRY)/siclaw-ocr:$(TAG)
 KBC_IMAGE      = $(REGISTRY)/siclaw-kbc-box:$(TAG)
-# Transition alias (remove next release): the KB compile box's former name. The
-# push-kbc target double-pushes this same digest so runtimes still pinned to the
-# old name keep resolving during the rename window.
-KBC_LEGACY_IMAGE = $(REGISTRY)/kbc-compile-box:$(TAG)
 
 # ── OCI labels injected into every image ──
 DOCKER_LABELS = \
@@ -108,14 +104,8 @@ push-portal: ## Push portal image
 push-ocr: ## Push OCR backend image
 	docker push $(OCR_IMAGE)
 
-push-kbc: ## Push KB compile-box image siclaw-kbc-box (+ transition legacy alias)
+push-kbc: ## Push KB compile-box image siclaw-kbc-box
 	docker push $(KBC_IMAGE)
-	# Transition double-push (remove next release): republish the SAME digest under
-	# the legacy name kbc-compile-box so a runtime pinned to it during the rename
-	# window still resolves. Drop these two lines once all runtimes ship on the
-	# siclaw-kbc-box name.
-	docker tag $(KBC_IMAGE) $(KBC_LEGACY_IMAGE)
-	docker push $(KBC_LEGACY_IMAGE)
 
 # ==================== Test ====================
 ##@ Test
@@ -142,7 +132,6 @@ info: ## Print build variables
 	@echo "PORTAL:      $(PORTAL_IMAGE)"
 	@echo "OCR:         $(OCR_IMAGE)"
 	@echo "KBC:         $(KBC_IMAGE)"
-	@echo "KBC(legacy): $(KBC_LEGACY_IMAGE)"
 
 logs: ## View recent logs (all components)
 	@echo "=== Runtime ===" && \


### PR DESCRIPTION
## Summary

- stop republishing the KBC image under the retired `kbc-compile-box` repository name
- remove the legacy image from `make info`
- record that the compatibility window has ended

## Verification

- `make -n push-kbc REGISTRY=registry.example/team TAG=test-tag`
- `make -n push REGISTRY=registry.example/team TAG=test-tag`
- `make info REGISTRY=registry.example/team TAG=test-tag`
- `git diff --check`