### PR TITLE
fix(channels): configure visual export endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+#### Visual export endpoint configuration
+
+Visual rendering no longer assumes an in-cluster `visual-export-web` DNS name. Deployments that enable the bundled `create-chart` MCP must set `runtime.visualExport.url` to a reachable `/siclaw-visual-export` page before upgrading. Runtime forwards the validated URL and one end-to-end timeout budget to AgentBox pods and their stdio MCP process; invalid configuration produces an operator-visible startup warning and a distinct tool error. Lark and DingTalk now suppress only source blocks paired with attempted renders, confirm image delivery before claiming success, and keep usable text fallbacks visible.
+
 #### KB compile box: distinct image name + pod prefix (operations)
 
 Renamed the KB compile box so operators can tell it apart from chat agentboxes at a glance during production troubleshooting (previously every pod was `agentbox-<id>` and the compile box could only be isolated by label/image filter).

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -194,6 +194,18 @@ spec:
                   key: {{ .tokenSecret.key | default "ANTHROPIC_AUTH_TOKEN" }}
             {{- end }}
             {{- end }}
+            {{- with .Values.runtime.visualExport }}
+            {{- if .url }}
+            # Visual rendering happens inside AgentBox pods. The Runtime-level
+            # values are forwarded by K8sSpawner when each box is created.
+            - name: SICLAW_VISUAL_EXPORT_URL
+              value: {{ .url | quote }}
+            - name: SICLAW_VISUAL_EXPORT_TIMEOUT_MS
+              value: {{ .timeoutMs | default 30000 | quote }}
+            - name: SICLAW_VISUAL_EXPORT_THEME
+              value: {{ .theme | default "light" | quote }}
+            {{- end }}
+            {{- end }}
             - name: NODE_OPTIONS
               value: {{ printf "--max-old-space-size=%v" (.Values.runtime.nodeMaxOldSpaceMB | default 1024) | quote }}
             # User-supplied env entries come last so callers can override any

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -80,6 +80,17 @@ runtime:
                           # endpoint on a DIFFERENT origin than the LLM provider.
                           # If the embedding baseUrl is the SAME origin as the
                           # default LLM provider, that provider's key is reused.
+  # Browser-rendered charts, diagrams, and report cards. The URL must point to
+  # a reachable ControlPlane Web /siclaw-visual-export page; this chart does not
+  # install that external renderer or assume its Kubernetes Service name.
+  # Values are forwarded from Runtime to every normal AgentBox because the MCP
+  # renderer executes inside the AgentBox process.
+  visualExport:
+    url: ""                # e.g. https://console.example.com/siclaw-visual-export
+    # One end-to-end renderer budget. The bundled MCP request timeout is this
+    # value plus a 5s transport grace period, so values above 60s remain effective.
+    timeoutMs: 30000
+    theme: light           # light or dark
   # Max sub-agent child sessions ONE CONVERSATION runs concurrently. A wide
   # spawn_subagent fan-out queues past this instead of starting one child agent +
   # one LLM stream per target at once (avoids provider 429s / pod pressure).

--- a/mcp/create-chart/src/handler.ts
+++ b/mcp/create-chart/src/handler.ts
@@ -1,5 +1,6 @@
 import { exportMarkdownVisualsWithVisualExportWeb } from "./visual-export.js";
 import type { RenderChartArgs, RenderChartResult, RenderChartToolResponse } from "./types.js";
+import { rendererError, VisualToolInputError, VisualToolRendererError } from "./tool-error.js";
 
 const CHART_SPEC_VERSION = 1;
 const VISUAL_SPEC_VERSION = 1;
@@ -115,9 +116,9 @@ export async function handleRenderChart(rawArgs: unknown): Promise<RenderChartTo
 
   const spec = JSON.stringify(args);
   const markdownEmbed = "```chart\n" + spec + "\n```";
-  const exported = await exportMarkdownVisualsWithVisualExportWeb(markdownEmbed);
+  const exported = await exportVisual(markdownEmbed);
   const visual = exported.find((item) => item.kind === "chart") ?? exported[0];
-  if (!visual?.image) throw new Error("render_chart: ControlPlane Web export returned no chart image");
+  if (!visual?.image) throw new VisualToolRendererError("render_chart: ControlPlane Web export returned no chart image");
   const png = visual.image;
 
   const result: RenderChartResult = {
@@ -161,9 +162,9 @@ export async function handleRenderMermaid(rawArgs: unknown): Promise<RenderChart
   const args = validateMermaid(rawArgs);
   const id = newChartId("mermaid");
   const markdownEmbed = "```mermaid\n" + args.source + "\n```";
-  const exported = await exportMarkdownVisualsWithVisualExportWeb(markdownEmbed);
+  const exported = await exportVisual(markdownEmbed);
   const visual = exported.find((item) => item.kind === "mermaid") ?? exported[0];
-  if (!visual?.image) throw new Error("render_mermaid: ControlPlane Web export returned no Mermaid image");
+  if (!visual?.image) throw new VisualToolRendererError("render_mermaid: ControlPlane Web export returned no Mermaid image");
 
   const meta = visualMetadata(id, "mermaid", markdownEmbed, visual.image);
 
@@ -193,9 +194,9 @@ export async function handleRenderVisualCard(rawArgs: unknown): Promise<RenderCh
   const id = newChartId("visual-card");
   const specJson = JSON.stringify(spec);
   const markdownEmbed = "```visual-card\n" + specJson + "\n```";
-  const exported = await exportMarkdownVisualsWithVisualExportWeb(markdownEmbed);
+  const exported = await exportVisual(markdownEmbed);
   const visual = exported.find((item) => item.kind === "visual-card") ?? exported[0];
-  if (!visual?.image) throw new Error("render_visual_card: ControlPlane Web export returned no visual-card image");
+  if (!visual?.image) throw new VisualToolRendererError("render_visual_card: ControlPlane Web export returned no visual-card image");
 
   const meta = visualMetadata(id, "visual-card", markdownEmbed, visual.image);
 
@@ -244,16 +245,16 @@ function visualMetadata(
 
 export function validate(raw: unknown): RenderChartArgs {
   if (!raw || typeof raw !== "object") {
-    throw new Error("render_chart: arguments must be an object");
+    throw new VisualToolInputError("render_chart: arguments must be an object");
   }
   const obj = raw as Record<string, unknown>;
   const type = obj.type;
   if (type !== "pie" && type !== "bar" && type !== "line") {
-    throw new Error("render_chart: type must be pie, bar, or line");
+    throw new VisualToolInputError("render_chart: type must be pie, bar, or line");
   }
   const data = obj.data;
   if (!data || typeof data !== "object") {
-    throw new Error("render_chart: data is required");
+    throw new VisualToolInputError("render_chart: data is required");
   }
   const common: Record<string, unknown> = {};
   for (const k of ["title", "x_label", "y_label"]) {
@@ -266,12 +267,12 @@ export function validate(raw: unknown): RenderChartArgs {
   if (type === "pie") {
     const slices = (data as { slices?: unknown }).slices;
     if (!Array.isArray(slices) || slices.length === 0) {
-      throw new Error("render_chart: pie.data.slices must be a non-empty array");
+      throw new VisualToolInputError("render_chart: pie.data.slices must be a non-empty array");
     }
     const cleaned = slices.map((s, i) => {
       const item = s as { label?: unknown; value?: unknown };
       if (typeof item.value !== "number" || !Number.isFinite(item.value)) {
-        throw new Error(`render_chart: pie slice[${i}].value must be a number`);
+        throw new VisualToolInputError(`render_chart: pie slice[${i}].value must be a number`);
       }
       return { label: String(item.label ?? `slice ${i}`), value: item.value };
     });
@@ -281,19 +282,19 @@ export function validate(raw: unknown): RenderChartArgs {
   if (type === "bar") {
     const d = data as { categories?: unknown; series?: unknown };
     if (!Array.isArray(d.categories) || !d.categories.length) {
-      throw new Error("render_chart: bar.data.categories must be a non-empty array");
+      throw new VisualToolInputError("render_chart: bar.data.categories must be a non-empty array");
     }
     if (!Array.isArray(d.series) || !d.series.length) {
-      throw new Error("render_chart: bar.data.series must be a non-empty array");
+      throw new VisualToolInputError("render_chart: bar.data.series must be a non-empty array");
     }
     const categories = d.categories.map(String);
     const series = d.series.map((s, i) => {
       const item = s as { name?: unknown; values?: unknown };
       if (!Array.isArray(item.values)) {
-        throw new Error(`render_chart: bar series[${i}].values must be an array`);
+        throw new VisualToolInputError(`render_chart: bar series[${i}].values must be an array`);
       }
       if (item.values.length !== categories.length) {
-        throw new Error(
+        throw new VisualToolInputError(
           `render_chart: bar series[${i}].values length (${item.values.length}) must equal categories length (${categories.length})`,
         );
       }
@@ -302,7 +303,7 @@ export function validate(raw: unknown): RenderChartArgs {
         values: item.values.map((v, j) => {
           const n = typeof v === "number" ? v : Number(v);
           if (!Number.isFinite(n)) {
-            throw new Error(
+            throw new VisualToolInputError(
               `render_chart: bar series[${i}].values[${j}] must be a finite number`,
             );
           }
@@ -315,17 +316,17 @@ export function validate(raw: unknown): RenderChartArgs {
 
   const d = data as { series?: unknown };
   if (!Array.isArray(d.series) || !d.series.length) {
-    throw new Error("render_chart: line.data.series must be a non-empty array");
+    throw new VisualToolInputError("render_chart: line.data.series must be a non-empty array");
   }
   const series = d.series.map((s, i) => {
     const item = s as { name?: unknown; points?: unknown };
     if (!Array.isArray(item.points) || !item.points.length) {
-      throw new Error(`render_chart: line series[${i}].points must be a non-empty array`);
+      throw new VisualToolInputError(`render_chart: line series[${i}].points must be a non-empty array`);
     }
     const points = item.points.map((p, j) => {
       const pt = p as { x?: unknown; y?: unknown };
       if (typeof pt.y !== "number" || !Number.isFinite(pt.y)) {
-        throw new Error(`render_chart: line series[${i}].points[${j}].y must be a number`);
+        throw new VisualToolInputError(`render_chart: line series[${i}].points[${j}].y must be a number`);
       }
       const x =
         typeof pt.x === "number" || typeof pt.x === "string"
@@ -340,11 +341,11 @@ export function validate(raw: unknown): RenderChartArgs {
 
 export function validateMermaid(raw: unknown): { source: string; title?: string } {
   if (!raw || typeof raw !== "object") {
-    throw new Error("render_mermaid: arguments must be an object");
+    throw new VisualToolInputError("render_mermaid: arguments must be an object");
   }
   const obj = raw as Record<string, unknown>;
   if (typeof obj.source !== "string" || !obj.source.trim()) {
-    throw new Error("render_mermaid: source is required");
+    throw new VisualToolInputError("render_mermaid: source is required");
   }
   const source = stripFence(obj.source.trim(), "mermaid");
   const out: { source: string; title?: string } = { source };
@@ -354,18 +355,18 @@ export function validateMermaid(raw: unknown): { source: string; title?: string 
 
 export function validateVisualCard(raw: unknown): Record<string, unknown> {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("render_visual_card: arguments must be an object");
+    throw new VisualToolInputError("render_visual_card: arguments must be an object");
   }
   const obj = raw as Record<string, unknown>;
   const type = typeof obj.type === "string" ? obj.type : "";
   if (!RENDER_VISUAL_CARD_INPUT_SCHEMA.properties.type.enum.includes(type as any)) {
-    throw new Error("render_visual_card: type is required and must be a supported ControlPlane visual-card type");
+    throw new VisualToolInputError("render_visual_card: type is required and must be a supported ControlPlane visual-card type");
   }
   if (typeof obj.title !== "string" || !obj.title.trim()) {
-    throw new Error("render_visual_card: title is required");
+    throw new VisualToolInputError("render_visual_card: title is required");
   }
   if (!hasVisualCardBody(obj)) {
-    throw new Error("render_visual_card: provide conclusion, items, metrics, segments, events, nodes, actions, or sections");
+    throw new VisualToolInputError("render_visual_card: provide conclusion, items, metrics, segments, events, nodes, actions, or sections");
   }
   const allowed = new Set(Object.keys(RENDER_VISUAL_CARD_INPUT_SCHEMA.properties));
   const out: Record<string, unknown> = {};
@@ -387,4 +388,12 @@ function hasVisualCardBody(obj: Record<string, unknown>): boolean {
 function stripFence(source: string, language: string): string {
   const re = new RegExp(`^\\s*\`\`\`${language}\\s*\\r?\\n([\\s\\S]*?)\\r?\\n\`\`\`\\s*$`, "i");
   return source.replace(re, "$1").trim();
+}
+
+async function exportVisual(markdown: string) {
+  try {
+    return await exportMarkdownVisualsWithVisualExportWeb(markdown);
+  } catch (err) {
+    throw rendererError(err);
+  }
 }

--- a/mcp/create-chart/src/index.ts
+++ b/mcp/create-chart/src/index.ts
@@ -32,6 +32,8 @@ import {
   handleRenderMermaid,
   handleRenderVisualCard,
 } from "./handler.js";
+import { visualToolErrorResponse } from "./tool-error.js";
+import { visualExportConfigurationWarning } from "./visual-export-config.js";
 
 async function main(): Promise<void> {
   const server = new Server(
@@ -72,16 +74,14 @@ async function main(): Promise<void> {
       }
       throw new Error(`Unknown tool: ${req.params.name}`);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      return {
-        isError: true,
-        content: [{ type: "text", text: msg }],
-      };
+      return visualToolErrorResponse(err);
     }
   });
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  const configurationWarning = visualExportConfigurationWarning();
+  if (configurationWarning) process.stderr.write(`[mcp-create-chart] warning: ${configurationWarning}\n`);
   process.stderr.write("[mcp-create-chart] ready\n");
 }
 

--- a/mcp/create-chart/src/tool-error.test.ts
+++ b/mcp/create-chart/src/tool-error.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  VisualToolConfigurationError,
+  VisualToolInputError,
+  VisualToolRendererError,
+  visualToolErrorResponse,
+} from "./tool-error.js";
+
+describe("visualToolErrorResponse", () => {
+  it("marks model argument validation separately from renderer failures", () => {
+    expect(visualToolErrorResponse(new VisualToolInputError("bad arguments"))).toMatchObject({
+      isError: true,
+      structuredContent: { error_kind: "input" },
+    });
+    expect(visualToolErrorResponse(new VisualToolRendererError("page unavailable"))).toMatchObject({
+      isError: true,
+      structuredContent: { error_kind: "renderer" },
+    });
+    expect(visualToolErrorResponse(new VisualToolConfigurationError("missing URL"))).toMatchObject({
+      isError: true,
+      structuredContent: { error_kind: "configuration" },
+    });
+  });
+
+  it("does not mislabel unexpected implementation errors as renderer outages", () => {
+    expect(visualToolErrorResponse(new Error("unexpected"))).toMatchObject({
+      isError: true,
+      structuredContent: { error_kind: "internal" },
+    });
+  });
+});

--- a/mcp/create-chart/src/tool-error.ts
+++ b/mcp/create-chart/src/tool-error.ts
@@ -1,0 +1,38 @@
+export type VisualToolErrorKind = "input" | "configuration" | "renderer" | "internal";
+
+export class VisualToolInputError extends Error {
+  readonly kind = "input" as const;
+}
+
+export class VisualToolRendererError extends Error {
+  readonly kind = "renderer" as const;
+}
+
+export class VisualToolConfigurationError extends Error {
+  readonly kind = "configuration" as const;
+}
+
+export function visualToolErrorResponse(err: unknown): {
+  isError: true;
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: { error_kind: VisualToolErrorKind };
+} {
+  const message = err instanceof Error ? err.message : String(err);
+  const errorKind: VisualToolErrorKind = err instanceof VisualToolInputError
+    ? "input"
+    : err instanceof VisualToolConfigurationError
+      ? "configuration"
+    : err instanceof VisualToolRendererError
+      ? "renderer"
+      : "internal";
+  return {
+    isError: true,
+    content: [{ type: "text", text: message }],
+    structuredContent: { error_kind: errorKind },
+  };
+}
+
+export function rendererError(err: unknown): VisualToolRendererError | VisualToolConfigurationError {
+  if (err instanceof VisualToolRendererError || err instanceof VisualToolConfigurationError) return err;
+  return new VisualToolRendererError(err instanceof Error ? err.message : String(err));
+}

--- a/mcp/create-chart/src/visual-export-config.ts
+++ b/mcp/create-chart/src/visual-export-config.ts
@@ -1,0 +1,54 @@
+import { VisualToolConfigurationError } from "./tool-error.js";
+
+export const DEFAULT_VISUAL_EXPORT_TIMEOUT_MS = 30_000;
+
+export function resolveVisualExportUrl(override?: string): string {
+  const configured = (override ?? process.env.SICLAW_VISUAL_EXPORT_URL)?.trim();
+  if (!configured) {
+    throw new VisualToolConfigurationError(
+      "Visual export is not configured; set SICLAW_VISUAL_EXPORT_URL to a reachable /siclaw-visual-export page",
+    );
+  }
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    throw new VisualToolConfigurationError(
+      "Visual export URL must be an absolute HTTP(S) URL",
+    );
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new VisualToolConfigurationError(
+      "Visual export URL must use the http or https scheme",
+    );
+  }
+  if (configured.includes("#")) {
+    throw new VisualToolConfigurationError(
+      "Visual export URL must not contain a fragment (#); configure the page URL before the hash payload",
+    );
+  }
+  const pathname = url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${pathname}${url.search}`;
+}
+
+export function resolveVisualExportTimeoutMs(override?: number): number {
+  const raw = override ?? Number(
+    process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS ?? DEFAULT_VISUAL_EXPORT_TIMEOUT_MS,
+  );
+  if (!Number.isFinite(raw) || raw <= 0) {
+    throw new VisualToolConfigurationError(
+      "Visual export timeout must be a positive number of milliseconds",
+    );
+  }
+  return Math.ceil(raw);
+}
+
+export function visualExportConfigurationWarning(): string | null {
+  try {
+    resolveVisualExportUrl();
+    resolveVisualExportTimeoutMs();
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}

--- a/mcp/create-chart/src/visual-export-runtime.test.ts
+++ b/mcp/create-chart/src/visual-export-runtime.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { launchMock } = vi.hoisted(() => ({ launchMock: vi.fn() }));
+
+vi.mock("playwright-core", () => ({
+  chromium: { launch: launchMock },
+}));
+
+import { exportMarkdownVisualsWithVisualExportWeb } from "./visual-export.js";
+
+const png =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+describe("visual export deadline", () => {
+  beforeEach(() => {
+    launchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shares one timeout budget across browser launch, navigation, and readiness", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const goto = vi.fn(async () => { now = 1_700; });
+    const waitForFunction = vi.fn(async () => { now = 1_800; });
+    const page = {
+      goto,
+      waitForFunction,
+      evaluate: vi.fn(async () => [{ kind: "visual-card", dataUrl: `data:image/png;base64,${png}` }]),
+    };
+    const browser = {
+      newPage: vi.fn(async () => { now = 1_200; return page; }),
+      close: vi.fn(async () => undefined),
+    };
+    launchMock.mockImplementation(async () => { now = 1_100; return browser; });
+
+    await exportMarkdownVisualsWithVisualExportWeb("```visual-card\n{}\n```", {
+      baseUrl: "https://console.example.com/siclaw-visual-export",
+      timeoutMs: 1_000,
+    });
+
+    expect(launchMock.mock.calls[0][0].timeout).toBe(1_000);
+    expect(goto.mock.calls[0][1].timeout).toBe(800);
+    expect(waitForFunction.mock.calls[0][2].timeout).toBe(300);
+  });
+
+  it("stops before the next phase when an earlier phase exhausts the shared budget", async () => {
+    let now = 2_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const waitForFunction = vi.fn();
+    const browser = {
+      newPage: vi.fn(async () => ({
+        goto: vi.fn(async () => { now = 2_501; }),
+        waitForFunction,
+        evaluate: vi.fn(),
+      })),
+      close: vi.fn(async () => undefined),
+    };
+    launchMock.mockResolvedValue(browser);
+
+    await expect(exportMarkdownVisualsWithVisualExportWeb("```chart\n{}\n```", {
+      baseUrl: "https://console.example.com/siclaw-visual-export",
+      timeoutMs: 500,
+    })).rejects.toThrow(/timed out after 500ms/);
+    expect(waitForFunction).not.toHaveBeenCalled();
+    expect(browser.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcp/create-chart/src/visual-export.test.ts
+++ b/mcp/create-chart/src/visual-export.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveVisualExportTimeoutMs,
+  resolveVisualExportUrl,
+  visualExportConfigurationWarning,
+} from "./visual-export-config.js";
+
+const originalUrl = process.env.SICLAW_VISUAL_EXPORT_URL;
+const originalTimeout = process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS;
+
+afterEach(() => {
+  if (originalUrl === undefined) delete process.env.SICLAW_VISUAL_EXPORT_URL;
+  else process.env.SICLAW_VISUAL_EXPORT_URL = originalUrl;
+  if (originalTimeout === undefined) delete process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS;
+  else process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS = originalTimeout;
+});
+
+describe("resolveVisualExportUrl", () => {
+  it("requires an explicitly configured renderer instead of inventing service DNS", () => {
+    delete process.env.SICLAW_VISUAL_EXPORT_URL;
+    expect(() => resolveVisualExportUrl()).toThrow(/set SICLAW_VISUAL_EXPORT_URL/);
+  });
+
+  it("uses the configured endpoint and removes trailing slashes", () => {
+    process.env.SICLAW_VISUAL_EXPORT_URL = "  https://console.example.com/siclaw-visual-export///  ";
+    expect(resolveVisualExportUrl()).toBe("https://console.example.com/siclaw-visual-export");
+  });
+
+  it("prefers a call-site override over the process environment", () => {
+    process.env.SICLAW_VISUAL_EXPORT_URL = "https://env.example.com/export";
+    expect(resolveVisualExportUrl("https://override.example.com/export/"))
+      .toBe("https://override.example.com/export");
+  });
+
+  it("rejects a configured fragment before the renderer burns its navigation timeout", () => {
+    expect(() => resolveVisualExportUrl("https://console.example.com/#/siclaw-visual-export"))
+      .toThrow(/must not contain a fragment/);
+    expect(() => resolveVisualExportUrl("https://console.example.com/siclaw-visual-export#"))
+      .toThrow(/must not contain a fragment/);
+  });
+
+  it("returns a normalized parsed URL while preserving query parameters", () => {
+    expect(resolveVisualExportUrl("https://console.example.com/export///?locale=zh-CN"))
+      .toBe("https://console.example.com/export?locale=zh-CN");
+  });
+
+  it("rejects relative and non-HTTP renderer locations as configuration errors", () => {
+    expect(() => resolveVisualExportUrl("console.example.com/export")).toThrow(/absolute HTTP\(S\)/);
+    expect(() => resolveVisualExportUrl("file:///tmp/export.html")).toThrow(/http or https/);
+  });
+
+  it("provides a startup warning for every invalid renderer endpoint", () => {
+    delete process.env.SICLAW_VISUAL_EXPORT_URL;
+    expect(visualExportConfigurationWarning()).toMatch(/set SICLAW_VISUAL_EXPORT_URL/);
+    process.env.SICLAW_VISUAL_EXPORT_URL = "https://console.example.com/#/export";
+    expect(visualExportConfigurationWarning()).toMatch(/must not contain a fragment/);
+    process.env.SICLAW_VISUAL_EXPORT_URL = "https://console.example.com/export";
+    process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS = "invalid";
+    expect(visualExportConfigurationWarning()).toMatch(/positive number/);
+    delete process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS;
+    expect(visualExportConfigurationWarning()).toBeNull();
+  });
+
+  it("validates and normalizes the end-to-end timeout budget", () => {
+    expect(resolveVisualExportTimeoutMs(12_345.2)).toBe(12_346);
+    expect(() => resolveVisualExportTimeoutMs(0)).toThrow(/positive number/);
+    expect(() => resolveVisualExportTimeoutMs(Number.NaN)).toThrow(/positive number/);
+  });
+});

--- a/mcp/create-chart/src/visual-export.ts
+++ b/mcp/create-chart/src/visual-export.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser } from "playwright-core";
+import { resolveVisualExportTimeoutMs, resolveVisualExportUrl } from "./visual-export-config.js";
 
 export interface ExportedVisual {
   kind: "chart" | "mermaid" | "visual-card";
@@ -14,30 +15,30 @@ interface VisualExportOptions {
   timeoutMs?: number;
 }
 
-const DEFAULT_EXPORT_URL = "http://visual-export-web:3000/siclaw-visual-export";
-
 export async function exportMarkdownVisualsWithVisualExportWeb(
   markdown: string,
   options: VisualExportOptions = {},
 ): Promise<ExportedVisual[]> {
-  const baseUrl =
-    options.baseUrl ??
-    process.env.SICLAW_VISUAL_EXPORT_URL ??
-    DEFAULT_EXPORT_URL;
-  const timeoutMs = options.timeoutMs ?? Number(process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS ?? 30_000);
-  const browser = await launchBrowser();
+  const baseUrl = resolveVisualExportUrl(options.baseUrl);
+  const timeoutMs = resolveVisualExportTimeoutMs(options.timeoutMs);
+  const deadline = Date.now() + timeoutMs;
+  const browser = await launchBrowser(remainingTimeout(deadline, timeoutMs));
   try {
-    const page = await browser.newPage({
-      viewport: { width: 1120, height: 900 },
-      deviceScaleFactor: 1,
-    });
+    const page = await withDeadline(
+      () => browser.newPage({
+        viewport: { width: 1120, height: 900 },
+        deviceScaleFactor: 1,
+      }),
+      deadline,
+      timeoutMs,
+    );
     const payload = base64UrlEncode(JSON.stringify({
       markdown,
       theme: options.theme ?? process.env.SICLAW_VISUAL_EXPORT_THEME ?? "light",
     }));
     await page.goto(`${baseUrl}#${payload}`, {
       waitUntil: "networkidle",
-      timeout: timeoutMs,
+      timeout: remainingTimeout(deadline, timeoutMs),
     });
     await page.waitForFunction(
       () => {
@@ -48,14 +49,18 @@ export async function exportMarkdownVisualsWithVisualExportWeb(
         return Boolean(w.__siclawVisualExportReady && w.__siclawExportVisuals);
       },
       undefined,
-      { timeout: timeoutMs },
+      { timeout: remainingTimeout(deadline, timeoutMs) },
     );
-    const exported = await page.evaluate(async () => {
-      const w = globalThis as typeof globalThis & {
-        __siclawExportVisuals?: () => Promise<unknown>;
-      };
-      return await w.__siclawExportVisuals?.();
-    });
+    const exported = await withDeadline(
+      () => page.evaluate(async () => {
+        const w = globalThis as typeof globalThis & {
+          __siclawExportVisuals?: () => Promise<unknown>;
+        };
+        return await w.__siclawExportVisuals?.();
+      }),
+      deadline,
+      timeoutMs,
+    );
     if (!Array.isArray(exported) || exported.length === 0) {
       throw new Error("ControlPlane visual export returned no images");
     }
@@ -78,7 +83,7 @@ export async function exportMarkdownVisualsWithVisualExportWeb(
   }
 }
 
-async function launchBrowser(): Promise<Browser> {
+async function launchBrowser(timeoutMs: number): Promise<Browser> {
   const executablePath =
     process.env.SICLAW_VISUAL_EXPORT_CHROMIUM ??
     process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ??
@@ -97,6 +102,7 @@ async function launchBrowser(): Promise<Browser> {
   return await chromium.launch({
     executablePath,
     headless: true,
+    timeout: timeoutMs,
     env: {
       ...process.env,
       HOME: homeDir,
@@ -111,6 +117,31 @@ async function launchBrowser(): Promise<Browser> {
       "--font-render-hinting=none",
     ],
   });
+}
+
+function remainingTimeout(deadline: number, timeoutMs: number): number {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw new Error(`Visual export timed out after ${timeoutMs}ms`);
+  return remaining;
+}
+
+async function withDeadline<T>(start: () => Promise<T>, deadline: number, timeoutMs: number): Promise<T> {
+  const remaining = remainingTimeout(deadline, timeoutMs);
+  const operation = start();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Visual export timed out after ${timeoutMs}ms`)),
+          remaining,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function pngFromDataUrl(dataUrl: string): Buffer {

--- a/src/core/mcp-client.test.ts
+++ b/src/core/mcp-client.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi } from "vitest";
-import { jsonSchemaToTypebox, normalizeMcpInputSchema, buildMcpToolName, isMcpTool, MCP_TOOL_PREFIX, mcpContentToAgentContent, McpClientManager } from "./mcp-client.js";
+import {
+  jsonSchemaToTypebox,
+  normalizeMcpInputSchema,
+  buildMcpToolName,
+  isMcpTool,
+  MCP_TOOL_PREFIX,
+  mcpContentToAgentContent,
+  McpClientManager,
+  mergeMcpStdioEnv,
+  visualMcpRequestTimeoutMs,
+} from "./mcp-client.js";
 
 describe("jsonSchemaToTypebox", () => {
   it("converts string type", () => {
@@ -143,6 +153,56 @@ describe("mcpContentToAgentContent", () => {
   });
 });
 
+describe("mergeMcpStdioEnv", () => {
+  it("forwards the visual export contract into stdio MCP child processes", () => {
+    expect(mergeMcpStdioEnv(undefined, {
+      SICLAW_VISUAL_EXPORT_URL: "https://console.example.com/siclaw-visual-export",
+      SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "15000",
+      SICLAW_VISUAL_EXPORT_THEME: "dark",
+      SICLAW_VISUAL_EXPORT_CHROMIUM: "/opt/chromium",
+      SECRET_NOT_FOR_MCP: "must-not-leak",
+    })).toEqual({
+      SICLAW_VISUAL_EXPORT_URL: "https://console.example.com/siclaw-visual-export",
+      SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "15000",
+      SICLAW_VISUAL_EXPORT_THEME: "dark",
+      SICLAW_VISUAL_EXPORT_CHROMIUM: "/opt/chromium",
+    });
+  });
+
+  it("lets an explicit MCP server config override the inherited value", () => {
+    expect(mergeMcpStdioEnv(
+      { SICLAW_VISUAL_EXPORT_THEME: "light", CUSTOM_MCP_VALUE: "configured" },
+      { SICLAW_VISUAL_EXPORT_THEME: "dark" },
+    )).toEqual({
+      SICLAW_VISUAL_EXPORT_THEME: "light",
+      CUSTOM_MCP_VALUE: "configured",
+    });
+  });
+});
+
+describe("visualMcpRequestTimeoutMs", () => {
+  it("adds transport grace to the configured bundled renderer budget", () => {
+    expect(visualMcpRequestTimeoutMs(
+      "mcp-create-chart",
+      "render_visual_card",
+      { SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "120000" },
+    )).toBe(125_000);
+  });
+
+  it("does not change unrelated MCP request timeouts", () => {
+    expect(visualMcpRequestTimeoutMs("other-renderer", "render_chart", {})).toBeUndefined();
+    expect(visualMcpRequestTimeoutMs("mcp-create-chart", "query", {})).toBeUndefined();
+  });
+
+  it("uses the same merged per-server override that is passed to the child", () => {
+    const childEnv = mergeMcpStdioEnv(
+      { SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "120000" },
+      { SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "10000" },
+    );
+    expect(visualMcpRequestTimeoutMs("mcp-create-chart", "render_chart", childEnv)).toBe(125_000);
+  });
+});
+
 describe("createToolDefinition server description", () => {
   const manager = new McpClientManager({ mcpServers: {} });
   const makeDef = (serverDescription: string | undefined, toolDescription?: string) =>
@@ -189,6 +249,38 @@ describe("createToolDefinition server description", () => {
     await expect(def.execute("call-1", {})).resolves.toMatchObject({
       details: { structuredContent },
     });
+  });
+
+  it("marks MCP call failures as transport errors for channel degradation", async () => {
+    const def = (manager as any).createToolDefinition(
+      "create-chart",
+      undefined,
+      { name: "render_visual_card" },
+      { callTool: vi.fn(async () => { throw new Error("stdio disconnected"); }) },
+    );
+
+    await expect(def.execute("call-1", {})).resolves.toMatchObject({
+      details: { error: "stdio disconnected", errorKind: "transport" },
+    });
+  });
+
+  it("passes a renderer-specific timeout to the MCP SDK call", async () => {
+    const callTool = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    const def = (manager as any).createToolDefinition(
+      "create-chart",
+      undefined,
+      { name: "render_visual_card" },
+      { callTool },
+      125_000,
+    );
+
+    await def.execute("call-1", {});
+
+    expect(callTool).toHaveBeenCalledWith(
+      { name: "render_visual_card", arguments: {} },
+      undefined,
+      { timeout: 125_000 },
+    );
   });
 });
 

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -49,6 +49,52 @@ export interface McpServersConfig {
   mcpServers: Record<string, McpServerConfig>;
 }
 
+const MCP_STDIO_FORWARDED_ENV = [
+  "SICLAW_VISUAL_EXPORT_URL",
+  "SICLAW_VISUAL_EXPORT_TIMEOUT_MS",
+  "SICLAW_VISUAL_EXPORT_THEME",
+  "SICLAW_VISUAL_EXPORT_CHROMIUM",
+] as const;
+const DEFAULT_VISUAL_EXPORT_TIMEOUT_MS = 30_000;
+const VISUAL_EXPORT_MCP_GRACE_MS = 5_000;
+
+/**
+ * Add the small platform-owned environment contract required by bundled stdio
+ * MCPs. The MCP SDK intentionally inherits only a safe OS baseline, so values
+ * present in the AgentBox process do not otherwise reach the child process.
+ * Explicit per-server configuration wins over the inherited platform value.
+ */
+export function mergeMcpStdioEnv(
+  configuredEnv: Record<string, string> | undefined,
+  parentEnv: Record<string, string | undefined> = process.env,
+): Record<string, string> | undefined {
+  const inherited: Record<string, string> = {};
+  for (const name of MCP_STDIO_FORWARDED_ENV) {
+    const value = parentEnv[name];
+    if (value !== undefined && value !== "") inherited[name] = value;
+  }
+  const merged = { ...inherited, ...configuredEnv };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+export function visualMcpRequestTimeoutMs(
+  serverImplementationName: unknown,
+  toolName: string,
+  env: Record<string, string | undefined> = {},
+): number | undefined {
+  if (
+    serverImplementationName !== "mcp-create-chart" ||
+    !/^render_(?:chart|mermaid|visual_card)$/.test(toolName)
+  ) {
+    return undefined;
+  }
+  const configured = Number(env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS ?? DEFAULT_VISUAL_EXPORT_TIMEOUT_MS);
+  const rendererBudget = Number.isFinite(configured) && configured > 0
+    ? Math.ceil(configured)
+    : DEFAULT_VISUAL_EXPORT_TIMEOUT_MS;
+  return rendererBudget + VISUAL_EXPORT_MCP_GRACE_MS;
+}
+
 interface ManagedMcpClient {
   serverName: string;
   client: any; // Client from @modelcontextprotocol/sdk
@@ -224,12 +270,13 @@ export class McpClientManager {
         const cfg = serverConfig as any;
         const detectedTransport: string = cfg.transport
           ?? (cfg.url ? "streamable-http" : cfg.command ? "stdio" : "");
+        const stdioEnv = detectedTransport === "stdio" ? mergeMcpStdioEnv(cfg.env) : undefined;
         switch (detectedTransport) {
           case "stdio":
             transport = new StdioClientTransport({
               command: cfg.command,
               args: cfg.args,
-              env: cfg.env,
+              env: stdioEnv,
             });
             break;
           case "sse":
@@ -255,13 +302,22 @@ export class McpClientManager {
 
         await client.connect(transport);
         console.log(`[mcp-client] Connected to "${serverName}" (${detectedTransport})`);
+        const serverImplementationName = client.getServerVersion()?.name;
 
         // Discover tools
         const { tools: mcpTools } = await client.listTools();
         console.log(`[mcp-client] "${serverName}" provides ${mcpTools.length} tools: ${mcpTools.map((t: any) => t.name).join(", ")}`);
 
         for (const mcpTool of mcpTools) {
-          const toolDef = this.createToolDefinition(serverName, cfg.description, mcpTool, client);
+          const toolDef = this.createToolDefinition(
+            serverName,
+            cfg.description,
+            mcpTool,
+            client,
+            detectedTransport === "stdio"
+              ? visualMcpRequestTimeoutMs(serverImplementationName, mcpTool.name, stdioEnv)
+              : undefined,
+          );
           this.tools.push(toolDef);
         }
 
@@ -312,6 +368,7 @@ export class McpClientManager {
     serverDescription: string | undefined,
     mcpTool: { name: string; description?: string; inputSchema?: any },
     client: any,
+    requestTimeoutMs?: number,
   ): ResolvedToolDefinition {
     const fullName = buildMcpToolName(serverName, mcpTool.name);
     const inputSchema = mcpTool.inputSchema ?? { type: "object", properties: {} };
@@ -343,10 +400,14 @@ export class McpClientManager {
       parameters,
       execute: async (_toolCallId, args) => {
         try {
-          const result = await client.callTool({
-            name: mcpTool.name,
-            arguments: args ?? {},
-          });
+          const result = await client.callTool(
+            {
+              name: mcpTool.name,
+              arguments: args ?? {},
+            },
+            undefined,
+            requestTimeoutMs === undefined ? undefined : { timeout: requestTimeoutMs },
+          );
 
           const isError = !!result.isError;
           const { content, text } = mcpContentToAgentContent(result.content);
@@ -364,7 +425,7 @@ export class McpClientManager {
           const errorMsg = err?.message ?? String(err);
           return {
             content: [{ type: "text" as const, text: `MCP tool error: ${errorMsg}` }],
-            details: { error: errorMsg },
+            details: { error: errorMsg, errorKind: "transport" },
           };
         }
       },

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -92,6 +92,10 @@ const originalGatewayEnv = {
   SICLAW_GATEWAY_HOSTNAME: process.env.SICLAW_GATEWAY_HOSTNAME,
   SICLAW_INTERNAL_PORT: process.env.SICLAW_INTERNAL_PORT,
   SICLAW_MEMORY_ENABLED: process.env.SICLAW_MEMORY_ENABLED,
+  SICLAW_VISUAL_EXPORT_URL: process.env.SICLAW_VISUAL_EXPORT_URL,
+  SICLAW_VISUAL_EXPORT_TIMEOUT_MS: process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS,
+  SICLAW_VISUAL_EXPORT_THEME: process.env.SICLAW_VISUAL_EXPORT_THEME,
+  SICLAW_VISUAL_EXPORT_CHROMIUM: process.env.SICLAW_VISUAL_EXPORT_CHROMIUM,
 };
 
 // Import SUT after mocks.
@@ -341,6 +345,34 @@ describe("K8sSpawner — spawn branches", () => {
     const env = calls.createNamespacedPod[0].body.spec.containers[0].env;
     expect(env.some((e: any) => e.name === "SICLAW_SUBAGENT_MODEL_TIER")).toBe(false);
     expect(env.some((e: any) => e.name === "SICLAW_SUBAGENT_GROUP_ENABLED")).toBe(false);
+  });
+
+  it("forwards the visual export contract from the runtime into the AgentBox", async () => {
+    process.env.SICLAW_VISUAL_EXPORT_URL = "https://console.example.com/siclaw-visual-export";
+    process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS = "15000";
+    process.env.SICLAW_VISUAL_EXPORT_THEME = "dark";
+    process.env.SICLAW_VISUAL_EXPORT_CHROMIUM = "/opt/chromium";
+
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "agentbox.example.test", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    await s.spawn({ agentId: "default" });
+    const env = calls.createNamespacedPod[0].body.spec.containers[0].env;
+    expect(env).toContainEqual({
+      name: "SICLAW_VISUAL_EXPORT_URL",
+      value: "https://console.example.com/siclaw-visual-export",
+    });
+    expect(env).toContainEqual({ name: "SICLAW_VISUAL_EXPORT_TIMEOUT_MS", value: "15000" });
+    expect(env).toContainEqual({ name: "SICLAW_VISUAL_EXPORT_THEME", value: "dark" });
+    expect(env).toContainEqual({ name: "SICLAW_VISUAL_EXPORT_CHROMIUM", value: "/opt/chromium" });
   });
 
   it("kb profile forwards KBC_* runtime env by prefix into the box pod, deduped, skipping empties", async () => {

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -629,6 +629,14 @@ export class K8sSpawner implements BoxSpawner {
         "SICLAW_EMBEDDING_MODEL",
         "SICLAW_EMBEDDING_DIMENSIONS",
         "SICLAW_EMBEDDING_API_KEY",
+        // Visual tools execute inside the AgentBox, while their renderer URL is
+        // configured on the Runtime deployment. Forward the complete non-secret
+        // renderer contract so a configured endpoint does not disappear at the
+        // process boundary and fall back to an invented cluster DNS name.
+        "SICLAW_VISUAL_EXPORT_URL",
+        "SICLAW_VISUAL_EXPORT_TIMEOUT_MS",
+        "SICLAW_VISUAL_EXPORT_THEME",
+        "SICLAW_VISUAL_EXPORT_CHROMIUM",
         // Trace deployment environment (Langfuse deployment.environment.name).
         "SICLAW_TRACING_ENVIRONMENT",
       ];

--- a/src/gateway/channels/dingtalk-image.test.ts
+++ b/src/gateway/channels/dingtalk-image.test.ts
@@ -143,4 +143,15 @@ describe("deliverImages", () => {
     expect(count).toBe(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the running delivery count when one image throws unexpectedly", async () => {
+    uploadImageMediaMock.mockRejectedValueOnce(new Error("upload crashed")).mockResolvedValueOnce("@m-2");
+    fetchMock.mockResolvedValue(okResponse());
+
+    const count = await deliverImages(config, { routeType: "group", openConversationId: "cidG" }, images);
+
+    expect(count).toBe(1);
+    expect(uploadImageMediaMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/gateway/channels/dingtalk-image.ts
+++ b/src/gateway/channels/dingtalk-image.ts
@@ -110,9 +110,14 @@ export async function deliverImages(
 ): Promise<number> {
   let delivered = 0;
   for (const { image, mimeType } of images) {
-    const mediaId = await uploadImageMedia(config, image, mimeType);
-    if (!mediaId) continue;
-    if (await sendImageMessage(config, target, mediaId)) delivered += 1;
+    try {
+      const mediaId = await uploadImageMedia(config, image, mimeType);
+      if (!mediaId) continue;
+      if (await sendImageMessage(config, target, mediaId)) delivered += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[dingtalk-image] unexpected image delivery error: ${redactSecrets(msg)}`);
+    }
   }
   return delivered;
 }

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -14,6 +14,7 @@ import { buildMarkdownMessage, DINGTALK_TITLE, sanitizeMarkdownForDingTalk } fro
 const promptMock = vi.fn();
 const streamEventsMock = vi.fn();
 const closeSessionMock = vi.fn();
+const deliverImagesMock = vi.fn();
 
 vi.mock("../agentbox/client.js", () => ({
   AgentBoxClient: class {
@@ -21,6 +22,10 @@ vi.mock("../agentbox/client.js", () => ({
     streamEvents = streamEventsMock;
     closeSession = closeSessionMock;
   },
+}));
+
+vi.mock("./dingtalk-image.js", () => ({
+  deliverImages: (...args: unknown[]) => deliverImagesMock(...args),
 }));
 
 // Stub channel-manager RPCs so we don't hit frontend-ws in unit tests.
@@ -83,6 +88,8 @@ beforeEach(() => {
   streamEventsMock.mockReset();
   closeSessionMock.mockReset();
   closeSessionMock.mockResolvedValue(undefined);
+  deliverImagesMock.mockReset();
+  deliverImagesMock.mockImplementation(async (_config, _target, images: unknown[]) => images.length);
   resolveBindingMock.mockReset();
   handlePairingCodeMock.mockReset();
   ensureChatSessionMock.mockReset();
@@ -462,6 +469,267 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
     const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
     expect(body.msgtype).toBe("text");
     expect(body.text.content).toContain("\u26A0");
+  });
+
+  it("hides visual-card source when its renderer failed", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-visual-failed" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {
+            error: "renderer unavailable",
+            structuredContent: { error_kind: "renderer" },
+          },
+          content: [{ type: "text", text: "renderer unavailable" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "```visual-card",
+              JSON.stringify({ type: "report", title: "Cluster diagnosis" }),
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("hello"),
+      "ch",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.msgtype).toBe("markdown");
+    expect(body.markdown.text).toContain("报告图片生成失败");
+    expect(body.markdown.text).not.toContain("```visual-card");
+    expect(body.markdown.text).not.toContain("Cluster diagnosis");
+  });
+
+  it("keeps prose and appends a notice when visual rendering fails", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-visual-mixed-failed" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_mermaid",
+        result: {
+          details: {
+            error: "renderer unavailable",
+            structuredContent: { error_kind: "renderer" },
+          },
+          content: [{ type: "text", text: "renderer unavailable" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "拓扑如下：\n\n```mermaid\ngraph TD; A-->B\n```" }],
+        },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("hello"),
+      "ch",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.markdown.text).toContain("拓扑如下");
+    expect(body.markdown.text).toContain("报告图片生成失败");
+    expect(body.markdown.text).not.toContain("```mermaid");
+  });
+
+  it("does not hide source or claim a renderer outage for invalid tool arguments", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-visual-input-error" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {
+            error: "render_visual_card: title is required",
+            structuredContent: { error_kind: "input" },
+          },
+          content: [{ type: "text", text: "render_visual_card: title is required" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "```visual-card\n{\"type\":\"report\"}\n```" }],
+        },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("hello"),
+      "ch",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.markdown.text).toContain("```visual-card");
+    expect(body.markdown.text).not.toContain("报告图片生成失败");
+  });
+
+  it("reports image delivery failure instead of claiming an image follows", async () => {
+    const onePixelBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    deliverImagesMock.mockResolvedValue(0);
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-image-delivery-failed" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {},
+          content: [{ type: "image", data: onePixelBase64, mimeType: "image/png" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "```visual-card\n{\"type\":\"report\",\"title\":\"x\"}\n```" }],
+        },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("hello"),
+      "ch",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      {} as any,
+    );
+
+    expect(deliverImagesMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.markdown.text).toContain("报告图片发送失败");
+    expect(body.markdown.text).not.toContain("图片如下");
+    expect(body.markdown.text).not.toContain("```visual-card");
+  });
+
+  it("reports missing channel configuration as an operator action, not a retry", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-image-config-missing" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_chart",
+        result: { details: {}, content: [{ type: "image", data: "AQ==", mimeType: "image/png" }] },
+      };
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "```chart\n{\"type\":\"bar\"}\n```" }] },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("hello"),
+      "ch",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(deliverImagesMock).not.toHaveBeenCalled();
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.markdown.text).toContain("请联系管理员检查渠道配置");
+    expect(body.markdown.text).not.toContain("请稍后重试");
+  });
+
+  it("distinguishes partial image delivery from total failure", async () => {
+    deliverImagesMock.mockResolvedValue(1);
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-image-delivery-partial" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_chart",
+        result: { details: {}, content: [
+          { type: "image", data: "AQ==", mimeType: "image/png" },
+          { type: "image", data: "Ag==", mimeType: "image/png" },
+        ] },
+      };
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "```chart\n{\"type\":\"bar\"}\n```" }] },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("hello"),
+      "ch",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      {} as any,
+    );
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.markdown.text).toContain("部分报告图片发送失败");
+  });
+
+  it("delivers a successful visual before posting an accurate text confirmation", async () => {
+    const onePixelBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    resolveBindingMock.mockResolvedValue({ agentId: "a1", bindingId: "b" });
+    promptMock.mockResolvedValue({ sessionId: "s-image-delivery-ok" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {},
+          content: [{ type: "image", data: onePixelBase64, mimeType: "image/png" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "```visual-card\n{\"type\":\"report\",\"title\":\"x\"}\n```" }],
+        },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("hello"),
+      "ch",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+      {} as any,
+    );
+
+    expect(deliverImagesMock).toHaveBeenCalledTimes(1);
+    expect(deliverImagesMock.mock.invocationCallOrder[0]).toBeLessThan(fetchMock.mock.invocationCallOrder[0]);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.markdown.text).toContain("报告图片已发送");
+    expect(body.markdown.text).not.toContain("```visual-card");
   });
 });
 

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -42,7 +42,12 @@ import { sessionRegistry } from "../session-registry.js";
 import { sessionTurnLocks } from "../session-turn-lock.js";
 import { appendMessage, bindMessageTraceId, ensureChatSession, warnTraceBindFailure } from "../chat-repo.js";
 import { collectChannelResponse } from "./lark.js";
-import type { RenderedReplyImage } from "./visual-image.js";
+import {
+  stripVisualBlocks,
+  type RenderedReplyImage,
+  type VisualFailureReason,
+  type VisualSourceKind,
+} from "./visual-image.js";
 import { deliverImages } from "./dingtalk-image.js";
 import {
   buildMarkdownMessage,
@@ -62,6 +67,12 @@ const TOPIC_ROBOT = "/v1.0/im/bot/messages/get";
  * data-exfiltration channel. Pin replies to the DingTalk OpenAPI domains.
  */
 const ALLOWED_WEBHOOK_HOSTS = new Set(["oapi.dingtalk.com", "api.dingtalk.com"]);
+const VISUAL_ONLY_NOTICE = "报告图片已发送。";
+const VISUAL_RENDER_FAILED_NOTICE = "报告图片生成失败，请稍后重试。";
+const VISUAL_CONFIGURATION_FAILED_NOTICE = "报告图片功能暂不可用，请联系管理员检查配置。";
+const IMAGE_DELIVERY_FAILED_NOTICE = "报告图片发送失败，请稍后重试。";
+const IMAGE_DELIVERY_PARTIAL_NOTICE = "部分报告图片发送失败，请稍后重试。";
+const IMAGE_DELIVERY_UNCONFIGURED_NOTICE = "报告图片无法发送，请联系管理员检查渠道配置。";
 
 function isAllowedWebhookHost(host: string): boolean {
   return ALLOWED_WEBHOOK_HOSTS.has(host) || host.endsWith(".dingtalk.com");
@@ -308,6 +319,8 @@ export async function handleDingTalkMessage(
   // two boxes and both would run — two writers on one transcript.
   let resultText = "";
   let replyImages: RenderedReplyImage[] = [];
+  let visualRenderFailures = new Map<VisualSourceKind, VisualFailureReason>();
+  let renderedVisualKinds = new Set<VisualSourceKind>();
   let agentError: Error | null = null;
   // Acquired INSIDE the try so a busy session surfaces through the SAME path the
   // AgentBox's 409 already used — the friendly "still working" notice. Outside it the
@@ -387,6 +400,8 @@ export async function handleDingTalkMessage(
     });
     resultText = collected.text;
     replyImages = collected.images;
+    visualRenderFailures = collected.visualRenderFailures;
+    renderedVisualKinds = collected.renderedVisualKinds;
   } catch (err) {
     agentError = err instanceof Error ? err : new Error(String(err));
     console.error(`[dingtalk] Agent execution failed for session=${sessionId}:`, agentError);
@@ -404,40 +419,70 @@ export async function handleDingTalkMessage(
     return;
   }
 
+  // Resolve image delivery before composing the text reply. The source fence is
+  // never safe as an IM fallback, but the text must state when no image reached
+  // the user instead of claiming that an image follows.
+  let deliveredImageCount = 0;
+  if (!agentError && replyImages.length > 0) {
+    if (config) {
+      const target = {
+        routeType,
+        openConversationId: routeType === "group" ? conversationId : undefined,
+        senderStaffId: message.senderStaffId,
+      };
+      try {
+        deliveredImageCount = await deliverImages(config, target, replyImages);
+      } catch (err) {
+        console.error(`[dingtalk] Image delivery failed for session=${sessionId}: ${safeErrorMessage(err)}`);
+      }
+      if (deliveredImageCount < replyImages.length) {
+        console.warn(`[dingtalk] Delivered ${deliveredImageCount}/${replyImages.length} reply images for session=${sessionId}`);
+      }
+    } else {
+      console.warn(`[dingtalk] Image delivery unavailable without channel config for session=${sessionId}`);
+    }
+  }
+  const imageDeliveryUnconfigured = !agentError && replyImages.length > 0 && !config;
+
   // On failure, reply with a generic notice only — the raw error message can
   // leak internal endpoints / infra details to everyone in the chat. The full
   // error was already logged above for operators.
   const finalBody = agentError
     ? AGENT_ERROR_NOTICE
     : (resultText || EMPTY_RESULT_NOTICE);
+  const strippedBody = agentError
+    ? finalBody
+    : stripVisualBlocks(finalBody, {
+        stripSourceKinds: new Set<VisualSourceKind>([
+          ...renderedVisualKinds,
+          ...visualRenderFailures.keys(),
+        ]),
+      });
+  let displayBody = strippedBody;
+  if ([...visualRenderFailures.values()].includes("configuration")) {
+    displayBody = appendChannelNotice(displayBody, VISUAL_CONFIGURATION_FAILED_NOTICE);
+  } else if (visualRenderFailures.size > 0) {
+    displayBody = appendChannelNotice(displayBody, VISUAL_RENDER_FAILED_NOTICE);
+  }
+  if (imageDeliveryUnconfigured) {
+    displayBody = appendChannelNotice(displayBody, IMAGE_DELIVERY_UNCONFIGURED_NOTICE);
+  } else if (replyImages.length > 0 && deliveredImageCount === 0) {
+    displayBody = appendChannelNotice(displayBody, IMAGE_DELIVERY_FAILED_NOTICE);
+  } else if (deliveredImageCount < replyImages.length) {
+    displayBody = appendChannelNotice(displayBody, IMAGE_DELIVERY_PARTIAL_NOTICE);
+  }
+  if (!displayBody) displayBody = VISUAL_ONLY_NOTICE;
 
   // Errors and the empty-result notice go out as plain text; real answers as
   // markdown so formatting (code blocks, lists, bold) renders.
   const body = agentError
-    ? buildTextMessage(finalBody)
-    : (resultText ? buildMarkdownMessage(finalBody) : buildTextMessage(finalBody));
+    ? buildTextMessage(displayBody)
+    : (resultText ? buildMarkdownMessage(displayBody) : buildTextMessage(displayBody));
   await replyToDingTalk(sessionWebhook, body);
+}
 
-  // Deliver any agent-produced images as separate robot messages (mirrors
-  // Lark's replyVisualImages). Best-effort and post-text: image delivery needs
-  // an access token + robot-send permission (config), and a failed image must
-  // never break the primary reply. Skipped when the agent errored, produced no
-  // images, or the channel config was not threaded through (older callers).
-  if (!agentError && config && replyImages.length > 0) {
-    const target = {
-      routeType,
-      openConversationId: routeType === "group" ? conversationId : undefined,
-      senderStaffId: message.senderStaffId,
-    };
-    try {
-      const delivered = await deliverImages(config, target, replyImages);
-      if (delivered < replyImages.length) {
-        console.warn(`[dingtalk] Delivered ${delivered}/${replyImages.length} reply images for session=${sessionId}`);
-      }
-    } catch (err) {
-      console.error(`[dingtalk] Image delivery failed for session=${sessionId}: ${safeErrorMessage(err)}`);
-    }
-  }
+function appendChannelNotice(body: string, notice: string): string {
+  return body.trim() ? `${body.trim()}\n\n${notice}` : notice;
 }
 
 /**

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -8,6 +8,7 @@ import {
   collectResponse,
   collectChannelResponse,
   extractInbound,
+  replyVisualImages,
   resetLarkBindingQueuesForTest,
 } from "./lark.js";
 import {
@@ -3309,6 +3310,331 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
   });
 
+  it("hides visual-card source when its renderer failed", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-visual-card-failed" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {
+            error: "renderer unavailable",
+            structuredContent: { error_kind: "renderer" },
+          },
+          content: [{ type: "text", text: "renderer unavailable" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "```visual-card",
+              JSON.stringify({
+                type: "report",
+                title: "Cluster diagnosis",
+                conclusion: "One gateway is unhealthy.",
+              }),
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("报告图片生成失败");
+    expect(cardContent).not.toContain("```visual-card");
+    expect(cardContent).not.toContain("Cluster diagnosis");
+    expect(lark.im.image.create).not.toHaveBeenCalled();
+    expect(lark.cardkit.v1.cardElement.create).not.toHaveBeenCalled();
+  });
+
+  it("keeps prose, appends a render-failure notice, and keeps feedback for the surviving answer", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-visual-card-mixed-failure" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_mermaid",
+        result: {
+          details: {
+            error: "renderer unavailable",
+            structuredContent: { error_kind: "renderer" },
+          },
+          content: [{ type: "text", text: "renderer unavailable" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "拓扑如下：\n\n```mermaid\ngraph TD; A-->B\n```" }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("拓扑如下");
+    expect(cardContent).toContain("报告图片生成失败");
+    expect(cardContent).not.toContain("```mermaid");
+    expect(lark.cardkit.v1.cardElement.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a hand-written Mermaid fallback when only chart rendering failed", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-chart-failed-mermaid-fallback" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_chart",
+        result: {
+          details: { error: "renderer unavailable", structuredContent: { error_kind: "renderer" } },
+          content: [{ type: "text", text: "renderer unavailable" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "改用文本拓扑：\n\n```mermaid\ngraph TD; A-->B\n```" }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("hello"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("```mermaid");
+    expect(cardContent).toContain("A-->B");
+    expect(cardContent).toContain("报告图片生成失败");
+  });
+
+  it("reports one failed visual kind even when another kind delivered an image", async () => {
+    const onePixelBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-mixed-visual-outcomes" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_chart",
+        result: { details: {}, content: [{ type: "image", data: onePixelBase64, mimeType: "image/png" }] },
+      };
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_mermaid",
+        result: {
+          details: { error: "renderer unavailable", structuredContent: { error_kind: "renderer" } },
+          content: [{ type: "text", text: "renderer unavailable" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "```chart\n{\"type\":\"bar\"}\n```\n\n```mermaid\ngraph TD; A-->B\n```" }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("hello"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("报告图片生成失败");
+    expect(cardContent).not.toContain("```chart");
+    expect(cardContent).not.toContain("```mermaid");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports visual configuration errors without suggesting a retry", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-visual-config-failed" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: { error: "missing URL", structuredContent: { error_kind: "configuration" } },
+          content: [{ type: "text", text: "missing URL" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "```visual-card\n{\"type\":\"report\"}\n```" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("hello"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("请联系管理员检查配置");
+    expect(cardContent).not.toContain("请稍后重试");
+    expect(cardContent).not.toContain("```visual-card");
+  });
+
+  it("does not hide source or claim a renderer outage for invalid tool arguments", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-visual-card-input-error" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {
+            error: "render_visual_card: title is required",
+            structuredContent: { error_kind: "input" },
+          },
+          content: [{ type: "text", text: "render_visual_card: title is required" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "```visual-card\n{\"type\":\"report\"}\n```" }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("```visual-card");
+    expect(cardContent).not.toContain("报告图片生成失败");
+  });
+
+  it("does not claim rendering failed when a later render delivered an image", async () => {
+    const onePixelBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-visual-card-retry" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {
+            error: "renderer timeout",
+            structuredContent: { error_kind: "renderer" },
+          },
+          content: [{ type: "text", text: "renderer timeout" }],
+        },
+      };
+      yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {},
+          content: [{ type: "image", data: onePixelBase64, mimeType: "image/png" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "```visual-card",
+              JSON.stringify({ type: "report", title: "Recovered render" }),
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("报告图片已发送");
+    expect(cardContent).not.toContain("报告图片生成失败");
+    expect(cardContent).not.toContain("```visual-card");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+    expect(lark.cardkit.v1.cardElement.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips all visual source blocks when an image has no observable renderer attribution", async () => {
+    const onePixelBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-unattributed-image" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "toolResult",
+          content: [{ type: "image", data: onePixelBase64, mimeType: "image/png" }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "```visual-card\n{\"type\":\"report\",\"title\":\"x\"}\n```" }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("报告图片已发送");
+    expect(cardContent).not.toContain("```visual-card");
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+  });
+
   it("does not reply with an image when the final answer has no image artifact", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-no-chart" });
@@ -3331,7 +3657,7 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the markdown card successful when image upload returns no key", async () => {
+  it("reports Lark image delivery failure before finalizing the card", async () => {
     const onePixelBase64 =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -3339,13 +3665,18 @@ describe("handleLarkMessage — streaming card flow", () => {
     promptMock.mockResolvedValue({ sessionId: "s-image-fail" });
     streamEventsMock.mockImplementation(async function* () {
       yield {
+        type: "tool_execution_end",
+        toolName: "mcp__create-chart__render_visual_card",
+        result: {
+          details: {},
+          content: [{ type: "image", data: onePixelBase64, mimeType: "image/png" }],
+        },
+      };
+      yield {
         type: "message_end",
         message: {
           role: "assistant",
-          content: [
-            { type: "text", text: "图片如下：" },
-            { type: "image", data: onePixelBase64, mimeType: "image/png" },
-          ],
+          content: [{ type: "text", text: "```visual-card\n{\"type\":\"report\",\"title\":\"x\"}\n```" }],
         },
       };
     });
@@ -3365,6 +3696,34 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(lark.im.image.create).toHaveBeenCalledTimes(1);
     expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
     expect(lark.im.message.reply.mock.calls[0][0].data.msg_type).toBe("interactive");
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls.at(-1)?.[0].data.content;
+    expect(cardContent).toContain("报告图片发送失败");
+    expect(cardContent).not.toContain("图片如下");
+    expect(cardContent).not.toContain("```visual-card");
+    expect(lark.im.image.create.mock.invocationCallOrder[0])
+      .toBeLessThan(lark.cardkit.v1.cardElement.content.mock.invocationCallOrder.at(-1)!);
+  });
+
+  it("bounds Lark image delivery with one total deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const lark = makeCardAwareLarkClient();
+      lark.im.image.create.mockReturnValue(new Promise(() => {}));
+      const delivery = replyVisualImages(
+        lark,
+        "mid-timeout",
+        [{ kind: "image", mimeType: "image/png", image: Buffer.from([1]) }],
+        false,
+        100,
+      );
+      expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(delivery).resolves.toBe(0);
+      expect(lark.im.message.reply).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("falls back to plain text reply when card.create fails (preserves the pre-card UX)", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -57,7 +57,14 @@ import {
   type GroupContextMode,
   type LarkLocale,
 } from "./lark-card.js";
-import { collectImageAttachments, stripVisualBlocks, type RenderedReplyImage } from "./visual-image.js";
+import {
+  collectImageAttachments,
+  stripVisualBlocks,
+  visualSourceKindFromToolName,
+  type RenderedReplyImage,
+  type VisualFailureReason,
+  type VisualSourceKind,
+} from "./visual-image.js";
 import { replyImageToLark } from "./lark-image.js";
 import { collectInboundImages, type LarkImageRef } from "./inbound-image.js";
 import { modelOptionsSupportImageInput } from "../../core/model-routing.js";
@@ -66,8 +73,25 @@ import { appendKnowledgeSourceCitations, normalizeKnowledgeSourceCitations } fro
 import { registerBackgroundChannelDelivery } from "./background-delivery.js";
 
 const VISUAL_ONLY_NOTICE_BY_LOCALE = {
-  "zh-CN": "已生成图片如下。",
-  "en-US": "Image generated below.",
+  "zh-CN": "报告图片已发送。",
+  "en-US": "The report image was sent.",
+} as const;
+const IMAGE_DELIVERY_BUDGET_MS = 10_000;
+const VISUAL_RENDER_FAILED_NOTICE_BY_LOCALE = {
+  "zh-CN": "报告图片生成失败，请稍后重试。",
+  "en-US": "The report image could not be generated. Please try again.",
+} as const;
+const VISUAL_CONFIGURATION_FAILED_NOTICE_BY_LOCALE = {
+  "zh-CN": "报告图片功能暂不可用，请联系管理员检查配置。",
+  "en-US": "Report images are unavailable. Please ask an administrator to check the configuration.",
+} as const;
+const IMAGE_DELIVERY_FAILED_NOTICE_BY_LOCALE = {
+  "zh-CN": "报告图片发送失败，请稍后重试。",
+  "en-US": "The report image could not be sent. Please try again.",
+} as const;
+const IMAGE_DELIVERY_PARTIAL_NOTICE_BY_LOCALE = {
+  "zh-CN": "部分报告图片发送失败，请稍后重试。",
+  "en-US": "Some report images could not be sent. Please try again.",
 } as const;
 const QUEUE_FULL_NOTICE_BY_LOCALE = {
   "zh-CN": "⏳ 当前会话还有较多消息排队处理中，请稍后再发。",
@@ -1969,6 +1993,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   // that closes the agent-execution block below.
   let resultText = "";
   let replyImages: RenderedReplyImage[] = [];
+  let visualRenderFailures = new Map<VisualSourceKind, VisualFailureReason>();
+  let renderedVisualKinds = new Set<VisualSourceKind>();
+  let unattributedImageCount = 0;
   let assistantMessageId: string | null = null;
   let agentError: Error | null = null;
   let sessionBusy = false;
@@ -2049,6 +2076,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     resultText = collected.text;
     replyImages = collected.images;
     assistantMessageId = collected.assistantMessageId;
+    visualRenderFailures = collected.visualRenderFailures;
+    renderedVisualKinds = collected.renderedVisualKinds;
+    unattributedImageCount = collected.unattributedImageCount;
   } catch (err) {
     if (isSessionBusyError(err)) {
       // Still busy after the retry window — surface a friendly notice, don't clobber.
@@ -2071,23 +2101,57 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       ? AGENT_ERROR_NOTICE_BY_LOCALE[locale]
       : (resultText || EMPTY_RESULT_NOTICE_BY_LOCALE[locale]);
   if (agentError || sessionBusy) replyImages = [];
-  const displayBody = stripVisualBlocks(finalBody, { stripSourceBlocks: replyImages.length > 0 })
-    || VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
+
+  // Stop milestone renders before image delivery, otherwise a late coalesced
+  // update can overwrite the terminal card while the Lark media APIs are slow.
+  cardFinalizing = true;
+  if (cardFlushPromise) { try { await cardFlushPromise; } catch { /* logged in flush */ } }
+
+  // Resolve delivery before finalizing the text card. A source fence is stripped
+  // once its renderer returned an image, so the replacement copy must reflect
+  // whether that image actually reached Lark. The shared budget prevents slow
+  // media APIs from holding the primary answer on its typing card indefinitely.
+  const deliveredImageCount = await replyVisualImages(
+    larkClient,
+    messageId,
+    replyImages,
+    replyInThread,
+  );
+  const stripSourceKinds = new Set<VisualSourceKind>([
+    ...renderedVisualKinds,
+    ...visualRenderFailures.keys(),
+  ]);
+  const strippedBody = stripVisualBlocks(finalBody, {
+    ...(unattributedImageCount > 0
+      ? { stripSourceBlocks: true }
+      : { stripSourceKinds }),
+  });
+  let displayBody = strippedBody;
+  if ([...visualRenderFailures.values()].includes("configuration")) {
+    displayBody = appendChannelNotice(
+      displayBody,
+      VISUAL_CONFIGURATION_FAILED_NOTICE_BY_LOCALE[locale],
+    );
+  } else if (visualRenderFailures.size > 0) {
+    displayBody = appendChannelNotice(displayBody, VISUAL_RENDER_FAILED_NOTICE_BY_LOCALE[locale]);
+  }
+  if (replyImages.length > 0 && deliveredImageCount === 0) {
+    displayBody = appendChannelNotice(displayBody, IMAGE_DELIVERY_FAILED_NOTICE_BY_LOCALE[locale]);
+  } else if (deliveredImageCount < replyImages.length) {
+    displayBody = appendChannelNotice(displayBody, IMAGE_DELIVERY_PARTIAL_NOTICE_BY_LOCALE[locale]);
+  }
+  if (!displayBody) displayBody = VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
   // The final card is JUST the conclusion — the live step indicator is replaced
   // entirely, no milestone trail is kept on the card.
   const finalCardBody = buildMilestoneCardMarkdown({ milestones: [], finalText: displayBody });
-
-  // Stop any further coalesced milestone renders and let the in-flight one
-  // settle, so finalizeCard isn't overwritten by a later (higher-sequence)
-  // milestone-only update.
-  cardFinalizing = true;
-  if (cardFlushPromise) { try { await cardFlushPromise; } catch { /* logged in flush */ } }
 
   if (cardSession) {
     // Only solicit 👍/👎 on a real answer — never under an error or
     // empty-result notice, where a click would write a rating against a
     // non-answer and skew the feedback signal Metrics aggregates.
-    const isAnswer = !agentError && resultText.trim().length > 0;
+    const usableAnswer = strippedBody.trim().length > 0
+      || (visualRenderFailures.size === 0 && deliveredImageCount > 0);
+    const isAnswer = !agentError && !sessionBusy && usableAnswer && resultText.trim().length > 0;
     const { ok, contentOk } = await finalizeCard(larkClient, cardSession, finalCardBody,
       isAnswer && assistantMessageId
         ? { ctx: { sessionId, channelId, messageId: assistantMessageId }, locale }
@@ -2120,8 +2184,6 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     await replyToLark(larkClient, messageId, finalCardBody, replyInThread);
     deliveredTextChars = finalCardBody.length;
   }
-
-  await replyVisualImages(larkClient, messageId, replyImages, replyInThread);
 }
 
 async function resolveQueuedBinding(
@@ -3015,17 +3077,50 @@ async function deliverVisibleChannelText(
   return true;
 }
 
-async function replyVisualImages(
+export async function replyVisualImages(
   larkClient: any,
   messageId: string,
   images: RenderedReplyImage[],
   replyInThread: boolean = false,
-): Promise<void> {
+  timeoutMs: number = IMAGE_DELIVERY_BUDGET_MS,
+): Promise<number> {
+  let delivered = 0;
+  const deadline = Date.now() + timeoutMs;
   for (const { kind, image } of images) {
-    const ok = await replyImageToLark(larkClient, messageId, image, replyInThread);
-    if (!ok) {
-      console.warn(`[lark] ${kind} image reply failed for messageId=${messageId}; markdown card remains primary`);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      console.warn(`[lark] image delivery deadline exceeded for messageId=${messageId}`);
+      break;
     }
+    try {
+      const ok = await settleWithin(
+        () => replyImageToLark(larkClient, messageId, image, replyInThread),
+        remaining,
+      );
+      if (ok === undefined) {
+        console.warn(`[lark] ${kind} image reply timed out for messageId=${messageId}`);
+        break;
+      }
+      if (ok) delivered += 1;
+      else console.warn(`[lark] ${kind} image reply failed for messageId=${messageId}; markdown card remains primary`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[lark] ${kind} image reply failed for messageId=${messageId}: ${message}`);
+    }
+  }
+  return delivered;
+}
+
+async function settleWithin<T>(start: () => Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  if (timeoutMs <= 0) return undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => resolve(undefined), timeoutMs);
+  });
+  try {
+    return await Promise.race([start(), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -3034,6 +3129,12 @@ async function replyVisualImages(
 export interface CollectedChannelResponse {
   text: string;
   images: RenderedReplyImage[];
+  /** Last observed render failure by visual kind; a later successful retry clears that kind. */
+  visualRenderFailures: Map<VisualSourceKind, VisualFailureReason>;
+  /** Visual kinds that returned an image artifact in this turn. */
+  renderedVisualKinds: Set<VisualSourceKind>;
+  /** Image artifacts collected without an observable render tool kind. */
+  unattributedImageCount: number;
   /** Persisted id of the final assistant turn, or null when audit persistence failed/was disabled. */
   assistantMessageId: string | null;
 }
@@ -3075,6 +3176,9 @@ export async function collectChannelResponse(
   // for the user). pi-agent's agent_end signals the last turn is complete.
   let lastAssistantText = "";
   let lastAssistantMessageId: string | null = null;
+  const visualRenderFailures = new Map<VisualSourceKind, VisualFailureReason>();
+  const renderedVisualKinds = new Set<VisualSourceKind>();
+  let unattributedImageCount = 0;
   let pendingKnowledgeSources: unknown = null;
   // URLs already rendered into an assistant reply this stream (= one turn).
   // Append only the not-yet-rendered delta and keep pending, so an intermediate
@@ -3161,9 +3265,28 @@ export async function collectChannelResponse(
       }
 
       if (ev.type === "tool_execution_end" || ev.type === "tool_end") {
-        if (options.includeImages) collectImageAttachments(ev.result?.content, images, seenImageKeys);
+        const name = (ev.toolName as string) || (ev.name as string) || "tool";
+        const visualKind = visualSourceKindFromToolName(name);
+        const imageCollection = options.includeImages
+          ? collectImageAttachments(ev.result?.content, images, seenImageKeys)
+          : { found: false, added: 0 };
+        const visualErrorKind = ev.result?.details?.structuredContent?.error_kind
+          ?? ev.result?.details?.errorKind;
+        if (options.includeImages && visualKind) {
+          if (
+            visualErrorKind === "configuration" ||
+            visualErrorKind === "renderer" ||
+            visualErrorKind === "transport"
+          ) {
+            visualRenderFailures.set(visualKind, visualErrorKind);
+          } else if (imageCollection.found) {
+            renderedVisualKinds.add(visualKind);
+            visualRenderFailures.delete(visualKind);
+          }
+        } else if (options.includeImages) {
+          unattributedImageCount += imageCollection.added;
+        }
         if (persist) {
-          const name = (ev.toolName as string) || (ev.name as string) || "tool";
           const resultText = Array.isArray(ev.result?.content)
             ? ev.result.content.filter((c: any) => c?.type === "text").map((c: any) => c.text ?? "").join("")
             : "";
@@ -3189,13 +3312,19 @@ export async function collectChannelResponse(
       }
 
       if (options.includeImages && ev.type === "message_end" && (ev.message?.role === "toolResult" || ev.message?.role === "tool")) {
-        collectImageAttachments(ev.message?.content, images, seenImageKeys);
+        unattributedImageCount += collectImageAttachments(
+          ev.message?.content,
+          images,
+          seenImageKeys,
+        ).added;
       }
       // pi-agent-brain emits the final assistant reply as message_end with
       // a content array of blocks; collect the text blocks only.
       if (ev.type === "message_end" && ev.message?.role === "assistant") {
         const blocks = Array.isArray(ev.message.content) ? ev.message.content : [];
-        if (options.includeImages) collectImageAttachments(blocks, images, seenImageKeys);
+        if (options.includeImages) {
+          unattributedImageCount += collectImageAttachments(blocks, images, seenImageKeys).added;
+        }
         let turnText = contentBlocksToMarkdown(blocks);
         if (pendingKnowledgeSources && turnText.trim() && ev.message?.stopReason !== "error") {
           const freshSources = normalizeKnowledgeSourceCitations(pendingKnowledgeSources)
@@ -3245,7 +3374,18 @@ export async function collectChannelResponse(
       content: redact(text),
     });
   }
-  return { text, images, assistantMessageId: lastAssistantMessageId };
+  return {
+    text,
+    images,
+    visualRenderFailures,
+    renderedVisualKinds,
+    unattributedImageCount,
+    assistantMessageId: lastAssistantMessageId,
+  };
+}
+
+function appendChannelNotice(body: string, notice: string): string {
+  return body.trim() ? `${body.trim()}\n\n${notice}` : notice;
 }
 
 /**

--- a/src/gateway/channels/visual-image.test.ts
+++ b/src/gateway/channels/visual-image.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { collectImageAttachments, stripVisualBlocks, type RenderedReplyImage } from "./visual-image.js";
+import {
+  collectImageAttachments,
+  stripVisualBlocks,
+  visualSourceKindFromToolName,
+  type RenderedReplyImage,
+} from "./visual-image.js";
 
 const onePixelBase64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
@@ -92,5 +97,33 @@ describe("stripVisualBlocks", () => {
       "",
       "Keep this.",
     ].join("\n"));
+  });
+
+  it("removes only the visual kinds that were rendered or failed", () => {
+    const markdown = [
+      "```chart",
+      "{\"type\":\"bar\"}",
+      "```",
+      "",
+      "```mermaid",
+      "flowchart LR",
+      "A --> B",
+      "```",
+    ].join("\n");
+
+    const display = stripVisualBlocks(markdown, { stripSourceKinds: ["chart"] });
+
+    expect(display).not.toContain("```chart");
+    expect(display).toContain("```mermaid");
+    expect(display).toContain("A --> B");
+  });
+});
+
+describe("visualSourceKindFromToolName", () => {
+  it("maps bundled MCP render tool names to their source fence kinds", () => {
+    expect(visualSourceKindFromToolName("mcp__create-chart__render_chart")).toBe("chart");
+    expect(visualSourceKindFromToolName("mcp__create-chart__render_mermaid")).toBe("mermaid");
+    expect(visualSourceKindFromToolName("mcp__create-chart__render_visual_card")).toBe("visual-card");
+    expect(visualSourceKindFromToolName("mcp__other__query")).toBeNull();
   });
 });

--- a/src/gateway/channels/visual-image.ts
+++ b/src/gateway/channels/visual-image.ts
@@ -4,8 +4,17 @@ export interface RenderedReplyImage {
   image: Buffer;
 }
 
+export type VisualSourceKind = "chart" | "mermaid" | "visual-card";
+export type VisualFailureReason = "configuration" | "renderer" | "transport";
+
 export interface StripVisualBlocksOptions {
   stripSourceBlocks?: boolean;
+  stripSourceKinds?: Iterable<VisualSourceKind>;
+}
+
+export interface ImageCollectionResult {
+  found: boolean;
+  added: number;
 }
 
 const DATA_IMAGE_URL_PATTERN =
@@ -20,29 +29,42 @@ export function collectImageAttachments(
   content: unknown,
   target: RenderedReplyImage[],
   seenImageKeys: Set<string>,
-): void {
-  if (!Array.isArray(content)) return;
+): ImageCollectionResult {
+  if (!Array.isArray(content)) return { found: false, added: 0 };
+  let found = false;
+  let collected = 0;
   for (const block of content) {
     if (!block || typeof block !== "object") continue;
     const image = imageAttachmentFromBlock(block as Record<string, unknown>);
     if (!image) continue;
+    found = true;
     const key = `${image.mimeType}:${image.image.toString("base64")}`;
     if (seenImageKeys.has(key)) continue;
     seenImageKeys.add(key);
     target.push(image);
+    collected += 1;
   }
+  return { found, added: collected };
 }
 
 export function stripVisualBlocks(markdown: string, options: StripVisualBlocksOptions = {}): string {
   let output = stripDataImages(markdown);
   if (options.stripSourceBlocks) {
-    output = stripFences(output, "chart");
-    output = stripFences(output, "mermaid");
-    output = stripFences(output, "visual-card");
-    output = stripFences(output, "siclaw-card");
-    output = stripFences(output, "conclusion-card");
+    output = stripVisualSourceKind(output, "chart");
+    output = stripVisualSourceKind(output, "mermaid");
+    output = stripVisualSourceKind(output, "visual-card");
+  } else if (options.stripSourceKinds) {
+    for (const kind of new Set(options.stripSourceKinds)) {
+      output = stripVisualSourceKind(output, kind);
+    }
   }
   return cleanupMarkdown(output);
+}
+
+export function visualSourceKindFromToolName(toolName: string): VisualSourceKind | null {
+  const match = toolName.match(/(?:^|[._/-])render_(chart|mermaid|visual_card)$/);
+  if (!match) return null;
+  return match[1] === "visual_card" ? "visual-card" : match[1] as VisualSourceKind;
 }
 
 function imageAttachmentFromBlock(block: Record<string, unknown>): RenderedReplyImage | null {
@@ -115,6 +137,16 @@ function normalizeMimeType(mimeType: string): RenderedReplyImage["mimeType"] | n
 
 function stripFences(markdown: string, language: string): string {
   return markdown.replace(fenceRegex(language), (full, prefix: string) => prefix || "");
+}
+
+function stripVisualSourceKind(markdown: string, kind: VisualSourceKind): string {
+  if (kind === "visual-card") {
+    return stripFences(
+      stripFences(stripFences(markdown, "visual-card"), "siclaw-card"),
+      "conclusion-card",
+    );
+  }
+  return stripFences(markdown, kind);
 }
 
 function fenceRegex(language: string): RegExp {


### PR DESCRIPTION
## Summary

Visual rendering ran inside AgentBox pods but relied on an assumed cluster DNS name and could not receive Runtime-level endpoint configuration. This makes the renderer endpoint explicit, forwards its settings into new AgentBoxes and bundled stdio MCP processes, and prevents failed visual source blocks from being shown to IM users.

### Solution

- add Helm values for the visual export endpoint, end-to-end timeout, and theme
- forward the renderer contract from Runtime to normal AgentBox pods and bundled stdio MCP child processes
- validate and normalize the endpoint and timeout at startup, including empty URL fragments, and return a distinct `configuration` tool error instead of mislabeling deployment mistakes as renderer outages
- use one Playwright deadline without orphaning already-started operations, and set the MCP SDK timeout from the same merged child environment to that budget plus transport grace
- identify the bundled renderer from its MCP server implementation metadata rather than its executable spelling
- distinguish model input, configuration, renderer, and MCP transport failures
- track render outcomes per `chart`, `mermaid`, and `visual-card` kind, with a conservative strip-all fallback for unattributed image artifacts
- preserve feedback controls for successful visual-only answers and usable prose that survives a visual failure
- bound Lark image delivery to one 10-second budget and use position-independent completion copy
- resolve Lark and DingTalk image delivery before composing success copy, including accurate unconfigured, total-failure, and partial-failure notices

### Upgrade requirement

Deployments that enable the bundled `create-chart` MCP must set `runtime.visualExport.url` to a reachable `/siclaw-visual-export` page. The chart default intentionally remains empty because this repository does not deploy a renderer service and cannot infer an environment-specific address.

## Test Plan

- [x] focused renderer, MCP timeout, image collection, and Lark channel tests (294 passed)
- [x] `npm run build`
- [x] `npm run build` in `mcp/create-chart`
- [x] `helm lint helm/siclaw`
- [x] `helm template` with the chart defaults
