### PR TITLE
fix(agentbox): prevent NFS ownership scans from exhausting startup probes

### DIFF
--- a/docker/agentbox-entrypoint.sh
+++ b/docker/agentbox-entrypoint.sh
@@ -106,8 +106,62 @@ fi
 chown -R agentbox:agentbox /app/.siclaw/skills 2>/dev/null || true
 chmod 0755 /app/.siclaw/skills 2>/dev/null || true
 
-chown -R agentbox:agentbox /app/.siclaw/user-data 2>/dev/null || true
-chmod 0777 /app/.siclaw/user-data 2>/dev/null || true
+# 🔴 user-data is the one directory here that is NOT a local emptyDir: it is a subPath on a
+# shared NFS PVC, and EVERY box of an agent mounts the SAME path (by design — session history
+# lives there, so a session can be picked up by another box). Two consequences that an
+# unconditional `chown -R` gets badly wrong:
+#
+#   - It is O(agent's whole history), over NFS, one SETATTR round trip per file, and that
+#     history only grows. It ran BEFORE node starts and is silent, so it was invisible from
+#     every angle: it consumed the entire 60s startupProbe window, kubelet killed the
+#     container, and under `restartPolicy: Never` that is permanent. The box's own startup
+#     work, once it got to run, took 0.4 seconds.
+#   - Boxes starting together each run it over the SAME inodes — the same idempotent work N
+#     times, contending on one NFS server, while any already-serving box takes the IO hit.
+#
+# So the root directory's ownership IS the completion marker: correct means "this tree has
+# already been claimed", and every later start is one stat.
+#
+# ORDER IS LOAD-BEARING — contents first, root last. `chown -R` does the opposite (root, then
+# recurse), which is exactly what makes it unsafe to resume: killed midway it leaves the root
+# already correct and the tree half-done, so every future start skips the repair forever. And
+# "killed midway" is not hypothetical here; it is the failure this whole block is about.
+#
+# `-h` is not pedantry: without it chown FOLLOWS symlinks and changes the target's owner, and
+# this tree holds agent-written content — one link pointing outside would let the root-owned
+# entrypoint retitle a file beyond it.
+#
+# Numeric ids rather than names, so nothing depends on name resolution inside the container.
+# 1000 is `useradd --uid 1000 agentbox` in Dockerfile.agentbox — keep in step. Both halves are
+# checked: a root left at `1000:0` is not claimed, and reading only the uid would call it done.
+#
+# Assumes the export preserves the writer's ids. If it maps them (all_squash / anonuid) every
+# file reads as wrongly-owned forever, the guard never matches, and this degenerates into the
+# full walk on every start — that has to be fixed at the mount, not here.
+user_data_dir=/app/.siclaw/user-data
+if [ "$(stat -c '%u:%g' "$user_data_dir" 2>/dev/null || echo '')" != "1000:1000" ]; then
+  if find "$user_data_dir" -xdev -mindepth 1 \( ! -uid 1000 -o ! -gid 1000 \) \
+       -exec chown -h 1000:1000 {} + 2>/dev/null \
+     && chown 1000:1000 "$user_data_dir" 2>/dev/null
+  then
+    :
+  else
+    # Deliberately not fatal, unlike the credential checks above. Those guard an isolation
+    # property — running without it is worse than not running. This is a degradation: the
+    # directory itself is world-writable (below), so the box still works, it just may not be
+    # able to write some pre-existing file. Exiting here would also brick `docker run` without
+    # CAP_CHOWN, which every `|| true` in this script exists to keep working.
+    #
+    # But it must not be SILENT — a silent chown over this directory is what made the outage
+    # unreadable. Not marking the root is the other half: the repair simply runs again next
+    # start.
+    echo "WARNING: could not claim ownership of $user_data_dir — the box may be unable to" >&2
+    echo "         write files left by an earlier version; retrying on next start." >&2
+  fi
+fi
+# Outside the guard: O(1), idempotent, and a freshly provisioned subPath needs it before the
+# box can write at all.
+chmod 0777 "$user_data_dir" 2>/dev/null || true
 
 chown -R agentbox:agentbox /app/.siclaw/config 2>/dev/null || true
 chmod 0700 /app/.siclaw/config 2>/dev/null || true

--- a/src/gateway/agentbox/entrypoint-user-data.test.ts
+++ b/src/gateway/agentbox/entrypoint-user-data.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * The entrypoint's handling of `user-data` — the only NFS-backed mount it touches.
+ *
+ * This block reads as needlessly elaborate next to the two `chown -R` lines around it, and the
+ * obvious "simplification" back to `chown -R` is what caused a production outage: it is
+ * O(the agent's entire session history) over NFS, one SETATTR round trip per file, and it runs
+ * before node can log anything. It consumed the whole 60s startupProbe window; kubelet killed
+ * the container; `restartPolicy: Never` made that permanent; the Runtime respawned a box that
+ * met the same end, so the pool never filled.
+ *
+ * Nothing in the shell says any of that at runtime, and a reviewer has no way to feel the
+ * difference between this directory and the emptyDirs beside it. So the shape is pinned here.
+ */
+const entrypoint = readFileSync(
+  resolve(import.meta.dirname, "../../../docker/agentbox-entrypoint.sh"),
+  "utf8",
+);
+
+/** The `user-data` block: from its marker comment to the chmod that closes it. */
+function userDataBlock(): string {
+  const start = entrypoint.indexOf("user_data_dir=/app/.siclaw/user-data");
+  expect(start, "the user-data block").toBeGreaterThan(-1);
+  const end = entrypoint.indexOf("chmod 0777", start);
+  expect(end, "the chmod closing the user-data block").toBeGreaterThan(start);
+  return entrypoint.slice(start, end);
+}
+
+describe("agentbox entrypoint: user-data ownership", () => {
+  it("never walks the tree unconditionally", () => {
+    // The emptyDirs may be chowned recursively — they are local and small. This one may not.
+    expect(entrypoint).not.toMatch(/chown\s+-R\s+\S+\s+\S*\.siclaw\/user-data/);
+  });
+
+  it("guards the walk on the root's ownership, so a claimed tree costs one stat", () => {
+    const block = userDataBlock();
+    expect(block).toMatch(/stat -c '%u:%g'/);
+    // Both halves: a root left at 1000:0 is not claimed, and checking only the uid calls it done.
+    expect(block).toContain("1000:1000");
+  });
+
+  it("claims the contents BEFORE the root, so an interrupted repair resumes", () => {
+    // `chown -R` does the opposite — root first, then recurse — which is precisely why it
+    // cannot be resumed: killed midway it leaves the root correct and the tree half-done, and
+    // every later start then skips the repair forever. Being killed midway is the failure this
+    // whole block exists for, so the order is the contract.
+    const block = userDataBlock();
+    const contents = block.indexOf("find ");
+    const root = block.indexOf('chown 1000:1000 "$user_data_dir"');
+    expect(contents, "the contents walk").toBeGreaterThan(-1);
+    expect(root, "the root claim").toBeGreaterThan(-1);
+    expect(contents).toBeLessThan(root);
+  });
+
+  it("does not follow symlinks when claiming", () => {
+    // Without -h, chown retitles the symlink's TARGET. This tree holds agent-written content,
+    // so a link pointing outside it would reach a file the entrypoint has no business touching
+    // — and the entrypoint is still root here.
+    expect(userDataBlock()).toMatch(/chown -h 1000:1000/);
+  });
+
+  it("reports a failed claim instead of failing the box", () => {
+    const block = userDataBlock();
+    // Not fatal: unlike the credential checks, this is a degradation, not a lost isolation
+    // property — and exiting would brick `docker run` without CAP_CHOWN.
+    expect(block).not.toMatch(/exit 1/);
+    // But not silent either: silence over this directory is what made the outage unreadable.
+    expect(block).toMatch(/WARNING/);
+  });
+});

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -95,7 +95,12 @@ const originalGatewayEnv = {
 };
 
 // Import SUT after mocks.
-import { K8sSpawner, parseK8sQuantity, clampRequestToLimit } from "./k8s-spawner.js";
+import {
+  K8sSpawner,
+  parseK8sQuantity,
+  clampRequestToLimit,
+  STARTUP_PROBE_WINDOW_MS,
+} from "./k8s-spawner.js";
 
 // ── Fake cert manager ─────────────────────────────────────────────────
 
@@ -479,9 +484,12 @@ describe("K8sSpawner — spawn branches", () => {
     await s.spawn({ agentId: "probe-gate" }).catch(() => {});
     const container = calls.createNamespacedPod[0].body.spec.containers[0];
     expect(container.startupProbe.httpGet).toMatchObject({ path: "/health", scheme: "HTTPS" });
-    // 30 x 2s: the same 60s the manager waits before calling a box crashed, so the two
-    // do not disagree about when a box has failed to come up.
-    expect(container.startupProbe.periodSeconds! * container.startupProbe.failureThreshold!).toBe(60);
+    // Assert the RELATION, not the number, so the emitted window cannot drift from the one
+    // the module exports. (It was a literal 60, justified by a comment claiming the manager
+    // waits the same 60s before calling a box crashed — it does not; `exitedUnexpectedly` is
+    // pod phase `Failed`. Raising the window after a production outage surfaced the claim.)
+    expect(container.startupProbe.periodSeconds! * container.startupProbe.failureThreshold! * 1000)
+      .toBe(STARTUP_PROBE_WINDOW_MS);
     expect(container.startupProbe.initialDelaySeconds).toBeUndefined();
   });
 

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -128,13 +128,33 @@ export function clampRequestToLimit(request: string, limit: string, podName: str
  * Startup gate handed to kubelet: `periodSeconds × failureThreshold` is how long a container
  * gets to answer its first probe.
  *
+ * 🔴 IT MUST COVER WORK THAT HAPPENS BEFORE THE BOX CAN LOG ANYTHING, and 60s did not.
+ * A production pool could never fill: kubelet killed every box here, the Runtime reported a
+ * spawn failure and respawned one that met the same end. Under `restartPolicy: Never` the
+ * kill is terminal:
+ *
+ *   t+0s    container starts
+ *   t+59s   30th probe fails → kubelet: "Container agentbox failed startup probe", KillPod
+ *   t+119s  termination grace elapses → SIGKILL → exitCode 137, phase Failed
+ *
+ * The box was not slow at anything it logs — measured from its own first line to `listen()`
+ * is 0.4s. The time went to the entrypoint's `chown -R` over the NFS-backed user-data
+ * subPath, which runs before node starts, is silent, and grows with the agent's accumulated
+ * session history. **That is the root cause and it is NOT fixed here** — this number only
+ * stops a slow start from being a permanent one.
+ *
+ * Which is also why the margin is wide rather than merely sufficient: the span this window
+ * has to cover includes pre-node work that no code here can see or time, and it grows on its
+ * own. Nobody connects "the agent accumulated more state" to "pods stopped starting", and
+ * being one second short costs a pod that never runs again.
+ *
  * Named constants rather than literals at the call site because two other timeouts are
  * defined RELATIVE to this window — the Runtime's readiness wait above it and the box's own
  * startup budget below it — and `startup-probe-window.test.ts` asserts those relations. A
  * literal here would let the window move without the relations being rechecked.
  */
 export const STARTUP_PROBE_PERIOD_SECONDS = 2;
-export const STARTUP_PROBE_FAILURE_THRESHOLD = 30;
+export const STARTUP_PROBE_FAILURE_THRESHOLD = 90;
 
 /** The window itself, in ms: how long kubelet allows before it gives up on the container. */
 export const STARTUP_PROBE_WINDOW_MS =
@@ -144,9 +164,15 @@ export const STARTUP_PROBE_WINDOW_MS =
  * How long the Runtime waits for a pod it created to become Ready.
  *
  * MUST stay well above {@link STARTUP_PROBE_WINDOW_MS} — see waitForPodReady for why the two
- * measure different spans and what happened when they were equal.
+ * measure different spans and what happened when they were equal. Raised with the window for
+ * that reason; `startup-probe-window.test.ts` pins the ratio.
+ *
+ * Seven minutes reads long, and the two costs are not symmetric: a window too SMALL kills a
+ * healthy box permanently, while a timeout too LARGE only delays reporting a spawn that is
+ * genuinely broken — and is only ever waited out in that case, since a box that comes up
+ * returns in under a minute.
  */
-export const POD_READY_TIMEOUT_MS = 180_000;
+export const POD_READY_TIMEOUT_MS = 420_000;
 
 /**
  * How kubelet asks a box whether it is up.


### PR DESCRIPTION
## Summary

- increase the AgentBox startup probe window from 60 seconds to 180 seconds
- extend the Runtime wait for AgentBox readiness from 180 seconds to 420 seconds
- avoid recursively reclaiming the entire NFS-backed user-data tree on every startup when its root ownership is already correct

## Context

In affected pods, the startup probe ran every 2 seconds with a failure threshold of 30, so a pre-server startup delay longer than 60 seconds caused kubelet to mark the probe as failed and initiate pod termination. After the 60-second termination grace period, containerd sent SIGKILL and the container exited with code 137. Runtime cleanup happened only after the pod had already failed.

Once the Node.js process started logging, resource sync and HTTPS startup completed in roughly 0.4 seconds. The long silent interval occurred before Node.js startup and was consistent with the entrypoint recursively running `chown -R` over the shared NFS user-data tree.

This change widens the immediate startup safety margin and adds a fast path that skips the recursive ownership scan once the user-data root is already owned by the AgentBox user.

## Verification

- `npx vitest run src/gateway/agentbox/entrypoint-user-data.test.ts src/gateway/agentbox/k8s-spawner.test.ts src/gateway/agentbox/startup-probe-window.test.ts` (95 tests passed)
- `bash -n docker/agentbox-entrypoint.sh`

## Follow-up

This is an operational mitigation. A longer-term ownership model for shared storage, such as shared-group/setgid permissions or a coordinated migration mechanism, should remove the need for recursive ownership repair entirely.
