### PR TITLE
fix(kbc): make image permissions independent of build context

### DIFF
--- a/.github/workflows/kbc-ci.yml
+++ b/.github/workflows/kbc-ci.yml
@@ -61,3 +61,5 @@ jobs:
         working-directory: kbc/platform/pod
       - run: python test_emit.py
         working-directory: kbc/tools
+      - name: Build and start the KBC image as its default non-root user
+        run: sh kbc/platform/pod/test_image_permissions.sh

--- a/kbc/platform/pod/Dockerfile
+++ b/kbc/platform/pod/Dockerfile
@@ -38,6 +38,12 @@ COPY platform/pod/*.py /app/
 COPY platform/pod/prompts/ /app/prompts/
 COPY tools/ /app/tools/
 
+# Docker preserves build-context modes for copied files. Normalize the whole
+# application tree so a checkout created under a restrictive umask cannot make
+# the root-owned sources unreadable after the image switches to USER kbc.
+# Keep the tree root-owned and non-writable by the runtime user.
+RUN chmod -R u=rwX,go=rX /app
+
 # Tenant isolation: never load external memory (prevents cross-tenant bleed).
 ENV CLAUDE_CODE_DISABLE_AUTO_MEMORY=1
 # The proxy/Bedrock path rejects the `context_management` request field (HTTP 400).

--- a/kbc/platform/pod/test_image_permissions.sh
+++ b/kbc/platform/pod/test_image_permissions.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+KBC_TEST_ROOT=$(git rev-parse --show-toplevel)
+KBC_TEST_CONTEXT=$(mktemp -d "${TMPDIR:-/tmp}/siclaw-kbc-permissions.XXXXXX")
+KBC_TEST_IMAGE=${KBC_PERMISSION_TEST_IMAGE:-siclaw-kbc-box:permission-smoke}
+KBC_TEST_CONTAINER=
+
+cleanup() {
+  if [ -n "$KBC_TEST_CONTAINER" ]; then
+    docker rm -f "$KBC_TEST_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$KBC_TEST_CONTEXT" ] && [ -d "$KBC_TEST_CONTEXT" ]; then
+    rm -rf -- "$KBC_TEST_CONTEXT"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+cp -R "$KBC_TEST_ROOT/kbc/." "$KBC_TEST_CONTEXT/"
+
+# Reproduce a checkout/build context created under a restrictive umask. Docker
+# can read these files as the builder user, but USER kbc must not depend on the
+# original host modes after COPY.
+find "$KBC_TEST_CONTEXT" -type d -exec chmod 0700 {} +
+find "$KBC_TEST_CONTEXT" -type f -exec chmod 0600 {} +
+
+docker build \
+  -f "$KBC_TEST_CONTEXT/platform/pod/Dockerfile" \
+  -t "$KBC_TEST_IMAGE" \
+  "$KBC_TEST_CONTEXT"
+
+docker run --rm --entrypoint python "$KBC_TEST_IMAGE" -c '
+import os
+from pathlib import Path
+
+assert os.getuid() == 1000, f"expected uid 1000, got {os.getuid()}"
+unreadable = []
+for path in Path("/app").rglob("*"):
+    if not path.is_file():
+        continue
+    try:
+        with path.open("rb") as handle:
+            handle.read(1)
+    except OSError as exc:
+        unreadable.append(f"{path}: {exc}")
+assert not unreadable, "unreadable application files:\n" + "\n".join(unreadable)
+import compile_box  # noqa: F401
+'
+
+KBC_TEST_CONTAINER=$(docker run -d -p 127.0.0.1:0:3000 "$KBC_TEST_IMAGE")
+KBC_TEST_ADDRESS=$(docker port "$KBC_TEST_CONTAINER" 3000/tcp | sed -n '1p')
+
+attempt=0
+while [ "$attempt" -lt 30 ]; do
+  if curl -fsS "http://$KBC_TEST_ADDRESS/health" >/dev/null; then
+    echo "KBC image permission smoke passed as uid 1000 at $KBC_TEST_ADDRESS"
+    exit 0
+  fi
+  if [ "$(docker inspect --format '{{.State.Running}}' "$KBC_TEST_CONTAINER")" != true ]; then
+    echo "KBC container exited before becoming healthy" >&2
+    docker logs "$KBC_TEST_CONTAINER" >&2 || true
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 1
+done
+
+echo "KBC container did not become healthy within 30 seconds" >&2
+docker logs "$KBC_TEST_CONTAINER" >&2 || true
+exit 1


### PR DESCRIPTION
## Summary

- normalize the root-owned KBC application tree before switching to the non-root `kbc` user
- add an image-level regression smoke that builds from a deliberately restrictive `0600`/`0700` context
- verify the image default user can read every `/app` file, import `compile_box`, start the real entrypoint, and pass `/health`

## Root cause

Docker preserves build-context modes on `COPY`. The production image was built from KBC source files with mode `0600`, then switched to `USER kbc` (uid 1000), so Python could not read `/app/compile_box.py` and every compile box exited before compilation began. Source-level Python CI did not build or start the final image as its runtime user.

## Verification

- `sh -n kbc/platform/pod/test_image_permissions.sh`
- `git diff --check`
- dev02 (`si-dev02`), exact commit `721d18f3845d0156c028269608819db46e317fcd`: restrictive-context image build, uid 1000 full-tree readability, import, entrypoint startup, and `/health` passed
- negative control using the pre-fix Dockerfile failed on the expected unreadable `/app` files

## Deployment

No production change is included. Recovery requires publishing a new immutable KBC image digest and updating the production compile-box image after approval.