### PR TITLE
refactor(timing): move model-call timing to the provider boundary

### DIFF
--- a/docs/design/2026-08-02-error-surfacing-contract.md
+++ b/docs/design/2026-08-02-error-surfacing-contract.md
@@ -82,6 +82,14 @@ with no answers and no explanation.
 Persisted error rows follow the same scoping, so a reload agrees with what was
 on screen while it was happening.
 
+ADR-018 retains failed-call telemetry separately from the visible error:
+recovered failures have empty model-call carrier rows; on terminal failure,
+earlier failed calls keep their carriers and the final envelope rides the single
+`error_response` row. A rolled-back routing attempt instead rides the route
+notice's `discarded_llm_calls`. Revocation removes the error bubble, not the
+measurement of time spent on failed calls. Transcript readers hide empty
+carriers and thinking rows; metrics/timeline readers may still consume them.
+
 ### Ordering guarantee
 
 Turn N's `stream_error` is emitted BEFORE turn N+1's events. The flush happens
@@ -116,7 +124,7 @@ recovers, but the failing `message_end` is already in the consumer's hands — s
 a consumer that buffers without also forgetting resurrects the withdrawn error
 at the fallback step, and paints it under the answer that succeeded. That is the
 original bug, reintroduced through the safety net meant to prevent it. Worse, it
-is invisible on reload: siclaw wrote no row for a turn that recovered, so the
+is invisible on reload: siclaw wrote no visible error row for a turn that recovered, so the
 live view and the reloaded view disagree.
 
 The condition is "produced output", not "stopReason is not error". An empty 200

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -727,3 +727,71 @@ the supporting leaf pages.
 
 **Files**: `kbc/platform/pod/selfcheck.py`, `src/knowledge/labels.ts`,
 `src/knowledge/resolver.ts`, `src/tools/query/knowledge-search.ts`
+
+---
+
+## ADR-018: Model Timing Is Measured at the Provider Boundary, One Row per Model Call
+
+**Status**: Active
+
+**Context**:
+Model timing used to be inferred in the gateway from the arrival times of SSE
+events: `pre_thinking_ms` on tool rows (previous boundary → tool start),
+`timing.{ttft_ms, thinking_ms, output_ms, turn_total_ms}` on assistant rows, a
+`NOISE_FLOOR` heuristic to stop `ttft` and `thinking` double-counting, and a
+portal-supplied `turnStartMs` anchor on another pod's clock. A model call that
+returned only tool calls had no row at all, so its time was parked on the tool
+rows; reasoning text was dropped; the provider's `usage` (including reasoning
+tokens) never reached the database. Downstream time accounting had to
+carry a page of caveats about which field to add when.
+
+**Decision**:
+Measure every provider request where it happens. `src/core/llm-call-recorder.ts`
+wraps `agent.streamFn` as the innermost layer (before the guard pipeline) and
+records, on the agentbox's own clock: request sent, HTTP headers (`start`), first
+content token, every thinking/text/tool-call block edge, response end, the
+provider's `usage`, and the stop reason. The result is stamped onto the assistant
+message as `llmCall` and travels with `message_end`; the gateway persists a
+redacted copy as `chat_messages.metadata.llm_call`.
+
+Persistence contract (web/api/a2a `sse-consumer.ts` and Lark
+`collectChannelResponse` alike):
+
+- **One agent-loop model call ⇒ one assistant row** carrying `metadata.llm_call`,
+  even when `content` is empty (tool-only call). Rounds are numbered from 1 per
+  prompt; a routing rollback rewinds the counter, and the discarded attempt's
+  envelopes ride the `model_route_notice` row as `discarded_llm_calls`. For
+  in-turn provider retries, recovered failures remain as empty model-call rows;
+  if the turn ultimately fails, earlier failures remain empty model-call rows
+  and the final failure's envelope rides the single `error_response` row.
+- **Reasoning text is its own row** (`kind: "thinking"`, `metadata.llm_round`),
+  written immediately before the model-call row and linked back via
+  `llm_call.thinking_row_id`. Redacted like any other content.
+- **Tool rows carry `metadata.llm_round` and `metadata.tool_call_id`**; their
+  `duration_ms` and `started_at` come from `startedAt`/`endedAt` stamped by
+  `PiAgentBrain.enrichToolEvent` on the same clock. Two consecutive model calls
+  bound a *tool group*; its span is the next call's `since_prev_ms`.
+- Compaction / summarisation calls share `streamFn` but consume no round; they
+  are folded into the next agent call's `aux_calls`.
+- The prompt boundary is explicit (`brain.llmCalls.beginPrompt` at HTTP receipt,
+  `endPrompt` in `actuallyFinish`) so round 1's `since_prev_ms` is the setup time;
+  paths that bypass the HTTP layer open it implicitly on the first call.
+
+The old fields are **not written any more and readers must not fall back to
+them**. `turnStartMs` is accepted on the wire and ignored.
+
+**Consequences**:
+
+- ✅ `net_ttft + thinking + output == total` per call, and `setup + Σ call + Σ tool group ≈ wall` per prompt — a partition that can be audited instead of a set of overlapping badges.
+- ✅ Reasoning tokens (`usage.reasoning`) and reasoning text are retained; output tok/s is computable.
+- ✅ Tool-only calls, failed calls and rolled-back attempts all appear on the timeline.
+- ✅ No schema change: envelope in `metadata`, thinking in `content`, grouping keys in `metadata`.
+- ⚠️ One extra row per model call, plus one per call with reasoning text. Thinking rows and empty model-call carriers are hidden in transcripts, but `chat_sessions.message_count` and the Portal's generic `message_count` metric remain physical-row counts by the existing persistence contract. Any reader of `chat_messages` must treat `kind: "thinking"` as a hidden assistant kind before this runtime ships, or a call's own reasoning counts as a reply.
+- ⚠️ Providers that hide reasoning (`reasoning_tokens` without `reasoning_content`) report `thinking_visible: false`; their reasoning time is inside `net_ttft` and is not guessed at.
+- ❌ Historical rows without `llm_call` have no time accounting — only the wall clock.
+
+**Files**: `src/core/llm-call-recorder.ts`, `src/core/agent-factory.ts`,
+`src/core/brains/pi-agent-brain.ts`, `src/agentbox/http-server.ts`,
+`src/gateway/sse-consumer.ts`, `src/gateway/llm-call-rows.ts`,
+`src/gateway/channels/lark.ts`, `src/portal/metrics-timing.ts`,
+`src/shared/message-kinds.ts`

--- a/docs/design/decisions.md
+++ b/docs/design/decisions.md
@@ -536,7 +536,8 @@ and `/metrics/timing` endpoints, the gateway `metrics.live` RPC, the aggregator'
 maps, and the whole `LocalCollector`. `MetricsAggregator` is now a federation-only pull
 loop. The agentbox `/api/internal/metrics-snapshot` pull and the SIGTERM
 `/api/internal/metrics-flush` push share one `MetricsFlushPayload { incarnation, prom }`.
-Per-message `ttft_ms` (still consumed by the chat timing badge) is kept.
+At the time of ADR-014, per-message `ttft_ms` was kept for the chat badge.
+ADR-018 supersedes that field: timing now comes only from `metadata.llm_call.ms`.
 
 **Scope — which boxes are pulled**:
 Only boxes running the default `agent` profile serve `/api/internal/metrics-snapshot`.
@@ -766,7 +767,10 @@ Persistence contract (web/api/a2a `sse-consumer.ts` and Lark
   and the final failure's envelope rides the single `error_response` row.
 - **Reasoning text is its own row** (`kind: "thinking"`, `metadata.llm_round`),
   written immediately before the model-call row and linked back via
-  `llm_call.thinking_row_id`. Redacted like any other content.
+  `llm_call.thinking_row_id`. Redacted like any other content, then clipped at
+  a UTF-8 boundary to MySQL TEXT's 65,535-byte limit, including the truncation
+  marker (`metadata.truncated: true`). A failed reasoning insert is logged and
+  does not prevent the answer row from being written.
 - **Tool rows carry `metadata.llm_round` and `metadata.tool_call_id`**; their
   `duration_ms` and `started_at` come from `startedAt`/`endedAt` stamped by
   `PiAgentBrain.enrichToolEvent` on the same clock. Two consecutive model calls
@@ -775,7 +779,13 @@ Persistence contract (web/api/a2a `sse-consumer.ts` and Lark
   are folded into the next agent call's `aux_calls`.
 - The prompt boundary is explicit (`brain.llmCalls.beginPrompt` at HTTP receipt,
   `endPrompt` in `actuallyFinish`) so round 1's `since_prev_ms` is the setup time;
-  paths that bypass the HTTP layer open it implicitly on the first call.
+  synthetic notification turns also explicitly bracket the entire routing run
+  and apply attempt/rollback events. Other paths open it implicitly on the first call.
+- Buffered failed attempts carry only their envelopes on the routing switch's
+  `discardedLlmCalls`; consumers attach those to the same notice as live-attempt
+  envelopes. Discarded answer/reasoning text is never replayed. The synthetic
+  notification path still uses its existing conditional report persistence,
+  rather than the full SSE timeline persistence described above.
 
 The old fields are **not written any more and readers must not fall back to
 them**. `turnStartMs` is accepted on the wire and ignored.
@@ -786,6 +796,12 @@ them**. `turnStartMs` is accepted on the wire and ignored.
 - ✅ Reasoning tokens (`usage.reasoning`) and reasoning text are retained; output tok/s is computable.
 - ✅ Tool-only calls, failed calls and rolled-back attempts all appear on the timeline.
 - ✅ No schema change: envelope in `metadata`, thinking in `content`, grouping keys in `metadata`.
+- Empty model-call carriers deliberately have no separate row kind: they are
+  identified by assistant role, empty content, `llm_call`, and no `kind`.
+  Error/route notice kinds take precedence, even when content is empty.
+  Portal chat list/count and task traces share `transcriptVisiblePredicate`,
+  using dialect-aware JSON extraction before pagination rather than serialized
+  substring matching. NULL-metadata legacy rows remain visible.
 - ⚠️ One extra row per model call, plus one per call with reasoning text. Thinking rows and empty model-call carriers are hidden in transcripts, but `chat_sessions.message_count` and the Portal's generic `message_count` metric remain physical-row counts by the existing persistence contract. Any reader of `chat_messages` must treat `kind: "thinking"` as a hidden assistant kind before this runtime ships, or a call's own reasoning counts as a reply.
 - ⚠️ Providers that hide reasoning (`reasoning_tokens` without `reasoning_content`) report `thinking_visible: false`; their reasoning time is inside `net_ttft` and is not guessed at.
 - ❌ Historical rows without `llm_call` have no time accounting — only the wall clock.

--- a/portal-web/src/components/chat/PilotArea.tsx
+++ b/portal-web/src/components/chat/PilotArea.tsx
@@ -100,20 +100,15 @@ function formatTimingMs(ms: number): string {
 }
 
 /**
- * Inline "model time" shown next to the assistant's header. Combines the
- * three model-side phases (ttft + thinking + output) into one user-facing
- * figure so chat doesn't surface dashboard-level timing breakdowns.
- * Dashboard latency stats keep their per-phase split.
+ * Inline "model time" shown next to the assistant's header: the model call's
+ * total (request sent → response end). Chat shows one figure; the dashboard
+ * keeps the net_ttft / thinking / output split.
  */
 function combinedModelMs(timing: MessageTiming | undefined): number | undefined {
   if (!timing) return undefined
-  // ttftMs already covers user-message → first-token (and contains the
-  // thinking portion). Add outputMs (first-delta → message_end) to get
-  // total model wall-clock. thinkingMs is a subset of ttftMs and is
-  // intentionally not summed to avoid double-counting.
-  const ttft = typeof timing.ttftMs === "number" ? timing.ttftMs : 0
-  const out = typeof timing.outputMs === "number" ? timing.outputMs : 0
-  const total = ttft + out
+  const total = typeof timing.totalMs === "number"
+    ? timing.totalMs
+    : (timing.netTtftMs ?? 0) + (timing.thinkingMs ?? 0) + (timing.outputMs ?? 0)
   if (total <= 0) return undefined
   return total
 }
@@ -2794,16 +2789,13 @@ function ToolItem({ message, nested }: { message: PilotMessage; nested?: boolean
           <div className="ml-auto flex items-center gap-1.5 shrink-0">
             {(() => {
               const t = message.timing
-              const showThink = typeof t?.thinkingMs === "number"
               const showDur = typeof t?.durationMs === "number"
               const durationLabel = message.toolStatus === "running" ? "running" : "ran"
               return (
                 <>
-                  {(showThink || showDur) && (
+                  {showDur && (
                     <span className="text-[11px] text-muted-foreground tabular-nums select-text">
-                      {showThink && <>thinking {formatTimingMs(t!.thinkingMs!)}</>}
-                      {showThink && showDur && ", "}
-                      {showDur && <>{durationLabel} {formatTimingMs(t!.durationMs!)}</>}
+                      {durationLabel} {formatTimingMs(t!.durationMs!)}
                     </span>
                   )}
                 </>

--- a/portal-web/src/components/chat/types.ts
+++ b/portal-web/src/components/chat/types.ts
@@ -7,26 +7,22 @@ export type ToolStatus = "running" | "success" | "error" | "aborted"
 /**
  * Per-message timing data shown as small badges in the chat bubble.
  *
- * Designed so a naive sum of all visible badges equals the turn's wall clock
- * (within event-dispatch noise) — no double-counting, no missing intervals.
- *
- * Assistant messages:
- *   - ⏳ ttftMs:     first message of a turn ONLY. Time to first token.
- *   - 💭 thinkingMs: boundary (turn-start or last tool_end) → first text token.
- *   - ✍️ outputMs:  first text token → message_end (text streaming time).
+ * Assistant messages carry ONE model call's partition, measured by the runtime at
+ * the provider boundary (`metadata.llm_call.ms`, live: `event.llmCall.ms`):
+ *   - netTtftMs:  request sent → first token (network + queue + hidden reasoning)
+ *   - thinkingMs: streamed reasoning blocks
+ *   - outputMs:   text + tool-call argument streaming
+ *   - totalMs:    request sent → response end (= the three above)
  *
  * Tool messages:
- *   - 💭 thinkingMs: model reasoning before this tool fired (boundary-based).
- *   - ⚙️ durationMs: tool wall-clock execution time.
- *
- * turnTotalMs is carried for cross-checking but not rendered as a badge.
+ *   - durationMs: tool wall-clock execution time (agentbox clock).
  */
 export interface MessageTiming {
-  ttftMs?: number
+  netTtftMs?: number
   thinkingMs?: number
   outputMs?: number
+  totalMs?: number
   durationMs?: number
-  turnTotalMs?: number
 }
 
 export interface ModelRouteMetadata {

--- a/portal-web/src/components/metrics/TimingStatsCard.tsx
+++ b/portal-web/src/components/metrics/TimingStatsCard.tsx
@@ -66,18 +66,13 @@ export function TimingStatsCard({
   data,
   rangeLabel,
   entryLabel,
-  entry,
 }: {
   data: TimingStats | null
   rangeLabel: string
   entryLabel: string
+  /** Kept for call-site compatibility; model-call rows are written on every entry path. */
   entry: EntryMode
 }) {
-  // TTFT / thinking come from assistant metadata.timing, written only on the
-  // web/api/a2a path (sse-consumer). Channel (IM) sessions persist assistant
-  // rows without it, so those two rows are always empty for entry=channel —
-  // flag it so a count of 0 doesn't read as a bug. Tool latency still populates.
-  const noModelTiming = entry === "channel"
   const [topN, setTopN] = useState<TopN>(3)
   const tools = data?.tools ?? []
   const visibleTools: ToolLatencyStats[] = tools.slice(0, topN)
@@ -103,15 +98,11 @@ export function TimingStatsCard({
 
       <StatGrid>
         <GridHeader />
-        <StatRow label="TTFT" hint="time to first token" stats={data?.ttft ?? EMPTY_STATS} />
-        <StatRow label="Thinking" hint="reasoning before output" stats={data?.thinking ?? EMPTY_STATS} />
+        <StatRow label="Net + TTFT" hint="request sent → first token" stats={data?.ttft ?? EMPTY_STATS} />
+        <StatRow label="Thinking" hint="streamed reasoning" stats={data?.thinking ?? EMPTY_STATS} />
+        <StatRow label="Output" hint="text + tool-call streaming" stats={data?.output ?? EMPTY_STATS} />
+        <StatRow label="Model call" hint="request sent → response end" stats={data?.total ?? EMPTY_STATS} />
       </StatGrid>
-
-      {noModelTiming && (
-        <p className="mt-2 text-[10px] text-muted-foreground/80">
-          TTFT &amp; thinking aren&apos;t recorded for channel (IM) sessions — only tool latency below.
-        </p>
-      )}
 
       <div className="mt-4 pt-3 border-t border-border">
         <div className="flex items-center justify-between gap-3 mb-2">

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -94,8 +94,14 @@ export interface ToolLatencyStats extends LatencyStats {
 }
 
 export interface TimingStats {
+  /** request sent → first token (network + queue + hidden reasoning) */
   ttft: LatencyStats
+  /** streamed reasoning blocks */
   thinking: LatencyStats
+  /** text + tool-call argument streaming */
+  output: LatencyStats
+  /** request sent → response end */
+  total: LatencyStats
   tools: ToolLatencyStats[]
   truncated?: boolean
 }

--- a/portal-web/src/hooks/usePilotChat.llm-call.test.ts
+++ b/portal-web/src/hooks/usePilotChat.llm-call.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { attachLiveAssistantCall, type PilotMessage } from "./usePilotChat"
+
+describe("attachLiveAssistantCall", () => {
+  it("does not put a tool-only call's timing on the previous completed bubble", () => {
+    const messages: PilotMessage[] = [{
+      id: "previous",
+      role: "assistant",
+      content: "previous answer",
+      timestamp: "12:00",
+      isStreaming: false,
+      timing: { totalMs: 100 },
+    }]
+
+    expect(attachLiveAssistantCall(messages, { totalMs: 900 })).toBe(messages)
+    expect(messages[0].timing).toEqual({ totalMs: 100 })
+  })
+
+  it("attaches timing to the current streaming assistant bubble", () => {
+    const messages: PilotMessage[] = [{
+      id: "current",
+      role: "assistant",
+      content: "answer",
+      timestamp: "12:00",
+      isStreaming: true,
+    }]
+
+    const updated = attachLiveAssistantCall(messages, { netTtftMs: 20, totalMs: 100 })
+    expect(updated[0].timing).toEqual({ netTtftMs: 20, totalMs: 100 })
+  })
+})

--- a/portal-web/src/hooks/usePilotChat.llm-call.test.ts
+++ b/portal-web/src/hooks/usePilotChat.llm-call.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { attachLiveAssistantCall, type PilotMessage } from "./usePilotChat"
+import { attachLiveAssistantCall, toPilotMessage, type PilotMessage } from "./usePilotChat"
 
 describe("attachLiveAssistantCall", () => {
   it("does not put a tool-only call's timing on the previous completed bubble", () => {
@@ -29,3 +29,12 @@ describe("attachLiveAssistantCall", () => {
     expect(updated[0].timing).toEqual({ netTtftMs: 20, totalMs: 100 })
   })
 })
+
+
+it("hides empty call carriers but preserves explicit error and route notices", () => {
+  const row = { id: "m", role: "assistant", content: "", created_at: "2026-09-01", metadata: { llm_call: {} } };
+  expect(toPilotMessage(row as any).hidden).toBe(true);
+  for (const kind of ["error_response", "model_route_notice"]) {
+    expect(toPilotMessage({ ...row, metadata: { ...row.metadata, kind } } as any).hidden).toBeFalsy();
+  }
+});

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -382,26 +382,49 @@ export function dropFailedAttemptOutput(messages: PilotMessage[]): PilotMessage[
   return [...head, ...tailHidden];
 }
 
-function extractTiming(metadata: Record<string, unknown> | undefined, durationMs: number | null | undefined): import("../components/chat/types").MessageTiming | undefined {
-  // Tool rows: duration_ms (⚙️ exec) is its own column; pre_thinking_ms
-  // (💭 model-thinking-before-this-tool) lives at metadata.pre_thinking_ms.
-  // Assistant rows: timing sub-object inside metadata holds ⏳ ttft, 💭
-  // thinking-before-text, and turn-total.
+/** Map a runtime `llm_call.ms` partition onto the chat's MessageTiming shape. */
+function timingFromLlmCall(llmCall: unknown): import("../components/chat/types").MessageTiming {
   const t: import("../components/chat/types").MessageTiming = {}
-  const rawTiming = metadata?.timing as Record<string, unknown> | undefined
-  if (rawTiming) {
-    if (typeof rawTiming.ttft_ms === "number") t.ttftMs = rawTiming.ttft_ms
-    if (typeof rawTiming.thinking_ms === "number") t.thinkingMs = rawTiming.thinking_ms
-    if (typeof rawTiming.output_ms === "number") t.outputMs = rawTiming.output_ms
-    if (typeof rawTiming.turn_total_ms === "number") t.turnTotalMs = rawTiming.turn_total_ms
+  const ms = (llmCall as { ms?: Record<string, unknown> } | undefined)?.ms
+  if (!ms || typeof ms !== "object") return t
+  if (typeof ms.net_ttft === "number") t.netTtftMs = ms.net_ttft
+  if (typeof ms.thinking === "number") t.thinkingMs = ms.thinking
+  if (typeof ms.output === "number") t.outputMs = ms.output
+  if (typeof ms.total === "number") t.totalMs = ms.total
+  return t
+}
+
+/** Attach a live call only to the bubble produced by that call. Tool-only calls
+ * have no streaming assistant bubble and therefore stay as hidden rows after
+ * reload instead of overwriting the previous visible answer's timing. */
+export function attachLiveAssistantCall(
+  messages: PilotMessage[],
+  timing?: import("../components/chat/types").MessageTiming,
+  route?: ModelRouteMetadata | null,
+): PilotMessage[] {
+  if (!timing && !route) return messages
+  const idx = findLastMessageIndex(messages, (m) =>
+    m.role === "assistant" &&
+    m.metadata?.kind !== "model_route_notice" &&
+    m.metadata?.kind !== "delegation_status_notice",
+  )
+  if (idx < 0) return messages
+  const current = messages[idx]
+  const applyTiming = timing && current.isStreaming
+  if (!applyTiming && !route) return messages
+  const mergedTiming = applyTiming ? { ...(current.timing ?? {}), ...timing } : current.timing
+  const next = {
+    ...current,
+    ...(mergedTiming && Object.keys(mergedTiming).length > 0 ? { timing: mergedTiming } : {}),
+    ...(route ? { metadata: { ...(current.metadata ?? {}), model_route: route } } : {}),
   }
-  // Pre-tool thinking gets surfaced as the same `thinkingMs` field — it's
-  // semantically the same emoji (💭 model reasoning) just attached to a
-  // tool row instead of a text row. UI uses one badge code path either way.
-  // No threshold: a 0/small 💭 on the 2nd-Nth tool of a batch is the visible
-  // proof that they came from one thinking burst (not N independent ones).
-  const preThinking = metadata?.pre_thinking_ms
-  if (typeof preThinking === "number") t.thinkingMs = preThinking
+  return [...messages.slice(0, idx), next, ...messages.slice(idx + 1)]
+}
+
+function extractTiming(metadata: Record<string, unknown> | undefined, durationMs: number | null | undefined): import("../components/chat/types").MessageTiming | undefined {
+  // Assistant model-call rows: metadata.llm_call.ms (measured at the provider
+  // boundary by the runtime). Tool rows: duration_ms is its own column.
+  const t = timingFromLlmCall(metadata?.llm_call)
   if (typeof durationMs === "number" && durationMs >= 0) t.durationMs = durationMs
   return Object.keys(t).length > 0 ? t : undefined
 }
@@ -556,6 +579,11 @@ export function toPilotMessage(m: ChatMessage): PilotMessage {
   // A background exec job's completion marker — folded into the launching tool's box
   // (annotateExecJobCompletions), never shown as its own row.
   const isExecJobEvent = metadata?.kind === "exec_job_event"
+  // A model call's reasoning text — its own row, folded into the timeline, never a bubble.
+  const isThinkingRow = metadata?.kind === "thinking"
+  // A model call that produced only tool calls still gets a row (it carries the
+  // call's timing/tokens in metadata.llm_call); there is nothing to render for it.
+  const isEmptyModelCallRow = m.role === "assistant" && !m.content?.trim() && metadata?.llm_call != null
   const staleRunning = isStaleRunningTool(m)
   const toolIsDelegation = isDelegationTool(m.tool_name)
   const toolStatus = toolStatusFromMessage(m)
@@ -598,7 +626,7 @@ export function toPilotMessage(m: ChatMessage): PilotMessage {
     toolDetails: m.role === "tool" ? (recoveredMetadata ?? undefined) : undefined,
     metadata: recoveredMetadata,
     timing,
-    hidden: m.hidden || isDelegationEvent || isTaskEvent || isTaskNotification || isExecJobEvent || isTaskTool(m.tool_name),
+    hidden: m.hidden || isDelegationEvent || isTaskEvent || isTaskNotification || isExecJobEvent || isThinkingRow || isEmptyModelCallRow || isTaskTool(m.tool_name),
     fromAgentId: m.from_agent_id ?? null,
     parentSessionId: m.parent_session_id ?? null,
     delegationId: m.delegation_id ?? null,
@@ -1710,11 +1738,6 @@ export function usePilotChat({ agentId, sessionId, forceLive }: UsePilotChatOpti
           const toolInput = formatToolInput(toolName ?? "", args)
           const hidden = toolName === "update_plan" || isTaskTool(toolName)
           const dbMessageId = evt.dbMessageId as string | undefined
-          // 💭 Pre-tool thinking time (gap from previous tool_end / turn-start
-          // to now). Server-stamped; matches the value persisted in the row's
-          // metadata.pre_thinking_ms, so live and reload render identically.
-          const preThinkingMs = typeof evt.preThinkingMs === "number" ? evt.preThinkingMs : undefined
-          const showThinking = preThinkingMs != null
 
           setMessages((prev) => [
             ...prev,
@@ -1730,7 +1753,6 @@ export function usePilotChat({ agentId, sessionId, forceLive }: UsePilotChatOpti
               timestamp: timeNow(),
               isStreaming: true,
               hidden,
-              ...(showThinking ? { timing: { thinkingMs: preThinkingMs } } : {}),
             },
           ])
           break
@@ -1875,38 +1897,16 @@ export function usePilotChat({ agentId, sessionId, forceLive }: UsePilotChatOpti
           const endMsg = evt.message as
             | { role?: string; toolName?: string; details?: Record<string, unknown> }
             | undefined
-          // ⏳/💭/✍️ Server-stamped per-message timing block, attached to
-          // the event by sse-consumer right before persistence.
-          const evtTiming = evt.timing as
-            | { ttft_ms?: number; thinking_ms?: number; output_ms?: number; turn_total_ms?: number }
-            | undefined
+          // The model call's timing partition, stamped by the runtime at the
+          // provider boundary and attached to the event by sse-consumer; the same
+          // values land in the row's metadata.llm_call, so live and reload agree.
+          const evtTiming = evt.llmCall ? timingFromLlmCall(evt.llmCall) : undefined
           const evtRoute = endMsg?.role === "assistant" ? (modelRouteFromEvent(evt) ?? currentModelRouteRef.current) : null
           if (endMsg?.role === "assistant" && evtRoute) {
             currentModelRouteRef.current = evtRoute
           }
           if (endMsg?.role === "assistant" && (evtTiming || evtRoute)) {
-            setMessages((prev) => {
-              const idx = findLastMessageIndex(prev, (m) =>
-                m.role === "assistant" &&
-                m.metadata?.kind !== "model_route_notice" &&
-                m.metadata?.kind !== "delegation_status_notice",
-              )
-              if (idx < 0) return prev
-              const current = prev[idx]
-              const timing = {
-                ...(current.timing ?? {}),
-                ...(typeof evtTiming?.ttft_ms === "number" ? { ttftMs: evtTiming.ttft_ms } : {}),
-                ...(typeof evtTiming?.thinking_ms === "number" ? { thinkingMs: evtTiming.thinking_ms } : {}),
-                ...(typeof evtTiming?.output_ms === "number" ? { outputMs: evtTiming.output_ms } : {}),
-                ...(typeof evtTiming?.turn_total_ms === "number" ? { turnTotalMs: evtTiming.turn_total_ms } : {}),
-              }
-              const next = {
-                ...current,
-                ...(Object.keys(timing).length > 0 ? { timing } : {}),
-                ...(evtRoute ? { metadata: { ...(current.metadata ?? {}), model_route: evtRoute } } : {}),
-              }
-              return [...prev.slice(0, idx), next, ...prev.slice(idx + 1)]
-            })
+            setMessages((prev) => attachLiveAssistantCall(prev, evtTiming, evtRoute))
           }
           if (endMsg?.role === "toolResult" && endMsg.details && Object.keys(endMsg.details).length > 0) {
             // Pi-agent brain: tool result details arrive via message_end (not tool_execution_end).

--- a/portal-web/src/hooks/usePilotChat.ts
+++ b/portal-web/src/hooks/usePilotChat.ts
@@ -583,7 +583,7 @@ export function toPilotMessage(m: ChatMessage): PilotMessage {
   const isThinkingRow = metadata?.kind === "thinking"
   // A model call that produced only tool calls still gets a row (it carries the
   // call's timing/tokens in metadata.llm_call); there is nothing to render for it.
-  const isEmptyModelCallRow = m.role === "assistant" && !m.content?.trim() && metadata?.llm_call != null
+  const isEmptyModelCallRow = m.role === "assistant" && !m.content?.trim() && metadata?.llm_call != null && metadata?.kind == null
   const staleRunning = isStaleRunningTool(m)
   const toolIsDelegation = isDelegationTool(m.tool_name)
   const toolStatus = toolStatusFromMessage(m)

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -960,6 +960,10 @@ export function createHttpServer(
     // fast double-submit cannot start a second prompt on the same brain.
     managed._promptDone = false;
     managed._aborted = false;
+    // LLM-call timeline: the prompt is accepted NOW. Everything between here and
+    // the first provider request (model setup, media preflight, language
+    // detection, routing preflight) is round 1's `since_prev_ms` (= setup).
+    managed.brain.llmCalls?.beginPrompt(Date.now(), { explicit: true });
     // Pre-spawn Stop: a /abort that arrived before this session existed recorded a pending abort.
     // Consume it HERE — AFTER the unconditional `_aborted = false` reset above (placing it before
     // would be wiped by that reset) — so the pre-prompt latch below short-circuits this turn.
@@ -1006,6 +1010,7 @@ export function createHttpServer(
       console.error(`[agentbox-http] Prompt setup failed for session ${managed.id}:`, err);
       managed._promptDone = true;
       managed._routeBrainEventsThroughExtra = false;
+      managed.brain.llmCalls?.endPrompt({ explicit: true });
       if (managed._bufferUnsub) {
         managed._bufferUnsub();
         managed._bufferUnsub = null;
@@ -1141,6 +1146,7 @@ export function createHttpServer(
     const actuallyFinish = () => {
       managed._promptDone = true;
       managed._routeBrainEventsThroughExtra = false;
+      managed.brain.llmCalls?.endPrompt({ explicit: true });
       clearTurnTierState(managed);
 
       // Emit prompt metrics via diagnostic event bus
@@ -1235,6 +1241,17 @@ export function createHttpServer(
     };
 
     const emitRouteEvent = (event: ModelRouteEvent): void => {
+      // Round numbering must survive a live-primary rollback: the discarded
+      // attempt's rounds are rewound so the surviving candidate's first call is
+      // round 1 again (attempt +1). See LlmCallRecorder.rollbackAttempt.
+      if (event.type === "model_route_attempt" && event.status === "started") {
+        managed.brain.llmCalls?.beginAttempt(event.attempt);
+      } else if (
+        (event.type === "model_route_attempt" && event.status === "failed") ||
+        event.type === "model_route_rollback"
+      ) {
+        managed.brain.llmCalls?.rollbackAttempt();
+      }
       emitSessionExtraEvent({ ...event, sessionId: managed.id });
     };
 

--- a/src/agentbox/notify-parent.test.ts
+++ b/src/agentbox/notify-parent.test.ts
@@ -1,3 +1,4 @@
+import { LlmCallRecorder } from "../core/llm-call-recorder.js";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AgentBoxSessionManager } from "./session.js";
 
@@ -301,13 +302,23 @@ describe("notifyParent", () => {
     let currentModel = models[0];
     const seenModels: string[] = [];
     const routeFlagDuringPrompt: boolean[] = [];
+    const recorder = new LlmCallRecorder();
+    const attempts: number[] = [];
+    const endPrompt = vi.spyOn(recorder, "endPrompt");
     const brain = {
+      llmCalls: recorder,
       followUp: vi.fn(async () => {}),
       subscribe: vi.fn((fn: (e: any) => void) => {
         listeners.add(fn);
         return () => listeners.delete(fn);
       }),
       prompt: vi.fn(async () => {
+        // PiAgentBrain opens/closes each candidate implicitly. The explicit
+        // synthetic boundary must prevent those from resetting attempt state.
+        recorder.beginPrompt();
+        attempts.push(recorder.snapshot().attempt);
+        recorder.endPrompt();
+        expect(recorder.snapshot().promptOpen).toBe(true);
         seenModels.push(`${currentModel.provider}/${currentModel.id}`);
         // The routed runner buffers brain events; the SSE route's live brain
         // subscription must be suppressed for the whole turn or a connected
@@ -362,6 +373,9 @@ describe("notifyParent", () => {
     await flushCoalesce();
 
     expect(seenModels).toEqual(["openai/gpt-4", "anthropic/claude"]);
+    expect(attempts).toEqual([1, 2]);
+    expect(recorder.snapshot().promptOpen).toBe(false);
+    expect(endPrompt).toHaveBeenLastCalledWith({ explicit: true });
     expect(routeFlagDuringPrompt).toEqual([true, true]);
     expect(managed._routeBrainEventsThroughExtra).toBe(false);
     expect(managed.modelRouteState.activeCandidateKey).toBe("anthropic/claude");

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -2181,7 +2181,13 @@ export class AgentBoxSessionManager {
         managed._routeBrainEventsThroughExtra = effectivePolicy !== undefined;
         let latestModelRouteSwitch: Extract<ModelRouteEvent, { type: "model_route_switch" }> | null = null;
         let currentModelRouteMetadata: Record<string, unknown> | null = null;
+        managed.brain.llmCalls?.beginPrompt(Date.now(), { explicit: true });
         const handleRouteEvent = (event: ModelRouteEvent): void => {
+          if (event.type === "model_route_attempt" && event.status === "started") {
+            managed.brain.llmCalls?.beginAttempt(event.attempt);
+          } else if ((event.type === "model_route_attempt" && event.status === "failed") || event.type === "model_route_rollback") {
+            managed.brain.llmCalls?.rollbackAttempt();
+          }
           if (!managed._promptDone) managed._eventBuffer.push({ ...event, sessionId: sid });
           if (event.type === "model_route_switch") {
             latestModelRouteSwitch = event;
@@ -2270,6 +2276,7 @@ export class AgentBoxSessionManager {
         } catch (err) {
           console.warn(`[agentbox-session] synthetic prompt failed for ${managed.id}:`, err);
         } finally {
+          managed.brain.llmCalls?.endPrompt({ explicit: true });
           managed._promptDone = true;
           managed._routeBrainEventsThroughExtra = false;
           if (managed._bufferUnsub) { managed._bufferUnsub(); managed._bufferUnsub = null; }

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -58,6 +58,7 @@ import { loadConfig, getEmbeddingConfig, getConfigPath, getDefaultLlm, isMemoryE
 import { initExtraCommands } from "../tools/infra/extra-commands.js";
 import { filterHarnessSkills } from "./skill-overlay.js";
 import { createGuardRegistry, installGuardPipeline } from "./guard-pipeline.js";
+import { LlmCallRecorder } from "./llm-call-recorder.js";
 import {
   ToolResultArtifactStore,
   createToolResultArtifactTools,
@@ -958,6 +959,13 @@ export async function createSiclawSession(
     return finalPayload;
   };
 
+  // ── LLM call recorder: innermost streamFn wrap, BEFORE the guard pipeline ──
+  // Installed closest to the network so guard transforms and context work land
+  // in setup / tool-group time, not in net_ttft. Stamps `message.llmCall`,
+  // which the gateway persists as metadata.llm_call (the timing source of truth).
+  const llmCallRecorder = new LlmCallRecorder();
+  session.agent.streamFn = llmCallRecorder.wrapStreamFn(session.agent.streamFn);
+
   // ── Guard pipeline: unified guard registration and installation ──
   const contextWindow = configuredModel?.contextWindow ?? 128_000;
   const guardRegistry = createGuardRegistry(contextWindow);
@@ -969,7 +977,7 @@ export async function createSiclawSession(
       return toolset ? [[tool.name, toolset] as const] : [];
     }),
   );
-  const brain: BrainSession = new PiAgentBrain(session, toolsetsByName);
+  const brain: BrainSession = new PiAgentBrain(session, toolsetsByName, llmCallRecorder);
   const getSkillSnapshot = () => {
     const currentSkills = loader.getSkills().skills;
     const skillNames = currentSkills.map((skill) => skill.name).sort();

--- a/src/core/brain-session.ts
+++ b/src/core/brain-session.ts
@@ -12,6 +12,8 @@
  * - auto_compaction_start/end, auto_retry_start/end
  */
 
+import type { LlmCallPromptBoundary } from "./llm-call-recorder.js";
+
 export type BrainType = "pi-agent";
 
 /**
@@ -166,6 +168,14 @@ export interface BrainContextPreflightResult {
 
 export interface BrainSession {
   readonly brainType: BrainType;
+
+  /**
+   * Optional: prompt / routing-attempt boundaries for the LLM call recorder
+   * (`src/core/llm-call-recorder.ts`). The agentbox HTTP layer marks receipt and
+   * completion so round 1's `since_prev_ms` covers setup; the routing runner's
+   * attempt events rewind rounds on rollback.
+   */
+  readonly llmCalls?: LlmCallPromptBoundary;
 
   /** Send a prompt to the agent. Resolves when the agent finishes responding. */
   prompt(text: string, media?: PromptMedia, requirements?: PromptRequirements): Promise<void>;

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -19,6 +19,7 @@ import type {
   PromptRequirements,
 } from "../brain-session.js";
 import { estimateMessagesTokens } from "../compaction.js";
+import type { LlmCallRecorder } from "../llm-call-recorder.js";
 import { rememberPromptFiles } from "../openai-file-payload.js";
 
 /** Valid pi thinking levels; guards reasoningEffort coming off the wire. */
@@ -109,20 +110,37 @@ export class PiAgentBrain implements BrainSession {
   constructor(
     readonly session: AgentSession,
     private readonly toolsetsByName: ReadonlyMap<string, string> = new Map(),
+    readonly llmCalls?: LlmCallRecorder,
   ) {}
 
+  /**
+   * Tool events are the only timeline points not produced at the streamFn
+   * boundary, so they are stamped HERE — the single funnel every subscriber
+   * goes through — on the same process clock as `llmCall`. Memoised per event
+   * object: several subscribers must see one timestamp, not one each.
+   */
+  private static readonly toolEventStamps = new WeakMap<object, number>();
+
   private enrichToolEvent(event: any): any {
-    if (!event || typeof event !== "object" || event.toolset != null) return event;
-    if (
-      event.type !== "tool_execution_start" && event.type !== "tool_start" &&
-      event.type !== "tool_execution_end" && event.type !== "tool_end"
-    ) return event;
-    const toolName = typeof event.toolName === "string"
-      ? event.toolName
-      : typeof event.name === "string" ? event.name : undefined;
-    if (!toolName) return event;
+    if (!event || typeof event !== "object") return event;
+    const isStart = event.type === "tool_execution_start" || event.type === "tool_start";
+    const isEnd = event.type === "tool_execution_end" || event.type === "tool_end";
+    if (!isStart && !isEnd) return event;
+    let stamp = PiAgentBrain.toolEventStamps.get(event);
+    if (stamp === undefined) {
+      stamp = Date.now();
+      PiAgentBrain.toolEventStamps.set(event, stamp);
+    }
+    const stamped = isStart
+      ? (event.startedAt === undefined ? { ...event, startedAt: stamp } : event)
+      : (event.endedAt === undefined ? { ...event, endedAt: stamp } : event);
+    if (stamped.toolset != null) return stamped;
+    const toolName = typeof stamped.toolName === "string"
+      ? stamped.toolName
+      : typeof stamped.name === "string" ? stamped.name : undefined;
+    if (!toolName) return stamped;
     const toolset = this.toolsetsByName.get(toolName);
-    return toolset ? { ...event, toolset } : event;
+    return toolset ? { ...stamped, toolset } : stamped;
   }
 
   private static readonly MAX_EMPTY_RETRIES = 2;
@@ -167,6 +185,10 @@ export class PiAgentBrain implements BrainSession {
 
   async prompt(text: string, media?: PromptMedia, requirements?: PromptRequirements): Promise<void> {
     this.aborted = false;
+    // Implicit prompt boundary for callers that bypass the agentbox HTTP layer
+    // (child sub-agents, synthetic notifies). A no-op when the HTTP layer already
+    // opened the prompt explicitly — routing calls prompt() once per attempt.
+    this.llmCalls?.beginPrompt(Date.now());
     let lastAssistantHadContent = false;
     let lastAssistantMessage: any = null;
     const successfulTools = new Set<string>();
@@ -174,6 +196,7 @@ export class PiAgentBrain implements BrainSession {
     const promptOptions = this.promptOptionsForMedia(media);
 
     const unsub = this.session.subscribe((event: any) => {
+      if (event?.message?.role === "assistant") this.llmCalls?.attachPendingFailure(event.message);
       if (event.type === "message_start" && event.message?.role === "assistant") {
         lastAssistantHadContent = false;
         lastAssistantMessage = null;
@@ -281,6 +304,7 @@ export class PiAgentBrain implements BrainSession {
       }
     } finally {
       unsub();
+      this.llmCalls?.endPrompt();
     }
   }
 
@@ -359,7 +383,10 @@ export class PiAgentBrain implements BrainSession {
   subscribe(listener: (event: any) => void): () => void {
     // Subscribe to both pi-agent events AND our own retry events
     this.extraListeners.add(listener);
-    const unsubSession = this.session.subscribe((event: any) => listener(this.enrichToolEvent(event)));
+    const unsubSession = this.session.subscribe((event: any) => {
+      if (event?.message?.role === "assistant") this.llmCalls?.attachPendingFailure(event.message);
+      listener(this.enrichToolEvent(event));
+    });
     return () => {
       this.extraListeners.delete(listener);
       unsubSession();

--- a/src/core/llm-call-recorder.test.ts
+++ b/src/core/llm-call-recorder.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect } from "vitest";
+import {
+  LlmCallRecorder,
+  llmCallFromMessage,
+  thinkingBlocksFromMessage,
+  type LlmCallEnvelope,
+} from "./llm-call-recorder.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/** Deterministic clock: each call to `now()` returns the next scripted value, then repeats the last. */
+function makeClock(ticks: number[]) {
+  let i = 0;
+  return () => ticks[Math.min(i++, ticks.length - 1)];
+}
+
+/** Events with the tick at which they are observed; `advanceTo` lets a test place the clock. */
+interface Scripted { tick: number; event: unknown }
+
+function makeStream(events: Scripted[], finalMessage: any, clock: { set: (t: number) => void }, endTick?: number) {
+  let i = 0;
+  return {
+    async result() {
+      if (endTick !== undefined) clock.set(endTick);
+      return finalMessage;
+    },
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          if (i < events.length) {
+            const { tick, event } = events[i++];
+            clock.set(tick);
+            return { done: false, value: event };
+          }
+          return { done: true, value: undefined };
+        },
+        async return() { return { done: true as const, value: undefined }; },
+        async throw() { return { done: true as const, value: undefined }; },
+      };
+    },
+  };
+}
+
+function settableClock(start: number) {
+  let t = start;
+  return { now: () => t, set: (v: number) => { t = v; } };
+}
+
+async function drain(stream: any): Promise<any> {
+  for await (const _ of stream) { /* consume */ }
+  return stream.result();
+}
+
+const AGENT_CTX = { systemPrompt: "s", messages: [], tools: [] };
+const AUX_CTX = { systemPrompt: "summarise", messages: [] };
+const MODEL = { provider: "openai", id: "gpt-5" };
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("LlmCallRecorder", () => {
+  it("measures net_ttft / thinking / output as a partition of total, with ordered non-overlapping blocks", async () => {
+    const clock = settableClock(1_000);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    recorder.beginPrompt(0, { explicit: true });
+
+    const final = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "let me think" },
+        { type: "text", text: "answer" },
+        { type: "toolCall", id: "call_1", name: "bash", arguments: {} },
+      ],
+      usage: { input: 100, output: 40, reasoning: 25, cacheRead: 80, cacheWrite: 0, totalTokens: 140 },
+      stopReason: "toolUse",
+      responseId: "chatcmpl-1",
+    };
+    const events: Scripted[] = [
+      { tick: 1_300, event: { type: "start" } },
+      { tick: 1_500, event: { type: "thinking_start", contentIndex: 0 } },
+      { tick: 1_600, event: { type: "thinking_delta", contentIndex: 0, delta: "let me " } },
+      { tick: 3_500, event: { type: "thinking_end", contentIndex: 0, content: "let me think" } },
+      { tick: 3_510, event: { type: "text_start", contentIndex: 1 } },
+      { tick: 4_000, event: { type: "text_end", contentIndex: 1, content: "answer" } },
+      { tick: 4_010, event: { type: "toolcall_start", contentIndex: 2 } },
+      { tick: 4_500, event: { type: "toolcall_end", contentIndex: 2, toolCall: { id: "call_1", name: "bash" } } },
+    ];
+    const streamFn = recorder.wrapStreamFn(() => makeStream(events, final, clock, 4_600));
+
+    clock.set(1_000);
+    const message = await drain(streamFn(MODEL, AGENT_CTX, {}));
+
+    const env = llmCallFromMessage(message)!;
+    expect(env).toBeDefined();
+    expect(env.round).toBe(1);
+    expect(env.kind).toBe("agent");
+    expect(env.prompt_received_at).toBe(new Date(0).toISOString());
+    expect(env.since_prev_ms).toBe(1_000);
+    expect(env.request_at).toBe(new Date(1_000).toISOString());
+    expect(env.headers_at).toBe(new Date(1_300).toISOString());
+    expect(env.first_token_at).toBe(new Date(1_500).toISOString());
+    expect(env.response_end_at).toBe(new Date(4_600).toISOString());
+    expect(env.ms.total).toBe(3_600);
+    expect(env.ms.net_ttft).toBe(500);
+    expect(env.ms.thinking).toBe(2_000);
+    expect(env.ms.output).toBe(1_100);
+    expect(env.ms.net_ttft + env.ms.thinking + env.ms.output).toBe(env.ms.total);
+    expect(env.blocks.map((b) => b.type)).toEqual(["thinking", "text", "tool_call"]);
+    for (let i = 1; i < env.blocks.length; i++) {
+      expect(Date.parse(env.blocks[i].start_at)).toBeGreaterThanOrEqual(Date.parse(env.blocks[i - 1].end_at));
+    }
+    expect(env.blocks[0].chars).toBe("let me think".length);
+    expect(env.blocks[2]).toMatchObject({ id: "call_1", name: "bash" });
+    expect(env.usage).toEqual({ input: 100, output: 40, reasoning: 25, cache_read: 80, cache_write: 0, total: 140 });
+    expect(env.stop_reason).toBe("toolUse");
+    expect(env.model).toMatchObject({ provider: "openai", id: "gpt-5", response_id: "chatcmpl-1" });
+    expect(env.thinking_visible).toBe(true);
+    expect(env.tool_call_ids).toEqual(["call_1"]);
+  });
+
+  it("numbers agent rounds contiguously and derives since_prev_ms from the previous response end", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    recorder.beginPrompt(0, { explicit: true });
+    const streamFn = recorder.wrapStreamFn(() => makeStream([], { role: "assistant", content: [], stopReason: "stop" }, clock));
+
+    clock.set(100);
+    const m1 = await drain(streamFn(MODEL, AGENT_CTX, {})); // seals at 100
+    // tool group runs 100 → 5_000
+    clock.set(5_000);
+    const m2 = await drain(streamFn(MODEL, AGENT_CTX, {}));
+
+    const e1 = llmCallFromMessage(m1)!;
+    const e2 = llmCallFromMessage(m2)!;
+    expect(e1.round).toBe(1);
+    expect(e2.round).toBe(2);
+    expect(e2.prompt_received_at).toBeUndefined();
+    expect(e2.since_prev_ms).toBe(4_900);
+    expect(e2.since_prev_ms).toBe(Date.parse(e2.request_at) - Date.parse(e1.response_end_at));
+  });
+
+  it("does not consume a round for aux (compaction) calls and folds them into the next agent call", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    recorder.beginPrompt(0, { explicit: true });
+    const streamFn = recorder.wrapStreamFn(() => makeStream([], { role: "assistant", content: [{ type: "text", text: "summary" }], stopReason: "stop" }, clock));
+
+    clock.set(10);
+    const agent1 = await drain(streamFn(MODEL, AGENT_CTX, {}));
+    clock.set(20);
+    const aux = await drain(streamFn(MODEL, AUX_CTX, {}));
+    clock.set(30);
+    const agent2 = await drain(streamFn(MODEL, AGENT_CTX, {}));
+
+    expect(llmCallFromMessage(agent1)!.round).toBe(1);
+    const auxEnv = llmCallFromMessage(aux)!;
+    expect(auxEnv.kind).toBe("aux");
+    expect(auxEnv.round).toBe(0);
+    const e2 = llmCallFromMessage(agent2)!;
+    expect(e2.round).toBe(2);
+    expect(e2.aux_calls).toHaveLength(1);
+    expect(e2.aux_calls![0].kind).toBe("aux");
+    expect(recorder.snapshot().pendingAux).toBe(0);
+  });
+
+  it("retires trailing aux calls at the prompt boundary as residual", async () => {
+    const clock = settableClock(0);
+    const warnings: string[] = [];
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: (message) => warnings.push(message) });
+    recorder.beginPrompt(0, { explicit: true });
+    const streamFn = recorder.wrapStreamFn(() => makeStream([], { role: "assistant", content: [{ type: "text", text: "summary" }] }, clock));
+
+    clock.set(100);
+    await drain(streamFn(MODEL, AUX_CTX, {}));
+    expect(recorder.snapshot().pendingAux).toBe(1);
+
+    recorder.endPrompt({ explicit: true });
+    expect(recorder.snapshot().pendingAux).toBe(0);
+    expect(warnings).toEqual([
+      expect.stringContaining("trailing aux call(s) had no following agent call"),
+    ]);
+  });
+
+  it("marks hidden reasoning as thinking_visible=false with zero thinking time", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    const final = { role: "assistant", content: [{ type: "text", text: "hi" }], usage: { input: 10, output: 50, reasoning: 40 }, stopReason: "stop" };
+    const events: Scripted[] = [
+      { tick: 100, event: { type: "start" } },
+      { tick: 2_000, event: { type: "text_start", contentIndex: 0 } },
+      { tick: 2_100, event: { type: "text_end", contentIndex: 0, content: "hi" } },
+    ];
+    const streamFn = recorder.wrapStreamFn(() => makeStream(events, final, clock, 2_100));
+    clock.set(0);
+    const env = llmCallFromMessage(await drain(streamFn(MODEL, AGENT_CTX, {})))!;
+    expect(env.thinking_visible).toBe(false);
+    expect(env.ms.thinking).toBe(0);
+    expect(env.ms.net_ttft).toBe(2_000);
+    expect(env.ms.output).toBe(100);
+    expect(env.usage?.reasoning).toBe(40);
+  });
+
+  it("closes blocks left open at stream end and records error / aborted stop reasons", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    const final = { role: "assistant", content: [{ type: "text", text: "par" }], stopReason: "error", errorMessage: "boom" };
+    const events: Scripted[] = [
+      { tick: 50, event: { type: "start" } },
+      { tick: 100, event: { type: "text_start", contentIndex: 0 } },
+      { tick: 150, event: { type: "text_delta", contentIndex: 0, delta: "par" } },
+    ];
+    const streamFn = recorder.wrapStreamFn(() => makeStream(events, final, clock, 300));
+    const env = llmCallFromMessage(await drain(streamFn(MODEL, AGENT_CTX, {})))!;
+    expect(env.blocks).toHaveLength(1);
+    expect(env.blocks[0].end_at).toBe(new Date(300).toISOString());
+    expect(env.blocks[0].chars).toBe(3);
+    expect(env.stop_reason).toBe("error");
+    expect(env.error_message).toBe("boom");
+  });
+
+  it("supports promise-returning base streamFn and result()-only consumers", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    const final = { role: "assistant", content: [{ type: "toolCall", id: "c9", name: "x" }], stopReason: "toolUse" };
+    const streamFn = recorder.wrapStreamFn(async () => makeStream([], final, clock, 400));
+    const stream = await streamFn(MODEL, AGENT_CTX, {});
+    const message = await stream.result();
+    const again = await stream.result();
+    expect(again).toBe(message);
+    const env = llmCallFromMessage(message)!;
+    expect(env.ms.total).toBe(400);
+    expect(env.ms.net_ttft).toBe(400);
+    expect(env.first_token_at).toBeUndefined();
+    expect(env.tool_call_ids).toEqual(["c9"]);
+  });
+
+  it("seals synchronous streamFn failures onto pi-agent's synthetic error message", () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    const streamFn = recorder.wrapStreamFn(() => { throw new Error("sync boom"); });
+
+    clock.set(100);
+    expect(() => streamFn(MODEL, AGENT_CTX, {})).toThrow("sync boom");
+    clock.set(250);
+    const failure = { role: "assistant", content: [], stopReason: "error", errorMessage: "sync boom" };
+    recorder.attachPendingFailure(failure);
+
+    expect(llmCallFromMessage(failure)).toMatchObject({
+      round: 1,
+      kind: "agent",
+      stop_reason: "error",
+      error_message: "sync boom",
+      ms: { total: 0 },
+    });
+  });
+
+  it("seals rejected stream creation and result promises exactly once", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    const rejectedCreation = recorder.wrapStreamFn(async () => { throw new Error("create boom"); });
+
+    clock.set(100);
+    await expect(rejectedCreation(MODEL, AGENT_CTX, {})).rejects.toThrow("create boom");
+    const first = { role: "assistant", content: [], stopReason: "error", errorMessage: "create boom" };
+    recorder.attachPendingFailure(first);
+    expect(llmCallFromMessage(first)?.round).toBe(1);
+
+    const rejectedResult = recorder.wrapStreamFn(() => ({
+      result: async () => { throw new Error("result boom"); },
+      async *[Symbol.asyncIterator]() { /* no events */ },
+    }));
+    clock.set(200);
+    const stream = rejectedResult(MODEL, AGENT_CTX, {});
+    await expect(stream.result()).rejects.toThrow("result boom");
+    await expect(stream.result()).rejects.toThrow("result boom");
+    const second = { role: "assistant", content: [], stopReason: "error", errorMessage: "result boom" };
+    recorder.attachPendingFailure(second);
+    expect(llmCallFromMessage(second)?.round).toBe(2);
+    expect(recorder.snapshot().round).toBe(2);
+  });
+
+  it("rewinds rounds on rollbackAttempt and bumps attempt; keeps prev response end", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    recorder.beginPrompt(0, { explicit: true });
+    const streamFn = recorder.wrapStreamFn(() => makeStream([], { role: "assistant", content: [], stopReason: "error" }, clock));
+
+    recorder.beginAttempt(1);
+    clock.set(100);
+    const failed = await drain(streamFn(MODEL, AGENT_CTX, {}));
+    expect(llmCallFromMessage(failed)!.round).toBe(1);
+    expect(llmCallFromMessage(failed)!.attempt).toBe(1);
+
+    recorder.rollbackAttempt(); // attempt failed
+    recorder.rollbackAttempt(); // live rollback — idempotent
+    recorder.beginAttempt(2);
+    clock.set(900);
+    const survivor = await drain(streamFn(MODEL, AGENT_CTX, {}));
+    const env = llmCallFromMessage(survivor)!;
+    expect(env.round).toBe(1);
+    expect(env.attempt).toBe(2);
+    // spans the discarded attempt: 900 − 100
+    expect(env.since_prev_ms).toBe(800);
+  });
+
+  it("explicit prompt boundaries win over implicit ones", () => {
+    const recorder = new LlmCallRecorder({ now: () => 0, warn: () => {} });
+    recorder.beginPrompt(5, { explicit: true });
+    recorder.beginPrompt(99); // implicit — ignored
+    recorder.endPrompt(); // implicit — ignored
+    expect(recorder.snapshot().promptOpen).toBe(true);
+    recorder.endPrompt({ explicit: true });
+    expect(recorder.snapshot().promptOpen).toBe(false);
+  });
+
+  it("opens a prompt implicitly on the first call when nobody did", async () => {
+    const clock = settableClock(0);
+    const recorder = new LlmCallRecorder({ now: clock.now, warn: () => {} });
+    const streamFn = recorder.wrapStreamFn(() => makeStream([], { role: "assistant", content: [] }, clock));
+    const env = llmCallFromMessage(await drain(streamFn(MODEL, AGENT_CTX, {})))!;
+    expect(env.round).toBe(1);
+    expect(env.since_prev_ms).toBe(0);
+  });
+});
+
+describe("thinkingBlocksFromMessage", () => {
+  it("returns text with redaction and signature flags", () => {
+    const blocks = thinkingBlocksFromMessage({
+      content: [
+        { type: "thinking", thinking: "abc", thinkingSignature: "sig" },
+        { type: "thinking", thinking: "", redacted: true, thinkingSignature: "enc" },
+        { type: "text", text: "x" },
+      ],
+    });
+    expect(blocks).toEqual([
+      { text: "abc", redacted: false, signature_present: true },
+      { text: "", redacted: true, signature_present: true },
+    ]);
+  });
+
+  it("is empty for non-array content", () => {
+    expect(thinkingBlocksFromMessage({ content: "plain" })).toEqual([]);
+    expect(thinkingBlocksFromMessage(undefined)).toEqual([]);
+  });
+});
+
+describe("llmCallFromMessage", () => {
+  it("rejects foreign versions", () => {
+    const env = { v: 2 } as unknown as LlmCallEnvelope;
+    expect(llmCallFromMessage({ llmCall: env })).toBeUndefined();
+    expect(llmCallFromMessage({})).toBeUndefined();
+  });
+});

--- a/src/core/llm-call-recorder.ts
+++ b/src/core/llm-call-recorder.ts
@@ -1,0 +1,585 @@
+/**
+ * LLM call recorder — measures every provider request at the `streamFn`
+ * boundary and stamps the result onto the assistant message as `llmCall`.
+ *
+ * This is the single source of truth for model-side timing. The gateway
+ * (`src/gateway/sse-consumer.ts`) reads `message.llmCall` off `message_end`
+ * and persists a redacted copy as `chat_messages.metadata.llm_call`; a reader
+ * decodes the linear timeline from those rows. Nothing downstream infers
+ * timing from event arrival any more.
+ *
+ * Why here and not in the SSE consumer: only the streamFn boundary sees the
+ * request leaving, the HTTP headers arriving (pi-ai pushes `start` after
+ * `withResponse()` resolves), the exact thinking/text/tool-call block edges,
+ * and the provider's own `usage`. Everything is on ONE clock — this process.
+ *
+ * Pure module: no I/O, no pi imports at runtime, vitest-friendly. Wiring
+ * lives in agent-factory.ts (wrap) and agentbox http-server.ts (prompt/attempt
+ * boundaries).
+ *
+ * Contract for consumers: the envelope's shape is documented on
+ * LlmCallEnvelope below, field by field. Nothing outside this module infers
+ * timing — a reader that wants a different number derives it from these.
+ */
+
+export const LLM_CALL_ENVELOPE_VERSION = 1 as const;
+
+export type LlmCallKind = "agent" | "aux";
+
+export interface LlmCallBlock {
+  type: "thinking" | "text" | "tool_call";
+  start_at: string;
+  end_at: string;
+  /** Characters produced by the block (thinking/text). */
+  chars?: number;
+  /** Tool call id / name (tool_call blocks). */
+  id?: string;
+  name?: string;
+}
+
+export interface LlmCallUsage {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cache_read?: number;
+  cache_write?: number;
+  total?: number;
+}
+
+export interface LlmCallEnvelope {
+  v: typeof LLM_CALL_ENVELOPE_VERSION;
+  /** 1-based index of this model call within the prompt. Only `agent` calls consume rounds. */
+  round: number;
+  /** Model-routing attempt number the call belongs to (1 when routing never switched). */
+  attempt: number;
+  /** `agent` = agent-loop turn (context carried tools); `aux` = compaction / summarisation. */
+  kind: LlmCallKind;
+  model: {
+    provider?: string;
+    id?: string;
+    response_model?: string;
+    response_id?: string;
+  };
+  /** Only on round 1: when the box accepted the prompt (same clock). */
+  prompt_received_at?: string;
+  request_at: string;
+  /** HTTP response headers arrived (`start` event). */
+  headers_at?: string;
+  /** First content-bearing stream event (thinking / text / tool call). */
+  first_token_at?: string;
+  response_end_at: string;
+  /**
+   * round 1: request_at − prompt_received_at (setup).
+   * round>1: request_at − previous agent call's response_end_at (= previous tool group span).
+   */
+  since_prev_ms?: number;
+  ms: {
+    net_ttft: number;
+    thinking: number;
+    output: number;
+    total: number;
+  };
+  /** Non-overlapping block edges in emission order. */
+  blocks: LlmCallBlock[];
+  usage?: LlmCallUsage;
+  stop_reason?: string;
+  error_message?: string;
+  /** false when the provider reports reasoning tokens but streams no thinking text. */
+  thinking_visible: boolean;
+  tool_call_ids: string[];
+  /** Auxiliary calls (compaction) that ran between the previous agent call and this one. */
+  aux_calls?: LlmCallEnvelope[];
+  /** Set by the gateway: id of the persisted `kind: "thinking"` row for this call. */
+  thinking_row_id?: string;
+}
+
+/** Envelope fields captured while the stream is in flight, before the result is known. */
+interface InFlightCall {
+  kind: LlmCallKind;
+  requestAt: number;
+  headersAt?: number;
+  firstTokenAt?: number;
+  blocks: LlmCallBlock[];
+  openBlocks: Map<number, { type: LlmCallBlock["type"]; startAt: number; chars: number; id?: string; name?: string }>;
+  toolCallIds: string[];
+  modelProvider?: string;
+  modelId?: string;
+  sealedEnvelope?: LlmCallEnvelope;
+}
+
+export interface LlmCallRecorderOptions {
+  now?: () => number;
+  /** Diagnostic sink; defaults to console.warn. */
+  warn?: (message: string) => void;
+}
+
+/**
+ * Handle exposed on the brain so the agentbox can mark prompt / attempt
+ * boundaries without reaching into the recorder's internals.
+ */
+export interface LlmCallPromptBoundary {
+  /** A new prompt was accepted at `receivedAt` (ms epoch). Resets rounds. */
+  beginPrompt(receivedAt?: number, opts?: { explicit?: boolean }): void;
+  /** The prompt finished (every terminal path). */
+  endPrompt(opts?: { explicit?: boolean }): void;
+  /** A model-routing attempt is starting: remember where its rounds begin. */
+  beginAttempt(attempt?: number): void;
+  /** The attempt failed / was rolled back: rewind its rounds. Idempotent. */
+  rollbackAttempt(): void;
+}
+
+export class LlmCallRecorder implements LlmCallPromptBoundary {
+  private readonly now: () => number;
+  private readonly warn: (message: string) => void;
+
+  private promptOpen = false;
+  private promptExplicit = false;
+  private promptReceivedAt?: number;
+  private round = 0;
+  private attempt = 1;
+  private attemptStartRound = 0;
+  private prevResponseEndAt?: number;
+  private pendingAux: LlmCallEnvelope[] = [];
+  private pendingFailedAgentCalls: LlmCallEnvelope[] = [];
+
+  constructor(options: LlmCallRecorderOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.warn = options.warn ?? ((message) => console.warn(message));
+  }
+
+  // ── Prompt / attempt boundaries ────────────────────────────────────────
+
+  beginPrompt(receivedAt?: number, opts?: { explicit?: boolean }): void {
+    // An explicit open (HTTP receipt) wins over the brain's implicit one, which
+    // fires later from inside the routing runner and must not reset the rounds.
+    if (this.promptOpen && this.promptExplicit && !opts?.explicit) return;
+    this.promptOpen = true;
+    this.promptExplicit = opts?.explicit === true;
+    this.promptReceivedAt = receivedAt ?? this.now();
+    this.round = 0;
+    this.attempt = 1;
+    this.attemptStartRound = 0;
+    this.attemptStarted = false;
+    this.prevResponseEndAt = undefined;
+    if (this.pendingAux.length > 0) {
+      this.warn(`[llm-call-recorder] dropping ${this.pendingAux.length} aux call(s) left over from the previous prompt`);
+      this.pendingAux = [];
+    }
+    if (this.pendingFailedAgentCalls.length > 0) {
+      this.warn(`[llm-call-recorder] dropping ${this.pendingFailedAgentCalls.length} unmatched failed call(s) left over from the previous prompt`);
+      this.pendingFailedAgentCalls = [];
+    }
+  }
+
+  endPrompt(opts?: { explicit?: boolean }): void {
+    // The brain's implicit end (each brain.prompt() return) must not close a
+    // prompt the HTTP layer opened explicitly — routing calls brain.prompt()
+    // once per attempt inside one HTTP prompt.
+    if (this.promptExplicit && !opts?.explicit) return;
+    this.promptOpen = false;
+    this.promptExplicit = false;
+    if (this.pendingAux.length > 0) {
+      // Compaction can finish after the final agent call while the HTTP layer is
+      // deliberately keeping the prompt open. The current cross-service
+      // contract has no following call on which to carry these aux_calls, so
+      // their span remains visible as the prompt's residual rather than being
+      // mislabelled as another round or another prompt's setup.
+      this.warn(
+        `[llm-call-recorder] ${this.pendingAux.length} trailing aux call(s) had no following agent call ` +
+          `to ride; their span stays in the prompt tail (residual)`,
+      );
+      this.pendingAux = [];
+    }
+  }
+
+  beginAttempt(attempt?: number): void {
+    this.attemptStartRound = this.round;
+    if (typeof attempt === "number" && attempt >= 1) this.attempt = attempt;
+    else this.attempt += this.attemptStarted ? 1 : 0;
+    this.attemptStarted = true;
+  }
+
+  rollbackAttempt(): void {
+    // Fires for `model_route_attempt{failed}` AND `model_route_rollback` (the
+    // live-output case emits both) — hence idempotent: rewinding twice is a no-op.
+    this.round = this.attemptStartRound;
+    // prevResponseEndAt is deliberately NOT rewound: the discarded attempt's
+    // time is real, and the survivor's since_prev_ms must span it so the
+    // prompt timeline stays a partition.
+  }
+
+  private attemptStarted = false;
+
+  /** Test / diagnostics visibility. */
+  snapshot(): { promptOpen: boolean; round: number; attempt: number; pendingAux: number } {
+    return { promptOpen: this.promptOpen, round: this.round, attempt: this.attempt, pendingAux: this.pendingAux.length };
+  }
+
+  // ── streamFn wrapper ───────────────────────────────────────────────────
+
+  wrapStreamFn<T extends (...args: any[]) => any>(baseFn: T): T {
+    const recorder = this;
+    const wrapped = (model: any, context: any, options: any) => {
+      const call = recorder.openCall(model, context);
+      let maybeStream: any;
+      try {
+        maybeStream = baseFn(model, context, options);
+      } catch (error) {
+        recorder.sealFailedCall(call, error);
+        throw error;
+      }
+      if (maybeStream && typeof maybeStream === "object" && typeof (maybeStream as Promise<unknown>).then === "function") {
+        return (maybeStream as Promise<any>).then(
+          (stream) => recorder.wrapStream(stream, call),
+          (error) => {
+            recorder.sealFailedCall(call, error);
+            throw error;
+          },
+        );
+      }
+      return recorder.wrapStream(maybeStream, call);
+    };
+    return wrapped as unknown as T;
+  }
+
+  /**
+   * pi-agent synthesizes a fresh assistant error message when streamFn throws,
+   * so the envelope cannot be stamped directly onto the message at the provider
+   * boundary. Pair that message with the failed call before subscribers see it.
+   */
+  attachPendingFailure(message: unknown): void {
+    if (!message || typeof message !== "object") return;
+    const target = message as Record<string, unknown>;
+    if (target.role !== "assistant" || (target.stopReason !== "error" && target.stopReason !== "aborted")) return;
+    if (llmCallFromMessage(target)) return;
+    const envelope = this.pendingFailedAgentCalls.shift();
+    if (!envelope) return;
+    envelope.stop_reason = target.stopReason;
+    if (typeof target.errorMessage === "string") envelope.error_message = target.errorMessage.slice(0, 500);
+    target.llmCall = envelope;
+  }
+
+  private openCall(model: any, context: any): InFlightCall {
+    if (!this.promptOpen) {
+      // Late/implicit open — a prompt path that never went through the HTTP
+      // layer (child sub-agent, synthetic notify). Rounds still start at 1.
+      this.beginPrompt(this.now());
+    }
+    return {
+      kind: Array.isArray(context?.tools) ? "agent" : "aux",
+      requestAt: this.now(),
+      blocks: [],
+      openBlocks: new Map(),
+      toolCallIds: [],
+      modelProvider: typeof model?.provider === "string" ? model.provider : undefined,
+      modelId: typeof model?.id === "string" ? model.id : undefined,
+    };
+  }
+
+  private wrapStream(stream: any, call: InFlightCall): any {
+    if (!stream || typeof stream !== "object") return stream;
+
+    if (typeof stream[Symbol.asyncIterator] === "function") {
+      const originalIterator = stream[Symbol.asyncIterator].bind(stream);
+      stream[Symbol.asyncIterator] = () => {
+        const iterator = originalIterator();
+        return {
+          next: async () => {
+            try {
+              const result = await iterator.next();
+              if (!result.done && result.value) this.observeEvent(call, result.value);
+              return result;
+            } catch (error) {
+              this.sealFailedCall(call, error);
+              throw error;
+            }
+          },
+          return: async (value?: unknown) =>
+            iterator.return?.(value) ?? { done: true as const, value: undefined },
+          throw: async (error?: unknown) =>
+            iterator.throw?.(error) ?? { done: true as const, value: undefined },
+        };
+      };
+    }
+
+    if (typeof stream.result === "function") {
+      const originalResult = stream.result.bind(stream);
+      let sealed: Promise<any> | undefined;
+      stream.result = () => {
+        // result() may be awaited more than once (pi-agent awaits it on `done`
+        // and again after the loop); the envelope must be built exactly once.
+        if (!sealed) {
+          sealed = Promise.resolve().then(originalResult).then(
+            (message: any) => {
+              this.sealCall(call, message);
+              return message;
+            },
+            (error: unknown) => {
+              this.sealFailedCall(call, error);
+              throw error;
+            },
+          );
+        }
+        return sealed;
+      };
+    }
+    return stream;
+  }
+
+  private observeEvent(call: InFlightCall, event: any): void {
+    const type = event?.type;
+    if (typeof type !== "string") return;
+    const at = this.now();
+    switch (type) {
+      case "start":
+        call.headersAt ??= at;
+        return;
+      case "thinking_start":
+        call.firstTokenAt ??= at;
+        this.openBlock(call, event, "thinking", at);
+        return;
+      case "text_start":
+        call.firstTokenAt ??= at;
+        this.openBlock(call, event, "text", at);
+        return;
+      case "toolcall_start":
+        call.firstTokenAt ??= at;
+        this.openBlock(call, event, "tool_call", at);
+        return;
+      case "thinking_delta":
+      case "text_delta": {
+        call.firstTokenAt ??= at;
+        const block = this.ensureBlock(call, event, type === "thinking_delta" ? "thinking" : "text", at);
+        if (typeof event.delta === "string") block.chars += event.delta.length;
+        return;
+      }
+      case "toolcall_delta":
+        call.firstTokenAt ??= at;
+        this.ensureBlock(call, event, "tool_call", at);
+        return;
+      case "thinking_end":
+      case "text_end": {
+        const block = this.ensureBlock(call, event, type === "thinking_end" ? "thinking" : "text", at);
+        if (typeof event.content === "string") block.chars = Math.max(block.chars, event.content.length);
+        this.closeBlock(call, event, at);
+        return;
+      }
+      case "toolcall_end": {
+        const block = this.ensureBlock(call, event, "tool_call", at);
+        const toolCall = event.toolCall;
+        if (toolCall && typeof toolCall === "object") {
+          if (typeof toolCall.id === "string") block.id = toolCall.id;
+          if (typeof toolCall.name === "string") block.name = toolCall.name;
+        }
+        this.closeBlock(call, event, at);
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  private blockKey(event: any): number {
+    return typeof event?.contentIndex === "number" ? event.contentIndex : -1;
+  }
+
+  private openBlock(call: InFlightCall, event: any, type: LlmCallBlock["type"], at: number): void {
+    const key = this.blockKey(event);
+    if (call.openBlocks.has(key)) return;
+    call.openBlocks.set(key, { type, startAt: at, chars: 0 });
+  }
+
+  private ensureBlock(call: InFlightCall, event: any, type: LlmCallBlock["type"], at: number) {
+    const key = this.blockKey(event);
+    let block = call.openBlocks.get(key);
+    if (!block) {
+      block = { type, startAt: at, chars: 0 };
+      call.openBlocks.set(key, block);
+    }
+    return block;
+  }
+
+  private closeBlock(call: InFlightCall, event: any, at: number): void {
+    const key = this.blockKey(event);
+    const block = call.openBlocks.get(key);
+    if (!block) return;
+    call.openBlocks.delete(key);
+    this.pushBlock(call, block, at);
+  }
+
+  private pushBlock(
+    call: InFlightCall,
+    block: { type: LlmCallBlock["type"]; startAt: number; chars: number; id?: string; name?: string },
+    endAt: number,
+  ): void {
+    const out: LlmCallBlock = {
+      type: block.type,
+      start_at: iso(block.startAt),
+      end_at: iso(Math.max(block.startAt, endAt)),
+    };
+    if (block.type !== "tool_call") out.chars = block.chars;
+    if (block.id) {
+      out.id = block.id;
+      call.toolCallIds.push(block.id);
+    }
+    if (block.name) out.name = block.name;
+    call.blocks.push(out);
+  }
+
+  private sealFailedCall(call: InFlightCall, error: unknown): void {
+    if (call.sealedEnvelope) return;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const envelope = this.sealCall(call, { stopReason: "error", errorMessage });
+    if (call.kind === "agent") this.pendingFailedAgentCalls.push(envelope);
+  }
+
+  private sealCall(call: InFlightCall, message: any): LlmCallEnvelope {
+    if (call.sealedEnvelope) {
+      if (message && typeof message === "object") {
+        (message as Record<string, unknown>).llmCall = call.sealedEnvelope;
+      }
+      return call.sealedEnvelope;
+    }
+    const responseEndAt = this.now();
+    // Blocks still open when the stream ended (provider never sent *_end).
+    for (const [key, block] of [...call.openBlocks.entries()]) {
+      call.openBlocks.delete(key);
+      this.pushBlock(call, block, responseEndAt);
+    }
+    // Tool-call ids the block stream missed (e.g. result() consumed without iteration).
+    if (message && Array.isArray(message.content)) {
+      for (const c of message.content) {
+        if (c && typeof c === "object" && c.type === "toolCall" && typeof c.id === "string" && !call.toolCallIds.includes(c.id)) {
+          call.toolCallIds.push(c.id);
+        }
+      }
+    }
+
+    const totalMs = Math.max(0, responseEndAt - call.requestAt);
+    const firstTokenAt = call.firstTokenAt;
+    const netTtftMs = firstTokenAt === undefined ? totalMs : Math.max(0, firstTokenAt - call.requestAt);
+    let thinkingMs = 0;
+    for (const b of call.blocks) {
+      if (b.type === "thinking") thinkingMs += Math.max(0, Date.parse(b.end_at) - Date.parse(b.start_at));
+    }
+    const streamingMs = firstTokenAt === undefined ? 0 : Math.max(0, responseEndAt - firstTokenAt);
+    thinkingMs = Math.min(thinkingMs, streamingMs);
+    const outputMs = Math.max(0, streamingMs - thinkingMs);
+
+    const usage = usageFromMessage(message?.usage);
+    const thinkingChars = call.blocks.reduce((acc, b) => acc + (b.type === "thinking" ? (b.chars ?? 0) : 0), 0);
+    const thinkingVisible = thinkingChars > 0 || messageHasThinkingText(message);
+
+    const envelope: LlmCallEnvelope = {
+      v: LLM_CALL_ENVELOPE_VERSION,
+      round: 0,
+      attempt: this.attempt,
+      kind: call.kind,
+      model: {
+        provider: call.modelProvider ?? (typeof message?.provider === "string" ? message.provider : undefined),
+        id: call.modelId ?? (typeof message?.model === "string" ? message.model : undefined),
+        response_model: typeof message?.responseModel === "string" ? message.responseModel : undefined,
+        response_id: typeof message?.responseId === "string" ? message.responseId : undefined,
+      },
+      request_at: iso(call.requestAt),
+      headers_at: call.headersAt === undefined ? undefined : iso(call.headersAt),
+      first_token_at: firstTokenAt === undefined ? undefined : iso(firstTokenAt),
+      response_end_at: iso(responseEndAt),
+      ms: { net_ttft: netTtftMs, thinking: thinkingMs, output: outputMs, total: totalMs },
+      blocks: call.blocks,
+      usage,
+      stop_reason: typeof message?.stopReason === "string" ? message.stopReason : undefined,
+      error_message: typeof message?.errorMessage === "string" ? message.errorMessage.slice(0, 500) : undefined,
+      thinking_visible: thinkingVisible,
+      tool_call_ids: call.toolCallIds,
+    };
+    call.sealedEnvelope = envelope;
+
+    if (call.kind === "aux") {
+      this.pendingAux.push(envelope);
+    } else {
+      this.round += 1;
+      envelope.round = this.round;
+      if (this.round === 1 && this.promptReceivedAt !== undefined) {
+        envelope.prompt_received_at = iso(this.promptReceivedAt);
+      }
+      // After a routing rollback round 1 recurs with a real predecessor (the
+      // discarded attempt); only the very first call measures from receipt.
+      const anchor = this.prevResponseEndAt ?? (this.round === 1 ? this.promptReceivedAt : undefined);
+      if (anchor !== undefined) {
+        envelope.since_prev_ms = Math.max(0, call.requestAt - anchor);
+      }
+      if (this.pendingAux.length > 0) {
+        envelope.aux_calls = this.pendingAux;
+        this.pendingAux = [];
+      }
+      this.prevResponseEndAt = responseEndAt;
+    }
+
+    if (message && typeof message === "object") {
+      (message as Record<string, unknown>).llmCall = envelope;
+    }
+    return envelope;
+  }
+}
+
+function iso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function usageFromMessage(raw: unknown): LlmCallUsage | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const u = raw as Record<string, unknown>;
+  const num = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+  const usage: LlmCallUsage = {};
+  const input = num(u.input);
+  const output = num(u.output);
+  const reasoning = num(u.reasoning);
+  const cacheRead = num(u.cacheRead);
+  const cacheWrite = num(u.cacheWrite);
+  const total = num(u.totalTokens);
+  if (input !== undefined) usage.input = input;
+  if (output !== undefined) usage.output = output;
+  if (reasoning !== undefined) usage.reasoning = reasoning;
+  if (cacheRead !== undefined) usage.cache_read = cacheRead;
+  if (cacheWrite !== undefined) usage.cache_write = cacheWrite;
+  if (total !== undefined) usage.total = total;
+  return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
+function messageHasThinkingText(message: any): boolean {
+  if (!message || !Array.isArray(message.content)) return false;
+  return message.content.some(
+    (c: any) => c && typeof c === "object" && c.type === "thinking" && typeof c.thinking === "string" && c.thinking.length > 0,
+  );
+}
+
+/** Read the envelope back off a message (gateway side). */
+export function llmCallFromMessage(message: unknown): LlmCallEnvelope | undefined {
+  if (!message || typeof message !== "object") return undefined;
+  const raw = (message as Record<string, unknown>).llmCall;
+  if (!raw || typeof raw !== "object") return undefined;
+  const env = raw as LlmCallEnvelope;
+  return env.v === LLM_CALL_ENVELOPE_VERSION ? env : undefined;
+}
+
+/**
+ * Extract thinking blocks from an assistant message: full text plus redaction /
+ * signature flags. Empty when the provider streamed none.
+ */
+export function thinkingBlocksFromMessage(message: unknown): Array<{ text: string; redacted: boolean; signature_present: boolean }> {
+  if (!message || typeof message !== "object") return [];
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return [];
+  const out: Array<{ text: string; redacted: boolean; signature_present: boolean }> = [];
+  for (const c of content) {
+    if (!c || typeof c !== "object" || (c as { type?: unknown }).type !== "thinking") continue;
+    const block = c as { thinking?: unknown; redacted?: unknown; thinkingSignature?: unknown };
+    out.push({
+      text: typeof block.thinking === "string" ? block.thinking : "",
+      redacted: block.redacted === true,
+      signature_present: typeof block.thinkingSignature === "string" && block.thinkingSignature.length > 0,
+    });
+  }
+  return out;
+}

--- a/src/core/llm-call-recorder.wire.test.ts
+++ b/src/core/llm-call-recorder.wire.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+// Relative import on purpose: the converter is not on pi-ai's export map, and
+// this test exists precisely to pin the behaviour of the installed version.
+import { convertMessages } from "../../node_modules/@earendil-works/pi-ai/dist/api/openai-completions.js";
+
+/** The compat shape openai-completions' converter reads; plain OpenAI defaults. */
+const OPENAI_COMPAT = {
+  supportsStore: true,
+  supportsDeveloperRole: true,
+  supportsReasoningEffort: true,
+  supportsUsageInStreaming: true,
+  maxTokensField: "max_completion_tokens",
+  requiresToolResultName: false,
+  requiresAssistantAfterToolResult: false,
+  requiresThinkingAsText: false,
+  requiresReasoningContentOnAssistantMessages: false,
+  thinkingFormat: "openai",
+  openRouterRouting: {},
+  supportsStrictMode: true,
+};
+
+/**
+ * The recorder stamps `llmCall` onto the assistant message object that pi-agent
+ * keeps in its context. That object is replayed to the provider on every later
+ * turn, so the stamp must never reach the request body. Pinned against the
+ * installed pi-ai: an upgrade that starts forwarding unknown message fields
+ * would fail here rather than in production.
+ */
+describe("llmCall stamp does not leak into the provider request", () => {
+  const model = {
+    id: "gpt-5",
+    name: "gpt-5",
+    api: "openai-completions",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+  } as any;
+
+  it("openai-completions convertMessages drops the llmCall property", () => {
+    const assistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "hmm", thinkingSignature: "sig" },
+        { type: "text", text: "answer" },
+        { type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+      ],
+      api: "openai-completions",
+      provider: "openai",
+      model: "gpt-5",
+      usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "toolUse",
+      timestamp: 1,
+      llmCall: { v: 1, round: 1, ms: { net_ttft: 1, thinking: 1, output: 1, total: 3 }, blocks: [], tool_call_ids: ["call_1"] },
+    } as any;
+    const context = {
+      systemPrompt: "sys",
+      messages: [
+        { role: "user", content: "hi", timestamp: 0 },
+        assistant,
+        { role: "toolResult", toolCallId: "call_1", toolName: "bash", content: [{ type: "text", text: "ok" }], isError: false, timestamp: 2 },
+      ],
+    } as any;
+
+    const params = convertMessages(model, context, OPENAI_COMPAT as any);
+    const serialized = JSON.stringify(params);
+    expect(serialized).not.toContain("llmCall");
+    expect(serialized).not.toContain("net_ttft");
+    // Sanity: the assistant turn itself is still forwarded.
+    expect(params.some((m: any) => m.role === "assistant")).toBe(true);
+  });
+});

--- a/src/core/model-routing.test.ts
+++ b/src/core/model-routing.test.ts
@@ -1583,3 +1583,28 @@ describe("modelOptionsSupportImageInput", () => {
 function isEventType(event: unknown, type: string): boolean {
   return typeof event === "object" && event !== null && (event as { type?: unknown }).type === type;
 }
+
+
+it("carries buffered failed-call envelopes on the switch without relaying discarded text", async () => {
+  const brain = makeBrain([]);
+  const call = { v: 1, kind: "agent", round: 1, attempt: 1, model: { provider: "openai", id: "gpt-4" },
+    request_at: "2026-09-03T08:00:00.000Z", response_end_at: "2026-09-03T08:00:01.000Z",
+    ms: { net_ttft: 1000, thinking: 0, output: 0, total: 1000 }, blocks: [], thinking_visible: false, tool_call_ids: [] };
+  let attempt = 0;
+  vi.mocked(brain.prompt).mockImplementation(async () => {
+    attempt++;
+    brain.emitter.emit("event", { type: "message_end", message: { role: "assistant",
+      content: [{ type: "text", text: attempt === 1 ? "discarded answer" : "survivor" }],
+      stopReason: attempt === 1 ? "error" : "stop", errorMessage: attempt === 1 ? "429 rate limit" : undefined,
+      ...(attempt === 1 ? { llmCall: call } : {}),
+    } });
+  });
+  const route: ModelRouteEvent[] = [];
+  const relayed: any[] = [];
+  await runPromptWithModelRouting(brain, "test", makePolicy(), createModelRouteState(), {
+    optimisticPrimaryStream: false, emitEvent: event => route.push(event), emitBrainEvent: event => relayed.push(event),
+  });
+  expect(route.find(e => e.type === "model_route_switch")).toMatchObject({ discardedLlmCalls: [call] });
+  expect(relayed).toHaveLength(1);
+  expect(relayed[0].message.content[0].text).toBe("survivor");
+});

--- a/src/core/model-routing.ts
+++ b/src/core/model-routing.ts
@@ -1,3 +1,4 @@
+import { llmCallFromMessage, type LlmCallEnvelope } from "./llm-call-recorder.js";
 import { modelNeedsRebind } from "./brain-session.js";
 import type {
   BrainModelInfo,
@@ -92,6 +93,8 @@ export type ModelRouteEvent =
   | {
       type: "model_route_switch";
       attempt: number;
+      /** Calls whose buffered messages were discarded before reaching consumers. */
+      discardedLlmCalls?: LlmCallEnvelope[];
       fromCandidateKey: string;
       toCandidateKey: string;
       fromProvider: string;
@@ -989,6 +992,13 @@ export async function runPromptWithModelRouting(
     emitEvent({
       type: "model_route_switch",
       attempt: attempt.attempt,
+      // Buffered events never reached consumers. Carry only their envelopes;
+      // replaying message_end would resurrect discarded text and errors.
+      discardedLlmCalls: attemptResult.events.flatMap((event) => {
+        if (!isRecord(event) || event.type !== "message_end") return [];
+        const call = llmCallFromMessage(event.message);
+        return call ? [call] : [];
+      }),
       fromCandidateKey: key,
       toCandidateKey: candidateKey(nextCandidate),
       fromProvider: candidate.provider,

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -3872,10 +3872,17 @@ describe("collectResponse — SSE event flattening", () => {
     updateMessageMock.mockReset();
     appendMessageMock.mockResolvedValueOnce("row-primary").mockResolvedValueOnce("row-fallback");
     updateMessageMock.mockResolvedValue(undefined);
+    const call = {
+      v: 1, kind: "agent", round: 1, attempt: 1,
+      model: { provider: "openai", id: "gpt-4" },
+      request_at: "2026-09-01T00:00:00.000Z", response_end_at: "2026-09-01T00:00:01.000Z",
+      ms: { net_ttft: 100, thinking: 0, output: 900, total: 1000 },
+      blocks: [], tool_call_ids: [], thinking_visible: false,
+    };
     const events = [
       { type: "model_route_start", candidateCount: 2 },
       { type: "knowledge_sources", sources: [{ title: "Primary Runbook", url: "https://example.com/primary", resource: "r.md", page: "p.md" }] },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "partial primary answer" }], stopReason: "stop" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "partial primary answer" }], stopReason: "stop", llmCall: call } },
       { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-4", failureKind: "rate_limit" },
       { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "answer from fallback" }], stopReason: "stop" } },
       { type: "model_route_success", attempt: 2, candidateKey: "anthropic/claude", provider: "anthropic", modelId: "claude", isFallback: true, primaryCandidateKey: "openai/gpt-4" },
@@ -3886,7 +3893,7 @@ describe("collectResponse — SSE event flattening", () => {
     // The primary row was written with citations, then marked discarded without them.
     expect(appendMessageMock.mock.calls[0][0].metadata).toHaveProperty("knowledge_citations");
     expect(updateMessageMock).toHaveBeenCalledWith(expect.objectContaining({
-      messageId: "row-primary", metadata: { discarded_route_attempt: true },
+      messageId: "row-primary", metadata: { discarded_route_attempt: true, llm_call: call },
     }));
     expect(updateMessageMock.mock.calls[0][0].metadata).not.toHaveProperty("knowledge_citations");
     // The fallback row carries no leftover citations from the discarded attempt.

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -4324,16 +4324,17 @@ describe("collectChannelResponse — audit persistence", () => {
     expect(rows.filter((row) => row.metadata?.llm_call?.stop_reason === "error")).toHaveLength(1);
   });
 
-  it("moves a rolled-back attempt's failed call onto the fallback notice", async () => {
+  it.each([false, true])("keeps a failed call on the fallback notice (buffered=%s)", async (buffered) => {
     await collectChannelResponse(fakeClient([
       { type: "model_route_start", candidateCount: 2 },
-      { type: "message_end", message: {
+      ...(buffered ? [] : [{ type: "message_end", message: {
         role: "assistant", content: [], stopReason: "error", errorMessage: "primary 429 sk-secret123",
         llmCall: envelope({ round: 1, attempt: 1, stop_reason: "error", error_message: "primary 429 sk-secret123" }),
       } },
-      { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-5", failureKind: "rate_limit" },
+      { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-5", failureKind: "rate_limit" }]),
       {
         type: "model_route_switch",
+        ...(buffered ? { discardedLlmCalls: [envelope({ round: 1, attempt: 1, stop_reason: "error", error_message: "primary 429 sk-secret123" })] } : {}),
         attempt: 2,
         fromCandidateKey: "openai/gpt-5",
         toCandidateKey: "anthropic/claude",

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -4090,6 +4090,20 @@ describe("collectChannelResponse — audit persistence", () => {
   function fakeClient(events: unknown[]) {
     return { streamEvents: async function* () { for (const e of events) yield e; } } as any;
   }
+  const envelope = (overrides: Record<string, unknown> = {}) => ({
+    v: 1,
+    round: 1,
+    attempt: 1,
+    kind: "agent",
+    model: { provider: "openai", id: "gpt-5" },
+    request_at: "2026-09-03T08:00:00.000Z",
+    response_end_at: "2026-09-03T08:00:01.000Z",
+    ms: { net_ttft: 300, thinking: 0, output: 700, total: 1000 },
+    blocks: [],
+    thinking_visible: false,
+    tool_call_ids: [],
+    ...overrides,
+  });
 
   it("persists every assistant turn + each tool call when persist is set", async () => {
     appendMessageMock
@@ -4185,6 +4199,230 @@ describe("collectChannelResponse — audit persistence", () => {
     const collected = await collectChannelResponse(fakeClient(events), "s-fail", "lark", { persist: { agentId: "a1" } });
     expect(collected.text).toBe("still replies");
     expect(collected.assistantMessageId).toBeNull();
+  });
+
+  it("deduplicates independently parsed message_end and turn_end envelopes", async () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+      stopReason: "stop",
+      llmCall: envelope(),
+    };
+    await collectChannelResponse(fakeClient([
+      { type: "message_end", message },
+      { type: "turn_end", message: JSON.parse(JSON.stringify(message)) },
+    ]), "s-dedup", "lark", { persist: { agentId: "a1" } });
+
+    const rows = appendMessageMock.mock.calls.map((call) => call[0] as any)
+      .filter((row) => row.role === "assistant");
+    expect(rows).toHaveLength(1);
+  });
+
+  it("revokes recovered error rows while retaining every model call", async () => {
+    await collectChannelResponse(fakeClient([
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "transient",
+        llmCall: envelope({ round: 1, stop_reason: "error" }),
+      } },
+      { type: "message_end", message: {
+        role: "assistant", content: [{ type: "text", text: "recovered" }], stopReason: "stop",
+        llmCall: envelope({ round: 2, request_at: "2026-09-03T08:00:02.000Z", response_end_at: "2026-09-03T08:00:03.000Z" }),
+      } },
+    ]), "s-retry", "lark", { persist: { agentId: "a1" } });
+
+    const rows = appendMessageMock.mock.calls.map((call) => call[0] as any)
+      .filter((row) => row.role === "assistant");
+    expect(rows.map((row) => row.metadata.llm_call.round)).toEqual([1, 2]);
+    expect(rows[0].content).toBe("");
+    expect(rows[1].content).toBe("recovered");
+    expect(rows.some((row) => row.metadata?.kind === "error_response")).toBe(false);
+  });
+
+  it("persists only the final retry error and redacts its envelope metadata", async () => {
+    await collectChannelResponse(fakeClient([
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "first",
+        llmCall: envelope({ round: 1, stop_reason: "error", error_message: "first" }),
+      } },
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "last sk-secret123",
+        llmCall: envelope({
+          round: 2,
+          request_at: "2026-09-03T08:00:02.000Z",
+          response_end_at: "2026-09-03T08:00:03.000Z",
+          stop_reason: "error",
+          error_message: "last sk-secret123",
+        }),
+      } },
+    ]), "s-errors", "lark", {
+      persist: { agentId: "a1", modelConfig: { apiKey: "sk-secret123" } },
+    });
+
+    const rows = appendMessageMock.mock.calls.map((call) => call[0] as any)
+      .filter((row) => row.role === "assistant");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ content: "", metadata: { llm_call: { round: 1 } } });
+    expect(rows[1].metadata.kind).toBe("error_response");
+    expect(rows[1].content).not.toContain("sk-secret123");
+    expect(rows[1].metadata.llm_call.error_message).not.toContain("sk-secret123");
+  });
+
+  // [persist gate] Every write in the audit block is opt-in. The failure
+  // bookkeeping was not, so a non-audited binding still queued rows and the
+  // end-of-run flush wrote chat_messages for a session with no chat_sessions row
+  // — an FK violation swallowed as a console.warn, or orphan rows where the FK is
+  // not enforced. It also bypassed redaction outright: `redact` is the identity
+  // function when there is no model config to build a redactor from.
+  it("writes nothing at all when the binding is not audited", async () => {
+    await collectChannelResponse(fakeClient([
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "boom sk-secret123",
+        llmCall: envelope({ round: 1, stop_reason: "error", error_message: "boom sk-secret123" }),
+      } },
+    ]), "s-unaudited", "lark", {});
+
+    expect(appendMessageMock.mock.calls).toHaveLength(0);
+  });
+
+  // [error text required] pi emits synthetic error message_ends that carry no
+  // errorMessage. Coercing those to "" persisted a content-empty error_response:
+  // with no envelope it is not hidden as an empty carrier either, so it rendered
+  // as a blank assistant bubble on reload, and a reader scanning error content
+  // reported the turn empty rather than failed.
+  it("does not persist an error row for a failure that carries no message", async () => {
+    await collectChannelResponse(fakeClient([
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error" } },
+    ]), "s-no-msg", "lark", {
+      persist: { agentId: "a1", modelConfig: {} },
+    });
+
+    const rows = appendMessageMock.mock.calls.map((call) => call[0] as any);
+    expect(rows.some((row) => row.metadata?.kind === "error_response")).toBe(false);
+  });
+
+  // [shared output rule] The local re-derivation read only the content ARRAY, so
+  // a recovered turn whose final message carries STRING content looked like no
+  // output: the error stayed pending and the end-of-run flush wrote a terminal
+  // error_response over a perfectly good answer.
+  it("treats a string-content recovery as output and revokes the pending error", async () => {
+    await collectChannelResponse(fakeClient([
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "transient 500",
+        llmCall: envelope({ round: 1, stop_reason: "error" }),
+      } },
+      { type: "message_end", message: {
+        role: "assistant", content: "recovered answer", stopReason: "stop",
+        llmCall: envelope({ round: 2 }),
+      } },
+    ]), "s-string-recovery", "lark", {
+      persist: { agentId: "a1", modelConfig: {} },
+    });
+
+    const rows = appendMessageMock.mock.calls.map((call) => call[0] as any);
+    expect(rows.some((row) => row.metadata?.kind === "error_response")).toBe(false);
+    // The failed call is not lost — it becomes a call-only row.
+    expect(rows.filter((row) => row.metadata?.llm_call?.stop_reason === "error")).toHaveLength(1);
+  });
+
+  it("moves a rolled-back attempt's failed call onto the fallback notice", async () => {
+    await collectChannelResponse(fakeClient([
+      { type: "model_route_start", candidateCount: 2 },
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "primary 429 sk-secret123",
+        llmCall: envelope({ round: 1, attempt: 1, stop_reason: "error", error_message: "primary 429 sk-secret123" }),
+      } },
+      { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-5", failureKind: "rate_limit" },
+      {
+        type: "model_route_switch",
+        attempt: 2,
+        fromCandidateKey: "openai/gpt-5",
+        toCandidateKey: "anthropic/claude",
+        fromProvider: "openai",
+        fromModelId: "gpt-5",
+        toProvider: "anthropic",
+        toModelId: "claude",
+        failureKind: "rate_limit",
+      },
+      { type: "message_end", message: {
+        role: "assistant", content: [{ type: "text", text: "fallback answer" }], stopReason: "stop",
+        llmCall: envelope({ round: 1, attempt: 2 }),
+      } },
+      { type: "model_route_success" },
+    ]), "s-route", "lark", {
+      persist: { agentId: "a1", modelConfig: { apiKey: "sk-secret123" } },
+    });
+
+    const rows = appendMessageMock.mock.calls.map((call) => call[0] as any)
+      .filter((row) => row.role === "assistant");
+    const notice = rows.find((row) => row.metadata?.kind === "model_route_notice");
+    expect(notice.metadata.discarded_llm_calls).toHaveLength(1);
+    expect(notice.metadata.discarded_llm_calls[0]).toMatchObject({ round: 1, attempt: 1 });
+    expect(notice.metadata.discarded_llm_calls[0].error_message).not.toContain("sk-secret123");
+    expect(rows.some((row) => row.metadata?.kind === "error_response")).toBe(false);
+  });
+
+  // The discriminating case for the same notice. This path writes a successful
+  // call's row INLINE as it arrives, and a rollback cannot unwrite it — so an
+  // attempt that narrated before it failed has one call with a row and one
+  // without. Only the second belongs on the notice. Draining the whole attempt
+  // into it, as this used to, recorded the narration twice and made channel turns
+  // over-count model calls against identical web turns.
+  it("puts only the row-less call on the notice when a rolled-back attempt also narrated", async () => {
+    await collectChannelResponse(fakeClient([
+      { type: "model_route_start", candidateCount: 2 },
+      // Round 1 of attempt 1 succeeds and is persisted as its own row.
+      { type: "message_end", message: {
+        role: "assistant", content: [{ type: "text", text: "let me check that" }], stopReason: "stop",
+        llmCall: envelope({ round: 1, attempt: 1 }),
+      } },
+      // Round 2 of the same attempt fails, so it gets no row of its own.
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "primary 429 sk-secret123",
+        llmCall: envelope({ round: 2, attempt: 1, stop_reason: "error", error_message: "primary 429 sk-secret123" }),
+      } },
+      { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-5", failureKind: "rate_limit" },
+      {
+        type: "model_route_switch",
+        attempt: 2,
+        fromCandidateKey: "openai/gpt-5",
+        toCandidateKey: "anthropic/claude",
+        fromProvider: "openai",
+        fromModelId: "gpt-5",
+        toProvider: "anthropic",
+        toModelId: "claude",
+        failureKind: "rate_limit",
+      },
+      { type: "message_end", message: {
+        role: "assistant", content: [{ type: "text", text: "fallback answer" }], stopReason: "stop",
+        llmCall: envelope({ round: 1, attempt: 2 }),
+      } },
+      { type: "model_route_success" },
+    ]), "s-route-mixed", "lark", {
+      persist: { agentId: "a1", modelConfig: { apiKey: "sk-secret123" } },
+    });
+
+    const rows = appendMessageMock.mock.calls.map((call) => call[0] as any)
+      .filter((row) => row.role === "assistant");
+    const notice = rows.find((row) => row.metadata?.kind === "model_route_notice");
+
+    // Only the failed round is on the notice.
+    expect(notice.metadata.discarded_llm_calls).toHaveLength(1);
+    expect(notice.metadata.discarded_llm_calls[0]).toMatchObject({ round: 2, attempt: 1 });
+
+    // Every envelope appears under exactly ONE carrier — the invariant the double
+    // count broke. Counting rows and notice entries together must find each
+    // (round, attempt) once.
+    const carried: string[] = [];
+    for (const row of rows) {
+      if (row.metadata?.llm_call) {
+        carried.push(`${row.metadata.llm_call.round}/${row.metadata.llm_call.attempt}`);
+      }
+      for (const call of row.metadata?.discarded_llm_calls ?? []) {
+        carried.push(`${call.round}/${call.attempt}`);
+      }
+    }
+    expect([...carried].sort()).toEqual(["1/1", "1/2", "2/1"]);
+    expect(new Set(carried).size).toBe(carried.length);
   });
 });
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -3205,12 +3205,13 @@ export async function collectChannelResponse(
         const discardedId = lastAssistantMessageId;
         lastAssistantMessageId = null;
         lastAssistantText = "";
+        const { knowledge_citations: _citations, ...retainedMetadata } = lastRowMetadata;
         try {
           await updateMessage({
             messageId: discardedId,
             sessionId,
             content: redact(lastRowContent),
-            metadata: { ...lastRowMetadata, knowledge_citations: undefined, discarded_route_attempt: true },
+            metadata: { ...retainedMetadata, discarded_route_attempt: true },
           });
         } catch (err) {
           console.warn(`[${logPrefix}] discard rolled-back assistant row failed session=${sessionId}:`, err);

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -68,6 +68,16 @@ import {
   normalizeKnowledgeSourceCitations,
   type KnowledgeSourceCitation,
 } from "../../shared/knowledge-citations.js";
+import type { LlmCallEnvelope } from "../../core/llm-call-recorder.js";
+import {
+  buildThinkingRow,
+  eventClock,
+  isModelCallRowEnvelope,
+  LlmCallTimeline,
+  redactLlmCallEnvelope,
+  toolDurationMs,
+} from "../llm-call-rows.js";
+import { messageProducedOutput, modelRouteNoticeContent, modelRouteSwitchMetadata } from "../sse-consumer.js";
 import { registerBackgroundChannelDelivery } from "./background-delivery.js";
 
 const VISUAL_ONLY_NOTICE_BY_LOCALE = {
@@ -3088,6 +3098,7 @@ export async function collectChannelResponse(
   let lastAssistantMessageId: string | null = null;
   // Exact text persisted on lastAssistantMessageId (updateMessage requires content).
   let lastRowContent = "";
+  let lastRowMetadata: Record<string, unknown> = {};
   let pendingKnowledgeSources: unknown = null;
   // Same contract as sse-consumer: the citations appended to THIS assistant row
   // ride on its metadata for feedback attribution.
@@ -3109,18 +3120,65 @@ export async function collectChannelResponse(
   // Invocation-id queues pair parallel start↔end events. Older runtimes without
   // toolCallId fall back to per-name FIFO for backward compatibility.
   const toolInputs = new Map<string, string[]>();
-  const toolStarts = new Map<string, number[]>();
+  const toolStarts = new Map<string, Array<{ startedAt?: number; localStartMs: number }>>();
   const toolsets = new Map<string, Array<string | undefined>>();
+  const toolRounds = new Map<string, Array<Record<string, unknown>>>();
   const pushQ = <T,>(m: Map<string, T[]>, k: string, v: T): void => { const a = m.get(k) ?? []; a.push(v); m.set(k, a); };
   const shiftQ = <T,>(m: Map<string, T[]>, k: string): T | undefined => m.get(k)?.shift();
   const toolKey = (ev: Record<string, any>, name: string): string =>
     ev.toolCallId != null ? `id:${String(ev.toolCallId)}` : `name:${name}`;
+  // Shared with sse-consumer: value-based envelope dedup, current round, and
+  // one-clock tool duration rules must stay identical across persistence paths.
+  const timeline = new LlmCallTimeline();
+  // The ONLY bucket of envelopes awaiting a carrier. An agent call that produced
+  // output gets its own row inline, so it is never in here; a call that FAILED
+  // gets no row (isModelCallRowEnvelope excludes stop_reason "error"), so it waits
+  // here until exactly one of three things claims it: a switch notice
+  // (discarded_llm_calls), a recovery (call-only row), or a terminal failure (the
+  // error_response row). One carrier each, never two.
+  let pendingFailedLlmCalls: LlmCallEnvelope[] = [];
+  let pendingError: { content: string; envelope?: LlmCallEnvelope } | null = null;
   const persistRow = async (msg: Parameters<typeof appendMessage>[0]): Promise<string | null> => {
     try { return await appendMessage({ ...msg, traceId: persist?.traceId ?? msg.traceId }); }
     catch (err) {
       console.warn(`[${logPrefix}] audit persist failed session=${sessionId}:`, err);
       return null;
     }
+  };
+  const persistCallOnlyRows = async (envelopes: LlmCallEnvelope[]) => {
+    for (const envelope of envelopes) {
+      await persistRow({
+        sessionId,
+        role: "assistant",
+        content: "",
+        metadata: { llm_call: redactLlmCallEnvelope(envelope, redact) },
+      });
+    }
+  };
+  const flushRecoveredLlmCalls = async () => {
+    const failedCalls = pendingFailedLlmCalls;
+    pendingFailedLlmCalls = [];
+    pendingError = null;
+    await persistCallOnlyRows(failedCalls);
+  };
+  const flushTerminalError = async () => {
+    if (!pendingError) return;
+    const failedCalls = pendingFailedLlmCalls;
+    pendingFailedLlmCalls = [];
+    const terminal = pendingError;
+    pendingError = null;
+    await persistCallOnlyRows(terminal.envelope ? failedCalls.slice(0, -1) : failedCalls);
+    await persistRow({
+      sessionId,
+      role: "assistant",
+      content: terminal.content,
+      metadata: {
+        kind: "error_response",
+        error_code: "MODEL_ERROR",
+        retriable: true,
+        ...(terminal.envelope ? { llm_call: redactLlmCallEnvelope(terminal.envelope, redact) } : {}),
+      },
+    });
   };
 
   try {
@@ -3131,6 +3189,12 @@ export async function collectChannelResponse(
         pendingKnowledgeSources = null;
         renderedKnowledgeSourceUrls.clear();
         pendingRowCitations = [];
+        if (ev.type === "model_route_rollback") {
+          // The failed call is NOT dropped here: the switch notice that follows a
+          // rollback is its carrier. Only the user-visible error goes, because a
+          // rollback means the turn has not failed — a candidate has.
+          pendingError = null;
+        }
       }
       if (ev.type === "model_route_rollback" && lastAssistantMessageId && persist) {
         // Lark persists every assistant turn as it lands (sse-consumer buffers
@@ -3146,10 +3210,32 @@ export async function collectChannelResponse(
             messageId: discardedId,
             sessionId,
             content: redact(lastRowContent),
-            metadata: { discarded_route_attempt: true },
+            metadata: { ...lastRowMetadata, knowledge_citations: undefined, discarded_route_attempt: true },
           });
         } catch (err) {
           console.warn(`[${logPrefix}] discard rolled-back assistant row failed session=${sessionId}:`, err);
+        }
+      }
+      if (ev.type === "model_route_switch" && persist && redaction) {
+        const metadata = modelRouteSwitchMetadata(ev, redaction);
+        if (metadata) {
+          // ONLY the calls that have no row of their own. This path writes each
+          // successful call's row inline as it arrives and a rollback cannot
+          // unwrite them, so attaching the whole attempt here — as it used to —
+          // recorded those calls TWICE and made channel turns over-count model
+          // calls against identical web turns. The failed call is the one with no
+          // row, and this notice is its carrier.
+          const discarded = pendingFailedLlmCalls;
+          pendingFailedLlmCalls = [];
+          if (discarded.length > 0) {
+            metadata.discarded_llm_calls = discarded.map((call) => redactLlmCallEnvelope(call, redact));
+          }
+          await persistRow({
+            sessionId,
+            role: "assistant",
+            content: modelRouteNoticeContent(metadata),
+            metadata,
+          });
         }
       }
       if (ev.type === "knowledge_sources") {
@@ -3193,8 +3279,9 @@ export async function collectChannelResponse(
         const name = (ev.toolName as string) || (ev.name as string) || "tool";
         const key = toolKey(ev, name);
         pushQ(toolInputs, key, ev.args ? JSON.stringify(ev.args) : "");
-        pushQ(toolStarts, key, Date.now());
+        pushQ(toolStarts, key, { startedAt: eventClock(ev, "startedAt"), localStartMs: Date.now() });
         pushQ(toolsets, key, typeof ev.toolset === "string" && ev.toolset.length > 0 ? ev.toolset : undefined);
+        pushQ(toolRounds, key, timeline.toolMetadata(ev));
       }
 
       if (ev.type === "tool_execution_end" || ev.type === "tool_end") {
@@ -3209,9 +3296,14 @@ export async function collectChannelResponse(
           else if (ev.result?.details?.error) outcome = "error";
           const key = toolKey(ev, name);
           const input = shiftQ(toolInputs, key) || "";
-          const startedAt = shiftQ(toolStarts, key);
+          const start = shiftQ(toolStarts, key);
+          const endedAt = eventClock(ev, "endedAt");
+          const startedAt = start?.startedAt ?? start?.localStartMs;
           const toolset = shiftQ(toolsets, key) ??
             (typeof ev.toolset === "string" && ev.toolset.length > 0 ? ev.toolset : undefined);
+          const roundMeta = shiftQ(toolRounds, key) ?? timeline.toolMetadata(ev);
+          const metadata: Record<string, unknown> = { ...roundMeta };
+          if (startedAt != null) metadata.started_at = new Date(startedAt).toISOString();
           await persistRow({
             sessionId,
             role: "tool",
@@ -3220,7 +3312,8 @@ export async function collectChannelResponse(
             toolset: toolset ?? null,
             toolInput: input ? redact(input) : null,
             outcome,
-            durationMs: startedAt != null ? Date.now() - startedAt : null,
+            durationMs: start ? toolDurationMs(start, endedAt) : null,
+            metadata: Object.keys(metadata).length > 0 ? metadata : null,
           });
         }
       }
@@ -3230,10 +3323,43 @@ export async function collectChannelResponse(
       }
       // pi-agent-brain emits the final assistant reply as message_end with
       // a content array of blocks; collect the text blocks only.
+      let envelope: LlmCallEnvelope | undefined;
+      if ((ev.type === "message_end" || ev.type === "turn_end") && ev.message?.role === "assistant") {
+        envelope = timeline.take(ev.message);
+        // Gated on `persist` like every other write in this block. Without it a
+        // non-audited binding still queued rows, and the queue is flushed by
+        // flushRecoveredLlmCalls/flushTerminalError — writing chat_messages for a
+        // session that has no chat_sessions row (an FK violation swallowed as a
+        // console.warn, or orphan rows where the FK is not enforced). It also
+        // bypassed redaction outright: `redact` is the identity function when
+        // `redaction` is null, so a provider's error text would land verbatim.
+        //
+        // `errorMessage` must be TRUTHY, not merely present: pi emits synthetic
+        // error message_ends that carry none, and coercing those to "" persisted a
+        // content-empty error_response — a blank assistant bubble on reload, and a
+        // reader scanning error content reports the turn empty rather than failed.
+        // Same guard as sse-consumer's.
+        if (persist && ev.type === "message_end" && ev.message?.stopReason === "error"
+            && typeof ev.message.errorMessage === "string" && ev.message.errorMessage) {
+          if (envelope) pendingFailedLlmCalls.push(envelope);
+          pendingError = {
+            content: redact(ev.message.errorMessage),
+            ...(envelope ? { envelope } : {}),
+          };
+        }
+      }
       if (ev.type === "message_end" && ev.message?.role === "assistant") {
         const blocks = Array.isArray(ev.message.content) ? ev.message.content : [];
         if (options.includeImages) collectImageAttachments(blocks, images, seenImageKeys);
+        const rowEnvelope = isModelCallRowEnvelope(envelope, ev.message?.stopReason)
+          ? redactLlmCallEnvelope(envelope, redact)
+          : undefined;
         let turnText = contentBlocksToMarkdown(blocks);
+        // The SHARED rule, not a second copy of it. The local re-derivation read
+        // only `blocks`, so a recovered turn whose final message carries STRING
+        // content looked like no output — the error stayed pending and a terminal
+        // error_response was written over a successful answer.
+        if (pendingError && messageProducedOutput(ev.message)) await flushRecoveredLlmCalls();
         if (pendingKnowledgeSources && turnText.trim() && ev.message?.stopReason !== "error") {
           const freshSources = normalizeKnowledgeSourceCitations(pendingKnowledgeSources)
             .filter((source) => !renderedKnowledgeSourceUrls.has(source.url));
@@ -3255,30 +3381,47 @@ export async function collectChannelResponse(
             if (m) options.onMilestone(m);
           }
           lastAssistantText = turnText;
-          // Persist every assistant turn (intermediate narration + final answer),
-          // mirroring sse-consumer. Awaited so its created_at precedes the next
-          // tool row in the transcript.
-          // Replace the id even when this write fails: retaining an earlier
-          // narration id would link the final card to the wrong assistant turn.
-          const rowCitations = pendingRowCitations;
+        }
+        // Persist every model call (intermediate narration, tool-only call, final
+        // answer), mirroring sse-consumer. Awaited so its created_at precedes the
+        // next tool row in the transcript. Without an envelope (older runtime)
+        // only calls that produced text get a row.
+        if (persist && (turnText || rowEnvelope)) {
+          if (rowEnvelope) {
+            const thinkingRow = buildThinkingRow(ev.message, rowEnvelope, redact);
+            if (thinkingRow) {
+              const thinkingRowId = await persistRow({ sessionId, role: "assistant", ...thinkingRow });
+              if (thinkingRowId) rowEnvelope.thinking_row_id = thinkingRowId;
+            }
+          }
+          // Only a turn that produced TEXT is a card, so only that turn claims the
+          // id — and it claims it even when the write failed (rowId null), because
+          // retaining an earlier narration id would link the card to the wrong
+          // assistant turn. A tool-only model call writes a row here too, but it
+          // is not a card and must leave the id alone.
+          const rowMetadata = {
+            ...(rowEnvelope ? { llm_call: rowEnvelope } : {}),
+            ...(pendingRowCitations.length > 0 ? { knowledge_citations: knowledgeCitationsMetadata(pendingRowCitations) } : {}),
+          };
           pendingRowCitations = [];
-          lastRowContent = turnText;
-          lastAssistantMessageId = persist
-            ? await persistRow({
-                sessionId,
-                role: "assistant",
-                content: redact(turnText),
-                ...(rowCitations.length > 0
-                  ? { metadata: { knowledge_citations: knowledgeCitationsMetadata(rowCitations) } }
-                  : {}),
-              })
-            : null;
+          const rowId = await persistRow({
+            sessionId,
+            role: "assistant",
+            content: redact(turnText),
+            metadata: rowMetadata,
+          });
+          if (turnText) {
+            lastAssistantMessageId = rowId;
+            lastRowContent = turnText;
+            lastRowMetadata = rowMetadata;
+          }
         }
       }
     }
   } catch (err) {
     console.error(`[${logPrefix}] SSE collect error for session=${sessionId}:`, err);
   }
+  if (persist) await flushTerminalError();
   // Prefer the last full assistant turn; fall back to streamed deltas if the
   // brain only emits content_block_delta events.
   const text = lastAssistantText || parts.join("");

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -3225,7 +3225,7 @@ export async function collectChannelResponse(
           // recorded those calls TWICE and made channel turns over-count model
           // calls against identical web turns. The failed call is the one with no
           // row, and this notice is its carrier.
-          const discarded = pendingFailedLlmCalls;
+          const discarded = [...pendingFailedLlmCalls, ...((ev.discardedLlmCalls as LlmCallEnvelope[] | undefined) ?? [])];
           pendingFailedLlmCalls = [];
           if (discarded.length > 0) {
             metadata.discarded_llm_calls = discarded.map((call) => redactLlmCallEnvelope(call, redact));

--- a/src/gateway/delegate-api.test.ts
+++ b/src/gateway/delegate-api.test.ts
@@ -753,6 +753,32 @@ describe("handleDelegate — cross-Runtime routing", () => {
     expect(delegateResult(res)).toMatchObject({ ok: true, status: "done", finalText: "durable aries result" });
   });
 
+  it("does not include persisted thinking text in a recovered delegation result", async () => {
+    const deps = makeDeps({ found: true, user_id: "u", agent_id: COORD });
+    deps.frontendClient.request = vi.fn(async (method: string, params: any) => {
+      if (method === "config.getDelegates") return { members: [{ id: PEER, name: "peer", description: "", clusters: [], hosts: [] }] };
+      if (method === "delegation.resolveRoute") return { local: false, sourceRuntimeId: "shanghai", targetRuntimeId: "aries" };
+      if (method === "delegation.start") {
+        getMessages.mockResolvedValueOnce([
+          { role: "user", content: "inspect", delegationId: params.delegationId, metadata: null },
+          { role: "assistant", content: "private chain of thought", delegationId: null, metadata: { kind: "thinking" } },
+          { role: "assistant", content: "durable answer", delegationId: null, metadata: { llm_call: { v: 1 } } },
+        ] as any);
+        deps.eventHandlers.get("delegation.event")!({
+          delegationId: params.delegationId,
+          sessionId: params.sessionId,
+          event: { type: "prompt_done" },
+        });
+        return { ok: true };
+      }
+      return {};
+    });
+
+    const res = makeRes();
+    await handleDelegate(makeReq({ peerAgentId: PEER, text: "inspect" }), res as any, identity, deps);
+    expect(delegateResult(res)).toMatchObject({ ok: true, status: "done", finalText: "durable answer" });
+  });
+
   it("marks a finished remote delegation settled so a re-sent terminal is acknowledged", async () => {
     // Reliable control delivery retries until the source acknowledges. Once the
     // consumer has finished there is nobody to accept a re-sent terminal, and

--- a/src/gateway/delegate-api.ts
+++ b/src/gateway/delegate-api.ts
@@ -248,6 +248,7 @@ async function recoverRemoteResult(
     .filter((message) =>
       message.role === "assistant" &&
       message.metadata?.kind !== "error_response" &&
+      message.metadata?.kind !== "thinking" &&
       message.content.trim().length > 0,
     )
     .map((message) => message.content.trim())

--- a/src/gateway/llm-call-rows.ts
+++ b/src/gateway/llm-call-rows.ts
@@ -1,0 +1,151 @@
+/**
+ * Row shapes for one model call, shared by every persistence path (web/api/a2a
+ * `sse-consumer.ts`, Lark `collectChannelResponse`). Pure: no I/O.
+ *
+ * One model call ⇒ one assistant "model-call row" carrying `metadata.llm_call`,
+ * preceded by one `kind: "thinking"` row when the provider streamed reasoning
+ * text.
+ */
+
+import {
+  llmCallFromMessage,
+  thinkingBlocksFromMessage,
+  type LlmCallEnvelope,
+} from "../core/llm-call-recorder.js";
+import type { ChatMessageMetadata } from "../shared/message-kinds.js";
+
+export interface ToolCallClock {
+  /** AgentBox-clock start, present when the runtime stamps the event. */
+  startedAt?: number;
+  /** Consumer-local fallback start. */
+  localStartMs: number;
+}
+
+/** Read one finite AgentBox-clock timestamp from an SSE event. */
+export function eventClock(
+  event: Record<string, unknown>,
+  key: "startedAt" | "endedAt",
+): number | undefined {
+  const value = event[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Measure a tool call without ever subtracting timestamps from different
+ * processes. Use AgentBox stamps only when both are present; otherwise use the
+ * consumer's local clock for both ends.
+ */
+export function toolDurationMs(
+  start: ToolCallClock,
+  endedAt: number | undefined,
+  localEndMs = Date.now(),
+): number {
+  if (start.startedAt !== undefined && endedAt !== undefined) {
+    return Math.max(0, endedAt - start.startedAt);
+  }
+  return Math.max(0, localEndMs - start.localStartMs);
+}
+
+/**
+ * Value identity for an envelope crossing an SSE/JSON boundary. `message_end`
+ * and `turn_end` are parsed independently by AgentBoxClient, so object identity
+ * cannot deduplicate them.
+ */
+export function llmCallEnvelopeKey(envelope: LlmCallEnvelope): string {
+  return JSON.stringify([
+    envelope.v,
+    envelope.kind,
+    envelope.attempt,
+    envelope.round,
+    envelope.request_at,
+    envelope.response_end_at,
+  ]);
+}
+
+/** Shared round/dedup state for every gateway persistence path. */
+export class LlmCallTimeline {
+  private readonly seenEnvelopeKeys = new Set<string>();
+  private round = 0;
+
+  take(message: unknown): LlmCallEnvelope | undefined {
+    const envelope = llmCallFromMessage(message);
+    if (!envelope) return undefined;
+    const key = llmCallEnvelopeKey(envelope);
+    if (this.seenEnvelopeKeys.has(key)) return undefined;
+    this.seenEnvelopeKeys.add(key);
+    if (envelope.kind === "agent" && envelope.round > 0) this.round = envelope.round;
+    return envelope;
+  }
+
+  nextRound(): number {
+    return this.round + 1;
+  }
+
+  toolMetadata(event: Record<string, unknown>): Record<string, unknown> {
+    const metadata: Record<string, unknown> = {};
+    if (this.round > 0) metadata.llm_round = this.round;
+    if (typeof event.toolCallId === "string" && event.toolCallId) {
+      metadata.tool_call_id = event.toolCallId;
+    }
+    return metadata;
+  }
+}
+
+/**
+ * Clone an envelope for persistence and redact provider error text, including
+ * errors on folded auxiliary calls. Live events retain the original envelope.
+ */
+export function redactLlmCallEnvelope(
+  envelope: LlmCallEnvelope,
+  redact: (text: string) => string,
+): LlmCallEnvelope {
+  return {
+    ...envelope,
+    model: { ...envelope.model },
+    ms: { ...envelope.ms },
+    blocks: envelope.blocks.map((block) => ({ ...block })),
+    ...(envelope.usage ? { usage: { ...envelope.usage } } : {}),
+    tool_call_ids: [...envelope.tool_call_ids],
+    ...(envelope.error_message ? { error_message: redact(envelope.error_message) } : {}),
+    ...(envelope.aux_calls
+      ? { aux_calls: envelope.aux_calls.map((call) => redactLlmCallEnvelope(call, redact)) }
+      : {}),
+  };
+}
+
+export interface ThinkingRowSpec {
+  content: string;
+  metadata: ChatMessageMetadata;
+}
+
+/**
+ * Build the thinking row for a model call, or null when there is nothing to
+ * store (no thinking blocks, or only empty non-redacted ones). `redact` is the
+ * caller's content redactor — reasoning text leaks secrets like any other text.
+ */
+export function buildThinkingRow(
+  message: unknown,
+  envelope: LlmCallEnvelope,
+  redact: (text: string) => string,
+): ThinkingRowSpec | null {
+  const blocks = thinkingBlocksFromMessage(message).filter((b) => b.text.length > 0 || b.redacted);
+  if (blocks.length === 0) return null;
+  return {
+    content: redact(blocks.map((b) => b.text).join("\n\n")),
+    metadata: {
+      kind: "thinking",
+      llm_round: envelope.round,
+      redacted: blocks.some((b) => b.redacted),
+      signature_present: blocks.some((b) => b.signature_present),
+    },
+  };
+}
+
+/**
+ * Whether this envelope should get a model-call row of its own. Aux
+ * (compaction) calls ride the next agent call's `aux_calls`; a failed call's
+ * envelope rides the error row instead.
+ */
+export function isModelCallRowEnvelope(envelope: LlmCallEnvelope | undefined, stopReason: unknown): envelope is LlmCallEnvelope {
+  return envelope !== undefined && envelope.kind === "agent" && envelope.round > 0 && stopReason !== "error";
+}

--- a/src/gateway/llm-call-rows.ts
+++ b/src/gateway/llm-call-rows.ts
@@ -130,10 +130,19 @@ export function buildThinkingRow(
 ): ThinkingRowSpec | null {
   const blocks = thinkingBlocksFromMessage(message).filter((b) => b.text.length > 0 || b.redacted);
   if (blocks.length === 0) return null;
+  // chat_messages.content is MySQL TEXT (65,535 bytes), including on existing
+  // deployments. Clip after redaction, on a UTF-8 boundary, without a migration.
+  const text = redact(blocks.map((b) => b.text).join("\n\n"));
+  const bytes = Buffer.from(text, "utf8");
+  const suffix = "\n[thinking truncated]";
+  let end = 65_535 - Buffer.byteLength(suffix);
+  while (end < bytes.length && (bytes[end] & 0xc0) === 0x80) end--;
+  const truncated = bytes.length > 65_535;
   return {
-    content: redact(blocks.map((b) => b.text).join("\n\n")),
+    content: truncated ? bytes.subarray(0, end).toString("utf8") + suffix : text,
     metadata: {
       kind: "thinking",
+      ...(truncated ? { truncated: true } : {}),
       llm_round: envelope.round,
       redacted: blocks.some((b) => b.redacted),
       signature_present: blocks.some((b) => b.signature_present),

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -747,12 +747,6 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const requiredResultToolName = typeof params.requiredResultToolName === "string"
       ? params.requiredResultToolName.trim() || undefined
       : undefined;
-    // Portal stamps turnStartMs at POST receipt — closer to user click than
-    // the runtime's loop start. Use it as the canonical turn anchor when
-    // present; fall back gracefully so direct callers (tests, /run path)
-    // still work without it.
-    const turnStartMs = typeof params.turnStartMs === "number" ? params.turnStartMs : undefined;
-
     if (!agentId || !userId || !text) {
       throw new Error("agentId, userId, and text are required");
     }
@@ -1114,7 +1108,6 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
             },
             redactionConfig,
             signal: abortCtrl.signal,
-            turnStartTime: turnStartMs,
             onEvent: (evt, _eventType, extras) => {
               context.sendEvent("chat.event", {
                 sessionId: promptResult.sessionId,

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -44,6 +44,24 @@ function mkClient(events: unknown[], onBeforeEvent?: (event: unknown) => void): 
   return c as unknown as AgentBoxClient;
 }
 
+/** A minimal, valid `llm_call` envelope as LlmCallRecorder would stamp it. */
+function mkEnvelope(overrides: Record<string, unknown> = {}) {
+  return {
+    v: 1,
+    round: 1,
+    attempt: 1,
+    kind: "agent",
+    model: { provider: "openai", id: "gpt-5" },
+    request_at: "2026-09-03T08:00:00.000Z",
+    response_end_at: "2026-09-03T08:00:01.000Z",
+    ms: { net_ttft: 300, thinking: 0, output: 700, total: 1000 },
+    blocks: [],
+    thinking_visible: false,
+    tool_call_ids: [],
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   appendCalls.length = 0;
   updateCalls.length = 0;
@@ -776,47 +794,91 @@ describe("consumeAgentSse — routed turn commit gating", () => {
     expect(appendCalls.filter((r) => r.metadata?.kind === "error_response")).toHaveLength(0);
   });
 
-  it("emits ttft_ms on only the first assistant row across two message_ends before commit", async () => {
+  it("persists each committed model call's llm_call envelope on its own row", async () => {
     const events = [
       { type: "model_route_start", candidateCount: 2 },
       { type: "message_start" },
       { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "first" } },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "first" }], stopReason: "stop" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "first" }], stopReason: "stop", llmCall: mkEnvelope({ round: 1 }) } },
       { type: "message_start" },
       { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "second" } },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "second" }], stopReason: "stop" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "second" }], stopReason: "stop", llmCall: mkEnvelope({ round: 2 }) } },
       { type: "model_route_success", attempt: 1, candidateKey: "openai/gpt-4", provider: "openai", modelId: "gpt-4", isFallback: false, primaryCandidateKey: "openai/gpt-4" },
     ];
-    // Anchor the turn start in the past so ttft is a positive, recorded value.
-    await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true, turnStartTime: Date.now() - 5000 });
+    await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true });
     const rows = appendCalls.filter((r) => r.role === "assistant" && (r.content === "first" || r.content === "second"));
     expect(rows).toHaveLength(2);
-    const withTtft = rows.filter((r) => r.metadata?.timing?.ttft_ms !== undefined);
-    expect(withTtft).toHaveLength(1);
-    expect(withTtft[0].content).toBe("first");
+    expect(rows[0].metadata.llm_call.round).toBe(1);
+    expect(rows[1].metadata.llm_call.round).toBe(2);
   });
 
-  it("keeps ttft_ms on the fallback reply when the primary streamed text then failed", async () => {
-    // Regression: the primary's enqueued assistant op flips firstAssistantPersisted;
-    // rollback discards that op, so without re-arming the flag the surviving
-    // fallback reply (the turn's real first assistant) loses its ttft anchor.
+  // ONE consume run carries several turns — a steer reuses it. attemptLlmCalls was
+  // cleared only on model_route_success, so a turn whose routing EXHAUSTED left
+  // its envelope behind (already persisted on that turn's error row); the next
+  // steered turn's rollback then drained the stale envelope into that turn's
+  // discarded_llm_calls — persisted a second time and attributed to the wrong
+  // turn. The channel path already reset on model_route_start, which is what made
+  // the asymmetry visible.
+  it("does not leak a previous turn's envelope into a later turn's switch notice", async () => {
+    const events = [
+      // Turn 1: a real routing turn (so its envelopes are collected), which then
+      // exhausts. Its failure rides turn 1's own error row.
+      { type: "model_route_start", candidateCount: 2 },
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error", errorMessage: "turn one died", llmCall: mkEnvelope({ round: 1, attempt: 1, stop_reason: "error", error_message: "turn one died" }) } },
+      { type: "model_route_exhausted", attempts: 1 },
+      // Turn 2 (a steer on the same run): primary rolls back, fallback answers.
+      { type: "model_route_start", candidateCount: 2 },
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error", errorMessage: "turn two primary 429", llmCall: mkEnvelope({ round: 1, attempt: 1, stop_reason: "error", error_message: "turn two primary 429", request_at: "2026-09-03T08:01:00.000Z", response_end_at: "2026-09-03T08:01:01.000Z" }) } },
+      { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-4", failureKind: "rate_limit" },
+      { type: "model_route_switch", attempt: 2, fromCandidateKey: "openai/gpt-4", toCandidateKey: "anthropic/claude", fromProvider: "openai", fromModelId: "gpt-4", toProvider: "anthropic", toModelId: "claude", failureKind: "rate_limit" },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "second answer" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "second answer" }], stopReason: "stop", llmCall: mkEnvelope({ round: 1, attempt: 2, request_at: "2026-09-03T08:01:02.000Z", response_end_at: "2026-09-03T08:01:03.000Z" }) } },
+      { type: "model_route_success", attempt: 2, candidateKey: "anthropic/claude", provider: "anthropic", modelId: "claude", isFallback: true, primaryCandidateKey: "openai/gpt-4" },
+    ];
+    await consumeAgentSse({
+      client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true,
+      redactionConfig: { patterns: [] },
+    });
+
+    const notice = appendCalls.find((r) => r.metadata?.kind === "model_route_notice");
+    expect(notice).toBeDefined();
+    expect(notice.metadata.discarded_llm_calls).toHaveLength(1);
+    // Turn TWO's primary, not turn one's.
+    expect(notice.metadata.discarded_llm_calls[0].error_message).toBe("turn two primary 429");
+
+    // And turn one's failure is still recorded exactly once, on its own error row.
+    const turnOne = appendCalls.filter((r) => r.content === "turn one died");
+    expect(turnOne).toHaveLength(1);
+    expect(turnOne[0].metadata.kind).toBe("error_response");
+  });
+
+  it("carries a rolled-back primary's model calls onto the switch notice as discarded_llm_calls", async () => {
     const events = [
       { type: "model_route_start", candidateCount: 2 },
       { type: "message_start" },
       { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "primary text" } },
-      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error", errorMessage: "primary 429" } },
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error", errorMessage: "primary 429 sk-secret123", llmCall: mkEnvelope({ round: 1, attempt: 1, stop_reason: "error", error_message: "primary 429 sk-secret123" }) } },
       { type: "model_route_rollback", attempt: 1, candidateKey: "openai/gpt-4", failureKind: "rate_limit" },
+      { type: "model_route_switch", attempt: 2, fromCandidateKey: "openai/gpt-4", toCandidateKey: "anthropic/claude", fromProvider: "openai", fromModelId: "gpt-4", toProvider: "anthropic", toModelId: "claude", failureKind: "rate_limit" },
       { type: "message_start" },
       { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "fallback answer" } },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "fallback answer" }], stopReason: "stop" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "fallback answer" }], stopReason: "stop", llmCall: mkEnvelope({ round: 1, attempt: 2 }) } },
       { type: "model_route_success", attempt: 2, candidateKey: "anthropic/claude", provider: "anthropic", modelId: "claude", isFallback: true, primaryCandidateKey: "openai/gpt-4" },
     ];
-    await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true, turnStartTime: Date.now() - 5000 });
+    await consumeAgentSse({
+      client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true,
+      redactionConfig: { patterns: [/sk-[a-z0-9]+/g] },
+    });
+    const notice = appendCalls.find((r) => r.metadata?.kind === "model_route_notice");
+    expect(notice).toBeDefined();
+    expect(notice.metadata.discarded_llm_calls).toHaveLength(1);
+    expect(notice.metadata.discarded_llm_calls[0]).toMatchObject({ round: 1, attempt: 1, stop_reason: "error" });
+    expect(notice.metadata.discarded_llm_calls[0].error_message).toBe("primary 429 [REDACTED]");
     const fallbackRow = appendCalls.find((r) => r.role === "assistant" && r.content === "fallback answer");
-    expect(fallbackRow).toBeDefined();
-    expect(fallbackRow.metadata?.timing?.ttft_ms).toBeDefined();
-    // The rolled-back primary text never persists.
+    expect(fallbackRow.metadata.llm_call).toMatchObject({ round: 1, attempt: 2 });
+    // The rolled-back primary text never persists, and its envelope is not duplicated on an error row.
     expect(appendCalls.some((r) => r.content === "primary text")).toBe(false);
+    expect(appendCalls.filter((r) => r.metadata?.kind === "error_response")).toHaveLength(0);
   });
 });
 
@@ -916,20 +978,19 @@ describe("consumeAgentSse — tool execution", () => {
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
     const toolRow = updateCalls[0];
-    // blocked/error stripped; pre_thinking_ms is the lone surviving field
-    // (always persisted to support 💭 audit on every tool).
-    expect(toolRow.metadata).toEqual({ pre_thinking_ms: expect.any(Number) });
+    // blocked/error stripped; started_at is the lone surviving field.
+    expect(toolRow.metadata).toEqual({ started_at: expect.any(String) });
     expect(toolRow.metadata.error).toBeUndefined();
   });
 
-  it("metadata contains only pre_thinking_ms when details is absent", async () => {
+  it("metadata contains only started_at when details is absent and no model call preceded the tool", async () => {
     const events = [
       { type: "tool_execution_start", toolName: "kubectl", args: {} },
       { type: "tool_execution_end", toolName: "kubectl", result: { content: [{ type: "text", text: "ok" }] } },
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
     const toolRow = updateCalls[0];
-    expect(toolRow.metadata).toEqual({ pre_thinking_ms: expect.any(Number) });
+    expect(toolRow.metadata).toEqual({ started_at: expect.any(String) });
   });
 
   it("redacts secrets inside persisted metadata via JSON round-trip", async () => {
@@ -1077,100 +1138,237 @@ describe("consumeAgentSse — abort finalization", () => {
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
     expect(updateCalls.find((u) => u.metadata?.status === "stopped")).toBeUndefined();
   });
+
+  it("attributes a mid-call partial row to the next round", async () => {
+    const controller = new AbortController();
+    const client = {
+      async *streamEvents() {
+        yield { type: "message_end", message: {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "c1", name: "bash", arguments: {} }],
+          stopReason: "toolUse",
+          llmCall: mkEnvelope({ round: 3 }),
+        } };
+        yield { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "partial next call" } };
+        controller.abort();
+        yield { type: "ignored" };
+      },
+    } as unknown as AgentBoxClient;
+
+    await consumeAgentSse({ client, sessionId: "s", userId: "u", persistMessages: true, signal: controller.signal });
+    const partial = appendCalls.find((row) => row.metadata?.incomplete === true);
+    expect(partial.metadata.llm_round).toBe(4);
+  });
 });
 
-// ── Timing (TTFT / 💭 / ⚙️ / turn total) ──────────────
+// ── LLM-call timeline (metadata.llm_call / thinking rows / llm_round) ──────────────
 
-describe("consumeAgentSse — timing", () => {
-  it("attributes pre-tool thinking only to the first tool of a one-thinking-many-tools batch", async () => {
-    // Simulate: model thinks, emits assistant message with text + 3 tool_use
-    // blocks. The runtime executes them serially. Only the FIRST tool should
-    // see meaningful pre_thinking_ms; the next two should be ~0 because the
-    // boundary advances on each tool_execution_end (no new model thinking
-    // happened between them).
+describe("consumeAgentSse — llm_call timeline", () => {
+  it("persists a model-call row even when the call produced only tool calls, and stamps its tools with llm_round + tool_call_id", async () => {
     const events = [
       { type: "message_start", message: { role: "assistant" } },
-      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "checking pods" } },
-      { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods -A" } },
-      { type: "tool_execution_end", toolName: "bash",
-        result: { content: [{ type: "text", text: "pod1" }] } },
-      { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods -n a" } },
-      { type: "tool_execution_end", toolName: "bash",
-        result: { content: [{ type: "text", text: "pod2" }] } },
-      { type: "tool_execution_start", toolName: "bash", args: { command: "kubectl get pods -n b" } },
-      { type: "tool_execution_end", toolName: "bash",
-        result: { content: [{ type: "text", text: "pod3" }] } },
+      { type: "message_end", message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_a", name: "bash", arguments: {} }, { type: "toolCall", id: "call_b", name: "bash", arguments: {} }],
+        stopReason: "toolUse",
+        llmCall: mkEnvelope({ round: 3, tool_call_ids: ["call_a", "call_b"] }),
+      } },
+      { type: "tool_execution_start", toolName: "bash", toolCallId: "call_a", args: { command: "a" }, startedAt: 10_000 },
+      { type: "tool_execution_start", toolName: "bash", toolCallId: "call_b", args: { command: "b" }, startedAt: 10_005 },
+      { type: "tool_execution_end", toolName: "bash", toolCallId: "call_b", result: { content: [{ type: "text", text: "B" }] }, endedAt: 10_205 },
+      { type: "tool_execution_end", toolName: "bash", toolCallId: "call_a", result: { content: [{ type: "text", text: "A" }] }, endedAt: 12_000 },
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
-    expect(updateCalls).toHaveLength(3);
-    // Every tool row carries pre_thinking_ms — the badge is auditable on all of them.
-    for (const row of updateCalls) {
-      expect(row.metadata.pre_thinking_ms).toEqual(expect.any(Number));
-      expect(row.metadata.pre_thinking_ms).toBeGreaterThanOrEqual(0);
-    }
-    // Crucially, no double-counting: tools 2 and 3 should be near-zero
-    // because the boundary advanced on the previous tool_execution_end.
-    expect(updateCalls[1].metadata.pre_thinking_ms).toBeLessThan(50);
-    expect(updateCalls[2].metadata.pre_thinking_ms).toBeLessThan(50);
+
+    const callRow = appendCalls.find((c) => c.role === "assistant");
+    expect(callRow).toBeDefined();
+    expect(callRow.content).toBe("");
+    expect(callRow.metadata.llm_call.round).toBe(3);
+    expect(callRow.metadata.timing).toBeUndefined();
+
+    const startRows = appendCalls.filter((c) => c.role === "tool");
+    expect(startRows).toHaveLength(2);
+    expect(startRows[0].metadata).toMatchObject({ status: "running", llm_round: 3, tool_call_id: "call_a", started_at: new Date(10_000).toISOString() });
+    expect(startRows[0].metadata.pre_thinking_ms).toBeUndefined();
+
+    // Durations come from the agentbox clock on the events, not the local one.
+    const endA = updateCalls.find((u) => u.toolInput === JSON.stringify({ command: "a" }));
+    const endB = updateCalls.find((u) => u.toolInput === JSON.stringify({ command: "b" }));
+    expect(endA.durationMs).toBe(2_000);
+    expect(endB.durationMs).toBe(200);
+    expect(endA.metadata).toEqual({ llm_round: 3, tool_call_id: "call_a", started_at: new Date(10_000).toISOString() });
   });
 
-  it("persists ttft_ms / output_ms / turn_total_ms on the first assistant message; thinking_ms suppressed because it equals ttft", async () => {
-    const events = [
-      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hello" } },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hello" }] } },
+  it("never mixes the agentbox and gateway clocks when one of the stamps is missing", async () => {
+    // The agentbox stamps startedAt/endedAt; this process is a different pod.
+    // A duration built from one stamp and one local Date.now() is clock skew
+    // wearing a measurement's clothes — and Math.max(0, …) hides the negative
+    // case, so it never even looks wrong. The events below are the two ways a
+    // stamp goes missing: an older runtime that sends neither, and a mixed pair.
+    const stampedStartOnly = [
+      { type: "message_end", message: { role: "assistant", content: [{ type: "toolCall", id: "call_a", name: "bash", arguments: {} }], stopReason: "toolUse", llmCall: mkEnvelope({ round: 1, tool_call_ids: ["call_a"] }) } },
+      // startedAt is an agentbox timestamp from 2001; endedAt is absent.
+      { type: "tool_execution_start", toolName: "bash", toolCallId: "call_a", args: { command: "a" }, startedAt: 1_000_000_000_000 },
+      { type: "tool_execution_end", toolName: "bash", toolCallId: "call_a", result: { content: [{ type: "text", text: "A" }] } },
     ];
-    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
-    const assistantRow = appendCalls.find((c) => c.role === "assistant");
-    expect(assistantRow).toBeDefined();
-    expect(assistantRow.metadata.timing.ttft_ms).toEqual(expect.any(Number));
-    // thinking_ms intentionally absent on first message: ttft already covers
-    // the same boundary→firstToken interval, so a naive sum would otherwise
-    // double-count it.
-    expect(assistantRow.metadata.timing.thinking_ms).toBeUndefined();
-    expect(assistantRow.metadata.timing.output_ms).toEqual(expect.any(Number));
-    expect(assistantRow.metadata.timing.turn_total_ms).toEqual(expect.any(Number));
+    await consumeAgentSse({ client: mkClient(stampedStartOnly), sessionId: "s", userId: "u", persistMessages: true });
+    const mixed = updateCalls.find((u) => u.toolInput === JSON.stringify({ command: "a" }));
+    // Local-clock start minus local-clock end: a few milliseconds, not the
+    // ~25 years that subtracting the 2001 stamp from Date.now() would give.
+    expect(mixed.durationMs).toBeLessThan(60_000);
+
+    appendCalls.length = 0;
+    updateCalls.length = 0;
+
+    const noStamps = [
+      { type: "message_end", message: { role: "assistant", content: [{ type: "toolCall", id: "call_b", name: "bash", arguments: {} }], stopReason: "toolUse", llmCall: mkEnvelope({ round: 1, tool_call_ids: ["call_b"] }) } },
+      { type: "tool_execution_start", toolName: "bash", toolCallId: "call_b", args: { command: "b" } },
+      { type: "tool_execution_end", toolName: "bash", toolCallId: "call_b", result: { content: [{ type: "text", text: "B" }] } },
+    ];
+    await consumeAgentSse({ client: mkClient(noStamps), sessionId: "s", userId: "u", persistMessages: true });
+    const legacy = updateCalls.find((u) => u.toolInput === JSON.stringify({ command: "b" }));
+    expect(legacy.durationMs).toBeGreaterThanOrEqual(0);
+    expect(legacy.durationMs).toBeLessThan(60_000);
   });
 
-  it("uses caller-supplied turnStartTime when provided (portal POST anchor)", async () => {
-    const earlyAnchor = Date.now() - 5000; // simulate portal stamp 5s ago
+  it("writes the thinking text as its own hidden row right before the model-call row and links them", async () => {
     const events = [
-      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "answer" } },
+      { type: "message_end", message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "deep thoughts sk-abc123", thinkingSignature: "sig" }, { type: "text", text: "answer" }],
+        stopReason: "stop",
+        llmCall: mkEnvelope({ round: 1, thinking_visible: true }),
+      } },
     ];
     await consumeAgentSse({
-      client: mkClient(events), sessionId: "s", userId: "u",
-      persistMessages: true, turnStartTime: earlyAnchor,
+      client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true,
+      redactionConfig: { patterns: [/sk-[a-z0-9]+/g] },
     });
-    const assistantRow = appendCalls.find((c) => c.role === "assistant");
-    // ttft must reflect the supplied anchor — at least the simulated 5s gap.
-    expect(assistantRow.metadata.timing.ttft_ms).toBeGreaterThanOrEqual(5000);
+    const rows = appendCalls.filter((c) => c.role === "assistant");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].metadata).toEqual({ kind: "thinking", llm_round: 1, redacted: false, signature_present: true });
+    expect(rows[0].content).toBe("deep thoughts [REDACTED]");
+    expect(rows[1].content).toBe("answer");
+    expect(rows[1].metadata.llm_call.thinking_row_id).toBe("msg-1");
   });
 
-  it("emits ttft_ms only on the first assistant message of a turn (avoids double-counting)", async () => {
+  it("does not write a thinking row when the provider streamed no thinking text", async () => {
     const events = [
-      // First assistant message
       { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }] } },
-      // Second assistant message in same turn — same turnStart anchor, but
-      // ttft would just repeat the same value, so it must be omitted.
-      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "more" } },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "more" }] } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }], stopReason: "stop", llmCall: mkEnvelope({ round: 1, thinking_visible: false }) } },
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
-    const assistantRows = appendCalls.filter((c) => c.role === "assistant");
-    expect(assistantRows).toHaveLength(2);
-    expect(assistantRows[0].metadata.timing.ttft_ms).toEqual(expect.any(Number));
-    expect(assistantRows[1].metadata.timing.ttft_ms).toBeUndefined();
-    // Both messages still carry thinking_ms + output_ms (their per-message
-    // intervals are independent and additive).
-    expect(assistantRows[1].metadata.timing.thinking_ms).toEqual(expect.any(Number));
-    expect(assistantRows[1].metadata.timing.output_ms).toEqual(expect.any(Number));
+    const rows = appendCalls.filter((c) => c.role === "assistant");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata.llm_call.thinking_row_id).toBeUndefined();
   });
 
-  it("surfaces preThinkingMs and durationMs onto live events for frontend rendering", async () => {
+  it("writes the row once when message_end and turn_end deliver the same message", async () => {
+    const message = { role: "assistant", content: [{ type: "text", text: "hi" }], stopReason: "stop", llmCall: mkEnvelope({ round: 1 }) };
     const events = [
-      { type: "tool_execution_start", toolName: "kubectl", args: {} },
-      { type: "tool_execution_end", toolName: "kubectl", result: { content: [{ type: "text", text: "ok" }] } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
+      { type: "message_end", message },
+      // AgentBoxClient JSON-parses each SSE frame independently in production.
+      { type: "turn_end", message: JSON.parse(JSON.stringify(message)), toolResults: [] },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    expect(appendCalls.filter((c) => c.role === "assistant")).toHaveLength(1);
+  });
+
+  it("keeps failed internal retries as call-only rows when a later retry succeeds", async () => {
+    const events = [
+      { type: "message_end", message: {
+        role: "assistant", content: [], stopReason: "error", errorMessage: "transient",
+        llmCall: mkEnvelope({ round: 1, stop_reason: "error" }),
+      } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "recovered" } },
+      { type: "message_end", message: {
+        role: "assistant", content: [{ type: "text", text: "recovered" }], stopReason: "stop",
+        llmCall: mkEnvelope({ round: 2, request_at: "2026-09-03T08:00:02.000Z", response_end_at: "2026-09-03T08:00:03.000Z" }),
+      } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+
+    const rows = appendCalls.filter((row) => row.role === "assistant");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.metadata.llm_call.round)).toEqual([1, 2]);
+    expect(rows[0].content).toBe("");
+    expect(rows[0].metadata.llm_call.stop_reason).toBe("error");
+    expect(rows[1].content).toBe("recovered");
+    expect(rows.some((row) => row.metadata?.kind === "error_response")).toBe(false);
+  });
+
+  it("redacts provider errors in llm_call metadata", async () => {
+    const secret = "sk-secret123";
+    const events = [{ type: "message_end", message: {
+      role: "assistant", content: [], stopReason: "error", errorMessage: `proxy rejected ${secret}`,
+      llmCall: mkEnvelope({ round: 1, stop_reason: "error", error_message: `url?api_key=${secret}` }),
+    } }];
+    await consumeAgentSse({
+      client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true,
+      redactionConfig: { patterns: [/sk-[a-z0-9]+/g] },
+    });
+    const row = appendCalls.find((entry) => entry.metadata?.kind === "error_response");
+    expect(row.content).not.toContain(secret);
+    expect(row.metadata.llm_call.error_message).toBe("url?api_key=[REDACTED]");
+  });
+
+  it("puts a failed call's envelope on the error row, not on a separate model-call row", async () => {
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "error", errorMessage: "429", llmCall: mkEnvelope({ round: 2, stop_reason: "error" }) } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    const rows = appendCalls.filter((c) => c.role === "assistant");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata.kind).toBe("error_response");
+    expect(rows[0].metadata.llm_call).toMatchObject({ round: 2, stop_reason: "error" });
+  });
+
+  it("keeps the terminal failure envelope when turn_end repeats message_end", async () => {
+    const message = {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      errorMessage: "terminal 429",
+      llmCall: mkEnvelope({ round: 2, stop_reason: "error", error_message: "terminal 429" }),
+    };
+    await consumeAgentSse({
+      client: mkClient([
+        { type: "message_end", message },
+        { type: "turn_end", message: JSON.parse(JSON.stringify(message)), toolResults: [] },
+      ]),
+      sessionId: "s",
+      userId: "u",
+      persistMessages: true,
+    });
+
+    const rows = appendCalls.filter((c) => c.role === "assistant");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metadata).toMatchObject({
+      kind: "error_response",
+      llm_call: { round: 2, stop_reason: "error" },
+    });
+  });
+
+  it("keeps the legacy text-only rule for messages without an envelope", async () => {
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [{ type: "toolCall", id: "x", name: "bash", arguments: {} }], stopReason: "toolUse" } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "hi" } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }], stopReason: "stop" } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    const rows = appendCalls.filter((c) => c.role === "assistant");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe("hi");
+    expect(rows[0].metadata.llm_call).toBeUndefined();
+  });
+
+  it("surfaces llmCall, llmRound and durationMs onto live events for frontend rendering", async () => {
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "toolUse", llmCall: mkEnvelope({ round: 4 }) } },
+      { type: "tool_execution_start", toolName: "kubectl", toolCallId: "c1", args: {} },
+      { type: "tool_execution_end", toolName: "kubectl", toolCallId: "c1", result: { content: [{ type: "text", text: "ok" }] } },
     ];
     const seen: any[] = [];
     await consumeAgentSse({
@@ -1178,10 +1376,13 @@ describe("consumeAgentSse — timing", () => {
       persistMessages: true,
       onEvent: (evt) => seen.push(evt),
     });
+    const endMsg = seen.find((e) => e.type === "message_end");
     const startEvt = seen.find((e) => e.type === "tool_execution_start");
     const endEvt = seen.find((e) => e.type === "tool_execution_end");
-    expect(typeof startEvt.preThinkingMs).toBe("number");
-    expect(typeof endEvt.preThinkingMs).toBe("number");
+    expect(endMsg.llmCall.round).toBe(4);
+    expect(endMsg.timing).toBeUndefined();
+    expect(startEvt.llmRound).toBe(4);
+    expect(startEvt.preThinkingMs).toBeUndefined();
     expect(typeof endEvt.durationMs).toBe("number");
   });
 });

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -1462,7 +1462,7 @@ describe("consumeAgentSse — knowledge citation attribution", () => {
       { type: "knowledge_sources", sources: [
         { title: "A", url: a, page: "repos/kb-1/a.md", repoId: "repo-1", claim: "A says so." },
       ] },
-      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "first" }] } },
+      { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "first" }], llmCall: mkEnvelope() } },
       { type: "knowledge_sources", sources: [
         { title: "A", url: a, page: "repos/kb-1/a.md", repoId: "repo-1", claim: "A says so." },
         { title: "B", url: b, page: "repos/kb-2/b.md", repoId: "repo-2", evidence: "ev.b" },
@@ -1472,6 +1472,7 @@ describe("consumeAgentSse — knowledge citation attribution", () => {
     await consumeAgentSse({ client: mkClient(events), sessionId: "sid", userId: "u", persistMessages: true });
     const rows = appendCalls.filter((r) => r.role === "assistant");
     expect(rows).toHaveLength(2);
+    expect(rows[0].metadata.llm_call).toMatchObject({ round: 1 });
     // First row carries A; second row carries only the delta (B). Attribution
     // mirrors the rendered text: each source lands on exactly one row.
     expect(rows[0].metadata.knowledge_citations).toEqual({

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -1,3 +1,4 @@
+import { appendMessage } from "./chat-repo.js";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { consumeAgentSse } from "./sse-consumer.js";
 import { AgentBoxClient } from "./agentbox/client.js";
@@ -1493,4 +1494,57 @@ describe("consumeAgentSse — knowledge citation attribution", () => {
     expect(plainRows).toHaveLength(1);
     expect(plainRows[0].metadata).not.toHaveProperty("knowledge_citations");
   });
+});
+
+describe("review regressions: thinking and abort", () => {
+  it("clips multi-byte reasoning within MySQL TEXT and still stores the answer", async () => {
+    await consumeAgentSse({ client: mkClient([{ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "answer" } }, { type: "message_end", message: {
+      role: "assistant", stopReason: "stop", llmCall: mkEnvelope(),
+      content: [{ type: "thinking", thinking: "想🧠".repeat(20000) }, { type: "text", text: "answer" }],
+    } }]), sessionId: "s", userId: "u", persistMessages: true });
+    const thinking = appendCalls.find(r => r.metadata?.kind === "thinking");
+    expect(Buffer.byteLength(thinking.content)).toBeLessThanOrEqual(65535);
+    expect(thinking.content).not.toContain("\ufffd");
+    expect(thinking.metadata.truncated).toBe(true);
+    expect(appendCalls.at(-1).content).toBe("answer");
+  });
+
+  it("continues the answer and stream after a thinking insert fails", async () => {
+    vi.mocked(appendMessage).mockRejectedValueOnce(new Error("thinking insert failed"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await consumeAgentSse({ client: mkClient([
+        { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "answer" } },
+        { type: "message_end", message: { role: "assistant", stopReason: "stop", llmCall: mkEnvelope(),
+          content: [{ type: "thinking", thinking: "reason" }, { type: "text", text: "answer" }] } },
+        { type: "agent_end" },
+      ]), sessionId: "s", userId: "u", persistMessages: true });
+      expect(result.eventCount).toBe(3);
+      expect(appendCalls.at(-1).content).toBe("answer");
+      expect(appendCalls.at(-1).metadata.llm_call.thinking_row_id).toBeUndefined();
+      expect(warn).toHaveBeenCalled();
+    } finally { warn.mockRestore(); }
+  });
+
+  it("keeps all stopped parallel tools linked to their model round", async () => {
+    const controller = new AbortController();
+    const events = [
+      { type: "message_end", message: { role: "assistant", content: [], stopReason: "toolUse", llmCall: mkEnvelope({ round: 3 }) } },
+      ...["a", "b", "c"].map(toolCallId => ({ type: "tool_execution_start", toolCallId, toolName: "read", args: {} })),
+    ];
+    const client = { async *streamEvents() { for (const event of events) yield event; controller.abort(); } } as unknown as AgentBoxClient;
+    await consumeAgentSse({ client, sessionId: "s", userId: "u", persistMessages: true, signal: controller.signal });
+    expect(updateCalls.filter(r => r.metadata?.status === "stopped").map(r => [r.metadata.llm_round, r.metadata.tool_call_id]))
+      .toEqual([[3, "a"], [3, "b"], [3, "c"]]);
+  });
+});
+
+it("persists and redacts buffered failure envelopes from route switches", async () => {
+  const call = mkEnvelope({ stop_reason: "error", error_message: "secret sk-abc123" });
+  await consumeAgentSse({ client: mkClient([
+    { type: "model_route_start" },
+    { type: "model_route_switch", attempt: 1, fromCandidateKey: "a", toCandidateKey: "b", fromProvider: "openai", fromModelId: "a", toProvider: "openai", toModelId: "b", failureKind: "rate_limit", discardedLlmCalls: [call] },
+  ]), sessionId: "s", userId: "u", persistMessages: true, redactionConfig: { patterns: [/sk-[a-z0-9]+/g] } });
+  expect(appendCalls.filter(r => r.metadata?.kind === "model_route_notice")).toHaveLength(1);
+  expect(appendCalls[0].metadata.discarded_llm_calls).toEqual([{ ...call, error_message: "secret [REDACTED]" }]);
 });

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -605,8 +605,8 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           // The failed attempt's model calls ride on the notice row: their rows
           // were (or will be) discarded, but the time they took is part of the
           // prompt's timeline and the survivor's since_prev_ms spans it.
-          const discarded = takeDiscardedLlmCalls();
-          if (discarded) {
+          const discarded = [...(takeDiscardedLlmCalls() ?? []), ...((evt.discardedLlmCalls as LlmCallEnvelope[] | undefined) ?? [])];
+          if (discarded.length > 0) {
             metadata.discarded_llm_calls = discarded.map((call) =>
               redactLlmCallEnvelope(call, (text) => redactText(text, redactionConfig))
             );
@@ -922,7 +922,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
             }
           } else if (pendingStreamError && messageProducedOutput(message)) {
             // A later attempt produced a real assistant turn: the earlier failure
-            // was transient and must leave nothing behind — no bubble, no row, and
+            // was transient and must leave no visible error bubble or error row, and
             // nothing in the returned summary that a notification could quote.
             //
             // "Real" means it actually carried output. A non-error stopReason is
@@ -999,11 +999,15 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
             pendingRowCitations = [];
             const persistAssistant = async () => {
               // Thinking first: it happened before the answer, and seq order is
-              // the timeline. Full text, redacted like any other content.
+              // the timeline. Bounded and redacted by buildThinkingRow.
               if (rowEnvelope && thinkingRow) {
-                const thinkingRowId = await appendRow({ sessionId, role: "assistant", ...thinkingRow });
-                await incrementMessageCount(sessionId);
-                rowEnvelope.thinking_row_id = thinkingRowId;
+                try {
+                  const thinkingRowId = await appendRow({ sessionId, role: "assistant", ...thinkingRow });
+                  rowEnvelope.thinking_row_id = thinkingRowId;
+                  await incrementMessageCount(sessionId);
+                } catch (err) {
+                  console.warn(`[sse-consumer] thinking row persistence failed for ${sessionId}:`, err);
+                }
               }
               // Fold in the context-usage snapshot if agent_end already arrived
               // (the routed/default order — agent_end precedes this commit). The
@@ -1079,6 +1083,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       for (const pendingCall of queue) {
         if (!pendingCall.messageId) continue;
         const stoppedMeta: Record<string, unknown> = {
+          ...pendingCall.roundMeta,
           status: "stopped",
           started_at: new Date(pendingCall.startMs).toISOString(),
         };

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -22,6 +22,15 @@ import {
   normalizeKnowledgeSourceCitations,
   type KnowledgeSourceCitation,
 } from "../shared/knowledge-citations.js";
+import { llmCallFromMessage, type LlmCallEnvelope } from "../core/llm-call-recorder.js";
+import {
+  buildThinkingRow,
+  eventClock,
+  isModelCallRowEnvelope,
+  LlmCallTimeline,
+  redactLlmCallEnvelope,
+  toolDurationMs,
+} from "./llm-call-rows.js";
 
 // ── Public types ────────────────────────────────────
 
@@ -63,14 +72,6 @@ export interface ConsumeAgentSseOptions {
   /** Abort signal — breaks the loop when triggered. */
   signal?: AbortSignal;
   /**
-   * Optional explicit turn-start anchor (ms epoch). When provided, used as
-   * the basis for ⏳/💭/✍️/turn_total measurements instead of the local
-   * `Date.now()` taken when consumeAgentSse begins iterating. Portal sets
-   * this at POST receipt so the timing covers the portal→runtime RPC hop
-   * the runtime cannot otherwise see.
-   */
-  turnStartTime?: number;
-  /**
    * per-prompt root trace id (from the /api/prompt ack). Stamped onto every
    * assistant/tool row this consumer persists so a whole interaction's agent
    * output shares one trace_id in chat_messages. Absent → rows keep NULL.
@@ -92,29 +93,6 @@ export interface SseConsumptionResult {
 // ── Implementation ──────────────────────────────────
 
 const EMPTY_REDACTION: RedactionConfig = { patterns: [] };
-
-/**
- * Inter-event dispatch jitter — the tightest possible gap between two
- * timestamps that come from the SSE event loop's natural pacing rather than
- * any real wall-clock interval. Used by the ttft/thinking dedup below: if
- * the two values differ by less than this, they are treated as the same
- * instant and only one is emitted (avoids double-counting on naive sums).
- *
- * 50ms is a conservative ceiling for a single Node tick + WS hop; bump it
- * if you start seeing duplicate ⏳/💭 badges on first-of-turn messages.
- */
-const NOISE_FLOOR_MS = 50;
-
-/**
- * Drop negative timing deltas. Same-process measurements are always ≥0, but
- * cross-process anchors (e.g. portal POST timestamp passed to runtime via
- * RPC) can briefly produce negatives if the two pods' NTP clocks have drifted
- * apart. We treat negatives as "unknown" rather than persist them — downstream
- * (the chat timing badge) interprets absence as unmeasured, which is correct.
- */
-function nonNegative(ms: number): number | undefined {
-  return Number.isFinite(ms) && ms >= 0 ? ms : undefined;
-}
 
 /**
  * Strip pi-agent's `(Empty response: {...})` diagnostic markers that get
@@ -168,7 +146,7 @@ function extractPersistableDetails(
  * `stop` with zero content blocks (pi retries exactly this), and a Stop arrives
  * as `aborted`. Treating either as recovery erases the provider's verdict.
  */
-function messageProducedOutput(message: Record<string, unknown>): boolean {
+export function messageProducedOutput(message: Record<string, unknown>): boolean {
   if (message.stopReason === "error" || message.stopReason === "aborted") return false;
   const content = message.content;
   if (typeof content === "string") return content.trim().length > 0;
@@ -196,7 +174,7 @@ function compactRouteError(value: unknown, redactionConfig: RedactionConfig): st
   return redactText(text, redactionConfig).slice(0, 500);
 }
 
-function modelRouteSwitchMetadata(evt: SseEvent, redactionConfig: RedactionConfig): ChatMessageMetadata | null {
+export function modelRouteSwitchMetadata(evt: SseEvent, redactionConfig: RedactionConfig): ChatMessageMetadata | null {
   const fromCandidateKey = routeString(evt.fromCandidateKey);
   const toCandidateKey = routeString(evt.toCandidateKey);
   const fromProvider = routeString(evt.fromProvider);
@@ -286,7 +264,7 @@ function modelRouteRecoveryMetadata(evt: SseEvent): ChatMessageMetadata | null {
   };
 }
 
-function modelRouteNoticeContent(metadata: Record<string, unknown>): string {
+export function modelRouteNoticeContent(metadata: Record<string, unknown>): string {
   const eventType = routeString(metadata.event_type);
   const toProvider = routeString(metadata.to_provider) ?? "unknown";
   const toModelId = routeString(metadata.to_model_id) ?? "unknown";
@@ -333,10 +311,16 @@ interface PendingToolCall {
   toolset?: string;
   /** Raw JSON of the call args (unredacted — redacted at write time). */
   input: string;
+  /** Agentbox-clock start, when the runtime stamped one. Pairs with `endedAt`. */
+  startedAt?: number;
+  /** Gateway-clock start. Always set, and the fallback both ends fall back to together. */
+  localStartMs: number;
+  /** What `metadata.started_at` reports: the agentbox stamp when there is one. */
   startMs: number;
   /** DB row id of the eagerly-persisted "running" placeholder (persist mode only). */
   messageId?: string;
-  preThinkingMs?: number;
+  /** `llm_round` / `tool_call_id` captured at start; re-stamped at end (updateMessage replaces metadata). */
+  roundMeta: Record<string, unknown>;
 }
 
 /** Pairing key for a tool_execution_start/end pair: the invocation-unique
@@ -454,18 +438,54 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   const discardRoutedAttempt = () => {
     pendingAssistantOps.length = 0;
     pendingErrorOps.length = 0;
+    pendingFailedLlmCalls = [];
     pendingKnowledgeSources = null;
     renderedKnowledgeSourceUrls.clear();
     pendingRowCitations = [];
     pendingStreamError = null;
     errorMessage = "";
-    // The primary's deferred assistant op flipped firstAssistantPersisted when
-    // it was enqueued; we're now discarding that op, so undo the flip — else the
-    // surviving fallback reply, which becomes the turn's first persisted
-    // assistant, is wrongly gated out of ttft_ms (the turn anchor).
-    firstAssistantPersisted = false;
   };
   let lastToolName = "";
+
+  // ── LLM-call timeline bookkeeping ──
+  // timeline: value-based envelope dedup plus the latest agent-loop round,
+  //   stamped onto the tool rows it issued (metadata.llm_round). pi-agent emits
+  //   message_end before that turn's tool_execution_start, so "latest" is right.
+  // attemptLlmCalls: envelopes of the model calls made by the routing attempt
+  //   in flight. A failed attempt's rows are dropped (rollback / never
+  //   committed), but the calls happened and their time is real — they are
+  //   carried onto the model_route_notice row as `discarded_llm_calls` instead.
+  // pendingFailedLlmCalls: in-turn provider retries are revocable as user-facing
+  //   errors, but their calls still belong in the timing timeline. They are
+  //   written as empty model-call rows if a later retry recovers, or all but the
+  //   final one are written before the terminal error row.
+  const timeline = new LlmCallTimeline();
+  let attemptLlmCalls: LlmCallEnvelope[] = [];
+  let pendingFailedLlmCalls: LlmCallEnvelope[] = [];
+  const takeDiscardedLlmCalls = (): LlmCallEnvelope[] | undefined => {
+    if (attemptLlmCalls.length === 0) return undefined;
+    const drained = attemptLlmCalls;
+    attemptLlmCalls = [];
+    return drained;
+  };
+  const persistCallOnlyRows = async (envelopes: LlmCallEnvelope[]) => {
+    for (const envelope of envelopes) {
+      await appendRow({
+        sessionId,
+        role: "assistant",
+        content: "",
+        metadata: { llm_call: redactLlmCallEnvelope(envelope, (text) => redactText(text, redactionConfig)) },
+      });
+    }
+  };
+  const commitRecoveredLlmCalls = async () => {
+    const recovered = pendingFailedLlmCalls;
+    pendingFailedLlmCalls = [];
+    if (recovered.length === 0 || !persist) return;
+    const op = () => persistCallOnlyRows(recovered);
+    if (isRoutingTurn && !routingCommitted) pendingAssistantOps.push(op);
+    else await op();
+  };
 
   // In-flight tool calls awaiting their tool_execution_end. Keyed by the
   // event's toolCallId (stable per invocation): pi-agent runs a same-turn tool
@@ -478,26 +498,6 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   let eventCount = 0;
   const startTime = Date.now();
 
-  // ── Per-turn timing capture (for ⏳ TTFT / 💭 thinking / total) ──
-  // turnStartTime: server-side anchor for the whole user→assistant turn.
-  //   Prefer caller-supplied (portal POST timestamp) over local startTime so
-  //   the portal→runtime RPC hop is included in measurements.
-  // firstTokenTime: first model output of any kind (text or tool call) — TTFT.
-  // lastBoundaryTime: latest moment the model was *given input* — turn start
-  //   initially, then bumped to each tool_execution_end. The gap between
-  //   lastBoundaryTime and the next emission (text_delta or tool_execution_start)
-  //   is what we call "model thinking time" — the part the user previously
-  //   couldn't see for tool-call gaps. Single-clock by design.
-  const turnStartTime = opts.turnStartTime ?? startTime;
-  let firstTokenTime: number | undefined;
-  let lastBoundaryTime = turnStartTime;
-  let assistantMsgFirstTextTime: number | undefined;
-  let pendingThinkingMs: number | undefined;
-  // ttft_ms is a turn-scoped anchor (turnStart → first token of the very
-  // first assistant message). Persisting it on subsequent messages would
-  // make a naive UI sum double-count the same interval N times. Tracked
-  // and only emitted once.
-  let firstAssistantPersisted = false;
   // Latest persisted assistant message of the turn — so the `agent_end`
   // context-usage snapshot can be merged onto its metadata. Persisting the
   // snapshot lets the frontend restore the context meter when a session is
@@ -578,6 +578,14 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       if (eventType === "model_route_start") {
         latestModelRouteSwitch = null;
         currentModelRouteMetadata = null;
+        // A new attempt sequence starts here, so nothing from a previous turn may
+        // ride its switch notice. ONE consume run carries several turns (a steer
+        // reuses it — see the deferral note below), and attemptLlmCalls used to be
+        // cleared only on model_route_success: a turn whose final attempt FAILED
+        // left its envelope behind, already persisted on that turn's error row,
+        // and the next steered turn's rollback drained it into that turn's
+        // discarded_llm_calls — persisted twice, attributed to the wrong turn.
+        attemptLlmCalls = [];
         // Defer only when there is something to roll back TO. Since every prompt runs
         // through the routing entry, a turn with one candidate emits these events too —
         // and deferring there buys nothing (a rollback is only ever emitted before a
@@ -594,6 +602,15 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         const metadata = modelRouteSwitchMetadata(evt, redactionConfig);
         if (metadata) {
           latestModelRouteSwitch = metadata;
+          // The failed attempt's model calls ride on the notice row: their rows
+          // were (or will be) discarded, but the time they took is part of the
+          // prompt's timeline and the survivor's since_prev_ms spans it.
+          const discarded = takeDiscardedLlmCalls();
+          if (discarded) {
+            metadata.discarded_llm_calls = discarded.map((call) =>
+              redactLlmCallEnvelope(call, (text) => redactText(text, redactionConfig))
+            );
+          }
           if (persist) {
             dbMessageId = await appendRow({
               sessionId,
@@ -629,12 +646,19 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           }
         }
         if (isRoutingTurn) await commitRoutedTurn();
+        // The winning attempt's calls are persisted on their own rows.
+        attemptLlmCalls = [];
       }
 
       // ── Model route: exhausted commits the final attempt's output + error;
       //    rollback discards a failed live primary before the next candidate. ──
       if (eventType === "model_route_exhausted") {
         routingCommitted = true;
+        // Terminal: the final attempt's calls ride the error row this commits, so
+        // they must not also be left for a later turn's notice to pick up. NOT in
+        // discardRoutedAttempt — a rollback's calls are exactly what the following
+        // switch notice is supposed to carry.
+        attemptLlmCalls = [];
         await flushOps(pendingAssistantOps);
         await flushOps(pendingErrorOps);
       }
@@ -666,27 +690,26 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           : undefined;
         const toolset = pendingCall?.toolset ?? eventToolset;
         if (toolset) evt.toolset = toolset;
-        const durationMs = pendingCall ? Date.now() - pendingCall.startMs : undefined;
-        const preThinkingMs = pendingCall?.preThinkingMs;
-        // Surface duration + pre-thinking on the live event for frontend.
+        // Both ends on ONE clock — the agentbox's when the runtime stamped both,
+        // which is also the llm_call envelope's clock so tool bars and call bars
+        // line up in the parallel view.
+        const durationMs = pendingCall
+          ? toolDurationMs(pendingCall, eventClock(evt, "endedAt"))
+          : undefined;
         if (durationMs != null) {
           (evt as Record<string, unknown>).durationMs = durationMs;
-        }
-        if (preThinkingMs != null) {
-          (evt as Record<string, unknown>).preThinkingMs = preThinkingMs;
         }
         const toolInput = pendingCall?.input || "";
         const existingMessageId = pendingCall?.messageId;
         const detailsMeta = extractPersistableDetails(toolResult?.details, redactionConfig);
-        // Merge pre-thinking back in — extractPersistableDetails only looks at
-        // the tool *result*, so we'd otherwise lose what we recorded at
-        // tool_execution_start. We persist the value even when 0/small so the
-        // UI can render a 💭 badge on every tool: a 0ms badge on the 2nd-Nth
-        // tool of a batch makes "one thinking → many tools" auditable.
-        const metadata: Record<string, unknown> | null =
-          preThinkingMs != null
-            ? { ...(detailsMeta ?? {}), pre_thinking_ms: preThinkingMs }
-            : detailsMeta;
+        // Re-stamp the round markers — extractPersistableDetails only looks at
+        // the tool *result*, and updateMessage REPLACES metadata wholesale.
+        const roundMeta = pendingCall?.roundMeta ?? timeline.toolMetadata(evt);
+        const merged: Record<string, unknown> = { ...(detailsMeta ?? {}), ...roundMeta };
+        // started_at survives onto the final row (it did not before: updateMessage
+        // replaces metadata) so the parallel view can place the bar without a join.
+        if (pendingCall) merged.started_at = new Date(pendingCall.startMs).toISOString();
+        const metadata: Record<string, unknown> | null = Object.keys(merged).length > 0 ? merged : null;
         const metadataWithRoute = attachModelRouteMetadata(metadata, currentModelRouteMetadata);
         const delegationId = typeof metadata?.delegation_id === "string" ? metadata.delegation_id : null;
 
@@ -716,29 +739,12 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         if (toolName === "task_report" && text) {
           taskReportText = text;
         }
-        // Bump the model-input boundary: the model now has the tool result and
-        // any subsequent thinking/text/tool-use is computed from this point.
-        lastBoundaryTime = Date.now();
       }
 
       // ── DB persistence: message_update (accumulate assistant text) ──
       if (eventType === "message_update") {
         const ame = evt.assistantMessageEvent as { type?: string; delta?: string } | undefined;
         if (ame?.type === "text_delta" && ame.delta) {
-          const nowAtDelta = Date.now();
-          if (firstTokenTime === undefined) firstTokenTime = nowAtDelta;
-          if (assistantMsgFirstTextTime === undefined) {
-            assistantMsgFirstTextTime = nowAtDelta;
-            // Boundary-based: covers thinking after the previous tool result
-            // (or from turn start), not just the gap inside one assistant
-            // message. The thinking is fully attributed to *this* text bubble.
-            pendingThinkingMs = nowAtDelta - lastBoundaryTime;
-          }
-          // Bump boundary on every text delta so a tool emitted right after
-          // text doesn't double-count the same thinking interval. The text
-          // bubble already showed 💭 for that gap; the tool's pre-thinking
-          // measures only the (typically tiny) handoff after text emission.
-          lastBoundaryTime = nowAtDelta;
           assistantContent += ame.delta;
           currentMsgText += ame.delta;
         }
@@ -780,14 +786,6 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
             console.warn(`[sse-consumer] ${userId}: failed to mark user message as started:`, err);
           }
         }
-        if (message?.role === "assistant") {
-          // Per-message resets only — the boundary anchor (turn-start /
-          // last tool_execution_end) is intentionally NOT touched here, so
-          // pre-text thinking time still counts gaps that started before
-          // this message_start fired.
-          assistantMsgFirstTextTime = undefined;
-          pendingThinkingMs = undefined;
-        }
       }
 
       // ── tool_execution_start: capture input + start time ──
@@ -796,46 +794,40 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         // flush any assistant text deferred before this point so the tool row
         // lands after it in the transcript.
         if (isRoutingTurn && !routingCommitted) await commitRoutedTurn();
-        const nowAtStart = Date.now();
-        if (firstTokenTime === undefined) firstTokenTime = nowAtStart;
+        const stampedStart = eventClock(evt, "startedAt");
+        const localStartMs = Date.now();
+        // started_at reports the agentbox stamp when there is one — that is the
+        // clock the parallel view places bars on — and the local clock only as a
+        // last resort. The DURATION never mixes the two; see toolDurationMs.
+        const nowAtStart = stampedStart ?? localStartMs;
         const startToolName = (evt.toolName as string) || (evt.name as string) || "tool";
         const args = evt.args as Record<string, unknown> | undefined;
         const rawToolInput = args ? JSON.stringify(args) : "";
-        // Pre-tool thinking: gap between the previous model-input boundary
-        // (turn start, or the previous tool_execution_end) and this tool's
-        // start. This is the model's "I just got new info, deciding what to
-        // do next" interval — invisible until we measured it explicitly.
-        // nonNegative() drops cross-pod clock-drift artefacts; absence
-        // downstream means "unknown", which is the correct semantics.
-        const preThinkingMs = nonNegative(nowAtStart - lastBoundaryTime);
+        // Which model call issued this tool: the latest round. Captured at start
+        // so the end handler re-stamps the same markers after a rollback rewinds
+        // the round counter.
+        const roundMeta = timeline.toolMetadata(evt);
         const pendingCall: PendingToolCall = {
           toolName: startToolName,
           ...(typeof evt.toolset === "string" && evt.toolset.length > 0 ? { toolset: evt.toolset } : {}),
           input: rawToolInput,
+          startedAt: stampedStart,
+          localStartMs,
           startMs: nowAtStart,
+          roundMeta,
         };
-        if (preThinkingMs !== undefined) pendingCall.preThinkingMs = preThinkingMs;
         pushPending(pendingToolCalls, toolCallKey(evt, startToolName), pendingCall);
         lastToolName = startToolName;
-        // Surface on the live event so frontend can render 💭 immediately.
-        if (preThinkingMs !== undefined) {
-          (evt as Record<string, unknown>).preThinkingMs = preThinkingMs;
+        if (roundMeta.llm_round !== undefined) {
+          (evt as Record<string, unknown>).llmRound = roundMeta.llm_round;
         }
 
         if (persist) {
-          // pre_thinking_ms is durable telemetry, NOT debug-only. Persisted on
-          // every tool row even when ~0ms because a near-zero value on the 2nd-
-          // Nth tool of a batch is the visible proof that those tools came from
-          // a single model "thinking burst" — not noise to filter out. Once
-          // production rows carry this field, downstream consumers (analytics,
-          // replay, audit reports) may rely on its presence; keep it stable.
           const startMetadata: Record<string, unknown> = {
             status: "running",
             started_at: new Date(nowAtStart).toISOString(),
+            ...roundMeta,
           };
-          if (preThinkingMs !== undefined) {
-            startMetadata.pre_thinking_ms = preThinkingMs;
-          }
           const startMetadataWithRoute = attachModelRouteMetadata(startMetadata, currentModelRouteMetadata);
           dbMessageId = await appendRow({
             sessionId,
@@ -857,6 +849,19 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
       if (eventType === "message_end" || eventType === "turn_end") {
         const message = evt.message as Record<string, unknown> | undefined;
         if (message?.role === "assistant") {
+          // ── LLM-call envelope: the timing source of truth ──
+          // Stamped by LlmCallRecorder at the streamFn boundary. message_end and
+          // turn_end arrive as separately parsed JSON values, so the shared
+          // timeline deduplicates by envelope values rather than object identity.
+          // Aux (compaction) calls ride the next agent call's `aux_calls`.
+          const rawEnvelope = llmCallFromMessage(message);
+          const envelope = timeline.take(message);
+          if (envelope) {
+            if (isRoutingTurn && !routingCommitted) attemptLlmCalls.push(envelope);
+            // Surface on the live event so the frontend renders badges immediately.
+            (evt as Record<string, unknown>).llmCall = envelope;
+          }
+
           // Capture model-level errors (e.g. API 404, rate-limit) and surface
           // them upstream as a single stream_error event so the proxy/frontend
           // can render an inline error bubble instead of silently stopping.
@@ -877,9 +882,21 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
             // nothing about the failure reaches the database. One row per consume
             // run, carrying the LAST error — the reload must not disagree with
             // the bubble the operator was just looking at.
-            if (persist) {
-                const errorContent = redactText(errorMessage, redactionConfig);
+            // pi-agent emits the same failed assistant message through both
+            // message_end and turn_end. The timeline consumes its envelope on
+            // the first event; replacing the buffered write on the duplicate
+            // would therefore throw away the terminal call's llm_call.
+            if (persist && (!rawEnvelope || envelope)) {
+              const errorContent = redactText(errorMessage, redactionConfig);
+              // Failed calls remain timing facts even though their user-facing
+              // error is revocable. If a retry recovers they become empty call
+              // rows; if the turn fails, the final call rides the error row.
+              if (envelope) pendingFailedLlmCalls.push(envelope);
               const persistError = async () => {
+                const failedCalls = pendingFailedLlmCalls;
+                pendingFailedLlmCalls = [];
+                const errorEnvelope = envelope;
+                await persistCallOnlyRows(errorEnvelope ? failedCalls.slice(0, -1) : failedCalls);
                 await appendRow({
                   sessionId,
                   role: "assistant",
@@ -888,6 +905,9 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
                     kind: "error_response",
                     error_code: ErrorCodes.MODEL_ERROR,
                     retriable: true,
+                    ...(errorEnvelope
+                      ? { llm_call: redactLlmCallEnvelope(errorEnvelope, (text) => redactText(text, redactionConfig)) }
+                      : {}),
                   },
                 });
                 await incrementMessageCount(sessionId);
@@ -914,6 +934,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
             pendingStreamError = null;
             pendingErrorOps.length = 0;
             errorMessage = "";
+            await commitRecoveredLlmCalls();
           }
 
           // Extract text for resultText
@@ -949,115 +970,73 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           }
           resultText = extracted || currentMsgText || resultText;
 
-          // Build timing metadata for this assistant message. Audit-friendly
-          // by construction: every interval is non-overlapping with every
-          // other badge in the same turn, so a naive sum across all chat
-          // bubbles equals turn_total_ms (within event-dispatch noise).
-          //
-          //   ⏳ ttft_ms       — first message only (turn-anchor; would
-          //                       otherwise double-count if put on every msg)
-          //   💭 thinking_ms   — boundary → first text_delta (per message)
-          //   ✍️ output_ms    — first text_delta → message_end (per message)
-          //   turn_total_ms    — kept for the last message as audit cross-check
-          const nowAtEnd = Date.now();
-          // turn_total may be slightly negative under cross-pod clock drift
-          // (portal-supplied turnStartTime ahead of runtime's nowAtEnd); drop
-          // it in that case rather than persist garbage.
-          const turnTotal = nonNegative(nowAtEnd - turnStartTime);
-          const timing: Record<string, number> = {};
-          if (turnTotal !== undefined) timing.turn_total_ms = turnTotal;
-          if (!firstAssistantPersisted && firstTokenTime !== undefined) {
-            const ttft = nonNegative(firstTokenTime - turnStartTime);
-            if (ttft !== undefined) timing.ttft_ms = ttft;
-          }
-          if (pendingThinkingMs !== undefined) {
-            // Suppress thinking_ms on the first assistant message when ttft is
-            // already on the row — they cover the same interval (turnStart →
-            // first text token), within event-dispatch jitter. After the first
-            // message, ttft is omitted and thinking_ms takes over.
-            const overlapsTtft =
-              timing.ttft_ms !== undefined &&
-              Math.abs(pendingThinkingMs - timing.ttft_ms) < NOISE_FLOOR_MS;
-            const safeThinking = nonNegative(pendingThinkingMs);
-            if (!overlapsTtft && safeThinking !== undefined) {
-              timing.thinking_ms = safeThinking;
-            }
-          }
-          if (assistantMsgFirstTextTime !== undefined) {
-            // Text streaming time — was previously invisible. Captures the
-            // model's wall-clock cost of emitting the message body.
-            const out = nonNegative(nowAtEnd - assistantMsgFirstTextTime);
-            if (out !== undefined) timing.output_ms = out;
-          }
-          // Attach timing onto the live event so the SSE consumer (frontend)
-          // can render badges immediately without waiting for DB reload.
-          (evt as Record<string, unknown>).timing = timing;
           if (currentModelRouteMetadata) {
             (evt as Record<string, unknown>).modelRoute = currentModelRouteMetadata;
           }
 
-          // Persist assistant message (skip entirely if it's purely an empty-
-          // response marker — keeps the trace free of pi-agent diagnostics)
-          if (persist && assistantContent) {
-            const cleaned = stripEmptyResponseMarkers(assistantContent);
-            if (cleaned.length > 0) {
-              const assistantRowContent = redactText(cleaned, redactionConfig);
-              const assistantRowMetadata = {
-                timing,
-                ...(currentModelRouteMetadata ? { model_route: currentModelRouteMetadata } : {}),
-                ...(pendingRowCitations.length > 0
-                  ? { knowledge_citations: knowledgeCitationsMetadata(pendingRowCitations) }
-                  : {}),
-              };
-              pendingRowCitations = [];
-              const persistAssistant = async () => {
-                // Fold in the context-usage snapshot if agent_end already arrived
-                // (the routed/default order — agent_end precedes this commit). The
-                // closure reads capturedContextUsage at RUN time, not definition time.
-                const rowMetadata = capturedContextUsage
-                  ? { ...assistantRowMetadata, context_usage: capturedContextUsage }
-                  : assistantRowMetadata;
-                const id = await appendRow({
-                  sessionId,
-                  role: "assistant",
-                  content: assistantRowContent,
-                  metadata: rowMetadata,
-                });
-                // Remember the turn's latest assistant row so a later agent_end (the
-                // immediate/non-routed order) can patch the snapshot onto its metadata.
-                lastAssistantDbMessageId = id;
-                lastAssistantContent = assistantRowContent;
-                lastAssistantMetadata = rowMetadata;
-                // Carry the row id out on the relayed message_end so a consumer can match
-                // its live bubble to the persisted row by identity. Only meaningful when
-                // the write happened inline (the deferred path runs after the event has
-                // already been relayed), which is every turn that has no fallback to
-                // switch to.
-                dbMessageId = id;
+          // ── Persist: one model-call row per envelope, plus its thinking row ──
+          // A call that produced only tool calls still gets a row (content ""):
+          // it is the carrier of that round's timing, tokens and thinking. A
+          // failed call's envelope already rides the error row above, so here
+          // only its partial text (if any) is written, without the envelope.
+          // Rows without an envelope (runtime predating the recorder, or a
+          // duplicate turn_end delivery) keep the old rule: text or nothing.
+          const cleaned = assistantContent ? stripEmptyResponseMarkers(assistantContent) : "";
+          const rowEnvelope = isModelCallRowEnvelope(envelope, message.stopReason)
+            ? redactLlmCallEnvelope(envelope, (text) => redactText(text, redactionConfig))
+            : undefined;
+          if (persist && (cleaned.length > 0 || rowEnvelope)) {
+            const assistantRowContent = cleaned.length > 0 ? redactText(cleaned, redactionConfig) : "";
+            const thinkingRow = rowEnvelope
+              ? buildThinkingRow(message, rowEnvelope, (text) => redactText(text, redactionConfig))
+              : null;
+            const assistantRowMetadata: Record<string, unknown> = {
+              ...(rowEnvelope ? { llm_call: rowEnvelope } : {}),
+              ...(!rowEnvelope && envelope && envelope.round > 0 ? { llm_round: envelope.round } : {}),
+              ...(currentModelRouteMetadata ? { model_route: currentModelRouteMetadata } : {}),
+              ...(pendingRowCitations.length > 0 ? { knowledge_citations: knowledgeCitationsMetadata(pendingRowCitations) } : {}),
+            };
+            pendingRowCitations = [];
+            const persistAssistant = async () => {
+              // Thinking first: it happened before the answer, and seq order is
+              // the timeline. Full text, redacted like any other content.
+              if (rowEnvelope && thinkingRow) {
+                const thinkingRowId = await appendRow({ sessionId, role: "assistant", ...thinkingRow });
                 await incrementMessageCount(sessionId);
-              };
-              // Flip the first-assistant flag NOW (not inside the deferred op):
-              // ttft_ms is the turn anchor and is computed above from this flag, so
-              // a second assistant message_end in the same routed turn must already
-              // see it set, even though the op itself may not run until commit. The
-              // op-internal flip lagged and let a 2nd deferred row re-emit ttft.
-              firstAssistantPersisted = true;
-              // On a routed turn the primary streams live before we know it won;
-              // defer the durable write to the commit point so a failed primary's
-              // reply isn't left in the DB after a fallback takes over.
-              if (isRoutingTurn && !routingCommitted) pendingAssistantOps.push(persistAssistant);
-              else await persistAssistant();
-            }
-            assistantContent = "";
+                rowEnvelope.thinking_row_id = thinkingRowId;
+              }
+              // Fold in the context-usage snapshot if agent_end already arrived
+              // (the routed/default order — agent_end precedes this commit). The
+              // closure reads capturedContextUsage at RUN time, not definition time.
+              const rowMetadata = capturedContextUsage
+                ? { ...assistantRowMetadata, context_usage: capturedContextUsage }
+                : assistantRowMetadata;
+              const id = await appendRow({
+                sessionId,
+                role: "assistant",
+                content: assistantRowContent,
+                metadata: rowMetadata,
+              });
+              // Remember the turn's latest assistant row so a later agent_end (the
+              // immediate/non-routed order) can patch the snapshot onto its metadata.
+              lastAssistantDbMessageId = id;
+              lastAssistantContent = assistantRowContent;
+              lastAssistantMetadata = rowMetadata;
+              // Carry the row id out on the relayed message_end so a consumer can match
+              // its live bubble to the persisted row by identity. Only meaningful when
+              // the write happened inline (the deferred path runs after the event has
+              // already been relayed), which is every turn that has no fallback to
+              // switch to.
+              dbMessageId = id;
+              await incrementMessageCount(sessionId);
+            };
+            // On a routed turn the primary streams live before we know it won;
+            // defer the durable write to the commit point so a failed primary's
+            // reply isn't left in the DB after a fallback takes over.
+            if (isRoutingTurn && !routingCommitted) pendingAssistantOps.push(persistAssistant);
+            else await persistAssistant();
           }
-          // Reset per-message thinking marker so the next assistant message
-          // gets its own measurement (firstTokenTime stays — turn-scoped).
-          // Note: lastBoundaryTime is NOT touched here — text deltas already
-          // advanced it, and a pure tool-use assistant message (no text)
-          // intentionally leaves the boundary at the previous tool/turn-start
-          // so the *next* tool's pre-thinking covers the full reasoning gap.
-          pendingThinkingMs = undefined;
-          assistantMsgFirstTextTime = undefined;
+          assistantContent = "";
         } else if (message?.role === "toolResult" && lastToolName === "task_report") {
           // task_report via turn_end (alternative emission path)
           const content = message.content;
@@ -1129,7 +1108,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
             sessionId,
             role: "assistant",
             content: redactText(cleaned, redactionConfig),
-            metadata: { incomplete: true },
+            metadata: { incomplete: true, llm_round: timeline.nextRound() },
           });
           await incrementMessageCount(sessionId);
         } catch (err) {

--- a/src/portal/a2a-gateway.ts
+++ b/src/portal/a2a-gateway.ts
@@ -756,7 +756,6 @@ async function submitA2aTask(params: {
     modelRouting: modelBinding.modelRouting,
     subagentTiers: modelBinding.subagentTiers,
     systemPrompt: modelBinding.systemPrompt ?? undefined,
-    turnStartMs: Date.now(),
   });
 
   if (!result.ok) {

--- a/src/portal/adapter.test.ts
+++ b/src/portal/adapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { DatabaseSync } from "node:sqlite";
 import { EventEmitter } from "node:events";
 
 vi.mock("../gateway/db.js", () => ({
@@ -7,7 +8,7 @@ vi.mock("../gateway/db.js", () => ({
 
 import { getDb } from "../gateway/db.js";
 import { createRestRouter } from "../gateway/rest-router.js";
-import { registerAdapterRoutes } from "./adapter.js";
+import { registerAdapterRoutes, buildAdapterRpcHandlers } from "./adapter.js";
 
 const INTERNAL_SECRET = "test-internal-secret";
 
@@ -305,5 +306,47 @@ describe("registerAdapterRoutes — is_production filter", () => {
       expect(sql).not.toContain("agent_hosts");
       expect(sql).not.toContain("is_production");
     });
+  });
+});
+
+
+describe("adapter transcript visibility", () => {
+  it.each(["HTTP", "RPC"])("%s filters telemetry before limit and preserves legacy messages", async (transport) => {
+    const sqlite = new DatabaseSync(":memory:");
+    try {
+      sqlite.exec(`CREATE TABLE chat_messages (id TEXT, session_id TEXT, role TEXT, content TEXT,
+        tool_name TEXT, toolset TEXT, tool_input TEXT, metadata TEXT, outcome TEXT, duration_ms INTEGER,
+        from_agent_id TEXT, parent_session_id TEXT, delegation_id TEXT, target_agent_id TEXT,
+        created_at TEXT, seq INTEGER)`);
+      const insert = sqlite.prepare(`INSERT INTO chat_messages
+        (id, session_id, role, content, metadata, created_at, seq) VALUES (?, ?, ?, ?, ?, ?, ?)`);
+      insert.run("user", "s1", "user", "question", null, "2026-09-01 00:00:00", 1);
+      insert.run("answer", "s1", "assistant", "answer", null, "2026-09-01 00:00:01", 2);
+      insert.run("error", "s1", "assistant", "", '{"kind":"error_response","llm_call":{}}', "2026-09-01 00:00:02", 3);
+      insert.run("other", "s2", "assistant", "other session", null, "2026-09-01 00:00:03", 1);
+      insert.run("future", "s1", "assistant", "after cursor", null, "2026-09-03 00:00:00", 100);
+      for (let i = 0; i < 60; i++) {
+        insert.run(`hidden-${i}`, "s1", "assistant", i % 2 ? "reasoning" : "",
+          i % 2 ? '{"kind":"thinking"}' : '{"llm_call":{}}', "2026-09-01 00:00:04", i + 4);
+      }
+      const query = vi.fn(async (sql: string, params: any[]) => [sqlite.prepare(sql).all(...params), []]);
+      (getDb as any).mockReturnValue({ driver: "sqlite", query });
+      const params = { session_id: "s1", before: "2026-09-02T00:00:00.000Z", limit: 3 };
+      let result: any;
+      if (transport === "RPC") {
+        result = await buildAdapterRpcHandlers().get("chat.getMessages")!(params, "a1");
+      } else {
+        const router = createRestRouter();
+        registerAdapterRoutes(router, INTERNAL_SECRET);
+        const response = await runRoute(router, fakeReq({
+          url: "/api/internal/siclaw/chat/messages", method: "POST", body: params,
+        }));
+        expect(response.status).toBe(200);
+        result = response.body;
+      }
+      expect(result.messages.map((m: any) => m.id)).toEqual(["error", "answer", "user"]);
+      expect(result.messages[0].metadata.kind).toBe("error_response");
+      expect(result.messages[2].metadata).toBeNull();
+    } finally { sqlite.close(); }
   });
 });

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -27,6 +27,7 @@ import { safeParseSkillFiles } from "../shared/skill-package.js";
 import { walkJumpChainRows, chainHopFromRow } from "./host-api.js";
 import { resolveAgentModelRouting, resolveAgentSubagentTiers } from "./model-routing-config.js";
 import { nonTraceOriginPredicate, traceOriginSqlList } from "./session-origin.js";
+import { transcriptVisiblePredicate } from "./transcript-rows.js";
 import { humanPromptPredicate } from "./human-prompt.js";
 
 function requireInternalAuth(req: http.IncomingMessage, internalSecret: string): boolean {
@@ -1891,7 +1892,7 @@ export function registerAdapterRoutes(router: RestRouter, internalSecret: string
     const db = getDb();
     const limit = body.limit ?? 50;
     const params: unknown[] = [body.session_id];
-    let where = "session_id = ?";
+    let where = `session_id = ? AND ${transcriptVisiblePredicate(db)}`;
     if (body.before) {
       where += " AND created_at < ?";
       params.push(toSqlTimestamp(body.before));
@@ -2958,7 +2959,7 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
     const db = getDb();
     const limit = params.limit ?? 50;
     const sqlParams: unknown[] = [params.session_id];
-    let where = "session_id = ?";
+    let where = `session_id = ? AND ${transcriptVisiblePredicate(db)}`;
     if (params.before) {
       where += " AND created_at < ?";
       sqlParams.push(toSqlTimestamp(params.before));

--- a/src/portal/chat-gateway.ts
+++ b/src/portal/chat-gateway.ts
@@ -385,12 +385,6 @@ export function registerChatRoutes(
 ): void {
   // POST /api/v1/siclaw/agents/:id/chat/send — SSE streaming
   router.post("/api/v1/siclaw/agents/:id/chat/send", async (req, res, params) => {
-    // Capture the earliest possible server-side turn anchor: the moment the
-    // POST request lands at portal. This is closer to "user clicked send"
-    // than the runtime's sse-consumer entry, shaving the portal→runtime RPC
-    // overhead off of timing measurements. Single clock by design — passed
-    // down through chat.send so the runtime uses the same epoch.
-    const turnStartMs = Date.now();
     const auth = requireAuth(req, jwtSecret);
     if (!auth) {
       sendJson(res, 401, errorBody({ code: ErrorCodes.INTERNAL, message: "Authentication required", retriable: false }));
@@ -517,7 +511,6 @@ export function registerChatRoutes(
       modelRouting: modelBinding.modelRouting,
       subagentTiers: modelBinding.subagentTiers,
       systemPrompt: modelBinding.systemPrompt ?? undefined,
-      turnStartMs,
     });
 
     if (!result.ok) {

--- a/src/portal/metrics-timing.test.ts
+++ b/src/portal/metrics-timing.test.ts
@@ -1,55 +1,58 @@
 import { describe, it, expect } from "vitest";
-import { summariseLatency, extractTimingMs } from "./metrics-timing.js";
+import { summariseLatency, extractLlmCallMs } from "./metrics-timing.js";
 
 describe("summariseLatency", () => {
-  it("returns all-zero for an empty sample", () => {
+  it("returns zeros for an empty list", () => {
     expect(summariseLatency([])).toEqual({ count: 0, avg: 0, min: 0, max: 0, p90: 0 });
   });
 
-  it("summarises a single value", () => {
+  it("handles a single sample", () => {
     expect(summariseLatency([42])).toEqual({ count: 1, avg: 42, min: 42, max: 42, p90: 42 });
   });
 
-  it("computes count/avg/min/max + nearest-rank p90 (order-independent)", () => {
-    const vals = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]; // n=10
+  it("computes nearest-rank p90 on unsorted input", () => {
+    const vals = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
     const s = summariseLatency([...vals].reverse());
     expect(s.count).toBe(10);
     expect(s.min).toBe(10);
     expect(s.max).toBe(100);
     expect(s.avg).toBe(55);
-    // nearest-rank p90: index ceil(0.9*10)-1 = 8 → 90
     expect(s.p90).toBe(90);
   });
 
-  it("rounds avg to an integer", () => {
+  it("rounds the average", () => {
     expect(summariseLatency([1, 2]).avg).toBe(2); // 1.5 → 2
   });
 });
 
-describe("extractTimingMs", () => {
-  it("reads timing.<key> from a JSON metadata string", () => {
-    const md = JSON.stringify({ timing: { ttft_ms: 120, thinking_ms: 30 } });
-    expect(extractTimingMs(md, "ttft_ms")).toBe(120);
-    expect(extractTimingMs(md, "thinking_ms")).toBe(30);
+describe("extractLlmCallMs", () => {
+  const md = JSON.stringify({ llm_call: { v: 1, ms: { net_ttft: 120, thinking: 30, output: 400, total: 550 } } });
+
+  it("reads each partition key from a JSON string", () => {
+    expect(extractLlmCallMs(md, "net_ttft")).toBe(120);
+    expect(extractLlmCallMs(md, "thinking")).toBe(30);
+    expect(extractLlmCallMs(md, "output")).toBe(400);
+    expect(extractLlmCallMs(md, "total")).toBe(550);
   });
 
   it("accepts a pre-decoded object", () => {
-    expect(extractTimingMs({ timing: { ttft_ms: 7 } }, "ttft_ms")).toBe(7);
+    expect(extractLlmCallMs({ llm_call: { ms: { net_ttft: 7 } } }, "net_ttft")).toBe(7);
   });
 
-  it("returns undefined when timing / key is absent", () => {
-    expect(extractTimingMs(JSON.stringify({ pre_thinking_ms: 5 }), "ttft_ms")).toBeUndefined();
-    expect(extractTimingMs(JSON.stringify({ timing: {} }), "ttft_ms")).toBeUndefined();
+  it("ignores the retired timing.* / pre_thinking_ms shapes", () => {
+    expect(extractLlmCallMs(JSON.stringify({ timing: { ttft_ms: 5 } }), "net_ttft")).toBeUndefined();
+    expect(extractLlmCallMs(JSON.stringify({ pre_thinking_ms: 5 }), "thinking")).toBeUndefined();
+    expect(extractLlmCallMs(JSON.stringify({ llm_call: {} }), "total")).toBeUndefined();
   });
 
-  it("returns undefined for null / malformed / negative / non-numeric", () => {
-    expect(extractTimingMs(null, "ttft_ms")).toBeUndefined();
-    expect(extractTimingMs("{not json", "ttft_ms")).toBeUndefined();
-    expect(extractTimingMs(JSON.stringify({ timing: { ttft_ms: -5 } }), "ttft_ms")).toBeUndefined();
-    expect(extractTimingMs(JSON.stringify({ timing: { ttft_ms: "x" } }), "ttft_ms")).toBeUndefined();
+  it("returns undefined for absent / malformed / negative / non-numeric values", () => {
+    expect(extractLlmCallMs(null, "total")).toBeUndefined();
+    expect(extractLlmCallMs("{not json", "total")).toBeUndefined();
+    expect(extractLlmCallMs(JSON.stringify({ llm_call: { ms: { total: -5 } } }), "total")).toBeUndefined();
+    expect(extractLlmCallMs(JSON.stringify({ llm_call: { ms: { total: "x" } } }), "total")).toBeUndefined();
   });
 
-  it("rounds a fractional value", () => {
-    expect(extractTimingMs(JSON.stringify({ timing: { ttft_ms: 12.7 } }), "ttft_ms")).toBe(13);
+  it("rounds fractional milliseconds", () => {
+    expect(extractLlmCallMs(JSON.stringify({ llm_call: { ms: { total: 12.7 } } }), "total")).toBe(13);
   });
 });

--- a/src/portal/metrics-timing.ts
+++ b/src/portal/metrics-timing.ts
@@ -1,12 +1,14 @@
 /**
  * Latency summarisation for the metrics Timing endpoint.
  *
- * siclaw persists per-turn timing in `chat_messages.metadata` (JSON-in-TEXT):
- *   - assistant rows: `metadata.timing.ttft_ms` / `metadata.timing.thinking_ms`
- *   - tool rows: `duration_ms` column (+ `metadata.pre_thinking_ms`)
- * (written by src/gateway/sse-consumer.ts). This module turns a collected list
- * of millisecond values into the `{count, avg, min, max, p90}` shape the audit
- * UI renders.
+ * siclaw persists one row per model call in `chat_messages` with the timing
+ * envelope at `metadata.llm_call` (written by src/gateway/sse-consumer.ts from
+ * the recorder in src/core/llm-call-recorder.ts):
+ *   - `metadata.llm_call.ms.{net_ttft, thinking, output, total}` — non-overlapping
+ *     partition of one provider request
+ *   - tool rows: `duration_ms` column
+ * This module turns a collected list of millisecond values into the
+ * `{count, avg, min, max, p90}` shape the audit UI renders.
  */
 
 export interface LatencyStats {
@@ -36,21 +38,26 @@ export function summariseLatency(values: number[]): LatencyStats {
   };
 }
 
+export type LlmCallMsKey = "net_ttft" | "thinking" | "output" | "total";
+
 /**
- * Extract a finite, non-negative integer ms value from `metadata.timing[key]`
- * of a stored chat_messages.metadata string. Returns undefined when absent /
- * unparseable / negative (absence = "unmeasured", the correct downstream
- * semantics). `parsed` may be a pre-decoded object too (defensive).
+ * Extract a finite, non-negative integer ms value from
+ * `metadata.llm_call.ms[key]` of a stored chat_messages.metadata string.
+ * Returns undefined when absent / unparseable / negative (absence =
+ * "unmeasured", the correct downstream semantics). `metadata` may be a
+ * pre-decoded object too (defensive).
  */
-export function extractTimingMs(metadata: unknown, key: string): number | undefined {
+export function extractLlmCallMs(metadata: unknown, key: LlmCallMsKey): number | undefined {
   let obj: unknown = metadata;
   if (typeof metadata === "string") {
     try { obj = JSON.parse(metadata); } catch { return undefined; }
   }
   if (!obj || typeof obj !== "object") return undefined;
-  const timing = (obj as Record<string, unknown>).timing;
-  if (!timing || typeof timing !== "object") return undefined;
-  const v = (timing as Record<string, unknown>)[key];
+  const call = (obj as Record<string, unknown>).llm_call;
+  if (!call || typeof call !== "object") return undefined;
+  const ms = (call as Record<string, unknown>).ms;
+  if (!ms || typeof ms !== "object") return undefined;
+  const v = (ms as Record<string, unknown>)[key];
   const n = typeof v === "number" ? v : Number(v);
   if (!Number.isFinite(n) || n < 0) return undefined;
   return Math.round(n);

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -774,11 +774,13 @@ describe("siclaw-api misc routes", () => {
   });
 
   describe("GET /api/v1/siclaw/metrics/timing", () => {
-    it("summarises ttft/thinking from assistant metadata + per-tool latency", async () => {
+    it("summarises the llm_call partition from model-call rows + per-tool latency", async () => {
       query
         .mockResolvedValueOnce([[ // assistant metadata rows
-          { metadata: JSON.stringify({ timing: { ttft_ms: 100, thinking_ms: 20 } }) },
-          { metadata: JSON.stringify({ timing: { ttft_ms: 300 } }) },
+          { metadata: JSON.stringify({ llm_call: { v: 1, ms: { net_ttft: 100, thinking: 20, output: 80, total: 200 } } }) },
+          { metadata: JSON.stringify({ llm_call: { v: 1, ms: { net_ttft: 300, thinking: 0, output: 100, total: 400 } } }) },
+          { metadata: JSON.stringify({ kind: "thinking", llm_round: 1 }) }, // thinking row: no ms
+          { metadata: JSON.stringify({ timing: { ttft_ms: 999 } }) }, // retired shape: ignored
         ], []])
         .mockResolvedValueOnce([[ // tool duration rows
           { toolName: "bash", durationMs: 500 },
@@ -792,7 +794,9 @@ describe("siclaw-api misc routes", () => {
       }));
       expect(status).toBe(200);
       expect(body.ttft).toMatchObject({ count: 2, min: 100, max: 300, avg: 200 });
-      expect(body.thinking).toMatchObject({ count: 1, avg: 20 });
+      expect(body.thinking).toMatchObject({ count: 2, min: 0, max: 20, avg: 10 });
+      expect(body.output).toMatchObject({ count: 2, min: 80, max: 100 });
+      expect(body.total).toMatchObject({ count: 2, min: 200, max: 400 });
       const bash = body.tools.find((t: any) => t.toolName === "bash");
       expect(bash).toMatchObject({ count: 2, min: 300, max: 500 });
       // tools sorted by count desc → bash (2) before read (1)

--- a/src/portal/siclaw-api.misc.test.ts
+++ b/src/portal/siclaw-api.misc.test.ts
@@ -1,3 +1,4 @@
+import { DatabaseSync } from "node:sqlite";
 /**
  * Smoke tests for registerSiclawRoutes covering non-skills domains:
  * mcp, chat sessions, my-tasks, task runs, channel bindings, model providers,
@@ -88,6 +89,32 @@ describe("siclaw-api misc routes", () => {
     // driver is explicit: siclaw-api.ts builds dialect-aware SQL, and a mock
     // without it silently exercises the SQLite branch of every such helper.
     (getDb as any).mockReturnValue({ query, getConnection: vi.fn(), driver: "mysql" });
+  });
+
+  it("filters hidden rows in the actual chat and task trace SQL before applying limits", async () => {
+    const sqlite = new DatabaseSync(":memory:");
+    try {
+      sqlite.exec(`CREATE TABLE chat_messages (id TEXT, session_id TEXT, role TEXT, content TEXT,
+        metadata TEXT, seq INTEGER, tool_name TEXT, tool_input TEXT, outcome TEXT, duration_ms INTEGER, created_at TEXT)`);
+      const insert = sqlite.prepare("INSERT INTO chat_messages (id, session_id, role, content, metadata, seq, created_at) VALUES (?, 's1', ?, ?, ?, ?, '2026-09-01')");
+      insert.run("prompt", "user", "question", null, 1);
+      insert.run("answer", "assistant", "answer", null, 2);
+      for (let i = 0; i < 205; i++) insert.run(`thinking-${i}`, "assistant", "hidden", '{"kind":"thinking"}', i + 3);
+      query.mockImplementation(async (sql: string, params: any[]) => {
+        if (sql.includes("FROM chat_sessions")) return [[{ user_id: "u1", parent_session_id: null }], []];
+        if (sql.includes("FROM agent_task_runs")) return [[{ session_id: "s1" }], []];
+        return [sqlite.prepare(sql).all(...params), []];
+      });
+      (getDb as any).mockReturnValue({ query, driver: "sqlite" });
+      const chat = await runRoute(router, fakeReq({ url: "/api/v1/siclaw/agents/a1/chat/sessions/s1/messages", method: "GET" }));
+      expect(chat.status).toBe(200);
+      expect(chat.body.total).toBe(2);
+      expect(chat.body.data.map((m: any) => m.content)).toEqual(["question", "answer"]);
+      const trace = await runRoute(router, fakeReq({ url: "/api/v1/siclaw/agents/a1/tasks/t1/runs/r1/messages", method: "GET" }));
+      expect(trace.status).toBe(200);
+      expect(trace.body.truncated).toBe(false);
+      expect(trace.body.messages.map((m: any) => m.id).sort()).toEqual(["answer", "prompt"]);
+    } finally { sqlite.close(); }
   });
 
   // ── MCP endpoints ─────────────────────────────────────────

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -59,7 +59,7 @@ import {
 import { normalizeEntry, entrySessionPredicate, entryPromptPredicate, entryMessagePredicate, actorUserColumn, channelColExpr } from "./metrics-entry.js";
 import { nonTraceOriginPredicate, traceOriginSqlList } from "./session-origin.js";
 import { humanPromptPredicate } from "./human-prompt.js";
-import { summariseLatency, extractTimingMs } from "./metrics-timing.js";
+import { summariseLatency, extractLlmCallMs } from "./metrics-timing.js";
 import {
   assembleExporterHeaders,
   maskExporterAuth,
@@ -2273,12 +2273,39 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       return;
     }
 
+    // Rows the transcript never renders are excluded IN THE QUERY, not filtered
+    // client-side, and the count uses the same predicate so pagination stays
+    // consistent with what comes back.
+    //
+    // Two shapes, and both scale with every model round rather than being sparse
+    // per-job markers like the older hidden kinds:
+    //   - a reasoning row, which carries a call's whole joined thinking text;
+    //   - an empty model-call carrier, the row a tool-only call writes to hold
+    //     its timing.
+    // Fetching them anyway meant page 1 of a reopened tool-heavy session could
+    // spend its whole page budget on rows nobody sees — sometimes rendering no
+    // assistant text at all — and every background poll re-downloaded tens of KB
+    // of reasoning that is then thrown away.
+    //
+    // metadata is TEXT written with a compact JSON.stringify, so these LIKEs are
+    // exact for rows this runtime writes and behave the same on MySQL and SQLite.
+    // The carrier clause requires NO `kind`: an error_response or route notice can
+    // also be content-empty, and those must stay visible.
+    const HIDDEN_ROW_PREDICATE =
+      `(metadata LIKE '%"kind":"thinking"%'` +
+      ` OR (role = 'assistant' AND (content IS NULL OR content = '')` +
+      ` AND metadata LIKE '%"llm_call"%' AND metadata NOT LIKE '%"kind":%'))`;
+
     const [[countRows], [listRows]] = await Promise.all([
-      db.query("SELECT COUNT(*) AS count FROM chat_messages WHERE session_id = ?", [params.sid]),
+      db.query(
+        `SELECT COUNT(*) AS count FROM chat_messages WHERE session_id = ? AND NOT ${HIDDEN_ROW_PREDICATE}`,
+        [params.sid],
+      ),
       db.query(
         // Fetch newest N messages (DESC + LIMIT), then reverse in app to get chronological order.
         // This ensures page=1 returns the most recent messages (for initial load at bottom of chat).
-        "SELECT * FROM chat_messages WHERE session_id = ? ORDER BY (seq IS NULL) DESC, seq DESC, created_at DESC, id DESC LIMIT ? OFFSET ?",
+        `SELECT * FROM chat_messages WHERE session_id = ? AND NOT ${HIDDEN_ROW_PREDICATE}` +
+          " ORDER BY (seq IS NULL) DESC, seq DESC, created_at DESC, id DESC LIMIT ? OFFSET ?",
         [params.sid, pageSize, offset],
       ),
     ]) as [any, any];
@@ -4007,7 +4034,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const TIMING_ROW_LIMIT = 50_000;
     const db = getDb();
 
-    // ── TTFT / thinking from assistant metadata.timing.{ttft_ms,thinking_ms} ──
+    // ── Model-call partition from metadata.llm_call.ms.{net_ttft,thinking,output,total} ──
     const aParams: unknown[] = [from, to];
     let aSql = `SELECT m.metadata AS metadata FROM chat_messages m
       JOIN chat_sessions s ON m.session_id = s.id
@@ -4020,11 +4047,18 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const [aRows] = await db.query(aSql, aParams) as [Array<{ metadata: string | null }>, unknown];
     const ttftValues: number[] = [];
     const thinkingValues: number[] = [];
+    const outputValues: number[] = [];
+    const totalValues: number[] = [];
     for (const r of aRows.slice(0, TIMING_ROW_LIMIT)) {
-      const t = extractTimingMs(r.metadata, "ttft_ms");
+      const total = extractLlmCallMs(r.metadata, "total");
+      if (total === undefined) continue; // not a model-call row
+      totalValues.push(total);
+      const t = extractLlmCallMs(r.metadata, "net_ttft");
       if (t !== undefined) ttftValues.push(t);
-      const th = extractTimingMs(r.metadata, "thinking_ms");
+      const th = extractLlmCallMs(r.metadata, "thinking");
       if (th !== undefined) thinkingValues.push(th);
+      const out = extractLlmCallMs(r.metadata, "output");
+      if (out !== undefined) outputValues.push(out);
     }
 
     // ── Per-tool latency from tool rows' duration_ms ──
@@ -4051,6 +4085,8 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     sendJson(res, 200, {
       ttft: summariseLatency(ttftValues),
       thinking: summariseLatency(thinkingValues),
+      output: summariseLatency(outputValues),
+      total: summariseLatency(totalValues),
       tools,
       truncated: aRows.length > TIMING_ROW_LIMIT || tRows.length > TIMING_ROW_LIMIT,
     });

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -59,6 +59,7 @@ import {
 import { normalizeEntry, entrySessionPredicate, entryPromptPredicate, entryMessagePredicate, actorUserColumn, channelColExpr } from "./metrics-entry.js";
 import { nonTraceOriginPredicate, traceOriginSqlList } from "./session-origin.js";
 import { humanPromptPredicate } from "./human-prompt.js";
+import { transcriptVisiblePredicate } from "./transcript-rows.js";
 import { summariseLatency, extractLlmCallMs } from "./metrics-timing.js";
 import {
   assembleExporterHeaders,
@@ -2287,24 +2288,17 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // assistant text at all — and every background poll re-downloaded tens of KB
     // of reasoning that is then thrown away.
     //
-    // metadata is TEXT written with a compact JSON.stringify, so these LIKEs are
-    // exact for rows this runtime writes and behave the same on MySQL and SQLite.
-    // The carrier clause requires NO `kind`: an error_response or route notice can
-    // also be content-empty, and those must stay visible.
-    const HIDDEN_ROW_PREDICATE =
-      `(metadata LIKE '%"kind":"thinking"%'` +
-      ` OR (role = 'assistant' AND (content IS NULL OR content = '')` +
-      ` AND metadata LIKE '%"llm_call"%' AND metadata NOT LIKE '%"kind":%'))`;
+    const visibleRows = transcriptVisiblePredicate(db);
 
     const [[countRows], [listRows]] = await Promise.all([
       db.query(
-        `SELECT COUNT(*) AS count FROM chat_messages WHERE session_id = ? AND NOT ${HIDDEN_ROW_PREDICATE}`,
+        `SELECT COUNT(*) AS count FROM chat_messages WHERE session_id = ? AND ${visibleRows}`,
         [params.sid],
       ),
       db.query(
         // Fetch newest N messages (DESC + LIMIT), then reverse in app to get chronological order.
         // This ensures page=1 returns the most recent messages (for initial load at bottom of chat).
-        `SELECT * FROM chat_messages WHERE session_id = ? AND NOT ${HIDDEN_ROW_PREDICATE}` +
+        `SELECT * FROM chat_messages WHERE session_id = ? AND ${visibleRows}` +
           " ORDER BY (seq IS NULL) DESC, seq DESC, created_at DESC, id DESC LIMIT ? OFFSET ?",
         [params.sid, pageSize, offset],
       ),
@@ -2699,7 +2693,7 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     // Fetch newest N+1 rows DESC, then reverse to chronological order.
     const [msgRows] = await db.query(
       `SELECT id, role, content, tool_name, tool_input, outcome, duration_ms, created_at
-       FROM chat_messages WHERE session_id = ?
+       FROM chat_messages WHERE session_id = ? AND ${transcriptVisiblePredicate(db)}
        ORDER BY created_at DESC, id DESC LIMIT ?`,
       [sessionId, MAX_TRACE_MESSAGES + 1],
     ) as any;
@@ -4050,14 +4044,15 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
     const outputValues: number[] = [];
     const totalValues: number[] = [];
     for (const r of aRows.slice(0, TIMING_ROW_LIMIT)) {
-      const total = extractLlmCallMs(r.metadata, "total");
+      const metadata = safeParseJson(r.metadata, null);
+      const total = extractLlmCallMs(metadata, "total");
       if (total === undefined) continue; // not a model-call row
       totalValues.push(total);
-      const t = extractLlmCallMs(r.metadata, "net_ttft");
+      const t = extractLlmCallMs(metadata, "net_ttft");
       if (t !== undefined) ttftValues.push(t);
-      const th = extractLlmCallMs(r.metadata, "thinking");
+      const th = extractLlmCallMs(metadata, "thinking");
       if (th !== undefined) thinkingValues.push(th);
-      const out = extractLlmCallMs(r.metadata, "output");
+      const out = extractLlmCallMs(metadata, "output");
       if (out !== undefined) outputValues.push(out);
     }
 

--- a/src/portal/transcript-rows.test.ts
+++ b/src/portal/transcript-rows.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import type { Db } from "../gateway/db.js";
+import { transcriptVisiblePredicate } from "./transcript-rows.js";
+
+describe("transcript visibility SQL", () => {
+  it("keeps NULL-metadata prompts and answers while filtering before count and pagination", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec("CREATE TABLE chat_messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, metadata TEXT)");
+      const insert = db.prepare("INSERT INTO chat_messages VALUES (?, 's', ?, ?, ?)");
+      const rows = [
+        [1, "user", "question", null],
+        [2, "assistant", "legacy answer", null],
+        [3, "assistant", "", '{"llm_call":{"v":1}}'],
+        [4, "assistant", "reasoning", '{ "kind": "thinking" }'],
+        [5, "assistant", "answer", '{"llm_call":{"v":1}}'],
+        [6, "assistant", "", '{"kind":"error_response","llm_call":{"v":1}}'],
+        [7, "assistant", "notice", '{"nested":{"kind":"thinking"}}'],
+        [8, "assistant", "legacy malformed metadata", 'not json'],
+        [9, "assistant", "", '{"kind":"model_route_notice","llm_call":{"v":1}}'],
+      ] as const;
+      for (const row of rows) insert.run(...row);
+      const where = `session_id = 's' AND ${transcriptVisiblePredicate({ driver: "sqlite" } as Db)}`;
+      expect(db.prepare(`SELECT id FROM chat_messages WHERE ${where} ORDER BY id`).all().map(r => r.id))
+        .toEqual([1, 2, 5, 6, 7, 8, 9]);
+      expect(db.prepare(`SELECT COUNT(*) AS count FROM chat_messages WHERE ${where}`).get()?.count).toBe(7);
+      expect(db.prepare(`SELECT id FROM chat_messages WHERE ${where} ORDER BY id LIMIT 3`).all().map(r => r.id))
+        .toEqual([1, 2, 5]);
+    } finally { db.close(); }
+  });
+});

--- a/src/portal/transcript-rows.ts
+++ b/src/portal/transcript-rows.ts
@@ -1,0 +1,14 @@
+import type { Db } from "../gateway/db.js";
+import { jsonScalarOrNull } from "../gateway/dialect-helpers.js";
+
+/** Keep transcript rows, including legacy rows with NULL metadata. Shared by
+ * chat pagination/count and task-run traces so hidden rows never use the limit.
+ * Read JSON paths, not serialized substrings: nested kinds are not row kinds.
+ */
+export function transcriptVisiblePredicate(db: Db): string {
+  const kind = jsonScalarOrNull(db, "metadata", "$.kind");
+  const call = jsonScalarOrNull(db, "metadata", "$.llm_call");
+  return `NOT (COALESCE(${kind}, '') = 'thinking'
+    OR (role = 'assistant' AND TRIM(COALESCE(content, '')) = ''
+      AND COALESCE(${kind}, '') = '' AND ${call} IS NOT NULL))`;
+}

--- a/src/shared/message-kinds.test.ts
+++ b/src/shared/message-kinds.test.ts
@@ -21,6 +21,7 @@ describe("CHAT_MESSAGE_KINDS", () => {
       "steer",
       "task_event",
       "task_notification",
+      "thinking",
     ]);
   });
 });

--- a/src/shared/message-kinds.ts
+++ b/src/shared/message-kinds.ts
@@ -75,6 +75,10 @@ export const CHAT_MESSAGE_KINDS = [
   "task_event",
   // The <task_notification> text injected when a background job finishes.
   "task_notification",
+  // A model call's reasoning text, persisted as its own row right before the
+  // model-call row it belongs to (`metadata.llm_round` links them). role='assistant';
+  // hidden in transcripts, excluded from search and reply counts.
+  "thinking",
 ] as const;
 
 export type ChatMessageKind = (typeof CHAT_MESSAGE_KINDS)[number];


### PR DESCRIPTION
## Summary

Record model-call timing at the provider boundary so tool-only calls, provider latency, reasoning, output, and failed routing attempts can be accounted for independently. Persist one assistant carrier per model call, bounded/redacted thinking rows, and tool-to-call attribution; remove the former gateway timing inference.

Transcript queries preserve legacy NULL-metadata messages and filter hidden telemetry before pagination in both chat and task-run traces. Thinking storage failures cannot prevent answer persistence, and stopped tools retain their call linkage.

## Timing and persistence contract

- `metadata.llm_call.ms` records `net_ttft`, `thinking`, `output`, and `total` on one clock. Provider usage and stop reason travel with the envelope.
- The chat bubble badge now shows that message's single model-call duration, not cumulative turn time. For a multi-round tool turn, the final answer badge covers the final call only; the UI does not currently display the whole turn's wall-clock duration.
- SSE and Lark persist failed calls on error/carrier rows and rolled-back calls on route notices. Buffered failed attempts send only their envelopes with the switch event; discarded text is not replayed.
- Thinking text is redacted and clipped on a UTF-8 boundary to the existing MySQL TEXT limit (65,535 bytes including the marker). Truncation is explicit in metadata.
- Thinking rows and empty assistant carriers with `llm_call` and no `kind` are hidden in transcripts. Explicit error/route kinds remain visible. Physical database message counts still count physical rows.
- Synthetic notification turns now preserve recorder attempt state across fallback, but retain their existing conditional report persistence; they do not have the full SSE/Lark database timeline contract.
- Historical rows without envelopes have no timing telemetry. There is no backfill or fallback to retired timing fields.

## Deploy requirement

Rebuild the agentbox image, bump `SICLAW_AGENTBOX_IMAGE`, then recycle running agentbox pods. `imagePullPolicy: Always` pulls only when a pod is created. A gateway-only rollout leaves old pods emitting no envelopes and their sessions reporting timing count 0 until recycled.

## Relationship to #536

Both changes carry tool-to-model-call attribution through different mechanisms. Reconcile that overlap before merging both.

## Test Plan

- [x] Backend full suite: 6,694 passed, 2 skipped; adapter/transcript/recovery targeted suite: 280 passed.
- [x] Frontend suite: 249 passed.
- [x] Root TypeScript build and frontend production build.
- [x] Real node:sqlite chat/count/trace queries; multi-byte reasoning cap and failed insert; parallel tool abort linkage; buffered routing envelope delivery and redaction; synthetic recorder lifecycle.
- [ ] Live MySQL and production rollout validation.

