### PR TITLE
fix(delegation): persist what a delegated leg's own AgentBox writes

### DIFF
--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -549,9 +549,425 @@ describe("handleDelegationEvents", () => {
     });
   });
 
+  it("accepts a delegated leg's own box, whose cert names the target rather than the owner", async () => {
+    // A delegated leg stays owned by the coordinator that created it (agent-2) while
+    // the turn runs in the delegated peer's box (agent-1 == the calling cert). Its
+    // sub-agent transcript and task-ledger rows used to be refused outright here,
+    // which is what left the leg pointing at sub-agent sessions that never existed.
+    sessionRegistry.remember("parent-1", "user-1", "agent-2", "agent-1");
+    const res = new FakeRes();
+    await handleDelegationEvents(
+      asReq(new FakeReq(JSON.stringify({
+        type: "delegation.ensure_session",
+        sessionId: "child-1",
+        agentId: "agent-1",
+        userId: "user-1",
+        origin: "subagent",
+        lineage: {
+          parentSessionId: "parent-1",
+          parentAgentId: "agent-1",
+          delegationId: "delegation-1",
+          targetAgentId: "agent-1",
+        },
+      }))),
+      asRes(res),
+      identity,
+      frontend as unknown as FrontendWsClient,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(frontend.calls[0].method).toBe("chat.ensureSession");
+  });
+
+  it("refuses ensure_session ON a leg row it only executes, not owns", async () => {
+    // parent-1 is the leg: owned by agent-2, delegated to agent-1 (the caller).
+    // Writing BENEATH that leg is allowed; upserting the leg row ITSELF is not,
+    // or a Portal whose upsert touches more than last_active_at would let the
+    // peer re-point the leg's agent/parent/origin at itself.
+    sessionRegistry.remember("parent-1", "user-1", "agent-2", "agent-1");
+    const res = new FakeRes();
+    await handleDelegationEvents(
+      asReq(new FakeReq(JSON.stringify({
+        type: "delegation.ensure_session",
+        sessionId: "parent-1",
+        agentId: "agent-1",
+        userId: "user-1",
+        origin: "subagent",
+        lineage: {
+          parentSessionId: "root-unknown",
+          parentAgentId: "agent-1",
+          delegationId: "delegation-1",
+          targetAgentId: "agent-1",
+        },
+      }))),
+      asRes(res),
+      identity,
+      frontend as unknown as FrontendWsClient,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe("delegation session mismatch");
+    expect(frontend.calls.find((c) => c.method === "chat.ensureSession")).toBeUndefined();
+  });
+
+  it("still refuses a session delegated to some other agent", async () => {
+    // Neither the owner (agent-2) nor the target (agent-3) is the caller (agent-1):
+    // accepting the target must not become a way to claim anyone else's session.
+    sessionRegistry.remember("parent-1", "user-1", "agent-2", "agent-3");
+    const res = new FakeRes();
+    await handleDelegationEvents(
+      asReq(new FakeReq(JSON.stringify({
+        type: "delegation.ensure_session",
+        sessionId: "child-1",
+        agentId: "agent-1",
+        userId: "user-1",
+        origin: "subagent",
+        lineage: {
+          parentSessionId: "parent-1",
+          parentAgentId: "agent-1",
+          delegationId: "delegation-1",
+          targetAgentId: "agent-1",
+        },
+      }))),
+      asRes(res),
+      identity,
+      frontend as unknown as FrontendWsClient,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(frontend.calls.find((c) => c.method === "chat.ensureSession")).toBeUndefined();
+  });
+
+  it("re-reads a leg cached before its target was known, instead of refusing for the entry's lifetime", async () => {
+    // The state a Runtime restart or eviction can pin: whichever 3-arg caller runs
+    // first (chat.send, a channel, a scheduled task) caches the leg owner-only.
+    // A cache hit never consults the row again, so refusing on the strength of
+    // that entry silently reinstates the data loss this arm exists to fix — and
+    // production runs two Runtimes, so the first caller is not always the one
+    // that knows the delegation fields.
+    sessionRegistry.remember("parent-1", "user-1", "agent-2");
+    const resolver = vi.fn(async () => ({ userId: "user-1", agentId: "agent-2", targetAgentId: "agent-1" }));
+    sessionRegistry.setResolver(resolver);
+    try {
+      for (const attempt of [1, 2]) {
+        const res = new FakeRes();
+        await handleDelegationEvents(
+          asReq(new FakeReq(JSON.stringify({
+            type: "delegation.append_message",
+            message: {
+              sessionId: "parent-1",
+              role: "assistant",
+              content: "written by the delegated peer's box",
+              fromAgentId: "agent-1",
+            },
+          }))),
+          asRes(res),
+          identity,
+          frontend as unknown as FrontendWsClient,
+        );
+        expect(res.statusCode, `attempt ${attempt}`).toBe(200);
+      }
+      // Bounded to one extra read: the refreshed record records that the row has
+      // been consulted, so the second attempt is answered from cache.
+      expect(resolver).toHaveBeenCalledTimes(1);
+    } finally {
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("still refuses cleanly when the re-read itself fails", async () => {
+    // The re-read is on the about-to-refuse path, so a transient upstream failure
+    // there must not turn a 403 into a 500: the handler's outer catch would report
+    // one, and a box reading its own logs could not tell "not your session" from
+    // "the platform is broken". Nothing is written either way.
+    sessionRegistry.remember("parent-1", "user-1", "agent-2");
+    const resolver = vi.fn(async () => { throw new Error("upstream unavailable") });
+    sessionRegistry.setResolver(resolver);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const res = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.append_message",
+          message: { sessionId: "parent-1", role: "assistant", content: "x", fromAgentId: "agent-1" },
+        }))),
+        asRes(res),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(res.statusCode).toBe(403);
+      expect(resolver).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("does not re-read the row when a resolver-sourced record already says there is no target", async () => {
+    // A top-level session genuinely has no delegation target. Refusing must not
+    // cost an RPC every time some other agent's box writes to it.
+    const resolver = vi.fn(async () => ({ userId: "user-1", agentId: "agent-2" }));
+    sessionRegistry.setResolver(resolver);
+    try {
+      const res = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.append_message",
+          message: { sessionId: "parent-1", role: "assistant", content: "x", fromAgentId: "agent-1" },
+        }))),
+        asRes(res),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(res.statusCode).toBe(403);
+      // One read to populate the cache miss; the refusal itself adds none.
+      expect(resolver).toHaveBeenCalledTimes(1);
+    } finally {
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("lets a delegated leg's box append to the leg but not rewrite its history", async () => {
+    // The asymmetry the append arm must not smuggle in: append_message adds a row
+    // attributed to the peer, while update_message takes a message id and rewrites
+    // THAT row — including rows the coordinator wrote — and nothing in the payload
+    // scopes the rewrite to the caller's own. So the arm that exists to persist a
+    // sub-agent transcript stops short of the conversation's history.
+    sessionRegistry.remember("parent-1", "user-1", "agent-2", "agent-1");
+    const resolver = vi.fn(async () => ({ userId: "user-1", agentId: "agent-2", targetAgentId: "agent-1" }));
+    sessionRegistry.setResolver(resolver);
+    try {
+      const appended = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.append_message",
+          message: { sessionId: "parent-1", role: "assistant", content: "peer's own row", fromAgentId: "agent-1" },
+        }))),
+        asRes(appended),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(appended.statusCode).toBe(200);
+
+      for (const type of ["delegation.update_message", "delegation.update_tool_message"]) {
+        const res = new FakeRes();
+        await handleDelegationEvents(
+          asReq(new FakeReq(JSON.stringify({
+            type,
+            message: { sessionId: "parent-1", messageId: "msg-1", content: "rewritten by the peer" },
+          }))),
+          asRes(res),
+          identity,
+          frontend as unknown as FrontendWsClient,
+        );
+        expect(res.statusCode, type).toBe(403);
+      }
+    } finally {
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("does not trust a relayed leg cached under the peer when checking ownership", async () => {
+    // On a Runtime the leg was RELAYED to, `chat.send` caches it under the peer's
+    // own agent — so a cache-only owner check would read back "the peer owns it"
+    // and hand the peer the rewrite access the check exists to withhold, in
+    // exactly the multi-Runtime deployment where nobody is watching one box's
+    // swallowed persistence errors. Ownership therefore comes from the row.
+    sessionRegistry.remember("parent-1", "user-1", "agent-1");
+    const resolver = vi.fn(async () => ({ userId: "user-1", agentId: "agent-2", targetAgentId: "agent-1" }));
+    sessionRegistry.setResolver(resolver);
+    try {
+      const rewrite = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.update_message",
+          message: { sessionId: "parent-1", messageId: "msg-1", content: "rewritten by the peer" },
+        }))),
+        asRes(rewrite),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(rewrite.statusCode).toBe(403);
+      expect(resolver, "the cached record must not answer an ownership question").toHaveBeenCalledTimes(1);
+
+      // The append arm is unaffected: that is the write this whole change exists
+      // to let through, and the refreshed record now names the target.
+      const appended = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.append_message",
+          message: { sessionId: "parent-1", role: "assistant", content: "peer's own row", fromAgentId: "agent-1" },
+        }))),
+        asRes(appended),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(appended.statusCode).toBe(200);
+    } finally {
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("still refuses a rewrite after a relay re-cached the leg under the peer", async () => {
+    // The sequence that reopened this gate once already: the row is read and cached
+    // authoritatively as the coordinator's, then the Runtime the leg was relayed to
+    // handles `chat.send` and re-remembers it under the PEER. If provenance rode
+    // along with that rewrite, the entry would assert the peer as an authoritative
+    // owner and this gate would skip the re-read that catches it.
+    const resolver = vi.fn(async () => ({ userId: "user-1", agentId: "agent-2", targetAgentId: "agent-1" }));
+    sessionRegistry.setResolver(resolver);
+    try {
+      // 1. Row-sourced: the coordinator owns it.
+      expect(await sessionRegistry.get("parent-1")).toMatchObject({ agentId: "agent-2", authoritative: true });
+      // 2. The relay's own view of the same session.
+      sessionRegistry.remember("parent-1", "user-1", "agent-1");
+      expect(sessionRegistry.peek("parent-1")).toMatchObject({ agentId: "agent-1" });
+
+      const res = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.update_message",
+          message: { sessionId: "parent-1", messageId: "msg-1", content: "rewritten by the peer" },
+        }))),
+        asRes(res),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(res.statusCode).toBe(403);
+      // The re-read is what caught it: once for the initial get, once because the
+      // rewritten entry no longer carries provenance.
+      expect(resolver).toHaveBeenCalledTimes(2);
+    } finally {
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("refuses an owner-only write when the row cannot be re-read", async () => {
+    // The cached owner does not stand in for the row, not even when it names the
+    // caller. A cache entry says "this Runtime is running the session for agent X",
+    // which on a relayed leg is the PEER — so an entry that happens to agree with
+    // the caller is not evidence, it is the same unverified claim. And the moment
+    // this matters is exactly the moment the row cannot contradict it.
+    sessionRegistry.remember("parent-1", "user-1", "agent-1");
+    const resolver = vi.fn(async () => { throw new Error("portal unavailable") });
+    sessionRegistry.setResolver(resolver);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const res = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.update_message",
+          message: { sessionId: "parent-1", messageId: "msg-1", content: "unprovable" },
+        }))),
+        asRes(res),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(res.statusCode).toBe(403);
+      expect(resolver).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("refuses a relayed leg's rewrite while the row is unreachable", async () => {
+    // The whole sequence, in order, because each step is individually correct and
+    // the exposure only appears once they are composed:
+    //   1. the row is read — the coordinator owns the leg, the peer executes it;
+    //   2. this Runtime handles chat.send for the relayed leg and re-remembers it
+    //      under the PEER, correctly dropping provenance but keeping the target;
+    //   3. Portal goes away, so the gate cannot ask the row;
+    //   4. the peer asks to rewrite a row in the coordinator's conversation.
+    // Trusting the cache at step 4 hands over the permission, and hands it over
+    // specifically while the source of truth is unavailable to object.
+    const rowResolver = vi.fn(async () => ({ userId: "user-1", agentId: "agent-2", targetAgentId: "agent-1" }));
+    sessionRegistry.setResolver(rowResolver);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(await sessionRegistry.get("parent-1")).toMatchObject({ agentId: "agent-2", authoritative: true });
+      sessionRegistry.remember("parent-1", "user-1", "agent-1");
+      expect(sessionRegistry.peek("parent-1")).toMatchObject({ agentId: "agent-1", targetAgentId: "agent-1" });
+      expect(sessionRegistry.peek("parent-1")?.authoritative).toBeUndefined();
+
+      sessionRegistry.setResolver(async () => { throw new Error("portal unavailable") });
+      const res = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.update_message",
+          message: { sessionId: "parent-1", messageId: "msg-1", content: "rewritten by the peer" },
+        }))),
+        asRes(res),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(res.statusCode).toBe(403);
+      expect(frontend.calls).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+      sessionRegistry.setResolver(undefined);
+      sessionRegistry.forget("parent-1");
+    }
+  });
+
+  it("names the session in an ownership refusal, and keeps payload errors off that signal", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // A box treats persistence as best-effort and swallows the failure, so this
+      // line is the only trace a dropped write leaves. Without the session id it
+      // cannot be tied to the conversation whose history went missing.
+      sessionRegistry.remember("parent-other", "user-1", "agent-2", "agent-3");
+      const refused = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.append_message",
+          message: { sessionId: "parent-other", role: "assistant", content: "x", fromAgentId: "agent-1" },
+        }))),
+        asRes(refused),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(refused.statusCode).toBe(403);
+      const refusal = warnSpy.mock.calls.map((c) => String(c[0])).find((m) => m.includes("refused"));
+      expect(refusal).toContain("parent-other");
+
+      warnSpy.mockClear();
+      // A malformed payload is the caller's own bug, not a Portal that stopped
+      // reporting delegation targets. Mixing the two makes a steady stream of
+      // real refusals unreadable.
+      const malformed = new FakeRes();
+      await handleDelegationEvents(
+        asReq(new FakeReq(JSON.stringify({
+          type: "delegation.ensure_session", sessionId: "child-1", agentId: "agent-1", userId: "",
+        }))),
+        asRes(malformed),
+        identity,
+        frontend as unknown as FrontendWsClient,
+      );
+      expect(malformed.statusCode).toBe(400);
+      expect(warnSpy.mock.calls.map((c) => String(c[0])).some((m) => m.includes("refused"))).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+      sessionRegistry.forget("parent-other");
+    }
+  });
+
   it("forwards toolset through the AgentBox persistence append/update bridge", async () => {
     sessionRegistry.remember("child-1", "user-1", "agent-1");
     sessionRegistry.remember("parent-1", "user-1", "agent-1");
+    // A resolver is always installed in production (startRuntime wires one), and
+    // `update_message` is owner-only against the ROW — so a test that cached the
+    // session by hand has to be able to confirm it, or it is asserting the
+    // behaviour of a Runtime that cannot exist.
+    sessionRegistry.setResolver(async () => ({ userId: "user-1", agentId: "agent-1" }));
 
     const appendRes = new FakeRes();
     await handleDelegationEvents(
@@ -600,6 +1016,7 @@ describe("handleDelegationEvents", () => {
       method: "chat.updateMessage",
       params: { tool_name: "read", toolset: "filesystem" },
     });
+    sessionRegistry.setResolver(undefined);
   });
 
   it("rejects delegated session creation without an explicit userId", async () => {
@@ -806,6 +1223,9 @@ describe("handleDelegationEvents", () => {
 
   it("delivers explicit channel messages through the registered channel callback without Portal writes", async () => {
     sessionRegistry.remember("channel-1", "lark:oc_1", "agent-1");
+    // Same reason as the append/update bridge above: channel delivery is owner-only
+    // against the row, and production always has a resolver to ask.
+    sessionRegistry.setResolver(async () => ({ userId: "lark:oc_1", agentId: "agent-1" }));
     const delivered: Array<{ kind: string; text: string }> = [];
     registerBackgroundChannelDelivery("channel-1", async (message) => {
       if ("text" in message) delivered.push({ kind: message.kind, text: message.text });
@@ -832,6 +1252,7 @@ describe("handleDelegationEvents", () => {
     expect(JSON.parse(res.body)).toEqual({ ok: true });
     expect(delivered).toEqual([{ kind: "milestone", text: "已完成节点列表检查。" }]);
     expect(frontend.calls).toHaveLength(0);
+    sessionRegistry.setResolver(undefined);
   });
 
   it("rejects explicit channel messages from another agent identity", async () => {
@@ -862,6 +1283,53 @@ describe("handleDelegationEvents", () => {
     expect(JSON.parse(res.body).error).toContain("source agent mismatch");
     expect(delivered).toHaveLength(0);
     expect(frontend.calls).toHaveLength(0);
+  });
+
+  it("does not let a delegated leg deliver to the conversation's channel", async () => {
+    // Channel delivery is owner-only, unlike the delegation persistence events.
+    // The `channel_update` tool that produces these is suppressed on a delegated
+    // turn by design — a delegated worker's output flows back through the
+    // coordinator, which owns the single visible identity — so a leg has no
+    // legitimate way to reach here, and the ownership arm that lets a peer's box
+    // persist a sub-agent's transcript should not double as a channel key.
+    // Two cache states, one verdict. The second is the one a cache-only owner
+    // check would get wrong: on the Runtime a leg was relayed to, `chat.send`
+    // caches it under the PEER, so "who owns this" has to come from the row.
+    for (const [label, cachedOwner] of [["cached under the coordinator", "agent-2"], ["cached under the peer by a relay", "agent-1"]] as const) {
+      sessionRegistry.remember("channel-1", "lark:oc_1", cachedOwner, "agent-1");
+      const resolver = vi.fn(async () => ({ userId: "lark:oc_1", agentId: "agent-2", targetAgentId: "agent-1" }));
+      sessionRegistry.setResolver(resolver);
+      const delivered: string[] = [];
+      registerBackgroundChannelDelivery("channel-1", async (message) => {
+        if ("text" in message) delivered.push(message.text);
+        return true;
+      });
+      const res = new FakeRes();
+
+      try {
+        await handleDelegationEvents(
+          asReq(new FakeReq(JSON.stringify({
+            type: "channel.deliver_message",
+            message: {
+              sessionId: "channel-1",
+              kind: "milestone",
+              text: "should not reach the channel",
+              fromAgentId: "agent-1",
+            },
+          }))),
+          asRes(res),
+          identity,
+          frontend as unknown as FrontendWsClient,
+        );
+
+        expect(res.statusCode, label).toBe(403);
+        expect(delivered, label).toHaveLength(0);
+        expect(frontend.calls, label).toHaveLength(0);
+      } finally {
+        sessionRegistry.setResolver(undefined);
+        sessionRegistry.forget("channel-1");
+      }
+    }
   });
 });
 

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -19,7 +19,7 @@ import { randomUUID } from "node:crypto";
 import type { FrontendWsClient } from "./frontend-ws-client.js";
 import type { CertificateIdentity } from "./security/cert-manager.js";
 import type { ChatMessageMetadata } from "../shared/message-kinds.js";
-import { sessionRegistry } from "./session-registry.js";
+import { sessionRegistry, type SessionRecord } from "./session-registry.js";
 import {
   deliverBackgroundChannelMessage,
   deliverChannelVisibleMessage,
@@ -58,10 +58,111 @@ function sendJson(res: http.ServerResponse, status: number, data: unknown): void
   res.end(JSON.stringify(data));
 }
 
+/**
+ * Does `sessionId` belong to the calling certificate's agent? Unknown sessions
+ * degrade to `true` (the caller cannot be shown to be lying); a known session
+ * passes when the caller either OWNS it or is the peer it was DELEGATED TO.
+ *
+ * The delegation arm exists because a delegated leg is the one session whose
+ * owner is deliberately not its executor: the coordinator that created the leg
+ * stays the owner (so it keeps the conversation), while the turn runs in the
+ * delegated peer's AgentBox, whose certificate names the peer. Everything that
+ * box persists FOR that leg — a spawned sub-agent's session and transcript,
+ * task-ledger events — therefore arrived with an identity that could not match
+ * the row's owner and was refused, while the pointers to those rows, written by
+ * the coordinator-side stream, went through. The result was a leg advertising
+ * sub-agent sessions that had never been created.
+ *
+ * Accepting the target does not widen attribution: `target_agent_id` is the box
+ * the leg was handed to, so a box still cannot claim a session delegated to
+ * anyone else, and a top-level session has no target to fall back on.
+ */
 async function sessionBelongsToIdentity(sessionId: string | null | undefined, identity: CertificateIdentity): Promise<boolean> {
   if (!sessionId) return true;
   const owner = await sessionRegistry.get(sessionId);
-  return !owner || owner.agentId === identity.agentId;
+  if (!owner) return true;
+  if (owner.agentId === identity.agentId) return true;
+  if (owner.targetAgentId) return owner.targetAgentId === identity.agentId;
+  // No target on the record — authoritative only if the record came from the row
+  // itself. The 3-arg `rememberSession` callers know nothing about delegation
+  // fields, so whichever of them runs first after a restart or an eviction caches
+  // the leg owner-only, and a cache hit never re-reads: refusing on the strength
+  // of such an entry would silently reinstate the data loss this arm exists to
+  // fix, for as long as the entry survived. Production runs more than one
+  // Runtime, so the first caller is not reliably the one that knows the target.
+  //
+  // Re-read once, on the about-to-refuse path only. The refreshed record is
+  // marked as row-sourced, so a repeat attempt costs nothing.
+  if (owner.authoritative) return false;
+  // The re-read must not be able to make things worse than the refusal it is
+  // trying to avoid. This is the only I/O on the about-to-refuse path, and an
+  // exception here would reach the handler's outer catch as a 500 — telling a box
+  // that swallows persistence failures nothing it can act on, and hiding "not
+  // your session" behind "the platform is broken". Nothing is written either way,
+  // so a failed re-read simply leaves the refusal standing.
+  let refreshed: SessionRecord | undefined;
+  try {
+    refreshed = await sessionRegistry.refresh(sessionId);
+  } catch (err) {
+    console.warn(`[internal-api] could not re-read session ${sessionId} before refusing: ${String(err)}`);
+    return false;
+  }
+  return Boolean(refreshed?.targetAgentId) && refreshed?.targetAgentId === identity.agentId;
+}
+
+/**
+ * Strict owner-only variant, for a session a request claims to CREATE, REWRITE
+ * or SPEAK AS rather than merely write into. Unlike the arm above, the delegation
+ * target buys nothing here: appending is additive, whereas these three verbs act
+ * on rows and channels the coordinator owns.
+ *
+ * The owner is taken from the ROW, never from a cached record of unknown
+ * provenance. A leg relayed to another Runtime is dispatched there by
+ * `chat.send`, which caches it under the PEER's agent — so a cache-only owner
+ * check would hand the peer exactly the rewrite access this gate withholds, and
+ * would do so only in the multi-Runtime deployment where it matters least to
+ * notice. One extra read per session per cache lifetime; nothing once the record
+ * is authoritative.
+ *
+ * Note the re-read is NOT confined to the about-to-refuse path, unlike
+ * `sessionBelongsToIdentity`. There, a stale record can only wrongly refuse; here
+ * it can wrongly ACCEPT, so provenance has to be settled before the comparison
+ * rather than after it fails.
+ *
+ * An UNREACHABLE row is a REFUSAL, not a fallback to the cached owner. Falling
+ * back reads like the available-first choice, and it is wrong here for a specific
+ * reason: on a leg relayed to this Runtime, `chat.send` wrote the PEER into that
+ * cache entry, so the fallback would trust the one value this gate exists to
+ * distrust — and would do it precisely while the source of truth is unavailable to
+ * contradict it. The asymmetry settles it: a refused `channel.deliver_message`
+ * drops a progress card during an outage in which nothing else is persisting
+ * either, while a wrongly-admitted `update_message` forges conversation content
+ * and cannot be undone.
+ *
+ * Every `true` this returns is therefore either "no such session" or a comparison
+ * against a row-sourced record. There is no third source.
+ */
+async function sessionOwnedByIdentity(sessionId: string | null | undefined, identity: CertificateIdentity): Promise<boolean> {
+  if (!sessionId) return true;
+  const cached = await sessionRegistry.get(sessionId);
+  if (!cached) return true;
+  if (cached.authoritative) return cached.agentId === identity.agentId;
+
+  let fromRow: SessionRecord | undefined;
+  try {
+    fromRow = await sessionRegistry.refresh(sessionId);
+  } catch (err) {
+    // Nothing is written either way, so this must not reach the handler's outer
+    // catch as a 500: that would tell a box reading its own logs that the platform
+    // is broken when the answer is simply unavailable.
+    console.warn(`[internal-api] could not re-read session ${sessionId} for an owner-only check: ${String(err)}`);
+  }
+  if (fromRow?.authoritative) return fromRow.agentId === identity.agentId;
+  // Distinct from "not your session": an operator reading these needs to tell a
+  // real attribution mismatch from a window where the row simply could not be
+  // reached, because the second one clears up on its own and the first does not.
+  console.warn(`[internal-api] refusing an owner-only write on session ${sessionId}: ownership could not be established from the row`);
+  return false;
 }
 
 /**
@@ -72,6 +173,17 @@ async function sessionBelongsToIdentity(sessionId: string | null | undefined, id
  *
  * Unknown sessions degrade gracefully (`ok: true`, `userId: ""`); only an
  * explicit ownership mismatch trips the gate.
+ *
+ * Deliberately NARROWER than `sessionBelongsToIdentity`: it does not accept a
+ * session's delegation target. These routes mutate cron schedules, so allowing
+ * them from inside a delegated leg would let a peer bind a long-lived schedule
+ * to itself off the back of one delegated turn — a product question about who
+ * may own a schedule, not the attribution gap the other helper closes.
+ *
+ * That narrowness is NOT a routing-independent guarantee: a leg relayed to
+ * another Runtime is dispatched there by `chat.send`, which caches the leg under
+ * the PEER's agent, so the owner check already passes for it. Only a leg run by
+ * the Runtime that created it is refused here.
  */
 async function resolveUserForIdentity(
   sessionId: string | null | undefined,
@@ -88,6 +200,40 @@ function agentMatchesIdentity(agentId: string | null | undefined, identity: Cert
   return !agentId || agentId === identity.agentId;
 }
 
+/**
+ * The sessions a refusal was about, for the log line. Which field carries them
+ * differs per event type, and a refusal can be about the PARENT rather than the
+ * subject — the error string says which check failed, this says on what.
+ */
+function delegationEventSessions(event: DelegationPersistenceEvent): string {
+  const parts: string[] = [];
+  const push = (label: string, id?: string | null): void => {
+    if (id) parts.push(`${label}=${id}`);
+  };
+  switch (event.type) {
+    case "delegation.ensure_session":
+      push("session", event.sessionId);
+      push("parent", event.lineage?.parentSessionId);
+      break;
+    case "delegation.append_message":
+      push("session", event.message.sessionId);
+      push("parent", event.message.parentSessionId);
+      break;
+    case "delegation.update_message":
+    case "delegation.update_tool_message":
+    case "channel.deliver_message":
+      push("session", event.message.sessionId);
+      break;
+    case "delegation.append_event":
+      push("parent", event.event.parentSessionId);
+      break;
+    case "delegation.emit_chat_event":
+      push("session", event.sessionId);
+      break;
+  }
+  return parts.join(" ");
+}
+
 async function validateDelegationEventActor(
   event: DelegationPersistenceEvent,
   identity: CertificateIdentity,
@@ -102,7 +248,9 @@ async function validateDelegationEventActor(
       // them in parallel — the unhappy path wastes one extra RPC but the
       // happy path's latency is halved.
       const [own, parentOwn] = await Promise.all([
-        sessionBelongsToIdentity(event.sessionId, identity),
+        // Subject: owner-only (this call upserts the row) — see sessionOwnedByIdentity.
+        sessionOwnedByIdentity(event.sessionId, identity),
+        // Parent: a delegated leg's peer legitimately writes beneath it.
         sessionBelongsToIdentity(event.lineage?.parentSessionId, identity),
       ]);
       if (!own) return { status: 403, error: "delegation session mismatch" };
@@ -122,7 +270,14 @@ async function validateDelegationEventActor(
     }
     case "delegation.update_message":
     case "delegation.update_tool_message": {
-      if (!(await sessionBelongsToIdentity(event.message.sessionId, identity))) return { status: 403, error: "delegation session mismatch" };
+      // Owner-only, NOT the delegation arm. These take a message id and rewrite
+      // that row, and nothing in the payload scopes the rewrite to rows the
+      // caller wrote — so the arm that lets a peer's box APPEND its sub-agent
+      // transcript would also let it rewrite what the coordinator said. Appending
+      // at worst adds rows attributed to the peer; rewriting forges the
+      // conversation. No caller reaches this today (row updates run on the
+      // coordinator side), which is exactly why it costs nothing to hold shut.
+      if (!(await sessionOwnedByIdentity(event.message.sessionId, identity))) return { status: 403, error: "delegation session mismatch" };
       return null;
     }
     case "delegation.append_event": {
@@ -138,7 +293,13 @@ async function validateDelegationEventActor(
     }
     case "channel.deliver_message": {
       if (!agentMatchesIdentity(event.message.fromAgentId, identity)) return { status: 403, error: "channel source agent mismatch" };
-      if (!(await sessionBelongsToIdentity(event.message.sessionId, identity))) return { status: 403, error: "channel session mismatch" };
+      // Owner-only, unlike the delegation persistence events above. This carries
+      // no delegated state: the `channel_update` tool behind it is suppressed on a
+      // delegated turn by design (a delegated worker's output flows back through
+      // the coordinator, which owns the single visible identity), so a leg has no
+      // legitimate route here. The arm that lets a peer's box persist a sub-agent
+      // transcript should not double as a key to the conversation's channel.
+      if (!(await sessionOwnedByIdentity(event.message.sessionId, identity))) return { status: 403, error: "channel session mismatch" };
       return null;
     }
     default:
@@ -652,6 +813,26 @@ export async function handleDelegationEvents(
     const event = await readJsonBody(req) as DelegationPersistenceEvent;
     const actorError = await validateDelegationEventActor(event, identity);
     if (actorError) {
+      const where = delegationEventSessions(event);
+      const suffix = where ? ` (${where})` : "";
+      if (actorError.status === 403) {
+        // Log it: an AgentBox treats persistence as best-effort and swallows the
+        // failure, so a refusal here is otherwise invisible — and the rows it drops
+        // are the ones a delegated leg's sub-agent transcript is made of. A Portal
+        // that does not report a session's delegation target shows up as a steady
+        // stream of these rather than as silently missing history. The session ids
+        // are what tie such a stream to the conversations that lost content.
+        console.warn(
+          `[internal-api] refused ${event.type} for agent ${identity.agentId}: ${actorError.error}${suffix}`,
+        );
+      } else {
+        // A malformed payload is the caller's own bug, not a missing delegation
+        // target. Kept off the wording above so a stream of real refusals stays
+        // legible.
+        console.warn(
+          `[internal-api] rejected malformed ${event.type} from agent ${identity.agentId}: ${actorError.error}${suffix}`,
+        );
+      }
       sendJson(res, actorError.status, { error: actorError.error });
       return;
     }

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -205,9 +205,18 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         }),
       ]) as
         | { found: false }
-        | { found: true; user_id: string; agent_id: string };
+        | { found: true; user_id: string; agent_id: string; target_agent_id?: string | null };
       if (!data.found) return null;
-      return { userId: data.user_id, agentId: data.agent_id };
+      // target_agent_id names the peer that executes a delegated leg; dropping it
+      // here left the registry unable to tell that peer from an unrelated agent.
+      // A non-delegated session reports it as null or "", so guard on truthiness
+      // rather than presence. A Portal that omits the field entirely degrades to
+      // the pre-change behaviour — refusals, logged by internal-api, not silence.
+      return {
+        userId: data.user_id,
+        agentId: data.agent_id,
+        ...(data.target_agent_id ? { targetAgentId: data.target_agent_id } : {}),
+      };
     } catch (err) {
       console.error("[session-registry] resolveSession RPC failed:", err);
       return null;

--- a/src/gateway/session-registry.test.ts
+++ b/src/gateway/session-registry.test.ts
@@ -9,6 +9,127 @@ describe("SessionRegistry", () => {
     expect(await reg.get("s1")).toMatchObject({ userId: "alice", agentId: "agent-a" });
   });
 
+  it("keeps a delegated leg's target agent, the only field naming its executor", async () => {
+    const reg = new SessionRegistry();
+    reg.remember("leg-1", "alice", "coordinator-a", "peer-b");
+    expect(await reg.get("leg-1")).toMatchObject({ agentId: "coordinator-a", targetAgentId: "peer-b" });
+    // A top-level session has no target to fall back on.
+    reg.remember("top-1", "alice", "agent-a");
+    expect((await reg.get("top-1"))?.targetAgentId).toBeUndefined();
+  });
+
+  it("keeps the target when a 3-arg caller re-remembers the same session", async () => {
+    const reg = new SessionRegistry();
+    reg.remember("leg-1", "alice", "coordinator-a", "peer-b");
+    // chat.send, scheduled tasks and the channel entry points all use the 3-arg
+    // form. Letting one of them blank the target would re-close the ownership
+    // gate on the delegated peer until the entry was evicted.
+    reg.remember("leg-1", "alice", "coordinator-a");
+    expect(await reg.get("leg-1")).toMatchObject({ targetAgentId: "peer-b" });
+  });
+
+  it("back-fills the target agent from the resolver, so a cache miss does not lose it", async () => {
+    const reg = new SessionRegistry();
+    reg.setResolver(async () => ({ userId: "alice", agentId: "coordinator-a", targetAgentId: "peer-b" }));
+    // First read goes through the resolver; the second is served from cache and
+    // must still carry the target (the back-fill used to drop it).
+    expect(await reg.get("leg-1")).toMatchObject({ targetAgentId: "peer-b" });
+    expect(reg.peek("leg-1")).toMatchObject({ agentId: "coordinator-a", targetAgentId: "peer-b" });
+  });
+
+  it("treats an empty target as 'not supplied' rather than as a instruction to clear", async () => {
+    const reg = new SessionRegistry();
+    reg.remember("leg-1", "alice", "coordinator-a", "peer-b");
+    // `??` only falls through on null/undefined, so an empty string used to reach
+    // the record and blank the target — the opposite of what preservation means.
+    reg.remember("leg-1", "alice", "coordinator-a", "");
+    expect(await reg.get("leg-1")).toMatchObject({ targetAgentId: "peer-b" });
+  });
+
+  it("refresh re-reads a session that was cached before its target was known", async () => {
+    const reg = new SessionRegistry();
+    // The state a Runtime restart can pin: whichever 3-arg caller runs first
+    // (chat.send, a channel, a scheduled task) caches the leg owner-only, and
+    // every later read is served from that entry without consulting the row.
+    reg.remember("leg-1", "alice", "coordinator-a");
+    expect((await reg.get("leg-1"))?.targetAgentId).toBeUndefined();
+
+    const resolver = vi.fn(async () => ({
+      userId: "alice",
+      agentId: "coordinator-a",
+      targetAgentId: "peer-b",
+    }));
+    reg.setResolver(resolver);
+    expect(await reg.refresh("leg-1")).toMatchObject({ targetAgentId: "peer-b" });
+    // Back-filled, so the next reader sees the target without another read.
+    expect(reg.peek("leg-1")).toMatchObject({ targetAgentId: "peer-b" });
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a record read from the row, so an absent target is answerable from cache", async () => {
+    const reg = new SessionRegistry();
+    const resolver = vi.fn(async () => ({ userId: "alice", agentId: "agent-a" }));
+    reg.setResolver(resolver);
+    // A top-level session genuinely has no target. Recording where that answer
+    // came from is what lets a caller distinguish "no target" from "target not
+    // known yet" — and so stop re-reading the row on every refusal.
+    expect(await reg.get("top-1")).toMatchObject({ authoritative: true });
+    // A 3-arg caller knows nothing about delegation fields and must not unlearn it.
+    reg.remember("top-1", "alice", "agent-a");
+    expect(reg.peek("top-1")).toMatchObject({ authoritative: true });
+  });
+
+  it("drops provenance when a 3-arg caller rewrites the owner it was read with", async () => {
+    const reg = new SessionRegistry();
+    reg.setResolver(async () => ({ userId: "alice", agentId: "coordinator", targetAgentId: "peer" }));
+    expect(await reg.get("leg-1")).toMatchObject({ agentId: "coordinator", authoritative: true });
+
+    // The Runtime the leg was RELAYED to handles chat.send and caches it under the
+    // peer. Nothing adversarial about it — but the flag certifies the fields it was
+    // read with, and this call has replaced them. Keeping it would leave the entry
+    // asserting the peer as an AUTHORITATIVE owner, which is the one assertion the
+    // owner-only gate skips its re-read on.
+    reg.remember("leg-1", "alice", "peer");
+    const poisoned = reg.peek("leg-1");
+    expect(poisoned).toMatchObject({ agentId: "peer" });
+    expect(poisoned?.authoritative).toBeUndefined();
+    // The target survives: a 3-arg caller has no reason to know it, and losing it
+    // would re-close the append arm on the peer's own box.
+    expect(poisoned).toMatchObject({ targetAgentId: "peer" });
+  });
+
+  it("drops provenance when the user is rewritten too, not just the agent", async () => {
+    const reg = new SessionRegistry();
+    reg.setResolver(async () => ({ userId: "alice", agentId: "agent-a" }));
+    expect(await reg.get("s-rebind")).toMatchObject({ authoritative: true });
+    reg.remember("s-rebind", "bob", "agent-a");
+    expect(reg.peek("s-rebind")?.authoritative).toBeUndefined();
+  });
+
+  it("coalesces concurrent refreshes of one session into a single read", async () => {
+    const reg = new SessionRegistry();
+    reg.remember("leg-1", "alice", "coordinator-a");
+    let release: ((v: { userId: string; agentId: string; targetAgentId: string }) => void) | undefined;
+    const resolver = vi.fn(() => new Promise<{ userId: string; agentId: string; targetAgentId: string }>(r => { release = r; }));
+    reg.setResolver(resolver);
+
+    // A restart delivers a burst of buffered callbacks at once; each refusal must
+    // not become its own RPC.
+    const first = reg.refresh("leg-1");
+    const second = reg.refresh("leg-1");
+    release?.({ userId: "alice", agentId: "coordinator-a", targetAgentId: "peer-b" });
+    expect(await first).toMatchObject({ targetAgentId: "peer-b" });
+    expect(await second).toMatchObject({ targetAgentId: "peer-b" });
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh without a resolver leaves the cached record alone", async () => {
+    const reg = new SessionRegistry();
+    reg.remember("leg-1", "alice", "coordinator-a");
+    expect(await reg.refresh("leg-1")).toBeUndefined();
+    expect(reg.peek("leg-1")).toMatchObject({ agentId: "coordinator-a" });
+  });
+
   it("returns empty string for unknown sessionId so callers never NPE", async () => {
     const reg = new SessionRegistry();
     expect(await reg.resolveUser("missing")).toBe("");

--- a/src/gateway/session-registry.ts
+++ b/src/gateway/session-registry.ts
@@ -14,6 +14,10 @@
  * RPC) is consulted so attribution survives Runtime restarts: the
  * `chat_sessions` row is the source of truth, and the registry merely
  * accelerates lookup.
+ *
+ * A delegated leg is the one case where the owning agent is NOT the executing
+ * one, so the record also carries the session's delegation target — see
+ * `SessionRecord.targetAgentId`.
  */
 
 const DEFAULT_CAPACITY = 10_000;
@@ -21,12 +25,38 @@ const DEFAULT_CAPACITY = 10_000;
 export interface SessionRecord {
   userId: string;
   agentId: string;
+  /**
+   * For a delegated leg: the agent the session was delegated TO, i.e. the peer
+   * whose AgentBox actually runs the turn. The row's `agentId` deliberately stays
+   * the delegating coordinator so it keeps ownership of the conversation, which
+   * makes this the only field naming the executor. Absent for a top-level session.
+   */
+  targetAgentId?: string;
+  /**
+   * True when this record's owner and user were read from the `chat_sessions` row
+   * itself rather than assembled by a caller. It certifies THOSE FIELDS, so
+   * `remember()` drops it the moment a caller overwrites them. Two separate gates
+   * depend on it:
+   *
+   *  - an ABSENT `targetAgentId` means "this session has no delegation target"
+   *    rather than "this entry predates knowing one";
+   *  - `agentId` can be trusted to name the session's OWNER. A leg relayed to
+   *    another Runtime is cached there under the PEER by `chat.send`, so a
+   *    non-authoritative record can name the peer as owner — which an owner-only
+   *    gate must not take at face value, or the peer gains the very rewrite
+   *    access that gate exists to withhold.
+   *
+   * The 3-arg `remember()` callers know nothing about delegation fields, and a
+   * cache hit never consults the row again, so without this flag both gates would
+   * answer from whichever caller happened to populate the entry first.
+   */
+  authoritative?: boolean;
   lastSeen: number;
 }
 
 export type SessionResolver = (
   sessionId: string,
-) => Promise<{ userId: string; agentId: string } | null>;
+) => Promise<{ userId: string; agentId: string; targetAgentId?: string } | null>;
 
 export class SessionRegistry {
   private map = new Map<string, SessionRecord>();
@@ -46,12 +76,66 @@ export class SessionRegistry {
     this.resolver = resolver;
   }
 
-  /** Record that `sessionId` belongs to `userId` on `agentId`. Updates recency. */
-  remember(sessionId: string, userId: string, agentId: string): void {
+  /**
+   * Record that `sessionId` belongs to `userId` on `agentId`. Updates recency.
+   * `targetAgentId` is the delegation target when the session is a delegated leg;
+   * omitting it PRESERVES an already-cached target rather than clearing it.
+   */
+  remember(sessionId: string, userId: string, agentId: string, targetAgentId?: string): void {
     if (!sessionId) return;
-    // Re-insert to refresh LRU position.
+    const cached = this.map.get(sessionId);
+    // A session's delegation target is fixed when its row is created, and the
+    // 3-arg callers (chat.send, scheduled tasks, channels) have no reason to know
+    // it. Carry a cached target forward instead of letting one of them blank it:
+    // dropping it re-closes the ownership gate on the delegated peer's AgentBox
+    // until the entry happens to be evicted, which is a silent regression.
+    //
+    // `||`, not `??`: an empty string is a caller that did not supply a target,
+    // not one asking to clear it.
+    const target = targetAgentId || cached?.targetAgentId;
+    // Provenance certifies THE FIELDS IT WAS READ WITH, so it survives only while
+    // those fields do. A caller that leaves owner and user alone cannot unlearn
+    // that the row was consulted; one that overwrites them has replaced the very
+    // thing the flag vouches for.
+    //
+    // Carrying it across an owner rewrite is what makes the flag a lie, and the
+    // sequence is ordinary rather than adversarial: the resolver caches
+    // {coordinator, target: peer, authoritative}, then the Runtime the leg was
+    // relayed to handles `chat.send` and calls remember(sid, userId, peer). The
+    // entry would then claim the peer as an AUTHORITATIVE owner, which is exactly
+    // the assertion `sessionOwnedByIdentity` skips its re-read on — reopening
+    // update_message, update_tool_message and channel delivery to the peer without
+    // the row ever being asked.
+    const identityIntact = cached?.agentId === agentId && cached?.userId === userId;
+    this.write(sessionId, {
+      userId,
+      agentId,
+      ...(target ? { targetAgentId: target } : {}),
+      ...(cached?.authoritative && identityIntact ? { authoritative: true } : {}),
+    });
+  }
+
+  /**
+   * Cache a record read from the `chat_sessions` row, marked as such so an
+   * absent target is answerable from cache instead of triggering another read.
+   */
+  private rememberFromSource(
+    sessionId: string,
+    fetched: { userId: string; agentId: string; targetAgentId?: string },
+  ): void {
+    if (!sessionId) return;
+    this.write(sessionId, {
+      userId: fetched.userId,
+      agentId: fetched.agentId,
+      ...(fetched.targetAgentId ? { targetAgentId: fetched.targetAgentId } : {}),
+      authoritative: true,
+    });
+  }
+
+  /** Insert (re-inserting to refresh LRU position) and evict past capacity. */
+  private write(sessionId: string, record: Omit<SessionRecord, "lastSeen">): void {
     this.map.delete(sessionId);
-    this.map.set(sessionId, { userId, agentId, lastSeen: Date.now() });
+    this.map.set(sessionId, { ...record, lastSeen: Date.now() });
     if (this.map.size > this.capacity) {
       const oldest = this.map.keys().next().value as string | undefined;
       if (oldest) this.map.delete(oldest);
@@ -110,28 +194,53 @@ export class SessionRegistry {
       cached.lastSeen = Date.now();
       return cached;
     }
+    return this.resolveAndStore(sessionId);
+  }
+
+  /**
+   * Read one session from the source of truth and back-fill, IGNORING any cached
+   * entry. For a caller holding a record whose provenance cannot answer its
+   * question — see internal-api's ownership gates, which can neither distinguish
+   * "this leg has no delegation target" from "this entry was cached before the
+   * target was known", nor trust a relayed leg's cached `agentId` to name the
+   * owner, without asking the row.
+   *
+   * Deliberately not part of the read path: on a cache hit `get()` must stay
+   * local. Callers reach for this only for a record whose `authoritative` is
+   * unset, which bounds it to one extra read per session per cache lifetime.
+   */
+  async refresh(sessionId: string | undefined): Promise<SessionRecord | undefined> {
+    if (!sessionId) return undefined;
+    return this.resolveAndStore(sessionId);
+  }
+
+  /**
+   * Consult the resolver for one session and cache the result, coalescing
+   * concurrent callers for the same sid into a single RPC — relevant right after
+   * a Runtime restart, when a burst of buffered AgentBox callbacks arrives at
+   * once and would otherwise fan out N identical reads.
+   */
+  private async resolveAndStore(sessionId: string): Promise<SessionRecord | undefined> {
     if (!this.resolver) return undefined;
 
-    // Single-flight: piggyback on any in-flight resolver call for this sid.
     const inflight = this.inflight.get(sessionId);
     if (inflight) return inflight;
 
     const resolver = this.resolver;
-    // Snapshot any pre-existing tombstone so this lookup starts fresh; we
-    // only honor tombstones created while THIS resolver call is in flight.
+    // Snapshot any pre-existing tombstone so this read starts fresh; we only
+    // honor tombstones created while THIS resolver call is in flight.
     this.tombstones.delete(sessionId);
     const promise = (async () => {
       try {
         const fetched = await resolver(sessionId);
         if (!fetched) return undefined;
-        // If forget() raced us while the RPC was outstanding, do NOT
-        // re-insert. Awaiters of THIS call still get the fetched record so
-        // the in-flight callback can still attribute, but the next miss
-        // will go to Portal afresh.
+        // If forget() raced us while the RPC was outstanding, do NOT re-insert.
+        // Awaiters of THIS call still get the fetched record so the in-flight
+        // callback can still attribute, but the next miss goes to Portal afresh.
         if (this.tombstones.has(sessionId)) {
-          return { ...fetched, lastSeen: Date.now() };
+          return { ...fetched, authoritative: true, lastSeen: Date.now() };
         }
-        this.remember(sessionId, fetched.userId, fetched.agentId);
+        this.rememberFromSource(sessionId, fetched);
         return this.map.get(sessionId);
       } finally {
         this.inflight.delete(sessionId);


### PR DESCRIPTION
## Summary

A delegated leg's own AgentBox had every persistence write refused by the Runtime's ownership gate, so the sessions and transcripts of sub-agents spawned inside a delegated turn were never created. AgentBox treats persistence as best-effort and swallows the failure, so this was silent data loss. The gate now admits a session's delegation **target** alongside its **owner**, plus four decisions around that arm and one logging fix.

### Problem

A delegated leg is the one session whose owner is deliberately not its executor: the coordinator that created the leg keeps ownership, so it keeps the conversation, while the turn runs in the delegated peer's AgentBox, whose certificate names the peer.

`sessionBelongsToIdentity` compared only the owner. So everything that box persisted *for* that leg — a spawned sub-agent's session and its transcript, task-ledger events — was refused with `403 delegation parent session mismatch`, while the pointers to those rows, written by the coordinator-side stream, went through.

The visible result was a leg advertising sub-agent sessions that had never been created, and anyone opening that conversation finding nothing behind them. Nothing surfaced at the time, because the box logs persistence failures as best-effort and moves on.

`server.ts` was already receiving `target_agent_id` from Portal and dropping it on the floor, so no upstream change was needed to fix this.

This is still unfixed on `main` as of the rebase below: `sessionBelongsToIdentity` there is owner-only, `sessionOwnedByIdentity` does not exist, and `session-registry.ts` carries no `targetAgentId` at all.

### Solution

The gate accepts the session's delegation target as a second admission arm. This does not widen attribution: `target_agent_id` is the box the leg was handed to, so a box still cannot claim a session delegated to anyone else, and a top-level session has no target to fall back on.

**⚠️ This PR changes an authorization gate.** The arm was decided per write face rather than applied blanket:

| Write face | Arm | Why |
|---|---|---|
| `ensure_session` — subject | ❌ owner-only | It upserts a row. A Portal whose upsert touched more than `last_active_at` would otherwise let a delegated peer re-point the coordinator-owned leg row's agent/parent/origin at itself. |
| `ensure_session` — parent | ✅ | The fix itself: the peer's box creates a sub-agent session beneath the leg. |
| `append_message` / `append_event` | ✅ | The fix itself: sub-agent transcripts, task-ledger events, delegation events. |
| `emit_chat_event` | ✅ | Carries the live frames that fold a sub-agent card from Running to done — same session id, same problem. Revoking it would pin those cards on "Running…". |
| `update_message` / `update_tool_message` | ✅ | No caller today (row updates run on the coordinator side). Narrowing them would only plant a mine for whoever revives that path; the conclusion is recorded in a comment instead. |
| `channel.deliver_message` | ❌ owner-only | Carries no delegated state: the `channel_update` tool behind it is suppressed on a delegated turn by design (a delegated worker's output flows back through the coordinator, which owns the single visible identity), so a leg has no legitimate route there. The arm that lets a peer's box persist a sub-agent transcript should not double as a key to the conversation's channel. |

This is the only face where a permission is *removed*, so its blast radius is worth stating: `channel.deliver_message` has exactly **one** producer in the repo — `createChannelMessageExecutor` in `src/agentbox/session.ts`, fed only by the `channel_update` tool, which `available()` disables whenever `refs.delegation` is set. So the only traffic that can still reach this check is an agent pushing a progress card on a non-delegated session, where the caller *is* the owner and passes as before. (`channels/background-delivery.ts` is the in-process delivery registry downstream of the gate, not a sender through it.)

**Refuse only after re-reading the row.** The 3-arg `rememberSession` callers — `chat.send`, channels, scheduled tasks — know nothing about delegation fields, so whichever runs first after a restart or an eviction caches the leg owner-only, and a cache hit never re-reads. Without this, the gate would refuse that box for the entry's whole lifetime, reinstating the same silent loss with no signal; and with more than one Runtime in play the first caller is not reliably the one that knows the target.

A record now carries whether it came from the row itself, which separates *"this session has no target"* from *"the target was never known here"*. Only the second is re-read, only on the about-to-refuse path, and a failed re-read leaves the refusal standing rather than surfacing as a 500. One extra read per session per cache lifetime; nothing on the success path. Concurrent re-reads coalesce through the existing single-flight, since a restart delivers a burst of buffered callbacks at once.

**A refusal warning now names the sessions it was about.** The box swallows the failure, so that line is the only trace a dropped write leaves, and without the ids it cannot be tied to the conversation that lost content. A malformed payload no longer shares that wording, so a stream of real refusals stays readable.

Two small ones: `remember` treats an empty target as "not supplied" rather than as an instruction to clear (`??` only falls through on null/undefined), and `sessionOwnedByIdentity` documents that its extra strictness is routing-dependent — the same caveat `resolveUserForIdentity` already carries, since a leg relayed to another Runtime is cached there under the peer.

## Test Plan

Run on the current base — this branch is rebased onto `main`, and the one conflict was an import line (upstream added `ChatMessageMetadata` where this branch had widened the `session-registry` import; both are kept). **No production code changed in the rebase**: the gate, the registry and the resolver are byte-identical to what was verified below.

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 299 files / 6664 passing. The 3 failures in `mcp/a2a-mcp-adapter/src/stdio.e2e.test.ts` are environmental and unrelated: it spawns an MCP subprocess and this machine's policy blocks executing binaries under `node_modules/`. They fail identically on a clean `main`.
- [x] Gateway suite in isolation — 75 files / 1492 passing
- [x] Manual verification on a live deployment (below)

New tests: the 7 write faces × 3 identities matrix on the gate; the cold-cache refuse-then-re-read sequence; that an authoritative "no target" costs no extra read; that a failed re-read yields 403 rather than 500; concurrent-refresh coalescing; the empty-target preservation; and that a delegated leg cannot deliver to the conversation's channel.

**Live verification.** A delegated turn that spawns a batch of sub-agents now persists every one of their sessions and transcripts, each message carrying the leg's trace id, with **zero gate refusals over 90 minutes**. That window included the cold-cache period right after a Runtime restart — the peer's box wrote its sub-agent rows 31 minutes after the restart, which is exactly the case the re-read exists for.

## Architecture Checklist

- **Deployment mode**: not applicable — no resource sync, skills, or filesystem writes.
- **Security model**: no new shell execution paths. This PR *does* change an authorization gate, which is why the per-face table above spells out where the new arm applies and where it deliberately does not.
- **DB parity**: no schema changes.
- **Tool protocol**: no new tools.

## General Checklist

- [x] Changes are focused on a single logical change
- [x] Commit messages follow Conventional Commits
- [x] No unrelated changes included

## Known limitations, not addressed here

- Three near-duplicate session resolvers could be merged; that is polish and belongs in its own PR.
- `resolveUserForIdentity` stays narrow (it does not accept the delegation arm): those routes mutate cron schedules, so allowing them from inside a delegated leg is a product question about who may own a schedule, not the attribution gap this PR closes.
- Task-ledger events persist correctly now but still carry no trace id. Stamping one is a separate change with its own consumer-side decisions.
