### PR TITLE
fix(runtime): support strict product support sessions

### DIFF
--- a/portal-web/src/lib/agentTypes.ts
+++ b/portal-web/src/lib/agentTypes.ts
@@ -2,7 +2,7 @@
 // capability set and provide an immutable type contract. The Portal edits only
 // an optional Agent Addendum; it never replaces that contract.
 
-export type AgentTypeKey = "sre" | "coordinator" | "knowledge_qa" | "custom"
+export type AgentTypeKey = "sre" | "coordinator" | "knowledge_qa" | "product_support" | "custom"
 
 export interface AgentTypeOption {
   key: AgentTypeKey
@@ -33,6 +33,13 @@ export const AGENT_TYPES: AgentTypeOption[] = [
     key: "knowledge_qa",
     label: "Knowledge Q&A Agent",
     description: "Researches bound knowledge bases and answers with synthesized, source-backed information.",
+    capabilities: ["read_files"],
+    defaultNoSkills: true,
+  },
+  {
+    key: "product_support",
+    label: "Product Support Agent",
+    description: "Answers product questions and prepares structured customer-support handoffs through its bound result tool.",
     capabilities: ["read_files"],
     defaultNoSkills: true,
   },

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -642,6 +642,35 @@ describe("http-server — prompt + session lifecycle", () => {
     expect(seen).not.toContain("�");
   });
 
+  it("POST /api/prompt forwards a strict result-tool requirement only when supplied", async () => {
+    const session = await sm.getOrCreate("strict-result");
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "hi",
+      sessionId: "strict-result",
+      requiredResultToolName: "mcp__result__submit",
+    });
+    await flushAsync();
+
+    expect(r.status).toBe(200);
+    expect(session.brain.prompt).toHaveBeenCalledWith(
+      "hi",
+      undefined,
+      { requiredResultToolName: "mcp__result__submit" },
+    );
+  });
+
+  it("POST /api/prompt rejects a non-string strict result-tool requirement", async () => {
+    const session = await sm.getOrCreate("invalid-strict-result");
+    const r = await getJson(port, "/api/prompt", "POST", {
+      text: "hi",
+      sessionId: "invalid-strict-result",
+      requiredResultToolName: { name: "mcp__result__submit" },
+    });
+
+    expect(r.status).toBe(400);
+    expect(session.brain.prompt).not.toHaveBeenCalled();
+  });
+
   it("POST /api/prompt falls back to a healthy secondary when the bound primary is missing", async () => {
     // The binding is handed to the routing runner as the primary candidate rather
     // than resolved before it, so a primary that cannot be found is an ordinary

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -113,6 +113,8 @@ interface PromptRequestBody {
    * lets the box mint nothing can still correlate.
    */
   turnId?: string;
+  /** Trusted control-plane contract for one required structured result tool. */
+  requiredResultToolName?: string;
 }
 
 /**
@@ -876,6 +878,13 @@ export function createHttpServer(
       console.log(`[agentbox-http] /api/prompt result boxId=${process.env.SICLAW_POD_NAME ?? "unknown"} sessionId=${sessionId ?? "pending"} turnId=${body.turnId ?? "unknown"} status=${status} outcome=${outcome} durationMs=${Date.now() - promptStartedAt}${suffix}`);
     };
 
+    if (body.requiredResultToolName !== undefined && typeof body.requiredResultToolName !== "string") {
+      logPromptResponse(400, "rejected", "'requiredResultToolName' must be a string");
+      sendJson(res, 400, { error: "'requiredResultToolName' must be a string" });
+      return;
+    }
+    const requiredResultToolName = body.requiredResultToolName?.trim() || undefined;
+
     const promptMediaValidation = validatePromptMedia(body.images, body.files);
     if (promptMediaValidation.error) {
       logPromptResponse(400, "rejected", promptMediaValidation.error);
@@ -1294,6 +1303,9 @@ export function createHttpServer(
         },
       },
       promptMedia,
+      requiredResultToolName
+        ? { requiredResultToolName }
+        : undefined,
     );
 
     promptPromise.then((result) => {

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -461,7 +461,7 @@ export class AgentBoxSessionManager {
    */
   harnessResolvedState = true;
 
-  /** Agent type (sre/coordinator/knowledge_qa/custom), fetched alongside allowedTools.
+  /** Agent type, fetched alongside allowedTools.
    *  Drives capabilities and the legacy-row prompt fallback. */
   agentTypeState: string = "custom";
 

--- a/src/agentbox/sync-handlers.test.ts
+++ b/src/agentbox/sync-handlers.test.ts
@@ -198,6 +198,18 @@ describe("createToolsHandler", () => {
     expect(target.harnessResolvedState).toBe(true);
   });
 
+  it("accepts the product_support harness and keeps its locked whitelist", async () => {
+    const target = { allowedToolsState: null as string[] | null, harnessResolvedState: false, agentTypeState: "custom" };
+    const handler = createToolsHandler(target, null);
+    await expect(handler.materialize({ allowedTools: ["read", "grep"], agentType: "product_support" })).resolves.toBe(2);
+    expect(target).toEqual({
+      allowedToolsState: ["read", "grep"],
+      harnessResolvedState: true,
+      agentTypeState: "product_support",
+      subagentTierMenuState: null,
+    });
+  });
+
   it("materialize treats null as 'no restriction' (whitelist off), returns 0", async () => {
     const target = { allowedToolsState: ["read"] as string[] | null };
     const handler = createToolsHandler(target, null);
@@ -206,7 +218,7 @@ describe("createToolsHandler", () => {
     expect(target.allowedToolsState).toBeNull();
   });
 
-  it.each(["sre", "coordinator", "knowledge_qa"])(
+  it.each(["sre", "coordinator", "knowledge_qa", "product_support"])(
     "rejects unrestricted tools for built-in agent type %s",
     async (agentType) => {
       const target = {

--- a/src/agentbox/sync-handlers.ts
+++ b/src/agentbox/sync-handlers.ts
@@ -781,7 +781,7 @@ export function createHostHandler(broker: CredentialBroker): AgentBoxSyncHandler
  */
 interface ToolsPayload {
   allowedTools: string[] | null;
-  /** Agent type (sre/coordinator/knowledge_qa/custom) — drives capabilities and prompt fallback. */
+  /** Agent type — drives capabilities and prompt fallback. */
   agentType: string;
   /**
    * Sub-agent model tier MENU — `{revision, items:[{tier, whenToUse}]}`, credential
@@ -796,7 +796,7 @@ interface ToolsPayload {
   subagentTierMenu?: unknown;
 }
 
-const VALID_AGENT_TYPES = new Set(["sre", "coordinator", "knowledge_qa", "custom"]);
+const VALID_AGENT_TYPES = new Set(["sre", "coordinator", "knowledge_qa", "product_support", "custom"]);
 
 /**
  * Minimal structural target the tools handler writes to. Deliberately NOT the

--- a/src/core/agent-context.test.ts
+++ b/src/core/agent-context.test.ts
@@ -50,6 +50,23 @@ describe("resolveAgentHarness", () => {
     expect(harness.includeInfrastructureGuidance).toBe(false);
   });
 
+  it("keeps Product Support read-only while exposing its configured result MCP", () => {
+    const harness = resolveAgentHarness({
+      agentType: "product_support",
+      allowedTools: null,
+      memoryConfigured: true,
+    });
+
+    expect(harness.allowedTools).toEqual([
+      "read", "grep", "find", "ls", "knowledge_search", "knowledge_cite",
+    ]);
+    expect(harness.mcpExposure).toBe("configured");
+    expect(harness.memoryEnabled).toBe(false);
+    expect(harness.includeInfrastructureGuidance).toBe(false);
+    expect(harness.includeOperationalSafety).toBe(false);
+    expect(harness.legacyUnrestrictedCustom).toBe(false);
+  });
+
   it("rejects an unknown type instead of normalizing it to unrestricted Custom", () => {
     expect(() => resolveAgentHarness({
       agentType: "future_type",
@@ -91,6 +108,23 @@ describe("resolveAgentHarness", () => {
 });
 
 describe("compileAgentContext", () => {
+  it("uses Product Support's managed persisted prompt without SRE guidance", () => {
+    const context = compileAgentContext({
+      agentType: "product_support",
+      allowedTools: ["read", "knowledge_search", "knowledge_cite"],
+      memoryConfigured: true,
+      mode: "channel",
+      agentPrompt: "Managed product support contract",
+    });
+
+    expect(context.systemPrompt).toContain("Managed product support contract");
+    expect(context.systemPrompt).toContain("product-support agent");
+    expect(context.systemPrompt).toContain("result-submission tool");
+    expect(context.systemPrompt).not.toContain("personal SRE AI assistant");
+    expect(context.systemPrompt).not.toContain("cluster_list");
+    expect(context.harness.mcpExposure).toBe("configured");
+  });
+
   it("gives Knowledge QA a role-clean prompt with no SRE or memory guidance", () => {
     const context = compileAgentContext({
       agentType: "knowledge_qa",

--- a/src/core/agent-types.test.ts
+++ b/src/core/agent-types.test.ts
@@ -5,15 +5,17 @@ import {
   COMPLETE_CATALOG_KNOWLEDGE_QA_DEFAULT_PROMPT,
   LEGACY_KNOWLEDGE_QA_DEFAULT_PROMPT,
   PREVIOUS_KNOWLEDGE_QA_DEFAULT_PROMPT,
+  PRODUCT_SUPPORT_DEFAULT_PROMPT,
   normalizeAgentType,
+  requireAgentType,
   effectiveAgentPrompt,
   effectiveCapabilityKeys,
   resolveAgentPromptLayers,
 } from "./agent-types.js";
 
 describe("agent-types", () => {
-  it("has the four designed types; built-ins lock capabilities and own immutable contracts", () => {
-    expect(Object.keys(AGENT_TYPES).sort()).toEqual(["coordinator", "custom", "knowledge_qa", "sre"]);
+  it("has the five designed types; built-ins lock capabilities and own their runtime contracts", () => {
+    expect(Object.keys(AGENT_TYPES).sort()).toEqual(["coordinator", "custom", "knowledge_qa", "product_support", "sre"]);
     expect(AGENT_TYPES.sre.capabilities).toBeTruthy();
     expect(AGENT_TYPES.sre.defaultPrompt).toBeTruthy();
     expect(AGENT_TYPES.coordinator.capabilities).toContain("delegate_agents");
@@ -23,6 +25,9 @@ describe("agent-types", () => {
     expect(AGENT_TYPES.knowledge_qa.capabilities).toEqual(["read_files"]);
     expect(AGENT_TYPES.knowledge_qa.defaultPrompt).toBeTruthy();
     expect(AGENT_TYPES.knowledge_qa.defaultNoSkills).toBe(true);
+    expect(AGENT_TYPES.product_support.capabilities).toEqual(["read_files"]);
+    expect(AGENT_TYPES.product_support.defaultPrompt).toBe(PRODUCT_SUPPORT_DEFAULT_PROMPT);
+    expect(AGENT_TYPES.product_support.defaultNoSkills).toBe(true);
     expect(AGENT_TYPES.custom.capabilities).toBeNull();
     expect(AGENT_TYPES.custom.defaultPrompt).toBeNull();
   });
@@ -62,15 +67,22 @@ describe("agent-types", () => {
     expect(normalizeAgentType("sre")).toBe("sre");
     expect(normalizeAgentType("coordinator")).toBe("coordinator");
     expect(normalizeAgentType("knowledge_qa")).toBe("knowledge_qa");
+    expect(normalizeAgentType("product_support")).toBe("product_support");
     expect(normalizeAgentType("custom")).toBe("custom");
     expect(normalizeAgentType(undefined)).toBe("custom");
     expect(normalizeAgentType("bogus")).toBe("custom");
+  });
+
+  it("requireAgentType accepts product_support at the fail-closed harness boundary", () => {
+    expect(requireAgentType("product_support")).toBe("product_support");
+    expect(() => requireAgentType("future_type")).toThrow("Invalid or missing agent_type");
   });
 
   it("effectiveCapabilityKeys: built-in types override, custom uses own selection", () => {
     expect(effectiveCapabilityKeys("coordinator", ["run_commands"])).toEqual(AGENT_TYPES.coordinator.capabilities);
     expect(effectiveCapabilityKeys("sre", null)).toEqual(AGENT_TYPES.sre.capabilities);
     expect(effectiveCapabilityKeys("knowledge_qa", ["run_commands"])).toEqual(["read_files"]);
+    expect(effectiveCapabilityKeys("product_support", ["run_commands"])).toEqual(["read_files"]);
     expect(effectiveCapabilityKeys("custom", ["read_files"])).toEqual(["read_files"]);
     expect(effectiveCapabilityKeys("custom", null)).toBeNull();
   });
@@ -86,6 +98,14 @@ describe("agent-types", () => {
     expect(resolveAgentPromptLayers("coordinator", "maintainer truth")).toEqual({
       typeContract: AGENT_TYPES.coordinator.defaultPrompt,
       addendum: "maintainer truth",
+    });
+    expect(resolveAgentPromptLayers("product_support", "Managed business contract")).toEqual({
+      typeContract: PRODUCT_SUPPORT_DEFAULT_PROMPT,
+      addendum: "Managed business contract",
+    });
+    expect(resolveAgentPromptLayers("product_support", "")).toEqual({
+      typeContract: PRODUCT_SUPPORT_DEFAULT_PROMPT,
+      addendum: undefined,
     });
     expect(resolveAgentPromptLayers("custom", "custom truth")).toEqual({ addendum: "custom truth" });
   });

--- a/src/core/agent-types.ts
+++ b/src/core/agent-types.ts
@@ -15,6 +15,9 @@
  *                   No skills by default.
  *   - knowledge_qa — researches bound knowledge bases and synthesizes sourced
  *                    answers. Read-only, no skills by default, and no delegation.
+ *   - product_support — managed front-door customer support. Its persisted
+ *                       prompt and bound MCP define the intake/result contract;
+ *                       built-in filesystem access stays read-only.
  *   - custom      — the legacy free-form agent. Standalone Portal may persist
  *                   an operator's tool_capabilities selection; integrations
  *                   that omit it intentionally retain unrestricted built-ins.
@@ -24,7 +27,7 @@
  * is the built-in type contract; Custom has no built-in contract.
  */
 
-export type AgentType = "sre" | "coordinator" | "knowledge_qa" | "custom";
+export type AgentType = "sre" | "coordinator" | "knowledge_qa" | "product_support" | "custom";
 
 export interface AgentTypeDef {
   label: string;
@@ -236,10 +239,21 @@ const REPLACED_KNOWLEDGE_QA_DEFAULT_PROMPTS = new Set([
   COMPLETE_CATALOG_KNOWLEDGE_QA_DEFAULT_PROMPT,
 ]);
 
+/**
+ * Public runtime invariant for Product Support. The control plane still owns
+ * the released business prompt and result schema; this layer only keeps the
+ * built-in type safe and meaningful when its managed addendum is absent.
+ */
+export const PRODUCT_SUPPORT_DEFAULT_PROMPT =
+  "You are a product-support agent. Answer product questions using the configured tools and resources. " +
+  "When the current turn provides a result-submission tool, call it exactly once with a machine-readable outcome that follows its declared schema. " +
+  "Do not claim that downstream actions such as ticket creation or human handoff succeeded unless the caller confirms them.";
+
 const MATERIALIZED_TYPE_PROMPTS: Record<Exclude<AgentType, "custom">, ReadonlySet<string>> = {
   sre: new Set([SRE_DEFAULT_PROMPT]),
   coordinator: new Set([COORDINATOR_DEFAULT_PROMPT, PREVIOUS_COORDINATOR_DEFAULT_PROMPT]),
   knowledge_qa: REPLACED_KNOWLEDGE_QA_DEFAULT_PROMPTS,
+  product_support: new Set([PRODUCT_SUPPORT_DEFAULT_PROMPT]),
 };
 
 export interface AgentPromptLayers {
@@ -277,6 +291,16 @@ export const AGENT_TYPES: Record<AgentType, AgentTypeDef> = {
     defaultPrompt: KNOWLEDGE_QA_DEFAULT_PROMPT,
     defaultNoSkills: true,
   },
+  product_support: {
+    label: "Product Support Agent",
+    description: "Answers product questions and prepares structured customer-support handoffs through its bound result tool.",
+    capabilities: ["read_files"],
+    // The control plane owns the managed business prompt and result schema.
+    // This generic runtime contract is deliberately schema-free, so those stay
+    // single-source.
+    defaultPrompt: PRODUCT_SUPPORT_DEFAULT_PROMPT,
+    defaultNoSkills: true,
+  },
   custom: {
     label: "Custom Agent",
     description: "Free-form built-in capabilities; explicitly resolved Custom agents with no selection retain legacy unrestricted compatibility.",
@@ -288,7 +312,7 @@ export const AGENT_TYPES: Record<AgentType, AgentTypeDef> = {
 
 /** Normalize an unknown stored value to a valid AgentType (default custom). */
 export function normalizeAgentType(v: unknown): AgentType {
-  return v === "sre" || v === "coordinator" || v === "knowledge_qa" ? v : "custom";
+  return v === "sre" || v === "coordinator" || v === "knowledge_qa" || v === "product_support" ? v : "custom";
 }
 
 /**
@@ -299,7 +323,7 @@ export function normalizeAgentType(v: unknown): AgentType {
  * tools enter a model session must fail closed when provenance is absent.
  */
 export function requireAgentType(v: unknown): AgentType {
-  if (v === "sre" || v === "coordinator" || v === "knowledge_qa" || v === "custom") {
+  if (v === "sre" || v === "coordinator" || v === "knowledge_qa" || v === "product_support" || v === "custom") {
     return v;
   }
   throw new Error(`Invalid or missing agent_type: ${String(v)}`);

--- a/src/core/brain-session.ts
+++ b/src/core/brain-session.ts
@@ -35,6 +35,16 @@ export interface PromptMedia {
   files?: PromptFile[];
 }
 
+/** Runtime-only completion requirements supplied by a trusted control plane. */
+export interface PromptRequirements {
+  /**
+   * Exact MCP result tool that must succeed before this prompt may finish.
+   * The normal agent run remains unrestricted. If it omits the result, the
+   * runtime performs one bounded, tool-forced repair pass.
+   */
+  requiredResultToolName?: string;
+}
+
 export interface BrainModelInfo {
   id: string;
   name: string;
@@ -158,7 +168,7 @@ export interface BrainSession {
   readonly brainType: BrainType;
 
   /** Send a prompt to the agent. Resolves when the agent finishes responding. */
-  prompt(text: string, media?: PromptMedia): Promise<void>;
+  prompt(text: string, media?: PromptMedia, requirements?: PromptRequirements): Promise<void>;
 
   /** Abort the current agent run. */
   abort(): Promise<void>;

--- a/src/core/brains/pi-agent-brain.test.ts
+++ b/src/core/brains/pi-agent-brain.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { PiAgentBrain } from "./pi-agent-brain.js";
+import { PiAgentBrain, requiredToolChoice } from "./pi-agent-brain.js";
 
 /** Fake AgentSession providing only what PiAgentBrain touches. */
 function makeFakeSession(overrides: Partial<Record<string, any>> = {}) {
   const listeners = new Set<(event: any) => void>();
   const emit = (event: any) => { for (const l of listeners) l(event); };
+  let activeToolNames = ["read", "mcp__result__submit"];
 
   const session: any = {
     prompt: vi.fn(async (_text: string) => {}),
@@ -19,7 +20,13 @@ function makeFakeSession(overrides: Partial<Record<string, any>> = {}) {
     getContextUsage: vi.fn(() => ({ tokens: 10, contextWindow: 100, percent: 10 })),
     getSessionStats: vi.fn(() => ({ tokens: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, total: 3 }, cost: 0.001 })),
     model: { id: "m", name: "M", provider: "p", contextWindow: 100, maxTokens: 10, reasoning: false },
-    agent: { onResponse: vi.fn(async () => {}), state: { messages: [] } },
+    agent: {
+      onResponse: vi.fn(async () => {}),
+      state: { messages: [] },
+      streamFn: vi.fn((_model: any, _context: any, _options?: any) => ({})),
+    },
+    getActiveToolNames: vi.fn(() => [...activeToolNames]),
+    setActiveToolsByName: vi.fn((names: string[]) => { activeToolNames = [...names]; }),
     compact: vi.fn(async () => ({ summary: "ok", firstKeptEntryId: "entry-1", tokensBefore: 100 })),
     settingsManager: {
       getCompactionSettings: vi.fn(() => ({ enabled: true, reserveTokens: 16, keepRecentTokens: 20 })),
@@ -86,6 +93,188 @@ describe("PiAgentBrain", () => {
     const brain = new PiAgentBrain(session);
     await brain.prompt("ask something");
     expect(session.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it("repairs one missing required result with only that tool and a forced first provider call", async () => {
+    const requiredTool = "mcp__result__submit";
+    const session = makeFakeSession();
+    const originalStreamFn = session.agent.streamFn;
+    let promptCount = 0;
+    session.prompt = vi.fn(async (_text: string) => {
+      promptCount++;
+      session.__emit({ type: "message_start", message: { role: "assistant" } });
+      if (promptCount === 1) {
+        session.__emit({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: "draft" }], stopReason: "stop" },
+        });
+        return;
+      }
+
+      expect(session.getActiveToolNames()).toEqual([requiredTool]);
+      session.agent.streamFn(
+        { api: "openai-completions" },
+        { tools: [{ name: requiredTool }] },
+        { reasoning: "high" },
+      );
+      session.__emit({
+        type: "tool_execution_end",
+        toolName: requiredTool,
+        isError: false,
+        result: { details: { structuredContent: { label: false } } },
+      });
+      session.__emit({
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "final" }], stopReason: "stop" },
+      });
+    });
+
+    const brain = new PiAgentBrain(session);
+    const events: any[] = [];
+    brain.subscribe((event) => events.push(event));
+    await brain.prompt("question", undefined, { requiredResultToolName: requiredTool });
+
+    expect(session.prompt).toHaveBeenCalledTimes(2);
+    expect(originalStreamFn).toHaveBeenCalledWith(
+      { api: "openai-completions" },
+      { tools: [{ name: requiredTool }] },
+      {
+        reasoning: "high",
+        toolChoice: { type: "function", function: { name: requiredTool } },
+      },
+    );
+    expect(session.getActiveToolNames()).toEqual(["read", requiredTool]);
+    expect(session.agent.streamFn).toBe(originalStreamFn);
+    expect(events).toContainEqual({ type: "required_result_repair_start", toolName: requiredTool });
+    expect(events).toContainEqual({ type: "required_result_repair_end", toolName: requiredTool, success: true });
+  });
+
+  it("does not repair when the required result tool already succeeded", async () => {
+    const requiredTool = "mcp__result__submit";
+    const session = makeFakeSession();
+    session.prompt = vi.fn(async () => {
+      session.__emit({
+        type: "tool_execution_end",
+        toolName: requiredTool,
+        isError: false,
+        result: { details: { structuredContent: { label: false } } },
+      });
+      session.__emit({
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "final" }], stopReason: "stop" },
+      });
+    });
+
+    const brain = new PiAgentBrain(session);
+    await brain.prompt("question", undefined, { requiredResultToolName: requiredTool });
+
+    expect(session.prompt).toHaveBeenCalledTimes(1);
+    expect(session.setActiveToolsByName).not.toHaveBeenCalled();
+  });
+
+  it("repairs a result-tool call that succeeded at transport level without structuredContent", async () => {
+    const requiredTool = "mcp__result__submit";
+    const session = makeFakeSession();
+    let promptCount = 0;
+    session.prompt = vi.fn(async () => {
+      promptCount++;
+      session.__emit({
+        type: "tool_execution_end",
+        toolName: requiredTool,
+        isError: false,
+        result: promptCount === 1
+          ? { details: {} }
+          : { details: { structuredContent: { label: false } } },
+      });
+      session.__emit({
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: promptCount === 1 ? "draft" : "final" }], stopReason: "stop" },
+      });
+    });
+
+    const brain = new PiAgentBrain(session);
+    await brain.prompt("question", undefined, { requiredResultToolName: requiredTool });
+
+    expect(session.prompt).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps required tool choice to provider-specific values", () => {
+    const toolName = "mcp__result__submit";
+    expect(requiredToolChoice("anthropic-messages", toolName)).toBe("any");
+    expect(requiredToolChoice("google-generative-ai", toolName)).toBe("any");
+    expect(requiredToolChoice("openai-completions", toolName)).toEqual({
+      type: "function",
+      function: { name: toolName },
+    });
+    expect(requiredToolChoice("openai-responses", toolName)).toBe("required");
+  });
+
+  it("does not spend the repair force on pre-prompt compaction", async () => {
+    const requiredTool = "mcp__result__submit";
+    const session = makeFakeSession();
+    const originalStreamFn = session.agent.streamFn;
+    let promptCount = 0;
+    session.prompt = vi.fn(async () => {
+      promptCount++;
+      if (promptCount === 1) {
+        session.__emit({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: "draft" }], stopReason: "stop" },
+        });
+        return;
+      }
+
+      // AgentSession.prompt may compact before its actual agent request. That
+      // request has no tools and must pass through untouched.
+      session.agent.streamFn({ api: "openai-completions" }, { tools: [] }, { phase: "compaction" });
+      session.agent.streamFn(
+        { api: "openai-completions" },
+        { tools: [{ name: requiredTool }] },
+        { phase: "repair" },
+      );
+      session.__emit({
+        type: "tool_execution_end",
+        toolName: requiredTool,
+        isError: false,
+        result: { details: { structuredContent: { label: false } } },
+      });
+      session.__emit({
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "final" }], stopReason: "stop" },
+      });
+    });
+
+    const brain = new PiAgentBrain(session);
+    await brain.prompt("question", undefined, { requiredResultToolName: requiredTool });
+
+    expect(originalStreamFn.mock.calls[0][2]).toEqual({ phase: "compaction" });
+    expect(originalStreamFn.mock.calls[1][2]).toEqual({
+      phase: "repair",
+      toolChoice: { type: "function", function: { name: requiredTool } },
+    });
+  });
+
+  it("reports an inactive required result tool as an observable failed repair", async () => {
+    const session = makeFakeSession();
+    session.getActiveToolNames = vi.fn(() => ["read"]);
+    session.prompt = vi.fn(async () => {
+      session.__emit({
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "draft" }], stopReason: "stop" },
+      });
+    });
+    const brain = new PiAgentBrain(session);
+    const events: any[] = [];
+    brain.subscribe((event) => events.push(event));
+
+    await brain.prompt("question", undefined, { requiredResultToolName: "mcp__result__submit" });
+
+    expect(events).toContainEqual({
+      type: "required_result_repair_end",
+      toolName: "mcp__result__submit",
+      success: false,
+      reason: "required_tool_inactive",
+    });
   });
 
   it("prompt maps images to ImageContent and passes them to session.prompt", async () => {
@@ -237,6 +426,45 @@ describe("PiAgentBrain", () => {
     const brain = new PiAgentBrain(session);
     await brain.steer("steer me");
     expect(session.steer).toHaveBeenCalledWith("steer me");
+  });
+
+  it("rejects a steer while a required-result repair owns the session", async () => {
+    const requiredTool = "mcp__result__submit";
+    const session = makeFakeSession();
+    let promptCount = 0;
+    let releaseRepair!: () => void;
+    const repairBlocked = new Promise<void>((resolve) => { releaseRepair = resolve; });
+    session.prompt = vi.fn(async () => {
+      promptCount++;
+      if (promptCount === 1) {
+        session.__emit({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: "draft" }], stopReason: "stop" },
+        });
+        return;
+      }
+      await repairBlocked;
+      session.__emit({
+        type: "tool_execution_end",
+        toolName: requiredTool,
+        isError: false,
+        result: { details: { structuredContent: { label: false } } },
+      });
+      session.__emit({
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "final" }], stopReason: "stop" },
+      });
+    });
+    const brain = new PiAgentBrain(session);
+
+    const prompt = brain.prompt("question", undefined, { requiredResultToolName: requiredTool });
+    while (promptCount < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(brain.steer("next query")).rejects.toMatchObject({
+      name: "RequiredResultRepairInProgress",
+    });
+    expect(session.steer).not.toHaveBeenCalled();
+    releaseRepair();
+    await prompt;
   });
 
   it("steer forwards images through prompt streaming steer", async () => {

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -16,6 +16,7 @@ import type {
   BrainProviderResponse,
   BrainContextPreflightResult,
   PromptMedia,
+  PromptRequirements,
 } from "../brain-session.js";
 import { estimateMessagesTokens } from "../compaction.js";
 import { rememberPromptFiles } from "../openai-file-payload.js";
@@ -48,6 +49,46 @@ function readCompatBoolean(compat: unknown, key: string): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
+/**
+ * Provider-neutral "call this tool" choice. OpenAI chat-completions providers
+ * can name the exact function; providers without a named-tool form still get a
+ * deterministic choice because the repair exposes exactly one tool.
+ */
+export function requiredToolChoice(
+  api: unknown,
+  toolName: string,
+): "any" | "required" | { type: "function"; function: { name: string } } {
+  if (api === "openai-completions") {
+    return { type: "function", function: { name: toolName } };
+  }
+  return api === "anthropic-messages" || api === "bedrock-converse-stream" ||
+    api === "google-generative-ai" || api === "google-vertex"
+    ? "any"
+    : "required";
+}
+
+function requiredResultRepairOptions(
+  model: unknown,
+  options: Record<string, any> | undefined,
+  requiredToolName: string,
+): Record<string, any> {
+  return {
+    ...options,
+    toolChoice: requiredToolChoice(
+      model && typeof model === "object" ? (model as { api?: unknown }).api : undefined,
+      requiredToolName,
+    ),
+  };
+}
+
+function contextHasTool(context: unknown, toolName: string): boolean {
+  if (!context || typeof context !== "object") return false;
+  const tools = (context as { tools?: unknown }).tools;
+  return Array.isArray(tools) && tools.some((tool) =>
+    tool != null && typeof tool === "object" && (tool as { name?: unknown }).name === toolName
+  );
+}
+
 export class PiAgentBrain implements BrainSession {
   readonly brainType = "pi-agent" as const;
 
@@ -61,6 +102,9 @@ export class PiAgentBrain implements BrainSession {
   /** True from abort() until the next prompt() starts. Stops the empty-response retry loop from
    *  firing a fresh (un-aborted) re-prompt when Stop lands during the backoff sleep. */
   private aborted = false;
+
+  /** A strict repair owns the session loop; steers must become separate turns. */
+  private requiredResultRepairActive = false;
 
   constructor(
     readonly session: AgentSession,
@@ -101,6 +145,11 @@ export class PiAgentBrain implements BrainSession {
   }
   private static readonly RETRY_DELAY_MS = 2000;
   private static readonly PROMPT_PREFLIGHT_SAFETY_TOKENS = 2048;
+  private static readonly REQUIRED_RESULT_REPAIR_PROMPT =
+    "[System: required-result repair]\n" +
+    "The preceding attempt did not submit the required structured turn result. " +
+    "Call the only available result-submission tool exactly once now, using the conversation and any preceding draft to fill its schema. " +
+    "If validation rejects the call, correct it. After one successful call, give the user the final answer without mentioning this repair, tools, or schemas.";
 
   private emit(event: any): void {
     for (const listener of this.extraListeners) {
@@ -116,10 +165,11 @@ export class PiAgentBrain implements BrainSession {
     });
   }
 
-  async prompt(text: string, media?: PromptMedia): Promise<void> {
+  async prompt(text: string, media?: PromptMedia, requirements?: PromptRequirements): Promise<void> {
     this.aborted = false;
     let lastAssistantHadContent = false;
     let lastAssistantMessage: any = null;
+    const successfulTools = new Set<string>();
 
     const promptOptions = this.promptOptionsForMedia(media);
 
@@ -134,6 +184,17 @@ export class PiAgentBrain implements BrainSession {
         const hasText = content.some((c: any) => c.type === "text" && c.text?.trim());
         const hasToolCalls = content.some((c: any) => c.type === "toolCall");
         if (hasText || hasToolCalls) lastAssistantHadContent = true;
+      }
+      if (
+        event.type === "tool_execution_end" &&
+        typeof event.toolName === "string" &&
+        event.isError !== true &&
+        event.result?.details?.error === undefined &&
+        event.result?.details?.structuredContent !== null &&
+        typeof event.result?.details?.structuredContent === "object" &&
+        !Array.isArray(event.result?.details?.structuredContent)
+      ) {
+        successfulTools.add(event.toolName);
       }
     });
 
@@ -207,8 +268,78 @@ export class PiAgentBrain implements BrainSession {
           `usage=${JSON.stringify(msg?.usage ?? {})}`,
         );
       }
+
+      const requiredResultToolName = requirements?.requiredResultToolName?.trim();
+      if (
+        requiredResultToolName &&
+        !this.aborted &&
+        lastAssistantMessage?.stopReason !== "aborted" &&
+        lastAssistantMessage?.stopReason !== "error" &&
+        !successfulTools.has(requiredResultToolName)
+      ) {
+        await this.repairMissingRequiredResult(requiredResultToolName, successfulTools);
+      }
     } finally {
       unsub();
+    }
+  }
+
+  /**
+   * Perform one bounded repair after the normal agent run omitted its required
+   * result. The repair sees the full session context, but only the contracted
+   * tool is exposed and the first provider request is forced to use a tool.
+   * This turns a prompt convention into a runtime guarantee without forcing
+   * the result tool before the agent has finished knowledge/tool gathering.
+   */
+  private async repairMissingRequiredResult(
+    requiredToolName: string,
+    successfulTools: ReadonlySet<string>,
+  ): Promise<void> {
+    const session = this.session as AgentSession & {
+      getActiveToolNames?: () => string[];
+      setActiveToolsByName?: (names: string[]) => void;
+      agent: AgentSession["agent"] & { streamFn: (...args: any[]) => any };
+    };
+    const activeToolNames = session.getActiveToolNames?.() ?? [];
+    if (!activeToolNames.includes(requiredToolName) || !session.setActiveToolsByName) {
+      console.error(`[pi-agent-brain] Required result tool is not active: ${requiredToolName}`);
+      this.emit({ type: "required_result_repair_start", toolName: requiredToolName });
+      this.emit({
+        type: "required_result_repair_end",
+        toolName: requiredToolName,
+        success: false,
+        reason: "required_tool_inactive",
+      });
+      return;
+    }
+
+    const originalStreamFn = session.agent.streamFn;
+    let forceNextProviderRequest = true;
+    session.agent.streamFn = ((model: any, context: any, options?: Record<string, unknown>) => {
+      // AgentSession can auto-compact before starting the repair turn. Compaction
+      // uses the same streamFn but carries no result tool; do not spend the
+      // one-shot force on that unrelated provider request.
+      const forceThisRequest = forceNextProviderRequest && contextHasTool(context, requiredToolName);
+      if (forceThisRequest) forceNextProviderRequest = false;
+      return originalStreamFn(model, context, forceThisRequest
+        ? requiredResultRepairOptions(model, options, requiredToolName)
+        : options);
+    }) as typeof session.agent.streamFn;
+
+    this.emit({ type: "required_result_repair_start", toolName: requiredToolName });
+    this.requiredResultRepairActive = true;
+    session.setActiveToolsByName([requiredToolName]);
+    try {
+      await session.prompt(PiAgentBrain.REQUIRED_RESULT_REPAIR_PROMPT);
+    } finally {
+      session.agent.streamFn = originalStreamFn;
+      session.setActiveToolsByName(activeToolNames);
+      this.requiredResultRepairActive = false;
+      this.emit({
+        type: "required_result_repair_end",
+        toolName: requiredToolName,
+        success: successfulTools.has(requiredToolName),
+      });
     }
   }
 
@@ -240,6 +371,11 @@ export class PiAgentBrain implements BrainSession {
   }
 
   steer(text: string, media?: PromptMedia): Promise<void> {
+    if (this.requiredResultRepairActive) {
+      const err = new Error("A required-result repair is in progress; submit this input as a new turn");
+      err.name = "RequiredResultRepairInProgress";
+      return Promise.reject(err);
+    }
     const promptOptions = this.promptOptionsForMedia(media);
     if (!promptOptions) {
       return this.session.steer(text);

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -1,5 +1,11 @@
 import { modelNeedsRebind } from "./brain-session.js";
-import type { BrainModelInfo, BrainProviderResponse, BrainSession, PromptMedia } from "./brain-session.js";
+import type {
+  BrainModelInfo,
+  BrainProviderResponse,
+  BrainSession,
+  PromptMedia,
+  PromptRequirements,
+} from "./brain-session.js";
 import { withResolvedModelCompat } from "./model-compat.js";
 
 export type ModelRouteFailureKind =
@@ -714,9 +720,11 @@ export async function runPromptWithModelRouting(
   state: ModelRouteState,
   options: RunPromptWithModelRoutingOptions = {},
   media?: PromptMedia,
+  requirements?: PromptRequirements,
 ): Promise<ModelRouteRunResult> {
   if (!isModelRoutePolicyEnabled(policy)) {
-    await brain.prompt(text, media);
+    if (requirements) await brain.prompt(text, media, requirements);
+    else await brain.prompt(text, media);
     return { success: true, exhausted: false, attempted: [] };
   }
 
@@ -826,7 +834,7 @@ export async function runPromptWithModelRouting(
     const streamFromStart = optimisticPrimaryStream && i === 0;
     const attemptResult = await runAttempt(
       brain, text, candidate, emitBrainEvent, streamFromStart, media, options.applyCandidateModelParams,
-      options.onEventCaptureChange, options.onAttemptReady,
+      options.onEventCaptureChange, options.onAttemptReady, requirements,
     );
     const failure = attemptResult.failure;
     attempt.finishedAt = now();
@@ -1013,6 +1021,7 @@ async function runAttempt(
   applyCandidateModelParams?: (candidate: ModelRouteCandidate) => void,
   onEventCaptureChange?: (capturing: boolean) => void,
   onAttemptReady?: (candidate: ModelRouteCandidate) => void,
+  requirements?: PromptRequirements,
 ): Promise<AttemptResult> {
   const checkpoint = brain.createPromptCheckpoint?.();
   let lastProviderResponse: BrainProviderResponse | undefined;
@@ -1156,7 +1165,8 @@ async function runAttempt(
     // effective model from here on. Publish it before prompting so a tool call
     // made during the prompt (spawn_subagent above all) can read it.
     onAttemptReady?.(candidate);
-    await brain.prompt(text, media);
+    if (requirements) await brain.prompt(text, media, requirements);
+    else await brain.prompt(text, media);
   } catch (err) {
     const message = errorMessage(err);
     return {

--- a/src/gateway/agentbox/client.test.ts
+++ b/src/gateway/agentbox/client.test.ts
@@ -141,6 +141,17 @@ describe("AgentBoxClient — prompt + session CRUD", () => {
     });
   });
 
+  it("prompt() preserves the strict result-tool requirement", async () => {
+    await client.prompt({
+      text: "hi",
+      requiredResultToolName: "mcp__result__submit",
+    });
+
+    const req = srv.captures[srv.captures.length - 1];
+    expect(req.url).toBe("/api/prompt");
+    expect(JSON.parse(req.body).requiredResultToolName).toBe("mcp__result__submit");
+  });
+
   it("prompt() preserves native PDF files", async () => {
     await client.prompt({
       text: "read this",

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -26,6 +26,8 @@ export interface PromptOptions {
    * abort addressed by session alone can land on a successor.
    */
   turnId?: string;
+  /** Exact result tool required by a strict control-plane turn. */
+  requiredResultToolName?: string;
   /** User who initiated this prompt. Forwarded per-request to the trace
    *  recorder as the root span's user.id (mirrors sessionId's per-request
    *  path), so tracing carries the user dimension in every deployment mode. */

--- a/src/gateway/agentbox/local-spawner.test.ts
+++ b/src/gateway/agentbox/local-spawner.test.ts
@@ -327,6 +327,18 @@ describe("LocalSpawner — tool-capabilities injection", () => {
 });
 
 describe("LocalSpawner — locked agent-type policy (P1: parity with K8s)", () => {
+  it("locks Product Support to read-only built-ins while preserving its managed type", async () => {
+    dbQueryImpl = async () => [[{ tool_capabilities: JSON.stringify(["run_commands"]), agent_type: "product_support" }], undefined];
+    const spawner = new LocalSpawner(new FakeCertManager() as any, "https://127.0.0.1:3002", 5000);
+    const handle = await spawner.spawn({ agentId: "a1" });
+    const box = (spawner as any).boxes.get(handle.boxId);
+    expect(new Set(box.sessionManager.allowedToolsState)).toEqual(
+      new Set(["read", "grep", "find", "ls", "knowledge_search", "knowledge_cite"]),
+    );
+    expect(box.sessionManager.agentTypeState).toBe("product_support");
+    expect(box.sessionManager.harnessResolvedState).toBe(true);
+  });
+
   it("locks a Coordinator's capabilities + persona even with an EMPTY raw tool_capabilities", async () => {
     // The exact bug: a built-in type with no raw tool_capabilities used to resolve
     // to null (unrestricted) + default "custom" persona in local mode. It must now

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -203,6 +203,18 @@ describe("handleMcpServers", () => {
 // ── handleToolCapabilities ────────────────────────────────
 
 describe("handleToolCapabilities", () => {
+  it("resolves product_support as a locked read-only built-in harness", async () => {
+    frontend.responses.set("config.getAgent", { agent_type: "product_support", tool_capabilities: ["run_commands"] });
+    const res = new FakeRes();
+    await handleToolCapabilities(asReq(new FakeReq("")), asRes(res), identity, frontend as unknown as FrontendWsClient);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.agentType).toBe("product_support");
+    expect(new Set(body.allowedTools)).toEqual(
+      new Set(["read", "grep", "find", "ls", "knowledge_search", "knowledge_cite"]),
+    );
+  });
+
   it("resolves the agent's capability groups to a concrete allowedTools list", async () => {
     frontend.responses.set("config.getAgent", { agent_type: "custom", tool_capabilities: ["read_files", "search_memory"] });
     const res = new FakeRes();

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -293,7 +293,7 @@ export async function handleToolCapabilities(
     const agent = await frontendClient.request("config.getAgent", {
       agentId: identity.agentId,
     });
-    // Built-in types (sre/coordinator/knowledge_qa) LOCK the capability set; custom uses the
+    // Built-in types LOCK the capability set; custom uses the
     // agent's own tool_capabilities. resolveCapabilities(null/[]) === null keeps
     // the backward-compatible "unrestricted" default for custom with no selection.
     const agentType = requireAgentType(agent?.agent_type);

--- a/src/gateway/server-chat-abort.test.ts
+++ b/src/gateway/server-chat-abort.test.ts
@@ -14,6 +14,9 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 
 const bindMessageTraceIdMock = vi.hoisted(() => vi.fn(async () => {}));
 const updateMessageMock = vi.hoisted(() => vi.fn(async () => {}));
+const steerSessionMock = vi.hoisted(() =>
+  vi.fn(async () => ({ ok: true, traceId: "fedcba9876543210fedcba9876543210" })),
+);
 
 vi.mock("./chat-repo.js", async (importOriginal) => ({
   ensureChatSession: vi.fn(async () => {}),
@@ -87,7 +90,7 @@ vi.mock("./agentbox/client.js", () => ({
       if (attempt === 0 && abortFirstAttempt) throw abortFirstAttempt;
       if (abortSessionError) throw abortSessionError;
     });
-    steerSession = vi.fn(async () => ({ ok: true, traceId: "fedcba9876543210fedcba9876543210" }));
+    steerSession = steerSessionMock;
     streamEvents = async function* () {};
   },
 }));
@@ -814,6 +817,66 @@ describe("startRuntime — chat.abort wiring", () => {
     expect(updateMessageMock.mock.invocationCallOrder[0]).toBeLessThan(
       bindMessageTraceIdMock.mock.invocationCallOrder[0],
     );
+  });
+
+  it("does not fold a strict concurrent request into the running turn as a steer", async () => {
+    promptError = new Error("Session is already running");
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+    const context = { sendEvent: vi.fn() };
+
+    const ack = await send({
+      agentId: "a",
+      userId: "u",
+      text: "one more detail",
+      sessionId: "strict-S",
+      requiredResultToolName: "mcp__result__submit",
+      requireSessionPersistence: true,
+    }, context) as { turnId: string; strictResultProtocolVersion?: number };
+    await waitFor(() => promptCalls.length > 0);
+    await waitFor(() => context.sendEvent.mock.calls.some(([, payload]) =>
+      payload?.turnId === ack.turnId && payload?.event?.type === "prompt_done"
+    ));
+
+    expect(ack.strictResultProtocolVersion).toBe(1);
+    expect(steerSessionMock).not.toHaveBeenCalled();
+    expect(context.sendEvent).toHaveBeenCalledWith("chat.event", expect.objectContaining({
+      sessionId: "strict-S",
+      turnId: ack.turnId,
+      event: expect.objectContaining({ type: "stream_error" }),
+    }));
+    expect(context.sendEvent).toHaveBeenCalledWith("chat.event", {
+      sessionId: "strict-S",
+      turnId: ack.turnId,
+      event: { type: "prompt_done" },
+    });
+  });
+
+  it("does not steer a strict request while the runtime session lock is busy", async () => {
+    let releasePrompt!: () => void;
+    promptBlocker = new Promise<void>((resolve) => { releasePrompt = resolve; });
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+    const abort = server.rpcMethods.get("chat.abort")!;
+
+    await send({ agentId: "a", userId: "u", text: "first", sessionId: "strict-lock" }, { sendEvent: vi.fn() });
+    await waitFor(() => promptCalls.length === 1);
+    await send({
+      agentId: "a",
+      userId: "u",
+      text: "second",
+      sessionId: "strict-lock",
+      requiredResultToolName: "mcp__result__submit",
+    }, { sendEvent: vi.fn() });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(promptCalls).toHaveLength(1);
+    expect(steerSessionMock).not.toHaveBeenCalled();
+
+    releasePrompt();
+    promptBlocker = undefined;
+    await waitFor(() => capturedSignal !== undefined);
+    await abort({ agentId: "a", sessionId: "strict-lock" });
   });
 
   it("clears the registration after the turn settles (no leak / no stale abort)", async () => {

--- a/src/gateway/server-chat-system-prompt.test.ts
+++ b/src/gateway/server-chat-system-prompt.test.ts
@@ -46,7 +46,11 @@ vi.mock("./sse-consumer.js", () => ({
   }),
 }));
 
-const promptCalls: Array<{ systemPromptTemplate?: string; sessionId: string }> = [];
+const promptCalls: Array<{
+  systemPromptTemplate?: string;
+  sessionId: string;
+  requiredResultToolName?: string;
+}> = [];
 vi.mock("./agentbox/client.js", () => ({
   AgentBoxClient: class {
     endpoint: string;
@@ -64,6 +68,7 @@ vi.mock("./agentbox/client.js", () => ({
 }));
 
 const { startRuntime } = await import("./server.js");
+const { sessionRegistry } = await import("./session-registry.js");
 
 // getAgentResult drives what config.getAgent resolves to (or throws when set to
 // an Error), letting each test model "custom prompt present / absent / lookup
@@ -163,6 +168,39 @@ describe("startRuntime — chat.send custom system prompt", () => {
     expect(getAgentCalls).toEqual([]);
   });
 
+  it("forwards a strict result-tool requirement to AgentBox", async () => {
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+
+    const ack = await send({
+      agentId: "a",
+      userId: "u",
+      text: "hi",
+      sessionId: "strict-result",
+      requiredResultToolName: "mcp__result__submit",
+      requireSessionPersistence: true,
+    }, { sendEvent: vi.fn() }) as { strictResultProtocolVersion?: number };
+    await waitFor(() => promptCalls.length > 0);
+
+    expect(promptCalls[0].requiredResultToolName).toBe("mcp__result__submit");
+    expect(ack.strictResultProtocolVersion).toBe(1);
+  });
+
+  it("does not advertise strict protocol support for a partial opt-in", async () => {
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+
+    const ack = await send({
+      agentId: "a",
+      userId: "u",
+      text: "hi",
+      sessionId: "result-without-durable-ack",
+      requiredResultToolName: "mcp__result__submit",
+    }, { sendEvent: vi.fn() }) as { strictResultProtocolVersion?: number };
+
+    expect(ack.strictResultProtocolVersion).toBeUndefined();
+  });
+
   it("falls back to the agent's custom prompt when the caller omits systemPrompt (control-plane web path)", async () => {
     getAgentResult = { system_prompt: "custom agent persona" };
     server = await bootRuntime();
@@ -197,5 +235,36 @@ describe("startRuntime — chat.send custom system prompt", () => {
     await waitFor(() => promptCalls.length > 0);
 
     expect(promptCalls[0].systemPromptTemplate).toBeUndefined();
+  });
+
+  it("rejects a strict persistence ACK before any AgentBox prompt starts", async () => {
+    vi.mocked(chatRepo.ensureChatSession).mockRejectedValueOnce(new Error("database unavailable"));
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+
+    await expect(send({
+      agentId: "a",
+      userId: "u",
+      text: "hi",
+      sessionId: "strict-session",
+      requireSessionPersistence: true,
+    }, { sendEvent: vi.fn() })).rejects.toMatchObject({ name: "SessionPersistenceError" });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(promptCalls).toEqual([]);
+    expect(sessionRegistry.peek("strict-session")).toBeUndefined();
+  });
+
+  it("keeps best-effort persistence for ordinary interactive chat", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(chatRepo.ensureChatSession).mockRejectedValueOnce(new Error("database unavailable"));
+    server = await bootRuntime();
+    const send = server.rpcMethods.get("chat.send")!;
+
+    await expect(send({ agentId: "a", userId: "u", text: "hi", sessionId: "web-session" }, {
+      sendEvent: vi.fn(),
+    })).resolves.toMatchObject({ ok: true, sessionId: "web-session" });
+    await waitFor(() => promptCalls.length > 0);
+    warn.mockRestore();
   });
 });

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -731,6 +731,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // Runtime already persisted and sequenced the user row, so the target must
     // not bind or update a second local copy of it.
     const skipInitialPersistence = params.skipInitialPersistence === true && Boolean(delegation?.delegationId);
+    // Machine-facing strict callers cannot safely publish a reusable sessionId
+    // until its session and first user message are durable. Interactive chat
+    // keeps the legacy best-effort behavior; strict /run opts into this ACK.
+    const requireSessionPersistence = params.requireSessionPersistence === true;
+    const requiredResultToolName = typeof params.requiredResultToolName === "string"
+      ? params.requiredResultToolName.trim() || undefined
+      : undefined;
     // Portal stamps turnStartMs at POST receipt — closer to user click than
     // the runtime's loop start. Use it as the canonical turn anchor when
     // present; fall back gracefully so direct callers (tests, /run path)
@@ -797,6 +804,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const promptOpts: PromptOptions = {
       sessionId,
       turnId,
+      requiredResultToolName,
       userId,
       text,
       agentId,
@@ -840,9 +848,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // or the process died — the message vanished while the turn ran anyway, so "your
     // message was recorded" was not actually true when we said it.
     //
-    // A failure here does NOT fail the send. The caller loses the row id and falls back
-    // to matching by content; blocking a whole conversation on one database hiccup is the
-    // worse trade.
+    // Interactive callers retain the legacy best-effort behavior: they lose the
+    // row id and fall back to matching by content. A strict machine caller opts
+    // into failing this ACK because it will expose sessionId as a durable handle.
     // Registered before the async ack below, and before the persistence awaits: this
     // closes the cold-start window in which chat.abort had no local cancellation state
     // to update, and it is what makes the shutdown fence airtight — a handler that got
@@ -860,6 +868,17 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         promptMessageId = await appendMessage({ sessionId, role: "user", content: text, deferSequence: true });
         await incrementMessageCount(sessionId);
       } catch (persistErr) {
+        if (requireSessionPersistence) {
+          unregisterPendingStart(sessionId, turnAbort);
+          dropLiveTurn(sessionId, turnId);
+          delegatedTurns.delete(turnId);
+          sessionRegistry.forget(sessionId);
+          const err = new Error("chat.send could not durably persist the session before acknowledgement", {
+            cause: persistErr,
+          });
+          err.name = "SessionPersistenceError";
+          throw err;
+        }
         console.warn(`[runtime] failed to persist the user message session=${sessionId}; continuing without a row id:`, persistErr);
       }
     }
@@ -886,6 +905,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           releaseTurn = await sessionTurnLocks.acquire(sessionId);
         } catch (busyErr) {
           throwIfStoppedBeforePrompt();
+          // A strict machine request is one distinct turn with one distinct
+          // result. Folding it into the running turn as a steer would lose its
+          // required-result contract, so surface busy and let the caller retry.
+          if (requiredResultToolName) throw busyErr;
           const running = sessionTurnLocks.busyOn(sessionId);
           const steered = running ? await new AgentBoxClient(running.endpoint, 10000, agentBoxTlsOptions)
             .steerSession(sessionId, text, { images, files })
@@ -999,6 +1022,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           // prompt will fire its own when it actually finishes, and an
           // extra one would close the frontend stream prematurely.
           if (err instanceof Error && err.message.includes("Session is already running")) {
+            if (requiredResultToolName) throw err;
             const steerResult = await client.steerSession(sessionId, text, { images, files });
             if (promptMessageId) pendingUserRows.push(sessionId, promptMessageId, text);
             // chat.send persisted this row before it knew the active session would
@@ -1158,7 +1182,18 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     // write above failed.
     // turnId travels back so a supervisor can later abort THIS turn specifically
     // rather than "whatever is running on this session".
-    return { ok: true, sessionId, turnId, ...(promptMessageId ? { messageId: promptMessageId } : {}) };
+    return {
+      ok: true,
+      sessionId,
+      turnId,
+      ...(promptMessageId ? { messageId: promptMessageId } : {}),
+      // Version 1 promises all strict semantics as one capability: durable ACK,
+      // required structured-result repair, and a correlated failure terminal
+      // instead of degrading a concurrent request into the active turn.
+      ...(requireSessionPersistence && requiredResultToolName
+        ? { strictResultProtocolVersion: 1 }
+        : {}),
+    };
   });
 
   // ── Shared capability box client ───────────────────────────────────────────

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -2146,7 +2146,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
       // (legacy MySQL JSON, new MySQL TEXT, SQLite TEXT). The Gateway resolves
       // these group keys → concrete allowedTools at its boundary.
       tool_capabilities: parseToolCapabilitiesAtBoundary(agent.tool_capabilities),
-      // Agent type (sre/coordinator/knowledge_qa/custom). Built-in types lock
+      // Built-in Agent types lock
       // capabilities and an immutable behavior contract; system_prompt stores
       // only the optional Agent-owned Addendum.
       agent_type: agent.agent_type,


### PR DESCRIPTION
## Summary

- add `product_support` as a read-only built-in Agent type with a minimal runtime-owned contract while leaving the business prompt and result schema to the control plane
- let machine callers require durable session/message persistence and exactly one successful structured result-tool output per turn
- run one bounded, provider-neutral repair pass when the main response omits the required result, without allowing compaction or concurrent steers to consume the repair contract
- reject strict concurrent sends instead of degrading them into the active turn, and surface missing/inactive result tools as explicit failed outcomes
- advertise strict-result protocol version `1` only when the complete durable-session/result contract is active, so the control plane can reject older runtimes during rolling upgrades
- validate the strict result-tool input at the AgentBox boundary and clean up the in-memory session registry on strict persistence failure

Deploy this runtime support before accepting strict product-support traffic from a control plane.

## Contract boundary

- Siclaw owns the generic Agent type, strict turn mechanics, and runtime failure semantics.
- The control plane owns the released product-support prompt, result-tool schema, session API, and channel-facing streaming contract.
- A text-only tool completion is not a valid strict result; success requires the configured tool's non-error `structuredContent` object.

## Verification

- `npm run build`
- `npm test` (296 files; 6,604 passed, 2 skipped)
- `cd portal-web && npm test` (25 files; 246 passed)
- `cd portal-web && npm run build`
