### PR TITLE
fix(knowledge): keep labeled navigation pages out of the label index

### DIFF
--- a/src/knowledge/labels.ts
+++ b/src/knowledge/labels.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import yaml from "js-yaml";
 
 import { buildKnowledgeCatalogRoutes, type KnowledgeRouteProof } from "./catalog-graph.js";
+import { isKnowledgeNavigationPage } from "./page-kind.js";
 
 export const KNOWLEDGE_LABEL_FACETS = [
   "entity", "topic", "task", "component", "environment", "version",
@@ -270,13 +271,21 @@ export class KnowledgeLabelIndex {
         if (lowerName === "index.md" || lowerName === "log.md") continue;
         let markdown: string;
         try { markdown = fs.readFileSync(absolute, "utf8"); } catch { continue; }
+        const file = path.relative(this.knowledgeDir, absolute);
+        // Navigation pages (`_index.md` by path, `type: index` by frontmatter;
+        // plain `index.md` never gets here) must not enter the label index:
+        // citation validation rejects them as evidence, so a labeled navigation
+        // page would hand knowledge_search a candidate whose cite call then
+        // hard-fails the whole turn's citations. Same classifier as citation
+        // validation and the catalog graph, so the layers cannot disagree.
+        // They are routing surfaces, not content pages — no counter increments.
+        if (isKnowledgeNavigationPage(file, markdown)) continue;
         const parsed = parseKnowledgeLabels(markdown);
         if (!parsed) {
           if (declaresKnowledgeLabels(markdown)) invalidLabeledPages++;
           else unlabeledPages++;
           continue;
         }
-        const file = path.relative(this.knowledgeDir, absolute);
         next.set(file, { file, ...parsed });
       }
     };

--- a/src/tools/query/knowledge-search.test.ts
+++ b/src/tools/query/knowledge-search.test.ts
@@ -270,6 +270,43 @@ describe("knowledge_search", () => {
     expect(catalog.unlabeledPages).toBe(1);
   });
 
+  it("keeps labeled navigation pages out of the label index", async () => {
+    // Citation validation rejects navigation pages as evidence, so a labeled
+    // navigation page in the index would route the agent to a page it cannot
+    // cite — the search layer must classify pages the same way.
+    fs.writeFileSync(
+      path.join(knowledgeDir, "index.md"),
+      "# Knowledge Index\n\n- [Routes](routes-guide.md)\n- [Sub](sub/_index.md)\n- [Topic](topic.md)\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "routes-guide.md"),
+      "---\ntype: index\ntitle: 检索路由\nlabels:\n  - facet: topic\n    value: RouteGuide\n---\n# Routes\n\n- [Topic](topic.md)\n",
+    );
+    fs.mkdirSync(path.join(knowledgeDir, "sub"), { recursive: true });
+    fs.writeFileSync(
+      path.join(knowledgeDir, "sub", "_index.md"),
+      "---\ntype: Catalog\ntitle: Sub\nlabels:\n  - facet: topic\n    value: SubCatalog\n---\n# Sub\n",
+    );
+    fs.writeFileSync(
+      path.join(knowledgeDir, "topic.md"),
+      "---\ntype: Topic\ntitle: B300\nlabels:\n  - facet: entity\n    value: B300\n---\n# B300\n",
+    );
+    await resolver.sync();
+
+    const tool = createKnowledgeSearchTool(resolver);
+    const search = await tool.execute("call-nav-search", { query: "RouteGuide" });
+    const payload = JSON.parse((search.content[0] as { text: string }).text);
+    expect(payload.results).toEqual([]);
+    expect(payload.totalPages).toBe(1);
+    // Navigation pages are routing surfaces, not content pages missing labels.
+    expect(payload.unlabeledPages).toBe(0);
+    expect(payload.invalidLabeledPages).toBe(0);
+
+    const catalogResult = await tool.execute("call-nav-catalog", { listLabels: true });
+    const catalog = JSON.parse((catalogResult.content[0] as { text: string }).text);
+    expect(catalog.labels.map((label: { value: string }) => label.value)).toEqual(["B300"]);
+  });
+
   it("returns the canonical multi-library catalog trail without requiring intermediate reads", async () => {
     fs.mkdirSync(path.join(knowledgeDir, "repos", "gpu", "topics"), { recursive: true });
     fs.writeFileSync(


### PR DESCRIPTION
## Problem

The label index (`KnowledgeLabelIndex.sync`) excludes navigation pages by **filename only** (`index.md`, `log.md`), while citation validation and the catalog graph classify navigation with `isKnowledgeNavigationPage` — path (`index.md`/`_index.md`) **or** frontmatter `type: index`.

A page named anything else that carries `type: index` plus a `labels` array is therefore label-indexed and returned by `knowledge_search`; the agent reads it and cites it, and the cite call **hard-fails in full** (`Cannot cite navigation pages` registers zero citations for the whole call, valid refs included). This trap is about to become load-bearing: generated route/FAQ navigation pages are exactly this shape.

## Fix

Classify pages in the label index with the same `isKnowledgeNavigationPage` the citation validator and catalog graph use, so the three layers cannot disagree. Navigation pages are routing surfaces, not content pages missing labels — they no longer inflate the `unlabeledPages` diagnostic either (this also stops `_index.md` sub-catalogs being counted as unlabeled).

## Validation

- `npx vitest run src/tools/query/knowledge-search.test.ts src/knowledge/label-backfill.test.ts` — 14 passed, including a new regression test (labeled `type: index` page and labeled `sub/_index.md`: absent from search results and label catalog, zero diagnostic-counter noise)
- `npx tsc --noEmit`

## Deploy note

Agentbox image (label index runs in the box).