### PR TITLE
feat(mcp): add product-support-result stdio MCP

### DIFF
--- a/mcp/MCP_LIST.txt
+++ b/mcp/MCP_LIST.txt
@@ -27,3 +27,4 @@
 # and append <name> to this file.
 
 create-chart
+product-support-result

--- a/mcp/product-support-result/README.md
+++ b/mcp/product-support-result/README.md
@@ -1,0 +1,61 @@
+# mcp-product-support-result
+
+A stateless stdio MCP server that validates and serializes the handoff decision
+for a product-support conversation turn. It has no network access and performs
+no ticket, group, or notification side effect.
+
+## Tool
+
+`submit_product_support_result(label, info)` returns the canonical result as
+both MCP text content and `structuredContent`.
+
+```json
+{
+  "label": true,
+  "info": {
+    "ticket_type": "incident",
+    "product": "Example Product",
+    "summary": "Training task cannot start",
+    "description": "Task task-123 remains Pending after retry.",
+    "evidence": ["task_id=task-123", "status=Pending"],
+    "missing_fields": []
+  }
+}
+```
+
+`ticket_type` is one of `consultation`, `incident`, `requirement`, or
+`unknown`. A `label=true` result must resolve the type, provide a non-empty
+summary and description, and have no missing fields. Requirements must also
+name a concrete product grounded in product knowledge. For incidents and
+consultations, a concrete `product` must be established by the conversation or
+authoritative product knowledge; otherwise leave it empty, preserve the
+user-visible entry in `description`, and let first-line support determine
+ownership. `missing_fields` contains lowercase `snake_case` machine identifiers
+only, never questions or diagnostic instructions.
+
+The server validates each call independently. It does not know Siclaw session
+or turn identity, so "exactly one successful result per turn" is not enforced
+here — the caller that consumes the result owns that rule.
+
+## Portal MCP config
+
+```json
+{
+  "name": "product-support-result",
+  "transport": "stdio",
+  "command": "mcp-product-support-result",
+  "args": [],
+  "env": {}
+}
+```
+
+The binary is built into the AgentBox image from `mcp/MCP_LIST.txt` and linked
+as `mcp-product-support-result` on `PATH`, so the config above needs no
+absolute path.
+
+A successful call appears in the streamed `tool_execution_end` event for
+`mcp__product-support-result__submit_product_support_result`, carrying the
+validated object as MCP `structuredContent`. A control plane that pins this
+full tool name as an Agent's required result tool can therefore treat that
+object as the turn's single machine-readable outcome, and fail the turn closed
+when it is absent, duplicated, or upstream-failed.

--- a/mcp/product-support-result/README.md
+++ b/mcp/product-support-result/README.md
@@ -68,9 +68,28 @@ These fields are hints, not gates. Fill each one only from what the
 conversation establishes and leave it empty otherwise; a `label=true`
 `llm_incident` does not require any of them. While still gathering, the
 identifiers `llm_region`, `llm_aspect` and `llm_model` may appear in
-`missing_fields`. For every other `ticket_type` all three fields must be empty,
-so a stray region or model name is never read as an established fact. The
-block is always present.
+`missing_fields`. The block may already be filled while `ticket_type` is still
+`unknown`, so a region or model the user stated up front has somewhere to
+live; once the type resolves to `consultation`, `incident` or `requirement`
+all three fields must be empty, so a stray value is never read as an
+established fact. The block is always present.
+
+### Size limits
+
+The validated result is persisted downstream as one row's metadata, so every
+field is bounded and an oversized value is rejected here, where the model can
+shorten it. Limits are in characters, not bytes.
+
+| Field | Limit |
+| --- | --- |
+| `summary` | 200 |
+| `description` | 2000 |
+| `product`, `llm.model` | 128 |
+| `evidence` | 20 items, 300 characters each |
+| `missing_fields` | 20 items, 64 characters each |
+
+Enum fields (`ticket_type`, `llm.region`, `llm.aspect`) are trimmed and
+lower-cased on input and always returned in canonical lowercase.
 
 The server validates each call independently. It does not know Siclaw session
 or turn identity, so "exactly one successful result per turn" is not enforced

--- a/mcp/product-support-result/README.md
+++ b/mcp/product-support-result/README.md
@@ -18,8 +18,7 @@ both MCP text content and `structuredContent`.
     "summary": "Training task cannot start",
     "description": "Task task-123 remains Pending after retry.",
     "evidence": ["task_id=task-123", "status=Pending"],
-    "missing_fields": [],
-    "llm": { "region": "", "aspect": "", "model": "" }
+    "missing_fields": []
   }
 }
 ```
@@ -72,7 +71,9 @@ identifiers `llm_region`, `llm_aspect` and `llm_model` may appear in
 `unknown`, so a region or model the user stated up front has somewhere to
 live; once the type resolves to `consultation`, `incident` or `requirement`
 all three fields must be empty, so a stray value is never read as an
-established fact. The block is always present.
+established fact. The block is optional on input: omitting it means all three
+fields are empty, which is the correct value for every type except
+`llm_incident`. It is always present in the returned result.
 
 ### Size limits
 
@@ -88,8 +89,17 @@ shorten it. Limits are in characters, not bytes.
 | `evidence` | 20 items, 300 characters each |
 | `missing_fields` | 20 items, 64 characters each |
 
-Enum fields (`ticket_type`, `llm.region`, `llm.aspect`) are trimmed and
-lower-cased on input and always returned in canonical lowercase.
+Limits apply to the raw value before trimming, exactly as a host that
+validates the advertised schema before dispatch applies `maxLength`, so the
+parser is never more lenient than the schema the model was shown.
+
+### Canonicalization
+
+The parser mirrors the advertised JSON Schema and adds nothing the schema does
+not say: enum values (`ticket_type`, `llm.region`, `llm.aspect`) must be the
+exact lowercase spelling. String fields are trimmed. `evidence` and
+`missing_fields` items are trimmed and post-trim duplicates are removed, so the
+returned arrays can be shorter than the caller's.
 
 The server validates each call independently. It does not know Siclaw session
 or turn identity, so "exactly one successful result per turn" is not enforced

--- a/mcp/product-support-result/README.md
+++ b/mcp/product-support-result/README.md
@@ -18,20 +18,59 @@ both MCP text content and `structuredContent`.
     "summary": "Training task cannot start",
     "description": "Task task-123 remains Pending after retry.",
     "evidence": ["task_id=task-123", "status=Pending"],
-    "missing_fields": []
+    "missing_fields": [],
+    "llm": { "region": "", "aspect": "", "model": "" }
   }
 }
 ```
 
-`ticket_type` is one of `consultation`, `incident`, `requirement`, or
-`unknown`. A `label=true` result must resolve the type, provide a non-empty
-summary and description, and have no missing fields. Requirements must also
-name a concrete product grounded in product knowledge. For incidents and
-consultations, a concrete `product` must be established by the conversation or
-authoritative product knowledge; otherwise leave it empty, preserve the
-user-visible entry in `description`, and let first-line support determine
-ownership. `missing_fields` contains lowercase `snake_case` machine identifiers
-only, never questions or diagnostic instructions.
+`ticket_type` is one of `consultation`, `incident`, `llm_incident`,
+`requirement`, or `unknown`. A `label=true` result must resolve the type,
+provide a non-empty summary and description, and have no missing fields.
+Requirements must also name a concrete product grounded in product knowledge.
+For incidents and consultations, a concrete `product` must be established by
+the conversation or authoritative product knowledge; otherwise leave it empty,
+preserve the user-visible entry in `description`, and let first-line support
+determine ownership. `missing_fields` contains lowercase `snake_case` machine
+identifiers only, never questions or diagnostic instructions.
+
+### `llm_incident`
+
+`llm_incident` is the fault type for problems while calling an LLM / model API
+or inference endpoint: gateway errors, authentication and rate-limit or quota
+failures, broken streaming, or a specific named model misbehaving. `incident`
+remains every other fault.
+
+The `llm` block carries best-effort intake details for first-line support:
+
+```json
+{
+  "label": true,
+  "info": {
+    "ticket_type": "llm_incident",
+    "product": "",
+    "summary": "Chat completions return 429",
+    "description": "Every request to the model API has returned HTTP 429 since this morning.",
+    "evidence": ["HTTP 429", "model=example-model-v2"],
+    "missing_fields": [],
+    "llm": { "region": "overseas", "aspect": "model", "model": "example-model-v2" }
+  }
+}
+```
+
+| Field | Values | Meaning |
+| --- | --- | --- |
+| `llm.region` | `""`, `domestic`, `overseas` | Deployment region the user calls from, per the operator's own classification rules |
+| `llm.aspect` | `""`, `platform_api`, `network`, `model` | Failing part of the path: the API platform or gateway, network reachability, or a specific model |
+| `llm.model` | free text | Model name as the user stated it |
+
+These fields are hints, not gates. Fill each one only from what the
+conversation establishes and leave it empty otherwise; a `label=true`
+`llm_incident` does not require any of them. While still gathering, the
+identifiers `llm_region`, `llm_aspect` and `llm_model` may appear in
+`missing_fields`. For every other `ticket_type` all three fields must be empty,
+so a stray region or model name is never read as an established fact. The
+block is always present.
 
 The server validates each call independently. It does not know Siclaw session
 or turn identity, so "exactly one successful result per turn" is not enforced

--- a/mcp/product-support-result/package-lock.json
+++ b/mcp/product-support-result/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-product-support-result",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-product-support-result",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1"

--- a/mcp/product-support-result/package-lock.json
+++ b/mcp/product-support-result/package-lock.json
@@ -1,0 +1,1223 @@
+{
+  "name": "mcp-product-support-result",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-product-support-result",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "bin": {
+        "mcp-product-support-result": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/product-support-result/package-lock.json
+++ b/mcp/product-support-result/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-product-support-result",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-product-support-result",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0"

--- a/mcp/product-support-result/package-lock.json
+++ b/mcp/product-support-result/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "mcp-product-support-result",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-product-support-result",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.27.1"
       },
       "bin": {
         "mcp-product-support-result": "dist/index.js"
@@ -23,24 +23,24 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
-      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18.14.1"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
-      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -604,9 +604,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
-      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/mcp/product-support-result/package.json
+++ b/mcp/product-support-result/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mcp-product-support-result",
+  "version": "0.1.0",
+  "description": "Stateless MCP validator for product-support handoff results",
+  "type": "module",
+  "bin": {
+    "mcp-product-support-result": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "clean": "rm -rf dist"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/mcp/product-support-result/package.json
+++ b/mcp/product-support-result/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-product-support-result",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Stateless MCP validator for product-support handoff results",
   "type": "module",
   "bin": {
@@ -20,7 +20,7 @@
     "node": ">=22.12.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.27.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/mcp/product-support-result/package.json
+++ b/mcp/product-support-result/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-product-support-result",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Stateless MCP validator for product-support handoff results",
   "type": "module",
   "bin": {

--- a/mcp/product-support-result/package.json
+++ b/mcp/product-support-result/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-product-support-result",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Stateless MCP validator for product-support handoff results",
   "type": "module",
   "bin": {

--- a/mcp/product-support-result/src/index.ts
+++ b/mcp/product-support-result/src/index.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createProductSupportResultServer } from "./server.js";
+
+async function main(): Promise<void> {
+  const server = createProductSupportResultServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write("[mcp-product-support-result] ready\n");
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `[mcp-product-support-result] fatal: ${error instanceof Error ? error.stack : String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/mcp/product-support-result/src/result.test.ts
+++ b/mcp/product-support-result/src/result.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { parseProductSupportResult } from "./result.js";
+
+function validResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    label: true,
+    info: {
+      ticket_type: "incident",
+      product: "",
+      summary: "Training task cannot start",
+      description: "Task task-123 remains Pending after retry.",
+      evidence: ["task_id=task-123", "status=Pending"],
+      missing_fields: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("parseProductSupportResult", () => {
+  it("canonicalizes a ticket-ready result", () => {
+    const result = parseProductSupportResult(
+      validResult({
+        info: {
+          ticket_type: "incident",
+          product: "  Example Product  ",
+          summary: "  Task cannot start  ",
+          description: "  task-123 remains Pending.  ",
+          evidence: [" task_id=task-123 ", "task_id=task-123", " status=Pending "],
+          missing_fields: [],
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      label: true,
+      info: {
+        ticket_type: "incident",
+        product: "Example Product",
+        summary: "Task cannot start",
+        description: "task-123 remains Pending.",
+        evidence: ["task_id=task-123", "status=Pending"],
+        missing_fields: [],
+      },
+    });
+  });
+
+  it("accepts an incomplete non-handoff result", () => {
+    const result = parseProductSupportResult({
+      label: false,
+      info: {
+        ticket_type: "unknown",
+        product: "",
+        summary: "",
+        description: "",
+        evidence: [],
+        missing_fields: ["affected_product", "error_message"],
+      },
+    });
+
+    expect(result.label).toBe(false);
+    expect(result.info.missing_fields).toEqual(["affected_product", "error_message"]);
+  });
+
+  it("requires a concrete product for a ticket-ready requirement", () => {
+    expect(() =>
+        parseProductSupportResult(
+          validResult({
+            info: {
+              ticket_type: "requirement",
+              product: " ",
+              summary: "Add an export API",
+              description: "The team needs a CSV export API.",
+              evidence: [],
+              missing_fields: [],
+            },
+          }),
+        )).toThrow(/requires info\.product/);
+  });
+
+  it("rejects unresolved ticket-ready results", () => {
+    expect(() =>
+        parseProductSupportResult(
+          validResult({
+            info: {
+              ticket_type: "unknown",
+              product: "",
+              summary: "Needs support",
+              description: "The request cannot be resolved automatically.",
+              evidence: [],
+              missing_fields: [],
+            },
+          }),
+        )).toThrow(/resolved ticket_type/);
+  });
+
+  it("requires a boolean label", () => {
+    expect(() => parseProductSupportResult({ ...validResult(), label: 1 })).toThrow(/label must be a boolean/);
+  });
+
+  it("requires a complete ticket title and description", () => {
+    const input = validResult();
+    input.info = {
+      ...(input.info as Record<string, unknown>),
+      summary: " ",
+    };
+    expect(() => parseProductSupportResult(input)).toThrow(/non-empty info\.summary/);
+  });
+
+  it("rejects ticket-ready results with missing information", () => {
+    expect(() =>
+        parseProductSupportResult(
+          validResult({
+            info: {
+              ticket_type: "incident",
+              product: "",
+              summary: "Task failed",
+              description: "Task task-123 failed.",
+              evidence: [],
+              missing_fields: ["error_message"],
+            },
+          }),
+        )).toThrow(/missing_fields to be empty/);
+  });
+
+  it("rejects user-facing questions and prose in missing fields", () => {
+    // Both shapes a model reaches for instead of a machine identifier: an
+    // English phrase with a space, and a non-ASCII question addressed to the user.
+    for (const field of ["affected product", "受影响范围：请确认是否还有其他客户端失败"]) {
+      const input = validResult({ label: false });
+      input.info = {
+        ...(input.info as Record<string, unknown>),
+        missing_fields: [field],
+      };
+      expect(() => parseProductSupportResult(input)).toThrow(/lowercase snake_case field identifier/);
+    }
+  });
+
+  it("rejects extra fields at both schema levels", () => {
+    expect(() => parseProductSupportResult({ ...validResult(), action: "create_ticket" })).toThrow(/input\.action is not allowed/);
+
+    const input = validResult();
+    input.info = { ...(input.info as Record<string, unknown>), priority: "P0" };
+    expect(() => parseProductSupportResult(input)).toThrow(/input\.info\.priority is not allowed/);
+  });
+
+  it("rejects blank evidence entries", () => {
+    const input = validResult();
+    input.info = { ...(input.info as Record<string, unknown>), evidence: [" "] };
+    expect(() => parseProductSupportResult(input)).toThrow(/evidence\[0\] must not be blank/);
+  });
+});

--- a/mcp/product-support-result/src/result.test.ts
+++ b/mcp/product-support-result/src/result.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { parseProductSupportResult } from "./result.js";
 
+function emptyLlm(): Record<string, string> {
+  return { region: "", aspect: "", model: "" };
+}
+
 function validResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     label: true,
@@ -11,6 +15,7 @@ function validResult(overrides: Record<string, unknown> = {}): Record<string, un
       description: "Task task-123 remains Pending after retry.",
       evidence: ["task_id=task-123", "status=Pending"],
       missing_fields: [],
+      llm: emptyLlm(),
     },
     ...overrides,
   };
@@ -27,6 +32,7 @@ describe("parseProductSupportResult", () => {
           description: "  task-123 remains Pending.  ",
           evidence: [" task_id=task-123 ", "task_id=task-123", " status=Pending "],
           missing_fields: [],
+          llm: emptyLlm(),
         },
       }),
     );
@@ -40,6 +46,7 @@ describe("parseProductSupportResult", () => {
         description: "task-123 remains Pending.",
         evidence: ["task_id=task-123", "status=Pending"],
         missing_fields: [],
+        llm: { region: "", aspect: "", model: "" },
       },
     });
   });
@@ -54,6 +61,7 @@ describe("parseProductSupportResult", () => {
         description: "",
         evidence: [],
         missing_fields: ["affected_product", "error_message"],
+        llm: emptyLlm(),
       },
     });
 
@@ -72,6 +80,7 @@ describe("parseProductSupportResult", () => {
               description: "The team needs a CSV export API.",
               evidence: [],
               missing_fields: [],
+              llm: emptyLlm(),
             },
           }),
         )).toThrow(/requires info\.product/);
@@ -88,6 +97,7 @@ describe("parseProductSupportResult", () => {
               description: "The request cannot be resolved automatically.",
               evidence: [],
               missing_fields: [],
+              llm: emptyLlm(),
             },
           }),
         )).toThrow(/resolved ticket_type/);
@@ -117,6 +127,7 @@ describe("parseProductSupportResult", () => {
               description: "Task task-123 failed.",
               evidence: [],
               missing_fields: ["error_message"],
+              llm: emptyLlm(),
             },
           }),
         )).toThrow(/missing_fields to be empty/);
@@ -147,5 +158,105 @@ describe("parseProductSupportResult", () => {
     const input = validResult();
     input.info = { ...(input.info as Record<string, unknown>), evidence: [" "] };
     expect(() => parseProductSupportResult(input)).toThrow(/evidence\[0\] must not be blank/);
+  });
+
+  it("canonicalizes a ticket-ready llm_incident with best-effort intake details", () => {
+    const result = parseProductSupportResult(
+      validResult({
+        info: {
+          ticket_type: "llm_incident",
+          product: "",
+          summary: "Chat completions return 429",
+          description: "Calls to the model API return HTTP 429 since this morning.",
+          evidence: ["HTTP 429", "model=example-model-v2"],
+          missing_fields: [],
+          llm: { region: " Overseas ", aspect: "MODEL", model: "  example-model-v2 " },
+        },
+      }),
+    );
+
+    expect(result.info.ticket_type).toBe("llm_incident");
+    expect(result.info.llm).toEqual({
+      region: "overseas",
+      aspect: "model",
+      model: "example-model-v2",
+    });
+  });
+
+  it("lets an llm_incident hand off with empty intake details instead of forcing a guess", () => {
+    const result = parseProductSupportResult(
+      validResult({
+        info: {
+          ticket_type: "llm_incident",
+          product: "",
+          summary: "Model API requests time out",
+          description: "The user reports timeouts on every request; region and model were not stated.",
+          evidence: ["timeout"],
+          missing_fields: [],
+          llm: { region: "", aspect: "network", model: "" },
+        },
+      }),
+    );
+
+    expect(result.label).toBe(true);
+    expect(result.info.llm).toEqual({ region: "", aspect: "network", model: "" });
+  });
+
+  it("keeps llm intake identifiers usable in missing_fields while still gathering", () => {
+    const result = parseProductSupportResult({
+      label: false,
+      info: {
+        ticket_type: "llm_incident",
+        product: "",
+        summary: "",
+        description: "",
+        evidence: ["HTTP 401"],
+        missing_fields: ["llm_region", "llm_aspect"],
+        llm: { region: "", aspect: "", model: "example-model-v2" },
+      },
+    });
+
+    expect(result.info.missing_fields).toEqual(["llm_region", "llm_aspect"]);
+    expect(result.info.llm.model).toBe("example-model-v2");
+  });
+
+  it("rejects region and aspect values outside the enum", () => {
+    for (const llm of [
+      { region: "eu", aspect: "", model: "" },
+      { region: "", aspect: "billing", model: "" },
+    ]) {
+      const input = validResult({ label: false });
+      input.info = { ...(input.info as Record<string, unknown>), ticket_type: "llm_incident", llm };
+      expect(() => parseProductSupportResult(input)).toThrow(/must be empty or one of/);
+    }
+  });
+
+  it("rejects llm intake details on any other ticket type", () => {
+    for (const ticketType of ["incident", "consultation", "requirement", "unknown"]) {
+      const input = validResult({ label: false });
+      input.info = {
+        ...(input.info as Record<string, unknown>),
+        ticket_type: ticketType,
+        llm: { region: "domestic", aspect: "", model: "" },
+      };
+      expect(() => parseProductSupportResult(input)).toThrow(/unless ticket_type is llm_incident/);
+    }
+  });
+
+  it("requires the llm block with exactly its three keys", () => {
+    const missing = validResult();
+    delete (missing.info as Record<string, unknown>).llm;
+    expect(() => parseProductSupportResult(missing)).toThrow(/input\.info\.llm is required/);
+
+    const extra = validResult();
+    extra.info = {
+      ...(extra.info as Record<string, unknown>),
+      llm: { region: "", aspect: "", model: "", vendor: "x" },
+    };
+    expect(() => parseProductSupportResult(extra)).toThrow(/input\.info\.llm\.vendor is not allowed/);
+
+    const partial = validResult();
+    partial.info = { ...(partial.info as Record<string, unknown>), llm: { region: "", aspect: "" } };
+    expect(() => parseProductSupportResult(partial)).toThrow(/input\.info\.llm\.model is required/);
   });
 });

--- a/mcp/product-support-result/src/result.test.ts
+++ b/mcp/product-support-result/src/result.test.ts
@@ -170,7 +170,7 @@ describe("parseProductSupportResult", () => {
           description: "Calls to the model API return HTTP 429 since this morning.",
           evidence: ["HTTP 429", "model=example-model-v2"],
           missing_fields: [],
-          llm: { region: " Overseas ", aspect: "MODEL", model: "  example-model-v2 " },
+          llm: { region: "overseas", aspect: "model", model: "  example-model-v2 " },
         },
       }),
     );
@@ -261,21 +261,27 @@ describe("parseProductSupportResult", () => {
     expect(result.info.llm.region).toBe("domestic");
   });
 
-  it("normalizes ticket_type case like the other enum fields", () => {
-    const result = parseProductSupportResult(
-      validResult({
-        info: {
-          ticket_type: " Incident ",
-          product: "",
-          summary: "Task failed",
-          description: "Task task-123 failed.",
-          evidence: [],
-          missing_fields: [],
-          llm: emptyLlm(),
-        },
-      }),
-    );
-    expect(result.info.ticket_type).toBe("incident");
+  it("mirrors the advertised schema: enum values are exact and length applies to the raw string", () => {
+    // The host validates the advertised schema before dispatch on the primary
+    // path, so the parser must not be more lenient than that schema.
+    const enumInput = validResult({ label: false });
+    enumInput.info = { ...(enumInput.info as Record<string, unknown>), ticket_type: " Incident " };
+    expect(() => parseProductSupportResult(enumInput)).toThrow(/ticket_type must be one of/);
+
+    const regionInput = validResult({ label: false });
+    regionInput.info = {
+      ...(regionInput.info as Record<string, unknown>),
+      ticket_type: "llm_incident",
+      llm: { region: "Overseas", aspect: "", model: "" },
+    };
+    expect(() => parseProductSupportResult(regionInput)).toThrow(/region must be empty or one of/);
+
+    const lengthInput = validResult();
+    lengthInput.info = {
+      ...(lengthInput.info as Record<string, unknown>),
+      summary: "x".repeat(LIMITS.summaryMaxChars) + "\n",
+    };
+    expect(() => parseProductSupportResult(lengthInput)).toThrow(/summary must be at most 200 characters/);
   });
 
   it("reports missing_fields errors at the caller's index, not the deduplicated one", () => {
@@ -318,10 +324,10 @@ describe("parseProductSupportResult", () => {
     expect(parseProductSupportResult(input).info.summary.length).toBe(LIMITS.summaryMaxChars);
   });
 
-  it("requires the llm block with exactly its three keys", () => {
-    const missing = validResult();
-    delete (missing.info as Record<string, unknown>).llm;
-    expect(() => parseProductSupportResult(missing)).toThrow(/input\.info\.llm is required/);
+  it("treats an absent llm block as all-empty and requires all three keys when present", () => {
+    const absent = validResult();
+    delete (absent.info as Record<string, unknown>).llm;
+    expect(parseProductSupportResult(absent).info.llm).toEqual({ region: "", aspect: "", model: "" });
 
     const extra = validResult();
     extra.info = {

--- a/mcp/product-support-result/src/result.test.ts
+++ b/mcp/product-support-result/src/result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseProductSupportResult } from "./result.js";
+import { LIMITS, parseProductSupportResult } from "./result.js";
 
 function emptyLlm(): Record<string, string> {
   return { region: "", aspect: "", model: "" };
@@ -231,8 +231,8 @@ describe("parseProductSupportResult", () => {
     }
   });
 
-  it("rejects llm intake details on any other ticket type", () => {
-    for (const ticketType of ["incident", "consultation", "requirement", "unknown"]) {
+  it("rejects llm intake details once the type has resolved to a non-LLM one", () => {
+    for (const ticketType of ["incident", "consultation", "requirement"]) {
       const input = validResult({ label: false });
       input.info = {
         ...(input.info as Record<string, unknown>),
@@ -241,6 +241,81 @@ describe("parseProductSupportResult", () => {
       };
       expect(() => parseProductSupportResult(input)).toThrow(/unless ticket_type is llm_incident/);
     }
+  });
+
+  it("lets an unresolved turn record llm details the user already stated", () => {
+    // During intake ticket_type is unknown by construction; a region heard in
+    // the first message must have somewhere to live before the type resolves.
+    const result = parseProductSupportResult({
+      label: false,
+      info: {
+        ticket_type: "unknown",
+        product: "",
+        summary: "",
+        description: "",
+        evidence: [],
+        missing_fields: ["actual_behavior"],
+        llm: { region: "domestic", aspect: "", model: "" },
+      },
+    });
+    expect(result.info.llm.region).toBe("domestic");
+  });
+
+  it("normalizes ticket_type case like the other enum fields", () => {
+    const result = parseProductSupportResult(
+      validResult({
+        info: {
+          ticket_type: " Incident ",
+          product: "",
+          summary: "Task failed",
+          description: "Task task-123 failed.",
+          evidence: [],
+          missing_fields: [],
+          llm: emptyLlm(),
+        },
+      }),
+    );
+    expect(result.info.ticket_type).toBe("incident");
+  });
+
+  it("reports missing_fields errors at the caller's index, not the deduplicated one", () => {
+    const input = validResult({ label: false });
+    input.info = {
+      ...(input.info as Record<string, unknown>),
+      missing_fields: ["a", "a", "Bad Field"],
+    };
+    expect(() => parseProductSupportResult(input)).toThrow(/missing_fields\[2\] must be a lowercase snake_case/);
+  });
+
+  it("rejects oversized fields so the model can shorten them instead of losing the row", () => {
+    const long = (n: number) => "x".repeat(n + 1);
+    const cases: Array<[Record<string, unknown>, RegExp]> = [
+      [{ summary: long(LIMITS.summaryMaxChars) }, /summary must be at most 200 characters/],
+      [{ description: long(LIMITS.descriptionMaxChars) }, /description must be at most 2000 characters/],
+      [{ product: long(LIMITS.productMaxChars) }, /product must be at most 128 characters/],
+      [{ evidence: Array.from({ length: LIMITS.evidenceMaxItems + 1 }, (_, i) => `e${i}`) }, /evidence must have at most 20 items/],
+      [{ evidence: [long(LIMITS.evidenceItemMaxChars)] }, /evidence\[0\] must be at most 300 characters/],
+      [{ missing_fields: Array.from({ length: LIMITS.missingFieldsMaxItems + 1 }, (_, i) => `f${i}`) }, /missing_fields must have at most 20 items/],
+    ];
+    for (const [patch, re] of cases) {
+      const input = validResult({ label: false });
+      input.info = { ...(input.info as Record<string, unknown>), ...patch };
+      expect(() => parseProductSupportResult(input)).toThrow(re);
+    }
+
+    const model = validResult({ label: false });
+    model.info = {
+      ...(model.info as Record<string, unknown>),
+      ticket_type: "llm_incident",
+      llm: { region: "", aspect: "", model: long(LIMITS.modelMaxChars) },
+    };
+    expect(() => parseProductSupportResult(model)).toThrow(/llm\.model must be at most 128 characters/);
+  });
+
+  it("counts limits in characters, not bytes, so CJK text is not penalized", () => {
+    const input = validResult();
+    input.info = { ...(input.info as Record<string, unknown>), summary: "故".repeat(LIMITS.summaryMaxChars) };
+    expect(parseProductSupportResult(input).info.summary.length).toBe(LIMITS.summaryMaxChars);
   });
 
   it("requires the llm block with exactly its three keys", () => {

--- a/mcp/product-support-result/src/result.ts
+++ b/mcp/product-support-result/src/result.ts
@@ -1,11 +1,38 @@
 export const TICKET_TYPES = [
   "consultation",
   "incident",
+  "llm_incident",
   "requirement",
   "unknown",
 ] as const;
 
 export type TicketType = (typeof TICKET_TYPES)[number];
+
+/**
+ * Deployment region the user is calling the LLM API from, as classified by the
+ * operator's own rules. Empty when the conversation does not establish it.
+ */
+export const LLM_REGIONS = ["domestic", "overseas"] as const;
+export type LlmRegion = (typeof LLM_REGIONS)[number];
+
+/**
+ * Which part of the LLM API path the user reports as failing. Empty when the
+ * conversation does not establish it.
+ */
+export const LLM_ASPECTS = ["platform_api", "network", "model"] as const;
+export type LlmAspect = (typeof LLM_ASPECTS)[number];
+
+/**
+ * Best-effort intake details for an `llm_incident`. Every field may stay empty:
+ * the block exists so first-line support sees what the conversation did
+ * establish, not so the agent is forced to guess. Only the enum shape is
+ * validated; none of the fields is required for a ticket-ready result.
+ */
+export interface LlmIncidentInfo {
+  region: "" | LlmRegion;
+  aspect: "" | LlmAspect;
+  model: string;
+}
 
 export interface ProductSupportInfo {
   ticket_type: TicketType;
@@ -14,6 +41,7 @@ export interface ProductSupportInfo {
   description: string;
   evidence: string[];
   missing_fields: string[];
+  llm: LlmIncidentInfo;
 }
 
 export interface ProductSupportResult {
@@ -29,8 +57,12 @@ const INFO_KEYS = new Set([
   "description",
   "evidence",
   "missing_fields",
+  "llm",
 ]);
+const LLM_KEYS = new Set(["region", "aspect", "model"]);
 const TICKET_TYPE_SET = new Set<string>(TICKET_TYPES);
+const LLM_REGION_SET = new Set<string>(LLM_REGIONS);
+const LLM_ASPECT_SET = new Set<string>(LLM_ASPECTS);
 const MISSING_FIELD_PATTERN = /^[a-z][a-z0-9_]*$/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -61,6 +93,22 @@ function readString(value: unknown, path: string): string {
   return value.trim();
 }
 
+function readOptionalEnum<T extends string>(
+  value: unknown,
+  allowed: ReadonlySet<string>,
+  options: readonly T[],
+  path: string,
+): "" | T {
+  const text = readString(value, path).toLowerCase();
+  if (text.length === 0) {
+    return "";
+  }
+  if (!allowed.has(text)) {
+    throw new Error(`${path} must be empty or one of: ${options.join(", ")}`);
+  }
+  return text as T;
+}
+
 function readStringArray(value: unknown, path: string): string[] {
   if (!Array.isArray(value)) {
     throw new Error(`${path} must be an array of strings`);
@@ -79,6 +127,18 @@ function readStringArray(value: unknown, path: string): string[] {
     }
   });
   return canonical;
+}
+
+function readLlmInfo(value: unknown, path: string): LlmIncidentInfo {
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  assertExactKeys(value, LLM_KEYS, path);
+  return {
+    region: readOptionalEnum(value.region, LLM_REGION_SET, LLM_REGIONS, `${path}.region`),
+    aspect: readOptionalEnum(value.aspect, LLM_ASPECT_SET, LLM_ASPECTS, `${path}.aspect`),
+    model: readString(value.model, `${path}.model`),
+  };
 }
 
 export function parseProductSupportResult(input: unknown): ProductSupportResult {
@@ -114,6 +174,7 @@ export function parseProductSupportResult(input: unknown): ProductSupportResult 
         input.info.missing_fields,
         "input.info.missing_fields",
       ),
+      llm: readLlmInfo(input.info.llm, "input.info.llm"),
     },
   };
 
@@ -124,6 +185,17 @@ export function parseProductSupportResult(input: unknown): ProductSupportResult 
       );
     }
   });
+
+  // The llm block belongs to llm_incident only. A stray region or model on a
+  // consultation would be read by first-line support as an established fact.
+  if (result.info.ticket_type !== "llm_incident") {
+    const { region, aspect, model } = result.info.llm;
+    if (region !== "" || aspect !== "" || model !== "") {
+      throw new Error(
+        "input.info.llm fields must be empty unless ticket_type is llm_incident",
+      );
+    }
+  }
 
   if (!result.label) {
     return result;

--- a/mcp/product-support-result/src/result.ts
+++ b/mcp/product-support-result/src/result.ts
@@ -77,8 +77,12 @@ const INFO_KEYS = new Set([
   "description",
   "evidence",
   "missing_fields",
-  "llm",
 ]);
+// Optional: absent means "all three empty". All-empty is the correct value for
+// four of the five ticket types, so requiring the block would only turn the
+// most common shape into a host-side schema rejection on the turn's one
+// mandatory tool call.
+const INFO_OPTIONAL_KEYS = new Set(["llm"]);
 const LLM_KEYS = new Set(["region", "aspect", "model"]);
 const TICKET_TYPE_SET = new Set<string>(TICKET_TYPES);
 const LLM_REGION_SET = new Set<string>(LLM_REGIONS);
@@ -94,9 +98,10 @@ function assertExactKeys(
   value: Record<string, unknown>,
   expected: ReadonlySet<string>,
   path: string,
+  optional: ReadonlySet<string> = new Set(),
 ): void {
   for (const key of Object.keys(value)) {
-    if (!expected.has(key)) {
+    if (!expected.has(key) && !optional.has(key)) {
       throw new Error(`${path}.${key} is not allowed`);
     }
   }
@@ -111,11 +116,13 @@ function readString(value: unknown, path: string, maxChars: number): string {
   if (typeof value !== "string") {
     throw new Error(`${path} must be a string`);
   }
-  const text = value.trim();
-  if ([...text].length > maxChars) {
+  // Length is checked on the raw value, exactly as the advertised `maxLength`
+  // is applied by a host that validates arguments before dispatch, so this
+  // parser is never more lenient than the schema the model was shown.
+  if ([...value].length > maxChars) {
     throw new Error(`${path} must be at most ${maxChars} characters`);
   }
-  return text;
+  return value.trim();
 }
 
 function readEnum<T extends string>(
@@ -125,9 +132,14 @@ function readEnum<T extends string>(
   path: string,
   optional: boolean,
 ): "" | T {
-  // Enum fields are case-insensitive on input and canonical lowercase on
-  // output, uniformly: the model must not have to guess which field is strict.
-  const text = readString(value, path, 64).toLowerCase();
+  // Exact match only. The advertised JSON Schema `enum` is validated by the
+  // host before dispatch on the primary path, so any tolerance added here
+  // would apply on one host path and not the other; the schema is the single
+  // answer and the parser mirrors it.
+  if (typeof value !== "string") {
+    throw new Error(`${path} must be a string`);
+  }
+  const text = value;
   if (text.length === 0 && optional) {
     return "";
   }
@@ -164,6 +176,9 @@ function readStringArray(value: unknown, path: string, rules: StringArrayRules):
     if (rules.itemPattern && !rules.itemPattern.re.test(text)) {
       throw new Error(`${itemPath} ${rules.itemPattern.message}`);
     }
+    // Post-trim duplicates are dropped; this canonicalization is documented in
+    // the README and the schema description because consumers that diff the
+    // persisted tool_input against structuredContent will see it.
     if (!seen.has(text)) {
       seen.add(text);
       canonical.push(text);
@@ -196,7 +211,7 @@ export function parseProductSupportResult(input: unknown): ProductSupportResult 
   if (!isRecord(input.info)) {
     throw new Error("input.info must be an object");
   }
-  assertExactKeys(input.info, INFO_KEYS, "input.info");
+  assertExactKeys(input.info, INFO_KEYS, "input.info", INFO_OPTIONAL_KEYS);
 
   const ticketType = readEnum(
     input.info.ticket_type,
@@ -229,7 +244,10 @@ export function parseProductSupportResult(input: unknown): ProductSupportResult 
           message: "must be a lowercase snake_case field identifier",
         },
       }),
-      llm: readLlmInfo(input.info.llm, "input.info.llm"),
+      llm:
+        input.info.llm === undefined
+          ? { region: "", aspect: "", model: "" }
+          : readLlmInfo(input.info.llm, "input.info.llm"),
     },
   };
 

--- a/mcp/product-support-result/src/result.ts
+++ b/mcp/product-support-result/src/result.ts
@@ -1,0 +1,149 @@
+export const TICKET_TYPES = [
+  "consultation",
+  "incident",
+  "requirement",
+  "unknown",
+] as const;
+
+export type TicketType = (typeof TICKET_TYPES)[number];
+
+export interface ProductSupportInfo {
+  ticket_type: TicketType;
+  product: string;
+  summary: string;
+  description: string;
+  evidence: string[];
+  missing_fields: string[];
+}
+
+export interface ProductSupportResult {
+  label: boolean;
+  info: ProductSupportInfo;
+}
+
+const ROOT_KEYS = new Set(["label", "info"]);
+const INFO_KEYS = new Set([
+  "ticket_type",
+  "product",
+  "summary",
+  "description",
+  "evidence",
+  "missing_fields",
+]);
+const TICKET_TYPE_SET = new Set<string>(TICKET_TYPES);
+const MISSING_FIELD_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expected: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!expected.has(key)) {
+      throw new Error(`${path}.${key} is not allowed`);
+    }
+  }
+  for (const key of expected) {
+    if (!(key in value)) {
+      throw new Error(`${path}.${key} is required`);
+    }
+  }
+}
+
+function readString(value: unknown, path: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${path} must be a string`);
+  }
+  return value.trim();
+}
+
+function readStringArray(value: unknown, path: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${path} must be an array of strings`);
+  }
+
+  const canonical: string[] = [];
+  const seen = new Set<string>();
+  value.forEach((item, index) => {
+    const text = readString(item, `${path}[${index}]`);
+    if (text.length === 0) {
+      throw new Error(`${path}[${index}] must not be blank`);
+    }
+    if (!seen.has(text)) {
+      seen.add(text);
+      canonical.push(text);
+    }
+  });
+  return canonical;
+}
+
+export function parseProductSupportResult(input: unknown): ProductSupportResult {
+  if (!isRecord(input)) {
+    throw new Error("input must be an object");
+  }
+  assertExactKeys(input, ROOT_KEYS, "input");
+
+  if (typeof input.label !== "boolean") {
+    throw new Error("input.label must be a boolean");
+  }
+  if (!isRecord(input.info)) {
+    throw new Error("input.info must be an object");
+  }
+  assertExactKeys(input.info, INFO_KEYS, "input.info");
+
+  const ticketType = readString(input.info.ticket_type, "input.info.ticket_type");
+  if (!TICKET_TYPE_SET.has(ticketType)) {
+    throw new Error(
+      `input.info.ticket_type must be one of: ${TICKET_TYPES.join(", ")}`,
+    );
+  }
+
+  const result: ProductSupportResult = {
+    label: input.label,
+    info: {
+      ticket_type: ticketType as TicketType,
+      product: readString(input.info.product, "input.info.product"),
+      summary: readString(input.info.summary, "input.info.summary"),
+      description: readString(input.info.description, "input.info.description"),
+      evidence: readStringArray(input.info.evidence, "input.info.evidence"),
+      missing_fields: readStringArray(
+        input.info.missing_fields,
+        "input.info.missing_fields",
+      ),
+    },
+  };
+
+  result.info.missing_fields.forEach((field, index) => {
+    if (!MISSING_FIELD_PATTERN.test(field)) {
+      throw new Error(
+        `input.info.missing_fields[${index}] must be a lowercase snake_case field identifier`,
+      );
+    }
+  });
+
+  if (!result.label) {
+    return result;
+  }
+
+  if (result.info.ticket_type === "unknown") {
+    throw new Error("label=true requires a resolved ticket_type");
+  }
+  if (result.info.summary.length === 0) {
+    throw new Error("label=true requires a non-empty info.summary");
+  }
+  if (result.info.description.length === 0) {
+    throw new Error("label=true requires a non-empty info.description");
+  }
+  if (result.info.missing_fields.length > 0) {
+    throw new Error("label=true requires info.missing_fields to be empty");
+  }
+  if (result.info.ticket_type === "requirement" && result.info.product.length === 0) {
+    throw new Error("label=true with ticket_type=requirement requires info.product");
+  }
+
+  return result;
+}

--- a/mcp/product-support-result/src/result.ts
+++ b/mcp/product-support-result/src/result.ts
@@ -23,6 +23,26 @@ export const LLM_ASPECTS = ["platform_api", "network", "model"] as const;
 export type LlmAspect = (typeof LLM_ASPECTS)[number];
 
 /**
+ * Size bounds, enforced here and advertised in the tool's JSON Schema.
+ *
+ * The validated result is persisted downstream as one row's metadata, whose
+ * column is a MySQL TEXT (65,535 bytes). The bounds are chosen so that even a
+ * result filled to every limit with 3-byte UTF-8 characters stays well under
+ * that, and so that an oversized field is rejected here — where the model can
+ * shorten it — instead of being forwarded and then dropped by the INSERT.
+ */
+export const LIMITS = {
+  summaryMaxChars: 200,
+  descriptionMaxChars: 2000,
+  productMaxChars: 128,
+  modelMaxChars: 128,
+  evidenceMaxItems: 20,
+  evidenceItemMaxChars: 300,
+  missingFieldsMaxItems: 20,
+  missingFieldMaxChars: 64,
+} as const;
+
+/**
  * Best-effort intake details for an `llm_incident`. Every field may stay empty:
  * the block exists so first-line support sees what the conversation did
  * establish, not so the agent is forced to guess. Only the enum shape is
@@ -63,7 +83,8 @@ const LLM_KEYS = new Set(["region", "aspect", "model"]);
 const TICKET_TYPE_SET = new Set<string>(TICKET_TYPES);
 const LLM_REGION_SET = new Set<string>(LLM_REGIONS);
 const LLM_ASPECT_SET = new Set<string>(LLM_ASPECTS);
-const MISSING_FIELD_PATTERN = /^[a-z][a-z0-9_]*$/;
+export const MISSING_FIELD_PATTERN = "^[a-z][a-z0-9_]*$";
+const MISSING_FIELD_RE = new RegExp(MISSING_FIELD_PATTERN);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -86,40 +107,62 @@ function assertExactKeys(
   }
 }
 
-function readString(value: unknown, path: string): string {
+function readString(value: unknown, path: string, maxChars: number): string {
   if (typeof value !== "string") {
     throw new Error(`${path} must be a string`);
   }
-  return value.trim();
+  const text = value.trim();
+  if ([...text].length > maxChars) {
+    throw new Error(`${path} must be at most ${maxChars} characters`);
+  }
+  return text;
 }
 
-function readOptionalEnum<T extends string>(
+function readEnum<T extends string>(
   value: unknown,
   allowed: ReadonlySet<string>,
   options: readonly T[],
   path: string,
+  optional: boolean,
 ): "" | T {
-  const text = readString(value, path).toLowerCase();
-  if (text.length === 0) {
+  // Enum fields are case-insensitive on input and canonical lowercase on
+  // output, uniformly: the model must not have to guess which field is strict.
+  const text = readString(value, path, 64).toLowerCase();
+  if (text.length === 0 && optional) {
     return "";
   }
   if (!allowed.has(text)) {
-    throw new Error(`${path} must be empty or one of: ${options.join(", ")}`);
+    const prefix = optional ? "must be empty or one of" : "must be one of";
+    throw new Error(`${path} ${prefix}: ${options.join(", ")}`);
   }
   return text as T;
 }
 
-function readStringArray(value: unknown, path: string): string[] {
+interface StringArrayRules {
+  maxItems: number;
+  itemMaxChars: number;
+  /** Validated against each item at its ORIGINAL index, before dedup. */
+  itemPattern?: { re: RegExp; message: string };
+}
+
+function readStringArray(value: unknown, path: string, rules: StringArrayRules): string[] {
   if (!Array.isArray(value)) {
     throw new Error(`${path} must be an array of strings`);
+  }
+  if (value.length > rules.maxItems) {
+    throw new Error(`${path} must have at most ${rules.maxItems} items`);
   }
 
   const canonical: string[] = [];
   const seen = new Set<string>();
   value.forEach((item, index) => {
-    const text = readString(item, `${path}[${index}]`);
+    const itemPath = `${path}[${index}]`;
+    const text = readString(item, itemPath, rules.itemMaxChars);
     if (text.length === 0) {
-      throw new Error(`${path}[${index}] must not be blank`);
+      throw new Error(`${itemPath} must not be blank`);
+    }
+    if (rules.itemPattern && !rules.itemPattern.re.test(text)) {
+      throw new Error(`${itemPath} ${rules.itemPattern.message}`);
     }
     if (!seen.has(text)) {
       seen.add(text);
@@ -135,9 +178,9 @@ function readLlmInfo(value: unknown, path: string): LlmIncidentInfo {
   }
   assertExactKeys(value, LLM_KEYS, path);
   return {
-    region: readOptionalEnum(value.region, LLM_REGION_SET, LLM_REGIONS, `${path}.region`),
-    aspect: readOptionalEnum(value.aspect, LLM_ASPECT_SET, LLM_ASPECTS, `${path}.aspect`),
-    model: readString(value.model, `${path}.model`),
+    region: readEnum(value.region, LLM_REGION_SET, LLM_REGIONS, `${path}.region`, true),
+    aspect: readEnum(value.aspect, LLM_ASPECT_SET, LLM_ASPECTS, `${path}.aspect`, true),
+    model: readString(value.model, `${path}.model`, LIMITS.modelMaxChars),
   };
 }
 
@@ -155,44 +198,51 @@ export function parseProductSupportResult(input: unknown): ProductSupportResult 
   }
   assertExactKeys(input.info, INFO_KEYS, "input.info");
 
-  const ticketType = readString(input.info.ticket_type, "input.info.ticket_type");
-  if (!TICKET_TYPE_SET.has(ticketType)) {
-    throw new Error(
-      `input.info.ticket_type must be one of: ${TICKET_TYPES.join(", ")}`,
-    );
-  }
+  const ticketType = readEnum(
+    input.info.ticket_type,
+    TICKET_TYPE_SET,
+    TICKET_TYPES,
+    "input.info.ticket_type",
+    false,
+  ) as TicketType;
 
   const result: ProductSupportResult = {
     label: input.label,
     info: {
-      ticket_type: ticketType as TicketType,
-      product: readString(input.info.product, "input.info.product"),
-      summary: readString(input.info.summary, "input.info.summary"),
-      description: readString(input.info.description, "input.info.description"),
-      evidence: readStringArray(input.info.evidence, "input.info.evidence"),
-      missing_fields: readStringArray(
-        input.info.missing_fields,
-        "input.info.missing_fields",
+      ticket_type: ticketType,
+      product: readString(input.info.product, "input.info.product", LIMITS.productMaxChars),
+      summary: readString(input.info.summary, "input.info.summary", LIMITS.summaryMaxChars),
+      description: readString(
+        input.info.description,
+        "input.info.description",
+        LIMITS.descriptionMaxChars,
       ),
+      evidence: readStringArray(input.info.evidence, "input.info.evidence", {
+        maxItems: LIMITS.evidenceMaxItems,
+        itemMaxChars: LIMITS.evidenceItemMaxChars,
+      }),
+      missing_fields: readStringArray(input.info.missing_fields, "input.info.missing_fields", {
+        maxItems: LIMITS.missingFieldsMaxItems,
+        itemMaxChars: LIMITS.missingFieldMaxChars,
+        itemPattern: {
+          re: MISSING_FIELD_RE,
+          message: "must be a lowercase snake_case field identifier",
+        },
+      }),
       llm: readLlmInfo(input.info.llm, "input.info.llm"),
     },
   };
 
-  result.info.missing_fields.forEach((field, index) => {
-    if (!MISSING_FIELD_PATTERN.test(field)) {
-      throw new Error(
-        `input.info.missing_fields[${index}] must be a lowercase snake_case field identifier`,
-      );
-    }
-  });
-
-  // The llm block belongs to llm_incident only. A stray region or model on a
-  // consultation would be read by first-line support as an established fact.
-  if (result.info.ticket_type !== "llm_incident") {
+  // The llm block belongs to llm_incident. Once the type has resolved to a
+  // non-LLM one, a stray region or model would be read by first-line support as
+  // an established fact, so the block must be empty. While the type is still
+  // `unknown` the agent may already have heard the region or model name and
+  // needs somewhere to record it, so `unknown` is exempt.
+  if (result.info.ticket_type !== "llm_incident" && result.info.ticket_type !== "unknown") {
     const { region, aspect, model } = result.info.llm;
     if (region !== "" || aspect !== "" || model !== "") {
       throw new Error(
-        "input.info.llm fields must be empty unless ticket_type is llm_incident",
+        "input.info.llm fields must be empty unless ticket_type is llm_incident or unknown",
       );
     }
   }

--- a/mcp/product-support-result/src/server.test.ts
+++ b/mcp/product-support-result/src/server.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createProductSupportResultServer, TOOL_NAME } from "./server.js";
+
+async function withClient(
+  run: (client: Client) => Promise<void>,
+): Promise<void> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const server = createProductSupportResultServer();
+  const client = new Client({ name: "product-support-result-test", version: "0.1.0" });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    await run(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+describe("product support result MCP", () => {
+  it("advertises exactly one strict tool", async () => {
+    await withClient(async (client) => {
+      const response = await client.listTools();
+      expect(response.tools.length).toBe(1);
+      expect(response.tools[0]?.name).toBe(TOOL_NAME);
+      expect(response.tools[0]?.inputSchema.required).toEqual(["label", "info"]);
+      expect(response.tools[0]?.inputSchema.additionalProperties).toBe(false);
+      const advertisedSchema = response.tools[0]?.inputSchema as {
+        properties?: {
+          info?: {
+            properties?: {
+              missing_fields?: { items?: { pattern?: string } };
+            };
+          };
+        };
+      };
+      expect(advertisedSchema.properties?.info?.properties?.missing_fields?.items?.pattern).toBe("^[a-z][a-z0-9_]*$");
+      expect(response.tools[0]?.outputSchema).toEqual(response.tools[0]?.inputSchema);
+    });
+  });
+
+  it("returns canonical JSON as text and structured content", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool(
+        {
+          name: TOOL_NAME,
+          arguments: {
+            label: true,
+            info: {
+              ticket_type: "consultation",
+              product: "",
+              summary: "  Account access help  ",
+              description: "  User cannot find the access setting.  ",
+              evidence: [],
+              missing_fields: [],
+            },
+          },
+        },
+        CallToolResultSchema,
+      );
+
+      expect(response.isError).toBe(undefined);
+      expect(response.structuredContent).toEqual({
+        label: true,
+        info: {
+          ticket_type: "consultation",
+          product: "",
+          summary: "Account access help",
+          description: "User cannot find the access setting.",
+          evidence: [],
+          missing_fields: [],
+        },
+      });
+      expect(Array.isArray(response.content)).toBe(true);
+      const content = response.content as Array<{ type: string; text?: string }>;
+      expect(content[0]?.type).toBe("text");
+      if (content[0]?.type !== "text" || content[0].text === undefined) {
+        throw new Error("expected text content");
+      }
+      expect(JSON.parse(content[0].text)).toEqual(response.structuredContent);
+    });
+  });
+
+  it("fails closed for an invalid handoff", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool(
+        {
+          name: TOOL_NAME,
+          arguments: {
+            label: true,
+            info: {
+              ticket_type: "unknown",
+              product: "",
+              summary: "Needs support",
+              description: "User requested support.",
+              evidence: [],
+              missing_fields: [],
+            },
+          },
+        },
+        CallToolResultSchema,
+      );
+
+      expect(response.isError).toBe(true);
+      expect(response.structuredContent).toBe(undefined);
+    });
+  });
+});

--- a/mcp/product-support-result/src/server.test.ts
+++ b/mcp/product-support-result/src/server.test.ts
@@ -9,7 +9,7 @@ async function withClient(
 ): Promise<void> {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const server = createProductSupportResultServer();
-  const client = new Client({ name: "product-support-result-test", version: "0.1.0" });
+  const client = new Client({ name: "product-support-result-test", version: "0.2.0" });
 
   await server.connect(serverTransport);
   await client.connect(clientTransport);
@@ -32,13 +32,31 @@ describe("product support result MCP", () => {
       const advertisedSchema = response.tools[0]?.inputSchema as {
         properties?: {
           info?: {
+            required?: string[];
             properties?: {
+              ticket_type?: { enum?: string[] };
               missing_fields?: { items?: { pattern?: string } };
+              llm?: {
+                properties?: {
+                  region?: { enum?: string[] };
+                  aspect?: { enum?: string[] };
+                };
+              };
             };
           };
         };
       };
       expect(advertisedSchema.properties?.info?.properties?.missing_fields?.items?.pattern).toBe("^[a-z][a-z0-9_]*$");
+      expect(advertisedSchema.properties?.info?.properties?.ticket_type?.enum).toEqual([
+        "consultation",
+        "incident",
+        "llm_incident",
+        "requirement",
+        "unknown",
+      ]);
+      expect(advertisedSchema.properties?.info?.required).toContain("llm");
+      expect(advertisedSchema.properties?.info?.properties?.llm?.properties?.region?.enum).toEqual(["", "domestic", "overseas"]);
+      expect(advertisedSchema.properties?.info?.properties?.llm?.properties?.aspect?.enum).toEqual(["", "platform_api", "network", "model"]);
       expect(response.tools[0]?.outputSchema).toEqual(response.tools[0]?.inputSchema);
     });
   });
@@ -57,6 +75,7 @@ describe("product support result MCP", () => {
               description: "  User cannot find the access setting.  ",
               evidence: [],
               missing_fields: [],
+              llm: { region: "", aspect: "", model: "" },
             },
           },
         },
@@ -73,6 +92,7 @@ describe("product support result MCP", () => {
           description: "User cannot find the access setting.",
           evidence: [],
           missing_fields: [],
+          llm: { region: "", aspect: "", model: "" },
         },
       });
       expect(Array.isArray(response.content)).toBe(true);
@@ -99,6 +119,7 @@ describe("product support result MCP", () => {
               description: "User requested support.",
               evidence: [],
               missing_fields: [],
+              llm: { region: "", aspect: "", model: "" },
             },
           },
         },

--- a/mcp/product-support-result/src/server.test.ts
+++ b/mcp/product-support-result/src/server.test.ts
@@ -9,7 +9,7 @@ async function withClient(
 ): Promise<void> {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const server = createProductSupportResultServer();
-  const client = new Client({ name: "product-support-result-test", version: "0.2.0" });
+  const client = new Client({ name: "product-support-result-test", version: "0.2.1" });
 
   await server.connect(serverTransport);
   await client.connect(clientTransport);
@@ -35,7 +35,10 @@ describe("product support result MCP", () => {
             required?: string[];
             properties?: {
               ticket_type?: { enum?: string[] };
-              missing_fields?: { items?: { pattern?: string } };
+              summary?: { maxLength?: number };
+              description?: { maxLength?: number };
+              evidence?: { maxItems?: number };
+              missing_fields?: { maxItems?: number; items?: { pattern?: string } };
               llm?: {
                 properties?: {
                   region?: { enum?: string[] };
@@ -57,6 +60,10 @@ describe("product support result MCP", () => {
       expect(advertisedSchema.properties?.info?.required).toContain("llm");
       expect(advertisedSchema.properties?.info?.properties?.llm?.properties?.region?.enum).toEqual(["", "domestic", "overseas"]);
       expect(advertisedSchema.properties?.info?.properties?.llm?.properties?.aspect?.enum).toEqual(["", "platform_api", "network", "model"]);
+      expect(advertisedSchema.properties?.info?.properties?.summary?.maxLength).toBe(200);
+      expect(advertisedSchema.properties?.info?.properties?.description?.maxLength).toBe(2000);
+      expect(advertisedSchema.properties?.info?.properties?.evidence?.maxItems).toBe(20);
+      expect(advertisedSchema.properties?.info?.properties?.missing_fields?.maxItems).toBe(20);
       expect(response.tools[0]?.outputSchema).toEqual(response.tools[0]?.inputSchema);
     });
   });

--- a/mcp/product-support-result/src/server.test.ts
+++ b/mcp/product-support-result/src/server.test.ts
@@ -9,7 +9,7 @@ async function withClient(
 ): Promise<void> {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const server = createProductSupportResultServer();
-  const client = new Client({ name: "product-support-result-test", version: "0.2.1" });
+  const client = new Client({ name: "product-support-result-test", version: "0.2.2" });
 
   await server.connect(serverTransport);
   await client.connect(clientTransport);
@@ -57,7 +57,7 @@ describe("product support result MCP", () => {
         "requirement",
         "unknown",
       ]);
-      expect(advertisedSchema.properties?.info?.required).toContain("llm");
+      expect(advertisedSchema.properties?.info?.required).not.toContain("llm");
       expect(advertisedSchema.properties?.info?.properties?.llm?.properties?.region?.enum).toEqual(["", "domestic", "overseas"]);
       expect(advertisedSchema.properties?.info?.properties?.llm?.properties?.aspect?.enum).toEqual(["", "platform_api", "network", "model"]);
       expect(advertisedSchema.properties?.info?.properties?.summary?.maxLength).toBe(200);

--- a/mcp/product-support-result/src/server.ts
+++ b/mcp/product-support-result/src/server.ts
@@ -26,11 +26,14 @@ const inputSchema = {
         "description",
         "evidence",
         "missing_fields",
+        "llm",
       ],
       properties: {
         ticket_type: {
           type: "string",
-          enum: ["consultation", "incident", "requirement", "unknown"],
+          enum: ["consultation", "incident", "llm_incident", "requirement", "unknown"],
+          description:
+            "llm_incident covers failures while calling an LLM / model API or inference endpoint (gateway errors, auth, rate limits, quotas, a named model misbehaving). incident is every other fault.",
         },
         product: {
           type: "string",
@@ -53,6 +56,29 @@ const inputSchema = {
             pattern: "^[a-z][a-z0-9_]*$",
           },
         },
+        llm: {
+          type: "object",
+          additionalProperties: false,
+          required: ["region", "aspect", "model"],
+          description:
+            "Best-effort intake details for ticket_type=llm_incident, shown to first-line support as hints. Fill each field only from what the conversation establishes; leave it empty rather than guess. All three must be empty for any other ticket_type.",
+          properties: {
+            region: {
+              type: "string",
+              enum: ["", "domestic", "overseas"],
+              description: "Deployment region the user calls the LLM API from, per the operator's classification rules; empty when not established.",
+            },
+            aspect: {
+              type: "string",
+              enum: ["", "platform_api", "network", "model"],
+              description: "Failing part of the path: the API platform / gateway itself, network reachability, or a specific model; empty when not established.",
+            },
+            model: {
+              type: "string",
+              description: "Model name as the user stated it, when a specific model is involved; otherwise empty.",
+            },
+          },
+        },
       },
     },
   },
@@ -60,7 +86,7 @@ const inputSchema = {
 
 export function createProductSupportResultServer(): Server {
   const server = new Server(
-    { name: "mcp-product-support-result", version: "0.1.0" },
+    { name: "mcp-product-support-result", version: "0.2.0" },
     { capabilities: { tools: {} } },
   );
 

--- a/mcp/product-support-result/src/server.ts
+++ b/mcp/product-support-result/src/server.ts
@@ -3,7 +3,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { parseProductSupportResult } from "./result.js";
+import { LIMITS, MISSING_FIELD_PATTERN, parseProductSupportResult } from "./result.js";
 
 export const TOOL_NAME = "submit_product_support_result";
 
@@ -37,23 +37,27 @@ const inputSchema = {
         },
         product: {
           type: "string",
+          maxLength: LIMITS.productMaxChars,
           description:
             "Concrete, knowledge-grounded product for requirements. For incidents and consultations, use a concrete product only when established by the conversation or authoritative product knowledge; otherwise leave this empty and preserve the user-visible entry in description.",
         },
-        summary: { type: "string" },
-        description: { type: "string" },
+        summary: { type: "string", maxLength: LIMITS.summaryMaxChars },
+        description: { type: "string", maxLength: LIMITS.descriptionMaxChars },
         evidence: {
           type: "array",
-          items: { type: "string", minLength: 1 },
+          maxItems: LIMITS.evidenceMaxItems,
+          items: { type: "string", minLength: 1, maxLength: LIMITS.evidenceItemMaxChars },
         },
         missing_fields: {
           type: "array",
           description:
             "Blocking machine field identifiers only; never user-facing questions or diagnostic instructions.",
+          maxItems: LIMITS.missingFieldsMaxItems,
           items: {
             type: "string",
             minLength: 1,
-            pattern: "^[a-z][a-z0-9_]*$",
+            maxLength: LIMITS.missingFieldMaxChars,
+            pattern: MISSING_FIELD_PATTERN,
           },
         },
         llm: {
@@ -61,7 +65,7 @@ const inputSchema = {
           additionalProperties: false,
           required: ["region", "aspect", "model"],
           description:
-            "Best-effort intake details for ticket_type=llm_incident, shown to first-line support as hints. Fill each field only from what the conversation establishes; leave it empty rather than guess. All three must be empty for any other ticket_type.",
+            "Best-effort intake details for ticket_type=llm_incident, shown to first-line support as hints. Fill each field only from what the conversation establishes; leave it empty rather than guess. May already be filled while ticket_type is still unknown; must be empty once the type resolves to anything other than llm_incident.",
           properties: {
             region: {
               type: "string",
@@ -75,6 +79,7 @@ const inputSchema = {
             },
             model: {
               type: "string",
+              maxLength: LIMITS.modelMaxChars,
               description: "Model name as the user stated it, when a specific model is involved; otherwise empty.",
             },
           },
@@ -86,7 +91,7 @@ const inputSchema = {
 
 export function createProductSupportResultServer(): Server {
   const server = new Server(
-    { name: "mcp-product-support-result", version: "0.2.0" },
+    { name: "mcp-product-support-result", version: "0.2.1" },
     { capabilities: { tools: {} } },
   );
 

--- a/mcp/product-support-result/src/server.ts
+++ b/mcp/product-support-result/src/server.ts
@@ -1,0 +1,103 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { parseProductSupportResult } from "./result.js";
+
+export const TOOL_NAME = "submit_product_support_result";
+
+const inputSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["label", "info"],
+  properties: {
+    label: {
+      type: "boolean",
+      description: "True only when the downstream robot may create a support ticket now.",
+    },
+    info: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "ticket_type",
+        "product",
+        "summary",
+        "description",
+        "evidence",
+        "missing_fields",
+      ],
+      properties: {
+        ticket_type: {
+          type: "string",
+          enum: ["consultation", "incident", "requirement", "unknown"],
+        },
+        product: {
+          type: "string",
+          description:
+            "Concrete, knowledge-grounded product for requirements. For incidents and consultations, use a concrete product only when established by the conversation or authoritative product knowledge; otherwise leave this empty and preserve the user-visible entry in description.",
+        },
+        summary: { type: "string" },
+        description: { type: "string" },
+        evidence: {
+          type: "array",
+          items: { type: "string", minLength: 1 },
+        },
+        missing_fields: {
+          type: "array",
+          description:
+            "Blocking machine field identifiers only; never user-facing questions or diagnostic instructions.",
+          items: {
+            type: "string",
+            minLength: 1,
+            pattern: "^[a-z][a-z0-9_]*$",
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export function createProductSupportResultServer(): Server {
+  const server = new Server(
+    { name: "mcp-product-support-result", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: TOOL_NAME,
+        description:
+          "Validate and serialize the machine-readable decision for one product-support turn. This tool does not create a ticket or perform any external side effect. Produce exactly one successful result before sending the final user-facing reply; a rejected validation may be corrected and retried.",
+        inputSchema,
+        outputSchema: inputSchema,
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    if (request.params.name !== TOOL_NAME) {
+      return {
+        content: [{ type: "text", text: `Unknown tool: ${request.params.name}` }],
+        isError: true,
+      };
+    }
+
+    try {
+      const result = parseProductSupportResult(request.params.arguments ?? {});
+      return {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+        structuredContent: result,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text", text: `Invalid product support result: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}

--- a/mcp/product-support-result/src/server.ts
+++ b/mcp/product-support-result/src/server.ts
@@ -26,7 +26,6 @@ const inputSchema = {
         "description",
         "evidence",
         "missing_fields",
-        "llm",
       ],
       properties: {
         ticket_type: {
@@ -46,12 +45,14 @@ const inputSchema = {
         evidence: {
           type: "array",
           maxItems: LIMITS.evidenceMaxItems,
+          description:
+            "Error messages, timestamps, object ids and verified observations. Items are trimmed and post-trim duplicates are removed.",
           items: { type: "string", minLength: 1, maxLength: LIMITS.evidenceItemMaxChars },
         },
         missing_fields: {
           type: "array",
           description:
-            "Blocking machine field identifiers only; never user-facing questions or diagnostic instructions.",
+            "Blocking machine field identifiers only; never user-facing questions or diagnostic instructions. Items are trimmed and post-trim duplicates are removed.",
           maxItems: LIMITS.missingFieldsMaxItems,
           items: {
             type: "string",
@@ -65,7 +66,7 @@ const inputSchema = {
           additionalProperties: false,
           required: ["region", "aspect", "model"],
           description:
-            "Best-effort intake details for ticket_type=llm_incident, shown to first-line support as hints. Fill each field only from what the conversation establishes; leave it empty rather than guess. May already be filled while ticket_type is still unknown; must be empty once the type resolves to anything other than llm_incident.",
+            "Optional; omit it or send all three fields empty for any ticket_type other than llm_incident (absent means all empty). Best-effort intake details for ticket_type=llm_incident, shown to first-line support as hints. Fill each field only from what the conversation establishes; leave it empty rather than guess. May already be filled while ticket_type is still unknown; must be empty once the type resolves to consultation, incident or requirement.",
           properties: {
             region: {
               type: "string",
@@ -91,7 +92,7 @@ const inputSchema = {
 
 export function createProductSupportResultServer(): Server {
   const server = new Server(
-    { name: "mcp-product-support-result", version: "0.2.1" },
+    { name: "mcp-product-support-result", version: "0.2.2" },
     { capabilities: { tools: {} } },
   );
 

--- a/mcp/product-support-result/tsconfig.json
+++ b/mcp/product-support-result/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022"
+    ],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
## Why

`src/core/agent-types.ts` already ships the `product_support` agent type, and its built-in contract tells the agent to call a result-submission tool exactly once per turn with a machine-readable outcome. No such tool shipped in this repo, so a deployment had to layer one in from a private overlay and build the agentbox image from two sources.

This adds the tool the type already contracts for, so an agentbox image built from this repo alone can serve a Product Support agent.

## What

`mcp/product-support-result/` — a stateless stdio MCP exposing one tool:

`submit_product_support_result(label, info)` validates and canonicalizes one turn's handoff decision, returning it as both text content and MCP `structuredContent`.

- `ticket_type` is one of `consultation` / `incident` / `llm_incident` / `requirement` / `unknown`. `llm_incident` covers faults while calling an LLM / model API or inference endpoint (gateway errors, auth, rate limits, quotas, a named model misbehaving); `incident` is every other fault
- `info.llm = { region, aspect, model }` is optional on input (absent means all three empty) and always present in the result; it carries best-effort intake details for an `llm_incident`: `region` is `""` / `domestic` / `overseas`, `aspect` is `""` / `platform_api` / `network` / `model`, `model` is free text. These are hints for first-line support, not gates: a ticket-ready `llm_incident` does not require any of them, so the agent is never pushed to invent a value. For every other ticket type all three must be empty
- `label=true` requires a resolved type, non-empty summary and description, and no missing fields; a requirement additionally requires a concrete product
- `missing_fields` accepts lowercase `snake_case` machine identifiers only, never user-facing questions
- unknown keys are rejected at both schema levels

It has no network access, no ticket/group/notification side effect, and no session or turn identity, so "exactly one successful result per turn" is deliberately left to the caller that consumes the result.

Registered in `mcp/MCP_LIST.txt`, so `Dockerfile.agentbox` builds it and links `mcp-product-support-result` onto `PATH` alongside `create-chart`.

## Notes for review

- `tsconfig.json` excludes `src/**/*.test.ts` (mirroring `mcp/create-chart`) so the in-image `npm ci && npx tsc` needs no dev dependencies; `dist/` contains no test output. The tests run under the repo's vitest instead.
- The package pins `@modelcontextprotocol/sdk` `^1.27.1` with the lockfile resolving 1.27.1, the same version the repo root tests resolve, so the tested and shipped SDK are identical.

## Second commit

`c539adca` adds `llm_incident` and the `llm` block described above and bumps the package to 0.2.0. With it this package is now the single home of the tool; the private overlay copy is being removed and will not be maintained further.

`72df8e27` addresses the review: SDK pinned to the repo-root version (1.27.1), per-field size limits enforced in schema and parser, `missing_fields` errors at the caller's index, `unknown` exempt from the llm-emptiness rule, uniform enum case handling. Package 0.2.1.

`b6a6fbb5` addresses the follow-up on the approving review: the parser mirrors the advertised schema exactly (exact enum values, length checked on the raw value), `llm` is optional with absent meaning all-empty, and the post-trim de-duplication of `evidence` / `missing_fields` is documented. Package 0.2.2.

## Verification

- `npm ci && npx tsc` inside `mcp/product-support-result` — reproduces the image build step; `dist/` has `index.js`, `result.js`, `server.js` and no test output
- `npx vitest run mcp/product-support-result` — 24 passed (2 files), with the package's own `node_modules` removed so resolution goes to the repo root
- `npx vitest run` (full suite) — 304 files, 6748 passed, 2 skipped, 0 failed
- `npx tsc --noEmit` at the repo root — clean
- `npm audit` inside the package — 0 vulnerabilities

Not verified: no image was built and no deployment was exercised in this PR.


