### PR TITLE
fix(knowledge): label index correctness — hot-update re-sync and navigation-page exclusion

### DIFF
--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -26,6 +26,12 @@ const mockConfigState = vi.hoisted(() => ({
   mcpServers: {} as Record<string, unknown>,
 }));
 
+// Captures the options createHttpServer passes when building its per-server
+// knowledge handler, so tests can pin the afterMaterialize wiring.
+const knowledgeHandlerState = vi.hoisted(() => ({
+  lastOptions: null as null | { knowledgeDir?: string; afterMaterialize?: () => void | Promise<void> },
+}));
+
 // Silence metrics auth side effects.
 vi.mock("../shared/metrics.js", () => ({
   checkMetricsAuth: () => true,
@@ -71,12 +77,18 @@ vi.mock("./sync-handlers.js", async (importOriginal) => ({
   getSyncHandler: () => undefined,
   createClusterHandler: () => ({ type: "cluster", fetch: async () => 0, materialize: async (n: number) => n }),
   createHostHandler: () => ({ type: "host", fetch: async () => 0, materialize: async (n: number) => n }),
-  createKnowledgeHandler: () => ({
-    type: "knowledge",
-    fetch: async () => ({ repos: [] }),
-    materialize: async () => 0,
-    getLastKnowledgeSyncStatus: () => null,
-  }),
+  createKnowledgeHandler: (options: { knowledgeDir?: string; afterMaterialize?: () => void | Promise<void> } = {}) => {
+    knowledgeHandlerState.lastOptions = options;
+    return {
+      type: "knowledge",
+      fetch: async () => ({ repos: [] }),
+      // The real handler awaits afterMaterialize on EVERY materialize path
+      // (empty-wipe and normal) — the fake must model that, or the reload
+      // route test cannot see whether the wiring passed the hook at all.
+      materialize: async () => { await options.afterMaterialize?.(); return 0; },
+      getLastKnowledgeSyncStatus: () => null,
+    };
+  },
   createToolsHandler: (target: { allowedToolsState: string[] | null }) => ({
     type: "tools",
     fetch: async () => ({ allowedTools: null }),
@@ -262,6 +274,8 @@ function makeFakeSessionManager() {
     onSessionRelease: undefined as undefined | (() => void),
     credentialBroker: undefined,
     credentialsDir: undefined,
+    // K8s shape: knowledgeDir stays unset (only LocalSpawner assigns it).
+    syncKnowledgeIndex: vi.fn(async () => {}),
   };
 }
 
@@ -1965,6 +1979,20 @@ describe("http-server — reload routes delegate to handlers", () => {
     // short-circuits to 200 count:0 before ever calling the per-box handler.
     expect(r.status).toBe(200);
     expect(r.data).toMatchObject({ ok: true, count: 0, type: "tools" });
+  });
+
+  it("POST /api/reload-knowledge re-syncs the label index even when sessionManager.knowledgeDir is unset (K8s shape)", async () => {
+    // K8s boxes never set sessionManager.knowledgeDir (only LocalSpawner does),
+    // and the per-server knowledge handler used to be gated on it — so a hot
+    // update materialized new files while knowledge_search kept serving the
+    // label index built at pod start. Pin the wiring: the handler exists
+    // without the dir, and its materialize drives syncKnowledgeIndex.
+    process.env.SICLAW_GATEWAY_URL = "http://gateway.test";
+    const r = await getJson(port, "/api/reload-knowledge", "POST");
+    expect(r.status).toBe(200);
+    expect(r.data).toMatchObject({ ok: true, type: "knowledge" });
+    expect(knowledgeHandlerState.lastOptions?.knowledgeDir).toBeUndefined();
+    expect(sm.syncKnowledgeIndex).toHaveBeenCalledTimes(1);
   });
 
   it("POST /api/reload-tracing is wired standalone and is a clean no-op without a gateway URL", async () => {

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -655,16 +655,19 @@ export function createHttpServer(
     perServerHandlers.cluster = createClusterHandler(sessionManager.credentialBroker);
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
   }
-  const perServerKnowledgeHandler = sessionManager.knowledgeDir
-    ? options.knowledgeHandler
-      ?? createKnowledgeHandler({
-        knowledgeDir: sessionManager.knowledgeDir,
-        afterMaterialize: () => sessionManager.syncKnowledgeIndex(),
-      })
-    : undefined;
-  if (perServerKnowledgeHandler) {
-    perServerHandlers.knowledge = perServerKnowledgeHandler;
-  }
+  // The knowledge handler is per-server UNCONDITIONALLY — never gated on
+  // sessionManager.knowledgeDir. K8s boxes leave the dir unset (materialize
+  // falls back to config.paths.knowledgeDir, identical to the module-level
+  // handler's resolution), but only this closure carries the afterMaterialize
+  // hook that re-syncs the shared label index. Behind the gate, a K8s
+  // knowledge hot update landed on disk while knowledge_search kept serving
+  // the index built at pod start until the pod recycled.
+  const perServerKnowledgeHandler = options.knowledgeHandler
+    ?? createKnowledgeHandler({
+      knowledgeDir: sessionManager.knowledgeDir,
+      afterMaterialize: () => sessionManager.syncKnowledgeIndex(),
+    });
+  perServerHandlers.knowledge = perServerKnowledgeHandler;
   if (options.mcpHandler) {
     perServerHandlers.mcp = options.mcpHandler;
   } else if (sessionManager.mcpServersState !== undefined) {

--- a/src/knowledge/labels.ts
+++ b/src/knowledge/labels.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import yaml from "js-yaml";
 
 import { buildKnowledgeCatalogRoutes, type KnowledgeRouteProof } from "./catalog-graph.js";
+import { isKnowledgeNavigationPage } from "./page-kind.js";
 
 export const KNOWLEDGE_LABEL_FACETS = [
   "entity", "topic", "task", "component", "environment", "version",
@@ -270,13 +271,21 @@ export class KnowledgeLabelIndex {
         if (lowerName === "index.md" || lowerName === "log.md") continue;
         let markdown: string;
         try { markdown = fs.readFileSync(absolute, "utf8"); } catch { continue; }
+        const file = path.relative(this.knowledgeDir, absolute);
+        // Navigation pages (`_index.md` by path, `type: index` by frontmatter;
+        // plain `index.md` never gets here) must not enter the label index:
+        // citation validation rejects them as evidence, so a labeled navigation
+        // page would hand knowledge_search a candidate whose cite call then
+        // hard-fails the whole turn's citations. Same classifier as citation
+        // validation and the catalog graph, so the layers cannot disagree.
+        // They are routing surfaces, not content pages — no counter increments.
+        if (isKnowledgeNavigationPage(file, markdown)) continue;
         const parsed = parseKnowledgeLabels(markdown);
         if (!parsed) {
           if (declaresKnowledgeLabels(markdown)) invalidLabeledPages++;
           else unlabeledPages++;
           continue;
         }
-        const file = path.relative(this.knowledgeDir, absolute);
         next.set(file, { file, ...parsed });
       }
     };

--- a/src/tools/query/knowledge-search.test.ts
+++ b/src/tools/query/knowledge-search.test.ts
@@ -270,6 +270,43 @@ describe("knowledge_search", () => {
     expect(catalog.unlabeledPages).toBe(1);
   });
 
+  it("keeps labeled navigation pages out of the label index", async () => {
+    // Citation validation rejects navigation pages as evidence, so a labeled
+    // navigation page in the index would route the agent to a page it cannot
+    // cite — the search layer must classify pages the same way.
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [Routes](routes-guide.md)\n- [Sub](sub/_index.md)\n- [Topic](topic.md)\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "routes-guide.md"),
+      "---\ntype: index\ntitle: 检索路由\nlabels:\n  - facet: topic\n    value: RouteGuide\n---\n# Routes\n\n- [Topic](topic.md)\n",
+    );
+    fs.mkdirSync(path.join(knowledgeDir, "sub"), { recursive: true });
+    fs.writeFileSync(
+      path.join(knowledgeDir, "sub", "_index.md"),
+      "---\ntype: Catalog\ntitle: Sub\nlabels:\n  - facet: topic\n    value: SubCatalog\n---\n# Sub\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "topic.md"),
+      "---\ntype: Topic\ntitle: B300\nlabels:\n  - facet: entity\n    value: B300\n---\n# B300\n",
+    );
+    await resolver.sync();
+
+    const tool = createKnowledgeSearchTool(resolver);
+    const search = await tool.execute("call-nav-search", { query: "RouteGuide" });
+    const payload = JSON.parse((search.content[0] as { text: string }).text);
+    expect(payload.results).toEqual([]);
+    expect(payload.totalPages).toBe(1);
+    // Navigation pages are routing surfaces, not content pages missing labels.
+    expect(payload.unlabeledPages).toBe(0);
+    expect(payload.invalidLabeledPages).toBe(0);
+
+    const catalogResult = await tool.execute("call-nav-catalog", { listLabels: true });
+    const catalog = JSON.parse((catalogResult.content[0] as { text: string }).text);
+    expect(catalog.labels.map((label: { value: string }) => label.value)).toEqual(["B300"]);
+  });
+
   it("returns the canonical multi-library catalog trail without requiring intermediate reads", async () => {
     fs.mkdirSync(path.join(knowledgeDir, "repos", "gpu", "topics"), { recursive: true });
     fs.writeFileSync(


### PR DESCRIPTION
Two label-index correctness fixes, no agent-visible contract change. Together they make `knowledge_search` serve the index the mounted knowledge actually implies — after hot updates, and only for content pages.

## 1. Re-sync the label index on hot update in K8s

In K8s mode, a knowledge hot update (publish/takeover) lands on disk and the prompt catalog refreshes through `brain.reload()`, but `knowledge_search` keeps serving the label index built at pod start until the pod recycles; new sessions in the pod inherit the stale index (resolver is shared per process).

Observed live as `knowledge_search(listLabels=true)` returning `totalLabels: 0, totalPages: 0` on an agent whose repos had just been updated with labeled packages.

Cause: the per-server knowledge handler — the only one carrying the `afterMaterialize` hook that calls `sessionManager.syncKnowledgeIndex()` — was gated on `sessionManager.knowledgeDir`, which only `LocalSpawner` assigns. Fix: create it unconditionally; `materialize` already resolves its target dir with the same config fallback the module-level handler uses, so the only behavioral change is that the hook now fires. Local mode unchanged.

## 2. Keep labeled navigation pages out of the label index

The label index excluded navigation pages by filename only (`index.md`, `log.md`), while citation validation and the catalog graph classify with `isKnowledgeNavigationPage` (path or frontmatter `type: index`). A page named anything else carrying `type: index` plus labels was searchable, readable — and then hard-failed the entire `knowledge_cite` call as a navigation ref. This shape is about to become load-bearing (generated route/FAQ navigation pages).

Fix: classify with the same `isKnowledgeNavigationPage` so the three layers cannot disagree. Navigation pages are routing surfaces, not content pages missing labels — they no longer inflate the `unlabeledPages` diagnostic (also fixes `_index.md` sub-catalogs being counted as unlabeled).

## Validation

- `npx vitest run src/agentbox/http-server.test.ts src/tools/query/knowledge-search.test.ts` — 112 passed, including two new regression tests (K8s shape: reload → `syncKnowledgeIndex` called once; labeled `type: index` page and labeled `sub/_index.md` absent from search results, label catalog, and diagnostic counters)
- `npx tsc --noEmit`

## Deploy note

Agentbox image: rebuild + repoint `SICLAW_AGENTBOX_IMAGE` + recycle pods. After deploy, worth re-verifying the earlier `totalLabels: 0` incident against fix 1.
