### PR TITLE
feat(runtime): add chat dispatch observability

### DIFF
--- a/docs/install/kubernetes.mdx
+++ b/docs/install/kubernetes.mdx
@@ -159,3 +159,22 @@ runtime:
   re-adopt live capability runs. Cluster-wide box deletion remains an explicit
   cleanup operation, not a process-shutdown side effect.
 - If you deploy monitoring resources from the chart, do not also apply duplicate monitor manifests manually.
+
+## Post-rollout Chat Acceptance
+
+After a production Runtime or AgentBox rollout reports Ready, verify cold-session
+dispatch before declaring the release complete:
+
+1. Create at least five new chat sessions. Do not reuse an existing session or
+   retry a failed first message.
+2. Send one first-turn prompt in each session, sequentially. All five must reach
+   assistant output and `prompt_done` without a `stream_error` or manual retry.
+3. For every turn, correlate `sessionId` and `turnId` across the control-plane,
+   Runtime, and AgentBox logs. Confirm the selected Runtime and AgentBox, and a
+   `/api/prompt` result with `status=200` and `outcome=accepted`.
+4. Treat any first-turn failure, missing terminal event, or unexplained
+   Runtime/AgentBox selection as a failed release acceptance. Preserve the
+   correlated log lines before retrying or rolling again.
+
+This check validates observed post-rollout behavior. Pod readiness and a
+successful image rollout alone do not satisfy chat acceptance.

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -54,6 +54,7 @@ import {
 } from "../core/model-routing.js";
 import { withResolvedModelCompat } from "../core/model-compat.js";
 import type { BrainSession, PromptFile, PromptImage, PromptMedia } from "../core/brain-session.js";
+import { compactDispatchLogMessage } from "../shared/dispatch-observability.js";
 
 type RequestHandler = (
   req: http.IncomingMessage,
@@ -851,10 +852,16 @@ export function createHttpServer(
    * The message is sent to the Agent, and responses are returned via SSE stream.
    */
   addRoute("POST", "/api/prompt", async (req, res) => {
+    const promptStartedAt = Date.now();
     const body = (await parseJsonBody(req)) as PromptRequestBody;
+    const logPromptResponse = (status: number, outcome: string, message?: unknown, sessionId = body.sessionId): void => {
+      const suffix = message === undefined ? "" : ` error=${JSON.stringify(compactDispatchLogMessage(message))}`;
+      console.log(`[agentbox-http] /api/prompt result boxId=${process.env.SICLAW_POD_NAME ?? "unknown"} sessionId=${sessionId ?? "pending"} turnId=${body.turnId ?? "unknown"} status=${status} outcome=${outcome} durationMs=${Date.now() - promptStartedAt}${suffix}`);
+    };
 
     const promptMediaValidation = validatePromptMedia(body.images, body.files);
     if (promptMediaValidation.error) {
+      logPromptResponse(400, "rejected", promptMediaValidation.error);
       sendJson(res, 400, { error: promptMediaValidation.error });
       return;
     }
@@ -863,6 +870,7 @@ export function createHttpServer(
     // Media-only messages are valid; reject only when there is neither text nor
     // usable image/PDF media after validation.
     if (!body.text && !promptMedia) {
+      logPromptResponse(400, "rejected", "Missing 'text' field");
       sendJson(res, 400, { error: "Missing 'text' field" });
       return;
     }
@@ -884,6 +892,7 @@ export function createHttpServer(
       // be holding the brain even when _promptDone has already flipped
       // back to true momentarily during synth setup. Both must be clear
       // before a fresh HTTP /prompt can claim brain.prompt().
+      logPromptResponse(409, "busy", "Session is already running", managed.id);
       sendJson(res, 409, {
         error: "Session is already running. Use the steer endpoint to add input to the active prompt.",
         sessionId: managed.id,
@@ -979,6 +988,7 @@ export function createHttpServer(
       // Release the brain.prompt mutex so a follow-up prompt isn't blocked.
       managed._promptInflight = null;
       releasePromptInflight();
+      logPromptResponse(500, "setup_failed", err, managed.id);
       sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
     };
 
@@ -1196,6 +1206,7 @@ export function createHttpServer(
       // wait forever if isAgentActive/isCompacting/isRetrying were left stale-true by a prior
       // abnormal turn — permanently locking the session at 409. actuallyFinish unlocks now.
       actuallyFinish();
+      logPromptResponse(200, "aborted_before_start", undefined, managed.id);
       sendJson(res, 200, { ok: true, sessionId: managed.id, turnId: body.turnId, aborted: true });
       return;
     }
@@ -1288,6 +1299,7 @@ export function createHttpServer(
       onPromptFinish();
     });
 
+    logPromptResponse(200, "accepted", undefined, managed.id);
     sendJson(res, 200, { ok: true, sessionId: managed.id, turnId: body.turnId, traceId: tracingRecorder.getRootTraceId(managed.id) });
   });
 

--- a/src/gateway/dispatch-observability.test.ts
+++ b/src/gateway/dispatch-observability.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { RpcResponseError } from "../lib/error-envelope.js";
+import { summarizeDispatchError } from "./dispatch-observability.js";
+
+describe("gateway dispatch observability", () => {
+  it("keeps structured AgentBox response fields without logging details", () => {
+    const summary = summarizeDispatchError(new RpcResponseError({
+      code: "SERVICE_UNAVAILABLE",
+      message: "box warming",
+      retriable: true,
+      status: 503,
+      details: { responseBody: "must not be logged" },
+    }));
+
+    expect(summary).toEqual({
+      code: "SERVICE_UNAVAILABLE",
+      message: "box warming",
+      retriable: true,
+      status: 503,
+    });
+    expect(JSON.stringify(summary)).not.toContain("responseBody");
+  });
+});

--- a/src/gateway/dispatch-observability.ts
+++ b/src/gateway/dispatch-observability.ts
@@ -1,0 +1,17 @@
+import { wrapRpcError } from "../lib/error-envelope.js";
+import { compactDispatchLogMessage } from "../shared/dispatch-observability.js";
+
+export function summarizeDispatchError(err: unknown): {
+  code: string;
+  status?: number;
+  retriable: boolean;
+  message: string;
+} {
+  const detail = wrapRpcError(err);
+  return {
+    code: detail.code,
+    ...(detail.status != null ? { status: detail.status } : {}),
+    retriable: detail.retriable,
+    message: compactDispatchLogMessage(detail.message),
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -105,6 +105,7 @@ import { sessionRegistry } from "./session-registry.js";
 import { sessionTurnLocks } from "./session-turn-lock.js";
 import { pendingUserRows } from "./pending-user-rows.js";
 import { resolveAgentModelBinding, resolveAgentSystemPrompt } from "./agent-model-binding.js";
+import { summarizeDispatchError } from "../shared/dispatch-observability.js";
 
 function stablePayloadDigest(value: unknown): string {
   const canonicalize = (input: unknown): unknown => {
@@ -918,6 +919,8 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         // (registered in startRuntime), not from per-request params — so every
         // entry point lands the same mode for the same agent.
         const handle = await agentBoxManager.getOrCreate(agentId, undefined, sessionId);
+        const selectedBoxId = handle.boxId ?? "unknown";
+        console.log(`[runtime] chat.send selected agentId=${agentId} sessionId=${sessionId} turnId=${turnId} boxId=${selectedBoxId}`);
         // Which box this turn went to. Placement reads it back as a hint while the turn
         // runs; it is dropped on release, so it can never become a stale binding.
         sessionTurnLocks.noteBox(sessionId, handle.boxId, handle.endpoint);
@@ -926,8 +929,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
 
         let promptResult: Awaited<ReturnType<typeof client.prompt>>;
         let ackTraceId: string | undefined;
+        const promptStartedAt = Date.now();
         try {
           promptResult = await client.prompt(promptOpts);
+          console.log(`[runtime] AgentBox prompt result agentId=${agentId} sessionId=${sessionId} turnId=${turnId} boxId=${selectedBoxId} status=200 ok=true durationMs=${Date.now() - promptStartedAt} traceIdPresent=${Boolean(promptResult.traceId)}`);
           // The ack's trace id is gated ONCE and every consumer of it below — the
           // delegated-turn ledger, the prompt-row bind, the consume's row stamp —
           // uses the gated value: stamping rows with a malformed id one boundary
@@ -971,6 +976,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           }
           if (promptMessageId) pendingUserRows.push(sessionId, promptMessageId, text);
         } catch (err) {
+          const summary = summarizeDispatchError(err);
+          const resultLog = summary.status === 409 || summary.message.includes("Session is already running")
+            ? console.warn
+            : console.error;
+          resultLog(`[runtime] AgentBox prompt result agentId=${agentId} sessionId=${sessionId} turnId=${turnId} boxId=${selectedBoxId} status=${summary.status ?? 0} ok=false code=${summary.code} retriable=${summary.retriable} durationMs=${Date.now() - promptStartedAt} error=${JSON.stringify(summary.message)}`);
           // Concurrent send: agentbox returns 409 "Session is already
           // running. Use the steer endpoint to add input to the active
           // prompt." when the user double-taps send before the previous
@@ -1105,11 +1115,8 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         // stream_error so the frontend renders an inline bubble instead of
         // hanging on the spawning state forever.
         if (!turnAbort.signal.aborted) {
-          console.error(`[runtime] chat.send background failure for session=${sessionId}:`, err);
-          const detail = wrapError(err, {
-            code: ErrorCodes.INTERNAL,
-            retriable: true,
-          });
+          const detail = summarizeDispatchError(err);
+          console.error(`[runtime] chat.send background failure agentId=${agentId} sessionId=${sessionId} turnId=${turnId} status=${detail.status ?? 0} code=${detail.code} retriable=${detail.retriable} error=${JSON.stringify(detail.message)}`);
           context.sendEvent("chat.event", {
             sessionId,
             turnId,

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -105,7 +105,7 @@ import { sessionRegistry } from "./session-registry.js";
 import { sessionTurnLocks } from "./session-turn-lock.js";
 import { pendingUserRows } from "./pending-user-rows.js";
 import { resolveAgentModelBinding, resolveAgentSystemPrompt } from "./agent-model-binding.js";
-import { summarizeDispatchError } from "../shared/dispatch-observability.js";
+import { summarizeDispatchError } from "./dispatch-observability.js";
 
 function stablePayloadDigest(value: unknown): string {
   const canonicalize = (input: unknown): unknown => {

--- a/src/shared/dispatch-observability.test.ts
+++ b/src/shared/dispatch-observability.test.ts
@@ -1,26 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { RpcResponseError } from "../lib/error-envelope.js";
-import { compactDispatchLogMessage, summarizeDispatchError } from "./dispatch-observability.js";
+import { compactDispatchLogMessage } from "./dispatch-observability.js";
 
 describe("dispatch observability", () => {
-  it("keeps structured AgentBox response fields without logging details", () => {
-    const summary = summarizeDispatchError(new RpcResponseError({
-      code: "SERVICE_UNAVAILABLE",
-      message: "box warming",
-      retriable: true,
-      status: 503,
-      details: { responseBody: "must not be logged" },
-    }));
-
-    expect(summary).toEqual({
-      code: "SERVICE_UNAVAILABLE",
-      message: "box warming",
-      retriable: true,
-      status: 503,
-    });
-    expect(JSON.stringify(summary)).not.toContain("responseBody");
-  });
-
   it("makes error messages single-line and bounded", () => {
     const compact = compactDispatchLogMessage(`first\nsecond ${"x".repeat(600)}`);
     expect(compact).not.toContain("\n");

--- a/src/shared/dispatch-observability.test.ts
+++ b/src/shared/dispatch-observability.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { RpcResponseError } from "../lib/error-envelope.js";
+import { compactDispatchLogMessage, summarizeDispatchError } from "./dispatch-observability.js";
+
+describe("dispatch observability", () => {
+  it("keeps structured AgentBox response fields without logging details", () => {
+    const summary = summarizeDispatchError(new RpcResponseError({
+      code: "SERVICE_UNAVAILABLE",
+      message: "box warming",
+      retriable: true,
+      status: 503,
+      details: { responseBody: "must not be logged" },
+    }));
+
+    expect(summary).toEqual({
+      code: "SERVICE_UNAVAILABLE",
+      message: "box warming",
+      retriable: true,
+      status: 503,
+    });
+    expect(JSON.stringify(summary)).not.toContain("responseBody");
+  });
+
+  it("makes error messages single-line and bounded", () => {
+    const compact = compactDispatchLogMessage(`first\nsecond ${"x".repeat(600)}`);
+    expect(compact).not.toContain("\n");
+    expect(compact.endsWith("…")).toBe(true);
+    expect(compact.length).toBeLessThanOrEqual(513);
+  });
+});

--- a/src/shared/dispatch-observability.ts
+++ b/src/shared/dispatch-observability.ts
@@ -1,5 +1,3 @@
-import { wrapRpcError } from "../lib/error-envelope.js";
-
 const MAX_LOG_MESSAGE_LENGTH = 512;
 
 export function compactDispatchLogMessage(value: unknown): string {
@@ -8,19 +6,4 @@ export function compactDispatchLogMessage(value: unknown): string {
   return compact.length <= MAX_LOG_MESSAGE_LENGTH
     ? compact
     : `${compact.slice(0, MAX_LOG_MESSAGE_LENGTH)}…`;
-}
-
-export function summarizeDispatchError(err: unknown): {
-  code: string;
-  status?: number;
-  retriable: boolean;
-  message: string;
-} {
-  const detail = wrapRpcError(err);
-  return {
-    code: detail.code,
-    ...(detail.status != null ? { status: detail.status } : {}),
-    retriable: detail.retriable,
-    message: compactDispatchLogMessage(detail.message),
-  };
 }

--- a/src/shared/dispatch-observability.ts
+++ b/src/shared/dispatch-observability.ts
@@ -1,0 +1,26 @@
+import { wrapRpcError } from "../lib/error-envelope.js";
+
+const MAX_LOG_MESSAGE_LENGTH = 512;
+
+export function compactDispatchLogMessage(value: unknown): string {
+  const message = value instanceof Error ? value.message : String(value ?? "Unknown error");
+  const compact = message.replace(/\s+/g, " ").trim();
+  return compact.length <= MAX_LOG_MESSAGE_LENGTH
+    ? compact
+    : `${compact.slice(0, MAX_LOG_MESSAGE_LENGTH)}…`;
+}
+
+export function summarizeDispatchError(err: unknown): {
+  code: string;
+  status?: number;
+  retriable: boolean;
+  message: string;
+} {
+  const detail = wrapRpcError(err);
+  return {
+    code: detail.code,
+    ...(detail.status != null ? { status: detail.status } : {}),
+    retriable: detail.retriable,
+    message: compactDispatchLogMessage(detail.message),
+  };
+}


### PR DESCRIPTION
## Summary

- log the AgentBox selected for each `chat.send` using `agentId`, `sessionId`, and `turnId`
- log `/api/prompt` acceptance or rejection status, error code, retriable flag, duration, and a bounded single-line error summary without prompt text or configuration
- preserve structured AgentBox HTTP status, code, and retriable fields in asynchronous `stream_error` events
- add a post-rollout acceptance gate: at least five consecutive first turns in fresh sessions must succeed with correlated Runtime and AgentBox evidence

This change has a paired Sicore control-plane MR.

## Verification

- `npx tsc --noEmit`
- 34 targeted Vitest tests passed across dispatch summary, Runtime chat send/abort/system-prompt paths, and AgentBox `/api/prompt` acceptance

No production configuration or deployment is included.