### PR TITLE
feat(delegation): stamp delegated legs with their own trace id and link them from the coordinator's tool row

### DIFF
--- a/docs/design/coordinator-routing.md
+++ b/docs/design/coordinator-routing.md
@@ -273,6 +273,43 @@ And a re-delivered terminal must be acknowledged, not rejected: its consumer is
 gone precisely because it consumed the original, and refusing it keeps a sender
 retrying — which keeps supervision alive over a turn that already ended.
 
+### The delegated leg is its own trace, linked — not folded — into the coordinator's
+
+A delegated turn runs under the peer's own authority (its persona, model,
+permissions), so its rows are persisted under the peer turn's OWN root trace id —
+the same rule every other cross-agent boundary follows — never under the
+coordinator's. What connects the two traces is an explicit link, written at three
+places:
+
+- **Row stamping.** The local route's consume stamps every persisted peer row with
+  the trace id from the box's prompt ack, exactly as the target Runtime's ordinary
+  `chat.send` path does for a remote peer — the two routes leave identical rows.
+  The opening user row is appended by the source before the trace exists and is
+  back-bound afterwards (`chat.bindMessageTraceId`, append-then-bind, the same
+  pattern `chat.send` uses for its prompt row).
+- **The terminal carries the id.** `chat.send` acks in milliseconds — before the
+  trace exists — and `chat.getMessages` does not project `trace_id`, so the
+  terminal event is the one channel the source can learn which trace a REMOTE
+  leg's rows were persisted under. Both terminal producers (the consumer paths and
+  the shutdown/box-roll supervisor) read the id from the delegated turn's ledger
+  entry, recorded at prompt ack, so they cannot disagree. A terminal that arrives
+  after its delegation settled (coordinator Stop, idle-timeout, source restart)
+  still salvages the opening-row bind — best-effort, memoized per delegation id.
+- **The tool row records the link.** `delegate_to_agent` returns
+  `child_trace_id` next to `child_session_id` in its result details, which persist
+  into the coordinator tool row's metadata: that is the machine-readable edge an
+  audit or analysis read walks to get from the coordinator's trace into the leg.
+  An early `delegate_trace` frame announces the id the moment the local ack names
+  it, so a stopped leg's tool row keeps the link even though the final
+  `delegate_result` frame dies with the destroyed socket.
+
+Trace ids cross process boundaries only through one gate (`validTraceId`,
+32 lowercase hex — the same contract the bind RPC enforces server-side): accepting
+a malformed id at one boundary and rejecting it at another is how rows end up
+persisted under an id no link references. Absent or malformed ids degrade to "no
+link", never to an error — an older peer Runtime simply produces the pre-feature
+behaviour.
+
 After the terminal event, the source always derives remote `finalText` from
 assistant rows after the current delegation boundary in durable session history.
 Recovery widens a window over the newest rows rather than walking a timestamp

--- a/src/agentbox/gateway-client.ts
+++ b/src/agentbox/gateway-client.ts
@@ -186,6 +186,13 @@ export class GatewayClient {
       };
       const client = isHttps ? https : http;
       let result: DelegateResponse | undefined;
+      // The peer session and trace ids from the EARLY delegate_session /
+      // delegate_trace frames. Kept so the fallbacks below (Stop, stream ended
+      // without a result) still name the leg: the gateway's own stopped/failed
+      // frame is written into a socket this side has already destroyed, so
+      // whatever arrived early is all there is.
+      let announcedPeerSessionId: string | undefined;
+      let announcedPeerTraceId: string | undefined;
       const request = client.request(requestOptions, (res: any) => {
         // Decode the stream as UTF-8 here, once, so Node's own StringDecoder holds
         // the partial bytes of a character split across two chunks. `chunk.toString()`
@@ -220,14 +227,18 @@ export class GatewayClient {
             } else if (frame?.type === "delegate_session" && frame.peerSessionId) {
               // Early frame: peer session id, known at delegation start. Forward as a
               // synthetic event so the translator can surface it to the card live.
+              announcedPeerSessionId = String(frame.peerSessionId);
               try { onPeerEvent({ type: "delegate_session", peerSessionId: frame.peerSessionId }); } catch { /* best-effort */ }
+            } else if (frame?.type === "delegate_trace" && frame.peerTraceId) {
+              // Early frame: the leg's own trace id, known at the peer's prompt ack.
+              announcedPeerTraceId = String(frame.peerTraceId);
             } else if (frame?.type === "delegate_result" && frame.result) {
               result = frame.result as DelegateResponse;
             }
           }
         });
         res.on("end", () => {
-          resolve(result ?? { ok: false, peerAgentId: req.peerAgentId, status: "failed", steps: [], error: "delegation stream ended without a result" });
+          resolve(result ?? { ok: false, peerAgentId: req.peerAgentId, status: "failed", steps: [], peerSessionId: announcedPeerSessionId, peerTraceId: announcedPeerTraceId, error: "delegation stream ended without a result" });
         });
       });
       request.on("error", (err: Error) => reject(new Error(`Delegate request failed: ${err.message}`)));
@@ -243,7 +254,7 @@ export class GatewayClient {
       if (signal) {
         signal.addEventListener("abort", () => {
           try { request.destroy(); } catch { /* already gone */ }
-          resolve(result ?? { ok: false, peerAgentId: req.peerAgentId, status: "failed", steps: [], error: "delegation stopped" });
+          resolve(result ?? { ok: false, peerAgentId: req.peerAgentId, status: "failed", steps: [], peerSessionId: announcedPeerSessionId, peerTraceId: announcedPeerTraceId, error: "delegation stopped" });
         }, { once: true });
       }
       request.write(JSON.stringify(req));

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -40,6 +40,8 @@ const ensureChatSessionMock = vi.fn();
 const appendMessageMock = vi.fn();
 const bindMessageTraceIdMock = vi.fn();
 vi.mock("../chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: (...args: unknown[]) => ensureChatSessionMock(...args),
   appendMessage: (...args: unknown[]) => appendMessageMock(...args),
   bindMessageTraceId: (...args: unknown[]) => bindMessageTraceIdMock(...args),

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -40,7 +40,7 @@ import { resolveAgentModelBinding, resolveAgentSystemPrompt } from "../agent-mod
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
 import { sessionTurnLocks } from "../session-turn-lock.js";
-import { appendMessage, bindMessageTraceId, ensureChatSession } from "../chat-repo.js";
+import { appendMessage, bindMessageTraceId, ensureChatSession, warnTraceBindFailure } from "../chat-repo.js";
 import { collectChannelResponse } from "./lark.js";
 import type { RenderedReplyImage } from "./visual-image.js";
 import { deliverImages } from "./dingtalk-image.js";
@@ -375,7 +375,7 @@ export async function handleDingTalkMessage(
     const promptResult = await client.prompt(promptOpts);
     if (promptMessageId) {
       void bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
-        console.warn(`[dingtalk] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
+        warnTraceBindFailure("dingtalk prompt", promptResult.sessionId, promptMessageId, bindErr);
       });
     }
     // Collect the reply with audit persistence (assistant + tool rows, when the

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -80,6 +80,8 @@ const bindMessageTraceIdMock = vi.fn();
 const recordChannelFeedbackMock = vi.fn();
 
 vi.mock("../chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: (...args: unknown[]) => ensureChatSessionMock(...args),
   appendMessage: (...args: unknown[]) => appendMessageMock(...args),
   bindMessageTraceId: (...args: unknown[]) => bindMessageTraceIdMock(...args),

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -34,7 +34,7 @@ import {
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { sessionRegistry } from "../session-registry.js";
 import { sessionTurnLocks } from "../session-turn-lock.js";
-import { appendMessage, bindMessageTraceId, ensureChatSession, recordChannelFeedback } from "../chat-repo.js";
+import { appendMessage, bindMessageTraceId, ensureChatSession, recordChannelFeedback, warnTraceBindFailure } from "../chat-repo.js";
 import { buildRedactionConfigForModelConfig, redactText } from "../output-redactor.js";
 import { resolveAgentModelBinding } from "../agent-model-binding.js";
 import {
@@ -1871,7 +1871,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     // queue-until-idle: wait out a busy session instead of dumping a raw 409.
     const promptResult = await promptWithBusyRetry(client, promptOpts);
     void bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
-      console.warn(`[lark] failed to bind prompt trace session=${promptResult.sessionId} message=${promptMessageId}:`, bindErr);
+      warnTraceBindFailure("lark prompt", promptResult.sessionId, promptMessageId, bindErr);
     });
     const collected = await collectChannelResponse(client, promptResult.sessionId, "lark", {
       includeImages: true,

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -202,6 +202,51 @@ export async function bindMessageTraceId(
 }
 
 /**
+ * OTel trace ids are 32 lowercase hex characters — the contract the bind RPC above
+ * enforces server-side. Exported so every place that INGESTS a trace id from another
+ * process (the box's prompt ack, a delegation terminal event) applies the same gate:
+ * accepting a malformed id at one boundary and rejecting it at another is how rows
+ * get persisted under an id no link references.
+ */
+const TRACE_ID_RE = /^[0-9a-f]{32}$/;
+export function validTraceId(value: unknown): string | undefined {
+  return typeof value === "string" && TRACE_ID_RE.test(value) ? value : undefined;
+}
+
+/**
+ * Report a failed trace bind — but only once per process when the upstream simply does
+ * not implement the method.
+ *
+ * Binding a message to its trace is best-effort and optional: an upstream that has no
+ * trace consumer yet answers "unknown method" to every prompt and every steer, and a
+ * conversation steered a dozen times buries a real failure under a dozen identical lines.
+ * Any OTHER failure is a genuine one-off and keeps its own line.
+ *
+ * Lives here, next to bindMessageTraceId, because its dedup only works if every bind
+ * caller shares one reporter — server.ts (prompt/steer rows), delegate-api.ts
+ * (delegated opening rows) and the lark/dingtalk channels all report through it.
+ */
+const unsupportedUpstreamMethodsReported = new Set<string>();
+export function warnTraceBindFailure(kind: string, sessionId: string, messageId: string, err: unknown): void {
+  const message = String((err as Error)?.message ?? err);
+  if (/unknown method|not implemented|method not found/i.test(message)) {
+    // Keyed by the method the upstream is missing, not by a single global flag: one
+    // absent method must not silence the next one. The match runs on a bounded HEAD
+    // of the message with a non-backtracking shape (\w+(\.\w+)+ is linear; the old
+    // unanchored [\w.]+\.[\w]+ was measured quadratic — ~87s on a 400k-char error
+    // echoed by an upstream) so a huge error payload cannot stall the event loop
+    // from a fire-and-forget warn path.
+    const head = message.slice(0, 256);
+    const method = head.match(/\w+(?:\.\w+)+/)?.[0] ?? head;
+    if (unsupportedUpstreamMethodsReported.has(method)) return;
+    unsupportedUpstreamMethodsReported.add(method);
+    console.warn(`[runtime] upstream does not implement ${method}; that capability is off for this process (${message.slice(0, 2000)})`);
+    return;
+  }
+  console.warn(`[runtime] failed to bind ${kind} trace session=${sessionId} message=${messageId}:`, err);
+}
+
+/**
  * Record (or re-vote) end-user feedback on a channel reply. `messageRef` is a
  * channel-level reply reference (Feishu CardKit card_id), not a chat_messages
  * id — see the message_feedback DDL comment. One vote per (reply, person);

--- a/src/gateway/delegate-api.test.ts
+++ b/src/gateway/delegate-api.test.ts
@@ -22,12 +22,19 @@ const consumeAgentSse = vi.fn(async (opts: any) => {
 vi.mock("./sse-consumer.js", () => ({ consumeAgentSse: (o: any) => consumeAgentSse(o) }));
 
 const ensureChatSession = vi.fn(async () => {});
-const appendMessage = vi.fn(async () => {});
+const appendMessage = vi.fn(async () => "opening-row-1");
 const getMessages = vi.fn(async () => [] as any[]);
-vi.mock("./chat-repo.js", () => ({
+const bindMessageTraceId = vi.fn(async () => {});
+const warnTraceBindFailure = vi.fn();
+vi.mock("./chat-repo.js", async (importOriginal) => ({
   ensureChatSession: (...a: any[]) => ensureChatSession(...a),
   appendMessage: (...a: any[]) => appendMessage(...a),
   getMessages: (...a: any[]) => getMessages(...a),
+  bindMessageTraceId: (...a: any[]) => bindMessageTraceId(...a),
+  warnTraceBindFailure: (...a: any[]) => warnTraceBindFailure(...a),
+  // The real validator, not a stub: the code under test gates ingested ids
+  // through it, and the malformed-id test depends on the actual contract.
+  validTraceId: (await importOriginal<typeof import("./chat-repo.js")>()).validTraceId,
   incrementMessageCount: vi.fn(async () => {}),
   updateMessage: vi.fn(async () => {}),
 }));
@@ -52,7 +59,7 @@ vi.mock("./agentbox/client.js", () => ({
   },
 }));
 
-import { getRemoteDelegationIdleTimeoutMs, handleDelegate, isDelegationSettled } from "./delegate-api.js";
+import { getRemoteDelegationIdleTimeoutMs, handleDelegate, isDelegationSettled, salvageDelegationTraceBind } from "./delegate-api.js";
 import { sessionTurnLocks } from "./session-turn-lock.js";
 
 // ── Fakes ─────────────────────────────────────────────────────────────
@@ -271,6 +278,149 @@ describe("handleDelegate — model-failure propagation (P1)", () => {
     const result = delegateResult(res);
     expect(result?.ok).toBe(true);
     expect(result?.status).toBe("done");
+  });
+});
+
+describe("handleDelegate — delegated-leg trace id (own trace + link)", () => {
+  const TRACE = "f".repeat(32);
+
+  it("stamps the local peer consume with the box-acked trace id, binds the opening row, and reports peerTraceId", async () => {
+    promptMock.mockResolvedValueOnce({ ok: true, sessionId: "peer-sess", traceId: TRACE } as any);
+    const deps = makeDeps({ found: true, user_id: "u", agent_id: COORD });
+    const res = makeRes();
+    await handleDelegate(makeReq({ peerAgentId: PEER, text: "t", parentSessionId: "own-sess" }), res as any, identity, deps);
+
+    // Every row the local consume persists carries the leg's own trace id …
+    expect(consumeAgentSse).toHaveBeenCalledWith(expect.objectContaining({ traceId: TRACE }));
+    // … the opening user row (appended before the trace existed) is back-bound …
+    expect(bindMessageTraceId).toHaveBeenCalledWith("opening-row-1", expect.any(String), TRACE);
+    // … and the coordinator gets the id to persist as the cross-trace link.
+    expect(delegateResult(res)).toMatchObject({ ok: true, status: "done", peerTraceId: TRACE });
+    // The id is ALSO announced early, like delegate_session: a Stop destroys the
+    // client's socket before the final frame, so the early announcement is what a
+    // stopped leg's tool row gets to keep.
+    expect(res.frames).toContainEqual({ type: "delegate_trace", peerTraceId: TRACE });
+  });
+
+  it("leaves rows unstamped and omits peerTraceId when the box ack has no trace id (tracing off)", async () => {
+    const deps = makeDeps({ found: true, user_id: "u", agent_id: COORD });
+    const res = makeRes();
+    await handleDelegate(makeReq({ peerAgentId: PEER, text: "t", parentSessionId: "own-sess" }), res as any, identity, deps);
+
+    expect(consumeAgentSse).toHaveBeenCalledWith(expect.objectContaining({ traceId: undefined }));
+    expect(bindMessageTraceId).not.toHaveBeenCalled();
+    expect(delegateResult(res)?.peerTraceId).toBeUndefined();
+  });
+
+  it("learns a remote leg's trace id from the terminal event, binds the opening row, and reports it", async () => {
+    const deps = makeDeps({ found: true, user_id: "u", agent_id: COORD });
+    deps.frontendClient.request = vi.fn(async (method: string, params: any) => {
+      if (method === "config.getDelegates") return { members: [{ id: PEER, name: "peer", description: "", clusters: [], hosts: [] }] };
+      if (method === "delegation.resolveRoute") return { local: false, sourceRuntimeId: "shanghai", targetRuntimeId: "aries" };
+      if (method === "delegation.start") {
+        getMessages.mockResolvedValueOnce([
+          { role: "user", content: "inspect", delegationId: params.delegationId, metadata: null },
+          { role: "assistant", content: "remote answer", delegationId: null, metadata: null },
+        ] as any);
+        deps.eventHandlers.get("delegation.event")!({
+          delegationId: params.delegationId,
+          sessionId: params.sessionId,
+          event: { type: "prompt_done", traceId: TRACE },
+        });
+        return { ok: true };
+      }
+      return {};
+    });
+    const res = makeRes();
+    await handleDelegate(makeReq({ peerAgentId: PEER, text: "inspect" }), res as any, identity, deps);
+
+    expect(delegateResult(res)).toMatchObject({ ok: true, status: "done", peerTraceId: TRACE });
+    expect(bindMessageTraceId).toHaveBeenCalledWith("opening-row-1", expect.any(String), TRACE);
+    // The remote path persists via the TARGET Runtime's own consume — the source
+    // must not stamp anything itself.
+    expect(consumeAgentSse).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed terminal trace id instead of persisting a link that matches nothing", async () => {
+    const deps = makeDeps({ found: true, user_id: "u", agent_id: COORD });
+    deps.frontendClient.request = vi.fn(async (method: string, params: any) => {
+      if (method === "config.getDelegates") return { members: [{ id: PEER, name: "peer", description: "", clusters: [], hosts: [] }] };
+      if (method === "delegation.resolveRoute") return { local: false, sourceRuntimeId: "shanghai", targetRuntimeId: "aries" };
+      if (method === "delegation.start") {
+        getMessages.mockResolvedValueOnce([
+          { role: "user", content: "inspect", delegationId: params.delegationId, metadata: null },
+          { role: "assistant", content: "remote answer", delegationId: null, metadata: null },
+        ] as any);
+        deps.eventHandlers.get("delegation.event")!({
+          delegationId: params.delegationId,
+          sessionId: params.sessionId,
+          // Uppercase hex: valid to a typeof-string check, invalid to the 32-lowercase-hex
+          // contract the bind RPC enforces — must be dropped at ingestion.
+          event: { type: "prompt_done", traceId: "F".repeat(32) },
+        });
+        return { ok: true };
+      }
+      return {};
+    });
+    const res = makeRes();
+    await handleDelegate(makeReq({ peerAgentId: PEER, text: "inspect" }), res as any, identity, deps);
+
+    expect(delegateResult(res)?.peerTraceId).toBeUndefined();
+    expect(bindMessageTraceId).not.toHaveBeenCalled();
+  });
+
+  it("salvages the opening-row bind from a terminal that arrived after the delegation settled", async () => {
+    getMessages.mockResolvedValueOnce([
+      { id: "row-user", role: "user", content: "inspect", delegationId: "d-late-1", metadata: null },
+      { id: "row-a", role: "assistant", content: "partial", delegationId: null, metadata: null },
+    ] as any);
+    await salvageDelegationTraceBind({ sessionId: "peer-s", delegationId: "d-late-1", event: { type: "prompt_done", aborted: true, traceId: TRACE } });
+    expect(bindMessageTraceId).toHaveBeenCalledWith("row-user", "peer-s", TRACE);
+  });
+
+  it("walks the history at most once per delegation id across terminal redeliveries", async () => {
+    getMessages.mockResolvedValueOnce([
+      { id: "row-user", role: "user", content: "inspect", delegationId: "d-late-memo", metadata: null },
+    ] as any);
+    const terminal = { sessionId: "peer-s", delegationId: "d-late-memo", event: { type: "prompt_done", traceId: TRACE } };
+    await salvageDelegationTraceBind(terminal);
+    await salvageDelegationTraceBind(terminal);
+    expect(getMessages).toHaveBeenCalledTimes(1);
+    expect(bindMessageTraceId).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a settled terminal whose trace id is missing or malformed", async () => {
+    await salvageDelegationTraceBind({ sessionId: "peer-s", delegationId: "d-late-2", event: { type: "prompt_done" } });
+    await salvageDelegationTraceBind({ sessionId: "peer-s", delegationId: "d-late-2", event: { type: "prompt_done", traceId: "F".repeat(32) } });
+    expect(getMessages).not.toHaveBeenCalled();
+    expect(bindMessageTraceId).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a terminal without a trace id from an older target Runtime", async () => {
+    const deps = makeDeps({ found: true, user_id: "u", agent_id: COORD });
+    deps.frontendClient.request = vi.fn(async (method: string, params: any) => {
+      if (method === "config.getDelegates") return { members: [{ id: PEER, name: "peer", description: "", clusters: [], hosts: [] }] };
+      if (method === "delegation.resolveRoute") return { local: false, sourceRuntimeId: "shanghai", targetRuntimeId: "aries" };
+      if (method === "delegation.start") {
+        getMessages.mockResolvedValueOnce([
+          { role: "user", content: "inspect", delegationId: params.delegationId, metadata: null },
+          { role: "assistant", content: "remote answer", delegationId: null, metadata: null },
+        ] as any);
+        deps.eventHandlers.get("delegation.event")!({
+          delegationId: params.delegationId,
+          sessionId: params.sessionId,
+          event: { type: "prompt_done" },
+        });
+        return { ok: true };
+      }
+      return {};
+    });
+    const res = makeRes();
+    await handleDelegate(makeReq({ peerAgentId: PEER, text: "inspect" }), res as any, identity, deps);
+
+    expect(delegateResult(res)).toMatchObject({ ok: true, status: "done" });
+    expect(delegateResult(res)?.peerTraceId).toBeUndefined();
+    expect(bindMessageTraceId).not.toHaveBeenCalled();
   });
 });
 

--- a/src/gateway/delegate-api.ts
+++ b/src/gateway/delegate-api.ts
@@ -27,7 +27,7 @@ import type { AgentBoxManager } from "./agentbox/manager.js";
 import { AgentBoxClient, type AgentBoxTlsOptions } from "./agentbox/client.js";
 import { consumeAgentSse } from "./sse-consumer.js";
 import { sessionTurnLocks } from "./session-turn-lock.js";
-import { ensureChatSession, appendMessage, getMessages } from "./chat-repo.js";
+import { ensureChatSession, appendMessage, getMessages, bindMessageTraceId, warnTraceBindFailure, validTraceId } from "./chat-repo.js";
 import { resolveAgentModelBinding } from "./agent-model-binding.js";
 import { parsePositiveIntEnv } from "../core/subagent-registry.js";
 import type {
@@ -52,6 +52,12 @@ const DEFAULT_REMOTE_DELEGATION_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
  */
 const REMOTE_RESULT_WINDOW_START = 200;
 const REMOTE_RESULT_WINDOW_MAX = 20_000;
+
+// Trace ids from another process (the box's prompt ack, a remote terminal event) are
+// gated through chat-repo's validTraceId at ingestion: a malformed id from a buggy or
+// differently-versioned peer would otherwise be persisted verbatim as the tool row's
+// child_trace_id (a link that matches nothing) while the opening-row bind for the same
+// value fails on the server's stricter check — a half-written link.
 
 /**
  * The control plane keeps its own relay lease and tears the relay down when it
@@ -184,47 +190,52 @@ type DurableRemoteResult =
  * guarantees that later rows up to prompt_done belong to this turn even when a
  * peer session is reused.
  */
+/**
+ * The widening-window walk both durable readers share: find the CURRENT turn's
+ * opening user row (the durable boundary marker — delegationId is minted per
+ * delegate call, so the reverse scan is unique). A fixed window would make the
+ * search a function of how chatty the turn was: tool rows are messages too, so
+ * one tool-heavy investigation can bury its own opening row.
+ *
+ * Returns the window and the boundary index, or undefined when the whole session
+ * was read without finding the row. Throws what getMessages throws — each caller
+ * reports that in its own vocabulary.
+ */
+async function findTurnBoundary(
+  peerSessionId: string,
+  delegationId: string,
+): Promise<{ window: Awaited<ReturnType<typeof getMessages>>; boundary: number } | undefined> {
+  // The update clause doubles AND clamps in one expression (min(2l, MAX)):
+  // doubling blindly would overshoot the stated ceiling on the last step
+  // (12800 → 25600) and request more rows than the cap admits.
+  for (let limit = REMOTE_RESULT_WINDOW_START; ; limit = Math.min(limit * 2, REMOTE_RESULT_WINDOW_MAX)) {
+    const window = await getMessages(peerSessionId, { limit });
+    for (let i = window.length - 1; i >= 0; i -= 1) {
+      if (window[i].role === "user" && window[i].delegationId === delegationId) {
+        return { window, boundary: i };
+      }
+    }
+    // A window that came back short IS the whole session: widening cannot reveal
+    // a boundary row that is not there.
+    if (window.length < limit || limit >= REMOTE_RESULT_WINDOW_MAX) return undefined;
+  }
+}
+
 async function recoverRemoteResult(
   peerSessionId: string,
   delegationId: string,
 ): Promise<DurableRemoteResult> {
-  // Widen the window until this turn's opening row is inside it. A fixed window
-  // would make recovery a function of how chatty the turn was: tool rows are
-  // messages too, so one tool-heavy investigation can bury its own opening row and
-  // have its finished answer reported as unrecoverable.
-  let turnMessages: Awaited<ReturnType<typeof getMessages>> = [];
-  let boundaryFound = false;
-  for (let limit = REMOTE_RESULT_WINDOW_START; !boundaryFound; limit *= 2) {
-    let window: Awaited<ReturnType<typeof getMessages>>;
-    try {
-      window = await getMessages(peerSessionId, { limit });
-    } catch (err) {
-      console.warn(`[delegate-api] failed to recover remote delegation ${delegationId} from chat history:`, err);
-      return { status: "failed", error: "Remote delegation completed, but its result could not be recovered" };
-    }
-
-    let boundary = -1;
-    for (let i = window.length - 1; i >= 0; i -= 1) {
-      if (window[i].role === "user" && window[i].delegationId === delegationId) {
-        boundary = i;
-        break;
-      }
-    }
-    if (boundary >= 0) {
-      turnMessages = window.slice(boundary + 1);
-      boundaryFound = true;
-      break;
-    }
-    // A window that came back short IS the whole session: widening cannot reveal
-    // a boundary row that is not there.
-    if (window.length < limit || limit >= REMOTE_RESULT_WINDOW_MAX) break;
-    // Doubling blindly would overshoot the stated ceiling on the last step
-    // (12800 → 25600); land exactly on it instead.
-    limit = Math.min(limit, REMOTE_RESULT_WINDOW_MAX / 2);
+  let found: Awaited<ReturnType<typeof findTurnBoundary>>;
+  try {
+    found = await findTurnBoundary(peerSessionId, delegationId);
+  } catch (err) {
+    console.warn(`[delegate-api] failed to recover remote delegation ${delegationId} from chat history:`, err);
+    return { status: "failed", error: "Remote delegation completed, but its result could not be recovered" };
   }
-  if (!boundaryFound) {
+  if (!found) {
     return { status: "failed", error: "Remote delegation completed, but its durable turn boundary was not found" };
   }
+  const turnMessages = found.window.slice(found.boundary + 1);
 
   const persistedError = [...turnMessages].reverse().find((message) =>
     message.role === "assistant" &&
@@ -244,6 +255,52 @@ async function recoverRemoteResult(
   if (assistantText) return { status: "found", finalText: assistantText };
 
   return { status: "empty" };
+}
+
+/**
+ * Salvage the trace link from a terminal that arrived AFTER its delegation's
+ * live subscriber was gone (coordinator Stop, relay idle-timeout, or a source
+ * restart that emptied the settled set): the target kept retrying delivery and
+ * the id is right here in-process. Binding the opening user row makes the leg's
+ * trace complete, so the leg stays reachable from the tool row's
+ * child_session_id even though that row's own child_trace_id was already
+ * persisted without it.
+ *
+ * Best-effort by design: the boundary walk is the shared findTurnBoundary (the
+ * current turn's opening row is the durable marker), and the bind RPC is
+ * NULL-to-value idempotent, so a re-delivered terminal repeating this is
+ * harmless. The memo below keeps a redelivery storm from re-walking the history
+ * — terminal retries back off for ~63s per delegation, so one walk per
+ * delegation id is all a correct sender ever needs.
+ */
+const salvagedDelegations = new Set<string>();
+const SALVAGED_DELEGATIONS_CAP = 512;
+export async function salvageDelegationTraceBind(params: Record<string, unknown>): Promise<void> {
+  const sessionId = typeof params?.sessionId === "string" ? params.sessionId : "";
+  const delegationId = typeof params?.delegationId === "string" ? params.delegationId : "";
+  const event = params?.event as Record<string, unknown> | undefined;
+  const traceId = validTraceId(event?.traceId);
+  if (!sessionId || !delegationId || !traceId) return;
+  if (salvagedDelegations.has(delegationId)) return;
+  salvagedDelegations.add(delegationId);
+  if (salvagedDelegations.size > SALVAGED_DELEGATIONS_CAP) {
+    // FIFO eviction, same shape as the settled-delegations bound: Set iteration
+    // order is insertion order.
+    const oldest = salvagedDelegations.values().next().value;
+    if (oldest !== undefined) salvagedDelegations.delete(oldest);
+  }
+  const found = await findTurnBoundary(sessionId, delegationId);
+  if (!found) {
+    // Loud, not silent: a salvage that found no opening row (the append failed at
+    // delegation time) is the one outcome an operator cannot distinguish from
+    // success without this line.
+    console.warn(`[delegate-api] settled-delegation trace salvage found no opening row for delegation=${delegationId} session=${sessionId}`);
+    return;
+  }
+  const row = found.window[found.boundary];
+  await bindMessageTraceId(row.id, sessionId, traceId).catch((err) => {
+    warnTraceBindFailure("settled delegation", sessionId, row.id, err);
+  });
 }
 
 /** GET /api/internal/delegates — the calling coordinator's roster. */
@@ -298,6 +355,27 @@ export async function handleDelegate(
   let delegationId = "";
   let peerSessionId = "";
   let remoteStartRequested = false;
+  // The peer turn's own root trace id, once the runtime serving it reports one
+  // (local: the box's prompt ack; remote: the terminal event). A delegated turn
+  // is its OWN trace, so this is what the delegate_result carries back for the
+  // coordinator to persist as the cross-trace link — and what the opening user
+  // row below is bound to, since that row is appended before the trace exists.
+  let peerTraceId: string | undefined;
+  // The opening user row's id, kept so peerTraceId can be bound to it later.
+  let openingMessageId = "";
+  const bindOpeningRowTrace = (traceId: string | undefined) => {
+    if (!traceId || !openingMessageId) return;
+    // openingMessageId is deliberately NOT cleared here: it is a per-request local
+    // (a reused peer session's next turn is a NEW handleDelegate call with its own
+    // opening row), and the bind RPC is value-idempotent server-side — so a
+    // re-delivered remote terminal retrying the bind is harmless, while clearing
+    // before the fire-and-forget settles would let one transient RPC failure
+    // permanently strand the opening row at trace_id NULL.
+    const messageId = openingMessageId;
+    void bindMessageTraceId(messageId, peerSessionId, traceId).catch((err) => {
+      warnTraceBindFailure("delegated prompt", peerSessionId, messageId, err);
+    });
+  };
   /**
    * Wind this delegation down, RETURNING the abort it issues — once.
    *
@@ -473,8 +551,10 @@ export async function handleDelegate(
       { parentSessionId: trustedParent, parentAgentId: coordinatorAgentId, delegationId, targetAgentId: peerAgentId },
     );
     // Persist the delegated task as the opening user turn so the opened session
-    // reads naturally (and a reuse turn appends its new task).
-    await appendMessage({ sessionId: peerSessionId, role: "user", content: text, parentSessionId: trustedParent, delegationId, targetAgentId: peerAgentId });
+    // reads naturally (and a reuse turn appends its new task). The row is written
+    // BEFORE the peer turn exists, so its trace id is bound later (bindOpeningRowTrace)
+    // — the same append-then-bind pattern chat.send uses for its prompt row.
+    openingMessageId = await appendMessage({ sessionId: peerSessionId, role: "user", content: text, parentSessionId: trustedParent, delegationId, targetAgentId: peerAgentId });
   } catch (err) {
     if (cancelled()) return;
     console.warn("[delegate-api] failed to persist peer session:", err);
@@ -596,6 +676,24 @@ export async function handleDelegate(
       observePeerEvent(envelope.event, false);
       const type = String((envelope.event as any)?.type ?? "");
       if (type === "prompt_done" || type === "done") {
+        // The target Runtime reports the peer turn's own trace id on the terminal
+        // (its rows were already persisted under it by that Runtime's chat.send
+        // consume). Absent or malformed from an older/foreign target — the link
+        // then simply stays unwritten, which is exactly the pre-fix behaviour.
+        //
+        // KNOWN GAP: a coordinator Stop or relay idle-timeout tears this
+        // subscription down before any terminal arrives, so THOSE remote legs'
+        // delegate_result carries no peerTraceId (the local route keeps it on the
+        // same paths — captured at prompt ack) and the tool row loses its
+        // child_trace_id. The opening-row bind is NOT lost: the target retries the
+        // terminal, and the settled branch of delegation.control salvages it via
+        // salvageDelegationTraceBind — the leg then stays reachable through the
+        // tool row's child_session_id → session trace listing.
+        const eventTraceId = validTraceId((envelope.event as any).traceId);
+        if (eventTraceId) {
+          peerTraceId = eventTraceId;
+          bindOpeningRowTrace(eventTraceId);
+        }
         if ((envelope.event as any).aborted === true) {
           const reason = typeof (envelope.event as any).reason === "string"
             ? (envelope.event as any).reason.trim()
@@ -713,10 +811,25 @@ export async function handleDelegate(
       },
     });
 
+    // The box's prompt ack names the peer turn's own root trace id. Stamp it on
+    // every row this consume persists and bind it to the opening user row —
+    // exactly what the target Runtime's chat.send path does for a REMOTE peer,
+    // so the two routes leave identical rows behind. Before this, the local
+    // route persisted the whole delegated leg with trace_id NULL, which is what
+    // made delegation legs invisible to trace-keyed audit and analysis reads.
+    peerTraceId = validTraceId(promptResult.traceId);
+    bindOpeningRowTrace(peerTraceId);
+    // Announce the leg's trace EARLY, the way delegate_session announces the
+    // session: a coordinator Stop destroys the client's socket before the final
+    // delegate_result frame is written, so whatever the client learned early is
+    // all a stopped leg's tool row gets to keep.
+    if (peerTraceId) writeFrame({ type: "delegate_trace", peerTraceId });
+
     const consumption = await consumeAgentSse({
       client,
       sessionId: promptResult.sessionId,
       userId: ownerUserId,
+      traceId: peerTraceId,
       // Stop propagation: break the drain loop the moment the coordinator aborts.
       signal: peerAbort.signal,
       // Persist the peer session's rows so the coordinator can open its full
@@ -779,7 +892,9 @@ export async function handleDelegate(
       console.error(`[delegate-api] delegation to ${peerAgentId} failed: ${outcome.error}`);
       writeFrame({
         type: "delegate_result",
-        result: { ok: false, peerAgentId, peerName: member.name, status: "failed", steps, peerSessionId, error: outcome.error } satisfies DelegateResponse,
+        // peerTraceId rides failure frames too: a failed leg still persisted rows
+        // under its trace, and failed legs are exactly what a review drills into.
+        result: { ok: false, peerAgentId, peerName: member.name, status: "failed", steps, peerSessionId, peerTraceId, error: outcome.error } satisfies DelegateResponse,
       });
       res.end();
       return;
@@ -791,7 +906,7 @@ export async function handleDelegate(
     if (peerAbort.signal.aborted) {
       writeFrame({
         type: "delegate_result",
-        result: { ok: false, peerAgentId, peerName: member.name, status: "failed", steps, peerSessionId, error: "delegation stopped" } satisfies DelegateResponse,
+        result: { ok: false, peerAgentId, peerName: member.name, status: "failed", steps, peerSessionId, peerTraceId, error: "delegation stopped" } satisfies DelegateResponse,
       });
       res.end();
       return;
@@ -799,7 +914,7 @@ export async function handleDelegate(
     console.error(`[delegate-api] delegation to ${peerAgentId} failed:`, err);
     writeFrame({
       type: "delegate_result",
-      result: { ok: false, peerAgentId, peerName: member.name, status: "failed", steps, peerSessionId, error: err instanceof Error ? err.message : String(err) } satisfies DelegateResponse,
+      result: { ok: false, peerAgentId, peerName: member.name, status: "failed", steps, peerSessionId, peerTraceId, error: err instanceof Error ? err.message : String(err) } satisfies DelegateResponse,
     });
     res.end();
     return;
@@ -828,7 +943,7 @@ export async function handleDelegate(
       type: "delegate_result",
       result: {
         ok: true, peerAgentId, peerName: member.name, status: "input_required",
-        inputQuestion, steps, finalText: finalTextCapped || undefined, peerSessionId,
+        inputQuestion, steps, finalText: finalTextCapped || undefined, peerSessionId, peerTraceId,
       } satisfies DelegateResponse,
     });
     res.end();
@@ -838,7 +953,7 @@ export async function handleDelegate(
     type: "delegate_result",
     result: {
       ok: true, peerAgentId, peerName: member.name, status: "done", artifact, steps,
-      finalText: finalTextCapped || undefined, peerSessionId,
+      finalText: finalTextCapped || undefined, peerSessionId, peerTraceId,
     } satisfies DelegateResponse,
   });
   res.end();

--- a/src/gateway/server-capability-cancel.test.ts
+++ b/src/gateway/server-capability-cancel.test.ts
@@ -5,6 +5,8 @@ const box = vi.hoisted(() => ({
 }));
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   incrementMessageCount: vi.fn(async () => {}),

--- a/src/gateway/server-capability-command.test.ts
+++ b/src/gateway/server-capability-command.test.ts
@@ -11,6 +11,8 @@ const streamState = vi.hoisted(() => ({
 }));
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-capability-input-revision.test.ts
+++ b/src/gateway/server-capability-input-revision.test.ts
@@ -5,6 +5,8 @@ const effects = vi.hoisted(() => [] as string[]);
 const boxPosts = vi.hoisted(() => [] as Array<{ path: string; body: unknown }>);
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-capability-message-id.test.ts
+++ b/src/gateway/server-capability-message-id.test.ts
@@ -5,6 +5,8 @@ const box = vi.hoisted(() => ({
 }));
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-capability-setup-failure.test.ts
+++ b/src/gateway/server-capability-setup-failure.test.ts
@@ -10,6 +10,8 @@ const postJsonMock = vi.hoisted(() => vi.fn());
 const streamPathMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-capability-test-close.test.ts
+++ b/src/gateway/server-capability-test-close.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const postJsonMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-capability-test-recommend.test.ts
+++ b/src/gateway/server-capability-test-recommend.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const posts = vi.hoisted(() => [] as Array<{ path: string; body: unknown; timeoutMs?: number }>);
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-capability-test-sessions.test.ts
+++ b/src/gateway/server-capability-test-sessions.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const getJsonMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -15,12 +15,16 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 const bindMessageTraceIdMock = vi.hoisted(() => vi.fn(async () => {}));
 const updateMessageMock = vi.hoisted(() => vi.fn(async () => {}));
 
-vi.mock("./chat-repo.js", () => ({
+vi.mock("./chat-repo.js", async (importOriginal) => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: bindMessageTraceIdMock,
   updateMessage: updateMessageMock,
   incrementMessageCount: vi.fn(async () => {}),
+  warnTraceBindFailure: vi.fn(),
+  // The real validator: the delegated-turn ledger gates the box ack through it.
+  validTraceId: (await importOriginal<typeof import("./chat-repo.js")>()).validTraceId,
+  getMessages: vi.fn(async () => []),
 }));
 
 vi.mock("./output-redactor.js", () => ({
@@ -353,6 +357,34 @@ describe("startRuntime — chat.abort wiring", () => {
     });
   });
 
+  it("carries the delegated turn's own trace id on its terminal event", async () => {
+    // The terminal is the ONE channel the coordinator Runtime can learn which
+    // trace this leg's rows were persisted under: chat.send acks before the
+    // trace exists and chat.getMessages does not project trace_id. The source
+    // stores it as the tool row's child_trace_id — the cross-trace link.
+    const frontendClient = fakeFrontendClient();
+    frontendClient.request = vi.fn(async (method: string) =>
+      method === "delegation.terminal" ? { ok: true } : { found: false });
+
+    server = await bootRuntime(fakeAgentBoxManager(), frontendClient);
+    const send = server.rpcMethods.get("chat.send")!;
+
+    await send({
+      agentId: "a", userId: "u", text: "inspect", sessionId: "delegated",
+      delegation: { delegationId: "d2", parentAgentId: "coord", readOnly: false },
+    }, { sendEvent: vi.fn() });
+    await waitFor(() => settleConsumer !== undefined);
+    settleConsumer!(); // the turn finishes normally
+
+    await waitFor(() =>
+      frontendClient.request.mock.calls.some(([method]: any[]) => method === "delegation.terminal"));
+    const call = frontendClient.request.mock.calls.find(([method]: any[]) => method === "delegation.terminal");
+    expect(call?.[1]).toMatchObject({
+      delegationId: "d2",
+      event: { type: "prompt_done", traceId: "0123456789abcdef0123456789abcdef" },
+    });
+  });
+
   it("does not ask for an acknowledgement on an ordinary turn", async () => {
     const frontendClient = fakeFrontendClient();
     server = await bootRuntime(fakeAgentBoxManager(), frontendClient);
@@ -441,7 +473,10 @@ describe("startRuntime — chat.abort wiring", () => {
       delegationId: "d9",
       sessionId: "interrupted",
       turnId: ack.turnId,
-      event: { type: "prompt_done", aborted: true, reason: "runtime_restart" },
+      // The interrupted leg's rows were persisted under the trace the prompt ack
+      // named; the supervisor terminal must carry it (from the delegatedTurns ledger
+      // entry) or exactly the legs a review drills into lose their link.
+      event: { type: "prompt_done", aborted: true, reason: "runtime_restart", traceId: "0123456789abcdef0123456789abcdef" },
     });
     expect(frontendClient.close).toHaveBeenCalled();
     expect(frontendClient.request.mock.invocationCallOrder[0])

--- a/src/gateway/server-chat-system-prompt.test.ts
+++ b/src/gateway/server-chat-system-prompt.test.ts
@@ -18,6 +18,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-session-status.test.ts
+++ b/src/gateway/server-session-status.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-shutdown-turns.test.ts
+++ b/src/gateway/server-shutdown-turns.test.ts
@@ -11,6 +11,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import type { BoxSyncStatus } from "../shared/agentbox-sync-status.js";
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server-tracing-reload.test.ts
+++ b/src/gateway/server-tracing-reload.test.ts
@@ -10,6 +10,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -88,9 +88,9 @@ import {
   handleDelegationEvents,
   handleMetricsFlush,
 } from "./internal-api.js";
-import { handleDelegate, handleDelegates, isDelegationSettled } from "./delegate-api.js";
+import { handleDelegate, handleDelegates, isDelegationSettled, salvageDelegationTraceBind } from "./delegate-api.js";
 // siclaw-api.ts routes moved to Portal — Runtime no longer registers CRUD routes.
-import { appendMessage, bindMessageTraceId, incrementMessageCount, ensureChatSession, updateMessage, sequenceMessage } from "./chat-repo.js";
+import { appendMessage, bindMessageTraceId, incrementMessageCount, ensureChatSession, updateMessage, sequenceMessage, warnTraceBindFailure, validTraceId } from "./chat-repo.js";
 import { consumeAgentSse } from "./sse-consumer.js";
 import { buildRedactionConfigForModelConfig } from "./output-redactor.js";
 import { MetricsAggregator } from "./metrics-aggregator.js";
@@ -149,29 +149,9 @@ export interface StartRuntimeOptions {
  * seconds. Long enough to cover that; short enough that a genuinely missing session fails
  * while the user is still looking at the screen.
  */
-/**
- * Report a failed trace bind — but only once per process when the upstream simply does
- * not implement the method.
- *
- * Binding a message to its trace is best-effort and optional: an upstream that has no
- * trace consumer yet answers "unknown method" to every prompt and every steer, and a
- * conversation steered a dozen times buries a real failure under a dozen identical lines.
- * Any OTHER failure is a genuine one-off and keeps its own line.
- */
-const unsupportedUpstreamMethodsReported = new Set<string>();
-function warnTraceBindFailure(kind: string, sessionId: string, messageId: string, err: unknown): void {
-  const message = String((err as Error)?.message ?? err);
-  if (/unknown method|not implemented|method not found/i.test(message)) {
-    // Keyed by the method the upstream is missing, not by a single global flag: one
-    // absent method must not silence the next one.
-    const method = message.match(/[\w.]+\.[\w]+/)?.[0] ?? message;
-    if (unsupportedUpstreamMethodsReported.has(method)) return;
-    unsupportedUpstreamMethodsReported.add(method);
-    console.warn(`[runtime] upstream does not implement ${method}; that capability is off for this process (${message})`);
-    return;
-  }
-  console.warn(`[runtime] failed to bind ${kind} trace session=${sessionId} message=${messageId}:`, err);
-}
+// warnTraceBindFailure moved to chat-repo.ts, next to bindMessageTraceId: the
+// delegation transport (delegate-api.ts) now binds opening rows too, and the
+// once-per-process dedup only works if every bind caller shares one reporter.
 
 const STEER_SESSION_WAIT_MS = 3_000;
 
@@ -353,7 +333,14 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
    * turn's own reporting (see supervisorEndedTurns), which is exactly why they
    * needed their own route to it.
    */
-  const delegatedTurns = new Map<string, { delegationId: string; sessionId: string }>();
+  // traceId is the delegated turn's own root trace id, recorded the moment the box's
+  // prompt ack names it. It lives HERE — on the turn's ledger entry — rather than in
+  // the chat.send closure, so both terminal producers (the consumer paths in the
+  // handler and the shutdown/box-roll supervisor above) report the same trace and an
+  // interrupted leg keeps its cross-trace link. (A delegated send that degrades into
+  // a steer of an already-running turn produces no terminal at all — a pre-existing
+  // gap that ends in the source's relay idle-timeout, not a divergent trace.)
+  const delegatedTurns = new Map<string, { delegationId: string; sessionId: string; traceId?: string }>();
   /**
    * Work that outlives the turn it belongs to and that shutdown must still flush.
    *
@@ -606,6 +593,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           type: "prompt_done",
           aborted: true,
           reason,
+          // The interrupted leg's rows were already persisted under this trace by the
+          // consume that just got cut short — an aborted terminal without it would
+          // leave exactly the legs a review drills into unlinked.
+          ...(delegated.traceId ? { traceId: delegated.traceId } : {}),
         });
         started.push(trackForShutdown(delivery));
       }
@@ -774,11 +765,20 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
      * makes it safe: the supervisor will not also report it, so a shutdown during
      * the retries cannot turn a finished turn into an interrupted one.
      */
+    // Riding the trace id on the terminal event is what hands it to the SOURCE
+    // Runtime: chat.send acks in milliseconds (before the trace exists) and
+    // chat.getMessages does not project trace_id, so the terminal is the one channel
+    // the coordinator side can learn which trace this leg's rows were persisted
+    // under — the value it stores as the tool row's `child_trace_id` link. The id is
+    // read from the delegatedTurns ledger entry (recorded at prompt ack), the same
+    // place the supervisor path reads it, so the two producers cannot disagree.
     const reportTerminal = (event: Record<string, unknown>): void => {
       const delegationId = delegation?.delegationId;
       if (!delegationId) return;
+      const traceId = delegatedTurns.get(turnId)?.traceId;
       delegatedTurns.delete(turnId);
-      void trackForShutdown(deliverDelegationTerminal(delegationId, sessionId, turnId, event));
+      const terminal = traceId ? { ...event, traceId } : event;
+      void trackForShutdown(deliverDelegationTerminal(delegationId, sessionId, turnId, terminal));
     };
     const promptOpts: PromptOptions = {
       sessionId,
@@ -881,7 +881,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             if (promptMessageId) pendingUserRows.push(sessionId, promptMessageId, text);
             if (promptMessageId) await updateMessage({ messageId: promptMessageId, sessionId, content: text, metadata: { kind: "steer" } })
               .catch((e) => console.warn(`[runtime] failed to mark steer message session=${sessionId}:`, e));
-            if (promptMessageId) void bindMessageTraceId(promptMessageId, sessionId, steered.traceId).catch(() => {});
+            if (promptMessageId) void bindMessageTraceId(promptMessageId, sessionId, steered.traceId).catch((bindErr) => {
+              warnTraceBindFailure("busy-degrade steer", sessionId, promptMessageId!, bindErr);
+            });
             return; // the running turn owns the stream and will emit its own prompt_done
           }
           // No steer target, or the turn ended between the rejection and the steer. Ask
@@ -918,8 +920,20 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         throwIfStoppedBeforePrompt();
 
         let promptResult: Awaited<ReturnType<typeof client.prompt>>;
+        let ackTraceId: string | undefined;
         try {
           promptResult = await client.prompt(promptOpts);
+          // The ack's trace id is gated ONCE and every consumer of it below — the
+          // delegated-turn ledger, the prompt-row bind, the consume's row stamp —
+          // uses the gated value: stamping rows with a malformed id one boundary
+          // accepts and another rejects is how a turn ends up persisted under an id
+          // no link references.
+          ackTraceId = validTraceId(promptResult.traceId);
+          // Record the delegated turn's trace id on its ledger entry IMMEDIATELY —
+          // before any Stop/abort handling below — so a turn interrupted between the
+          // ack and the consume still reports the trace its rows were persisted under.
+          const delegated = delegatedTurns.get(turnId);
+          if (delegated) delegated.traceId = ackTraceId;
           // The box now has the session: a steer racing this call can stop waiting, and
           // this row is in line to be processed (see pending-user-rows.ts).
           sessionTurnLocks.markPromptAccepted(sessionId);
@@ -1000,7 +1014,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           throw err;
         }
 
-        if (promptMessageId) void bindMessageTraceId(promptMessageId, promptResult.sessionId, promptResult.traceId).catch((bindErr) => {
+        if (promptMessageId) void bindMessageTraceId(promptMessageId, promptResult.sessionId, ackTraceId).catch((bindErr) => {
           warnTraceBindFailure("prompt", promptResult.sessionId, promptMessageId!, bindErr);
         });
 
@@ -1030,7 +1044,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             client,
             sessionId: promptResult.sessionId,
             userId,
-            traceId: promptResult.traceId,
+            traceId: ackTraceId,
             persistMessages: true,
             // The box has started consuming a user message: give that row its place in
             // the conversation now, which is the only moment processing order is visible.
@@ -2183,6 +2197,17 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // which keeps the sender's relay alive; a relay that later expires aborts by
     // (agent, session) and would kill a NEW turn reusing that peer session.
     const delegationId = typeof params?.delegationId === "string" ? params.delegationId : "";
+    // A terminal that outlived its consumer (Stop, idle-timeout — or a source
+    // restart that emptied the settled set) still carries the leg's trace id —
+    // salvage the opening-row bind, or the interrupted legs a review drills into
+    // stay unlinked. Fire-and-forget on BOTH branches: the ack (or the retry-driving
+    // throw below) must not wait on a best-effort bind, and the salvage's own memo
+    // keeps redelivery retries from repeating the history walk.
+    if (delegationId) {
+      void salvageDelegationTraceBind(params as Record<string, unknown>).catch((err) => {
+        console.warn(`[runtime] settled-delegation trace salvage failed for ${delegationId}:`, err);
+      });
+    }
     if (delegationId && isDelegationSettled(delegationId)) {
       return { ok: true, alreadySettled: true };
     }

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -11,6 +11,8 @@ const updateCalls: any[] = [];
 let appendCounter = 0;
 
 vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
   appendMessage: vi.fn(async (msg: any) => {
     appendCalls.push(msg);
     return `msg-${++appendCounter}`;

--- a/src/gateway/task-coordinator.test.ts
+++ b/src/gateway/task-coordinator.test.ts
@@ -8,7 +8,10 @@ const appendCalls: any[] = [];
 const ensureCalls: any[] = [];
 let appendCounter = 0;
 
-vi.mock("./chat-repo.js", () => ({
+vi.mock("./chat-repo.js", async (importOriginal) => ({
+  warnTraceBindFailure: vi.fn(),
+  // The real validator: the coordinator gates the box ack through it.
+  validTraceId: (await importOriginal<typeof import("./chat-repo.js")>()).validTraceId,
   appendMessage: vi.fn(async (msg: any) => {
     appendCalls.push(msg);
     return `msg-${++appendCounter}`;

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -18,7 +18,7 @@ import type { RuntimeConfig } from "./config.js";
 import type { AgentBoxManager } from "./agentbox/manager.js";
 import { AgentBoxClient, type AgentBoxTlsOptions, type PromptOptions } from "./agentbox/client.js";
 import { resolveAgentModelBinding } from "./agent-model-binding.js";
-import { appendMessage, ensureChatSession, incrementMessageCount } from "./chat-repo.js";
+import { appendMessage, ensureChatSession, incrementMessageCount, validTraceId } from "./chat-repo.js";
 import { consumeAgentSse } from "./sse-consumer.js";
 import { sessionTurnLocks } from "./session-turn-lock.js";
 import { buildRedactionConfigForModelConfig } from "./output-redactor.js";
@@ -294,13 +294,17 @@ export class TaskCoordinator {
         systemPromptTemplate: binding.systemPrompt ?? undefined,
       };
       const promptResult = await client.prompt(promptOpts);
+      // Cross-process trace ids are gated at ingestion (see chat-repo.validTraceId):
+      // stamping rows with an id the bind/link boundaries would reject strands them
+      // under an id no reader references.
+      const ackTraceId = validTraceId(promptResult.traceId);
 
       // Seed chat_sessions + user message via RPC. `origin: "task"` is the
       // one signal that lets upstream's Metrics dashboard split scheduled cron
       // activity from interactive chat — without it every cron-triggered
       // session collapses into the default Interactive world.
       await ensureChatSession(sessionId, agentId, userId, job.name, prompt, "task");
-      await appendMessage({ sessionId, role: "user", content: prompt, traceId: promptResult.traceId });
+      await appendMessage({ sessionId, role: "user", content: prompt, traceId: ackTraceId });
       await incrementMessageCount(sessionId);
 
       const redactionConfig = buildRedactionConfigForModelConfig(binding.modelConfig);
@@ -313,7 +317,7 @@ export class TaskCoordinator {
           client,
           sessionId,
           userId,
-          traceId: promptResult.traceId,
+          traceId: ackTraceId,
           persistMessages: true,
           redactionConfig,
           signal: abortCtrl.signal,

--- a/src/shared/agent-delegate.ts
+++ b/src/shared/agent-delegate.ts
@@ -63,6 +63,14 @@ export interface DelegateResponse {
    * it back as DelegateRequest.peerSessionId to continue the same peer thread.
    */
   peerSessionId?: string;
+  /**
+   * The peer turn's OWN root trace id (32-hex). A delegated turn is its own
+   * trace — the peer runs under its own authority — so the coordinator persists
+   * this as the cross-trace link (tool details `child_trace_id`) that lets the
+   * audit/analysis side walk from the coordinator's trace into the delegated
+   * leg. Absent when the peer runtime has tracing off or predates the field.
+   */
+  peerTraceId?: string;
   error?: string;
 }
 

--- a/src/tools/workflow/delegate-to-agent.test.ts
+++ b/src/tools/workflow/delegate-to-agent.test.ts
@@ -107,3 +107,48 @@ describe("delegate_to_agent tool", () => {
     expect((r.details as any).status).toBe("failed");
   });
 });
+
+/**
+ * The delegated leg runs as its OWN trace (the peer answers to its own config),
+ * so the coordinator's tool row is where the cross-trace link lives: details
+ * carry `child_trace_id` next to `child_session_id`, and the sse-consumer
+ * persists details into the tool row's metadata. These tests pin the link's
+ * presence/absence contract; the transport side is covered in
+ * delegate-api.test.ts.
+ */
+describe("delegate_to_agent tool — child trace link", () => {
+  const TRACE = "a".repeat(32);
+
+  it("persists child_trace_id next to child_session_id when the leg reported its trace", async () => {
+    const exec = vi.fn(async () => okResp({ peerSessionId: "child-sess", peerTraceId: TRACE }));
+    const tool = createDelegateToAgentTool(makeRefs({ delegationRoster: ROSTER, delegateToAgentExecutor: exec as any }));
+    const r = await tool.execute("c1", { agent_id: "agent-net", task: "x" });
+    expect(r.details as any).toMatchObject({
+      status: "done",
+      child_session_id: "child-sess",
+      child_trace_id: TRACE,
+    });
+  });
+
+  it("omits child_trace_id when the leg has none (tracing off / older runtime)", async () => {
+    const exec = vi.fn(async () => okResp({ peerSessionId: "child-sess" }));
+    const tool = createDelegateToAgentTool(makeRefs({ delegationRoster: ROSTER, delegateToAgentExecutor: exec as any }));
+    const r = await tool.execute("c1", { agent_id: "agent-net", task: "x" });
+    expect((r.details as any).child_session_id).toBe("child-sess");
+    expect(r.details as any).not.toHaveProperty("child_trace_id");
+  });
+
+  it("keeps the link on a failed leg — failed legs are exactly what a review drills into", async () => {
+    const exec = vi.fn(async () => okResp({
+      ok: false, status: "failed", artifact: null, error: "kubectl timed out",
+      peerSessionId: "child-sess", peerTraceId: TRACE,
+    }));
+    const tool = createDelegateToAgentTool(makeRefs({ delegationRoster: ROSTER, delegateToAgentExecutor: exec as any }));
+    const r = await tool.execute("c1", { agent_id: "agent-net", task: "x" });
+    expect(r.details as any).toMatchObject({
+      status: "failed",
+      child_session_id: "child-sess",
+      child_trace_id: TRACE,
+    });
+  });
+});

--- a/src/tools/workflow/delegate-to-agent.ts
+++ b/src/tools/workflow/delegate-to-agent.ts
@@ -111,21 +111,30 @@ export function createDelegateToAgentTool(refs: ToolRefs): ToolDefinition {
       };
       const continueSessionId = params.session_id?.trim() || undefined;
       const resp = await refs.delegateToAgentExecutor({ peerAgentId: member.id, text: task, peerSessionId: continueSessionId }, onProgress, signal)
-        .catch((err) => ({ ok: false, peerAgentId: member.id, peerName: member.name, status: "failed" as const, steps: [], peerSessionId: undefined as string | undefined, error: err instanceof Error ? err.message : String(err) }));
-
-      // Stopped by the coordinator (turn aborted): the relay was torn down and
-      // the peer turn cancelled. Report a clean stop, not a scary error.
-      if (signal?.aborted) {
-        const msg = `Delegation to ${member.name} was stopped.`;
-        return { content: [{ type: "text" as const, text: msg }], details: { agent_id: member.id, agent_name: member.name, tool_calls: resp.steps?.length ?? 0, steps: lastSteps, status: "stopped", summary: msg, ...(resp.peerSessionId ? { child_session_id: resp.peerSessionId } : {}) } };
-      }
+        .catch((err) => ({ ok: false, peerAgentId: member.id, peerName: member.name, status: "failed" as const, steps: [], peerSessionId: undefined as string | undefined, peerTraceId: undefined as string | undefined, error: err instanceof Error ? err.message : String(err) }));
 
       // Card-facing shape (portal-web AgentWorkCard reads target from args and
       // status/summary/tool_calls/steps from result details). Carry the accumulated
       // live steps into the FINAL result so the card keeps them after completion.
       // session_id (=peer session) lets the card OPEN the full peer session and lets
       // the model pass it back to continue this peer thread.
-      const cardBase = { agent_id: member.id, agent_name: member.name, tool_calls: resp.steps?.length ?? 0, steps: lastSteps, ...(resp.peerSessionId ? { child_session_id: resp.peerSessionId } : {}) };
+      // child_trace_id is the leg's own trace: it persists into this tool row's
+      // metadata (next to child_session_id) as the machine-readable link that lets
+      // trace-keyed audit/analysis reads walk into the delegated leg.
+      // Built ABOVE the stopped branch so every outcome shares one literal.
+      // child_session_id falls back to the id the EARLY delegate_session frame
+      // announced: a mid-stream relay error (or a Stop) surfaces as an executor
+      // fallback with no peerSessionId, and the failed/stopped legs are exactly
+      // the ones a review needs to open.
+      const childSessionId = resp.peerSessionId ?? liveChildSessionId;
+      const cardBase = { agent_id: member.id, agent_name: member.name, tool_calls: resp.steps?.length ?? 0, steps: lastSteps, ...(childSessionId ? { child_session_id: childSessionId } : {}), ...(resp.peerTraceId ? { child_trace_id: resp.peerTraceId } : {}) };
+
+      // Stopped by the coordinator (turn aborted): the relay was torn down and
+      // the peer turn cancelled. Report a clean stop, not a scary error.
+      if (signal?.aborted) {
+        const msg = `Delegation to ${member.name} was stopped.`;
+        return { content: [{ type: "text" as const, text: msg }], details: { ...cardBase, status: "stopped", summary: msg } };
+      }
 
       if (!resp.ok || resp.status === "failed") {
         const msg = `Delegation to ${member.name} failed: ${resp.error ?? "unknown error"}`;


### PR DESCRIPTION
## Summary

Delegated legs were invisible to every trace-keyed read: on the local route the peer's rows were persisted with `trace_id NULL`, and on both routes nothing recorded which trace a delegation produced. This PR stamps every delegated leg with the peer turn's own root trace id (a delegated turn is its own trace — the peer runs under its own authority) and records the cross-trace link as `child_trace_id` on the coordinator's `delegate_to_agent` tool row, next to the existing `child_session_id`.

### Problem

`delegate-api`'s local route ran `consumeAgentSse` without a trace id, so an entire delegated investigation (often the bulk of a coordinator turn) persisted as `trace_id NULL` — while the remote route already stamped the peer's own id. Either way there was no machine-readable edge from the coordinator's trace to the leg, so audit and analysis reads keyed by trace id stopped dead at the `delegate_to_agent` boundary.

### Solution

- **Local route parity**: consume stamps every persisted peer row with the trace id from the box's prompt ack; the opening user row (appended before the trace exists) is back-bound afterwards — the same append-then-bind pattern `chat.send` uses. The two routes now leave identical rows.
- **Terminal carries the id**: the target Runtime rides the leg's trace id on the delegation terminal event — the one channel the source can learn a REMOTE leg's trace from. Both terminal producers (consumer paths and the shutdown/box-roll supervisor) read it from the delegated turn's ledger entry, recorded at prompt ack, so they cannot disagree.
- **The tool row records the link**: `delegate_to_agent` result details gain `child_trace_id` on every outcome (done / failed / input_required / stopped). An early `delegate_trace` frame announces the id at prompt ack, so a stopped leg's tool row keeps the link even though the final result frame dies with the destroyed socket.
- **One ingestion gate**: every trace id crossing a process boundary goes through `validTraceId` (32 lowercase hex, the same contract the bind RPC enforces server-side). Absent or malformed ids degrade to "no link" — an older peer Runtime simply produces the pre-feature behaviour.
- **Late-terminal salvage**: a terminal that outlives its subscriber (Stop, relay idle-timeout, source restart) still binds the opening row, memoized per delegation id.
- Contract documented in `docs/design/coordinator-routing.md`.

### Compatibility

No breaking changes: the new SSE frame is ignored by older consumers (if/else-if dispatch), `DelegateResponse.peerTraceId` is an optional addition, no new RPC methods (`chat.bindMessageTraceId` pre-exists), and persistence changes are additive (leg rows gain a real `trace_id`; tool-row metadata gains one key). Rolling back simply stops writing them.

**Known gap** (also noted in code): on the REMOTE route, a coordinator Stop or relay idle-timeout tears the subscription down before the terminal arrives, so those tool rows carry no `child_trace_id`. The opening-row bind is still salvaged via the retried terminal, so the leg stays reachable through `child_session_id`.

## Test Plan

- [x] 12 new tests: local-route stamp/bind/frames, tracing-off degradation, remote terminal extraction, malformed-id gate, late-terminal salvage + memo, stop-path link retention, tool-row link fields on every outcome
- [x] Full vitest suite and `tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)