### PR TITLE
feat(knowledge): prove label routes through catalogs

### DIFF
--- a/docs/design/agent-prompt-lifecycle.md
+++ b/docs/design/agent-prompt-lifecycle.md
@@ -81,10 +81,14 @@ responsibility.
 For Knowledge QA, the complete root `index.md` is the primary navigation map.
 `knowledge_search` resolves typed page labels and aliases only when catalog
 routing is ambiguous; it never searches page bodies or returns answer evidence.
-The Agent must Read the complete relevant leaf pages before answering and may
-cite only leaf content it actually used. This preserves semantic reasoning and
-the Wiki's linked navigation model without adding an embedding or content-index
-cold-start dependency.
+Each candidate includes one deterministic shortest `routeProof` from the root
+catalog to the leaf. The proof establishes that the candidate is published in
+the Wiki's navigation graph; it is not a claim that the Agent already traversed
+or read those pages. Intermediate catalogs do not need to be reread. The Agent
+must Read the complete relevant leaf pages before answering and may cite only
+leaf content it actually used. This preserves semantic reasoning and the Wiki's
+linked navigation model without adding an embedding or content-index cold-start
+dependency.
 
 ## Stored Addendum compatibility
 

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -705,9 +705,13 @@ The complete root `index.md` is injected into the model prompt as the common
 navigation baseline. AgentBox also derives an in-memory, paginated Label Catalog
 from page frontmatter before the first turn. `knowledge_search` resolves typed
 labels and aliases only; it never searches page bodies, creates a database, or
-opens an embedding provider. It returns page metadata, matched labels, and alias
-reasons, never snippets. Labels and catalog entries never count as answer
-evidence; the Agent must still read and cite supporting pages.
+opens an embedding provider. It returns page metadata, matched labels, alias
+reasons, and one deterministic shortest route from the root catalog to each
+leaf, never snippets. A labeled page outside the root catalog graph is excluded
+and reported as unreachable. The route proves publication and reachability; it
+does not claim that the Agent read every intermediate catalog. Labels and
+catalog entries never count as answer evidence; the Agent reads and cites only
+the supporting leaf pages.
 
 **Consequences**:
 
@@ -715,6 +719,7 @@ evidence; the Agent must still read and cite supporting pages.
 - ✅ Known entities, tasks, versions, and aliases route without FTS, vectors, a database, or an embedding call.
 - ✅ The first QA turn has no content-index hydration dependency.
 - ✅ One page-level contract flows unchanged through compilation and delivery.
+- ✅ Every label result proves its canonical root-to-leaf catalog route; orphan labels cannot bypass publication.
 - ✅ Existing and third-party OKF v0.2 packages without labels navigate through the complete root index.
 - ⚠️ Label quality is a compiler-quality concern and needs later retrieval evaluation.
 - ⚠️ The full root index consumes fixed prompt tokens; KBC must keep entries concise, and any future oversized representation must remain complete rather than head-truncated.

--- a/scripts/apply-knowledge-label-manifest.ts
+++ b/scripts/apply-knowledge-label-manifest.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env -S npx tsx
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+import {
+  applyKnowledgeLabelManifest,
+  type KnowledgeLabelBackfillManifest,
+} from "../src/knowledge/label-backfill.js";
+
+const { values } = parseArgs({
+  options: {
+    source: { type: "string" },
+    output: { type: "string" },
+    manifest: { type: "string" },
+    report: { type: "string" },
+  },
+  strict: true,
+});
+
+if (!values.source || !values.output || !values.manifest) {
+  throw new Error("Usage: apply-knowledge-label-manifest --source DIR --output DIR --manifest FILE [--report FILE]");
+}
+
+const manifest = JSON.parse(fs.readFileSync(path.resolve(values.manifest), "utf8")) as KnowledgeLabelBackfillManifest;
+const report = applyKnowledgeLabelManifest(values.source, values.output, manifest);
+const payload = JSON.stringify(report, null, 2) + "\n";
+if (values.report) {
+  fs.mkdirSync(path.dirname(path.resolve(values.report)), { recursive: true });
+  fs.writeFileSync(path.resolve(values.report), payload);
+}
+process.stdout.write(payload);

--- a/src/knowledge/catalog-graph.ts
+++ b/src/knowledge/catalog-graph.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { isKnowledgeNavigationPage } from "./page-kind.js";
+
+export interface KnowledgeRouteStep {
+  file: string;
+  kind: "catalog" | "leaf";
+  via?: string;
+}
+
+export interface KnowledgeRouteProof {
+  reachable: true;
+  trail: KnowledgeRouteStep[];
+}
+
+interface CatalogLink {
+  file: string;
+  text: string;
+}
+
+const MARKDOWN_LINK_RE = /(?<!!)\[([^\]]+)\]\((<[^>]+>|[^)\n]+)\)/g;
+const WIKILINK_RE = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+
+function safeDecode(value: string): string {
+  try { return decodeURIComponent(value); } catch { return value; }
+}
+
+function markdownDestination(raw: string): string {
+  const value = raw.trim();
+  if (value.startsWith("<") && value.endsWith(">")) return value.slice(1, -1);
+  const titled = value.match(/^(.*?)\s+(?:"[^"]*"|'[^']*')$/);
+  return titled ? titled[1].trim() : value;
+}
+
+function resolveMarkdownTarget(catalogFile: string, rawTarget: string): string | null {
+  let target = safeDecode(rawTarget).split("#", 1)[0].split("?", 1)[0].trim();
+  if (!target || /^[a-z][a-z0-9+.-]*:/i.test(target)) return null;
+  target = target.replaceAll("\\", "/");
+  const base = target.startsWith("/") ? "" : path.posix.dirname(catalogFile);
+  const resolved = path.posix.normalize(path.posix.join(base, target.replace(/^\/+/, "")));
+  if (!resolved || resolved === "." || resolved === ".." || resolved.startsWith("../")) return null;
+  return resolved.toLowerCase().endsWith(".md") ? resolved : `${resolved}.md`;
+}
+
+function linksFromCatalog(catalogFile: string, markdown: string): CatalogLink[] {
+  const links: CatalogLink[] = [];
+  for (const match of markdown.matchAll(MARKDOWN_LINK_RE)) {
+    const file = resolveMarkdownTarget(catalogFile, markdownDestination(match[2]));
+    if (file) links.push({ file, text: match[1].trim() || file });
+  }
+  for (const match of markdown.matchAll(WIKILINK_RE)) {
+    const file = resolveMarkdownTarget(catalogFile, match[1].trim());
+    if (file) links.push({ file, text: match[2]?.trim() || match[1].trim() });
+  }
+  return links.sort((a, b) => a.file.localeCompare(b.file) || a.text.localeCompare(b.text));
+}
+
+/** Build one canonical, shortest catalog trail from root index.md to each reachable page. */
+export function buildKnowledgeCatalogRoutes(knowledgeDir: string): Map<string, KnowledgeRouteProof> {
+  const root = path.resolve(knowledgeDir);
+  const catalogs = new Map<string, CatalogLink[]>();
+  const catalogFiles = new Set<string>();
+
+  const visit = (dir: string) => {
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolute);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
+      let markdown: string;
+      try { markdown = fs.readFileSync(absolute, "utf8"); } catch { continue; }
+      const file = path.relative(root, absolute).replaceAll("\\", "/");
+      if (!isKnowledgeNavigationPage(file, markdown)) continue;
+      catalogFiles.add(file);
+      catalogs.set(file, linksFromCatalog(file, markdown));
+    }
+  };
+  visit(root);
+
+  const rootCatalog = "index.md";
+  if (!catalogFiles.has(rootCatalog)) return new Map();
+
+  const routes = new Map<string, KnowledgeRouteProof>();
+  routes.set(rootCatalog, {
+    reachable: true,
+    trail: [{ file: rootCatalog, kind: "catalog" }],
+  });
+  const queue = [rootCatalog];
+  for (let cursor = 0; cursor < queue.length; cursor++) {
+    const catalog = queue[cursor];
+    const parent = routes.get(catalog)!;
+    for (const link of catalogs.get(catalog) ?? []) {
+      if (routes.has(link.file)) continue;
+      const isCatalog = catalogFiles.has(link.file);
+      routes.set(link.file, {
+        reachable: true,
+        trail: [
+          ...parent.trail,
+          { file: link.file, kind: isCatalog ? "catalog" : "leaf", via: link.text },
+        ],
+      });
+      if (isCatalog) queue.push(link.file);
+    }
+  }
+  return routes;
+}

--- a/src/knowledge/label-backfill.test.ts
+++ b/src/knowledge/label-backfill.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { applyKnowledgeLabelManifest } from "./label-backfill.js";
+import { parseKnowledgeLabels } from "./labels.js";
+
+describe("knowledge label backfill", () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("labels every declared catalog leaf without changing its body or the source tree", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "siclaw-label-backfill-"));
+    roots.push(root);
+    const source = path.join(root, "source");
+    const output = path.join(root, "output");
+    fs.mkdirSync(path.join(source, "topics"), { recursive: true });
+    fs.writeFileSync(
+      path.join(source, "index.md"),
+      "# Index\n\n- [B300 benchmark](topics/b300.md)\n- [README](README.md)\n",
+    );
+    fs.writeFileSync(path.join(source, "README.md"), "# Maintenance\n");
+    const original = "---\ntype: Topic\ntitle: B300 benchmark\ndescription: LSTM CUDA Graph measurements\n---\n# Result\n\n29.71 ms\n";
+    fs.writeFileSync(path.join(source, "topics", "b300.md"), original);
+
+    const report = applyKnowledgeLabelManifest(source, output, {
+      version: 1,
+      pages: {
+        "topics/b300.md": [
+          { facet: "entity", value: "B300", aliases: ["B30X"] },
+          { facet: "component", value: "LSTM", aliases: [] },
+          { facet: "task", value: "CUDA Graph optimization", aliases: ["cudagraph"] },
+          { facet: "topic", value: "operator benchmark", aliases: [] },
+        ],
+      },
+      excluded: { "README.md": "maintenance navigation" },
+    });
+
+    const migrated = fs.readFileSync(path.join(output, "topics", "b300.md"), "utf8");
+    expect(parseKnowledgeLabels(migrated)?.labels).toHaveLength(4);
+    expect(migrated.slice(migrated.indexOf("# Result"))).toBe("# Result\n\n29.71 ms\n");
+    expect(fs.readFileSync(path.join(source, "topics", "b300.md"), "utf8")).toBe(original);
+    expect(report).toEqual({ reachableLeafPages: 2, taggedPages: 1, excludedPages: 1 });
+  });
+
+  it("fails closed when a reachable leaf is absent from the manifest", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "siclaw-label-backfill-"));
+    roots.push(root);
+    const source = path.join(root, "source");
+    const output = path.join(root, "output");
+    fs.mkdirSync(source, { recursive: true });
+    fs.writeFileSync(path.join(source, "index.md"), "# Index\n\n- [Published page](published.md)\n");
+    fs.writeFileSync(path.join(source, "published.md"), "---\ntitle: Published page\n---\n# Published\n");
+
+    expect(() => applyKnowledgeLabelManifest(source, output, {
+      version: 1,
+      pages: {},
+      excluded: {},
+    })).toThrow("Manifest does not cover reachable leaf pages: published.md");
+    expect(fs.existsSync(output)).toBe(false);
+  });
+});

--- a/src/knowledge/label-backfill.ts
+++ b/src/knowledge/label-backfill.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import yaml from "js-yaml";
+
+import { buildKnowledgeCatalogRoutes } from "./catalog-graph.js";
+import { parseKnowledgeLabels, type KnowledgeLabel } from "./labels.js";
+
+export interface KnowledgeLabelBackfillManifest {
+  version: 1;
+  pages: Record<string, KnowledgeLabel[]>;
+  excluded: Record<string, string>;
+}
+
+export interface KnowledgeLabelBackfillReport {
+  reachableLeafPages: number;
+  taggedPages: number;
+  excludedPages: number;
+}
+
+function normalizeManifestPath(value: string): string {
+  const normalized = path.posix.normalize(value.replaceAll("\\", "/"));
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
+    throw new Error(`Invalid manifest page path: ${value}`);
+  }
+  return normalized;
+}
+
+function frontmatterEndOffset(markdown: string): number {
+  const firstBreak = markdown.indexOf("\n");
+  if (firstBreak < 0 || markdown.slice(0, firstBreak).trim() !== "---") return -1;
+  let cursor = firstBreak + 1;
+  while (cursor <= markdown.length) {
+    const nextBreak = markdown.indexOf("\n", cursor);
+    const end = nextBreak < 0 ? markdown.length : nextBreak;
+    const line = markdown.slice(cursor, end).trim();
+    if (line === "---" || line === "...") return cursor;
+    if (nextBreak < 0) break;
+    cursor = nextBreak + 1;
+  }
+  return -1;
+}
+
+function insertLabels(markdown: string, labels: KnowledgeLabel[], file: string): string {
+  const endOffset = frontmatterEndOffset(markdown);
+  if (endOffset < 0) throw new Error(`Page has no parseable YAML frontmatter: ${file}`);
+  const frontmatter = markdown.slice(0, endOffset);
+  if (/^labels\s*:/m.test(frontmatter)) {
+    throw new Error(`Page already declares labels; refusing to overwrite: ${file}`);
+  }
+  if (labels.length < 4 || labels.length > 12) {
+    throw new Error(`Page must declare 4-12 labels: ${file}`);
+  }
+  const block = yaml.dump({ labels }, { lineWidth: -1, noRefs: true }).trimEnd();
+  const migrated = `${frontmatter}${block}\n${markdown.slice(endOffset)}`;
+  const parsed = parseKnowledgeLabels(migrated);
+  if (!parsed || parsed.labels.length !== labels.length) {
+    throw new Error(`Generated labels failed runtime validation: ${file}`);
+  }
+  return migrated;
+}
+
+/**
+ * Apply an explicit, complete typed-label manifest to a frozen Wiki snapshot.
+ *
+ * Every root-catalog-reachable leaf must be either labeled or excluded with a
+ * reason. The source is never modified and the output is published atomically.
+ */
+export function applyKnowledgeLabelManifest(
+  sourceDir: string,
+  outputDir: string,
+  manifest: KnowledgeLabelBackfillManifest,
+): KnowledgeLabelBackfillReport {
+  if (manifest.version !== 1) throw new Error(`Unsupported label manifest version: ${manifest.version}`);
+  const source = path.resolve(sourceDir);
+  const output = path.resolve(outputDir);
+  if (source === output || output.startsWith(`${source}${path.sep}`)) {
+    throw new Error("Output directory must be outside the source directory");
+  }
+  if (!fs.statSync(source).isDirectory()) throw new Error(`Source is not a directory: ${source}`);
+  if (fs.existsSync(output)) throw new Error(`Output already exists: ${output}`);
+
+  const pageEntries = new Map(Object.entries(manifest.pages).map(([file, labels]) => [normalizeManifestPath(file), labels]));
+  const excludedEntries = new Map(Object.entries(manifest.excluded).map(([file, reason]) => [normalizeManifestPath(file), reason.trim()]));
+  for (const file of pageEntries.keys()) {
+    if (excludedEntries.has(file)) throw new Error(`Page cannot be both labeled and excluded: ${file}`);
+  }
+  for (const [file, reason] of excludedEntries) {
+    if (!reason) throw new Error(`Excluded page requires a reason: ${file}`);
+  }
+
+  const routes = buildKnowledgeCatalogRoutes(source);
+  const reachableLeaves = [...routes.entries()]
+    .filter(([file, proof]) => proof.trail.at(-1)?.kind === "leaf" && fs.statSync(path.join(source, file), { throwIfNoEntry: false })?.isFile())
+    .map(([file]) => file)
+    .sort((a, b) => a.localeCompare(b));
+  const reachableSet = new Set(reachableLeaves);
+  const covered = new Set([...pageEntries.keys(), ...excludedEntries.keys()]);
+  const missing = reachableLeaves.filter((file) => !covered.has(file));
+  const extra = [...covered].filter((file) => !reachableSet.has(file)).sort((a, b) => a.localeCompare(b));
+  if (missing.length > 0) throw new Error(`Manifest does not cover reachable leaf pages: ${missing.join(", ")}`);
+  if (extra.length > 0) throw new Error(`Manifest contains non-reachable pages: ${extra.join(", ")}`);
+
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  const staging = `${output}.staging-${process.pid}-${Date.now()}`;
+  try {
+    fs.cpSync(source, staging, { recursive: true, errorOnExist: true, force: false });
+    const realStaging = fs.realpathSync(staging);
+    for (const [file, labels] of pageEntries) {
+      const target = path.join(staging, file);
+      const targetStat = fs.lstatSync(target);
+      if (!targetStat.isFile() || targetStat.isSymbolicLink()) {
+        throw new Error(`Manifest page must resolve to a regular file: ${file}`);
+      }
+      const realTarget = fs.realpathSync(target);
+      if (!realTarget.startsWith(`${realStaging}${path.sep}`)) {
+        throw new Error(`Manifest page escapes the staging directory: ${file}`);
+      }
+      const before = fs.readFileSync(target, "utf8");
+      fs.writeFileSync(target, insertLabels(before, labels, file));
+    }
+    fs.renameSync(staging, output);
+  } catch (error) {
+    fs.rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+
+  return {
+    reachableLeafPages: reachableLeaves.length,
+    taggedPages: pageEntries.size,
+    excludedPages: excludedEntries.size,
+  };
+}

--- a/src/knowledge/labels.ts
+++ b/src/knowledge/labels.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 
 import yaml from "js-yaml";
 
+import { buildKnowledgeCatalogRoutes, type KnowledgeRouteProof } from "./catalog-graph.js";
+
 export const KNOWLEDGE_LABEL_FACETS = [
   "entity", "topic", "task", "component", "environment", "version",
 ] as const;
@@ -27,6 +29,7 @@ export interface KnowledgeLabelCatalogResult {
   totalPages: number;
   offset: number;
   hasMore: boolean;
+  unreachableLabeledPages: number;
 }
 
 export interface MatchedKnowledgeLabel {
@@ -42,12 +45,14 @@ export interface KnowledgePageCandidate {
   score: number;
   labels: KnowledgeLabel[];
   matchedLabels: MatchedKnowledgeLabel[];
+  routeProof: KnowledgeRouteProof;
 }
 
 export interface KnowledgeResolutionResult {
   pages: KnowledgePageCandidate[];
   totalPages: number;
   totalLabels: number;
+  unreachableLabeledPages: number;
 }
 
 interface KnowledgePageLabels {
@@ -154,6 +159,7 @@ function matchLabel(query: string, label: KnowledgeLabel): { score: number; matc
 export class KnowledgeLabelIndex {
   private readonly knowledgeDir: string;
   private pages = new Map<string, KnowledgePageLabels>();
+  private routes = new Map<string, KnowledgeRouteProof>();
 
   constructor(knowledgeDir: string) {
     this.knowledgeDir = path.resolve(knowledgeDir);
@@ -184,11 +190,16 @@ export class KnowledgeLabelIndex {
     };
     visit(this.knowledgeDir);
     this.pages = next;
+    this.routes = buildKnowledgeCatalogRoutes(this.knowledgeDir);
   }
 
   search(query: string, topK = 10): KnowledgeResolutionResult {
     const candidates: KnowledgePageCandidate[] = [];
+    let reachableLabeledPages = 0;
     for (const page of this.pages.values()) {
+      const routeProof = this.routes.get(page.file.replaceAll("\\", "/"));
+      if (!routeProof) continue;
+      reachableLabeledPages++;
       const matches = page.labels.flatMap((label) => {
         const match = matchLabel(query, label);
         return match ? [{ facet: label.facet, value: label.value, matchedBy: match.matchedBy, score: match.score }] : [];
@@ -201,19 +212,24 @@ export class KnowledgeLabelIndex {
         score: Math.min(1, Math.max(...matches.map((match) => match.score)) + 0.03 * (matches.length - 1)),
         labels: page.labels,
         matchedLabels: matches.map(({ facet, value, matchedBy }) => ({ facet, value, matchedBy })),
+        routeProof,
       });
     }
     candidates.sort((a, b) => b.score - a.score || a.file.localeCompare(b.file));
     return {
       pages: candidates.slice(0, topK),
-      totalPages: this.pages.size,
+      totalPages: reachableLabeledPages,
       totalLabels: this.catalog({ limit: 1 }).totalLabels,
+      unreachableLabeledPages: this.pages.size - reachableLabeledPages,
     };
   }
 
   catalog(opts: { query?: string; facet?: string; offset?: number; limit?: number } = {}): KnowledgeLabelCatalogResult {
     const merged = new Map<string, KnowledgeLabelCatalogEntry>();
+    let reachableLabeledPages = 0;
     for (const page of this.pages.values()) {
+      if (!this.routes.has(page.file.replaceAll("\\", "/"))) continue;
+      reachableLabeledPages++;
       for (const label of page.labels) {
         if (opts.facet && label.facet !== opts.facet) continue;
         if (opts.query && !matchLabel(opts.query, label)) continue;
@@ -245,9 +261,10 @@ export class KnowledgeLabelIndex {
     return {
       labels: all.slice(offset, offset + limit),
       totalLabels: all.length,
-      totalPages: this.pages.size,
+      totalPages: reachableLabeledPages,
       offset,
       hasMore: offset + limit < all.length,
+      unreachableLabeledPages: this.pages.size - reachableLabeledPages,
     };
   }
 }

--- a/src/knowledge/labels.ts
+++ b/src/knowledge/labels.ts
@@ -155,6 +155,58 @@ function matchLabel(query: string, label: KnowledgeLabel): { score: number; matc
   return best.score > 0 ? best : null;
 }
 
+function queryCoverage(query: string, matchedTerms: string[]): number {
+  const queryChars = [...normalize(query)];
+  const meaningful = queryChars.map((char) => char !== " ");
+  const total = meaningful.filter(Boolean).length;
+  if (total === 0) return 0;
+
+  const covered = new Array(queryChars.length).fill(false);
+  const findSequence = (haystack: string[], needle: string[], from = 0): number => {
+    if (needle.length === 0) return -1;
+    for (let start = from; start <= haystack.length - needle.length; start++) {
+      if (needle.every((char, offset) => haystack[start + offset] === char)) return start;
+    }
+    return -1;
+  };
+  for (const rawTerm of matchedTerms) {
+    const termChars = [...normalize(rawTerm)];
+    if (termChars.length === 0) continue;
+    if (findSequence(termChars, queryChars) >= 0) {
+      for (let i = 0; i < queryChars.length; i++) covered[i] = meaningful[i];
+      continue;
+    }
+    let cursor = 0;
+    while (cursor < queryChars.length) {
+      const start = findSequence(queryChars, termChars, cursor);
+      if (start < 0) break;
+      for (let i = start; i < start + termChars.length; i++) covered[i] = meaningful[i];
+      cursor = start + termChars.length;
+    }
+  }
+  return covered.filter(Boolean).length / total;
+}
+
+function pageScore(
+  query: string,
+  matches: Array<MatchedKnowledgeLabel & { score: number }>,
+): number {
+  const uniqueTerms = new Map<string, number>();
+  for (const match of matches) {
+    const key = normalize(match.matchedBy);
+    uniqueTerms.set(key, Math.max(uniqueTerms.get(key) ?? 0, match.score));
+  }
+  const qualities = [...uniqueTerms.values()];
+  const best = Math.max(...qualities);
+  const coverage = queryCoverage(query, [...uniqueTerms.keys()]);
+  if (uniqueTerms.size === 1 && best === 1 && coverage === 1) return 1;
+
+  const distinctFacets = new Set(matches.map((match) => match.facet)).size;
+  const termBonus = 0.06 * Math.min(2, uniqueTerms.size - 1);
+  const facetBonus = 0.04 * Math.min(2, distinctFacets - 1);
+  return Math.min(1, best * (0.55 + 0.35 * coverage) + termBonus + facetBonus);
+}
+
 /** Fast page-label catalog. It scans local frontmatter only and never calls a model. */
 export class KnowledgeLabelIndex {
   private readonly knowledgeDir: string;
@@ -209,7 +261,7 @@ export class KnowledgeLabelIndex {
         file: page.file,
         title: page.title,
         description: page.description,
-        score: Math.min(1, Math.max(...matches.map((match) => match.score)) + 0.03 * (matches.length - 1)),
+        score: pageScore(query, matches),
         labels: page.labels,
         matchedLabels: matches.map(({ facet, value, matchedBy }) => ({ facet, value, matchedBy })),
         routeProof,

--- a/src/knowledge/labels.ts
+++ b/src/knowledge/labels.ts
@@ -29,6 +29,8 @@ export interface KnowledgeLabelCatalogResult {
   totalPages: number;
   offset: number;
   hasMore: boolean;
+  invalidLabeledPages: number;
+  unlabeledPages: number;
   unreachableLabeledPages: number;
 }
 
@@ -36,6 +38,7 @@ export interface MatchedKnowledgeLabel {
   facet: KnowledgeLabelFacet;
   value: string;
   matchedBy: string;
+  pageCount: number;
 }
 
 export interface KnowledgePageCandidate {
@@ -50,8 +53,11 @@ export interface KnowledgePageCandidate {
 
 export interface KnowledgeResolutionResult {
   pages: KnowledgePageCandidate[];
+  matchedPages: number;
   totalPages: number;
   totalLabels: number;
+  invalidLabeledPages: number;
+  unlabeledPages: number;
   unreachableLabeledPages: number;
 }
 
@@ -78,7 +84,7 @@ function normalize(value: string): string {
   return value.normalize("NFKC").trim().toLocaleLowerCase().replace(/[\s_\-./]+/g, " ");
 }
 
-function parseFrontmatter(markdown: string): Record<string, unknown> | null {
+function frontmatterSource(markdown: string): string | null {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   if (lines[0]?.trim() !== "---") return null;
   const end = lines.slice(1).findIndex((line) => {
@@ -87,12 +93,32 @@ function parseFrontmatter(markdown: string): Record<string, unknown> | null {
   });
   if (end < 0) return null;
   const delimiterLine = end + 1;
+  return lines.slice(1, delimiterLine).join("\n");
+}
+
+function parseFrontmatter(markdown: string): Record<string, unknown> | null {
+  const source = frontmatterSource(markdown);
+  if (source === null) return null;
   try {
-    const metadata = yaml.load(lines.slice(1, delimiterLine).join("\n"));
+    const metadata = yaml.load(source);
     if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
     return metadata as Record<string, unknown>;
   } catch {
     return null;
+  }
+}
+
+function declaresKnowledgeLabels(markdown: string): boolean {
+  const source = frontmatterSource(markdown);
+  if (source === null) return false;
+  try {
+    const metadata = yaml.load(source);
+    return Boolean(
+      metadata && typeof metadata === "object" && !Array.isArray(metadata) &&
+      Object.prototype.hasOwnProperty.call(metadata, "labels"),
+    );
+  } catch {
+    return /^labels\s*:/m.test(source);
   }
 }
 
@@ -191,20 +217,25 @@ function pageScore(
   query: string,
   matches: Array<MatchedKnowledgeLabel & { score: number }>,
 ): number {
-  const uniqueTerms = new Map<string, number>();
+  const uniqueTerms = new Map<string, { score: number; pageCount: number }>();
   for (const match of matches) {
     const key = normalize(match.matchedBy);
-    uniqueTerms.set(key, Math.max(uniqueTerms.get(key) ?? 0, match.score));
+    const previous = uniqueTerms.get(key);
+    if (!previous || match.score > previous.score) {
+      uniqueTerms.set(key, { score: match.score, pageCount: match.pageCount });
+    }
   }
-  const qualities = [...uniqueTerms.values()];
-  const best = Math.max(...qualities);
+  const terms = [...uniqueTerms.values()];
+  const best = Math.max(...terms.map((term) => term.score));
   const coverage = queryCoverage(query, [...uniqueTerms.keys()]);
-  if (uniqueTerms.size === 1 && best === 1 && coverage === 1) return 1;
+  if (uniqueTerms.size === 1 && best === 1 && coverage === 1 && terms[0].pageCount <= 2) return 1;
 
+  const bestAdjusted = Math.max(...terms.map((term) =>
+    term.score * (0.6 + 0.4 / Math.sqrt(term.pageCount))));
   const distinctFacets = new Set(matches.map((match) => match.facet)).size;
   const termBonus = 0.06 * Math.min(2, uniqueTerms.size - 1);
   const facetBonus = 0.04 * Math.min(2, distinctFacets - 1);
-  return Math.min(1, best * (0.55 + 0.35 * coverage) + termBonus + facetBonus);
+  return Math.min(1, bestAdjusted * (0.55 + 0.35 * coverage) + termBonus + facetBonus);
 }
 
 /** Fast page-label catalog. It scans local frontmatter only and never calls a model. */
@@ -212,6 +243,9 @@ export class KnowledgeLabelIndex {
   private readonly knowledgeDir: string;
   private pages = new Map<string, KnowledgePageLabels>();
   private routes = new Map<string, KnowledgeRouteProof>();
+  private termPageCounts = new Map<string, number>();
+  private invalidLabeledPages = 0;
+  private unlabeledPages = 0;
 
   constructor(knowledgeDir: string) {
     this.knowledgeDir = path.resolve(knowledgeDir);
@@ -219,6 +253,8 @@ export class KnowledgeLabelIndex {
 
   async sync(): Promise<void> {
     const next = new Map<string, KnowledgePageLabels>();
+    let invalidLabeledPages = 0;
+    let unlabeledPages = 0;
     const visit = (dir: string) => {
       let entries: fs.Dirent[];
       try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
@@ -235,7 +271,11 @@ export class KnowledgeLabelIndex {
         let markdown: string;
         try { markdown = fs.readFileSync(absolute, "utf8"); } catch { continue; }
         const parsed = parseKnowledgeLabels(markdown);
-        if (!parsed) continue;
+        if (!parsed) {
+          if (declaresKnowledgeLabels(markdown)) invalidLabeledPages++;
+          else unlabeledPages++;
+          continue;
+        }
         const file = path.relative(this.knowledgeDir, absolute);
         next.set(file, { file, ...parsed });
       }
@@ -243,6 +283,18 @@ export class KnowledgeLabelIndex {
     visit(this.knowledgeDir);
     this.pages = next;
     this.routes = buildKnowledgeCatalogRoutes(this.knowledgeDir);
+    this.invalidLabeledPages = invalidLabeledPages;
+    this.unlabeledPages = unlabeledPages;
+    const termPageCounts = new Map<string, number>();
+    for (const page of this.pages.values()) {
+      if (!this.routes.has(page.file.replaceAll("\\", "/"))) continue;
+      const pageTerms = new Set(page.labels.flatMap((label) =>
+        [label.value, ...label.aliases].map(normalize).filter(Boolean)));
+      for (const term of pageTerms) {
+        termPageCounts.set(term, (termPageCounts.get(term) ?? 0) + 1);
+      }
+    }
+    this.termPageCounts = termPageCounts;
   }
 
   search(query: string, topK = 10): KnowledgeResolutionResult {
@@ -254,7 +306,14 @@ export class KnowledgeLabelIndex {
       reachableLabeledPages++;
       const matches = page.labels.flatMap((label) => {
         const match = matchLabel(query, label);
-        return match ? [{ facet: label.facet, value: label.value, matchedBy: match.matchedBy, score: match.score }] : [];
+        if (!match) return [];
+        return [{
+          facet: label.facet,
+          value: label.value,
+          matchedBy: match.matchedBy,
+          pageCount: this.termPageCounts.get(normalize(match.matchedBy)) ?? 1,
+          score: match.score,
+        }];
       });
       if (matches.length === 0) continue;
       candidates.push({
@@ -263,15 +322,18 @@ export class KnowledgeLabelIndex {
         description: page.description,
         score: pageScore(query, matches),
         labels: page.labels,
-        matchedLabels: matches.map(({ facet, value, matchedBy }) => ({ facet, value, matchedBy })),
+        matchedLabels: matches.map(({ facet, value, matchedBy, pageCount }) => ({ facet, value, matchedBy, pageCount })),
         routeProof,
       });
     }
     candidates.sort((a, b) => b.score - a.score || a.file.localeCompare(b.file));
     return {
       pages: candidates.slice(0, topK),
+      matchedPages: candidates.length,
       totalPages: reachableLabeledPages,
       totalLabels: this.catalog({ limit: 1 }).totalLabels,
+      invalidLabeledPages: this.invalidLabeledPages,
+      unlabeledPages: this.unlabeledPages,
       unreachableLabeledPages: this.pages.size - reachableLabeledPages,
     };
   }
@@ -316,6 +378,8 @@ export class KnowledgeLabelIndex {
       totalPages: reachableLabeledPages,
       offset,
       hasMore: offset + limit < all.length,
+      invalidLabeledPages: this.invalidLabeledPages,
+      unlabeledPages: this.unlabeledPages,
       unreachableLabeledPages: this.pages.size - reachableLabeledPages,
     };
   }

--- a/src/knowledge/resolver.ts
+++ b/src/knowledge/resolver.ts
@@ -23,7 +23,10 @@ export class KnowledgeResolver {
   }
 
   search(query: string, topK = 10): KnowledgeResolutionResult {
-    if (this.closed) return { pages: [], totalPages: 0, totalLabels: 0, unreachableLabeledPages: 0 };
+    if (this.closed) return {
+      pages: [], matchedPages: 0, totalPages: 0, totalLabels: 0,
+      invalidLabeledPages: 0, unlabeledPages: 0, unreachableLabeledPages: 0,
+    };
     return this.labels.search(query, topK);
   }
 
@@ -31,7 +34,7 @@ export class KnowledgeResolver {
     if (this.closed) {
       return {
         labels: [], totalLabels: 0, totalPages: 0, offset: 0, hasMore: false,
-        unreachableLabeledPages: 0,
+        invalidLabeledPages: 0, unlabeledPages: 0, unreachableLabeledPages: 0,
       };
     }
     return this.labels.catalog(opts);

--- a/src/knowledge/resolver.ts
+++ b/src/knowledge/resolver.ts
@@ -23,13 +23,16 @@ export class KnowledgeResolver {
   }
 
   search(query: string, topK = 10): KnowledgeResolutionResult {
-    if (this.closed) return { pages: [], totalPages: 0, totalLabels: 0 };
+    if (this.closed) return { pages: [], totalPages: 0, totalLabels: 0, unreachableLabeledPages: 0 };
     return this.labels.search(query, topK);
   }
 
   catalog(opts: { query?: string; facet?: string; offset?: number; limit?: number } = {}): KnowledgeLabelCatalogResult {
     if (this.closed) {
-      return { labels: [], totalLabels: 0, totalPages: 0, offset: 0, hasMore: false };
+      return {
+        labels: [], totalLabels: 0, totalPages: 0, offset: 0, hasMore: false,
+        unreachableLabeledPages: 0,
+      };
     }
     return this.labels.catalog(opts);
   }

--- a/src/tools/query/knowledge-search.test.ts
+++ b/src/tools/query/knowledge-search.test.ts
@@ -80,7 +80,7 @@ describe("knowledge_search", () => {
       expect.objectContaining({ value: "B300" }),
       expect.objectContaining({ value: "CUDA Graph", matchedBy: "cudagraph" }),
     ]));
-    expect(payload.results[0].labels).toHaveLength(3);
+    expect(payload.results[0]).not.toHaveProperty("labels");
     expect(payload.results[0].routeProof).toEqual({
       reachable: true,
       trail: [
@@ -90,6 +90,13 @@ describe("knowledge_search", () => {
     });
     expect(payload.results[0]).not.toHaveProperty("content");
     expect(JSON.stringify(payload)).not.toContain("29.71 ms");
+
+    const expanded = await tool.execute("call-label-expanded", {
+      query: "B300 cudagraph 实测数据",
+      includeLabels: true,
+    });
+    const expandedPayload = JSON.parse((expanded.content[0] as { text: string }).text);
+    expect(expandedPayload.results[0].labels).toHaveLength(3);
   });
 
   it("ranks a page with more matching labels ahead of a generic page", async () => {
@@ -118,6 +125,40 @@ describe("knowledge_search", () => {
       "giga-b300-lstm.md",
       "generic-b300.md",
     ]);
+    expect(payload.results[0].score - payload.results[1].score).toBeGreaterThan(0.2);
+  });
+
+  it("downranks a generic alias that covers little of a multi-term query", async () => {
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [GPU driver](gpu-driver.md)\n- [Generic upgrade](generic-upgrade.md)\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "gpu-driver.md"),
+      "---\ntype: Procedure\ntitle: GPU driver upgrade\nlabels:\n" +
+      "  - facet: entity\n    value: GPU\n" +
+      "  - facet: task\n    value: GPU driver installation\n    aliases: [升级GPU驱动]\n" +
+      "  - facet: topic\n    value: SOP\n---\n# GPU driver\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "generic-upgrade.md"),
+      "---\ntype: Procedure\ntitle: Generic upgrade\nlabels:\n" +
+      "  - facet: task\n    value: Change management\n    aliases: [升级]\n---\n# Upgrade\n",
+    );
+    await resolver.sync();
+
+    const tool = createKnowledgeSearchTool(resolver);
+    const result = await tool.execute("call-specific-alias", {
+      query: "升级GPU驱动SOP",
+      topK: 2,
+    });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(payload.results.map((row: { file: string }) => row.file)).toEqual([
+      "gpu-driver.md",
+      "generic-upgrade.md",
+    ]);
+    expect(payload.results[0].score - payload.results[1].score).toBeGreaterThan(0.2);
   });
 
   it("does not route to a labeled page that is unreachable from the root catalog", async () => {
@@ -142,7 +183,11 @@ describe("knowledge_search", () => {
     expect(payload.results.map((row: { file: string }) => row.file)).toEqual(["published.md"]);
     expect(payload.unreachableLabeledPages).toBe(1);
 
-    const catalogResult = await tool.execute("call-reachable-catalog", { listLabels: true, limit: 100 });
+    const catalogResult = await tool.execute("call-reachable-catalog", {
+      listLabels: true,
+      includePages: true,
+      limit: 100,
+    });
     const catalog = JSON.parse((catalogResult.content[0] as { text: string }).text);
     expect(catalog.labels).toEqual([
       expect.objectContaining({ facet: "entity", value: "B300", pages: ["published.md"] }),
@@ -204,6 +249,22 @@ describe("knowledge_search", () => {
     expect(payload.totalLabels).toBe(2);
     expect(payload.hasMore).toBe(false);
     expect(payload.labels).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        facet: "entity",
+        value: "B300",
+        pageCount: 1,
+      }),
+    ]));
+    expect(payload.labels[0]).not.toHaveProperty("pages");
+    expect(payload.labels[0]).not.toHaveProperty("pagesTruncated");
+
+    const expanded = await tool.execute("call-catalog-expanded", {
+      listLabels: true,
+      includePages: true,
+      limit: 100,
+    });
+    const expandedPayload = JSON.parse((expanded.content[0] as { text: string }).text);
+    expect(expandedPayload.labels).toEqual(expect.arrayContaining([
       expect.objectContaining({
         facet: "entity",
         value: "B300",

--- a/src/tools/query/knowledge-search.test.ts
+++ b/src/tools/query/knowledge-search.test.ts
@@ -55,6 +55,10 @@ describe("knowledge_search", () => {
 
   it("routes by page labels and returns navigation metadata instead of page body content", async () => {
     fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [B300 LSTM evaluation](b300-lstm.md) - Giga B300 operator benchmark\n",
+    );
+    fs.writeFileSync(
       path.join(knowledgeDir, "b300-lstm.md"),
       "---\ntype: Benchmark\ntitle: B300 LSTM evaluation\ndescription: Giga B300 operator benchmark\nlabels:\n" +
       "  - facet: entity\n    value: B300\n" +
@@ -77,11 +81,22 @@ describe("knowledge_search", () => {
       expect.objectContaining({ value: "CUDA Graph", matchedBy: "cudagraph" }),
     ]));
     expect(payload.results[0].labels).toHaveLength(3);
+    expect(payload.results[0].routeProof).toEqual({
+      reachable: true,
+      trail: [
+        { file: "index.md", kind: "catalog" },
+        { file: "b300-lstm.md", kind: "leaf", via: "B300 LSTM evaluation" },
+      ],
+    });
     expect(payload.results[0]).not.toHaveProperty("content");
     expect(JSON.stringify(payload)).not.toContain("29.71 ms");
   });
 
   it("ranks a page with more matching labels ahead of a generic page", async () => {
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [B300](generic-b300.md)\n- [Giga B300 LSTM](giga-b300-lstm.md)\n",
+    );
     fs.writeFileSync(
       path.join(knowledgeDir, "generic-b300.md"),
       "---\ntype: Entity\ntitle: B300\nlabels:\n  - facet: entity\n    value: B300\n---\n# B300\n",
@@ -105,7 +120,75 @@ describe("knowledge_search", () => {
     ]);
   });
 
+  it("does not route to a labeled page that is unreachable from the root catalog", async () => {
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [Published B300 guide](published.md)\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "published.md"),
+      "---\ntype: Topic\ntitle: Published B300 guide\nlabels:\n  - facet: entity\n    value: B300\n---\n# Published\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "orphan.md"),
+      "---\ntype: Topic\ntitle: Unpublished scratch page\nlabels:\n  - facet: entity\n    value: B300\n  - facet: task\n    value: LSTM benchmark\n---\n# Scratch\n",
+    );
+    await resolver.sync();
+
+    const tool = createKnowledgeSearchTool(resolver);
+    const result = await tool.execute("call-reachable", { query: "B300 LSTM benchmark", topK: 5 });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(payload.results.map((row: { file: string }) => row.file)).toEqual(["published.md"]);
+    expect(payload.unreachableLabeledPages).toBe(1);
+
+    const catalogResult = await tool.execute("call-reachable-catalog", { listLabels: true, limit: 100 });
+    const catalog = JSON.parse((catalogResult.content[0] as { text: string }).text);
+    expect(catalog.labels).toEqual([
+      expect.objectContaining({ facet: "entity", value: "B300", pages: ["published.md"] }),
+    ]);
+    expect(catalog.totalPages).toBe(1);
+    expect(catalog.unreachableLabeledPages).toBe(1);
+  });
+
+  it("returns the canonical multi-library catalog trail without requiring intermediate reads", async () => {
+    fs.mkdirSync(path.join(knowledgeDir, "repos", "gpu", "topics"), { recursive: true });
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [[repos/gpu/index|GPU Wiki]] - GPU evaluation and operations\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "repos", "gpu", "index.md"),
+      "# GPU Wiki\n\n- [B300 LSTM evaluation](topics/b300-lstm.md)\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "repos", "gpu", "topics", "b300-lstm.md"),
+      "---\ntype: Topic\ntitle: B300 LSTM evaluation\nlabels:\n" +
+      "  - facet: entity\n    value: B300\n" +
+      "  - facet: task\n    value: CUDA Graph optimization\n    aliases: [cudagraph]\n---\n# Result\n",
+    );
+    await resolver.sync();
+
+    const tool = createKnowledgeSearchTool(resolver);
+    const result = await tool.execute("call-multi-repo", { query: "B300 cudagraph" });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(payload.results[0].routeProof).toEqual({
+      reachable: true,
+      trail: [
+        { file: "index.md", kind: "catalog" },
+        { file: "repos/gpu/index.md", kind: "catalog", via: "GPU Wiki" },
+        {
+          file: "repos/gpu/topics/b300-lstm.md",
+          kind: "leaf",
+          via: "B300 LSTM evaluation",
+        },
+      ],
+    });
+  });
+
   it("lists the complete typed label catalog through the same QA tool", async () => {
+    fs.writeFileSync(path.join(knowledgeDir, "index.md"), "# Knowledge Index\n\n- [Labels](labels.md)\n");
     fs.writeFileSync(
       path.join(knowledgeDir, "labels.md"),
       "---\ntype: Topic\nlabels:\n  - facet: entity\n    value: B300\n    aliases: [GB300]\n" +

--- a/src/tools/query/knowledge-search.test.ts
+++ b/src/tools/query/knowledge-search.test.ts
@@ -161,6 +161,49 @@ describe("knowledge_search", () => {
     expect(payload.results[0].score - payload.results[1].score).toBeGreaterThan(0.2);
   });
 
+  it("downranks an exact alias shared across many pages and reports truncation", async () => {
+    const links: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      const file = `upgrade-${i}.md`;
+      links.push(`- [Upgrade ${i}](${file})`);
+      fs.writeFileSync(
+        path.join(knowledgeDir, file),
+        "---\ntype: Procedure\ntitle: Upgrade " + i + "\nlabels:\n" +
+        `  - facet: task\n    value: Upgrade process ${i}\n    aliases: [升级]\n` +
+        "---\n# Upgrade\n",
+      );
+    }
+    fs.writeFileSync(
+      path.join(knowledgeDir, "zhaoyao.md"),
+      "---\ntype: Topic\ntitle: 招摇B30X\nlabels:\n" +
+      "  - facet: topic\n    value: 招摇B30X\n---\n# 招摇B30X\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      `# Knowledge Index\n\n${links.join("\n")}\n- [招摇B30X](zhaoyao.md)\n`,
+    );
+    await resolver.sync();
+
+    const tool = createKnowledgeSearchTool(resolver);
+    const broadResult = await tool.execute("call-broad-exact", { query: "升级" });
+    const broad = JSON.parse((broadResult.content[0] as { text: string }).text);
+
+    expect(broad.results).toHaveLength(3);
+    expect(broad.matchedPages).toBe(10);
+    expect(broad.hasMore).toBe(true);
+    expect(broad.results.every((row: { score: number }) => row.score < 0.7)).toBe(true);
+    expect(broad.results[0].matchedLabels[0].pageCount).toBe(10);
+    expect(broad.message).toContain("Weak or ambiguous label match");
+
+    const rareResult = await tool.execute("call-rare-exact", { query: "招摇B30X" });
+    const rare = JSON.parse((rareResult.content[0] as { text: string }).text);
+    expect(rare.results[0].score).toBe(1);
+    expect(rare.results[0].matchedLabels[0].pageCount).toBe(1);
+    expect(rare.matchedPages).toBe(1);
+    expect(rare.hasMore).toBe(false);
+    expect(rare).not.toHaveProperty("message");
+  });
+
   it("does not route to a labeled page that is unreachable from the root catalog", async () => {
     fs.writeFileSync(
       path.join(knowledgeDir, "index.md"),
@@ -194,6 +237,37 @@ describe("knowledge_search", () => {
     ]);
     expect(catalog.totalPages).toBe(1);
     expect(catalog.unreachableLabeledPages).toBe(1);
+  });
+
+  it("reports invalid label declarations separately from unlabeled pages", async () => {
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [Valid](valid.md)\n- [Invalid](invalid.md)\n- [Unlabeled](unlabeled.md)\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "valid.md"),
+      "---\ntype: Topic\ntitle: Valid\nlabels:\n  - facet: entity\n    value: B300\n---\n# Valid\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "invalid.md"),
+      "---\ntype: Topic\ntitle: Invalid\nlabels:\n  - facet: unsupported\n    value: broken\n---\n# Invalid\n",
+    );
+    fs.writeFileSync(path.join(knowledgeDir, "unlabeled.md"), "# Unlabeled\n");
+    await resolver.sync();
+
+    const tool = createKnowledgeSearchTool(resolver);
+    const result = await tool.execute("call-observability", { query: "B300" });
+    const payload = JSON.parse((result.content[0] as { text: string }).text);
+
+    expect(payload.totalPages).toBe(1);
+    expect(payload.invalidLabeledPages).toBe(1);
+    expect(payload.unlabeledPages).toBe(1);
+    expect(payload.unreachableLabeledPages).toBe(0);
+
+    const catalogResult = await tool.execute("call-observability-catalog", { listLabels: true });
+    const catalog = JSON.parse((catalogResult.content[0] as { text: string }).text);
+    expect(catalog.invalidLabeledPages).toBe(1);
+    expect(catalog.unlabeledPages).toBe(1);
   });
 
   it("returns the canonical multi-library catalog trail without requiring intermediate reads", async () => {

--- a/src/tools/query/knowledge-search.ts
+++ b/src/tools/query/knowledge-search.ts
@@ -46,7 +46,8 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
       "steps prove navigation only; do not reread them as evidence. Set listLabels=true to inspect the package's paginated " +
       "label catalog, but do not enumerate it before a normal search. Full candidate labels and catalog page lists are omitted " +
       "unless includeLabels/includePages is explicitly requested. Results are navigation metadata, not evidence: Read the complete relevant leaf pages before answering, " +
-      "then use knowledge_cite only for pages actually used.",
+      "then use knowledge_cite only for pages actually used. matchedPages counts all query matches before topK truncation; " +
+      "a top score below about 0.7 is normally a weak match, so refine the query or use the complete Wiki catalog.",
     parameters: Type.Object({
       query: Type.Optional(Type.String({ description: "Natural-language query, label alias, version, or exact term to retrieve." })),
       topK: Type.Optional(Type.Number({ description: "Maximum candidate pages to return (default 3, maximum 20)." })),
@@ -108,6 +109,11 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
           matchedLabels: page.matchedLabels,
           routeProof: page.routeProof,
         }));
+        const hasMore = result.matchedPages > results.length;
+        const weakOrAmbiguous = results.length > 0 && (
+          results[0].score < 0.7 ||
+          (hasMore && results.length > 1 && results[0].score - results[1].score < 0.05)
+        );
         return {
           content: [{
             type: "text",
@@ -116,9 +122,15 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
               results,
               ...(results.length === 0 ? {
                 message: "No label-matched knowledge page found. Use the complete Wiki catalog to choose and Read plausible pages, or inspect the label catalog with listLabels=true.",
+              } : weakOrAmbiguous ? {
+                message: "Weak or ambiguous label match. Refine the query with an entity, component, task, environment, or version, or use the complete Wiki catalog before reading a leaf.",
               } : {}),
+              matchedPages: result.matchedPages,
+              hasMore,
               totalPages: result.totalPages,
               totalLabels: result.totalLabels,
+              invalidLabeledPages: result.invalidLabeledPages,
+              unlabeledPages: result.unlabeledPages,
               unreachableLabeledPages: result.unreachableLabeledPages,
             }, null, 2),
           }],

--- a/src/tools/query/knowledge-search.ts
+++ b/src/tools/query/knowledge-search.ts
@@ -14,6 +14,8 @@ interface KnowledgeSearchParams {
   facet?: string;
   offset?: number;
   limit?: number;
+  includeLabels?: boolean;
+  includePages?: boolean;
 }
 
 function truncateUtf16Safe(value: string, maxLength: number): string {
@@ -42,15 +44,18 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
       "Use it when the complete Wiki catalog leaves multiple plausible pages or the question uses alternate names, versions, or task terms. " +
       "Each result includes a canonical routeProof showing that the leaf is reachable from the root catalog. The catalog " +
       "steps prove navigation only; do not reread them as evidence. Set listLabels=true to inspect the package's paginated " +
-      "label catalog. Results are navigation metadata, not evidence: Read the complete relevant leaf pages before answering, " +
+      "label catalog, but do not enumerate it before a normal search. Full candidate labels and catalog page lists are omitted " +
+      "unless includeLabels/includePages is explicitly requested. Results are navigation metadata, not evidence: Read the complete relevant leaf pages before answering, " +
       "then use knowledge_cite only for pages actually used.",
     parameters: Type.Object({
       query: Type.Optional(Type.String({ description: "Natural-language query, label alias, version, or exact term to retrieve." })),
-      topK: Type.Optional(Type.Number({ description: "Maximum candidate pages to return (default 8, maximum 20)." })),
+      topK: Type.Optional(Type.Number({ description: "Maximum candidate pages to return (default 3, maximum 20)." })),
       listLabels: Type.Optional(Type.Boolean({ description: "List the typed label catalog instead of searching page content." })),
       facet: Type.Optional(Type.String({ description: "When listing labels, restrict to one facet." })),
       offset: Type.Optional(Type.Number({ description: "When listing labels, zero-based pagination offset." })),
-      limit: Type.Optional(Type.Number({ description: "When listing labels, page size (default 100, maximum 500)." })),
+      limit: Type.Optional(Type.Number({ description: "When listing labels, page size (default 20, maximum 100)." })),
+      includeLabels: Type.Optional(Type.Boolean({ description: "Include every label on each search result; default false because matchedLabels is normally sufficient." })),
+      includePages: Type.Optional(Type.Boolean({ description: "When listing labels, include their page paths; default false." })),
     }),
     async execute(_toolCallId, rawParams) {
       const params = rawParams as KnowledgeSearchParams;
@@ -68,10 +73,17 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
           query: params.query?.trim() || undefined,
           facet: params.facet?.trim() || undefined,
           offset: params.offset,
-          limit: params.limit,
+          limit: Math.min(100, Math.max(1, Math.floor(params.limit ?? 20))),
         });
+        const labels = catalog.labels.map(({ pages, pagesTruncated, ...label }) => ({
+          ...label,
+          ...(params.includePages ? { pages, pagesTruncated } : {}),
+        }));
         return {
-          content: [{ type: "text", text: JSON.stringify({ mode: "label_catalog", ...catalog }, null, 2) }],
+          content: [{
+            type: "text",
+            text: JSON.stringify({ mode: "label_catalog", ...catalog, labels }, null, 2),
+          }],
           details: { resultCount: catalog.labels.length, totalLabels: catalog.totalLabels },
         };
       }
@@ -83,7 +95,7 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
         };
       }
 
-      const topK = Math.min(20, Math.max(1, Math.floor(params.topK ?? 8)));
+      const topK = Math.min(20, Math.max(1, Math.floor(params.topK ?? 3)));
       try {
         const result = resolver.search(query, topK);
         const results = result.pages.map((page, index) => ({
@@ -92,7 +104,7 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
           title: truncateUtf16Safe(page.title, 200),
           description: truncateUtf16Safe(page.description, 700),
           score: Math.round(page.score * 1000) / 1000,
-          labels: page.labels,
+          ...(params.includeLabels ? { labels: page.labels } : {}),
           matchedLabels: page.matchedLabels,
           routeProof: page.routeProof,
         }));

--- a/src/tools/query/knowledge-search.ts
+++ b/src/tools/query/knowledge-search.ts
@@ -40,8 +40,10 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
     description:
       "Resolve candidate knowledge pages using typed page labels and aliases only; this tool never searches page bodies. " +
       "Use it when the complete Wiki catalog leaves multiple plausible pages or the question uses alternate names, versions, or task terms. " +
-      "Set listLabels=true to inspect the package's paginated label catalog. Results are navigation metadata, not evidence: " +
-      "Read the complete relevant pages before answering, then use knowledge_cite only for pages actually used.",
+      "Each result includes a canonical routeProof showing that the leaf is reachable from the root catalog. The catalog " +
+      "steps prove navigation only; do not reread them as evidence. Set listLabels=true to inspect the package's paginated " +
+      "label catalog. Results are navigation metadata, not evidence: Read the complete relevant leaf pages before answering, " +
+      "then use knowledge_cite only for pages actually used.",
     parameters: Type.Object({
       query: Type.Optional(Type.String({ description: "Natural-language query, label alias, version, or exact term to retrieve." })),
       topK: Type.Optional(Type.Number({ description: "Maximum candidate pages to return (default 8, maximum 20)." })),
@@ -92,6 +94,7 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
           score: Math.round(page.score * 1000) / 1000,
           labels: page.labels,
           matchedLabels: page.matchedLabels,
+          routeProof: page.routeProof,
         }));
         return {
           content: [{
@@ -104,6 +107,7 @@ export function createKnowledgeSearchTool(resolver: KnowledgeResolver): ToolDefi
               } : {}),
               totalPages: result.totalPages,
               totalLabels: result.totalLabels,
+              unreachableLabeledPages: result.unreachableLabeledPages,
             }, null, 2),
           }],
           details: { resultCount: results.length },


### PR DESCRIPTION
## Outcome

`knowledge_search` returns only root-catalog-reachable labeled leaves and includes a deterministic shortest `routeProof` from `index.md` to each result. Label routing stays optional: the complete Wiki catalog remains the fallback, and answer evidence still comes from reading the final leaf.

## Changes

- parse standard Markdown links and legacy wikilinks from navigation pages
- build one canonical shortest root-to-leaf catalog route during label-index sync
- exclude orphan labeled pages from search and label-catalog results, with an explicit count
- rank label matches by query coverage, unique matched terms, facet diversity, and matched term frequency across reachable pages
- preserve full confidence for rare exact labels while downranking broad shared aliases
- return compact search metadata by default; expose full labels only with `includeLabels=true`
- return `matchedPages` and `hasMore` before and after top-K truncation, plus a non-blocking weak or ambiguous match hint
- report invalid label declarations separately from unlabeled pages so an empty label index is diagnosable
- return a compact paginated label catalog by default; expose page paths only with `includePages=true`
- use conservative defaults (`topK=3`, label-catalog page size 20) while preserving explicit expansion up to existing limits
- add a fail-closed, manifest-driven tool for backfilling typed labels into frozen Wiki snapshots without changing page bodies
- document the reachability and evidence contract

## Verification

- `npm test` — 296 files, 6582 passed, 2 skipped
- focused knowledge tests — 4 files, 20 passed
- `npm run build`
- `git diff --check`
- synthetic multi-constraint queries rank the intended leaf above generic candidates
- shared high-frequency aliases are downranked and report result truncation
- invalid, unlabeled, and unreachable page counters are covered by regression tests