### PR TITLE
feat(kbc): emit compiler attestation sidecar in standalone OKF packages

### DIFF
--- a/.github/workflows/kbc-ci.yml
+++ b/.github/workflows/kbc-ci.yml
@@ -47,6 +47,8 @@ jobs:
         working-directory: kbc/platform/pod
       - run: python test_okf_package.py
         working-directory: kbc/platform/pod
+      - run: python test_okf_attestation.py
+        working-directory: kbc/platform/pod
       - run: python test_incremental.py
         working-directory: kbc/platform/pod
       - run: python test_batching.py
@@ -60,4 +62,6 @@ jobs:
       - run: python test_mtls_auth.py
         working-directory: kbc/platform/pod
       - run: python test_emit.py
+        working-directory: kbc/tools
+      - run: python test_attach_okf_attestation.py
         working-directory: kbc/tools

--- a/kbc/platform/pod/fixtures/okf-attestation/conformance.json
+++ b/kbc/platform/pod/fixtures/okf-attestation/conformance.json
@@ -1,0 +1,210 @@
+{
+  "comment": "Shared OKF attestation conformance cases. This file must stay byte-identical between sicore internal/siclaw/knowledge/testdata/okf-attestation/conformance.json and siclaw kbc/platform/pod/fixtures/okf-attestation/conformance.json; each side's test pins its sha256. The bundle block is the ground truth the importer derives from the package itself; every case is validated against it.",
+  "bundle": {
+    "concept_pages": 2,
+    "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab"
+  },
+  "cases": [
+    {
+      "name": "clean_receipts_bound_to_payload",
+      "expect": "self_attested",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc", "version": "0.9.0"},
+        "input_revision": "sha256:a1b2c3",
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "coverage": {"closed": true, "cited": 4, "excluded": 1, "auto_attached": 0, "derived": 0, "unaccounted": 0, "dangling": 0},
+        "checks": [
+          {"name": "selfcheck", "status": "pass"},
+          {"name": "redblue", "status": "pass", "detail": "16/16 questions"}
+        ],
+        "signature": null
+      }
+    },
+    {
+      "name": "no_coverage_block_is_still_self_attested",
+      "expect": "self_attested",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "honest_check_failure_stays_unattested",
+      "expect": "unattested",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "fail", "detail": "2 pages unconverged"}]
+      }
+    },
+    {
+      "name": "open_coverage_honestly_reported_stays_unattested",
+      "expect": "unattested",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "coverage": {"closed": false, "cited": 4, "excluded": 1, "auto_attached": 0, "derived": 0, "unaccounted": 3, "dangling": 0},
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "coverage_closed_only_must_reject_not_zero_fill",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "coverage": {"closed": true},
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "coverage_missing_one_counter_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "coverage": {"closed": true, "cited": 4, "excluded": 1, "auto_attached": 0, "derived": 0, "unaccounted": 0},
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "payload_digest_mismatch_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "missing_payload_manifest_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "concept_pages_mismatch_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 37,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "closed_contradicting_counters_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "coverage": {"closed": true, "cited": 4, "excluded": 1, "auto_attached": 0, "derived": 0, "unaccounted": 5, "dangling": 0},
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "non_null_signature_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "pass"}],
+        "signature": "sig-bytes"
+      }
+    },
+    {
+      "name": "unknown_field_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "pass"}],
+        "extra": true
+      }
+    },
+    {
+      "name": "duplicate_check_names_reject",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [
+          {"name": "selfcheck", "status": "pass"},
+          {"name": "selfcheck", "status": "pass"}
+        ]
+      }
+    },
+    {
+      "name": "invalid_check_status_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "maybe"}]
+      }
+    },
+    {
+      "name": "empty_checks_reject",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": []
+      }
+    },
+    {
+      "name": "invalid_producer_name_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 1,
+        "producer": {"name": " "},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    },
+    {
+      "name": "unsupported_schema_version_rejects",
+      "expect": "reject",
+      "attestation": {
+        "schema_version": 9,
+        "producer": {"name": "siclaw-kbc"},
+        "concept_pages": 2,
+        "payload_manifest_sha256": "abababababababababababababababababababababababababababababababab",
+        "checks": [{"name": "selfcheck", "status": "pass"}]
+      }
+    }
+  ]
+}

--- a/kbc/platform/pod/okf_attestation.py
+++ b/kbc/platform/pod/okf_attestation.py
@@ -1,0 +1,194 @@
+"""Build and validate the .okf-attestation.json compiler-receipt sidecar.
+
+The sidecar makes compile-time verification receipts travel with the bundle:
+producer identity, the frozen input revision, the coverage ledger's summary,
+and named deterministic check results. The import side (sicore
+internal/siclaw/knowledge/okf_attestation.go) classifies bundles into
+"attested"/"unattested" from it and rejects receipts that contradict the
+bundle — this module mirrors that validation so a lying sidecar fails at
+packaging time, before an upload ever happens.
+
+Attestation is written by deterministic code about deterministic checks.
+The compile agent never authors it, for the same reason it may not write
+`verified`: a self-signed receipt is not a receipt.
+
+Pure stdlib on purpose, like selfcheck.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+ATTESTATION_SIDECAR = ".okf-attestation.json"
+ATTESTATION_SCHEMA_VERSION = 1
+MAX_ATTESTATION_CHECKS = 32
+
+TIER_UNATTESTED = "unattested"
+TIER_ATTESTED = "attested"
+
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_REVISION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9:._-]{0,127}$")
+_CHECK_STATUSES = ("pass", "warn", "fail")
+_COVERAGE_FIELDS = ("cited", "excluded", "auto_attached", "derived", "unaccounted", "dangling")
+_ALLOWED_KEYS = {
+    "schema_version", "producer", "input_revision", "concept_pages",
+    "coverage", "checks", "signature",
+}
+
+
+def _violation(kind: str, detail: str) -> dict:
+    return {"kind": kind, "detail": detail}
+
+
+def attestation_violations(doc: object, *, concept_pages: int) -> list[dict]:
+    """Mirror the importer's checks; [] means the sidecar would be accepted."""
+    if not isinstance(doc, dict):
+        return [_violation("attestation_shape", "attestation must be a JSON object")]
+    violations: list[dict] = []
+
+    unknown = sorted(set(doc) - _ALLOWED_KEYS)
+    if unknown:
+        violations.append(_violation("attestation_unknown_field", f"unknown fields: {', '.join(unknown)}"))
+    if doc.get("schema_version") != ATTESTATION_SCHEMA_VERSION:
+        violations.append(_violation(
+            "attestation_schema_version",
+            f"must declare schema_version {ATTESTATION_SCHEMA_VERSION}"))
+    if "signature" in doc and doc["signature"] is not None:
+        violations.append(_violation(
+            "attestation_signature",
+            "signatures are not supported yet; omit signature or set it to null"))
+
+    producer = doc.get("producer")
+    if not isinstance(producer, dict) or set(producer) - {"name", "version"}:
+        violations.append(_violation("attestation_producer", "producer must be {name[, version]}"))
+    else:
+        name = producer.get("name")
+        if not isinstance(name, str) or not _NAME_RE.match(name.strip()):
+            violations.append(_violation(
+                "attestation_producer", f"producer.name must match {_NAME_RE.pattern}"))
+        version = producer.get("version")
+        if version is not None and (not isinstance(version, str) or len(version) > 64):
+            violations.append(_violation(
+                "attestation_producer", "producer.version must be a string of at most 64 characters"))
+
+    revision = doc.get("input_revision")
+    if revision is not None and (not isinstance(revision, str) or not _REVISION_RE.match(revision.strip())):
+        violations.append(_violation(
+            "attestation_input_revision", f"input_revision must match {_REVISION_RE.pattern}"))
+
+    declared_pages = doc.get("concept_pages")
+    if not isinstance(declared_pages, int) or isinstance(declared_pages, bool):
+        violations.append(_violation("attestation_concept_pages", "concept_pages must be an integer"))
+    elif declared_pages != concept_pages:
+        violations.append(_violation(
+            "attestation_concept_pages",
+            f"concept_pages {declared_pages} does not match the bundle's {concept_pages} concept pages"))
+
+    checks = doc.get("checks")
+    if not isinstance(checks, list) or not 1 <= len(checks) <= MAX_ATTESTATION_CHECKS:
+        violations.append(_violation(
+            "attestation_checks", f"must declare 1-{MAX_ATTESTATION_CHECKS} checks"))
+    else:
+        seen: set[str] = set()
+        for index, check in enumerate(checks):
+            if not isinstance(check, dict) or set(check) - {"name", "status", "detail"}:
+                violations.append(_violation(
+                    "attestation_checks", f"checks[{index}] must be {{name, status[, detail]}}"))
+                continue
+            name = check.get("name")
+            if not isinstance(name, str) or not _NAME_RE.match(name.strip()):
+                violations.append(_violation(
+                    "attestation_checks", f"checks[{index}].name must match {_NAME_RE.pattern}"))
+            elif name.strip() in seen:
+                violations.append(_violation(
+                    "attestation_checks", f"checks[{index}] duplicates check {name.strip()!r}"))
+            else:
+                seen.add(name.strip())
+            if check.get("status") not in _CHECK_STATUSES:
+                violations.append(_violation(
+                    "attestation_checks", f"checks[{index}].status must be pass, warn, or fail"))
+            detail = check.get("detail")
+            if detail is not None and (not isinstance(detail, str) or len(detail) > 500):
+                violations.append(_violation(
+                    "attestation_checks", f"checks[{index}].detail must be at most 500 characters"))
+
+    coverage = doc.get("coverage")
+    if coverage is not None:
+        if not isinstance(coverage, dict) or set(coverage) - ({"closed"} | set(_COVERAGE_FIELDS)):
+            violations.append(_violation(
+                "attestation_coverage", "coverage must be {closed, cited, excluded, auto_attached, derived, unaccounted, dangling}"))
+        else:
+            counters_ok = True
+            for field in _COVERAGE_FIELDS:
+                count = coverage.get(field)
+                if not isinstance(count, int) or isinstance(count, bool) or not 0 <= count <= 1_000_000:
+                    violations.append(_violation(
+                        "attestation_coverage", f"coverage.{field} must be between 0 and 1000000"))
+                    counters_ok = False
+            closed = coverage.get("closed")
+            if not isinstance(closed, bool):
+                violations.append(_violation("attestation_coverage", "coverage.closed must be a boolean"))
+            elif counters_ok and closed != (
+                coverage.get("unaccounted") == 0 and coverage.get("dangling") == 0
+            ):
+                # The headline claim and its own arithmetic must agree, or the
+                # attestation is lying to one audience.
+                violations.append(_violation(
+                    "attestation_coverage", "coverage.closed contradicts its own counters"))
+
+    return violations
+
+
+def classify_tier(doc: dict) -> str:
+    """Tier for a doc that already passed attestation_violations."""
+    failing = any(check.get("status") == "fail" for check in doc.get("checks", []))
+    coverage = doc.get("coverage")
+    coverage_closed = coverage is None or bool(coverage.get("closed"))
+    if not failing and coverage_closed:
+        return TIER_ATTESTED
+    return TIER_UNATTESTED
+
+
+def build_attestation(
+    *,
+    producer_name: str,
+    concept_pages: int,
+    checks: list[dict],
+    producer_version: str | None = None,
+    coverage: dict | None = None,
+    input_revision: str | None = None,
+) -> dict:
+    """Return a canonical attestation dict, refusing to build an invalid one."""
+    producer: dict = {"name": producer_name}
+    if producer_version is not None:
+        producer["version"] = producer_version
+    doc: dict = {
+        "schema_version": ATTESTATION_SCHEMA_VERSION,
+        "producer": producer,
+        "concept_pages": concept_pages,
+        "checks": checks,
+        "signature": None,
+    }
+    if input_revision is not None:
+        doc["input_revision"] = input_revision
+    if coverage is not None:
+        doc["coverage"] = coverage
+    violations = attestation_violations(doc, concept_pages=concept_pages)
+    if violations:
+        raise ValueError(
+            "refusing to build an invalid attestation: "
+            + "; ".join(item["detail"] for item in violations)
+        )
+    return doc
+
+
+def parse_attestation(body: bytes | str) -> object:
+    """Parse sidecar bytes; a non-object result is reported by validation."""
+    if isinstance(body, bytes):
+        body = body.decode("utf-8")
+    return json.loads(body)
+
+
+def render_attestation(doc: dict) -> str:
+    return json.dumps(doc, ensure_ascii=False, indent=2, sort_keys=True) + "\n"

--- a/kbc/platform/pod/okf_attestation.py
+++ b/kbc/platform/pod/okf_attestation.py
@@ -2,11 +2,18 @@
 
 The sidecar makes compile-time verification receipts travel with the bundle:
 producer identity, the frozen input revision, the coverage ledger's summary,
-and named deterministic check results. The import side (sicore
-internal/siclaw/knowledge/okf_attestation.go) classifies bundles into
-"attested"/"unattested" from it and rejects receipts that contradict the
-bundle — this module mirrors that validation so a lying sidecar fails at
-packaging time, before an upload ever happens.
+and named deterministic check results. The mandatory payload_manifest_sha256
+binds the receipts to the exact bytes being packaged, so a receipt cannot be
+replayed onto edited content. The producer identity itself is NOT verified
+(signature is a reserved v2 slot) — which is why the resulting tier is called
+"self_attested" and must never gate trust, authorization, or publication on
+its own.
+
+The import side (sicore internal/siclaw/knowledge/okf_attestation.go) mirrors
+this validation and rejects receipts that contradict the bundle; this module
+applies the same rules at packaging time, before an upload ever happens. The
+two implementations are pinned together by the shared conformance fixture
+(fixtures/okf-attestation/conformance.json, sha256-pinned on both sides).
 
 Attestation is written by deterministic code about deterministic checks.
 The compile agent never authors it, for the same reason it may not write
@@ -17,6 +24,7 @@ Pure stdlib on purpose, like selfcheck.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 
@@ -25,23 +33,44 @@ ATTESTATION_SCHEMA_VERSION = 1
 MAX_ATTESTATION_CHECKS = 32
 
 TIER_UNATTESTED = "unattested"
-TIER_ATTESTED = "attested"
+TIER_SELF_ATTESTED = "self_attested"
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _REVISION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9:._-]{0,127}$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _CHECK_STATUSES = ("pass", "warn", "fail")
 _COVERAGE_FIELDS = ("cited", "excluded", "auto_attached", "derived", "unaccounted", "dangling")
 _ALLOWED_KEYS = {
     "schema_version", "producer", "input_revision", "concept_pages",
-    "coverage", "checks", "signature",
+    "payload_manifest_sha256", "coverage", "checks", "signature",
 }
+
+
+def payload_manifest_sha256(files) -> str:
+    """Digest of the canonical payload manifest.
+
+    files: iterable of (relative posix path, bytes); the attestation sidecar
+    itself is skipped. One record per file, sorted by path byte order:
+    "{sha256} {size} {path}\\n". The record format is a cross-repo contract
+    with sicore payloadManifestSHA256 (okf_attestation.go) — change both
+    together.
+    """
+    records = sorted(
+        (rel, data) for rel, data in files if rel != ATTESTATION_SIDECAR
+    )
+    digest = hashlib.sha256()
+    for rel, data in records:
+        digest.update(
+            f"{hashlib.sha256(data).hexdigest()} {len(data)} {rel}\n".encode("utf-8")
+        )
+    return digest.hexdigest()
 
 
 def _violation(kind: str, detail: str) -> dict:
     return {"kind": kind, "detail": detail}
 
 
-def attestation_violations(doc: object, *, concept_pages: int) -> list[dict]:
+def attestation_violations(doc: object, *, concept_pages: int, payload_sha256: str) -> list[dict]:
     """Mirror the importer's checks; [] means the sidecar would be accepted."""
     if not isinstance(doc, dict):
         return [_violation("attestation_shape", "attestation must be a JSON object")]
@@ -84,6 +113,18 @@ def attestation_violations(doc: object, *, concept_pages: int) -> list[dict]:
         violations.append(_violation(
             "attestation_concept_pages",
             f"concept_pages {declared_pages} does not match the bundle's {concept_pages} concept pages"))
+
+    declared_digest = doc.get("payload_manifest_sha256")
+    if not isinstance(declared_digest, str) or not _DIGEST_RE.match(declared_digest):
+        violations.append(_violation(
+            "attestation_payload_manifest",
+            "payload_manifest_sha256 must be 64 lowercase hex characters"))
+    elif declared_digest != payload_sha256:
+        # The receipts describe a different tree than the one being packaged —
+        # a replayed or stale attestation, never something to ship.
+        violations.append(_violation(
+            "attestation_payload_manifest",
+            "payload_manifest_sha256 does not match the bundle's payload manifest"))
 
     checks = doc.get("checks")
     if not isinstance(checks, list) or not 1 <= len(checks) <= MAX_ATTESTATION_CHECKS:
@@ -146,7 +187,7 @@ def classify_tier(doc: dict) -> str:
     coverage = doc.get("coverage")
     coverage_closed = coverage is None or bool(coverage.get("closed"))
     if not failing and coverage_closed:
-        return TIER_ATTESTED
+        return TIER_SELF_ATTESTED
     return TIER_UNATTESTED
 
 
@@ -154,6 +195,7 @@ def build_attestation(
     *,
     producer_name: str,
     concept_pages: int,
+    payload_sha256: str,
     checks: list[dict],
     producer_version: str | None = None,
     coverage: dict | None = None,
@@ -167,6 +209,7 @@ def build_attestation(
         "schema_version": ATTESTATION_SCHEMA_VERSION,
         "producer": producer,
         "concept_pages": concept_pages,
+        "payload_manifest_sha256": payload_sha256,
         "checks": checks,
         "signature": None,
     }
@@ -174,7 +217,8 @@ def build_attestation(
         doc["input_revision"] = input_revision
     if coverage is not None:
         doc["coverage"] = coverage
-    violations = attestation_violations(doc, concept_pages=concept_pages)
+    violations = attestation_violations(
+        doc, concept_pages=concept_pages, payload_sha256=payload_sha256)
     if violations:
         raise ValueError(
             "refusing to build an invalid attestation: "

--- a/kbc/platform/pod/okf_package.py
+++ b/kbc/platform/pod/okf_package.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 import gzip
 import hashlib
 import io
+import json
 import os
 import stat
 import tarfile
 import tempfile
 from pathlib import Path
+from posixpath import basename
 
+import okf_attestation
 import selfcheck
 
 MAX_ARCHIVE_BYTES = 25 * 1024 * 1024
@@ -143,7 +146,32 @@ def collect_import_files(wiki_dir: str | Path) -> list[tuple[str, bytes]]:
     violations = selfcheck.okf_import_violations(markdown_pages)
     if violations:
         raise OKFPackageError("Wiki is not importable OKF v0.2: " + _format_violations(violations))
+    _validate_attestation_sidecar(files, markdown_pages)
     return files
+
+
+def _validate_attestation_sidecar(files: list[tuple[str, bytes]], markdown_pages: dict[str, dict]) -> None:
+    """A lying compiler receipt must fail at packaging, not at the importer."""
+    sidecar = next(
+        (data for rel, data in files if rel == okf_attestation.ATTESTATION_SIDECAR), None,
+    )
+    if sidecar is None:
+        return
+    # Mirrors the importer's concept-page definition: every .md except the
+    # reserved index/log pages (sicore isOKFReservedPath).
+    concept_pages = sum(
+        1 for rel in markdown_pages if basename(rel) not in ("index.md", "log.md")
+    )
+    try:
+        doc = okf_attestation.parse_attestation(sidecar)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise OKFPackageError(f"{okf_attestation.ATTESTATION_SIDECAR} is invalid JSON: {error}") from error
+    violations = okf_attestation.attestation_violations(doc, concept_pages=concept_pages)
+    if violations:
+        raise OKFPackageError(
+            f"{okf_attestation.ATTESTATION_SIDECAR} would be rejected by the importer: "
+            + "; ".join(item["detail"] for item in violations[:10])
+        )
 
 
 def write_import_archive(

--- a/kbc/platform/pod/okf_package.py
+++ b/kbc/platform/pod/okf_package.py
@@ -166,7 +166,11 @@ def _validate_attestation_sidecar(files: list[tuple[str, bytes]], markdown_pages
         doc = okf_attestation.parse_attestation(sidecar)
     except (json.JSONDecodeError, UnicodeDecodeError) as error:
         raise OKFPackageError(f"{okf_attestation.ATTESTATION_SIDECAR} is invalid JSON: {error}") from error
-    violations = okf_attestation.attestation_violations(doc, concept_pages=concept_pages)
+    violations = okf_attestation.attestation_violations(
+        doc,
+        concept_pages=concept_pages,
+        payload_sha256=okf_attestation.payload_manifest_sha256(files),
+    )
     if violations:
         raise OKFPackageError(
             f"{okf_attestation.ATTESTATION_SIDECAR} would be rejected by the importer: "

--- a/kbc/platform/pod/test_okf_attestation.py
+++ b/kbc/platform/pod/test_okf_attestation.py
@@ -1,0 +1,152 @@
+"""Contract tests for the compiler attestation sidecar (build + packaging gate)."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import okf_attestation
+from okf_package import OKFPackageError, collect_import_files, write_import_archive
+
+
+INDEX = '---\nokf_version: "0.2"\n---\n\n# Contents\n'
+PAGE = "---\ntype: Topic\n---\n\nA compiled page.\n"
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+
+
+def _valid_doc(concept_pages: int = 2) -> dict:
+    return {
+        "schema_version": 1,
+        "producer": {"name": "siclaw-kbc", "version": "0.9.0"},
+        "input_revision": "sha256:a1b2c3",
+        "concept_pages": concept_pages,
+        "coverage": {"closed": True, "cited": 4, "excluded": 1, "auto_attached": 0,
+                     "derived": 0, "unaccounted": 0, "dangling": 0},
+        "checks": [
+            {"name": "selfcheck", "status": "pass"},
+            {"name": "redblue", "status": "pass", "detail": "16/16 questions"},
+        ],
+        "signature": None,
+    }
+
+
+def _wiki_with_sidecar(base: Path, doc: dict | str) -> Path:
+    wiki = base / "wiki"
+    _write(wiki, "index.md", INDEX)
+    _write(wiki, "topics/a.md", PAGE)
+    _write(wiki, "topics/b.md", PAGE)
+    body = doc if isinstance(doc, str) else okf_attestation.render_attestation(doc)
+    _write(wiki, okf_attestation.ATTESTATION_SIDECAR, body)
+    return wiki
+
+
+def test_valid_attestation_passes_and_classifies_attested() -> None:
+    doc = _valid_doc()
+    assert okf_attestation.attestation_violations(doc, concept_pages=2) == []
+    assert okf_attestation.classify_tier(doc) == okf_attestation.TIER_ATTESTED
+
+
+def test_honest_failure_classifies_unattested() -> None:
+    doc = _valid_doc()
+    doc["checks"][0]["status"] = "fail"
+    assert okf_attestation.attestation_violations(doc, concept_pages=2) == []
+    assert okf_attestation.classify_tier(doc) == okf_attestation.TIER_UNATTESTED
+
+
+def test_open_coverage_classifies_unattested() -> None:
+    doc = _valid_doc()
+    doc["coverage"].update({"closed": False, "unaccounted": 3})
+    assert okf_attestation.attestation_violations(doc, concept_pages=2) == []
+    assert okf_attestation.classify_tier(doc) == okf_attestation.TIER_UNATTESTED
+
+
+def test_lying_receipts_are_violations() -> None:
+    cases = [
+        ("concept_pages", lambda d: d.update(concept_pages=37)),
+        ("closed contradicts", lambda d: d["coverage"].update(unaccounted=5)),
+        ("unknown field", lambda d: d.update(extra=True)),
+        ("schema version", lambda d: d.update(schema_version=9)),
+        ("signature", lambda d: d.update(signature="sig-bytes")),
+        ("duplicate checks", lambda d: d["checks"].append({"name": "selfcheck", "status": "pass"})),
+        ("bad status", lambda d: d["checks"][0].update(status="maybe")),
+        ("empty checks", lambda d: d.update(checks=[])),
+        ("bad producer", lambda d: d["producer"].update(name=" ")),
+        ("bad revision", lambda d: d.update(input_revision="!!!")),
+    ]
+    for label, mutate in cases:
+        doc = _valid_doc()
+        mutate(doc)
+        assert okf_attestation.attestation_violations(doc, concept_pages=2), label
+
+
+def test_build_attestation_refuses_invalid_input() -> None:
+    try:
+        okf_attestation.build_attestation(
+            producer_name="siclaw-kbc", concept_pages=2,
+            checks=[{"name": "selfcheck", "status": "maybe"}],
+        )
+    except ValueError as error:
+        assert "status" in str(error)
+    else:
+        raise AssertionError("build_attestation accepted an invalid check status")
+
+
+def test_packager_ships_valid_sidecar_and_keeps_determinism() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = _wiki_with_sidecar(base, _valid_doc())
+        assert [rel for rel, _ in collect_import_files(wiki)] == [
+            okf_attestation.ATTESTATION_SIDECAR, "index.md", "topics/a.md", "topics/b.md",
+        ]
+        first = write_import_archive(wiki, base / "first.tar.gz")
+        second = write_import_archive(wiki, base / "second.tar.gz")
+        assert first["sha256"] == second["sha256"]
+
+
+def test_packager_rejects_lying_sidecar_before_upload() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = _wiki_with_sidecar(base, _valid_doc(concept_pages=37))
+        try:
+            collect_import_files(wiki)
+        except OKFPackageError as error:
+            assert "concept_pages 37 does not match" in str(error)
+        else:
+            raise AssertionError("packager accepted a sidecar that lies about page count")
+
+
+def test_packager_rejects_malformed_sidecar_json() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = _wiki_with_sidecar(base, "{not json")
+        try:
+            collect_import_files(wiki)
+        except OKFPackageError as error:
+            assert "invalid JSON" in str(error)
+        else:
+            raise AssertionError("packager accepted malformed attestation JSON")
+
+
+def test_packager_without_sidecar_is_unchanged() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        wiki = Path(raw) / "wiki"
+        _write(wiki, "index.md", INDEX)
+        _write(wiki, "topics/a.md", PAGE)
+        assert [rel for rel, _ in collect_import_files(wiki)] == ["index.md", "topics/a.md"]
+
+
+if __name__ == "__main__":
+    test_valid_attestation_passes_and_classifies_attested()
+    test_honest_failure_classifies_unattested()
+    test_open_coverage_classifies_unattested()
+    test_lying_receipts_are_violations()
+    test_build_attestation_refuses_invalid_input()
+    test_packager_ships_valid_sidecar_and_keeps_determinism()
+    test_packager_rejects_lying_sidecar_before_upload()
+    test_packager_rejects_malformed_sidecar_json()
+    test_packager_without_sidecar_is_unchanged()
+    print("OK  compiler attestation sidecar validation + packaging gate")

--- a/kbc/platform/pod/test_okf_attestation.py
+++ b/kbc/platform/pod/test_okf_attestation.py
@@ -1,5 +1,6 @@
 """Contract tests for the compiler attestation sidecar (build + packaging gate)."""
 
+import hashlib
 import json
 import tempfile
 from pathlib import Path
@@ -8,8 +9,21 @@ import okf_attestation
 from okf_package import OKFPackageError, collect_import_files, write_import_archive
 
 
+# Pinned digest of the shared conformance fixture. The same value is pinned in
+# sicore internal/siclaw/knowledge/okf_attestation_test.go — editing either
+# copy fails that side's test until both copies (and both pins) are updated
+# together.
+CONFORMANCE_SHA256 = "0d30e08f0e13acc74e2325edcc895d8ea04c70e6fac1ea32cc5b51e8fc4511bf"
+CONFORMANCE_PATH = Path(__file__).parent / "fixtures" / "okf-attestation" / "conformance.json"
+
 INDEX = '---\nokf_version: "0.2"\n---\n\n# Contents\n'
 PAGE = "---\ntype: Topic\n---\n\nA compiled page.\n"
+
+_WIKI_FILES = [
+    ("index.md", INDEX.encode("utf-8")),
+    ("topics/a.md", PAGE.encode("utf-8")),
+    ("topics/b.md", PAGE.encode("utf-8")),
+]
 
 
 def _write(root: Path, rel: str, body: str) -> None:
@@ -18,12 +32,17 @@ def _write(root: Path, rel: str, body: str) -> None:
     target.write_text(body, encoding="utf-8")
 
 
+def _payload_sha256() -> str:
+    return okf_attestation.payload_manifest_sha256(_WIKI_FILES)
+
+
 def _valid_doc(concept_pages: int = 2) -> dict:
     return {
         "schema_version": 1,
         "producer": {"name": "siclaw-kbc", "version": "0.9.0"},
         "input_revision": "sha256:a1b2c3",
         "concept_pages": concept_pages,
+        "payload_manifest_sha256": _payload_sha256(),
         "coverage": {"closed": True, "cited": 4, "excluded": 1, "auto_attached": 0,
                      "derived": 0, "unaccounted": 0, "dangling": 0},
         "checks": [
@@ -36,37 +55,43 @@ def _valid_doc(concept_pages: int = 2) -> dict:
 
 def _wiki_with_sidecar(base: Path, doc: dict | str) -> Path:
     wiki = base / "wiki"
-    _write(wiki, "index.md", INDEX)
-    _write(wiki, "topics/a.md", PAGE)
-    _write(wiki, "topics/b.md", PAGE)
+    for rel, data in _WIKI_FILES:
+        _write(wiki, rel, data.decode("utf-8"))
     body = doc if isinstance(doc, str) else okf_attestation.render_attestation(doc)
     _write(wiki, okf_attestation.ATTESTATION_SIDECAR, body)
     return wiki
 
 
-def test_valid_attestation_passes_and_classifies_attested() -> None:
+def _violations(doc: object) -> list[dict]:
+    return okf_attestation.attestation_violations(
+        doc, concept_pages=2, payload_sha256=_payload_sha256())
+
+
+def test_valid_attestation_passes_and_classifies_self_attested() -> None:
     doc = _valid_doc()
-    assert okf_attestation.attestation_violations(doc, concept_pages=2) == []
-    assert okf_attestation.classify_tier(doc) == okf_attestation.TIER_ATTESTED
+    assert _violations(doc) == []
+    assert okf_attestation.classify_tier(doc) == okf_attestation.TIER_SELF_ATTESTED
 
 
 def test_honest_failure_classifies_unattested() -> None:
     doc = _valid_doc()
     doc["checks"][0]["status"] = "fail"
-    assert okf_attestation.attestation_violations(doc, concept_pages=2) == []
+    assert _violations(doc) == []
     assert okf_attestation.classify_tier(doc) == okf_attestation.TIER_UNATTESTED
 
 
 def test_open_coverage_classifies_unattested() -> None:
     doc = _valid_doc()
     doc["coverage"].update({"closed": False, "unaccounted": 3})
-    assert okf_attestation.attestation_violations(doc, concept_pages=2) == []
+    assert _violations(doc) == []
     assert okf_attestation.classify_tier(doc) == okf_attestation.TIER_UNATTESTED
 
 
 def test_lying_receipts_are_violations() -> None:
     cases = [
         ("concept_pages", lambda d: d.update(concept_pages=37)),
+        ("payload digest mismatch", lambda d: d.update(payload_manifest_sha256="cd" * 32)),
+        ("payload digest missing", lambda d: d.pop("payload_manifest_sha256")),
         ("closed contradicts", lambda d: d["coverage"].update(unaccounted=5)),
         ("unknown field", lambda d: d.update(extra=True)),
         ("schema version", lambda d: d.update(schema_version=9)),
@@ -80,13 +105,14 @@ def test_lying_receipts_are_violations() -> None:
     for label, mutate in cases:
         doc = _valid_doc()
         mutate(doc)
-        assert okf_attestation.attestation_violations(doc, concept_pages=2), label
+        assert _violations(doc), label
 
 
 def test_build_attestation_refuses_invalid_input() -> None:
     try:
         okf_attestation.build_attestation(
             producer_name="siclaw-kbc", concept_pages=2,
+            payload_sha256=_payload_sha256(),
             checks=[{"name": "selfcheck", "status": "maybe"}],
         )
     except ValueError as error:
@@ -107,7 +133,23 @@ def test_packager_ships_valid_sidecar_and_keeps_determinism() -> None:
         assert first["sha256"] == second["sha256"]
 
 
-def test_packager_rejects_lying_sidecar_before_upload() -> None:
+def test_packager_rejects_replayed_receipts_after_content_edit() -> None:
+    # Same page count, different bytes: the exact hole the payload manifest
+    # digest exists to close.
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = _wiki_with_sidecar(base, _valid_doc())
+        (wiki / "topics" / "a.md").write_text(
+            PAGE + "\nEdited after the receipts were issued.\n", encoding="utf-8")
+        try:
+            collect_import_files(wiki)
+        except OKFPackageError as error:
+            assert "payload_manifest_sha256 does not match" in str(error)
+        else:
+            raise AssertionError("packager accepted receipts replayed onto edited content")
+
+
+def test_packager_rejects_lying_page_count_before_upload() -> None:
     with tempfile.TemporaryDirectory() as raw:
         base = Path(raw)
         wiki = _wiki_with_sidecar(base, _valid_doc(concept_pages=37))
@@ -139,14 +181,36 @@ def test_packager_without_sidecar_is_unchanged() -> None:
         assert [rel for rel, _ in collect_import_files(wiki)] == ["index.md", "topics/a.md"]
 
 
+def test_conformance_fixture_matches_go_importer() -> None:
+    raw = CONFORMANCE_PATH.read_bytes()
+    assert hashlib.sha256(raw).hexdigest() == CONFORMANCE_SHA256, (
+        "conformance fixture drifted — update BOTH repo copies and BOTH sha pins together")
+    fixture = json.loads(raw)
+    bundle = fixture["bundle"]
+    assert fixture["cases"], "conformance fixture has no cases"
+    for case in fixture["cases"]:
+        violations = okf_attestation.attestation_violations(
+            case["attestation"],
+            concept_pages=bundle["concept_pages"],
+            payload_sha256=bundle["payload_manifest_sha256"],
+        )
+        if case["expect"] == "reject":
+            assert violations, case["name"]
+        else:
+            assert violations == [], (case["name"], violations)
+            assert okf_attestation.classify_tier(case["attestation"]) == case["expect"], case["name"]
+
+
 if __name__ == "__main__":
-    test_valid_attestation_passes_and_classifies_attested()
+    test_valid_attestation_passes_and_classifies_self_attested()
     test_honest_failure_classifies_unattested()
     test_open_coverage_classifies_unattested()
     test_lying_receipts_are_violations()
     test_build_attestation_refuses_invalid_input()
     test_packager_ships_valid_sidecar_and_keeps_determinism()
-    test_packager_rejects_lying_sidecar_before_upload()
+    test_packager_rejects_replayed_receipts_after_content_edit()
+    test_packager_rejects_lying_page_count_before_upload()
     test_packager_rejects_malformed_sidecar_json()
     test_packager_without_sidecar_is_unchanged()
-    print("OK  compiler attestation sidecar validation + packaging gate")
+    test_conformance_fixture_matches_go_importer()
+    print("OK  compiler attestation sidecar validation + packaging gate + conformance")

--- a/kbc/tools/attach_okf_attestation.py
+++ b/kbc/tools/attach_okf_attestation.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Attach a compiler attestation sidecar to a standalone OKF v0.2 Wiki.
+
+Check results are explicit input from the deterministic tools that ran them
+(publish gate, lint, selfcheck) — this tool records receipts, it never invents
+them. The compile agent must not author the attestation for the same reason it
+may not write `verified`: a self-signed receipt is not a receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from posixpath import basename
+
+POD_DIR = Path(__file__).resolve().parents[1] / "platform" / "pod"
+sys.path.insert(0, str(POD_DIR))
+
+import okf_attestation  # noqa: E402
+from okf_package import OKFPackageError, write_import_archive  # noqa: E402
+
+
+class AttestationError(ValueError):
+    """The wiki or check input cannot produce a valid attested archive."""
+
+
+def load_checks(path: Path) -> list[dict]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise AttestationError(f"checks file is unreadable: {error}") from error
+    if not isinstance(payload, list):
+        raise AttestationError("checks file must contain a JSON array of {name, status[, detail]}")
+    return payload
+
+
+def load_coverage(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise AttestationError(f"coverage file is unreadable: {error}") from error
+    if not isinstance(payload, dict):
+        raise AttestationError("coverage file must contain a JSON object")
+    return payload
+
+
+def count_concept_pages(wiki: Path) -> int:
+    return sum(
+        1
+        for page in wiki.rglob("*.md")
+        if basename(page.relative_to(wiki).as_posix()) not in ("index.md", "log.md")
+    )
+
+
+def attach_attestation(
+    wiki: Path,
+    output_path: Path,
+    *,
+    producer: str,
+    producer_version: str | None,
+    checks_path: Path,
+    coverage_path: Path | None,
+    input_revision: str | None,
+) -> dict:
+    if not wiki.is_dir():
+        raise AttestationError(f"wiki directory does not exist: {wiki}")
+    coverage = load_coverage(coverage_path) if coverage_path is not None else None
+    try:
+        doc = okf_attestation.build_attestation(
+            producer_name=producer,
+            producer_version=producer_version,
+            concept_pages=count_concept_pages(wiki),
+            checks=load_checks(checks_path),
+            coverage=coverage,
+            input_revision=input_revision,
+        )
+    except ValueError as error:
+        raise AttestationError(str(error)) from error
+    sidecar = wiki / okf_attestation.ATTESTATION_SIDECAR
+    sidecar.write_text(okf_attestation.render_attestation(doc), encoding="utf-8")
+    receipt = write_import_archive(wiki, output_path, overwrite=True)
+    return {**receipt, "attestation_tier": okf_attestation.classify_tier(doc)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wiki", required=True, type=Path, help="Compiled OKF v0.2 Wiki directory")
+    parser.add_argument("--out", required=True, type=Path, help="Output attested .tar.gz")
+    parser.add_argument("--producer", required=True, help="Compiler identity, e.g. siclaw-kbc")
+    parser.add_argument("--producer-version", help="Compiler version string")
+    parser.add_argument(
+        "--checks", required=True, type=Path,
+        help="JSON array of deterministic check results: [{name, status[, detail]}]",
+    )
+    parser.add_argument(
+        "--coverage", type=Path,
+        help="Optional JSON object with the coverage ledger summary "
+             "({closed, cited, excluded, auto_attached, derived, unaccounted, dangling})",
+    )
+    parser.add_argument("--input-revision", help="Frozen source manifest revision the compile ran from")
+    args = parser.parse_args()
+    try:
+        receipt = attach_attestation(
+            args.wiki,
+            args.out,
+            producer=args.producer,
+            producer_version=args.producer_version,
+            checks_path=args.checks,
+            coverage_path=args.coverage,
+            input_revision=args.input_revision,
+        )
+    except (AttestationError, OKFPackageError, OSError) as error:
+        parser.exit(2, f"attach_okf_attestation: {error}\n")
+    print(json.dumps(receipt, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kbc/tools/attach_okf_attestation.py
+++ b/kbc/tools/attach_okf_attestation.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 from posixpath import basename
 
@@ -19,7 +21,7 @@ POD_DIR = Path(__file__).resolve().parents[1] / "platform" / "pod"
 sys.path.insert(0, str(POD_DIR))
 
 import okf_attestation  # noqa: E402
-from okf_package import OKFPackageError, write_import_archive  # noqa: E402
+from okf_package import OKFPackageError, collect_import_files, write_import_archive  # noqa: E402
 
 
 class AttestationError(ValueError):
@@ -46,14 +48,6 @@ def load_coverage(path: Path) -> dict:
     return payload
 
 
-def count_concept_pages(wiki: Path) -> int:
-    return sum(
-        1
-        for page in wiki.rglob("*.md")
-        if basename(page.relative_to(wiki).as_posix()) not in ("index.md", "log.md")
-    )
-
-
 def attach_attestation(
     wiki: Path,
     output_path: Path,
@@ -63,24 +57,41 @@ def attach_attestation(
     checks_path: Path,
     coverage_path: Path | None,
     input_revision: str | None,
+    overwrite: bool = False,
 ) -> dict:
     if not wiki.is_dir():
         raise AttestationError(f"wiki directory does not exist: {wiki}")
     coverage = load_coverage(coverage_path) if coverage_path is not None else None
-    try:
-        doc = okf_attestation.build_attestation(
-            producer_name=producer,
-            producer_version=producer_version,
-            concept_pages=count_concept_pages(wiki),
-            checks=load_checks(checks_path),
-            coverage=coverage,
-            input_revision=input_revision,
+    checks = load_checks(checks_path)
+    # Work on a staging copy: the caller's wiki directory is input, never
+    # mutated, and a failure at any step leaves nothing behind.
+    with tempfile.TemporaryDirectory(prefix="okf-attestation-attach-") as raw:
+        staging = Path(raw) / "wiki"
+        shutil.copytree(wiki, staging)
+        (staging / okf_attestation.ATTESTATION_SIDECAR).unlink(missing_ok=True)
+        # collect_import_files is the packer's own canonical, validated file
+        # set — computing pages and digest from it guarantees the receipt
+        # describes exactly what write_import_archive will ship.
+        files = collect_import_files(staging)
+        concept_pages = sum(
+            1 for rel, _ in files
+            if rel.lower().endswith(".md") and basename(rel) not in ("index.md", "log.md")
         )
-    except ValueError as error:
-        raise AttestationError(str(error)) from error
-    sidecar = wiki / okf_attestation.ATTESTATION_SIDECAR
-    sidecar.write_text(okf_attestation.render_attestation(doc), encoding="utf-8")
-    receipt = write_import_archive(wiki, output_path, overwrite=True)
+        try:
+            doc = okf_attestation.build_attestation(
+                producer_name=producer,
+                producer_version=producer_version,
+                concept_pages=concept_pages,
+                payload_sha256=okf_attestation.payload_manifest_sha256(files),
+                checks=checks,
+                coverage=coverage,
+                input_revision=input_revision,
+            )
+        except ValueError as error:
+            raise AttestationError(str(error)) from error
+        sidecar = staging / okf_attestation.ATTESTATION_SIDECAR
+        sidecar.write_text(okf_attestation.render_attestation(doc), encoding="utf-8")
+        receipt = write_import_archive(staging, output_path, overwrite=overwrite)
     return {**receipt, "attestation_tier": okf_attestation.classify_tier(doc)}
 
 
@@ -100,6 +111,7 @@ def main() -> int:
              "({closed, cited, excluded, auto_attached, derived, unaccounted, dangling})",
     )
     parser.add_argument("--input-revision", help="Frozen source manifest revision the compile ran from")
+    parser.add_argument("--overwrite", action="store_true", help="Replace an existing output archive")
     args = parser.parse_args()
     try:
         receipt = attach_attestation(
@@ -110,6 +122,7 @@ def main() -> int:
             checks_path=args.checks,
             coverage_path=args.coverage,
             input_revision=args.input_revision,
+            overwrite=args.overwrite,
         )
     except (AttestationError, OKFPackageError, OSError) as error:
         parser.exit(2, f"attach_okf_attestation: {error}\n")

--- a/kbc/tools/test_attach_okf_attestation.py
+++ b/kbc/tools/test_attach_okf_attestation.py
@@ -45,12 +45,16 @@ def test_attaches_receipts_and_reports_tier() -> None:
             coverage_path=None,
             input_revision="sha256:feedbeef",
         )
-        assert receipt["attestation_tier"] == "attested"
+        assert receipt["attestation_tier"] == "self_attested"
+        # The caller's wiki directory is input only — the sidecar lives in the
+        # staging copy and the archive, never in the source tree.
+        assert not (wiki / ".okf-attestation.json").exists()
         with tarfile.open(output, "r:gz") as archive:
             body = archive.extractfile(".okf-attestation.json").read()
         doc = json.loads(body)
         assert doc["producer"] == {"name": "siclaw-kbc-local", "version": "0.1.0"}
         assert doc["concept_pages"] == 1
+        assert len(doc["payload_manifest_sha256"]) == 64
         assert doc["signature"] is None
 
 
@@ -70,6 +74,41 @@ def test_failing_checks_still_package_but_report_unattested() -> None:
             input_revision=None,
         )
         assert receipt["attestation_tier"] == "unattested"
+
+
+def test_existing_output_requires_explicit_overwrite() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = base / "wiki"
+        _write(wiki, "index.md", INDEX)
+        _write(wiki, "page.md", PAGE)
+        _write(base, "checks.json", [{"name": "kb_eval", "status": "pass"}])
+        output = base / "out.tar.gz"
+        output.write_bytes(b"pre-existing")
+        try:
+            tool.attach_attestation(
+                wiki, output,
+                producer="siclaw-kbc-local",
+                producer_version=None,
+                checks_path=base / "checks.json",
+                coverage_path=None,
+                input_revision=None,
+            )
+        except Exception as error:  # OKFPackageError from the packer
+            assert "already exists" in str(error)
+        else:
+            raise AssertionError("tool overwrote an existing archive without --overwrite")
+        assert output.read_bytes() == b"pre-existing"
+        receipt = tool.attach_attestation(
+            wiki, output,
+            producer="siclaw-kbc-local",
+            producer_version=None,
+            checks_path=base / "checks.json",
+            coverage_path=None,
+            input_revision=None,
+            overwrite=True,
+        )
+        assert receipt["attestation_tier"] == "self_attested"
 
 
 def test_invalid_checks_refuse_to_build() -> None:
@@ -97,5 +136,6 @@ def test_invalid_checks_refuse_to_build() -> None:
 if __name__ == "__main__":
     test_attaches_receipts_and_reports_tier()
     test_failing_checks_still_package_but_report_unattested()
+    test_existing_output_requires_explicit_overwrite()
     test_invalid_checks_refuse_to_build()
     print("OK  OKF package attestation attach")

--- a/kbc/tools/test_attach_okf_attestation.py
+++ b/kbc/tools/test_attach_okf_attestation.py
@@ -1,0 +1,101 @@
+"""Focused tests for the standalone OKF attestation attach utility."""
+
+import importlib.util
+import json
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("attach_okf_attestation.py")
+SPEC = importlib.util.spec_from_file_location("attach_okf_attestation", MODULE_PATH)
+assert SPEC and SPEC.loader
+tool = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(tool)
+
+
+INDEX = '---\nokf_version: "0.2"\n---\n\n# Index\n'
+PAGE = "---\ntype: Concept\n---\n\n# Page\n"
+
+
+def _write(root: Path, rel: str, body) -> None:
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if not isinstance(body, str):
+        body = json.dumps(body, ensure_ascii=False)
+    target.write_text(body, encoding="utf-8")
+
+
+def test_attaches_receipts_and_reports_tier() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = base / "wiki"
+        _write(wiki, "index.md", INDEX)
+        _write(wiki, "page.md", PAGE)
+        _write(base, "checks.json", [
+            {"name": "kb_eval", "status": "pass", "detail": "gate 12/12"},
+            {"name": "lint_links", "status": "pass"},
+        ])
+        output = base / "attested.tar.gz"
+        receipt = tool.attach_attestation(
+            wiki, output,
+            producer="siclaw-kbc-local",
+            producer_version="0.1.0",
+            checks_path=base / "checks.json",
+            coverage_path=None,
+            input_revision="sha256:feedbeef",
+        )
+        assert receipt["attestation_tier"] == "attested"
+        with tarfile.open(output, "r:gz") as archive:
+            body = archive.extractfile(".okf-attestation.json").read()
+        doc = json.loads(body)
+        assert doc["producer"] == {"name": "siclaw-kbc-local", "version": "0.1.0"}
+        assert doc["concept_pages"] == 1
+        assert doc["signature"] is None
+
+
+def test_failing_checks_still_package_but_report_unattested() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = base / "wiki"
+        _write(wiki, "index.md", INDEX)
+        _write(wiki, "page.md", PAGE)
+        _write(base, "checks.json", [{"name": "kb_eval", "status": "fail", "detail": "gate 7/12"}])
+        receipt = tool.attach_attestation(
+            wiki, base / "out.tar.gz",
+            producer="siclaw-kbc-local",
+            producer_version=None,
+            checks_path=base / "checks.json",
+            coverage_path=None,
+            input_revision=None,
+        )
+        assert receipt["attestation_tier"] == "unattested"
+
+
+def test_invalid_checks_refuse_to_build() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        base = Path(raw)
+        wiki = base / "wiki"
+        _write(wiki, "index.md", INDEX)
+        _write(wiki, "page.md", PAGE)
+        _write(base, "checks.json", [{"name": "kb_eval", "status": "maybe"}])
+        try:
+            tool.attach_attestation(
+                wiki, base / "out.tar.gz",
+                producer="siclaw-kbc-local",
+                producer_version=None,
+                checks_path=base / "checks.json",
+                coverage_path=None,
+                input_revision=None,
+            )
+        except tool.AttestationError as error:
+            assert "status" in str(error)
+        else:
+            raise AssertionError("tool built an attestation from an invalid check status")
+
+
+if __name__ == "__main__":
+    test_attaches_receipts_and_reports_tier()
+    test_failing_checks_still_package_but_report_unattested()
+    test_invalid_checks_refuse_to_build()
+    print("OK  OKF package attestation attach")


### PR DESCRIPTION
## What

Knowledge artifacts (OKF bundles) can already travel; their trust evidence could not. This PR defines a `.okf-attestation.json` root sidecar (mirroring the `.okf-citations.json` precedent) that carries compile-time verification receipts, validates it at packaging time, and ships an **optional attach utility** to produce it. Wiring the platform pod's own compile flow to emit the sidecar is deliberately **not** in this PR.

- **`kbc/platform/pod/okf_attestation.py`** (pure stdlib, like selfcheck): builds and validates the sidecar — producer identity, frozen `input_revision`, **mandatory `payload_manifest_sha256`** (digest of the sorted `"{sha256} {size} {path}"` manifest over every packaged file except the sidecar), coverage-ledger summary, and named check results (`pass`/`warn`/`fail`). `signature` is reserved and must be `null` in v1 — no fake cryptographic assurance.
- **`okf_package.py`**: when a sidecar is present, the packer re-validates it against the exact tree it is packaging — page count **and payload digest**. Receipts replayed onto edited content (same page count, different bytes) fail at packaging, before an upload ever happens. Absent sidecar = unchanged behavior; archive determinism preserved.
- **`kbc/tools/attach_okf_attestation.py`** (optional utility): records receipts from explicit deterministic check input (publish gate / lint results), works on a **staging copy** (the caller's wiki is never mutated; failures leave nothing behind), requires explicit `--overwrite`, and computes pages + digest from `collect_import_files` so the receipt describes exactly what the archive ships. The compile agent never authors the attestation — same rule as `verified`: a self-signed receipt is not a receipt.

## Importer counterpart (deploy first)

sicore MR !1044 parses this sidecar at the single import choke point and classifies each imported version:

| tier | meaning |
|---|---|
| `self_attested` | receipts **bound to the uploaded bytes** (payload digest recomputed and matched), internally consistent, claiming a clean compile. Producer identity is **not** verified — this tier must never gate trust, authorization, or publication by itself |
| `unattested` | no sidecar, or receipts honestly reporting failures (warning attached) |
| *(import rejected)* | receipts contradict the bundle: digest or page count mismatch, missing/zero-filled coverage counters, schema violations, non-null signature (fail-closed, like the citation manifest) |

The two validators are pinned together by a **shared conformance fixture** (`kbc/platform/pod/fixtures/okf-attestation/conformance.json` ↔ sicore `testdata/okf-attestation/conformance.json`, byte-identical, sha256-pinned in both test suites) — including the coverage zero-fill drift case.

Rollout is soft: old receivers accept the sidecar silently as opaque `.json`. Receiver-first ordering still applies so classification exists before producers ship.

## Tests

- `kbc/platform/pod/test_okf_attestation.py`: build/validate/classify, packaging gate (replayed-receipt rejection, lying page count, malformed JSON, determinism), conformance fixture with pinned sha256.
- `kbc/tools/test_attach_okf_attestation.py`: attach + tier receipt; source wiki never mutated; failing checks package but report `unattested`; existing output refused without `--overwrite`; invalid check status refuses to build.
- Both wired into `kbc-ci.yml`; existing `test_okf_package.py` / `test_attach_okf_citations.py` pass unchanged.

## Deliberately out of scope (v1)

Cryptographic signing/verification (schema slot reserved — a future signature should cover `payload_manifest_sha256`; until then the adversary model is an honest-but-fallible compiler, not a malicious forger), wiring the platform pod's compile flow to emit the sidecar, and UI surfacing of the tier.
