### PR TITLE
Honor authoritative empty Skill bundles

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -1951,3 +1951,11 @@ describe("resolveDelegation (worker autonomy — readOnly is explicit opt-in)", 
     expect(resolveDelegation({ delegationId: "d1", readOnly: true }, "api")?.readOnly).toBe(true);
   });
 });
+
+describe("http-server — Skill handler wiring", () => {
+  it("does not disable empty-bundle preservation on the K8s/hot-reload path", () => {
+    const src = fs.readFileSync(path.resolve(__dirname, "http-server.ts"), "utf8");
+    expect(src).toContain("createSkillsHandler");
+    expect(src).not.toContain("preserveExistingOnEmpty");
+  });
+});

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -661,7 +661,6 @@ export function createHttpServer(
   } else if (sessionManager.skillsDir) {
     perServerHandlers.skills = createSkillsHandler({
       skillsDir: sessionManager.skillsDir,
-      preserveExistingOnEmpty: false,
       boxClient: sessionManager.gatewayClient ? sessionManager.gatewayClient.toClientLike() : null,
     });
   }

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -21,6 +21,7 @@ import { knowledgeRepoDirName } from "../shared/knowledge-package.js";
 import type { GatewaySyncClientLike } from "../shared/gateway-sync.js";
 import { CredentialBroker } from "./credential-broker.js";
 import { resolveSkillDirectories } from "../core/skill-directories.js";
+import { syncResource } from "./resource-sync.js";
 import type {
   CredentialTransport,
   ClusterMeta,
@@ -924,8 +925,8 @@ describe("createSkillsHandler scoped materialization", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "scoped-skills-handler-"));
     const aDir = path.join(root, "a");
     const bDir = path.join(root, "b");
-    const a = createSkillsHandler({ skillsDir: aDir, preserveExistingOnEmpty: false });
-    const b = createSkillsHandler({ skillsDir: bDir, preserveExistingOnEmpty: false });
+    const a = createSkillsHandler({ skillsDir: aDir });
+    const b = createSkillsHandler({ skillsDir: bDir });
     const skill = (dirName: string) => ({
       version: "1",
       skills: [{ dirName, scope: "global" as const, specs: `# ${dirName}`, scripts: [] }],
@@ -934,11 +935,55 @@ describe("createSkillsHandler scoped materialization", () => {
     try {
       await a.materialize(skill("alpha"));
       await b.materialize(skill("beta"));
-      await b.materialize({ version: "2", skills: [] });
+      await b.materialize({ version: "2", skillsAuthoritative: true, skills: [] });
 
       expect(fs.readFileSync(path.join(aDir, "resolved", "alpha", "SKILL.md"), "utf8")).toBe("# alpha");
       expect(fs.existsSync(path.join(bDir, "resolved", "beta"))).toBe(false);
     } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the production constructor: unmarked empty keeps, authoritative empty clears, fetch failure skips materialize", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "prod-skills-handler-"));
+    const handler = createSkillsHandler({ skillsDir: root });
+    const existing = {
+      version: "1",
+      skills: [{ dirName: "keep-me", scope: "global" as const, specs: "# keep-me", scripts: [] }],
+    };
+
+    try {
+      await handler.materialize(existing);
+      expect(fs.existsSync(path.join(root, "resolved", "keep-me"))).toBe(true);
+
+      const preserved = await handler.materialize({ version: "2", skills: [] });
+      expect(preserved).toBe(1);
+      expect(fs.existsSync(path.join(root, "resolved", "keep-me"))).toBe(true);
+
+      const cleared = await handler.materialize({
+        version: "3",
+        skillsAuthoritative: true,
+        skills: [],
+      });
+      expect(cleared).toBe(0);
+      expect(fs.existsSync(path.join(root, "resolved", "keep-me"))).toBe(false);
+
+      await handler.materialize(existing);
+      const failingClient: GatewaySyncClientLike = {
+        request: async () => {
+          throw new Error("bundle fetch failed");
+        },
+      };
+      vi.useFakeTimers();
+      const failed = syncResource("skills", failingClient, handler).catch((err) => err);
+      await vi.runAllTimersAsync();
+      const result = await failed;
+      vi.useRealTimers();
+      expect(result).toBeInstanceOf(Error);
+      expect((result as Error).message).toContain("bundle fetch failed");
+      expect(fs.existsSync(path.join(root, "resolved", "keep-me"))).toBe(true);
+    } finally {
+      vi.useRealTimers();
       fs.rmSync(root, { recursive: true, force: true });
     }
   });

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -605,6 +605,27 @@ describe("skillsHandler", () => {
     warnSpy.mockRestore();
   });
 
+  it("clears resolved/ when an authoritative empty bundle arrives", async () => {
+    await skillsHandler.materialize({
+      version: "v1",
+      skills: [
+        { dirName: "skill-a", scope: "global" as const, specs: "---\nname: a\n---\n", scripts: [] },
+        { dirName: "skill-b", scope: "global" as const, specs: "---\nname: b\n---\n", scripts: [] },
+      ],
+    });
+    expect(resolvedExists("skill-a")).toBe(true);
+    expect(resolvedExists("skill-b")).toBe(true);
+
+    const count = await skillsHandler.materialize({
+      version: "v2",
+      skillsAuthoritative: true,
+      skills: [],
+    });
+    expect(count).toBe(0);
+    expect(resolvedExists("skill-a")).toBe(false);
+    expect(resolvedExists("skill-b")).toBe(false);
+  });
+
   // ── 6. multiple skills, different names ───────────────────────────
   it("materializes multiple skills with different dirNames", async () => {
     const payload = {

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -230,6 +230,12 @@ interface SkillBundlePayload {
   inheritBuiltins?: boolean;
   /** Built-in image Skills explicitly masked by this preview instance. */
   disabledBuiltins?: string[];
+  /**
+   * Successful control-plane resolve of the full Skill set. Presence
+   * (including skills: []) replaces resolved/. Failed fetches never
+   * reach materialize, so they keep the last copy.
+   */
+  skillsAuthoritative?: boolean;
   skills: Array<{
     dirName: string;
     /** "builtin" is accepted for legacy producers; image Built-ins are not bundled. */
@@ -299,16 +305,16 @@ export function createSkillsHandler(
       );
     }
 
-    // Defense against empty-bundle erasure (belt-and-suspenders; the primary
-    // fix is Gateway-side so empty-bundles only arrive when the agent is
-    // genuinely unbound). If an empty payload arrives but we already have
-    // skills materialized, keep what we have and let the next reload retry.
-    // Legitimate "unbind-all" admin operations can force a fresh wipe by
-    // restarting the pod — which is cheap and explicit.
+    // Defense against empty-bundle erasure. A successful control-plane
+    // resolve sets skillsAuthoritative (or a preview builtin policy). Those
+    // empty lists replace resolved/. An unmarked empty payload is treated as
+    // a transient/legacy miss and keeps the last copy.
     const incomingCount = Array.isArray(payload?.skills) ? payload.skills.length : 0;
+    const isAuthoritativeEmpty = payload?.skillsAuthoritative === true
+      || hasExplicitBuiltinPolicy
+      || hasExplicitBuiltinMask;
     if (options.preserveExistingOnEmpty !== false
-        && !hasExplicitBuiltinPolicy
-        && !hasExplicitBuiltinMask
+        && !isAuthoritativeEmpty
         && incomingCount === 0
         && fs.existsSync(resolvedDir)) {
       const existing = fs.readdirSync(resolvedDir).filter((name) => {

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -250,7 +250,6 @@ interface SkillBundlePayload {
 export function createSkillsHandler(
   options: {
     skillsDir?: string;
-    preserveExistingOnEmpty?: boolean;
     boxClient?: GatewaySyncClientLike | null;
   } = {},
 ): AgentBoxSyncHandler<SkillBundlePayload> {
@@ -313,8 +312,7 @@ export function createSkillsHandler(
     const isAuthoritativeEmpty = payload?.skillsAuthoritative === true
       || hasExplicitBuiltinPolicy
       || hasExplicitBuiltinMask;
-    if (options.preserveExistingOnEmpty !== false
-        && !isAuthoritativeEmpty
+    if (!isAuthoritativeEmpty
         && incomingCount === 0
         && fs.existsSync(resolvedDir)) {
       const existing = fs.readdirSync(resolvedDir).filter((name) => {

--- a/src/gateway/agentbox/local-spawner.test.ts
+++ b/src/gateway/agentbox/local-spawner.test.ts
@@ -361,5 +361,6 @@ describe("LocalSpawner — invariant §1: never calls skillsHandler.materialize"
     // Defense-in-depth: the process-global singleton must not be imported.
     expect(src).not.toMatch(/\bskillsHandler\b[^,}]*from\s+["'][^"']*sync-handlers/);
     expect(src).toContain("createSkillsHandler");
+    expect(src).not.toContain("preserveExistingOnEmpty");
   });
 });

--- a/src/gateway/agentbox/local-spawner.ts
+++ b/src/gateway/agentbox/local-spawner.ts
@@ -120,7 +120,6 @@ export class LocalSpawner implements BoxSpawner {
     });
     const skillsHandler = createSkillsHandler({
       skillsDir: sessionManager.skillsDir,
-      preserveExistingOnEmpty: false,
       boxClient,
     });
     const mcpHandler = createMcpHandler(sessionManager, boxClient);

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -468,6 +468,7 @@ describe("config.getSkillBundle", () => {
     const result = await getHandler("config.getSkillBundle")({ skill_ids: [] }, "a1");
     expect(result.skills).toEqual([]);
     expect(result.version).toBeDefined();
+    expect(result.skillsAuthoritative).toBe(true);
   });
 
   it("uses approved version query in production mode", async () => {

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -2384,7 +2384,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     const skillIds = params.skill_ids ?? [];
     const isProduction = params.is_production ?? true;
     if (skillIds.length === 0) {
-      return { version: new Date().toISOString(), skills: [] };
+      return { version: new Date().toISOString(), skills: [], skillsAuthoritative: true };
     }
     const db = getDb();
     let rows: any[];
@@ -2411,7 +2411,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
       rows = result;
     }
     const skills = rows.map(skillBundleEntry);
-    return { version: new Date().toISOString(), skills };
+    return { version: new Date().toISOString(), skills, skillsAuthoritative: true };
   });
 
   handlers.set("config.getKnowledgeBundle", async (params) => {


### PR DESCRIPTION
## Summary
- Treat `skillsAuthoritative: true` as a successful full Skill resolve, including `skills: []`.
- Clear `resolved/` when that marker arrives so an archived last Skill actually stops executing without a pod restart.
- Keep unmarked empty payloads on the live K8s and Local reload constructors; a failed fetch never reaches materialize.

## Test plan
- [x] `npx vitest run src/agentbox/sync-handlers.test.ts src/agentbox/http-server.test.ts src/gateway/agentbox/local-spawner.test.ts src/agentbox/resource-sync.test.ts` (198 passed)
- [ ] Confirm the control plane emits `skillsAuthoritative` on a successful `config.getSkillBundle`, including an intentional empty set
- [ ] Withdraw the last Skill, reload, and check sync status no longer lists it