### PR TITLE
fix(runtime): preserve large MCP outputs as artifacts

### DIFF
--- a/docs/design/guards.md
+++ b/docs/design/guards.md
@@ -196,17 +196,41 @@ and related maps across events, cleared on `reset()`.
 
 Write-time validation for session history. Sanitizes malformed tool call
 blocks, tracks pending call/result pairing across messages, inserts
-synthetic error results for orphaned calls, truncates results exceeding
-400KB. Stateful — maintains `pending` Map and `droppedToolCallIds` Set.
+synthetic error results for orphaned calls, and caps results exceeding
+400KB. Artifact-backed results are replaced by a bounded preview plus their
+opaque recovery ID; uncaptured results retain the legacy truncation behavior.
+Stateful — maintains `pending` Map and `droppedToolCallIds` Set.
 
 ### Context: context-budget-guard
 
 **File**: `src/core/tool-result-context-guard.ts` (`createContextBudgetGuard`)
 
 Enforces context window budget. Three-tier strategy:
-1. Truncate any single result exceeding 50% of context window
-2. Compact oldest results when total exceeds 75% of window
+1. Replace any single result exceeding 50% of context window with its artifact
+   reference when available, otherwise truncate it
+2. Compact oldest results when total exceeds 75% of window, retaining artifact
+   recovery instructions when available
 3. Throw `PREEMPTIVE_CONTEXT_OVERFLOW` when still exceeding 90%
+
+### MCP tool-result artifacts
+
+**File**: `src/core/tool-result-artifact.ts`
+
+MCP text results of at least 32KiB are captured before the guard pipeline can
+shrink them. The live tool execution still returns the original content. If a
+persist or context guard later needs to reduce that content, the model receives
+an opaque artifact ID, digest, expiry, bounded head/tail preview, and instructions
+to use `tool_result_search` and `tool_result_read`.
+
+Artifacts are scoped to the Agent and session, stored below the framework
+session directory, and unavailable through generic file tools. The root and
+scope directories use mode `0700`; files use `0600`. The v0 bounds are a 24-hour
+TTL, 64MiB per artifact, and 256MiB or 256 artifacts per session scope with
+oldest-first eviction.
+Reads return at most 32,000 characters and searches are literal,
+case-insensitive, and bounded to 50 matches. A capture failure is carried into
+the guard result explicitly so the model knows the omitted portion cannot be
+recovered and can narrow or paginate the source query.
 
 ---
 

--- a/docs/design/guards.md
+++ b/docs/design/guards.md
@@ -223,8 +223,8 @@ an opaque artifact ID, digest, expiry, bounded head/tail preview, and instructio
 to use `tool_result_search` and `tool_result_read`.
 
 Artifacts are scoped to the Agent and session, stored below the framework
-session directory, and unavailable through generic file tools — including
-`.tool-results` trees that belong to sibling sessions on the same AgentBox. The root and
+session directory, and unavailable through generic file tools or `restricted_bash` —
+including `.tool-results` trees that belong to sibling sessions on the same AgentBox. The root and
 scope directories use mode `0700`; files use `0600`. The v0 bounds are a 24-hour
 TTL, 64MiB per artifact, and 256MiB or 256 artifacts per session scope with
 oldest-first eviction.

--- a/docs/design/guards.md
+++ b/docs/design/guards.md
@@ -223,7 +223,8 @@ an opaque artifact ID, digest, expiry, bounded head/tail preview, and instructio
 to use `tool_result_search` and `tool_result_read`.
 
 Artifacts are scoped to the Agent and session, stored below the framework
-session directory, and unavailable through generic file tools. The root and
+session directory, and unavailable through generic file tools — including
+`.tool-results` trees that belong to sibling sessions on the same AgentBox. The root and
 scope directories use mode `0700`; files use `0600`. The v0 bounds are a 24-hour
 TTL, 64MiB per artifact, and 256MiB or 256 artifacts per session scope with
 oldest-first eviction.

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -230,7 +230,7 @@ The `sandbox` user has no write permission on any of these by OS permission alon
 | Path | Owner | Mode | agentbox | sandbox | Notes |
 |------|-------|------|----------|---------|-------|
 | `.siclaw/user-data/` | agentbox:agentbox | 0777 | rwx | rwx | Memory files, PROFILE.md, investigation notes. |
-| `.siclaw/user-data/agent/sessions/<session>/.tool-results/` | agentbox:agentbox | 0700 dirs, 0600 files | rw | -- | Session-scoped MCP output artifacts; opaque tool access only. |
+| `.siclaw/user-data/agent/sessions/<session>/.tool-results/` | agentbox:agentbox | 0700 dirs, 0600 files | rw | -- | Session-scoped MCP output artifacts; opaque tool access only. File tools and `restricted_bash` both refuse any `.tool-results` tree. |
 | `/tmp/` | (any) | 1777 | rw | rw | Temporary files. Sticky bit prevents cross-user deletion. |
 
 The `user-data` directory is the **only** writable area for the sandbox user (besides /tmp).

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -230,12 +230,16 @@ The `sandbox` user has no write permission on any of these by OS permission alon
 | Path | Owner | Mode | agentbox | sandbox | Notes |
 |------|-------|------|----------|---------|-------|
 | `.siclaw/user-data/` | agentbox:agentbox | 0777 | rwx | rwx | Memory files, PROFILE.md, investigation notes. |
+| `.siclaw/user-data/agent/sessions/<session>/.tool-results/` | agentbox:agentbox | 0700 dirs, 0600 files | rw | -- | Session-scoped MCP output artifacts; opaque tool access only. |
 | `/tmp/` | (any) | 1777 | rw | rw | Temporary files. Sticky bit prevents cross-user deletion. |
 
 The `user-data` directory is the **only** writable area for the sandbox user (besides /tmp).
 This matches the application-level `writeAllowedDirs = [userDataDir]` — but enforced at OS level.
 
-**Critical**: No sensitive files should be placed in `/tmp/` or `user-data/`.
+**Critical**: No sensitive files should be placed directly in `/tmp/` or the
+world-writable part of `user-data/`. A private subtree below `user-data/` must be
+created by the agentbox process before tool execution, use `0700` directories
+and `0600` files, and remain inaccessible through generic file tools.
 
 ### 3.4 Pipeline Compatibility
 

--- a/src/core/agent-factory.test.ts
+++ b/src/core/agent-factory.test.ts
@@ -40,4 +40,14 @@ describe("agent-factory", () => {
     expect(source).toContain("customTools.push(...mcpTools)");
     expect(source).not.toContain("appendAllowedTools(customTools, mcpTools");
   });
+
+  it("captures MCP results as scoped artifacts and exposes intrinsic recovery tools", () => {
+    const source = fs.readFileSync(path.resolve(__dirname, "agent-factory.ts"), "utf8");
+    expect(source).toContain("withToolResultArtifactCapture(tool, toolResultArtifactStore)");
+    expect(source).toContain("customTools.push(...createToolResultArtifactTools(toolResultArtifactStore))");
+    expect(source).toContain("toolResultArtifactsDir");
+    expect(source).toMatch(/blockedFileDirs[\s\S]*toolResultArtifactsDir/);
+    expect(source).toContain("sessionId: sessionIdRef.current || sessionManagerId");
+    expect(source).not.toContain('sessionId: sessionIdRef.current || "standalone"');
+  });
 });

--- a/src/core/agent-factory.test.ts
+++ b/src/core/agent-factory.test.ts
@@ -45,6 +45,7 @@ describe("agent-factory", () => {
     const source = fs.readFileSync(path.resolve(__dirname, "agent-factory.ts"), "utf8");
     expect(source).toContain("withToolResultArtifactCapture(tool, toolResultArtifactStore)");
     expect(source).toContain("customTools.push(...createToolResultArtifactTools(toolResultArtifactStore))");
+    expect(source).not.toMatch(/if \(mcpTools\.length > 0\)[\s\S]{0,120}createToolResultArtifactTools/);
     expect(source).toContain("toolResultArtifactsDir");
     expect(source).toMatch(/blockedFileDirs[\s\S]*toolResultArtifactsDir/);
     expect(source).toContain("isToolResultArtifactPath(absolutePath)");

--- a/src/core/agent-factory.test.ts
+++ b/src/core/agent-factory.test.ts
@@ -47,6 +47,8 @@ describe("agent-factory", () => {
     expect(source).toContain("customTools.push(...createToolResultArtifactTools(toolResultArtifactStore))");
     expect(source).toContain("toolResultArtifactsDir");
     expect(source).toMatch(/blockedFileDirs[\s\S]*toolResultArtifactsDir/);
+    expect(source).toContain("isToolResultArtifactPath(absolutePath)");
+    expect(source).toContain("isToolResultArtifactPath(candidate)");
     expect(source).toContain("sessionId: sessionIdRef.current || sessionManagerId");
     expect(source).not.toContain('sessionId: sessionIdRef.current || "standalone"');
   });

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -59,6 +59,12 @@ import { initExtraCommands } from "../tools/infra/extra-commands.js";
 import { filterHarnessSkills } from "./skill-overlay.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
 import {
+  ToolResultArtifactStore,
+  createToolResultArtifactTools,
+  toolResultArtifactRoot,
+  withToolResultArtifactCapture,
+} from "./tool-result-artifact.js";
+import {
   buildKnowledgeCitationSystemPrompt,
   createKnowledgeCitationSupport,
 } from "./knowledge-citation-tool.js";
@@ -354,11 +360,13 @@ function assertToolPathAllowed(
   absolutePath: string,
   allowedDirs: string[],
   operation: string,
-  blockedMemoryDir: string | null,
+  blockedDirs: Array<{ dir: string; reason: string }>,
 ): void {
   assertPathAllowed(absolutePath, allowedDirs, operation);
-  if (blockedMemoryDir && isPathInsideDir(absolutePath, blockedMemoryDir)) {
-    throw new Error(`${operation} blocked: Siclaw memory is disabled.`);
+  for (const blocked of blockedDirs) {
+    if (isPathInsideDir(absolutePath, blocked.dir)) {
+      throw new Error(`${operation} blocked: ${blocked.reason}`);
+    }
   }
 }
 
@@ -398,6 +406,8 @@ export async function createSiclawSession(
   const userId = opts?.userId ?? "unknown";
   const agentId: string | null = opts?.agentId ?? null;
   const sessionIdRef: { current: string } = { current: "" };
+  const sessionManager = opts?.sessionManager ?? SessionManager.create(process.cwd());
+  const sessionManagerId = sessionManager.getSessionId() || `runtime:${randomUUID()}`;
   // Turn counter for per-attempt tool state; the prompt owner bumps it (see ToolRefs).
   const turnRef: { current: number } = { current: 0 };
   const mode = opts?.mode ?? "web";
@@ -436,6 +446,7 @@ export async function createSiclawSession(
   });
   const userDataDir = path.resolve(cwd, config.paths.userDataDir);
   const memoryDir = path.join(userDataDir, "memory");
+  const toolResultArtifactsDir = toolResultArtifactRoot(sessionManager.getSessionDir());
   const knowledgeDir = opts?.knowledgeDir
     ?? (opts?.portalKnowledgeDir && fs.existsSync(opts.portalKnowledgeDir)
       ? opts.portalKnowledgeDir
@@ -566,6 +577,21 @@ export async function createSiclawSession(
 
   // -- MCP external tools (dynamic discovery, not in registry) --
   const exposeConfiguredMcp = compiledContext.harness.mcpExposure === "configured";
+  const toolResultArtifactStore = new ToolResultArtifactStore({
+    rootDir: toolResultArtifactsDir,
+    getScope: () => ({
+      agentId: agentId ?? `user:${userId}`,
+      sessionId: sessionIdRef.current || sessionManagerId,
+    }),
+  });
+  try {
+    await toolResultArtifactStore.initialize();
+  } catch (error) {
+    console.warn(
+      "[agent-factory] Tool-result artifact storage unavailable; large MCP outputs will use explicit unrecoverable truncation:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
   let mcpManager: McpClientManager | undefined = exposeConfiguredMcp
     ? opts?.mcpManager
     : undefined;
@@ -574,7 +600,7 @@ export async function createSiclawSession(
   if (mcpManager) {
     const sharedTools = opts?.mcpTools ?? mcpManager.getTools();
     if (sharedTools.length > 0) {
-      mcpTools = sharedTools;
+      mcpTools = sharedTools.map((tool) => withToolResultArtifactCapture(tool, toolResultArtifactStore));
       console.log(`[agent-factory] Reusing ${sharedTools.length} shared MCP tools`);
     }
   } else if (mcpServers && Object.keys(mcpServers).length > 0) {
@@ -584,7 +610,7 @@ export async function createSiclawSession(
       const discovered = mcpManager.getTools();
       console.log(`[agent-factory] MCP initialization complete: ${discovered.length} tools discovered`);
       if (discovered.length > 0) {
-        mcpTools = discovered;
+        mcpTools = discovered.map((tool) => withToolResultArtifactCapture(tool, toolResultArtifactStore));
         console.log(`[agent-factory] Added ${discovered.length} MCP tools: ${discovered.map(t => t.name).join(", ")}`);
       }
     } catch (err) {
@@ -605,6 +631,9 @@ export async function createSiclawSession(
   // The whole `mcpTools` array is MCP by construction, so an unconditional push
   // is simpler than and equivalent to skipping by an `mcp__` name prefix.
   customTools.push(...mcpTools);
+  if (mcpTools.length > 0) {
+    customTools.push(...createToolResultArtifactTools(toolResultArtifactStore));
+  }
 
   // -- Path-restricted file I/O tools --
   // Whitelist: only skills directories + user-data + reports + repos + docs (no credentials, no config)
@@ -619,7 +648,15 @@ export async function createSiclawSession(
     ...(opts?.portalSkillsDir ? [opts.portalSkillsDir] : []),
   ];
   const writeAllowedDirs = [userDataDir];
-  const blockedMemoryDir = memoryEnabled ? null : memoryDir;
+  const blockedFileDirs = [
+    {
+      dir: toolResultArtifactsDir,
+      reason: "tool-result artifacts are internal; use tool_result_read or tool_result_search",
+    },
+    ...(memoryEnabled ? [] : [{ dir: memoryDir, reason: "Siclaw memory is disabled" }]),
+  ];
+  const isBlockedFilePath = (candidate: string) =>
+    blockedFileDirs.some((blocked) => isPathInsideDir(candidate, blocked.dir));
 
   // Read-only delegated turn: drop the write file tools (Edit/Write) so a
   // delegated worker cannot mutate even its own scratch dir. Reads (Read/Grep/
@@ -631,7 +668,7 @@ export async function createSiclawSession(
     createReadTool(cwd, {
       operations: {
         readFile: async (p) => {
-          assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir);
+          assertToolPathAllowed(p, readAllowedDirs, "read", blockedFileDirs);
           const start = citationSupport?.captureMount();
           const content = await fsReadFile(p);
           if (citationSupport && start !== undefined) {
@@ -639,48 +676,48 @@ export async function createSiclawSession(
           }
           return content;
         },
-        access: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedMemoryDir); return fsAccess(p, fs.constants.R_OK); },
+        access: async (p) => { assertToolPathAllowed(p, readAllowedDirs, "read", blockedFileDirs); return fsAccess(p, fs.constants.R_OK); },
       },
     }),
     ...(delegatedReadOnly ? [] : [
       createEditTool(cwd, {
         operations: {
-          readFile: async (p) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedMemoryDir); return fsReadFile(p); },
-          writeFile: async (p, c) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedMemoryDir); return fsWriteFile(p, c, "utf-8"); },
-          access: async (p) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedMemoryDir); return fsAccess(p, fs.constants.R_OK | fs.constants.W_OK); },
+          readFile: async (p) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedFileDirs); return fsReadFile(p); },
+          writeFile: async (p, c) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedFileDirs); return fsWriteFile(p, c, "utf-8"); },
+          access: async (p) => { assertToolPathAllowed(p, writeAllowedDirs, "edit", blockedFileDirs); return fsAccess(p, fs.constants.R_OK | fs.constants.W_OK); },
         },
       }),
       createWriteTool(cwd, {
         operations: {
-          writeFile: async (p, c) => { assertToolPathAllowed(p, writeAllowedDirs, "write", blockedMemoryDir); return fsWriteFile(p, c, "utf-8"); },
-          mkdir: async (d) => { assertToolPathAllowed(d, writeAllowedDirs, "write", blockedMemoryDir); await fsMkdir(d, { recursive: true }); },
+          writeFile: async (p, c) => { assertToolPathAllowed(p, writeAllowedDirs, "write", blockedFileDirs); return fsWriteFile(p, c, "utf-8"); },
+          mkdir: async (d) => { assertToolPathAllowed(d, writeAllowedDirs, "write", blockedFileDirs); await fsMkdir(d, { recursive: true }); },
         },
       }),
     ]),
     createGrepTool(cwd, {
       operations: {
-        isDirectory: (p) => { assertToolPathAllowed(p, readAllowedDirs, "grep", blockedMemoryDir); return fs.statSync(p).isDirectory(); },
-        readFile: (p) => { assertToolPathAllowed(p, readAllowedDirs, "grep", blockedMemoryDir); return fs.readFileSync(p, "utf-8"); },
+        isDirectory: (p) => { assertToolPathAllowed(p, readAllowedDirs, "grep", blockedFileDirs); return fs.statSync(p).isDirectory(); },
+        readFile: (p) => { assertToolPathAllowed(p, readAllowedDirs, "grep", blockedFileDirs); return fs.readFileSync(p, "utf-8"); },
       },
     }),
     createFindTool(cwd, {
       operations: {
-        exists: (p) => { assertToolPathAllowed(p, readAllowedDirs, "find", blockedMemoryDir); return fs.existsSync(p); },
+        exists: (p) => { assertToolPathAllowed(p, readAllowedDirs, "find", blockedFileDirs); return fs.existsSync(p); },
         glob: (pattern, searchCwd, options) => {
-          assertToolPathAllowed(searchCwd, readAllowedDirs, "find", blockedMemoryDir);
+          assertToolPathAllowed(searchCwd, readAllowedDirs, "find", blockedFileDirs);
           return globSync(pattern, { cwd: searchCwd, absolute: true, dot: true, ignore: options.ignore })
-            .filter((p) => !blockedMemoryDir || !isPathInsideDir(p, blockedMemoryDir))
+            .filter((p) => !isBlockedFilePath(p))
             .slice(0, options.limit);
         },
       },
     }),
     createLsTool(cwd, {
       operations: {
-        exists: (p) => { assertToolPathAllowed(p, readAllowedDirs, "ls", blockedMemoryDir); return fs.existsSync(p); },
-        stat: (p) => { assertToolPathAllowed(p, readAllowedDirs, "ls", blockedMemoryDir); return fs.statSync(p); },
+        exists: (p) => { assertToolPathAllowed(p, readAllowedDirs, "ls", blockedFileDirs); return fs.existsSync(p); },
+        stat: (p) => { assertToolPathAllowed(p, readAllowedDirs, "ls", blockedFileDirs); return fs.statSync(p); },
         readdir: (p) => {
-          assertToolPathAllowed(p, readAllowedDirs, "ls", blockedMemoryDir);
-          return fs.readdirSync(p).filter((entry) => !blockedMemoryDir || !isPathInsideDir(path.join(p, entry), blockedMemoryDir));
+          assertToolPathAllowed(p, readAllowedDirs, "ls", blockedFileDirs);
+          return fs.readdirSync(p).filter((entry) => !isBlockedFilePath(path.join(p, entry)));
         },
       },
     }),
@@ -859,9 +896,6 @@ export async function createSiclawSession(
   console.log(`[agent-context] ${JSON.stringify(contextManifest)}`);
   const modelEnvelopeManifestRef: { current?: ModelEnvelopeManifest } = {};
   const modelEnvelopeInspectionRef: { current?: ModelEnvelopeInspection } = {};
-
-  const sessionManager =
-    opts?.sessionManager ?? SessionManager.create(process.cwd());
 
   // Resolve the initial model: prefer the user's configured default over pi-agent's built-in
   const configuredModel = defaultLlm

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -61,6 +61,7 @@ import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
 import {
   ToolResultArtifactStore,
   createToolResultArtifactTools,
+  isToolResultArtifactPath,
   toolResultArtifactRoot,
   withToolResultArtifactCapture,
 } from "./tool-result-artifact.js";
@@ -363,6 +364,9 @@ function assertToolPathAllowed(
   blockedDirs: Array<{ dir: string; reason: string }>,
 ): void {
   assertPathAllowed(absolutePath, allowedDirs, operation);
+  if (isToolResultArtifactPath(absolutePath)) {
+    throw new Error(`${operation} blocked: tool-result artifacts are internal; use tool_result_read or tool_result_search`);
+  }
   for (const blocked of blockedDirs) {
     if (isPathInsideDir(absolutePath, blocked.dir)) {
       throw new Error(`${operation} blocked: ${blocked.reason}`);
@@ -656,7 +660,8 @@ export async function createSiclawSession(
     ...(memoryEnabled ? [] : [{ dir: memoryDir, reason: "Siclaw memory is disabled" }]),
   ];
   const isBlockedFilePath = (candidate: string) =>
-    blockedFileDirs.some((blocked) => isPathInsideDir(candidate, blocked.dir));
+    isToolResultArtifactPath(candidate)
+    || blockedFileDirs.some((blocked) => isPathInsideDir(candidate, blocked.dir));
 
   // Read-only delegated turn: drop the write file tools (Edit/Write) so a
   // delegated worker cannot mutate even its own scratch dir. Reads (Read/Grep/

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -635,9 +635,10 @@ export async function createSiclawSession(
   // The whole `mcpTools` array is MCP by construction, so an unconditional push
   // is simpler than and equivalent to skipping by an `mcp__` name prefix.
   customTools.push(...mcpTools);
-  if (mcpTools.length > 0) {
-    customTools.push(...createToolResultArtifactTools(toolResultArtifactStore));
-  }
+  // Recovery tools stay available even when this rebuild discovered no MCP
+  // tools. Persisted history and the context guard still tell the model to
+  // call them for artifacts captured earlier in the same session.
+  customTools.push(...createToolResultArtifactTools(toolResultArtifactStore));
 
   // -- Path-restricted file I/O tools --
   // Whitelist: only skills directories + user-data + reports + repos + docs (no credentials, no config)

--- a/src/core/session-tool-result-guard.test.ts
+++ b/src/core/session-tool-result-guard.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 
+function artifactReference(id = "tra_0123456789abcdef0123456789abcdef") {
+  return {
+    version: 1,
+    id,
+    sizeChars: 500_000,
+    sizeBytes: 500_000,
+    sha256: "a".repeat(64),
+    createdAt: "2026-09-03T00:00:00.000Z",
+    expiresAt: "2026-09-04T00:00:00.000Z",
+  };
+}
+
 function createMockSessionManager() {
   const appended: any[] = [];
   return {
@@ -196,5 +208,52 @@ describe("installSessionToolResultGuard", () => {
     const persistedText = persisted.content[0].text;
     expect(persistedText.length).toBeLessThan(450_000);
     expect(persistedText).toContain("[Content truncated");
+  });
+
+  it("persists a recoverable artifact reference for oversized captured results", () => {
+    const sm = createMockSessionManager();
+    installSessionToolResultGuard(sm as any);
+
+    const artifact = artifactReference();
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [{ type: "text", text: `head\n${"x".repeat(499_980)}\nroot cause` }],
+      details: { ignored: "large provider details", toolResultArtifact: artifact },
+      timestamp: Date.now(),
+    });
+
+    const persisted = sm._appended[0];
+    const persistedText = persisted.content[0].text;
+    expect(persistedText.length).toBeLessThanOrEqual(16_000);
+    expect(persistedText).toContain(artifact.id);
+    expect(persistedText).toContain("tool_result_search");
+    expect(persistedText).toContain("root cause");
+    expect(persisted.details).toEqual({ toolResultArtifact: artifact });
+  });
+
+  it("makes artifact capture failure explicit when persistence must truncate", () => {
+    const sm = createMockSessionManager();
+    installSessionToolResultGuard(sm as any);
+
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [{ type: "text", text: "x".repeat(500_000) }],
+      details: {
+        toolResultArtifactFailure: {
+          version: 1,
+          reason: "write_failed",
+          sizeChars: 500_000,
+          sizeBytes: 500_000,
+        },
+      },
+      timestamp: Date.now(),
+    });
+
+    const persistedText = sm._appended[0].content[0].text;
+    expect(persistedText).toContain("complete artifact is unavailable");
+    expect(persistedText).toContain("cannot be recovered");
+    expect(persistedText).toContain("reason: write_failed");
   });
 });

--- a/src/core/session-tool-result-guard.test.ts
+++ b/src/core/session-tool-result-guard.test.ts
@@ -239,7 +239,7 @@ describe("installSessionToolResultGuard", () => {
     sm.appendMessage({
       role: "toolResult",
       toolCallId: "call_1",
-      content: [{ type: "text", text: "x".repeat(500_000) }],
+      content: [{ type: "text", text: `HEAD-${"x".repeat(499_980)}-TAIL_ERROR` }],
       details: {
         toolResultArtifactFailure: {
           version: 1,
@@ -252,8 +252,11 @@ describe("installSessionToolResultGuard", () => {
     });
 
     const persistedText = sm._appended[0].content[0].text;
+    expect(persistedText.length).toBeLessThanOrEqual(16_000);
     expect(persistedText).toContain("complete artifact is unavailable");
     expect(persistedText).toContain("cannot be recovered");
     expect(persistedText).toContain("reason: write_failed");
+    expect(persistedText).toContain("HEAD-");
+    expect(persistedText).toContain("-TAIL_ERROR");
   });
 });

--- a/src/core/session-tool-result-guard.ts
+++ b/src/core/session-tool-result-guard.ts
@@ -15,10 +15,18 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./message-ut
 import { sanitizeToolCallInputs } from "./tool-call-repair.js";
 import type { PersistGuard } from "./guard-pipeline.js";
 import { guardLog } from "./guard-log.js";
+import {
+  formatToolResultArtifactReference,
+  formatUnrecoverableToolResult,
+  getToolResultArtifactDetails,
+  getToolResultArtifactFailure,
+  getToolResultArtifactReference,
+} from "./tool-result-artifact.js";
 
 // ── Tool result truncation ──────────────────────────────────────────────
 
 const HARD_MAX_TOOL_RESULT_CHARS = 400_000;
+const ARTIFACT_PREVIEW_CHARS = 16_000;
 const MIN_KEEP_CHARS = 2_000;
 const TRUNCATION_SUFFIX =
   "\n\n[Content truncated during persistence — original exceeded size limit. " +
@@ -73,6 +81,28 @@ function capToolResultSize(msg: AgentMessage): AgentMessage {
     }
   }
   if (totalChars <= HARD_MAX_TOOL_RESULT_CHARS) return msg;
+
+  const details = (msg as { details?: unknown }).details;
+  const artifact = getToolResultArtifactReference(details);
+  const artifactFailure = getToolResultArtifactFailure(details);
+  if (artifact || artifactFailure) {
+    const fullText = content
+      .filter((block: any) => block?.type === "text" && typeof block.text === "string")
+      .map((block: any) => block.text)
+      .join("\n");
+    const text = artifact
+      ? formatToolResultArtifactReference(artifact, fullText, ARTIFACT_PREVIEW_CHARS)
+      : formatUnrecoverableToolResult(artifactFailure!, fullText, ARTIFACT_PREVIEW_CHARS);
+    const artifactDetails = getToolResultArtifactDetails(msg);
+    return {
+      ...msg,
+      content: [
+        { type: "text", text },
+        ...content.filter((block: any) => block?.type !== "text"),
+      ],
+      ...(artifactDetails ? { details: artifactDetails } : {}),
+    } as unknown as AgentMessage;
+  }
 
   const newContent = content.map((block: any) => {
     if (!block || typeof block !== "object" || block.type !== "text" || typeof block.text !== "string") return block;

--- a/src/core/tool-result-artifact.test.ts
+++ b/src/core/tool-result-artifact.test.ts
@@ -8,6 +8,7 @@ import {
   createToolResultArtifactTools,
   formatToolResultArtifactReference,
   getToolResultArtifactReference,
+  isToolResultArtifactPath,
   withToolResultArtifactCapture,
 } from "./tool-result-artifact.js";
 
@@ -50,8 +51,14 @@ describe("ToolResultArtifactStore", () => {
     expect(first.nextOffset).toBe(32_000);
     expect(first.complete).toBe(false);
 
-    const rest = await artifacts.read(captured.reference.id, first.nextOffset!, 32_000);
-    expect(rest.offset).toBe(32_000);
+    let assembled = first.text;
+    let cursor = first.nextOffset;
+    while (cursor !== null) {
+      const page = await artifacts.read(captured.reference.id, cursor, 32_000);
+      assembled += page.text;
+      cursor = page.nextOffset;
+    }
+    expect(assembled).toBe(text);
     expect((await fs.stat(rootDir)).mode & 0o777).toBe(0o700);
   });
 
@@ -242,6 +249,16 @@ describe("tool-result artifact tools", () => {
     } finally {
       await fs.rm(rootDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("isToolResultArtifactPath", () => {
+  it("blocks the current session tree and sibling session trees", () => {
+    expect(isToolResultArtifactPath("/app/.siclaw/user-data/agent/sessions/s1/.tool-results")).toBe(true);
+    expect(isToolResultArtifactPath("/app/.siclaw/user-data/agent/sessions/s1/.tool-results/abc/tra_1.txt")).toBe(true);
+    expect(isToolResultArtifactPath("/app/.siclaw/user-data/agent/sessions/other/.tool-results/abc/tra_1.txt")).toBe(true);
+    expect(isToolResultArtifactPath("/app/.siclaw/user-data/agent/sessions/s1/session.jsonl")).toBe(false);
+    expect(isToolResultArtifactPath("/app/.siclaw/user-data/memory/notes.md")).toBe(false);
   });
 });
 

--- a/src/core/tool-result-artifact.test.ts
+++ b/src/core/tool-result-artifact.test.ts
@@ -7,6 +7,7 @@ import {
   ToolResultArtifactStore,
   createToolResultArtifactTools,
   formatToolResultArtifactReference,
+  formatUnrecoverableToolResult,
   getToolResultArtifactReference,
   isToolResultArtifactPath,
   withToolResultArtifactCapture,
@@ -262,21 +263,47 @@ describe("isToolResultArtifactPath", () => {
   });
 });
 
+function artifactRef(sizeChars: number) {
+  return {
+    version: 1 as const,
+    id: "tra_0123456789abcdef0123456789abcdef",
+    sizeChars,
+    sizeBytes: sizeChars,
+    sha256: "a".repeat(64),
+    createdAt: "2026-09-03T00:00:00.000Z",
+    expiresAt: "2026-09-04T00:00:00.000Z",
+  };
+}
+
 describe("formatToolResultArtifactReference", () => {
   it("keeps the artifact id, digest, and bounded head/tail preview", () => {
     const text = `HEAD-${"m".repeat(2_000)}-TAIL`;
-    const rendered = formatToolResultArtifactReference({
-      version: 1,
-      id: "tra_0123456789abcdef0123456789abcdef",
-      sizeChars: text.length,
-      sizeBytes: text.length,
-      sha256: "a".repeat(64),
-      createdAt: "2026-09-03T00:00:00.000Z",
-      expiresAt: "2026-09-04T00:00:00.000Z",
-    }, text, 1_000);
+    const rendered = formatToolResultArtifactReference(artifactRef(text.length), text, 1_000);
     expect(rendered.length).toBeLessThanOrEqual(1_000);
     expect(rendered).toContain("tra_0123456789abcdef0123456789abcdef");
     expect(rendered).toContain("HEAD-");
     expect(rendered).toContain("-TAIL");
+  });
+
+  it("does not invert the bound when the tail budget is zero", () => {
+    const text = "x".repeat(500_000);
+    const rendered = formatToolResultArtifactReference(artifactRef(text.length), text, 396);
+    expect(rendered.length).toBeLessThanOrEqual(396);
+  });
+});
+
+describe("formatUnrecoverableToolResult", () => {
+  it("keeps a bounded head and tail when the omitted portion cannot be recovered", () => {
+    const text = `HEAD-${"m".repeat(50_000)}-TAIL_ERROR`;
+    const rendered = formatUnrecoverableToolResult({
+      version: 1,
+      reason: "write_failed",
+      sizeChars: text.length,
+      sizeBytes: text.length,
+    }, text, 1_000);
+    expect(rendered.length).toBeLessThanOrEqual(1_000);
+    expect(rendered).toContain("cannot be recovered");
+    expect(rendered).toContain("HEAD-");
+    expect(rendered).toContain("-TAIL_ERROR");
   });
 });

--- a/src/core/tool-result-artifact.test.ts
+++ b/src/core/tool-result-artifact.test.ts
@@ -1,0 +1,265 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ToolResultArtifactStore,
+  createToolResultArtifactTools,
+  formatToolResultArtifactReference,
+  getToolResultArtifactReference,
+  withToolResultArtifactCapture,
+} from "./tool-result-artifact.js";
+
+describe("ToolResultArtifactStore", () => {
+  let rootDir: string;
+  let now: number;
+  let scope = { agentId: "agent-a", sessionId: "session-a" };
+
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-tool-result-artifact-"));
+    now = Date.parse("2026-09-03T00:00:00.000Z");
+  });
+
+  afterEach(async () => {
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  function store(options: { ttlMs?: number; maxArtifactBytes?: number; maxScopeBytes?: number; maxScopeArtifacts?: number } = {}) {
+    return new ToolResultArtifactStore({
+      rootDir,
+      getScope: () => scope,
+      now: () => now,
+      ...options,
+    });
+  }
+
+  it("persists complete text with digest and supports bounded continuation reads", async () => {
+    const artifacts = store();
+    const text = `prefix-${"x".repeat(40_000)}-ROOT_CAUSE-middle-${"y".repeat(40_000)}-tail`;
+    const captured = await artifacts.capture({ text, toolCallId: "call-1", toolName: "mcp__logs__query" });
+    expect(captured).toHaveProperty("reference");
+    if (!("reference" in captured)) throw new Error("capture failed");
+
+    expect(captured.reference.sizeChars).toBe(text.length);
+    expect(captured.reference.sizeBytes).toBe(Buffer.byteLength(text));
+    expect(captured.reference.sha256).toMatch(/^[0-9a-f]{64}$/);
+
+    const first = await artifacts.read(captured.reference.id, 0, 32_000);
+    expect(first.text).toBe(text.slice(0, 32_000));
+    expect(first.nextOffset).toBe(32_000);
+    expect(first.complete).toBe(false);
+
+    const rest = await artifacts.read(captured.reference.id, first.nextOffset!, 32_000);
+    expect(rest.offset).toBe(32_000);
+    expect((await fs.stat(rootDir)).mode & 0o777).toBe(0o700);
+  });
+
+  it("rejects a symlink as the private artifact root", async () => {
+    const parent = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-tool-result-symlink-"));
+    try {
+      const target = path.join(parent, "target");
+      const symlink = path.join(parent, "artifact-root");
+      await fs.mkdir(target);
+      await fs.symlink(target, symlink, "dir");
+      const artifacts = new ToolResultArtifactStore({
+        rootDir: symlink,
+        getScope: () => scope,
+      });
+      await expect(artifacts.initialize()).rejects.toThrow("real directory");
+      await expect(artifacts.capture({ text: "evidence", toolCallId: "call", toolName: "mcp__x__y" }))
+        .resolves.toEqual({
+          failure: { version: 1, reason: "write_failed", sizeChars: 8, sizeBytes: 8 },
+        });
+    } finally {
+      await fs.rm(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("finds decisive evidence from the omitted middle", async () => {
+    const artifacts = store();
+    const text = `${"x".repeat(300_000)}ROOT_CAUSE: exhausted connection pool${"y".repeat(300_000)}`;
+    const captured = await artifacts.capture({ text, toolCallId: "call-2", toolName: "mcp__logs__query" });
+    if (!("reference" in captured)) throw new Error("capture failed");
+
+    const result = await artifacts.search(captured.reference.id, "root_cause", 80, 5);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].offset).toBe(300_000);
+    expect(result.matches[0].snippet).toContain("exhausted connection pool");
+  });
+
+  it("denies an artifact after the session scope changes", async () => {
+    const artifacts = store();
+    const captured = await artifacts.capture({ text: "private evidence", toolCallId: "call-3", toolName: "mcp__x__y" });
+    if (!("reference" in captured)) throw new Error("capture failed");
+
+    scope = { agentId: "agent-a", sessionId: "session-b" };
+    await expect(artifacts.read(captured.reference.id)).rejects.toThrow("not found in this session");
+  });
+
+  it("expires artifacts and removes their files", async () => {
+    const artifacts = store({ ttlMs: 1_000 });
+    const captured = await artifacts.capture({ text: "temporary", toolCallId: "call-4", toolName: "mcp__x__y" });
+    if (!("reference" in captured)) throw new Error("capture failed");
+
+    now += 1_001;
+    await expect(artifacts.read(captured.reference.id)).rejects.toThrow("expired");
+    await expect(artifacts.read(captured.reference.id)).rejects.toThrow("not found");
+  });
+
+  it("fails closed for a single artifact beyond the configured limit", async () => {
+    const artifacts = store({ maxArtifactBytes: 8 });
+    const captured = await artifacts.capture({ text: "123456789", toolCallId: "call-5", toolName: "mcp__x__y" });
+    expect(captured).toEqual({
+      failure: { version: 1, reason: "too_large", sizeChars: 9, sizeBytes: 9 },
+    });
+  });
+
+  it("evicts oldest artifacts to keep the session quota bounded", async () => {
+    const artifacts = store({ maxScopeBytes: 10 });
+    const first = await artifacts.capture({ text: "123456", toolCallId: "call-6", toolName: "mcp__x__y" });
+    if (!("reference" in first)) throw new Error("capture failed");
+    now += 1;
+    const second = await artifacts.capture({ text: "abcdef", toolCallId: "call-7", toolName: "mcp__x__y" });
+    if (!("reference" in second)) throw new Error("capture failed");
+
+    await expect(artifacts.read(first.reference.id)).rejects.toThrow("not found");
+    await expect(artifacts.read(second.reference.id)).resolves.toMatchObject({ text: "abcdef" });
+  });
+
+  it("caps the number of artifacts retained in one session scope", async () => {
+    const artifacts = store({ maxScopeBytes: 1_000, maxScopeArtifacts: 1 });
+    const first = await artifacts.capture({ text: "first", toolCallId: "call-8", toolName: "mcp__x__y" });
+    if (!("reference" in first)) throw new Error("capture failed");
+    now += 1;
+    const second = await artifacts.capture({ text: "second", toolCallId: "call-9", toolName: "mcp__x__y" });
+    if (!("reference" in second)) throw new Error("capture failed");
+
+    await expect(artifacts.read(first.reference.id)).rejects.toThrow("not found");
+    await expect(artifacts.read(second.reference.id)).resolves.toMatchObject({ text: "second" });
+  });
+});
+
+describe("tool-result artifact tools", () => {
+  it("capture wrapper preserves live content and adds a recoverable reference", async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-tool-result-wrapper-"));
+    try {
+      const store = new ToolResultArtifactStore({
+        rootDir,
+        getScope: () => ({ agentId: "agent", sessionId: "session" }),
+      });
+      const wrapped = withToolResultArtifactCapture({
+        name: "mcp__logs__query",
+        label: "query",
+        description: "query logs",
+        parameters: Type.Object({}),
+        execute: async () => ({
+          content: [{ type: "text" as const, text: `complete live result ${"x".repeat(40_000)}` }],
+          details: { upstream: true },
+        }),
+      }, store);
+
+      const result = await wrapped.execute("call-1", {}, undefined, undefined, undefined);
+      expect((result.content[0] as any).text).toMatch(/^complete live result x+$/);
+      expect((result.details as any).upstream).toBe(true);
+      const reference = getToolResultArtifactReference(result.details);
+      expect(reference).not.toBeNull();
+      const stored = await store.read(reference!.id);
+      expect(stored.text).toBe((result.content[0] as any).text.slice(0, 16_000));
+      expect(stored.complete).toBe(false);
+      expect(reference!.sizeChars).toBe((result.content[0] as any).text.length);
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not spill small MCP results", async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-tool-result-small-"));
+    try {
+      const store = new ToolResultArtifactStore({
+        rootDir,
+        getScope: () => ({ agentId: "agent", sessionId: "session" }),
+      });
+      const wrapped = withToolResultArtifactCapture({
+        name: "mcp__status__get",
+        label: "status",
+        description: "get status",
+        parameters: Type.Object({}),
+        execute: async () => ({ content: [{ type: "text" as const, text: "healthy" }] }),
+      }, store);
+
+      const result = await wrapped.execute("call-small", {}, undefined, undefined, undefined);
+      expect(result).toEqual({ content: [{ type: "text", text: "healthy" }] });
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("read and search tools expose bounded data without accepting paths", async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-tool-result-tools-"));
+    try {
+      const store = new ToolResultArtifactStore({
+        rootDir,
+        getScope: () => ({ agentId: "agent", sessionId: "session" }),
+      });
+      const captured = await store.capture({ text: "alpha ROOT_CAUSE omega", toolCallId: "call", toolName: "mcp__x__y" });
+      if (!("reference" in captured)) throw new Error("capture failed");
+      const [readTool, searchTool] = createToolResultArtifactTools(store);
+
+      const read = await readTool.execute("read", { artifact_id: captured.reference.id, offset: 6, limit: 10 }, undefined, undefined, undefined);
+      expect(read.content[0]).toMatchObject({ type: "text" });
+      expect((read.content[0] as any).text).toContain("ROOT_CAUS");
+
+      const search = await searchTool.execute("search", { artifact_id: captured.reference.id, query: "root_cause" }, undefined, undefined, undefined);
+      expect((search.content[0] as any).text).toContain("ROOT_CAUSE");
+      expect((readTool.parameters as any).properties).not.toHaveProperty("path");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the serialized search response within the tool output bound", async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-tool-result-search-bound-"));
+    try {
+      const store = new ToolResultArtifactStore({
+        rootDir,
+        getScope: () => ({ agentId: "agent", sessionId: "session" }),
+      });
+      const text = Array.from({ length: 60 }, (_, i) => `${"x".repeat(2_000)} NEEDLE-${i} ${"y".repeat(2_000)}`).join("\n");
+      const captured = await store.capture({ text, toolCallId: "call", toolName: "mcp__x__y" });
+      if (!("reference" in captured)) throw new Error("capture failed");
+      const [, searchTool] = createToolResultArtifactTools(store);
+
+      const result = await searchTool.execute("search", {
+        artifact_id: captured.reference.id,
+        query: "needle",
+        context_chars: 2_000,
+        max_matches: 50,
+      }, undefined, undefined, undefined);
+      const output = (result.content[0] as any).text;
+      expect(output.length).toBeLessThanOrEqual(32_000);
+      expect(JSON.parse(output).truncated).toBe(true);
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("formatToolResultArtifactReference", () => {
+  it("keeps the artifact id, digest, and bounded head/tail preview", () => {
+    const text = `HEAD-${"m".repeat(2_000)}-TAIL`;
+    const rendered = formatToolResultArtifactReference({
+      version: 1,
+      id: "tra_0123456789abcdef0123456789abcdef",
+      sizeChars: text.length,
+      sizeBytes: text.length,
+      sha256: "a".repeat(64),
+      createdAt: "2026-09-03T00:00:00.000Z",
+      expiresAt: "2026-09-04T00:00:00.000Z",
+    }, text, 1_000);
+    expect(rendered.length).toBeLessThanOrEqual(1_000);
+    expect(rendered).toContain("tra_0123456789abcdef0123456789abcdef");
+    expect(rendered).toContain("HEAD-");
+    expect(rendered).toContain("-TAIL");
+  });
+});

--- a/src/core/tool-result-artifact.ts
+++ b/src/core/tool-result-artifact.ts
@@ -1,0 +1,544 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { ResolvedToolDefinition } from "./tool-registry.js";
+
+export const TOOL_RESULT_ARTIFACT_DETAIL_KEY = "toolResultArtifact";
+export const TOOL_RESULT_ARTIFACT_FAILURE_DETAIL_KEY = "toolResultArtifactFailure";
+
+const ARTIFACT_ID_PATTERN = /^tra_[0-9a-f]{32}$/;
+const DEFAULT_CAPTURE_MIN_BYTES = 32 * 1024;
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1_000;
+const DEFAULT_MAX_ARTIFACT_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_SCOPE_BYTES = 256 * 1024 * 1024;
+const DEFAULT_MAX_SCOPE_ARTIFACTS = 256;
+const DEFAULT_READ_CHARS = 16_000;
+const MAX_READ_CHARS = 32_000;
+const DEFAULT_SEARCH_CONTEXT_CHARS = 240;
+const MAX_SEARCH_CONTEXT_CHARS = 2_000;
+const DEFAULT_SEARCH_MATCHES = 20;
+const MAX_SEARCH_MATCHES = 50;
+
+export function toolResultArtifactRoot(sessionDir: string): string {
+  return path.join(path.resolve(sessionDir), ".tool-results");
+}
+
+export interface ToolResultArtifactScope {
+  agentId: string;
+  sessionId: string;
+}
+
+export interface ToolResultArtifactReference {
+  version: 1;
+  id: string;
+  sizeChars: number;
+  sizeBytes: number;
+  sha256: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface ToolResultArtifactFailure {
+  version: 1;
+  reason: "scope_unavailable" | "too_large" | "write_failed";
+  sizeChars: number;
+  sizeBytes: number;
+}
+
+interface ToolResultArtifactMetadata extends ToolResultArtifactReference {
+  scopeHash: string;
+  toolCallId: string;
+  toolName: string;
+}
+
+export type ToolResultArtifactCapture =
+  | { reference: ToolResultArtifactReference }
+  | { failure: ToolResultArtifactFailure };
+
+export interface ToolResultArtifactStoreOptions {
+  rootDir: string;
+  getScope: () => ToolResultArtifactScope | null;
+  ttlMs?: number;
+  maxArtifactBytes?: number;
+  maxScopeBytes?: number;
+  maxScopeArtifacts?: number;
+  now?: () => number;
+}
+
+export interface ToolResultArtifactReadResult {
+  reference: ToolResultArtifactReference;
+  text: string;
+  offset: number;
+  nextOffset: number | null;
+  complete: boolean;
+}
+
+export interface ToolResultArtifactSearchMatch {
+  offset: number;
+  snippet: string;
+}
+
+export interface ToolResultArtifactSearchResult {
+  reference: ToolResultArtifactReference;
+  query: string;
+  matches: ToolResultArtifactSearchMatch[];
+  truncated: boolean;
+}
+
+function safeInteger(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+function artifactTextPath(scopeDir: string, id: string): string {
+  return path.join(scopeDir, `${id}.txt`);
+}
+
+function artifactMetadataPath(scopeDir: string, id: string): string {
+  return path.join(scopeDir, `${id}.json`);
+}
+
+function publicReference(metadata: ToolResultArtifactMetadata): ToolResultArtifactReference {
+  const { version, id, sizeChars, sizeBytes, sha256, createdAt, expiresAt } = metadata;
+  return { version, id, sizeChars, sizeBytes, sha256, createdAt, expiresAt };
+}
+
+function errorResult(message: string) {
+  return {
+    content: [{ type: "text" as const, text: message }],
+    details: { error: message },
+  };
+}
+
+function formatSearchToolOutput(search: ToolResultArtifactSearchResult): string {
+  const payload = {
+    artifact_id: search.reference.id,
+    query: search.query,
+    matches: search.matches.map((match) => ({ ...match })),
+    truncated: search.truncated,
+    size_chars: search.reference.sizeChars,
+    sha256: search.reference.sha256,
+  };
+  let rendered = JSON.stringify(payload, null, 2);
+  while (rendered.length > MAX_READ_CHARS && payload.matches.length > 0) {
+    payload.truncated = true;
+    if (payload.matches.length > 1) {
+      payload.matches.pop();
+    } else {
+      const match = payload.matches[0];
+      const overflow = rendered.length - MAX_READ_CHARS;
+      match.snippet = match.snippet.slice(0, Math.max(0, match.snippet.length - overflow));
+    }
+    rendered = JSON.stringify(payload, null, 2);
+  }
+  return rendered;
+}
+
+export function getToolResultArtifactReference(value: unknown): ToolResultArtifactReference | null {
+  if (!value || typeof value !== "object") return null;
+  const details = value as Record<string, unknown>;
+  const candidate = details[TOOL_RESULT_ARTIFACT_DETAIL_KEY];
+  if (!candidate || typeof candidate !== "object") return null;
+  const row = candidate as Record<string, unknown>;
+  if (row.version !== 1 || typeof row.id !== "string" || !ARTIFACT_ID_PATTERN.test(row.id)) return null;
+  if (typeof row.sizeChars !== "number" || typeof row.sizeBytes !== "number" || typeof row.sha256 !== "string") return null;
+  if (typeof row.createdAt !== "string" || typeof row.expiresAt !== "string") return null;
+  return row as unknown as ToolResultArtifactReference;
+}
+
+export function getToolResultArtifactFailure(value: unknown): ToolResultArtifactFailure | null {
+  if (!value || typeof value !== "object") return null;
+  const details = value as Record<string, unknown>;
+  const candidate = details[TOOL_RESULT_ARTIFACT_FAILURE_DETAIL_KEY];
+  if (!candidate || typeof candidate !== "object") return null;
+  const row = candidate as Record<string, unknown>;
+  if (row.version !== 1 || !["scope_unavailable", "too_large", "write_failed"].includes(String(row.reason))) return null;
+  if (typeof row.sizeChars !== "number" || typeof row.sizeBytes !== "number") return null;
+  return row as unknown as ToolResultArtifactFailure;
+}
+
+export function getToolResultArtifactDetails(message: unknown): Record<string, unknown> | null {
+  if (!message || typeof message !== "object") return null;
+  const details = (message as { details?: unknown }).details;
+  const reference = getToolResultArtifactReference(details);
+  if (reference) return { [TOOL_RESULT_ARTIFACT_DETAIL_KEY]: reference };
+  const failure = getToolResultArtifactFailure(details);
+  if (failure) return { [TOOL_RESULT_ARTIFACT_FAILURE_DETAIL_KEY]: failure };
+  return null;
+}
+
+export function formatToolResultArtifactReference(
+  reference: ToolResultArtifactReference,
+  preview: string,
+  maxChars: number,
+): string {
+  const header = [
+    "[Full tool output stored as a recoverable artifact]",
+    `artifact_id: ${reference.id}`,
+    `size_chars: ${reference.sizeChars}`,
+    `size_bytes: ${reference.sizeBytes}`,
+    `sha256: ${reference.sha256}`,
+    `expires_at: ${reference.expiresAt}`,
+    "Use tool_result_search to locate evidence, then tool_result_read with offset/limit to inspect it.",
+  ].join("\n");
+  const separator = "\n\nPreview:\n";
+  const previewBudget = Math.max(0, maxChars - header.length - separator.length);
+  if (previewBudget === 0) return header.slice(0, Math.max(0, maxChars));
+  if (preview.length <= previewBudget) return header + separator + preview;
+
+  const omission = "\n\n[... preview middle omitted ...]\n\n";
+  const remaining = Math.max(0, previewBudget - omission.length);
+  const headChars = Math.ceil(remaining * 0.7);
+  const tailChars = remaining - headChars;
+  return header + separator + preview.slice(0, headChars) + omission + preview.slice(-tailChars);
+}
+
+export function formatUnrecoverableToolResult(
+  failure: ToolResultArtifactFailure,
+  preview: string,
+  maxChars: number,
+): string {
+  const notice = [
+    "[Tool output exceeded the inline context, and the complete artifact is unavailable]",
+    `reason: ${failure.reason}`,
+    `size_chars: ${failure.sizeChars}`,
+    `size_bytes: ${failure.sizeBytes}`,
+    "The omitted portion cannot be recovered. Rerun the source tool with narrower filters or pagination.",
+  ].join("\n");
+  const budget = Math.max(0, maxChars - notice.length - 2);
+  return `${notice}\n\n${preview.slice(0, budget)}`.slice(0, maxChars);
+}
+
+export class ToolResultArtifactStore {
+  private readonly rootDir: string;
+  private readonly getScope: () => ToolResultArtifactScope | null;
+  private readonly ttlMs: number;
+  private readonly maxArtifactBytes: number;
+  private readonly maxScopeBytes: number;
+  private readonly maxScopeArtifacts: number;
+  private readonly now: () => number;
+  private writeChain: Promise<void> = Promise.resolve();
+  private rootReady: Promise<void> | null = null;
+
+  constructor(options: ToolResultArtifactStoreOptions) {
+    this.rootDir = path.resolve(options.rootDir);
+    this.getScope = options.getScope;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxArtifactBytes = options.maxArtifactBytes ?? DEFAULT_MAX_ARTIFACT_BYTES;
+    this.maxScopeBytes = options.maxScopeBytes ?? DEFAULT_MAX_SCOPE_BYTES;
+    this.maxScopeArtifacts = options.maxScopeArtifacts ?? DEFAULT_MAX_SCOPE_ARTIFACTS;
+    this.now = options.now ?? Date.now;
+  }
+
+  async initialize(): Promise<void> {
+    await this.ensureRoot();
+  }
+
+  async capture(input: { text: string; toolCallId: string; toolName: string }): Promise<ToolResultArtifactCapture> {
+    const sizeBytes = Buffer.byteLength(input.text, "utf8");
+    const failureBase = { version: 1 as const, sizeChars: input.text.length, sizeBytes };
+    const scope = this.getScope();
+    if (!scope?.agentId || !scope.sessionId) {
+      return { failure: { ...failureBase, reason: "scope_unavailable" } };
+    }
+    if (sizeBytes > this.maxArtifactBytes || sizeBytes > this.maxScopeBytes) {
+      return { failure: { ...failureBase, reason: "too_large" } };
+    }
+
+    const run = this.writeChain.then(async () => {
+      await this.ensureRoot();
+      const scopeHash = this.scopeHash(scope);
+      const scopeDir = path.join(this.rootDir, scopeHash);
+      await fs.mkdir(scopeDir, { recursive: true, mode: 0o700 });
+      await fs.chmod(scopeDir, 0o700);
+      await this.cleanAndReserve(scopeDir, sizeBytes);
+
+      const id = `tra_${randomUUID().replaceAll("-", "")}`;
+      const now = this.now();
+      const metadata: ToolResultArtifactMetadata = {
+        version: 1,
+        id,
+        scopeHash,
+        toolCallId: input.toolCallId,
+        toolName: input.toolName,
+        sizeChars: input.text.length,
+        sizeBytes,
+        sha256: createHash("sha256").update(input.text, "utf8").digest("hex"),
+        createdAt: new Date(now).toISOString(),
+        expiresAt: new Date(now + this.ttlMs).toISOString(),
+      };
+      await this.writeAtomically(artifactTextPath(scopeDir, id), input.text);
+      try {
+        await this.writeAtomically(artifactMetadataPath(scopeDir, id), JSON.stringify(metadata));
+      } catch (error) {
+        await fs.rm(artifactTextPath(scopeDir, id), { force: true });
+        throw error;
+      }
+      return publicReference(metadata);
+    });
+    this.writeChain = run.then(() => undefined, () => undefined);
+    try {
+      return { reference: await run };
+    } catch {
+      return { failure: { ...failureBase, reason: "write_failed" } };
+    }
+  }
+
+  async read(id: string, offset = 0, limit = DEFAULT_READ_CHARS): Promise<ToolResultArtifactReadResult> {
+    const { metadata, text } = await this.load(id);
+    const safeOffset = safeInteger(offset, 0, 0, text.length);
+    const safeLimit = safeInteger(limit, DEFAULT_READ_CHARS, 1, MAX_READ_CHARS);
+    const nextOffsetValue = Math.min(text.length, safeOffset + safeLimit);
+    return {
+      reference: publicReference(metadata),
+      text: text.slice(safeOffset, nextOffsetValue),
+      offset: safeOffset,
+      nextOffset: nextOffsetValue < text.length ? nextOffsetValue : null,
+      complete: nextOffsetValue >= text.length,
+    };
+  }
+
+  async search(
+    id: string,
+    query: string,
+    contextChars = DEFAULT_SEARCH_CONTEXT_CHARS,
+    maxMatches = DEFAULT_SEARCH_MATCHES,
+  ): Promise<ToolResultArtifactSearchResult> {
+    const needle = query.trim();
+    if (!needle) throw new Error("query must not be empty");
+    if (needle.length > 512) throw new Error("query must be at most 512 characters");
+    const { metadata, text } = await this.load(id);
+    const safeContext = safeInteger(contextChars, DEFAULT_SEARCH_CONTEXT_CHARS, 0, MAX_SEARCH_CONTEXT_CHARS);
+    const safeMaxMatches = safeInteger(maxMatches, DEFAULT_SEARCH_MATCHES, 1, MAX_SEARCH_MATCHES);
+    const haystack = text.toLocaleLowerCase();
+    const normalizedNeedle = needle.toLocaleLowerCase();
+    const matches: ToolResultArtifactSearchMatch[] = [];
+    let cursor = 0;
+    let foundMore = false;
+    while (cursor <= haystack.length) {
+      const found = haystack.indexOf(normalizedNeedle, cursor);
+      if (found < 0) break;
+      if (matches.length >= safeMaxMatches) {
+        foundMore = true;
+        break;
+      }
+      const start = Math.max(0, found - safeContext);
+      const end = Math.min(text.length, found + needle.length + safeContext);
+      matches.push({ offset: found, snippet: text.slice(start, end) });
+      cursor = found + Math.max(1, normalizedNeedle.length);
+    }
+    return {
+      reference: publicReference(metadata),
+      query: needle,
+      matches,
+      truncated: foundMore,
+    };
+  }
+
+  private scopeHash(scope: ToolResultArtifactScope): string {
+    return createHash("sha256").update(`${scope.agentId}\0${scope.sessionId}`, "utf8").digest("hex");
+  }
+
+  private ensureRoot(): Promise<void> {
+    this.rootReady ??= (async () => {
+      await fs.mkdir(this.rootDir, { recursive: true, mode: 0o700 });
+      const stat = await fs.lstat(this.rootDir);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error("tool result artifact root must be a real directory");
+      }
+      await fs.chmod(this.rootDir, 0o700);
+    })();
+    return this.rootReady;
+  }
+
+  private currentScopeDir(): string {
+    const scope = this.getScope();
+    if (!scope?.agentId || !scope.sessionId) throw new Error("tool result artifact scope is unavailable");
+    return path.join(this.rootDir, this.scopeHash(scope));
+  }
+
+  private async load(id: string): Promise<{ metadata: ToolResultArtifactMetadata; text: string }> {
+    if (!ARTIFACT_ID_PATTERN.test(id)) throw new Error("invalid tool result artifact id");
+    const scopeDir = this.currentScopeDir();
+    let metadata: ToolResultArtifactMetadata;
+    try {
+      metadata = JSON.parse(await fs.readFile(artifactMetadataPath(scopeDir, id), "utf8")) as ToolResultArtifactMetadata;
+    } catch {
+      throw new Error("tool result artifact not found in this session");
+    }
+    if (metadata.id !== id || metadata.scopeHash !== path.basename(scopeDir)) {
+      throw new Error("tool result artifact not found in this session");
+    }
+    if (Date.parse(metadata.expiresAt) <= this.now()) {
+      await this.removeArtifact(scopeDir, id);
+      throw new Error("tool result artifact has expired");
+    }
+    let text: string;
+    try {
+      text = await fs.readFile(artifactTextPath(scopeDir, id), "utf8");
+    } catch {
+      throw new Error("tool result artifact content is unavailable");
+    }
+    const digest = createHash("sha256").update(text, "utf8").digest("hex");
+    if (Buffer.byteLength(text, "utf8") !== metadata.sizeBytes || digest !== metadata.sha256) {
+      throw new Error("tool result artifact failed integrity verification");
+    }
+    return { metadata, text };
+  }
+
+  private async cleanAndReserve(scopeDir: string, incomingBytes: number): Promise<void> {
+    const entries = await fs.readdir(scopeDir, { withFileTypes: true });
+    const now = this.now();
+    const live: ToolResultArtifactMetadata[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      try {
+        const metadata = JSON.parse(await fs.readFile(path.join(scopeDir, entry.name), "utf8")) as ToolResultArtifactMetadata;
+        if (!ARTIFACT_ID_PATTERN.test(metadata.id) || Date.parse(metadata.expiresAt) <= now) {
+          await this.removeArtifact(scopeDir, metadata.id);
+          continue;
+        }
+        live.push(metadata);
+      } catch {
+        await fs.rm(path.join(scopeDir, entry.name), { force: true });
+        const id = entry.name.slice(0, -".json".length);
+        if (ARTIFACT_ID_PATTERN.test(id)) {
+          await fs.rm(artifactTextPath(scopeDir, id), { force: true });
+        }
+      }
+    }
+    live.sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt));
+    let usedBytes = live.reduce((sum, metadata) => sum + metadata.sizeBytes, 0);
+    let liveCount = live.length;
+    for (const metadata of live) {
+      if (
+        usedBytes + incomingBytes <= this.maxScopeBytes
+        && liveCount + 1 <= this.maxScopeArtifacts
+      ) break;
+      await this.removeArtifact(scopeDir, metadata.id);
+      usedBytes -= metadata.sizeBytes;
+      liveCount -= 1;
+    }
+    if (usedBytes + incomingBytes > this.maxScopeBytes || liveCount + 1 > this.maxScopeArtifacts) {
+      throw new Error("tool result artifact scope quota exceeded");
+    }
+  }
+
+  private async removeArtifact(scopeDir: string, id: string): Promise<void> {
+    if (!ARTIFACT_ID_PATTERN.test(id)) return;
+    await Promise.all([
+      fs.rm(artifactTextPath(scopeDir, id), { force: true }),
+      fs.rm(artifactMetadataPath(scopeDir, id), { force: true }),
+    ]);
+  }
+
+  private async writeAtomically(target: string, content: string): Promise<void> {
+    const temp = `${target}.${randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(temp, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      await fs.rename(temp, target);
+    } finally {
+      await fs.rm(temp, { force: true });
+    }
+  }
+}
+
+function toolResultText(result: unknown): string {
+  if (!result || typeof result !== "object") return "";
+  const content = (result as { content?: unknown }).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.flatMap((block): string[] => {
+    if (!block || typeof block !== "object") return [];
+    const typed = block as { type?: unknown; text?: unknown };
+    return typed.type === "text" && typeof typed.text === "string" ? [typed.text] : [];
+  }).join("\n");
+}
+
+export function withToolResultArtifactCapture(
+  tool: ToolDefinition,
+  store: ToolResultArtifactStore,
+): ToolDefinition {
+  const originalExecute = tool.execute.bind(tool) as ToolDefinition["execute"];
+  return {
+    ...tool,
+    execute: async (...executeArgs: Parameters<ToolDefinition["execute"]>) => {
+      const [toolCallId] = executeArgs;
+      const result = await originalExecute(...executeArgs);
+      const text = toolResultText(result);
+      if (!text || Buffer.byteLength(text, "utf8") < DEFAULT_CAPTURE_MIN_BYTES) return result;
+      const capture = await store.capture({ text, toolCallId, toolName: tool.name });
+      const resultRecord = result as unknown as Record<string, unknown>;
+      const details = resultRecord.details && typeof resultRecord.details === "object"
+        ? resultRecord.details as Record<string, unknown>
+        : {};
+      return {
+        ...resultRecord,
+        details: "reference" in capture
+          ? { ...details, [TOOL_RESULT_ARTIFACT_DETAIL_KEY]: capture.reference }
+          : { ...details, [TOOL_RESULT_ARTIFACT_FAILURE_DETAIL_KEY]: capture.failure },
+      } as Awaited<ReturnType<typeof originalExecute>>;
+    },
+  };
+}
+
+export function createToolResultArtifactTools(store: ToolResultArtifactStore): ResolvedToolDefinition[] {
+  const readTool: ResolvedToolDefinition = {
+    name: "tool_result_read",
+    label: "Read tool result artifact",
+    description: "Read a bounded character range from a complete tool-result artifact. Use the artifact_id returned by an earlier tool result. Continue with next_offset until complete.",
+    toolset: "artifact",
+    parameters: Type.Object({
+      artifact_id: Type.String({ description: "Opaque tool-result artifact ID." }),
+      offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset; defaults to 0." })),
+      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_READ_CHARS, description: `Characters to return; defaults to ${DEFAULT_READ_CHARS}.` })),
+    }),
+    execute: async (_toolCallId, args: any) => {
+      try {
+        const read = await store.read(args.artifact_id, args.offset, args.limit);
+        const header = JSON.stringify({
+          artifact_id: read.reference.id,
+          offset: read.offset,
+          next_offset: read.nextOffset,
+          complete: read.complete,
+          size_chars: read.reference.sizeChars,
+          sha256: read.reference.sha256,
+        });
+        return {
+          content: [{ type: "text" as const, text: `${header}\n${read.text}` }],
+          details: { [TOOL_RESULT_ARTIFACT_DETAIL_KEY]: read.reference },
+        };
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+  };
+
+  const searchTool: ResolvedToolDefinition = {
+    name: "tool_result_search",
+    label: "Search tool result artifact",
+    description: "Search a complete tool-result artifact using a case-insensitive literal query. Returns bounded snippets and character offsets for follow-up tool_result_read calls.",
+    toolset: "artifact",
+    parameters: Type.Object({
+      artifact_id: Type.String({ description: "Opaque tool-result artifact ID." }),
+      query: Type.String({ minLength: 1, maxLength: 512, description: "Literal text to find (case-insensitive)." }),
+      context_chars: Type.Optional(Type.Integer({ minimum: 0, maximum: MAX_SEARCH_CONTEXT_CHARS, description: `Characters included on each side; defaults to ${DEFAULT_SEARCH_CONTEXT_CHARS}.` })),
+      max_matches: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_SEARCH_MATCHES, description: `Maximum matches; defaults to ${DEFAULT_SEARCH_MATCHES}.` })),
+    }),
+    execute: async (_toolCallId, args: any) => {
+      try {
+        const search = await store.search(args.artifact_id, args.query, args.context_chars, args.max_matches);
+        return {
+          content: [{ type: "text" as const, text: formatSearchToolOutput(search) }],
+          details: { [TOOL_RESULT_ARTIFACT_DETAIL_KEY]: search.reference },
+        };
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error));
+      }
+    },
+  };
+
+  return [readTool, searchTool];
+}

--- a/src/core/tool-result-artifact.ts
+++ b/src/core/tool-result-artifact.ts
@@ -25,6 +25,11 @@ export function toolResultArtifactRoot(sessionDir: string): string {
   return path.join(path.resolve(sessionDir), ".tool-results");
 }
 
+/** True for any path under a `.tool-results` directory, including sibling sessions. */
+export function isToolResultArtifactPath(candidate: string): boolean {
+  return path.resolve(candidate).split(path.sep).includes(".tool-results");
+}
+
 export interface ToolResultArtifactScope {
   agentId: string;
   sessionId: string;

--- a/src/core/tool-result-artifact.ts
+++ b/src/core/tool-result-artifact.ts
@@ -174,6 +174,20 @@ export function getToolResultArtifactDetails(message: unknown): Record<string, u
   return null;
 }
 
+function boundedHeadTailPreview(preview: string, budget: number): string {
+  if (budget <= 0) return "";
+  if (preview.length <= budget) return preview;
+
+  const omission = "\n\n[... preview middle omitted ...]\n\n";
+  const remaining = Math.max(0, budget - omission.length);
+  if (remaining === 0) return preview.slice(0, budget);
+  const headChars = Math.ceil(remaining * 0.7);
+  const tailChars = remaining - headChars;
+  const head = preview.slice(0, headChars);
+  const tail = tailChars > 0 ? preview.slice(-tailChars) : "";
+  return head + omission + tail;
+}
+
 export function formatToolResultArtifactReference(
   reference: ToolResultArtifactReference,
   preview: string,
@@ -191,13 +205,7 @@ export function formatToolResultArtifactReference(
   const separator = "\n\nPreview:\n";
   const previewBudget = Math.max(0, maxChars - header.length - separator.length);
   if (previewBudget === 0) return header.slice(0, Math.max(0, maxChars));
-  if (preview.length <= previewBudget) return header + separator + preview;
-
-  const omission = "\n\n[... preview middle omitted ...]\n\n";
-  const remaining = Math.max(0, previewBudget - omission.length);
-  const headChars = Math.ceil(remaining * 0.7);
-  const tailChars = remaining - headChars;
-  return header + separator + preview.slice(0, headChars) + omission + preview.slice(-tailChars);
+  return header + separator + boundedHeadTailPreview(preview, previewBudget);
 }
 
 export function formatUnrecoverableToolResult(
@@ -213,7 +221,7 @@ export function formatUnrecoverableToolResult(
     "The omitted portion cannot be recovered. Rerun the source tool with narrower filters or pagination.",
   ].join("\n");
   const budget = Math.max(0, maxChars - notice.length - 2);
-  return `${notice}\n\n${preview.slice(0, budget)}`.slice(0, maxChars);
+  return `${notice}\n\n${boundedHeadTailPreview(preview, budget)}`.slice(0, maxChars);
 }
 
 export class ToolResultArtifactStore {

--- a/src/core/tool-result-context-guard.test.ts
+++ b/src/core/tool-result-context-guard.test.ts
@@ -8,6 +8,18 @@ import {
   PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
 } from "./tool-result-context-guard.js";
 
+function artifactReference(id = "tra_0123456789abcdef0123456789abcdef") {
+  return {
+    version: 1,
+    id,
+    sizeChars: 10_000,
+    sizeBytes: 10_000,
+    sha256: "a".repeat(64),
+    createdAt: "2026-09-03T00:00:00.000Z",
+    expiresAt: "2026-09-04T00:00:00.000Z",
+  };
+}
+
 describe("estimateMessageChars", () => {
   it("estimates user text message", () => {
     const msg = { role: "user", content: "hello world", timestamp: Date.now() } as any;
@@ -145,6 +157,83 @@ describe("enforceToolResultContextBudgetInPlace", () => {
         : "";
     expect(text.length).toBeLessThan(longText.length);
     expect(text).toContain("[truncated:");
+  });
+
+  it("replaces an oversized captured result with a recoverable artifact reference", () => {
+    const artifact = artifactReference();
+    const messages = [{
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [{ type: "text", text: `head\n${"x".repeat(9_900)}\nroot cause` }],
+      details: { providerNoise: "drop me", toolResultArtifact: artifact },
+      timestamp: Date.now(),
+    }] as any[];
+
+    enforceToolResultContextBudgetInPlace({
+      messages,
+      contextBudgetChars: 100_000,
+      maxSingleToolResultChars: 1_000,
+    });
+
+    const text = getToolResultText(messages[0]);
+    expect(text).toContain(artifact.id);
+    expect(text).toContain("tool_result_search");
+    expect(text).toContain("root cause");
+    expect(messages[0].details).toEqual({ toolResultArtifact: artifact });
+  });
+
+  it("keeps artifact recovery instructions when old results are compacted", () => {
+    const artifact = artifactReference();
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        content: [{ type: "text", text: "old evidence ".repeat(300) }],
+        details: { toolResultArtifact: artifact },
+        timestamp: Date.now(),
+      },
+      { role: "user", content: "new context ".repeat(300), timestamp: Date.now() },
+    ] as any[];
+
+    enforceToolResultContextBudgetInPlace({
+      messages,
+      contextBudgetChars: 2_000,
+      maxSingleToolResultChars: 20_000,
+    });
+
+    const text = getToolResultText(messages[0]);
+    expect(text).toContain(artifact.id);
+    expect(text).toContain("tool_result_read");
+    expect(text).not.toContain("[compacted:");
+    expect(messages[0].details.toolResultArtifact).toEqual(artifact);
+  });
+
+  it("states when an oversized result cannot be recovered", () => {
+    const messages = [{
+      role: "toolResult",
+      toolCallId: "call_1",
+      content: [{ type: "text", text: "x".repeat(10_000) }],
+      details: {
+        toolResultArtifactFailure: {
+          version: 1,
+          reason: "too_large",
+          sizeChars: 10_000,
+          sizeBytes: 10_000,
+        },
+      },
+      timestamp: Date.now(),
+    }] as any[];
+
+    enforceToolResultContextBudgetInPlace({
+      messages,
+      contextBudgetChars: 100_000,
+      maxSingleToolResultChars: 1_000,
+    });
+
+    const text = getToolResultText(messages[0]);
+    expect(text).toContain("complete artifact is unavailable");
+    expect(text).toContain("cannot be recovered");
+    expect(text).toContain("reason: too_large");
   });
 
   it("compacts oldest tool results when total context exceeds budget", () => {

--- a/src/core/tool-result-context-guard.test.ts
+++ b/src/core/tool-result-context-guard.test.ts
@@ -236,6 +236,30 @@ describe("enforceToolResultContextBudgetInPlace", () => {
     expect(text).toContain("reason: too_large");
   });
 
+  it("does not replace a small artifact-tagged result with a larger recovery stub", () => {
+    const artifact = artifactReference();
+    const smallText = "recovered snippet";
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "call_read",
+        content: [{ type: "text", text: smallText }],
+        details: { toolResultArtifact: artifact },
+        timestamp: Date.now(),
+      },
+      { role: "user", content: "new context ".repeat(400), timestamp: Date.now() },
+    ] as any[];
+
+    enforceToolResultContextBudgetInPlace({
+      messages,
+      contextBudgetChars: 2_000,
+      maxSingleToolResultChars: 20_000,
+    });
+
+    expect(getToolResultText(messages[0])).toBe(smallText);
+    expect(messages[0].details.toolResultArtifact).toEqual(artifact);
+  });
+
   it("compacts oldest tool results when total context exceeds budget", () => {
     // Create many tool results that together exceed budget
     const messages = Array.from({ length: 20 }, (_, i) => ({

--- a/src/core/tool-result-context-guard.ts
+++ b/src/core/tool-result-context-guard.ts
@@ -284,10 +284,10 @@ function compactExistingToolResultsInPlace(params: {
     const compactedText = recoverableToolResultText(msg, "", 1_024)
       ?? COMPACTION_PLACEHOLDER;
     const compacted = replaceToolResultText(msg, compactedText);
-    applyMessageMutationInPlace(msg, compacted, cache);
-    const after = estimateMessageCharsCached(msg, cache);
+    const after = estimateMessageChars(compacted);
     if (after >= before) continue;
 
+    applyMessageMutationInPlace(msg, compacted, cache);
     reduced += before - after;
     if (reduced >= charsNeeded) break;
   }

--- a/src/core/tool-result-context-guard.ts
+++ b/src/core/tool-result-context-guard.ts
@@ -11,6 +11,13 @@
  */
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ContextGuard } from "./guard-pipeline.js";
+import {
+  formatToolResultArtifactReference,
+  formatUnrecoverableToolResult,
+  getToolResultArtifactDetails,
+  getToolResultArtifactFailure,
+  getToolResultArtifactReference,
+} from "./tool-result-artifact.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -199,10 +206,25 @@ function replaceToolResultText(msg: AgentMessage, text: string): AgentMessage {
 
   const sourceRecord = msg as unknown as Record<string, unknown>;
   const { details: _details, ...rest } = sourceRecord;
+  const artifactDetails = getToolResultArtifactDetails(msg);
   return {
     ...rest,
     content: replacementContent,
+    ...(artifactDetails ? { details: artifactDetails } : {}),
   } as AgentMessage;
+}
+
+function recoverableToolResultText(msg: AgentMessage, preview: string, maxChars: number): string | null {
+  const details = (msg as { details?: unknown }).details;
+  const artifact = getToolResultArtifactReference(details);
+  if (artifact) {
+    return formatToolResultArtifactReference(artifact, preview, maxChars);
+  }
+  const artifactFailure = getToolResultArtifactFailure(details);
+  if (artifactFailure) {
+    return formatUnrecoverableToolResult(artifactFailure, preview, maxChars);
+  }
+  return null;
 }
 
 function truncateToolResultToChars(
@@ -218,7 +240,8 @@ function truncateToolResultToChars(
   const rawText = getToolResultText(msg);
   if (!rawText) return replaceToolResultText(msg, TRUNCATION_NOTICE);
 
-  const truncatedText = truncateTextToBudget(rawText, maxChars);
+  const truncatedText = recoverableToolResultText(msg, rawText, maxChars)
+    ?? truncateTextToBudget(rawText, maxChars);
   return replaceToolResultText(msg, truncatedText);
 }
 
@@ -258,7 +281,9 @@ function compactExistingToolResultsInPlace(params: {
     const before = estimateMessageCharsCached(msg, cache);
     if (before <= COMPACTION_PLACEHOLDER.length) continue;
 
-    const compacted = replaceToolResultText(msg, COMPACTION_PLACEHOLDER);
+    const compactedText = recoverableToolResultText(msg, "", 1_024)
+      ?? COMPACTION_PLACEHOLDER;
+    const compacted = replaceToolResultText(msg, compactedText);
     applyMessageMutationInPlace(msg, compacted, cache);
     const after = estimateMessageCharsCached(msg, cache);
     if (after >= before) continue;

--- a/src/tools/infra/command-sets.ts
+++ b/src/tools/infra/command-sets.ts
@@ -2231,6 +2231,10 @@ export const CONTAINER_SENSITIVE_PATHS: RegExp[] = [
   /\.mysql_history/,
   /\.psql_history/,
   /\.node_repl_history/,
+  // Session-scoped MCP artifacts. File tools already refuse every `.tool-results`
+  // tree; this keeps restricted_bash from `cat`-ing sibling sessions on a shared
+  // LocalSpawner filesystem.
+  /\.tool-results(\/|$)/,
 ];
 
 /**
@@ -2283,4 +2287,5 @@ export const SENSITIVE_PATH_EXAMPLES: readonly string[] = [
   "/root/.mysql_history",
   "/root/.psql_history",
   "/root/.node_repl_history",
+  "/app/.siclaw/user-data/agent/sessions/s1/.tool-results/abc/tra_x.txt",
 ];

--- a/src/tools/infra/sensitive-path-protection.test.ts
+++ b/src/tools/infra/sensitive-path-protection.test.ts
@@ -59,6 +59,7 @@ describe("CONTAINER_SENSITIVE_PATHS pattern matching", () => {
     "cat ~/.mysql_history",
     "cat ~/.psql_history",
     "cat ~/.node_repl_history",
+    "cat .siclaw/user-data/agent/sessions/other/.tool-results/abc/tra_x.txt",
   ];
 
   for (const cmd of blocked) {
@@ -100,6 +101,7 @@ describe("validateCommand blocks sensitive paths in all contexts", () => {
     "head /root/.ssh/id_rsa",
     "ls /root/.aws/credentials",
     "grep password /proc/1/cmdline",
+    "cat .siclaw/user-data/agent/sessions/other/.tool-results/abc/tra_x.txt",
   ];
 
   for (const ctx of contexts) {


### PR DESCRIPTION
## Summary

Large MCP text results are now captured before context and persistence guards can shrink them. When a guard must reduce the inline result, Siclaw keeps a bounded preview plus an opaque recovery handle and exposes bounded read/search tools for retrieving the complete evidence.

### Problem

Large MCP results could be hard-truncated at persistence or removed during context compaction. Evidence in the omitted middle or tail was then unavailable to the model, which could lower diagnosis quality and encourage blind tool retries.

### Solution

- Capture MCP text results at or above 32 KiB without changing the live tool result delivered by the execution event path.
- Store artifacts under the framework session directory with Agent and session scoping, SHA-256 integrity metadata, 24-hour expiry, and per-artifact/per-scope limits.
- Expose intrinsic tool_result_search and tool_result_read companions only when MCP tools exist; neither accepts a filesystem path.
- Replace artifact-backed truncation and compaction with a bounded head/tail preview, digest, expiry, and recovery instructions.
- Preserve the legacy guard behavior for uncaptured output and explicitly state when artifact creation failed and omitted content is unrecoverable.
- Block generic file tools from every `.tool-results` tree on the AgentBox, including sibling sessions; reject a symlink storage root and use 0700 directories plus 0600 files.

This is Siclaw Runtime only. It does not add control-plane APIs, frontend surfaces, object storage, or alter MCP discovery.

## Test Plan

- [x] npx tsc --noEmit passes
- [x] npm test passes: 300 files, 6670 passed, 2 skipped
- [x] npm run build passes
- [x] Focused artifact, guard, and wiring tests pass: 48 passed, 1 skipped

## Architecture Checklist

- [ ] Deployment mode: no runtime image was deployed for this source-only change; storage behavior is covered with temporary-directory, permission, symlink, scope, expiry, quota, and recovery tests.
- [x] Security model: no shell execution path was added; artifacts are private, opaque, session-scoped, integrity-checked, and unavailable through generic file tools.
- [x] DB parity: not applicable; no schema or database changes.
- [x] Tool protocol: recovery tools use TypeBox ToolDefinition-compatible schemas and are intrinsic companions to configured MCP tools.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included