### PR TITLE
fix(channels): keep visual output supplemental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+#### IM visual output contract
+
+- Removed `render_visual_card` from the bundled `create-chart` MCP. Conclusions
+  remain natural-language answers; charts and Mermaid diagrams are optional PNG
+  attachments rather than report containers.
+- Removed renderer metadata and retained only the web-renderable chart/Mermaid
+  block plus its PNG; IM channels hide paired source blocks and legacy
+  visual-card source.
+- Replaced the assumed visual-export service DNS with an explicit
+  `runtime.visualExport.url` contract forwarded from Runtime to AgentBox and the
+  bundled stdio MCP process. Deployments that enable `create-chart` must point
+  this value at a reachable `/siclaw-visual-export` page.
+
 #### KB compile box: distinct image name + pod prefix (operations)
 
 Renamed the KB compile box so operators can tell it apart from chat agentboxes at a glance during production troubleshooting (previously every pod was `agentbox-<id>` and the compile box could only be isolated by label/image filter).

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -73,10 +73,11 @@ them into the sandbox would be a separate change with its own migration.
 
 ### 1.4 Browser-Engine Attack Surface (visual export)
 
-The `mcp/create-chart` tools (`render_chart`, `render_mermaid`, `render_visual_card`)
-launch headless Chromium **inside the AgentBox container** (`Dockerfile.agentbox`
-installs `chromium`) to rasterize LLM-generated markdown — chart JSON, Mermaid
-source, and visual-card JSON — into PNGs for IM channel replies.
+The `mcp/create-chart` tools (`render_chart`, `render_mermaid`) launch headless
+Chromium **inside the AgentBox container** (`Dockerfile.agentbox` installs
+`chromium`) to rasterize LLM-generated chart JSON and Mermaid source into PNGs
+for IM channel replies. Visuals are optional attachments; final conclusions
+remain natural-language answers.
 
 Chromium runs with `--no-sandbox --disable-setuid-sandbox`
 (`mcp/create-chart/src/visual-export.ts`). This is the standard workaround for

--- a/helm/siclaw/templates/gateway-deployment.yaml
+++ b/helm/siclaw/templates/gateway-deployment.yaml
@@ -194,6 +194,18 @@ spec:
                   key: {{ .tokenSecret.key | default "ANTHROPIC_AUTH_TOKEN" }}
             {{- end }}
             {{- end }}
+            {{- with .Values.runtime.visualExport }}
+            {{- if .url }}
+            # Visual rendering happens inside AgentBox pods. The Runtime-level
+            # values are forwarded by K8sSpawner when each box is created.
+            - name: SICLAW_VISUAL_EXPORT_URL
+              value: {{ .url | quote }}
+            - name: SICLAW_VISUAL_EXPORT_TIMEOUT_MS
+              value: {{ .timeoutMs | default 60000 | quote }}
+            - name: SICLAW_VISUAL_EXPORT_THEME
+              value: {{ .theme | default "light" | quote }}
+            {{- end }}
+            {{- end }}
             - name: NODE_OPTIONS
               value: {{ printf "--max-old-space-size=%v" (.Values.runtime.nodeMaxOldSpaceMB | default 1024) | quote }}
             # User-supplied env entries come last so callers can override any

--- a/helm/siclaw/values.yaml
+++ b/helm/siclaw/values.yaml
@@ -80,6 +80,13 @@ runtime:
                           # endpoint on a DIFFERENT origin than the LLM provider.
                           # If the embedding baseUrl is the SAME origin as the
                           # default LLM provider, that provider's key is reused.
+  # Browser-rendered charts and diagrams. The URL must point to a reachable
+  # ControlPlane Web /siclaw-visual-export page; this chart does not install an
+  # external renderer or assume its Kubernetes Service name.
+  visualExport:
+    url: ""                # e.g. https://console.example.com/siclaw-visual-export
+    timeoutMs: 60000       # total browser launch + render budget; MCP adds 5s grace
+    theme: light           # light or dark
   # Max sub-agent child sessions ONE CONVERSATION runs concurrently. A wide
   # spawn_subagent fan-out queues past this instead of starting one child agent +
   # one LLM stream per target at once (avoids provider 429s / pod pressure).

--- a/mcp/create-chart/src/handler.test.ts
+++ b/mcp/create-chart/src/handler.test.ts
@@ -5,12 +5,10 @@ import {
   RENDER_CHART_DESCRIPTION,
   RENDER_MERMAID_DESCRIPTION,
   RENDER_MERMAID_INPUT_SCHEMA,
-  RENDER_VISUAL_CARD_DESCRIPTION,
-  RENDER_VISUAL_CARD_INPUT_SCHEMA,
   validate,
   validateMermaid,
-  validateVisualCard,
   handleRenderChart,
+  handleRenderMermaid,
 } from "./handler.js";
 
 vi.mock("./visual-export.js", () => {
@@ -18,11 +16,7 @@ vi.mock("./visual-export.js", () => {
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
   return {
     exportMarkdownVisualsWithVisualExportWeb: vi.fn(async (markdown: string) => {
-      const kind = markdown.startsWith("```mermaid")
-        ? "mermaid"
-        : markdown.startsWith("```visual-card")
-          ? "visual-card"
-          : "chart";
+      const kind = markdown.startsWith("```mermaid") ? "mermaid" : "chart";
       return [{ kind, image: Buffer.from(png, "base64") }];
     }),
   };
@@ -42,13 +36,12 @@ describe("RENDER_CHART_INPUT_SCHEMA", () => {
     }
   });
 
-  it("description tells the model to paste the READY_TO_PASTE block exactly", () => {
-    expect(RENDER_CHART_DESCRIPTION).toMatch(/```chart/);
-    expect(RENDER_CHART_DESCRIPTION).toMatch(/READY_TO_PASTE/);
-    expect(RENDER_CHART_DESCRIPTION).toMatch(/exactly/i);
+  it("describes the web embed and supporting channel image without renderer metadata", () => {
     expect(RENDER_CHART_DESCRIPTION).toMatch(/PNG image artifact/);
-    expect(RENDER_CHART_DESCRIPTION).toMatch(/ControlPlane Web's own chart renderer\/export path/);
-    expect(RENDER_CHART_DESCRIPTION).toMatch(/Do not rewrite, escape, quote/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/natural-language/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/In web replies, include the returned chart block/);
+    expect(RENDER_CHART_DESCRIPTION).toMatch(/IM channel sessions/);
+    expect(RENDER_CHART_DESCRIPTION).not.toMatch(/READY_TO_PASTE/);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/mermaid/i);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/xychart-beta/);
     expect(RENDER_CHART_DESCRIPTION).toMatch(/画图/);
@@ -70,17 +63,9 @@ describe("visual image tool schemas", () => {
     expect(RENDER_MERMAID_INPUT_SCHEMA.additionalProperties).toBe(false);
     expect(RENDER_MERMAID_DESCRIPTION).toMatch(/ControlPlane Web's own Mermaid renderer\/export path/);
     expect(RENDER_MERMAID_DESCRIPTION).toMatch(/image\/png/);
-    expect(RENDER_MERMAID_DESCRIPTION).toMatch(/READY_TO_PASTE/);
-    expect(RENDER_MERMAID_DESCRIPTION).toMatch(/```mermaid/);
-  });
-
-  it("registers visual-card export as a ControlPlane Web image artifact tool", () => {
-    expect(RENDER_VISUAL_CARD_INPUT_SCHEMA.required).toEqual(["type", "title"]);
-    expect(RENDER_VISUAL_CARD_INPUT_SCHEMA.properties.type.enum).toContain("report");
-    expect(RENDER_VISUAL_CARD_INPUT_SCHEMA.properties.type.enum).toContain("root_cause_chain");
-    expect(RENDER_VISUAL_CARD_DESCRIPTION).toMatch(/ControlPlane Web's own visual-card renderer\/export path/);
-    expect(RENDER_VISUAL_CARD_DESCRIPTION).toMatch(/image\/png/);
-    expect(RENDER_VISUAL_CARD_DESCRIPTION).toMatch(/```visual-card/);
+    expect(RENDER_MERMAID_DESCRIPTION).toMatch(/natural-language/);
+    expect(RENDER_MERMAID_DESCRIPTION).toMatch(/In web replies, include the returned Mermaid block/);
+    expect(RENDER_MERMAID_DESCRIPTION).not.toMatch(/READY_TO_PASTE/);
   });
 });
 
@@ -233,31 +218,6 @@ describe("validateMermaid", () => {
   });
 });
 
-describe("validateVisualCard", () => {
-  it("keeps ControlPlane visual-card specs and strips unknown keys", () => {
-    const out = validateVisualCard({
-      type: "report",
-      title: "诊断结论",
-      tone: "danger",
-      conclusion: "api pods are restarting.",
-      items: [{ label: "Affected pods", status: "danger", value: "3" }],
-      extra: "drop",
-    });
-    expect(out).toMatchObject({
-      type: "report",
-      title: "诊断结论",
-      tone: "danger",
-      conclusion: "api pods are restarting.",
-    });
-    expect(out).not.toHaveProperty("extra");
-  });
-
-  it("rejects unsupported or empty visual-card specs", () => {
-    expect(() => validateVisualCard({ type: "unknown", title: "x", conclusion: "y" })).toThrow(/supported/);
-    expect(() => validateVisualCard({ type: "report", title: "x" })).toThrow(/provide conclusion/);
-  });
-});
-
 describe("handleRenderChart", () => {
   beforeEach(() => {
     vi.mocked(exportMarkdownVisualsWithVisualExportWeb).mockClear();
@@ -265,13 +225,7 @@ describe("handleRenderChart", () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  function splitEnvelope(text: string): { ready: string; meta: Record<string, unknown> } {
-    const m = text.match(/^READY_TO_PASTE:\n([\s\S]*?)\n\nMETADATA_JSON:\n([\s\S]*)$/);
-    if (!m) throw new Error(`unexpected envelope: ${text.slice(0, 80)}…`);
-    return { ready: m[1], meta: JSON.parse(m[2]) };
-  }
-
-  it("returns a content array with a parseable result envelope and PNG image artifact", async () => {
+  it("returns a web-renderable block and PNG image artifact", async () => {
     const res = await handleRenderChart({
       type: "pie",
       data: { slices: [{ label: "ok", value: 1 }] },
@@ -281,30 +235,16 @@ describe("handleRenderChart", () => {
     expect(res.content[1].type).toBe("image");
     expect(res.content[1].mimeType).toBe("image/png");
     expect([...Buffer.from(res.content[1].data, "base64").subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
-    const { ready, meta } = splitEnvelope(res.content[0].text);
-    expect(ready.startsWith("```chart\n")).toBe(true);
-    expect(ready.endsWith("\n```")).toBe(true);
-    // The READY_TO_PASTE block must be the unescaped fenced markdown — no
-    // backslash-escaped quotes, no surrounding JSON quotes. This is the whole
-    // point of the envelope: agents copy this verbatim. METADATA_JSON carries
-    // no embed string field, so there is no escaped form for the model to pick
-    // up and mangle.
-    expect(ready).not.toMatch(/\\"/);
-    expect(meta.type).toBe("pie");
-    expect(meta.schema_version).toBe(1);
-    expect(meta.artifact_kind).toBe("chart_spec");
-    expect(typeof meta.chart_id).toBe("string");
-    expect((meta.chart_id as string).startsWith("pie-")).toBe(true);
-    expect(typeof meta.bytes).toBe("number");
-    expect(meta.bytes as number).toBeGreaterThan(0);
-    expect(meta.renderer).toBe("visual-export-web");
-    expect(meta).not.toHaveProperty("markdown_embed");
-    expect(meta).not.toHaveProperty("markdown_embed_raw");
-    expect(meta.embed_instructions).toMatch(/READY_TO_PASTE/);
-    expect(exportMarkdownVisualsWithVisualExportWeb).toHaveBeenCalledWith(ready);
+    expect(res.content[0].text).toBe(
+      '```chart\n{"type":"pie","data":{"slices":[{"label":"ok","value":1}]}}\n```',
+    );
+    expect(res.content[0].text).not.toContain("READY_TO_PASTE");
+    expect(exportMarkdownVisualsWithVisualExportWeb).toHaveBeenCalledWith(
+      '```chart\n{"type":"pie","data":{"slices":[{"label":"ok","value":1}]}}\n```',
+    );
   });
 
-  it("embeds the validated spec (not the raw input) inside the chart fence", async () => {
+  it("returns only the validated spec in the web embed", async () => {
     const res = await handleRenderChart({
       type: "bar",
       data: {
@@ -314,31 +254,24 @@ describe("handleRenderChart", () => {
       title: "Demo",
       extra_garbage: "stripped",
     } as Record<string, unknown>);
-    const { ready, meta } = splitEnvelope(res.content[0].text);
-    const inner = ready.replace(/^```chart\n/, "").replace(/\n```$/, "");
+    const rendered = vi.mocked(exportMarkdownVisualsWithVisualExportWeb).mock.calls[0][0];
+    const inner = rendered.replace(/^```chart\n/, "").replace(/\n```$/, "");
     const spec = JSON.parse(inner);
     expect(spec.type).toBe("bar");
     expect(spec).not.toHaveProperty("schema_version");
     expect(spec.data.series[0].values).toEqual([10, 20]);
     expect(spec.title).toBe("Demo");
     expect(spec).not.toHaveProperty("extra_garbage");
-    expect(meta).not.toHaveProperty("markdown_embed");
+    expect(res.content[0].text).toBe(rendered);
+    expect(res.content[0].text).not.toContain("METADATA_JSON");
   });
 
-  it("does not rely on local AgentBox files for artifact delivery", async () => {
-    const res = await handleRenderChart({
-      type: "line",
-      data: { series: [{ name: "s", points: [{ x: 1, y: 2 }] }] },
-    });
-    const { ready, meta } = splitEnvelope(res.content[0].text);
-    expect(meta.svg_path).toBe("");
-    expect(meta.spec_path).toBe("");
-    expect(meta.png_path).toBe("");
-    expect(meta.image_mime).toBe("image/png");
-    expect(meta.image_bytes as number).toBeGreaterThan(0);
-    expect(res.content[1].type).toBe("image");
-    expect([...Buffer.from(res.content[1].data, "base64").subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
-    expect(meta.bytes as number).toBeGreaterThan(0);
-    expect(ready.startsWith("```chart\n")).toBe(true);
+  it("returns Mermaid as a web embed and image attachment", async () => {
+    const res = await handleRenderMermaid({ source: "flowchart TD\nA --> B" });
+    expect(res.content[0].text).toBe("```mermaid\nflowchart TD\nA --> B\n```");
+    expect(res.content[1]).toMatchObject({ type: "image", mimeType: "image/png" });
+    expect(exportMarkdownVisualsWithVisualExportWeb).toHaveBeenCalledWith(
+      "```mermaid\nflowchart TD\nA --> B\n```",
+    );
   });
 });

--- a/mcp/create-chart/src/handler.ts
+++ b/mcp/create-chart/src/handler.ts
@@ -1,8 +1,5 @@
 import { exportMarkdownVisualsWithVisualExportWeb } from "./visual-export.js";
-import type { RenderChartArgs, RenderChartResult, RenderChartToolResponse } from "./types.js";
-
-const CHART_SPEC_VERSION = 1;
-const VISUAL_SPEC_VERSION = 1;
+import type { RenderChartArgs, RenderChartToolResponse } from "./types.js";
 
 export const RENDER_CHART_INPUT_SCHEMA = {
   type: "object",
@@ -31,9 +28,9 @@ export const RENDER_CHART_INPUT_SCHEMA = {
 export const RENDER_CHART_DESCRIPTION =
   [
     "Render a pie/bar/line chart only when finalized structured numeric data is already in context and can be passed as valid tool arguments. This includes requests such as 画图, 画饼图, 柱状图, 趋势图 when the required numeric data is available.",
-    "For qualitative diagrams, workflows, topology, or decision trees, use a ```mermaid fenced block instead; xychart-beta is suitable for simple bar charts.",
+    "For qualitative diagrams, workflows, topology, or decision trees, use render_mermaid instead; xychart-beta is suitable for simple bar charts.",
     "Arguments must be one JSON object. data must be an object, never a JSON string. Use only literal finite numbers; never use placeholders, expressions, previous-message references, or bare tokens.",
-    "The tool renders through ControlPlane Web's own chart renderer/export path and returns a READY_TO_PASTE chart block as plain markdown, metadata, and a PNG image artifact. In your final reply, paste the READY_TO_PASTE block exactly as returned and preserve the image artifact. Do not rewrite, escape, quote, or wrap the chart JSON; the frontend renders ```chart fenced JSON blocks as SVG, while IM channels forward the PNG artifact.",
+    "After a successful render, the tool returns a web-renderable ```chart block plus a PNG image artifact. In web replies, include the returned chart block so the UI can render it. In IM channel sessions, preserve the image artifact and follow the channel instructions not to paste source. On every surface, make the natural-language answer complete on its own and never expose renderer metadata.",
   ].join(" ");
 
 export const RENDER_MERMAID_INPUT_SCHEMA = {
@@ -54,64 +51,13 @@ export const RENDER_MERMAID_INPUT_SCHEMA = {
 } as const;
 
 export const RENDER_MERMAID_DESCRIPTION = [
-  "Render a Mermaid diagram through ControlPlane Web's own Mermaid renderer/export path and return a PNG image artifact.",
+  "Render a Mermaid diagram through ControlPlane Web's own Mermaid renderer/export path and return an image/png artifact.",
   "Use this in Feishu/Lark channel replies whenever the user asks for a flowchart, sequence diagram, timeline, topology, remediation flow, or Mermaid diagram image.",
-  "Arguments must contain Mermaid source only, not fenced markdown. The tool returns READY_TO_PASTE ```mermaid markdown plus an image/png content block. Paste READY_TO_PASTE exactly and preserve the image artifact.",
+  "Arguments must contain Mermaid source only, not fenced markdown. After a successful render, the tool returns a web-renderable ```mermaid block plus an image/png artifact. In web replies, include the returned Mermaid block so the UI can render it. In IM channel sessions, preserve the image artifact and follow the channel instructions not to paste source. On every surface, make the natural-language answer complete on its own and never expose renderer metadata.",
 ].join(" ");
-
-export const RENDER_VISUAL_CARD_INPUT_SCHEMA = {
-  type: "object",
-  required: ["type", "title"],
-  properties: {
-    type: {
-      type: "string",
-      enum: [
-        "report",
-        "final_report",
-        "health_check",
-        "incident_timeline",
-        "root_cause_chain",
-        "metric_snapshot",
-        "status_distribution",
-        "action_plan",
-      ],
-      description: "ControlPlane Web visual-card type.",
-    },
-    title: { type: "string" },
-    label: { type: "string" },
-    subtitle: { type: "string" },
-    conclusion: { type: "string" },
-    summary: { type: "string", description: "Alias accepted by ControlPlane Web as conclusion." },
-    tone: { type: "string" },
-    status: { type: "string" },
-    footer: { type: "string" },
-    items: { type: "array" },
-    events: { type: "array" },
-    nodes: { type: "array" },
-    root_cause: { type: "string" },
-    rootCause: { type: "string" },
-    metrics: { type: "array" },
-    segments: { type: "array" },
-    total: { type: "number" },
-    actions: { type: "array" },
-    sections: { type: "array" },
-  },
-  additionalProperties: false,
-} as const;
-
-export const RENDER_VISUAL_CARD_DESCRIPTION = [
-  "Render a ControlPlane Web visual-card conclusion card through ControlPlane Web's own visual-card renderer/export path and return a PNG image artifact.",
-  "Use this for Feishu/Lark final diagnosis cards, health checks, root-cause summaries, incident timelines, metric snapshots, status distributions, and action plans when the group needs a conclusion-card image.",
-  "Arguments must be one visual-card JSON object, not Markdown and not a JSON string. The tool returns READY_TO_PASTE ```visual-card markdown plus an image/png content block. Paste READY_TO_PASTE exactly and preserve the image artifact.",
-].join(" ");
-
-function newChartId(type: string): string {
-  return `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
 
 export async function handleRenderChart(rawArgs: unknown): Promise<RenderChartToolResponse> {
   const args = validate(rawArgs);
-  const id = newChartId(args.type);
 
   const spec = JSON.stringify(args);
   const markdownEmbed = "```chart\n" + spec + "\n```";
@@ -120,33 +66,11 @@ export async function handleRenderChart(rawArgs: unknown): Promise<RenderChartTo
   if (!visual?.image) throw new Error("render_chart: ControlPlane Web export returned no chart image");
   const png = visual.image;
 
-  const result: RenderChartResult = {
-    schema_version: CHART_SPEC_VERSION,
-    chart_id: id,
-    type: args.type,
-    artifact_kind: "chart_spec",
-    spec_path: "",
-    svg_path: "",
-    png_path: "",
-    bytes: Buffer.byteLength(spec, "utf8"),
-    image_bytes: png.byteLength,
-    image_mime: "image/png",
-    renderer: "visual-export-web",
-    embed_instructions:
-      "Paste the READY_TO_PASTE block above verbatim into your reply where the chart should appear, and preserve the returned image artifact. Do not modify the JSON, add backslashes, escape non-ASCII characters, convert to ```svg, or inline an <img>.",
-  };
-
   return {
     content: [
       {
         type: "text",
-        text: [
-          "READY_TO_PASTE:",
-          markdownEmbed,
-          "",
-          "METADATA_JSON:",
-          JSON.stringify(result, null, 2),
-        ].join("\n"),
+        text: markdownEmbed,
       },
       {
         type: "image",
@@ -159,25 +83,16 @@ export async function handleRenderChart(rawArgs: unknown): Promise<RenderChartTo
 
 export async function handleRenderMermaid(rawArgs: unknown): Promise<RenderChartToolResponse> {
   const args = validateMermaid(rawArgs);
-  const id = newChartId("mermaid");
   const markdownEmbed = "```mermaid\n" + args.source + "\n```";
   const exported = await exportMarkdownVisualsWithVisualExportWeb(markdownEmbed);
   const visual = exported.find((item) => item.kind === "mermaid") ?? exported[0];
   if (!visual?.image) throw new Error("render_mermaid: ControlPlane Web export returned no Mermaid image");
 
-  const meta = visualMetadata(id, "mermaid", markdownEmbed, visual.image);
-
   return {
     content: [
       {
         type: "text",
-        text: [
-          "READY_TO_PASTE:",
-          markdownEmbed,
-          "",
-          "METADATA_JSON:",
-          JSON.stringify(meta, null, 2),
-        ].join("\n"),
+        text: markdownEmbed,
       },
       {
         type: "image",
@@ -185,60 +100,6 @@ export async function handleRenderMermaid(rawArgs: unknown): Promise<RenderChart
         data: visual.image.toString("base64"),
       },
     ],
-  };
-}
-
-export async function handleRenderVisualCard(rawArgs: unknown): Promise<RenderChartToolResponse> {
-  const spec = validateVisualCard(rawArgs);
-  const id = newChartId("visual-card");
-  const specJson = JSON.stringify(spec);
-  const markdownEmbed = "```visual-card\n" + specJson + "\n```";
-  const exported = await exportMarkdownVisualsWithVisualExportWeb(markdownEmbed);
-  const visual = exported.find((item) => item.kind === "visual-card") ?? exported[0];
-  if (!visual?.image) throw new Error("render_visual_card: ControlPlane Web export returned no visual-card image");
-
-  const meta = visualMetadata(id, "visual-card", markdownEmbed, visual.image);
-
-  return {
-    content: [
-      {
-        type: "text",
-        text: [
-          "READY_TO_PASTE:",
-          markdownEmbed,
-          "",
-          "METADATA_JSON:",
-          JSON.stringify(meta, null, 2),
-        ].join("\n"),
-      },
-      {
-        type: "image",
-        mimeType: "image/png",
-        data: visual.image.toString("base64"),
-      },
-    ],
-  };
-}
-
-function visualMetadata(
-  id: string,
-  kind: "mermaid" | "visual-card",
-  markdownEmbed: string,
-  image: Buffer,
-): Record<string, unknown> {
-  return {
-    schema_version: VISUAL_SPEC_VERSION,
-    visual_id: id,
-    type: kind,
-    artifact_kind: `${kind}_spec`,
-    spec_path: "",
-    png_path: "",
-    bytes: Buffer.byteLength(markdownEmbed, "utf8"),
-    image_bytes: image.byteLength,
-    image_mime: "image/png",
-    renderer: "visual-export-web",
-    embed_instructions:
-      "Paste the READY_TO_PASTE block above verbatim into your reply and preserve the returned image artifact. Do not expose escaped JSON or describe Feishu upload mechanics.",
   };
 }
 
@@ -350,38 +211,6 @@ export function validateMermaid(raw: unknown): { source: string; title?: string 
   const out: { source: string; title?: string } = { source };
   if (typeof obj.title === "string" && obj.title.trim()) out.title = obj.title.trim();
   return out;
-}
-
-export function validateVisualCard(raw: unknown): Record<string, unknown> {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("render_visual_card: arguments must be an object");
-  }
-  const obj = raw as Record<string, unknown>;
-  const type = typeof obj.type === "string" ? obj.type : "";
-  if (!RENDER_VISUAL_CARD_INPUT_SCHEMA.properties.type.enum.includes(type as any)) {
-    throw new Error("render_visual_card: type is required and must be a supported ControlPlane visual-card type");
-  }
-  if (typeof obj.title !== "string" || !obj.title.trim()) {
-    throw new Error("render_visual_card: title is required");
-  }
-  if (!hasVisualCardBody(obj)) {
-    throw new Error("render_visual_card: provide conclusion, items, metrics, segments, events, nodes, actions, or sections");
-  }
-  const allowed = new Set(Object.keys(RENDER_VISUAL_CARD_INPUT_SCHEMA.properties));
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    if (allowed.has(key)) out[key] = value;
-  }
-  return out;
-}
-
-function hasVisualCardBody(obj: Record<string, unknown>): boolean {
-  if (typeof obj.conclusion === "string" && obj.conclusion.trim()) return true;
-  if (typeof obj.summary === "string" && obj.summary.trim()) return true;
-  return ["items", "metrics", "segments", "events", "nodes", "actions", "sections"].some((key) => {
-    const value = obj[key];
-    return Array.isArray(value) && value.length > 0;
-  });
 }
 
 function stripFence(source: string, language: string): string {

--- a/mcp/create-chart/src/index.ts
+++ b/mcp/create-chart/src/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * create-chart MCP server — stdio transport, exposes ControlPlane Web-backed visual
- * tools. Each tool returns a READY_TO_PASTE source block plus a structured PNG
- * image content block; channel adapters own platform-specific delivery.
+ * create-chart MCP server — stdio transport, exposes ControlPlane Web-backed
+ * chart and diagram tools. Each tool returns a structured PNG image content
+ * block; channel adapters own platform-specific delivery.
  *
  * Packaged as a standalone npm package; Dockerfile.agentbox builds it via
  * mcp/MCP_LIST.txt and symlinks dist/index.js to /usr/local/bin/mcp-create-chart.
@@ -26,12 +26,10 @@ import {
   RENDER_CHART_INPUT_SCHEMA,
   RENDER_MERMAID_DESCRIPTION,
   RENDER_MERMAID_INPUT_SCHEMA,
-  RENDER_VISUAL_CARD_DESCRIPTION,
-  RENDER_VISUAL_CARD_INPUT_SCHEMA,
   handleRenderChart,
   handleRenderMermaid,
-  handleRenderVisualCard,
 } from "./handler.js";
+import { visualExportConfigurationWarning } from "./visual-export-config.js";
 
 async function main(): Promise<void> {
   const server = new Server(
@@ -51,11 +49,6 @@ async function main(): Promise<void> {
         description: RENDER_MERMAID_DESCRIPTION,
         inputSchema: RENDER_MERMAID_INPUT_SCHEMA,
       },
-      {
-        name: "render_visual_card",
-        description: RENDER_VISUAL_CARD_DESCRIPTION,
-        inputSchema: RENDER_VISUAL_CARD_INPUT_SCHEMA,
-      },
     ],
   }));
 
@@ -66,9 +59,6 @@ async function main(): Promise<void> {
       }
       if (req.params.name === "render_mermaid") {
         return await handleRenderMermaid(req.params.arguments ?? {}) as any;
-      }
-      if (req.params.name === "render_visual_card") {
-        return await handleRenderVisualCard(req.params.arguments ?? {}) as any;
       }
       throw new Error(`Unknown tool: ${req.params.name}`);
     } catch (err) {
@@ -82,6 +72,8 @@ async function main(): Promise<void> {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  const warning = visualExportConfigurationWarning();
+  if (warning) process.stderr.write(`[mcp-create-chart] warning: ${warning}\n`);
   process.stderr.write("[mcp-create-chart] ready\n");
 }
 

--- a/mcp/create-chart/src/types.ts
+++ b/mcp/create-chart/src/types.ts
@@ -34,25 +34,6 @@ export type RenderChartArgs =
     } & ChartCommonOpts)
   | ({ type: "line"; data: { series: LineSeries[] } } & ChartCommonOpts);
 
-export interface RenderChartResult {
-  schema_version: 1;
-  chart_id: string;
-  type: "pie" | "bar" | "line";
-  artifact_kind: "chart_spec";
-  /**
-   * Kept for backwards-compatible metadata shape. Empty because delivery uses
-   * the returned structured image content block, not AgentBox-local files.
-   */
-  spec_path: string;
-  svg_path: string;
-  png_path: string;
-  bytes: number;
-  image_bytes: number;
-  image_mime: "image/png";
-  renderer: "visual-export-web";
-  embed_instructions: string;
-}
-
 export type RenderChartToolContent =
   | { type: "text"; text: string }
   | { type: "image"; data: string; mimeType: "image/png" };

--- a/mcp/create-chart/src/visual-export-config.ts
+++ b/mcp/create-chart/src/visual-export-config.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_VISUAL_EXPORT_TIMEOUT_MS = 60_000;
+
+export function resolveVisualExportUrl(override?: string): string {
+  const configured = (override ?? process.env.SICLAW_VISUAL_EXPORT_URL)?.trim();
+  if (!configured) {
+    throw new Error(
+      "Visual export is not configured; set SICLAW_VISUAL_EXPORT_URL to a reachable /siclaw-visual-export page",
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    throw new Error("Visual export URL must be an absolute HTTP(S) URL");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Visual export URL must use the http or https scheme");
+  }
+  if (configured.includes("#")) {
+    throw new Error(
+      "Visual export URL must not contain a fragment (#); configure the page URL before the hash payload",
+    );
+  }
+
+  const pathname = url.pathname.replace(/\/+$/, "");
+  return `${url.origin}${pathname}${url.search}`;
+}
+
+export function resolveVisualExportTimeoutMs(override?: number): number {
+  const configured = process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS?.trim();
+  const raw = override ?? (configured ? Number(configured) : DEFAULT_VISUAL_EXPORT_TIMEOUT_MS);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    throw new Error("Visual export timeout must be a positive number of milliseconds");
+  }
+  return Math.ceil(raw);
+}
+
+export function visualExportConfigurationWarning(): string | null {
+  try {
+    resolveVisualExportUrl();
+    resolveVisualExportTimeoutMs();
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}

--- a/mcp/create-chart/src/visual-export-runtime.test.ts
+++ b/mcp/create-chart/src/visual-export-runtime.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { launchMock } = vi.hoisted(() => ({ launchMock: vi.fn() }));
+
+vi.mock("playwright-core", () => ({
+  chromium: { launch: launchMock },
+}));
+
+import { exportMarkdownVisualsWithVisualExportWeb } from "./visual-export.js";
+
+const png =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+describe("visual export deadline", () => {
+  beforeEach(() => launchMock.mockReset());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("shares one timeout budget across browser launch, navigation, and readiness", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const goto = vi.fn(async () => { now = 1_700; });
+    const waitForFunction = vi.fn(async () => { now = 1_800; });
+    const page = {
+      goto,
+      waitForFunction,
+      evaluate: vi.fn(async () => [{ kind: "chart", dataUrl: `data:image/png;base64,${png}` }]),
+    };
+    const browser = {
+      newPage: vi.fn(async () => { now = 1_200; return page; }),
+      close: vi.fn(async () => undefined),
+    };
+    launchMock.mockImplementation(async () => { now = 1_100; return browser; });
+
+    await exportMarkdownVisualsWithVisualExportWeb("```chart\n{}\n```", {
+      baseUrl: "https://console.example.com/siclaw-visual-export",
+      timeoutMs: 1_000,
+    });
+
+    expect(launchMock.mock.calls[0][0].timeout).toBe(1_000);
+    expect(goto.mock.calls[0][1].timeout).toBe(800);
+    expect(waitForFunction.mock.calls[0][2].timeout).toBe(300);
+  });
+
+  it("stops before the next phase when an earlier phase exhausts the budget", async () => {
+    let now = 2_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const waitForFunction = vi.fn();
+    const browser = {
+      newPage: vi.fn(async () => ({
+        goto: vi.fn(async () => { now = 2_501; }),
+        waitForFunction,
+        evaluate: vi.fn(),
+      })),
+      close: vi.fn(async () => undefined),
+    };
+    launchMock.mockResolvedValue(browser);
+
+    await expect(exportMarkdownVisualsWithVisualExportWeb("```chart\n{}\n```", {
+      baseUrl: "https://console.example.com/siclaw-visual-export",
+      timeoutMs: 500,
+    })).rejects.toThrow(/timed out after 500ms/);
+    expect(waitForFunction).not.toHaveBeenCalled();
+    expect(browser.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcp/create-chart/src/visual-export.test.ts
+++ b/mcp/create-chart/src/visual-export.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveVisualExportTimeoutMs,
+  resolveVisualExportUrl,
+  visualExportConfigurationWarning,
+} from "./visual-export-config.js";
+
+const originalUrl = process.env.SICLAW_VISUAL_EXPORT_URL;
+const originalTimeout = process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS;
+
+afterEach(() => {
+  if (originalUrl === undefined) delete process.env.SICLAW_VISUAL_EXPORT_URL;
+  else process.env.SICLAW_VISUAL_EXPORT_URL = originalUrl;
+  if (originalTimeout === undefined) delete process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS;
+  else process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS = originalTimeout;
+});
+
+describe("resolveVisualExportUrl", () => {
+  it("requires an explicitly configured renderer instead of inventing service DNS", () => {
+    delete process.env.SICLAW_VISUAL_EXPORT_URL;
+    expect(() => resolveVisualExportUrl()).toThrow(/set SICLAW_VISUAL_EXPORT_URL/);
+  });
+
+  it("normalizes the configured endpoint", () => {
+    expect(resolveVisualExportUrl(" https://console.example.com/export///?locale=zh-CN "))
+      .toBe("https://console.example.com/export?locale=zh-CN");
+  });
+
+  it("rejects relative, non-HTTP, and fragment-bearing locations", () => {
+    expect(() => resolveVisualExportUrl("console.example.com/export")).toThrow(/absolute HTTP\(S\)/);
+    expect(() => resolveVisualExportUrl("file:///tmp/export.html")).toThrow(/http or https/);
+    expect(() => resolveVisualExportUrl("https://console.example.com/#/export")).toThrow(/fragment/);
+    expect(() => resolveVisualExportUrl("https://console.example.com/export#")).toThrow(/fragment/);
+  });
+
+  it("surfaces invalid startup configuration without aborting the MCP server", () => {
+    delete process.env.SICLAW_VISUAL_EXPORT_URL;
+    expect(visualExportConfigurationWarning()).toMatch(/set SICLAW_VISUAL_EXPORT_URL/);
+    process.env.SICLAW_VISUAL_EXPORT_URL = "https://console.example.com/export";
+    process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS = "invalid";
+    expect(visualExportConfigurationWarning()).toMatch(/positive number/);
+    delete process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS;
+    expect(visualExportConfigurationWarning()).toBeNull();
+  });
+
+  it("validates and normalizes the renderer timeout", () => {
+    process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS = "";
+    expect(resolveVisualExportTimeoutMs()).toBe(60_000);
+    expect(resolveVisualExportTimeoutMs(12_345.2)).toBe(12_346);
+    expect(() => resolveVisualExportTimeoutMs(0)).toThrow(/positive number/);
+    expect(() => resolveVisualExportTimeoutMs(Number.NaN)).toThrow(/positive number/);
+  });
+});

--- a/mcp/create-chart/src/visual-export.ts
+++ b/mcp/create-chart/src/visual-export.ts
@@ -2,9 +2,10 @@ import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser } from "playwright-core";
+import { resolveVisualExportTimeoutMs, resolveVisualExportUrl } from "./visual-export-config.js";
 
 export interface ExportedVisual {
-  kind: "chart" | "mermaid" | "visual-card";
+  kind: "chart" | "mermaid";
   image: Buffer;
 }
 
@@ -14,30 +15,30 @@ interface VisualExportOptions {
   timeoutMs?: number;
 }
 
-const DEFAULT_EXPORT_URL = "http://visual-export-web:3000/siclaw-visual-export";
-
 export async function exportMarkdownVisualsWithVisualExportWeb(
   markdown: string,
   options: VisualExportOptions = {},
 ): Promise<ExportedVisual[]> {
-  const baseUrl =
-    options.baseUrl ??
-    process.env.SICLAW_VISUAL_EXPORT_URL ??
-    DEFAULT_EXPORT_URL;
-  const timeoutMs = options.timeoutMs ?? Number(process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS ?? 30_000);
-  const browser = await launchBrowser();
+  const baseUrl = resolveVisualExportUrl(options.baseUrl);
+  const timeoutMs = resolveVisualExportTimeoutMs(options.timeoutMs);
+  const deadline = Date.now() + timeoutMs;
+  const browser = await launchBrowser(remainingTimeout(deadline, timeoutMs));
   try {
-    const page = await browser.newPage({
-      viewport: { width: 1120, height: 900 },
-      deviceScaleFactor: 1,
-    });
+    const page = await withDeadline(
+      () => browser.newPage({
+        viewport: { width: 1120, height: 900 },
+        deviceScaleFactor: 1,
+      }),
+      deadline,
+      timeoutMs,
+    );
     const payload = base64UrlEncode(JSON.stringify({
       markdown,
       theme: options.theme ?? process.env.SICLAW_VISUAL_EXPORT_THEME ?? "light",
     }));
     await page.goto(`${baseUrl}#${payload}`, {
       waitUntil: "networkidle",
-      timeout: timeoutMs,
+      timeout: remainingTimeout(deadline, timeoutMs),
     });
     await page.waitForFunction(
       () => {
@@ -48,14 +49,18 @@ export async function exportMarkdownVisualsWithVisualExportWeb(
         return Boolean(w.__siclawVisualExportReady && w.__siclawExportVisuals);
       },
       undefined,
-      { timeout: timeoutMs },
+      { timeout: remainingTimeout(deadline, timeoutMs) },
     );
-    const exported = await page.evaluate(async () => {
-      const w = globalThis as typeof globalThis & {
-        __siclawExportVisuals?: () => Promise<unknown>;
-      };
-      return await w.__siclawExportVisuals?.();
-    });
+    const exported = await withDeadline(
+      () => page.evaluate(async () => {
+        const w = globalThis as typeof globalThis & {
+          __siclawExportVisuals?: () => Promise<unknown>;
+        };
+        return await w.__siclawExportVisuals?.();
+      }),
+      deadline,
+      timeoutMs,
+    );
     if (!Array.isArray(exported) || exported.length === 0) {
       throw new Error("ControlPlane visual export returned no images");
     }
@@ -64,7 +69,7 @@ export async function exportMarkdownVisualsWithVisualExportWeb(
         throw new Error(`ControlPlane visual export item[${i}] is invalid`);
       }
       const rec = item as { kind?: unknown; dataUrl?: unknown };
-      if (rec.kind !== "chart" && rec.kind !== "mermaid" && rec.kind !== "visual-card") {
+      if (rec.kind !== "chart" && rec.kind !== "mermaid") {
         throw new Error(`ControlPlane visual export item[${i}] has invalid kind`);
       }
       if (typeof rec.dataUrl !== "string") {
@@ -78,7 +83,7 @@ export async function exportMarkdownVisualsWithVisualExportWeb(
   }
 }
 
-async function launchBrowser(): Promise<Browser> {
+async function launchBrowser(timeoutMs: number): Promise<Browser> {
   const executablePath =
     process.env.SICLAW_VISUAL_EXPORT_CHROMIUM ??
     process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ??
@@ -97,6 +102,7 @@ async function launchBrowser(): Promise<Browser> {
   return await chromium.launch({
     executablePath,
     headless: true,
+    timeout: timeoutMs,
     env: {
       ...process.env,
       HOME: homeDir,
@@ -111,6 +117,35 @@ async function launchBrowser(): Promise<Browser> {
       "--font-render-hinting=none",
     ],
   });
+}
+
+function remainingTimeout(deadline: number, timeoutMs: number): number {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) throw new Error(`Visual export timed out after ${timeoutMs}ms`);
+  return remaining;
+}
+
+async function withDeadline<T>(
+  start: () => Promise<T>,
+  deadline: number,
+  timeoutMs: number,
+): Promise<T> {
+  const remaining = remainingTimeout(deadline, timeoutMs);
+  const operation = start();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Visual export timed out after ${timeoutMs}ms`)),
+          remaining,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function pngFromDataUrl(dataUrl: string): Buffer {

--- a/src/core/mcp-client.test.ts
+++ b/src/core/mcp-client.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
-import { jsonSchemaToTypebox, normalizeMcpInputSchema, buildMcpToolName, isMcpTool, MCP_TOOL_PREFIX, mcpContentToAgentContent, McpClientManager } from "./mcp-client.js";
+import {
+  jsonSchemaToTypebox,
+  normalizeMcpInputSchema,
+  buildMcpToolName,
+  isMcpTool,
+  MCP_TOOL_PREFIX,
+  mcpContentToAgentContent,
+  McpClientManager,
+  isBundledCreateChartCommand,
+  mergeMcpStdioEnv,
+  visualMcpRequestTimeoutMs,
+} from "./mcp-client.js";
 
 describe("jsonSchemaToTypebox", () => {
   it("converts string type", () => {
@@ -140,6 +151,80 @@ describe("mcpContentToAgentContent", () => {
     expect(result.content).toEqual([
       { type: "image", data: "aW1n", mimeType: "image/jpeg" },
     ]);
+  });
+});
+
+describe("mergeMcpStdioEnv", () => {
+  it("forwards only the visual export contract into stdio MCP child processes", () => {
+    expect(mergeMcpStdioEnv(undefined, {
+      SICLAW_VISUAL_EXPORT_URL: "https://console.example.com/siclaw-visual-export",
+      SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "15000",
+      SICLAW_VISUAL_EXPORT_THEME: "dark",
+      SICLAW_VISUAL_EXPORT_CHROMIUM: "/opt/chromium",
+      SECRET_NOT_FOR_MCP: "must-not-leak",
+    }, true)).toEqual({
+      SICLAW_VISUAL_EXPORT_URL: "https://console.example.com/siclaw-visual-export",
+      SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "15000",
+      SICLAW_VISUAL_EXPORT_THEME: "dark",
+      SICLAW_VISUAL_EXPORT_CHROMIUM: "/opt/chromium",
+    });
+  });
+
+  it("lets explicit MCP configuration override an inherited value", () => {
+    expect(mergeMcpStdioEnv(
+      { SICLAW_VISUAL_EXPORT_THEME: "light", CUSTOM_MCP_VALUE: "configured" },
+      { SICLAW_VISUAL_EXPORT_THEME: "dark" },
+      true,
+    )).toEqual({
+      SICLAW_VISUAL_EXPORT_THEME: "light",
+      CUSTOM_MCP_VALUE: "configured",
+    });
+  });
+
+  it("does not inherit renderer configuration into unrelated stdio MCPs", () => {
+    expect(mergeMcpStdioEnv(undefined, {
+      SICLAW_VISUAL_EXPORT_URL: "https://console.example.com/siclaw-visual-export",
+    })).toBeUndefined();
+    expect(mergeMcpStdioEnv(
+      { CUSTOM_MCP_VALUE: "configured" },
+      { SICLAW_VISUAL_EXPORT_URL: "https://console.example.com/siclaw-visual-export" },
+    )).toEqual({ CUSTOM_MCP_VALUE: "configured" });
+  });
+});
+
+describe("isBundledCreateChartCommand", () => {
+  it("recognizes supported direct and wrapper forms of the bundled chart renderer", () => {
+    expect(isBundledCreateChartCommand("mcp-create-chart")).toBe(true);
+    expect(isBundledCreateChartCommand("/usr/local/bin/mcp-create-chart")).toBe(true);
+    expect(isBundledCreateChartCommand("/usr/bin/env", ["mcp-create-chart"])).toBe(true);
+    expect(isBundledCreateChartCommand("node", ["/app/mcp/create-chart/dist/index.js"])).toBe(true);
+    expect(isBundledCreateChartCommand("other-mcp")).toBe(false);
+    expect(isBundledCreateChartCommand("node", ["/app/mcp/other/dist/index.js"])).toBe(false);
+    expect(isBundledCreateChartCommand(undefined)).toBe(false);
+  });
+});
+
+describe("visualMcpRequestTimeoutMs", () => {
+  it("uses the full default renderer budget plus transport grace", () => {
+    expect(visualMcpRequestTimeoutMs(
+      "mcp-create-chart",
+      "render_chart",
+      { SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "" },
+    )).toBe(65_000);
+  });
+
+  it("adds transport grace to the configured renderer budget", () => {
+    expect(visualMcpRequestTimeoutMs(
+      "mcp-create-chart",
+      "render_mermaid",
+      { SICLAW_VISUAL_EXPORT_TIMEOUT_MS: "120000" },
+    )).toBe(125_000);
+  });
+
+  it("does not change removed or unrelated MCP tool timeouts", () => {
+    expect(visualMcpRequestTimeoutMs("other-renderer", "render_chart", {})).toBeUndefined();
+    expect(visualMcpRequestTimeoutMs("mcp-create-chart", "render_visual_card", {})).toBeUndefined();
+    expect(visualMcpRequestTimeoutMs("mcp-create-chart", "query", {})).toBeUndefined();
   });
 });
 

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -49,6 +49,62 @@ export interface McpServersConfig {
   mcpServers: Record<string, McpServerConfig>;
 }
 
+const MCP_STDIO_FORWARDED_ENV = [
+  "SICLAW_VISUAL_EXPORT_URL",
+  "SICLAW_VISUAL_EXPORT_TIMEOUT_MS",
+  "SICLAW_VISUAL_EXPORT_THEME",
+  "SICLAW_VISUAL_EXPORT_CHROMIUM",
+] as const;
+const DEFAULT_VISUAL_EXPORT_TIMEOUT_MS = 60_000;
+const VISUAL_EXPORT_MCP_GRACE_MS = 5_000;
+
+/**
+ * Optionally forward the platform-owned renderer contract into a bundled stdio MCP.
+ * The MCP SDK otherwise inherits a deliberately small OS environment.
+ */
+export function mergeMcpStdioEnv(
+  configuredEnv: Record<string, string> | undefined,
+  parentEnv: Record<string, string | undefined> = process.env,
+  inheritVisualExport = false,
+): Record<string, string> | undefined {
+  const inherited: Record<string, string> = {};
+  if (inheritVisualExport) {
+    for (const name of MCP_STDIO_FORWARDED_ENV) {
+      const value = parentEnv[name];
+      if (value !== undefined && value !== "") inherited[name] = value;
+    }
+  }
+  const merged = { ...inherited, ...configuredEnv };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+export function isBundledCreateChartCommand(command: unknown, args: unknown = []): boolean {
+  const candidates = [command, ...(Array.isArray(args) ? args : [])];
+  return candidates.some((candidate) => {
+    if (typeof candidate !== "string") return false;
+    if (candidate.split(/[\\/]/).at(-1) === "mcp-create-chart") return true;
+    return /(?:^|[\\/])mcp[\\/]create-chart[\\/](?:dist[\\/])?index\.js$/.test(candidate);
+  });
+}
+
+export function visualMcpRequestTimeoutMs(
+  serverImplementationName: unknown,
+  toolName: string,
+  env: Record<string, string | undefined> = {},
+): number | undefined {
+  if (
+    serverImplementationName !== "mcp-create-chart" ||
+    !/^render_(?:chart|mermaid)$/.test(toolName)
+  ) {
+    return undefined;
+  }
+  const configured = Number(env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS ?? DEFAULT_VISUAL_EXPORT_TIMEOUT_MS);
+  const rendererBudget = Number.isFinite(configured) && configured > 0
+    ? Math.ceil(configured)
+    : DEFAULT_VISUAL_EXPORT_TIMEOUT_MS;
+  return rendererBudget + VISUAL_EXPORT_MCP_GRACE_MS;
+}
+
 interface ManagedMcpClient {
   serverName: string;
   client: any; // Client from @modelcontextprotocol/sdk
@@ -224,12 +280,15 @@ export class McpClientManager {
         const cfg = serverConfig as any;
         const detectedTransport: string = cfg.transport
           ?? (cfg.url ? "streamable-http" : cfg.command ? "stdio" : "");
+        const stdioEnv = detectedTransport === "stdio"
+          ? mergeMcpStdioEnv(cfg.env, process.env, isBundledCreateChartCommand(cfg.command, cfg.args))
+          : undefined;
         switch (detectedTransport) {
           case "stdio":
             transport = new StdioClientTransport({
               command: cfg.command,
               args: cfg.args,
-              env: cfg.env,
+              env: stdioEnv,
             });
             break;
           case "sse":
@@ -255,13 +314,22 @@ export class McpClientManager {
 
         await client.connect(transport);
         console.log(`[mcp-client] Connected to "${serverName}" (${detectedTransport})`);
+        const serverImplementationName = client.getServerVersion()?.name;
 
         // Discover tools
         const { tools: mcpTools } = await client.listTools();
         console.log(`[mcp-client] "${serverName}" provides ${mcpTools.length} tools: ${mcpTools.map((t: any) => t.name).join(", ")}`);
 
         for (const mcpTool of mcpTools) {
-          const toolDef = this.createToolDefinition(serverName, cfg.description, mcpTool, client);
+          const toolDef = this.createToolDefinition(
+            serverName,
+            cfg.description,
+            mcpTool,
+            client,
+            detectedTransport === "stdio"
+              ? visualMcpRequestTimeoutMs(serverImplementationName, mcpTool.name, stdioEnv)
+              : undefined,
+          );
           this.tools.push(toolDef);
         }
 
@@ -312,6 +380,7 @@ export class McpClientManager {
     serverDescription: string | undefined,
     mcpTool: { name: string; description?: string; inputSchema?: any },
     client: any,
+    requestTimeoutMs?: number,
   ): ResolvedToolDefinition {
     const fullName = buildMcpToolName(serverName, mcpTool.name);
     const inputSchema = mcpTool.inputSchema ?? { type: "object", properties: {} };
@@ -343,10 +412,14 @@ export class McpClientManager {
       parameters,
       execute: async (_toolCallId, args) => {
         try {
-          const result = await client.callTool({
-            name: mcpTool.name,
-            arguments: args ?? {},
-          });
+          const result = await client.callTool(
+            {
+              name: mcpTool.name,
+              arguments: args ?? {},
+            },
+            undefined,
+            requestTimeoutMs === undefined ? undefined : { timeout: requestTimeoutMs },
+          );
 
           const isError = !!result.isError;
           const { content, text } = mcpContentToAgentContent(result.content);

--- a/src/core/prompt.test.ts
+++ b/src/core/prompt.test.ts
@@ -75,19 +75,22 @@ describe("buildSreSystemPrompt output guidance", () => {
     expect(prompt).not.toContain("render_chart");
   });
 
-  it("adds channel-only guidance for visual Feishu replies and conclusion cards", () => {
+  it("adds channel-only guidance for natural-language answers with optional visuals", () => {
     const prompt = buildSreSystemPrompt("channel");
 
     expect(prompt).toContain("# Channel Reply Format");
     expect(prompt).toContain("render_mermaid");
-    expect(prompt).toContain("render_visual_card");
-    expect(prompt).toContain("```visual-card");
+    expect(prompt).toContain("render_chart");
+    expect(prompt).not.toContain("render_visual_card");
+    expect(prompt).not.toContain("```visual-card");
     expect(prompt).not.toContain("```siclaw-card");
     expect(prompt).toContain("structured image content blocks");
+    expect(prompt).toContain("Visuals are optional supporting material, never the answer container");
+    expect(prompt).toContain("do not paste renderer source, metadata, or tool output");
+    expect(prompt).toContain("If visual rendering fails, continue with the complete natural-language answer");
     expect(prompt).toContain("Do not inline `data:image/...");
     expect(prompt).toContain("forwards structured image artifacts");
     expect(prompt).toContain("channel adapter");
-    expect(prompt).toContain("Source-only ```chart`, Mermaid, and ```visual-card` blocks remain markdown text");
     expect(prompt).toContain("Use normal Markdown for direct answers");
     expect(prompt).toContain("Treat the latest channel message as the current request");
     expect(prompt).toContain("Do not force details from a previous incident into the new answer");

--- a/src/core/prompt.ts
+++ b/src/core/prompt.ts
@@ -223,26 +223,22 @@ const CHANNEL_SECTION = `
 
 # Channel Reply Format
 
-This session is replying in an IM group. Choose the final answer shape intentionally:
+This session is replying in an IM group. Answer the user's request in clear, natural language:
 
 - Treat the latest channel message as the current request. Earlier group context is background only; use it when the user explicitly says they are continuing, refers to "above/earlier/that/this", or when stable configuration facts are needed.
 - If the latest message names a different case, cluster, node, pod, namespace, time range, or task, treat it as a new request. Do not force details from a previous incident into the new answer.
 - If context is ambiguous, answer the current message directly and ask one concise clarifying question instead of assuming an older case still applies.
+- Make the text answer complete on its own. Lead with the conclusion or direct answer, then include only the evidence, caveats, and next actions that help the user.
 - Use normal Markdown for direct answers, short diagnoses, command results, and prose reports.
 - Use a small Markdown table when the user needs exact enumerable facts.
 - For visual replies, use tools or artifacts that return structured image content blocks. The channel runtime uploads those image attachments to Feishu/Lark.
-- When the corresponding visual tools are available, use \`render_chart\` for numeric charts, \`render_mermaid\` for Mermaid diagrams, and \`render_visual_card\` for conclusion-card images. These tools return PNG image artifacts for the channel adapter to forward.
-- Use source-only \`\`\`chart\`, Mermaid, or \`\`\`visual-card\` blocks only when the user wants readable source instead of an image.
-- When a tool generates a PNG chart, diagram, or conclusion card, include or preserve that image artifact in the final answer and keep one concise natural-language conclusion outside the image.
+- Visuals are optional supporting material, never the answer container. Use \`render_chart\` only for finalized numeric data and \`render_mermaid\` only when a diagram materially improves understanding.
+- The rendering tools return PNG image artifacts. Preserve the image artifact, but do not paste renderer source, metadata, or tool output into the final text.
+- Use source-only \`\`\`chart\` or \`\`\`mermaid\` blocks only when the user explicitly asks for editable source instead of an image.
+- If visual rendering fails, continue with the complete natural-language answer. Do not retry merely to decorate an otherwise sufficient answer.
 - Do not inline \`data:image/...\` URLs or base64 image data in Markdown. Image delivery is an attachment responsibility of the channel adapter, not the final text body.
 
-For \`\`\`visual-card\`, output JSON only inside the fence:
-
-\`\`\`visual-card
-{"type":"report","title":"Short incident title","tone":"danger|warning|success|info|neutral","conclusion":"One-sentence conclusion","items":[{"label":"Impact","status":"danger","value":"3 pods","note":"namespace prod"}],"sections":[{"type":"actions","title":"Next actions","actions":[{"title":"Restart after config fix","priority":"P1","status":"info"}]}]}
-\`\`\`
-
-The channel runtime forwards structured image artifacts to Feishu/Lark and hides paired visual source blocks from the group message body. Source-only \`\`\`chart\`, Mermaid, and \`\`\`visual-card\` blocks remain markdown text unless paired with a real image artifact; visual tools must return image artifacts when the group needs an actual image. Do not describe Feishu upload mechanics.`;
+The channel runtime forwards structured image artifacts to Feishu/Lark and hides paired chart or Mermaid source blocks from the group message body. Do not describe Feishu upload mechanics.`;
 
 // ---------------------------------------------------------------------------
 // Safety sections — hardcoded, cannot be overridden

--- a/src/gateway/agentbox/k8s-spawner.test.ts
+++ b/src/gateway/agentbox/k8s-spawner.test.ts
@@ -92,6 +92,10 @@ const originalGatewayEnv = {
   SICLAW_GATEWAY_HOSTNAME: process.env.SICLAW_GATEWAY_HOSTNAME,
   SICLAW_INTERNAL_PORT: process.env.SICLAW_INTERNAL_PORT,
   SICLAW_MEMORY_ENABLED: process.env.SICLAW_MEMORY_ENABLED,
+  SICLAW_VISUAL_EXPORT_URL: process.env.SICLAW_VISUAL_EXPORT_URL,
+  SICLAW_VISUAL_EXPORT_TIMEOUT_MS: process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS,
+  SICLAW_VISUAL_EXPORT_THEME: process.env.SICLAW_VISUAL_EXPORT_THEME,
+  SICLAW_VISUAL_EXPORT_CHROMIUM: process.env.SICLAW_VISUAL_EXPORT_CHROMIUM,
 };
 
 // Import SUT after mocks.
@@ -341,6 +345,34 @@ describe("K8sSpawner — spawn branches", () => {
     const env = calls.createNamespacedPod[0].body.spec.containers[0].env;
     expect(env.some((e: any) => e.name === "SICLAW_SUBAGENT_MODEL_TIER")).toBe(false);
     expect(env.some((e: any) => e.name === "SICLAW_SUBAGENT_GROUP_ENABLED")).toBe(false);
+  });
+
+  it("forwards the visual export contract from Runtime into AgentBox", async () => {
+    process.env.SICLAW_VISUAL_EXPORT_URL = "https://console.example.com/siclaw-visual-export";
+    process.env.SICLAW_VISUAL_EXPORT_TIMEOUT_MS = "15000";
+    process.env.SICLAW_VISUAL_EXPORT_THEME = "dark";
+    process.env.SICLAW_VISUAL_EXPORT_CHROMIUM = "/opt/chromium";
+
+    const cm = new FakeCertManager();
+    const s = new K8sSpawner({ namespace: "siclaw-debug" });
+    s.setCertManager(cm as any);
+
+    let reads = 0;
+    readPodImpl.fn = async () => {
+      reads++;
+      if (reads === 1) throw Object.assign(new Error("nf"), { code: 404 });
+      return { status: { phase: "Running", podIP: "agentbox.example.test", conditions: [{ type: "Ready", status: "True" }] }, metadata: { labels: {} } };
+    };
+
+    await s.spawn({ agentId: "default" });
+    const env = calls.createNamespacedPod[0].body.spec.containers[0].env;
+    expect(env).toContainEqual({
+      name: "SICLAW_VISUAL_EXPORT_URL",
+      value: "https://console.example.com/siclaw-visual-export",
+    });
+    expect(env).toContainEqual({ name: "SICLAW_VISUAL_EXPORT_TIMEOUT_MS", value: "15000" });
+    expect(env).toContainEqual({ name: "SICLAW_VISUAL_EXPORT_THEME", value: "dark" });
+    expect(env).toContainEqual({ name: "SICLAW_VISUAL_EXPORT_CHROMIUM", value: "/opt/chromium" });
   });
 
   it("kb profile forwards KBC_* runtime env by prefix into the box pod, deduped, skipping empties", async () => {

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -629,6 +629,12 @@ export class K8sSpawner implements BoxSpawner {
         "SICLAW_EMBEDDING_MODEL",
         "SICLAW_EMBEDDING_DIMENSIONS",
         "SICLAW_EMBEDDING_API_KEY",
+        // Visual tools execute inside the AgentBox, while their renderer is
+        // configured on Runtime. Forward the narrow non-secret contract.
+        "SICLAW_VISUAL_EXPORT_URL",
+        "SICLAW_VISUAL_EXPORT_TIMEOUT_MS",
+        "SICLAW_VISUAL_EXPORT_THEME",
+        "SICLAW_VISUAL_EXPORT_CHROMIUM",
         // Trace deployment environment (Langfuse deployment.environment.name).
         "SICLAW_TRACING_ENVIRONMENT",
       ];

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -307,6 +307,42 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
     sessionRegistry.forget(sessionId as string);
   });
 
+  it("never sends legacy visual-card JSON to the channel", async () => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-7", bindingId: "b1" });
+    promptMock.mockResolvedValue({ sessionId: "remote-session-visual" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: [
+              "结论：请求体过大是主要原因。",
+              "",
+              "```visual-card",
+              '{"type":"report","title":"internal shape","conclusion":"do not leak"}',
+              "```",
+            ].join("\n"),
+          }],
+        },
+      };
+    });
+
+    await handleDingTalkMessage(
+      makeDownstream("诊断一下"),
+      "ch",
+      makeAgentBoxManager("agent-7") as any,
+      undefined,
+      {} as any,
+    );
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.markdown.text).toContain("请求体过大");
+    expect(body.markdown.text).not.toContain("visual-card");
+    expect(body.markdown.text).not.toContain("internal shape");
+  });
+
   it("audits the session: persists origin=channel + user/assistant/tool rows when the binding has an owner", async () => {
     resolveBindingMock.mockResolvedValue({ agentId: "agent-7", bindingId: "b1", createdBy: "owner-1" });
     promptMock.mockResolvedValue({ sessionId: "remote-7", traceId: "0123456789abcdef0123456789abcdef" });

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -42,7 +42,7 @@ import { sessionRegistry } from "../session-registry.js";
 import { sessionTurnLocks } from "../session-turn-lock.js";
 import { appendMessage, bindMessageTraceId, ensureChatSession, warnTraceBindFailure } from "../chat-repo.js";
 import { collectChannelResponse } from "./lark.js";
-import type { RenderedReplyImage } from "./visual-image.js";
+import { stripVisualBlocks, type RenderedReplyImage } from "./visual-image.js";
 import { deliverImages } from "./dingtalk-image.js";
 import {
   buildMarkdownMessage,
@@ -407,15 +407,16 @@ export async function handleDingTalkMessage(
   // On failure, reply with a generic notice only — the raw error message can
   // leak internal endpoints / infra details to everyone in the chat. The full
   // error was already logged above for operators.
+  const sanitizedResult = stripVisualBlocks(resultText, { stripSourceBlocks: replyImages.length > 0 });
   const finalBody = agentError
     ? AGENT_ERROR_NOTICE
-    : (resultText || EMPTY_RESULT_NOTICE);
+    : (sanitizedResult || (replyImages.length > 0 ? "图片已生成。" : EMPTY_RESULT_NOTICE));
 
   // Errors and the empty-result notice go out as plain text; real answers as
   // markdown so formatting (code blocks, lists, bold) renders.
   const body = agentError
     ? buildTextMessage(finalBody)
-    : (resultText ? buildMarkdownMessage(finalBody) : buildTextMessage(finalBody));
+    : (sanitizedResult ? buildMarkdownMessage(finalBody) : buildTextMessage(finalBody));
   await replyToDingTalk(sessionWebhook, body);
 
   // Deliver any agent-produced images as separate robot messages (mirrors

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -2717,6 +2717,96 @@ describe("handleLarkMessage — streaming card flow", () => {
     clearBackgroundChannelDelivery(sessionId);
   });
 
+  it("surfaces an empty-result notice when a background final contains only a legacy visual card", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-background-legacy-card" });
+    let releaseStream: () => void = () => {};
+    const streamGate = new Promise<void>((resolve) => { releaseStream = resolve; });
+    streamEventsMock.mockImplementation(async function* () {
+      await streamGate;
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "最终结论。" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+    const handlePromise = handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    await waitForExpect(() => expect(promptMock).toHaveBeenCalledTimes(1));
+    const sessionId = promptMock.mock.calls[0][0].sessionId;
+    try {
+      await expect(deliverChannelVisibleMessage({
+        sessionId,
+        kind: "final",
+        text: '```visual-card\n{"type":"report","title":"legacy"}\n```',
+      })).resolves.toBe(true);
+
+      const delivered = lark.cardkit.v1.cardElement.content.mock.calls.at(-1)[0].data.content as string;
+      expect(delivered).toContain("⚠");
+      expect(delivered).not.toContain("visual-card");
+    } finally {
+      releaseStream();
+      await handlePromise;
+      clearBackgroundChannelDelivery(sessionId);
+    }
+  });
+
+  it("never exposes chart or Mermaid source from background delivery", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-background-visual-source" });
+    let releaseStream: () => void = () => {};
+    const streamGate = new Promise<void>((resolve) => { releaseStream = resolve; });
+    streamEventsMock.mockImplementation(async function* () {
+      await streamGate;
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "最终结论。" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+    const handlePromise = handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    await waitForExpect(() => expect(promptMock).toHaveBeenCalledTimes(1));
+    const sessionId = promptMock.mock.calls[0][0].sessionId;
+    try {
+      const updatesBeforeMilestone = lark.cardkit.v1.cardElement.content.mock.calls.length;
+      await expect(deliverChannelVisibleMessage({
+        sessionId,
+        kind: "milestone",
+        text: "```mermaid\nflowchart TD\nA --> B\n```",
+      })).resolves.toBe(true);
+      expect(lark.cardkit.v1.cardElement.content.mock.calls).toHaveLength(updatesBeforeMilestone);
+
+      await deliverBackgroundChannelMessage({
+        sessionId,
+        role: "assistant",
+        content: '```chart\n{"type":"bar","data":[1,2]}\n```',
+      });
+      const delivered = lark.cardkit.v1.cardElement.content.mock.calls.at(-1)[0].data.content as string;
+      expect(delivered).toContain("⚠");
+      expect(delivered).not.toContain("```chart");
+      expect(delivered).not.toContain('"type":"bar"');
+    } finally {
+      releaseStream();
+      await handlePromise;
+      clearBackgroundChannelDelivery(sessionId);
+    }
+  });
+
   it("surfaces foreground sub-agent progress (tool_execution_update) as a live card step", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-fg-progress" });
@@ -2780,6 +2870,31 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(contentCalls.some((c) => c.includes("Ran "))).toBe(false);
     expect(contentCalls.some((c) => c.includes("正在核对 conntrack 会话时间线"))).toBe(true);
     expect(contentCalls.at(-1)).toContain("结论：公网入口丢包。");
+  });
+
+  it("never restores renderer source through the activity milestone fallback", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-tool-visual-source" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_update",
+        toolCallId: "t1",
+        partialResult: {
+          content: [{ type: "text", text: '```chart\n{"type":"bar","data":[1,2]}\n```' }],
+        },
+      };
+      yield {
+        type: "message_end",
+        message: { role: "assistant", content: [{ type: "text", text: "结论：请求已恢复。" }] },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("排查"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const contentCalls = lark.cardkit.v1.cardElement.content.mock.calls.map((c: any) => c[0].data.content as string);
+    expect(contentCalls.some((c) => c.includes("```chart") || c.includes('"type":"bar"'))).toBe(false);
+    expect(contentCalls.at(-1)).toContain("结论：请求已恢复。");
   });
 
   it("localizes the sub-agent slot wait instead of leaking its English source text", async () => {
@@ -3262,7 +3377,42 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(lark.im.message.reply).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps ControlPlane visual-card source as markdown when no PNG artifact is available", async () => {
+  it("keeps feedback available for an image-only rendered answer", async () => {
+    const onePixelBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-image-only-feedback" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "tool_execution_end",
+        toolName: "render_chart",
+        result: { content: [{ type: "image", data: onePixelBase64, mimeType: "image/png" }] },
+      };
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: '```chart\n{"type":"bar","data":[1,2]}\n```' }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    expect(lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content).toContain("图片");
+    expect(lark.cardkit.v1.cardElement.create).toHaveBeenCalledTimes(1);
+    expect(lark.im.image.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips legacy visual-card source even when no PNG artifact is available", async () => {
     resolveBindingMock.mockResolvedValue(makeBinding());
     promptMock.mockResolvedValue({ sessionId: "s-visual-card" });
     streamEventsMock.mockImplementation(async function* () {
@@ -3303,10 +3453,42 @@ describe("handleLarkMessage — streaming card flow", () => {
 
     const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
     expect(cardContent).toContain("api pods");
-    expect(cardContent).toContain("```visual-card");
-    expect(cardContent).toContain("CrashLoopBackOff in prod");
+    expect(cardContent).not.toContain("```visual-card");
+    expect(cardContent).not.toContain("CrashLoopBackOff in prod");
     expect(lark.im.image.create).not.toHaveBeenCalled();
     expect(lark.im.message.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attach feedback to a legacy visual-card-only empty result", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-visual-card-only" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: '```visual-card\n{"type":"report","title":"legacy"}\n```',
+          }],
+        },
+      };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(
+      makeTextEvent("hello"),
+      lark,
+      "lark",
+      makeAgentBoxManager("a1") as any,
+      undefined,
+      {} as any,
+    );
+
+    const cardContent = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
+    expect(cardContent).toContain("⚠");
+    expect(cardContent).not.toContain("visual-card");
+    expect(lark.cardkit.v1.cardElement.create).not.toHaveBeenCalled();
   });
 
   it("does not reply with an image when the final answer has no image artifact", async () => {
@@ -3624,6 +3806,7 @@ describe("handleLarkMessage — streaming card flow", () => {
 
     const contentText = lark.cardkit.v1.cardElement.content.mock.calls[0][0].data.content;
     expect(contentText).toContain("\u26A0");  // warning emoji in EMPTY_RESULT_NOTICE
+    expect(lark.cardkit.v1.cardElement.create).not.toHaveBeenCalled();
   });
 });
 
@@ -3724,6 +3907,45 @@ describe("collectResponse — SSE event flattening", () => {
     expect(milestones).toEqual(["先看 node 状态", "node 正常,继续查 `sichek`"]);
     // The final turn is the answer, not a milestone.
     expect(collected.text).toBe("结论:GPU#3 fatal,建议换卡。");
+  });
+
+  it("never exposes renderer source in intermediate channel milestones", async () => {
+    const events = [
+      {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: "```chart\n{\"type\":\"bar\",\"data\":[1,2]}\n```\n继续核对指标",
+          }],
+        },
+      },
+      {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{
+            type: "text",
+            text: "```visual-card\n{\"type\":\"report\"}\n```",
+          }],
+        },
+      },
+      {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "最终结论" }],
+        },
+      },
+    ];
+    const milestones: string[] = [];
+    const collected = await collectChannelResponse(fakeClient(events), "s-ms-visual", "lark", {
+      onMilestone: (m) => milestones.push(m),
+    });
+
+    expect(milestones).toEqual(["继续核对指标"]);
+    expect(collected.text).toBe("最终结论");
   });
 
   it("ignores non-text blocks (e.g. tool_use blocks) inside an assistant message", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1923,7 +1923,8 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   };
   registerBackgroundChannelDelivery(sessionId, async (backgroundMessage) => {
     if ("text" in backgroundMessage) {
-      const display = stripVisualBlocks(backgroundMessage.text);
+      const display = stripVisualBlocks(backgroundMessage.text, { stripSourceBlocks: true })
+        || (backgroundMessage.kind === "final" ? EMPTY_RESULT_NOTICE_BY_LOCALE[locale] : "");
       if (!display || !display.trim()) return true;
 
       if (backgroundMessage.kind === "final") {
@@ -1945,7 +1946,8 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       return true;
     }
 
-    const display = stripVisualBlocks(backgroundMessage.content) || EMPTY_RESULT_NOTICE_BY_LOCALE[locale];
+    const display = stripVisualBlocks(backgroundMessage.content, { stripSourceBlocks: true })
+      || EMPTY_RESULT_NOTICE_BY_LOCALE[locale];
     if (!shouldDeliverBackgroundReply(display, deliveredTextChars)) return true;
     const md = buildMilestoneCardMarkdown({ milestones: [], finalText: display });
     if (cardSession) {
@@ -2065,14 +2067,16 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
 
   // Session-busy and other errors both get a sanitized notice \u2014 the raw error (internal
   // endpoints, 409 JSON) must never reach the chat; it was logged above.
-  const finalBody = sessionBusy
+  if (agentError || sessionBusy) replyImages = [];
+  const sanitizedResultBody = stripVisualBlocks(resultText, { stripSourceBlocks: replyImages.length > 0 });
+  const displayBody = sessionBusy
     ? SESSION_BUSY_NOTICE_BY_LOCALE[locale]
     : agentError
       ? AGENT_ERROR_NOTICE_BY_LOCALE[locale]
-      : (resultText || EMPTY_RESULT_NOTICE_BY_LOCALE[locale]);
-  if (agentError || sessionBusy) replyImages = [];
-  const displayBody = stripVisualBlocks(finalBody, { stripSourceBlocks: replyImages.length > 0 })
-    || VISUAL_ONLY_NOTICE_BY_LOCALE[locale];
+      : sanitizedResultBody
+        || (replyImages.length > 0
+          ? VISUAL_ONLY_NOTICE_BY_LOCALE[locale]
+          : EMPTY_RESULT_NOTICE_BY_LOCALE[locale]);
   // The final card is JUST the conclusion — the live step indicator is replaced
   // entirely, no milestone trail is kept on the card.
   const finalCardBody = buildMilestoneCardMarkdown({ milestones: [], finalText: displayBody });
@@ -2087,7 +2091,9 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
     // Only solicit 👍/👎 on a real answer — never under an error or
     // empty-result notice, where a click would write a rating against a
     // non-answer and skew the feedback signal Metrics aggregates.
-    const isAnswer = !agentError && resultText.trim().length > 0;
+    const isAnswer = !agentError
+      && !sessionBusy
+      && (sanitizedResultBody.trim().length > 0 || replyImages.length > 0);
     const { ok, contentOk } = await finalizeCard(larkClient, cardSession, finalCardBody,
       isAnswer && assistantMessageId
         ? { ctx: { sessionId, channelId, messageId: assistantMessageId }, locale }
@@ -3254,7 +3260,11 @@ export async function collectChannelResponse(
  * code/bold pass through so chips still render.
  */
 function condenseMilestone(text: string): string {
-  const firstLine = text.split("\n").map((s) => s.trim()).find(Boolean) ?? "";
+  // Intermediate assistant turns share the same IM output boundary as final
+  // replies. Strip renderer source before selecting the first visible line so
+  // a tool-result echo can never become a transient live-card milestone.
+  const visibleText = stripVisualBlocks(text, { stripSourceBlocks: true });
+  const firstLine = visibleText.split("\n").map((s) => s.trim()).find(Boolean) ?? "";
   const clean = firstLine.replace(/^#{1,6}\s+/, "").trim();
   if (!clean) return "";
   return clean.length > 90 ? `${clean.slice(0, 88)}…` : clean;
@@ -3283,7 +3293,8 @@ function channelActivityMilestone(activity: string, locale?: LarkLocale): string
   if (/^Waiting for a free slot/i.test(clean)) {
     return locale === "en-US" ? "Waiting for a free sub-agent slot…" : "排队等待子任务空位…";
   }
-  return condenseMilestone(clean) || clean;
+  return condenseMilestone(clean)
+    || stripVisualBlocks(clean, { stripSourceBlocks: true }).trim();
 }
 
 function contentBlocksToMarkdown(blocks: unknown[]): string {

--- a/src/gateway/channels/visual-image.test.ts
+++ b/src/gateway/channels/visual-image.test.ts
@@ -39,12 +39,16 @@ describe("collectImageAttachments", () => {
 });
 
 describe("stripVisualBlocks", () => {
-  it("removes only data images from display markdown by default", () => {
+  it("removes data images and legacy report-card source by default", () => {
     const markdown = [
       "Summary",
       "",
       "```chart",
       "{\"type\":\"bar\"}",
+      "```",
+      "",
+      "```visual-card",
+      "{\"type\":\"report\",\"title\":\"internal shape\"}",
       "```",
       "",
       `![chart](${onePixelPng})`,
@@ -55,6 +59,8 @@ describe("stripVisualBlocks", () => {
     const display = stripVisualBlocks(markdown);
 
     expect(display).toContain("```chart");
+    expect(display).not.toContain("```visual-card");
+    expect(display).not.toContain("internal shape");
     expect(display).not.toContain("data:image/png");
     expect(display).toContain("Keep this.");
   });

--- a/src/gateway/channels/visual-image.ts
+++ b/src/gateway/channels/visual-image.ts
@@ -35,12 +35,15 @@ export function collectImageAttachments(
 
 export function stripVisualBlocks(markdown: string, options: StripVisualBlocksOptions = {}): string {
   let output = stripDataImages(markdown);
+  // These legacy report containers are no longer authored by Siclaw. Existing
+  // web readers may remain tolerant, but never expose their JSON source in an
+  // IM channel when an older session or skill still produces one.
+  output = stripFences(output, "visual-card");
+  output = stripFences(output, "siclaw-card");
+  output = stripFences(output, "conclusion-card");
   if (options.stripSourceBlocks) {
     output = stripFences(output, "chart");
     output = stripFences(output, "mermaid");
-    output = stripFences(output, "visual-card");
-    output = stripFences(output, "siclaw-card");
-    output = stripFences(output, "conclusion-card");
   }
   return cleanupMarkdown(output);
 }


### PR DESCRIPTION
## Summary

- remove the bundled `render_visual_card` authoring path so final conclusions remain natural-language answers
- keep chart and Mermaid rendering as optional images for IM while retaining source blocks required by the existing web renderer; renderer metadata is no longer returned
- require an explicit visual export URL and forward that narrow runtime contract into AgentBox MCP processes
- suppress legacy visual-card source blocks in IM delivery while leaving existing web readers untouched

## Deployment note

Deployments that use the bundled chart or Mermaid renderer must set `runtime.visualExport.url` to a reachable ControlPlane Web `/siclaw-visual-export` endpoint. The chart no longer guesses an internal Service DNS name.

## Verification

- `npm test -- --run` (302 files, 6719 passed, 2 skipped)
- focused Lark, visual-image, and MCP-client tests (281 passed)
- `npm run build`
- `npm --prefix mcp/create-chart run build`
- `helm lint helm/siclaw`
- default and configured `helm template` renders
- `git diff --check`
