### PR TITLE
fix(knowledge): knowledge_cite accepts page paths carrying the mount prefix

### DIFF
--- a/src/core/knowledge-citation-tool.test.ts
+++ b/src/core/knowledge-citation-tool.test.ts
@@ -63,6 +63,22 @@ describe("knowledge_cite", () => {
     expect(events).toHaveLength(1);
   });
 
+  it("tolerates a mount-prefixed relative path copied from the model's own read call", async () => {
+    const { dir, page } = fixture();
+    const events: Record<string, unknown>[] = [];
+    const support = createKnowledgeCitationSupport({ knowledgeDir: dir, turnRef: { current: 1 }, sessionEventEmitter: (e) => events.push(e) });
+    readPage(support, page);
+    // The model echoes the mount prefix it saw in its read tool call.
+    const prefixed = `.siclaw/knowledge/${path.basename(page)}`;
+    const output = await support.tool.execute("call", { pages: [{ path: prefixed, claim: "The runbook documents the GPU reset procedure." }] } as never);
+    expect(output.details).toEqual({ cited: 1 });
+    expect(events).toHaveLength(1);
+    // Stripping never invents a read: an unread page stays unread however it is spelled.
+    const unread = await support.tool.execute("call", { pages: [{ path: ".siclaw/knowledge/other.md", claim: "The runbook documents the GPU reset procedure." }] } as never);
+    expect(unread.details).toEqual({ cited: 0 });
+    expect(JSON.stringify(unread)).toContain("Cannot cite unread knowledge page");
+  });
+
   it("rejects pages items that are not bound to a concrete claim", async () => {
     const { dir, page } = fixture();
     const events: Record<string, unknown>[] = [];

--- a/src/core/knowledge-citation-tool.ts
+++ b/src/core/knowledge-citation-tool.ts
@@ -39,6 +39,26 @@ function result(text: string, cited: number, unresolved?: string[]) {
 }
 
 /** Match selfcheck._norm_source_entry: strip raw/ or drop/, keep a leading slash. */
+/**
+ * Resolve a page path the model passed to knowledge_cite against the pages it
+ * actually read this turn. Models copy paths from their own read calls, which
+ * may carry the mount prefix (".siclaw/knowledge/repos/…", "./repos/…") or be
+ * absolute; a literal join against knowledgeDir then misses and the cite fails
+ * for a page that was demonstrably read. Strip leading segments until the path
+ * lands on a read page; never resolve to anything that was not read.
+ */
+export function resolveCitedPagePath(value: string, knowledgeDir: string, wasRead: (absolute: string) => boolean): string {
+  const trimmed = value.trim().replaceAll("\\", "/");
+  const literal = path.resolve(path.isAbsolute(trimmed) ? trimmed : path.join(knowledgeDir, trimmed));
+  if (wasRead(literal) || path.isAbsolute(trimmed)) return literal;
+  const segments = path.posix.normalize(trimmed).split("/").filter((segment) => segment !== "" && segment !== ".");
+  for (let i = 1; i < segments.length; i++) {
+    const candidate = path.resolve(path.join(knowledgeDir, segments.slice(i).join("/")));
+    if (wasRead(candidate)) return candidate;
+  }
+  return literal;
+}
+
 export function normalizedResource(value: string): string {
   let entry = path.posix.normalize(value.trim().replaceAll("\\", "/"));
   for (const prefix of ["raw/", "drop/"] as const) {
@@ -435,7 +455,7 @@ export function createKnowledgeCitationSupport(opts: {
         const pageValue = hash > 0 ? ref.slice(0, hash) : "";
         const evidenceId = hash > 0 ? ref.slice(hash + 1) : "";
         const page = pageValue
-          ? path.resolve(path.isAbsolute(pageValue) ? pageValue : path.join(opts.knowledgeDir, pageValue))
+          ? resolveCitedPagePath(pageValue, opts.knowledgeDir, (absolute) => readPages.has(absolute))
           : "";
         const root = path.resolve(opts.knowledgeDir);
         const snapshot = page ? readPages.get(page) : undefined;
@@ -509,7 +529,7 @@ export function createKnowledgeCitationSupport(opts: {
 
       if (pageArgs.length > 0) {
         const selected = pageArgs.map(({ path: value }) =>
-          path.resolve(path.isAbsolute(value) ? value : path.join(opts.knowledgeDir, value)));
+          resolveCitedPagePath(value, opts.knowledgeDir, (absolute) => readPages.has(absolute)));
         const unread = selected.find((page) => !readPages.has(page));
         if (unread) return result(`Cannot cite unread knowledge page: ${unread}`, 0);
         const navigationPage = selected.find((page) => {


### PR DESCRIPTION
## Why

In live traces (siflow-test, hardware KB) every answer spent two `knowledge_cite` calls: the first passed a page path copied from the model's own `read` call, `.siclaw/knowledge/repos/<repo>/topics/招摇B30X.md`, and was rejected as unread because the path was joined literally onto `knowledgeDir`; the retry with `repos/...` passed.

## What

`resolveCitedPagePath` strips leading path segments until the path lands on a page **read this turn**; otherwise it falls back to the literal resolution, so an unread page still fails as unread however it is spelled. Applied to both `pages[].path` and `evidence_refs`.

## Test

- new case in `src/core/knowledge-citation-tool.test.ts`: mount-prefixed relative path cites; the same prefix on an unread page still fails.
- `npm test`: 299 files, 6652 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)