### PR TITLE
Reduce repeated sub-agent work with explicit response forms

### DIFF
--- a/docs/design/2026-07-subagent-group.md
+++ b/docs/design/2026-07-subagent-group.md
@@ -68,6 +68,53 @@ one approval ─► tool layer: validateAndRenderGroupPlan (fail-fast) → rende
 
 ## Contracts (what must hold)
 
+### Plain-text response forms (2026-09)
+
+Every new `spawn_subagent` tool call requires `response_form`, an array of
+`{ name, question, options? }`. Names are unique headings without colons or newlines.
+Omitting `options` creates a fill-in question; providing a key-to-text object creates
+a single-choice question. Include an unknown/insufficient-evidence choice where applicable.
+The parent must still pass the target identity, time window and known facts in the briefing.
+
+Example tool argument:
+
+```json
+[
+  {"name":"cause","question":"What caused the target request to fail?","options":{"A":"Upstream service error","B":"Insufficient evidence"}},
+  {"name":"evidence","question":"Exact UTC time, service/provider, error excerpt and log coverage?"}
+]
+```
+
+The child fills the text artifact using a colon followed by an actual newline (`:\n`):
+
+```text
+cause:
+A
+
+evidence:
+12:00:00Z, target service, HTTP 429 server overload. Coverage is partial.
+```
+
+The runtime expands `A` to `Upstream service error` before returning the filled form
+as the existing `summary` text. No visual-card/JSON artifact is required from the child;
+the internal system instruction overrides presentation skills. CRLF is normalized to LF.
+Only declared headings delimit fields, so timestamps, URLs and multiline evidence survive.
+Missing, duplicate or invalid answers produce a failed report with explicit field errors
+and any valid answers preserved. There is no automatic repair prompt or second child run.
+Execution failures/timeouts keep their existing error reports and statuses.
+
+Forms propagate through single, map and reduce children, including background execution.
+The questions and option labels are retained in child audit briefings. Filled forms bypass
+the legacy 1800/6000-character summary clipping and reduce-input clipping; parents should
+ask for compact facts, not raw logs. Normal model context limits still apply.
+Full raw child responses remain available for audit.
+When reduce is requested it fills the same form for the group; omit it when per-item forms
+already answer the task to avoid an extra child execution. The existing envelope still
+returns the reduce answer instead of per-item answers when synthesis succeeds. Background
+batches without reduce now deliver the per-item answers, not just a completion count.
+
+The legacy capsule rules below continue to describe internal requests without a form.
+
 ### Tool layer (single entry)
 
 - **Uniform model-visible envelope.** Every call — collapse or batch — returns

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -1599,6 +1599,98 @@ describe("AgentBoxSessionManager — spawn_subagent batch (foreground)", () => {
   });
 
   // ── v3 decision #21: the reduce summary must come from the FULL reduce report, not the capsule ──
+  it.each(["single", "batch", "reduce", "background-single", "background-batch"])("delivers expanded, untruncated filled answers through the %s tool path", async (mode) => {
+    const mgr = new AgentBoxSessionManager() as any;
+    const persisted: any[] = [];
+    mgr.gatewayClient = { sendDelegationPersistenceEvent: async (event: any) => {
+      persisted.push(event);
+      return { ok: true };
+    } };
+    const background = mode.startsWith("background-");
+    const single = mode === "single" || mode === "background-single";
+    const notifications: any[] = [];
+    if (background) vi.spyOn(mgr, "notifyParent").mockImplementation(async (_session: unknown, _job: unknown, notification: unknown) => {
+      notifications.push(notification);
+    });
+    const prompts: string[] = [];
+    const evidence = "x".repeat(6500) + "\nLAST COVERAGE FACT";
+    const response_form = [
+      { name: "cause", question: "Cause?", options: { A: "Upstream service error", B: "Unknown" } },
+      { name: "evidence", question: "Evidence and coverage?" },
+    ];
+    const count = single ? 1 : mode === "reduce" ? 3 : 2;
+    for (let i = 0; i < count; i++) {
+      (globalThis as any).__fakeBrainFactories.push((emitter: any) => ({
+        prompt: async (prompt: string) => {
+          prompts.push(prompt);
+          emitter.emit("event", { type: "message_end", message: {
+            role: "assistant", content: [{ type: "text", text: `cause:\nA\n\nevidence:\n${evidence}` }],
+          } });
+        },
+      }));
+    }
+    const { createSpawnSubagentTool } = await import("../tools/workflow/spawn-subagent.js");
+    const tool = createSpawnSubagentTool({
+      spawnSubagentExecutor: mgr.createSpawnSubagentExecutor(), sessionIdRef: { current: "p1" },
+      agentId: "agent-1", userId: "u1", taskListId: "tl1",
+    } as any);
+    const result = await tool.execute("filled-form", {
+      description: "Check upstream", items: single ? ["Check pod-a"] : ["Check pod-a", "Check pod-b"],
+      response_form, run_in_background: background, ...(mode === "reduce" ? { reduce_prompt: "Combine the evidence" } : {}),
+    });
+    const visible = JSON.parse((result.content[0] as any).text);
+    if (background) {
+      expect(visible.status).toBe("launched");
+      await vi.waitFor(() => expect(notifications).toHaveLength(1));
+      expect(notifications[0].status).toBe("done");
+      expect(notifications[0].summary).toContain(`cause:\nUpstream service error\n\nevidence:\n${evidence}`);
+      if (!single) {
+        expect(notifications[0].summary).toContain("Check pod-a");
+        expect(notifications[0].summary).toContain("Check pod-b");
+      }
+    } else {
+      expect(visible.status).toBe("done");
+      const answers = mode === "reduce" ? [visible.reduce_summary] : visible.item_results.map((item: any) => item.summary);
+      for (const answer of answers) {
+        expect(answer).toBe(`cause:\nUpstream service error\n\nevidence:\n${evidence}`);
+      }
+    }
+    expect(prompts).toHaveLength(count);
+    const terminalEvents = persisted.filter((event) =>
+      event.type === "delegation.append_event" && !event.event.itemStatuses);
+    expect(terminalEvents).toHaveLength(count);
+    expect(terminalEvents[0].event.scope).toContain("A: Upstream service error");
+    expect(terminalEvents[0].event.capsule).toContain("cause:\nUpstream service error");
+    expect(terminalEvents[0].event.fullSummary).toContain("cause:\nA");
+    expect(prompts.every((prompt) => prompt.includes("cause:\n<answer>"))).toBe(true);
+    expect((globalThis as any).__createSessionCalls.every((opts: any) =>
+      opts.systemPromptAppend.includes("overrides presentation/report-card skills"))).toBe(true);
+    if (mode === "reduce") {
+      expect(prompts[2]).toContain("cause:\nUpstream service error");
+      expect(prompts[2]).toContain("LAST COVERAGE FACT");
+    }
+  });
+
+  it("returns valid fields plus a missing-field error without starting a repair child", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    (globalThis as any).__fakeBrainFactories.push((emitter: any) => ({
+      prompt: async () => emitter.emit("event", { type: "message_end", message: {
+        role: "assistant", content: [{ type: "text", text: "cause:\nA" }],
+      } }),
+    }));
+    const report = await mgr.createSpawnSubagentExecutor()(baseReq({
+      renderedTasks: [{ item: "pod-a", prompt: "Check pod-a" }],
+      responseForm: [
+        { name: "cause", question: "Cause?", options: { A: "Upstream service error" } },
+        { name: "evidence", question: "Evidence?" },
+      ],
+    }));
+    expect(report.status).toBe("failed");
+    expect(report.summary).toContain("cause:\nUpstream service error");
+    expect(report.summary).toContain("evidence: missing answer");
+    expect((globalThis as any).__createSessionCalls).toHaveLength(1);
+  });
+
   it("reduce summary uses the full reduce report (fullSummary), not the 1800-char capsule", async () => {
     const mgr = new AgentBoxSessionManager() as any;
     const LONG = "X".repeat(2500); // > MAX_DELEGATE_CAPSULE_CHARS (1800), < GROUP_REDUCE_SUMMARY_MAX_CHARS (6000)

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -11,6 +11,7 @@
  * and restored from JSONL on the next prompt.
  */
 
+import { buildResponseFormPrompt, parseResponseForm, SUBAGENT_RESPONSE_INSTRUCTIONS } from "../core/subagent-response-form.js";
 import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -1034,6 +1035,7 @@ export class AgentBoxSessionManager {
         const childReq: SpawnSubagentRequest = {
           description: request.description,
           prompt: task.prompt,
+          responseForm: request.responseForm,
           subagentType: request.subagentType,
           runInBackground: request.runInBackground,
           parentSessionId: request.parentSessionId,
@@ -1221,6 +1223,7 @@ export class AgentBoxSessionManager {
       const childReq: SpawnSubagentRequest = {
         description: `${request.description} [${i + 1}/${total}]`,
         prompt: tasks[i].prompt,
+        responseForm: request.responseForm,
         subagentType: request.subagentType,
         runInBackground: false,
         parentSessionId: request.parentSessionId,
@@ -1357,7 +1360,8 @@ export class AgentBoxSessionManager {
         }));
         const reduceReq: SpawnSubagentRequest = {
           description: `${request.description} — summary`,
-          prompt: buildReduceInput(request.reducePrompt, outcomes),
+          prompt: buildReduceInput(request.reducePrompt, outcomes, request.responseForm ? Number.POSITIVE_INFINITY : undefined),
+          responseForm: request.responseForm,
           subagentType: request.subagentType,
           runInBackground: false,
           parentSessionId: request.parentSessionId,
@@ -1391,7 +1395,9 @@ export class AgentBoxSessionManager {
             // Use the FULL reduce report, not the 1800-char capsule, before applying the group's
             // 6000-char budget (design decision #21): the capsule is already ≤1800, so truncating it
             // to 6000 was a no-op and the larger group budget never took effect.
-            const trunc = truncateReduceSummary(reduceRes.fullSummary ?? reduceRes.summary);
+            const trunc = request.responseForm
+              ? { text: reduceRes.summary, truncated: false }
+              : truncateReduceSummary(reduceRes.fullSummary ?? reduceRes.summary);
             reduceSummary = trunc.text;
             reduceTruncated = trunc.truncated;
             reduceChildSessionId = reduceRes.childSessionId;
@@ -2610,6 +2616,8 @@ export class AgentBoxSessionManager {
     signal?: AbortSignal,
   ): Promise<SpawnSubagentResult> {
     const startedAt = Date.now();
+    const childPrompt = this.buildSpawnedSubagentPrompt(request);
+    const auditPrompt = request.responseForm ? childPrompt : request.prompt;
     const childSessionId = opts?.childSessionId ?? randomUUID();
     // Trace context captured at dispatch by createSpawnSubagentExecutor (see there):
     //  - mainTraceId: the parent interaction's root trace id → stamps chat_messages.trace_id
@@ -2668,7 +2676,9 @@ export class AgentBoxSessionManager {
       // intentionally NOT shared with the child (nothing there would consume it).
       isSubagent: true,
       // The agent-type's prompt flavour for this child.
-      systemPromptAppend: type.systemPromptAddendum,
+      systemPromptAppend: type.systemPromptAddendum + (request.responseForm
+        ? `\n\n${SUBAGENT_RESPONSE_INSTRUCTIONS}`
+        : ""),
       // Deliberately omit spawnSubagentExecutor + delegate executors → the child
       // never sees spawn_subagent (no recursion).
     });
@@ -2716,7 +2726,7 @@ export class AgentBoxSessionManager {
     // Placed AFTER model setup so the ROOT captures llm.model_name; attach must precede
     // startPrompt (else startPrompt takes the id-only branch). Both self-gate on tracing state.
     tracingRecorder.attach(childSessionId, child.brain, { userId: request.userId, agentId });
-    tracingRecorder.startPrompt(childSessionId, request.prompt, request.userId, mainTraceId, spawnSpanContext);
+    tracingRecorder.startPrompt(childSessionId, auditPrompt, request.userId, mainTraceId, spawnSpanContext);
 
     // Cancellation: stopRequested is set by either the parent's abort signal
     // (main "stop" button → the spawn_subagent tool's signal) or job_stop.
@@ -2772,14 +2782,14 @@ export class AgentBoxSessionManager {
           agentId,
           request.userId,
           `Sub-agent: ${request.description}`,
-          redactText(request.prompt, redactionConfig).slice(0, 500),
+          redactText(auditPrompt, redactionConfig).slice(0, 500),
           "subagent",
           lineage,
         );
         await this.persistAppendMessage({
           sessionId: childSessionId,
           role: "user",
-          content: redactText(request.prompt, redactionConfig),
+          content: redactText(auditPrompt, redactionConfig),
           fromAgentId: agentId,
           parentSessionId: request.parentSessionId,
           delegationId,
@@ -2900,7 +2910,7 @@ export class AgentBoxSessionManager {
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("spawn_subagent_timeout")), DELEGATED_AGENT_MAX_RUNTIME_MS),
       );
-      await Promise.race([child.brain.prompt(this.buildSpawnedSubagentPrompt(request)), timeoutPromise]);
+      await Promise.race([child.brain.prompt(childPrompt), timeoutPromise]);
     } catch (err) {
       interruptedTool = [...pendingTools.values()][0]?.toolName;
       if (stopRequested) {
@@ -2953,13 +2963,21 @@ export class AgentBoxSessionManager {
       finalText = "(sub-agent produced no output)";
     }
 
+    const formResult = request.responseForm && status === "done"
+      ? parseResponseForm(request.responseForm, finalText)
+      : undefined;
+    if (formResult && !formResult.valid && status === "done") status = "failed";
+
     // Status is FINAL here → close the child's trace ROOT (span export). detach in the
     // finally below is the structural safety net: it ALWAYS runs even if a persist throws,
     // so no child trace is left open. endPrompt stays outside the try so it runs before the
     // terminal persist, mirroring the main-prompt ordering.
     tracingRecorder.endPrompt(childSessionId, status === "done" ? "completed" : "error");
     try {
-      const bundle = buildDelegateSummaryBundle(finalText);
+      // Filled answers are the deliverable: never clip fields into a UI-only report.
+      const bundle = formResult
+        ? { capsule: formResult.text, fullSummary: finalText, truncated: false }
+        : buildDelegateSummaryBundle(finalText);
       const durationMs = Date.now() - startedAt;
 
       // Drain prior (best-effort) trace writes, then emit the terminal event.
@@ -2981,7 +2999,7 @@ export class AgentBoxSessionManager {
             capsule: bundle.capsule,
             fullSummary: bundle.fullSummary,
             summaryTruncated: bundle.truncated,
-            scope: request.prompt,
+            scope: auditPrompt,
             toolCalls,
             durationMs,
             interruptedTool,
@@ -3019,7 +3037,8 @@ export class AgentBoxSessionManager {
     const langDirective = lang !== "English" ? `[System: respond in ${lang}]\n` : "";
     return `${langDirective}Task: ${request.description}\n\n${request.prompt.trim()}\n\n` +
       `Complete this task now and end with a concise findings report — the caller only sees your ` +
-      `final report, not your intermediate steps. Do not ask for confirmation.`;
+      `final report, not your intermediate steps. Do not ask for confirmation.` +
+      (request.responseForm ? `\n\n${buildResponseFormPrompt(request.responseForm)}` : "");
   }
 
   /**

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -3036,8 +3036,8 @@ export class AgentBoxSessionManager {
     const lang = detectLanguage(`${request.description}\n${request.prompt}`);
     const langDirective = lang !== "English" ? `[System: respond in ${lang}]\n` : "";
     return `${langDirective}Task: ${request.description}\n\n${request.prompt.trim()}\n\n` +
-      `Complete this task now and end with a concise findings report — the caller only sees your ` +
-      `final report, not your intermediate steps. Do not ask for confirmation.` +
+      `Complete this task now. Answer every question, including failures, following the completion ` +
+      `instructions. The caller only sees your final answer. Do not ask for confirmation.` +
       (request.responseForm ? `\n\n${buildResponseFormPrompt(request.responseForm)}` : "");
   }
 

--- a/src/core/subagent-registry.ts
+++ b/src/core/subagent-registry.ts
@@ -156,16 +156,24 @@ export function getSubagentMaxRuntimeMs(env: NodeJS.ProcessEnv = process.env): n
 
 export const DEFAULT_SUBAGENT_TYPE = "general-purpose";
 
+export const SUBAGENT_COMPLETION_INSTRUCTIONS =
+  "Answer every delegated question; failures count as answers too. Aggregate results only for the " +
+  "requested target. If the delegated question is answered, return the result directly without " +
+  "repeating methods or success justifications. If a required part remains unresolved, preserve " +
+  "the available result and quote the actual executed command and observed failure (the child's " +
+  "command when synthesising). Explain the concrete failure, not a generic limitations section. " +
+  "List the core errors the parent must not repeat. Never invent commands or failures; if no " +
+  "command was executed, say so. Do not present a failed investigation as a negative finding.";
+
 const GENERAL_PURPOSE: SubagentType = {
   agentType: "general-purpose",
   whenToUse:
     "General-purpose SRE sub-agent for a bounded diagnostic or research task: investigate one " +
-    "hypothesis, check one target, or gather specific evidence, then report concise findings.",
+    "hypothesis, check one target, or gather specific evidence. Answer every question; failures count as answers.",
   systemPromptAddendum:
     "You are a sub-agent handling ONE bounded task delegated by the main agent. " +
-    "Do exactly the task described, gather the requested evidence, and end with a concise findings " +
-    "report — the caller only sees your final report, not your steps. Do not ask for confirmation; " +
-    "if blocked, report what you found and what's missing.",
+    SUBAGENT_COMPLETION_INSTRUCTIONS +
+    " The caller only sees your final answer, not your intermediate steps. Do not ask for confirmation.",
   // No defaultModelTier: a general-purpose child inherits the parent's model, and
   // absent IS inherit. Setting a tier here would pick a model for every caller
   // that did not ask for one.

--- a/src/core/subagent-response-form.test.ts
+++ b/src/core/subagent-response-form.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { buildResponseFormPrompt, parseResponseForm, validateResponseForm, SUBAGENT_RESPONSE_INSTRUCTIONS } from "./subagent-response-form.js";
+
+const form = [
+  { name: "原因", question: "故障原因？", options: { A: "上游服务错误", B: "证据不足" } },
+  { name: "证据", question: "精确时间、错误和覆盖范围？" },
+];
+
+describe("sub-agent response form", () => {
+  it("expands a choice to its meaning while preserving multiline evidence and colon-containing data", () => {
+    const evidence = "12:00:00Z HTTP 429\nhttps://example.test/log\n覆盖:\n部分窗口";
+    expect(parseResponseForm(form, `原因:\nA\n\n证据:\n${evidence}`)).toEqual({
+      valid: true, text: `原因:\n上游服务错误\n\n证据:\n${evidence}`,
+    });
+  });
+
+  it("accepts CRLF and regex metacharacters in declared field names", () => {
+    expect(parseResponseForm([{ name: "evidence[1]", question: "What?" }], "evidence[1]:\r\n429")).toEqual({
+      valid: true, text: "evidence[1]:\n429",
+    });
+  });
+
+  it("does not clip later fields after 1800 or 6000 characters", () => {
+    const evidence = "x".repeat(7000) + "\nLAST EVIDENCE";
+    expect(parseResponseForm(form, `原因:\nA\n证据:\n${evidence}`).text).toContain(evidence);
+  });
+
+  it.each([
+    "原因:\nC\n证据:\n429", // unlisted choice
+    "原因:\nA", // missing field
+    "原因:\nA\n原因:\nB\n证据:\n429", // ambiguous duplicate
+    "原因: A\n证据: 429", // not colon + newline
+    "原因:\\nA\\n证据:\\n429", // literal backslash-n
+    '```visual-card\n{"conclusion":"429"}\n```',
+  ])("marks malformed answers incomplete without guessing: %s", (raw) => {
+    const result = parseResponseForm(form, raw);
+    expect(result.valid).toBe(false);
+    expect(result.text).toContain("Response form incomplete:");
+  });
+
+  it("preserves valid answers when another field is missing", () => {
+    expect(parseResponseForm(form, "原因:\nA").text).toContain("原因:\n上游服务错误");
+  });
+
+  it.each([undefined, [], [{ name: "bad:name", question: "?" }], [form[0], form[0]],
+    [{ name: "x", question: "" }], [{ name: "x", question: "?", options: {} }],
+    [{ name: "x", question: "?", options: { A: "" } }],
+  ])("rejects invalid parent configuration before spawning", (value) => {
+    expect(validateResponseForm(value)).toBeTypeOf("string");
+  });
+
+  it("instructs the child to fill the form instead of applying report-card skills", () => {
+    expect(validateResponseForm(form)).toBeUndefined();
+    const prompt = buildResponseFormPrompt(form);
+    expect(prompt).toContain("A: 上游服务错误");
+    expect(prompt).toContain("原因:\n<answer>");
+    expect(SUBAGENT_RESPONSE_INSTRUCTIONS).toContain("overrides presentation/report-card skills");
+  });
+});

--- a/src/core/subagent-response-form.ts
+++ b/src/core/subagent-response-form.ts
@@ -1,0 +1,84 @@
+/** Parent-owned answer contract. The wire format is plain text: `name:\nanswer`. */
+export interface SubagentResponseField {
+  name: string;
+  question: string;
+  /** Omit for free text; otherwise the child selects exactly one key. */
+  options?: Record<string, string>;
+}
+
+export function validateResponseForm(value: unknown): string | undefined {
+  if (!Array.isArray(value) || value.length === 0) return "response_form requires at least one field.";
+  const names = new Set<string>();
+  for (const field of value) {
+    if (!field || typeof field.name !== "string" || !field.name.trim() || /[:\r\n]/.test(field.name)) {
+      return "Each response_form field needs a non-empty name without colons or newlines.";
+    }
+    if (field.name !== field.name.trim() || names.has(field.name)) return "response_form field names must be unique and trimmed.";
+    names.add(field.name);
+    if (typeof field.question !== "string" || !field.question.trim()) return `response_form ${field.name} needs a question.`;
+    if (field.options !== undefined) {
+      if (!field.options || typeof field.options !== "object" || Array.isArray(field.options) || Object.keys(field.options).length === 0) {
+        return `response_form ${field.name} options must be a non-empty key-to-text object.`;
+      }
+      for (const [key, label] of Object.entries(field.options)) {
+        if (!/^[A-Z][A-Z0-9_]*$/.test(key) || typeof label !== "string" || !label.trim()) {
+          return `response_form ${field.name} needs uppercase option keys (e.g. A) and non-empty text labels.`;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+export const SUBAGENT_RESPONSE_INSTRUCTIONS = "INTERNAL SUB-AGENT RESPONSE CONTRACT (also applies to synthesis):\n" +
+    "Your final answer is data for the parent agent. Fill every field below exactly once, in order. " +
+    "Use the exact field name followed by a colon and an actual newline, then the answer. " +
+    "Do not output JSON, Markdown tables, code fences, visual cards, images, or artifact-only references. " +
+    "This contract overrides presentation/report-card skills for this internal response. " +
+    "For choice questions output only ONE listed key; the runtime expands it to its text for the parent. " +
+    "For free-text questions give concise facts directly, including needed evidence and coverage limits; " +
+    "if unknown or unavailable, state that and why. Never invent a finding to fill a field. " +
+    "Do not repeat field headings inside answers. No introduction or footer.";
+
+export function buildResponseFormPrompt(form: SubagentResponseField[]): string {
+  return "Required response form:\n\n" + form.map((field) => `${field.name}:\nQuestion: ${field.question}\n` +
+      (field.options
+        ? Object.entries(field.options).map(([key, label]) => `${key}: ${label}`).join("\n")
+        : "Answer: free text")).join("\n\n") +
+    "\n\nReturn this filled form:\n" + form.map((field) => `${field.name}:\n<answer>`).join("\n\n");
+}
+
+/** Parse only declared headings, so timestamps/URLs and multiline evidence remain intact. */
+export function parseResponseForm(form: SubagentResponseField[], raw: string): { text: string; valid: boolean } {
+  const source = raw.replace(/\r\n/g, "\n").trim();
+  const escapedNames = form.map((field) => field.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const headings = [...source.matchAll(new RegExp(`^(${escapedNames.join("|")}):\\n`, "gm"))];
+  const answers = new Map<string, string[]>();
+  for (let i = 0; i < headings.length; i++) {
+    const heading = headings[i];
+    const answer = source.slice(heading.index! + heading[0].length, headings[i + 1]?.index ?? source.length).trim();
+    answers.set(heading[1], [...(answers.get(heading[1]) ?? []), answer]);
+  }
+  const errors: string[] = [];
+  if (headings[0]?.index !== 0) errors.push("Expected the filled form without an introduction or code fence.");
+  if (/^```/m.test(source)) errors.push("Code fences are not part of the response form.");
+  const text = form.map((field) => {
+    const values = answers.get(field.name) ?? [];
+    let answer = values[0] ?? "";
+    if (values.length !== 1 || !answer || answer === "<answer>") {
+      errors.push(`${field.name}: ${values.length > 1 ? "duplicate field" : "missing answer"}`);
+      answer = `[${values.length > 1 ? "Duplicate field; answer not accepted" : "Answer not supplied"}]`;
+    } else if (field.options) {
+      if (Object.hasOwn(field.options, answer)) answer = field.options[answer];
+      else {
+        errors.push(`${field.name}: invalid option ${JSON.stringify(answer)}`);
+        answer = `[Invalid option: ${answer}]`;
+      }
+    }
+    return `${field.name}:\n${answer}`;
+  }).join("\n\n");
+  return {
+    text: errors.length ? `${text}\n\nResponse form incomplete:\n${errors.join("\n")}` : text,
+    valid: errors.length === 0,
+  };
+}

--- a/src/core/subagent-response-form.ts
+++ b/src/core/subagent-response-form.ts
@@ -1,3 +1,5 @@
+import { SUBAGENT_COMPLETION_INSTRUCTIONS } from "./subagent-registry.js";
+
 /** Parent-owned answer contract. The wire format is plain text: `name:\nanswer`. */
 export interface SubagentResponseField {
   name: string;
@@ -36,8 +38,8 @@ export const SUBAGENT_RESPONSE_INSTRUCTIONS = "INTERNAL SUB-AGENT RESPONSE CONTR
     "Do not output JSON, Markdown tables, code fences, visual cards, images, or artifact-only references. " +
     "This contract overrides presentation/report-card skills for this internal response. " +
     "For choice questions output only ONE listed key; the runtime expands it to its text for the parent. " +
-    "For free-text questions give concise facts directly, including needed evidence and coverage limits; " +
-    "if unknown or unavailable, state that and why. Never invent a finding to fill a field. " +
+    SUBAGENT_COMPLETION_INSTRUCTIONS + " " +
+    "Use the declared free-text fields for failure details; for successful questions return only the answer. " +
     "Do not repeat field headings inside answers. No introduction or footer.";
 
 export function buildResponseFormPrompt(form: SubagentResponseField[]): string {

--- a/src/core/task-notification.test.ts
+++ b/src/core/task-notification.test.ts
@@ -94,13 +94,13 @@ describe("spawn_subagent batch notification text", () => {
     expect(summary).toContain("Causes: 2 network, 1 storage.");
   });
 
-  it("buildGroupNotificationSummary omits the reduce block when there is no reduce", () => {
+  it("delivers item answers when there is no reduce instead of only reporting completion", () => {
     const report: SubagentGroupReport = {
       status: "done",
       durationMs: 5,
-      itemResults: [{ item: "a", status: "done", summary: "cap", childSessionId: "c1" }],
+      itemResults: [{ item: "a", status: "done", summary: "cause:\nUpstream service error", childSessionId: "c1" }],
     };
     const summary = buildGroupNotificationSummary("g", report);
-    expect(summary).toBe('Sub-agent group "g" done — 1 item(s): 1 done.');
+    expect(summary).toBe('Sub-agent group "g" done — 1 item(s): 1 done.\n\na — done\ncause:\nUpstream service error');
   });
 });

--- a/src/core/task-notification.ts
+++ b/src/core/task-notification.ts
@@ -113,9 +113,12 @@ export function summarizeItemStatuses(items: Array<{ status: GroupItemStatus }>)
  */
 export function buildGroupNotificationSummary(description: string, report: SubagentGroupReport): string {
   const head = `Sub-agent group "${description}" ${report.status} — ${summarizeItemStatuses(report.itemResults)}.`;
-  // Prefer the reduce synthesis; else fall back to the group-level explanation (circuit-break
-  // reason / reduce failure / cancel note) so the notification says WHY a batch stopped even when
-  // no reduce ran (#7).
-  const body = report.reduceSummary ?? report.groupSummary;
+  // Without synthesis, deliver the actual item answers along with any group failure reason.
+  // A completion count alone forces the parent to rediscover results it should already have.
+  const body = report.reduceSummary ?? [
+    report.groupSummary,
+    ...report.itemResults.map((item) =>
+      `${typeof item.item === "string" ? item.item : JSON.stringify(item.item)} — ${item.status}\n${item.summary}`),
+  ].filter(Boolean).join("\n\n");
   return body ? `${head}\n\n${body}` : head;
 }

--- a/src/core/tool-registry.ts
+++ b/src/core/tool-registry.ts
@@ -16,6 +16,7 @@ import type { ChildModelOutcome, SubagentTierMenu, SubagentTierPlan } from "./su
 import type { MemoryIndexer } from "../memory/indexer.js";
 import type { KnowledgeResolver } from "../knowledge/resolver.js";
 import type { SkillScriptResolver } from "../tools/infra/script-resolver.js";
+import type { SubagentResponseField } from "./subagent-response-form.js";
 
 export type { SessionMode };
 
@@ -46,6 +47,7 @@ export type ResolvedToolDefinition = ToolDefinition & {
 export type SpawnSubagentStatus = "done" | "partial" | "failed" | "timed_out" | "launched";
 
 export interface SpawnSubagentRequest {
+  responseForm?: SubagentResponseField[];
   /** Short UI label for the spawned task. */
   description: string;
   /** The bounded task briefing — the child's only context besides its system prompt. */
@@ -85,7 +87,7 @@ export type SpawnSubagentResult =
 
 export interface SpawnSubagentReport {
   status: Exclude<SpawnSubagentStatus, "launched">;
-  /** Budgeted capsule returned to the parent as model-visible tool content. */
+  /** Filled form (or legacy budgeted capsule) returned as model-visible tool content. */
   summary: string;
   /** Full child report for UI/debug persistence; not model-visible. */
   fullSummary?: string;
@@ -155,6 +157,8 @@ export type GroupItemStatus = "done" | "partial" | "failed" | "timed_out" | "ski
  * consumes; this is the tool→executor boundary.
  */
 export interface SpawnSubagentGroupRequest {
+  /** Parent-owned form shared by map and optional synthesis children. */
+  responseForm?: SubagentResponseField[];
   /** Short UI label for the whole call (single task or batch). */
   description: string;
   /** One rendered task per item (item original kept for the report/UI + reduce headers). */
@@ -238,7 +242,7 @@ export type SubagentGroupResult =
 export interface SubagentGroupReport {
   status: "done" | "partial" | "failed" | "timed_out";
   itemResults: SubagentGroupItemResult[];
-  /** Reduce output, ≤ GROUP_REDUCE_SUMMARY_MAX_CHARS (truncation is annotated). Absent when no reduce ran. */
+  /** Filled reduce form, or legacy capped summary. Absent when no reduce ran. */
   reduceSummary?: string;
   reduceChildSessionId?: string;
   /** True when the circuit breaker tripped; the reason is folded into the summary. */

--- a/src/tools/workflow/spawn-subagent.test.ts
+++ b/src/tools/workflow/spawn-subagent.test.ts
@@ -23,6 +23,8 @@ function makeRefs(executor: ToolRefs["spawnSubagentExecutor"]): ToolRefs {
   };
 }
 
+const response_form = [{ name: "findings", question: "What did you find?" }];
+
 const text = (r: any) => (r.content[0] as any).text as string;
 
 describe("spawn_subagent tool — availability & registration", () => {
@@ -47,7 +49,7 @@ describe("spawn_subagent tool — single-task collapse path", () => {
       return { status: "done", summary: "node-01 disk 92% full", childSessionId: "child-1", toolCalls: 3, durationMs: 1200 };
     });
     const tool = createSpawnSubagentTool(makeRefs(executor));
-    const r = await tool.execute("call-1", { description: "check node-01", items: ["Check disk usage on node-01"] });
+    const r = await tool.execute("call-1", { description: "check node-01", response_form, items: ["Check disk usage on node-01"] });
 
     // The tool hands the executor a batch plan (one rendered task) — never a lone `prompt`.
     expect(captured).toMatchObject({
@@ -64,6 +66,7 @@ describe("spawn_subagent tool — single-task collapse path", () => {
       { item: "Check disk usage on node-01", prompt: "Check disk usage on node-01" },
     ]);
     expect(captured?.reducePrompt).toBeUndefined();
+    expect(captured?.responseForm).toEqual(response_form);
 
     // Uniform model-visible envelope: always item_results[] (design decision #18).
     const mv = JSON.parse(text(r));
@@ -91,7 +94,7 @@ describe("spawn_subagent tool — single-task collapse path", () => {
         : { status: "done", summary: "probed", childSessionId: "child-9", toolCalls: 1, durationMs: 5 };
     });
     const tool = createSpawnSubagentTool(makeRefs(executor));
-    const r = await tool.execute("call-bg", { description: "probe net", items: ["probe all nodes"], run_in_background: true });
+    const r = await tool.execute("call-bg", { description: "probe net", response_form, items: ["probe all nodes"], run_in_background: true });
 
     if (RUN_IN_BACKGROUND_ENABLED) {
       expect(captured?.runInBackground).toBe(true);
@@ -137,7 +140,7 @@ describe("spawn_subagent tool — foregroundSubagentOnly (channel)", () => {
 
     await tool.execute("call-fg", {
       description: "triage 3 nodes",
-      items: ["check node-a", "check node-b", "check node-c"],
+      response_form, items: ["check node-a", "check node-b", "check node-c"],
     });
     expect(captured?.runInBackground).toBe(false);
   });
@@ -153,17 +156,27 @@ describe("spawn_subagent tool — foregroundSubagentOnly (channel)", () => {
     const tool = createSpawnSubagentTool(makeRefs(executor)); // foregroundSubagentOnly unset
     await tool.execute("call-web", {
       description: "triage 3 nodes",
-      items: ["check node-a", "check node-b", "check node-c"],
+      response_form, items: ["check node-a", "check node-b", "check node-c"],
     });
     expect(captured?.runInBackground).toBe(RUN_IN_BACKGROUND_ENABLED);
   });
 });
 
 describe("spawn_subagent tool — validation fail-fast (zero executor calls)", () => {
+  it("requires the parent to define a valid answer form before starting any child", async () => {
+    const executor = vi.fn();
+    const tool = createSpawnSubagentTool(makeRefs(executor));
+    for (const form of [undefined, [], [{ name: "cause", question: "?", options: { A: "" } }]]) {
+      const result = await tool.execute("bad-form", { description: "check", items: ["Check pod-a"], response_form: form } as any);
+      expect(text(result)).toContain("response_form");
+    }
+    expect(executor).not.toHaveBeenCalled();
+    expect((tool.parameters as any).required).toContain("response_form");
+  });
   it("rejects an empty items list before calling the executor", async () => {
     const executor = vi.fn();
     const tool = createSpawnSubagentTool(makeRefs(executor as any));
-    const r = await tool.execute("v0", { description: "x", items: [] });
+    const r = await tool.execute("v0", { description: "x", response_form, items: [] });
     expect(executor).not.toHaveBeenCalled();
     expect((r.details as any).error).toBe(true);
   });
@@ -174,7 +187,7 @@ describe("spawn_subagent tool — validation fail-fast (zero executor calls)", (
     const r = await tool.execute("v1", {
       description: "diagnose pods",
       task_template: "Investigate {{pod}} in {{ns}}",
-      items: [{ pod: "web-1" }], // missing ns
+      response_form, items: [{ pod: "web-1" }], // missing ns
     });
     expect(executor).not.toHaveBeenCalled();
     expect(text(r)).toMatch(/missing key/i);
@@ -183,7 +196,7 @@ describe("spawn_subagent tool — validation fail-fast (zero executor calls)", (
   it("rejects mixed items before calling the executor", async () => {
     const executor = vi.fn();
     const tool = createSpawnSubagentTool(makeRefs(executor as any));
-    const r = await tool.execute("v2", { description: "x", task_template: "{{item}}", items: ["a", { k: "v" }] as any });
+    const r = await tool.execute("v2", { description: "x", task_template: "{{item}}", response_form, items: ["a", { k: "v" }] as any });
     expect(executor).not.toHaveBeenCalled();
     expect(text(r)).toMatch(/homogeneous/i);
   });
@@ -191,14 +204,14 @@ describe("spawn_subagent tool — validation fail-fast (zero executor calls)", (
   it("rejects an unknown subagent_type without calling the executor", async () => {
     const executor = vi.fn();
     const tool = createSpawnSubagentTool(makeRefs(executor as any));
-    const r = await tool.execute("v3", { description: "x", items: ["a"], subagent_type: "nope" });
+    const r = await tool.execute("v3", { description: "x", response_form, items: ["a"], subagent_type: "nope" });
     expect(executor).not.toHaveBeenCalled();
     expect(text(r)).toMatch(/unknown subagent_type/i);
   });
 
   it("errors clearly when no executor is available", async () => {
     const tool = createSpawnSubagentTool(makeRefs(undefined));
-    const r = await tool.execute("v4", { description: "x", items: ["a"] });
+    const r = await tool.execute("v4", { description: "x", response_form, items: ["a"] });
     expect(text(r)).toMatch(/not available/i);
     expect((r.details as any).error).toBe(true);
   });
@@ -215,7 +228,7 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
     const r = await tool.execute("g5", {
       description: "diagnose crashing pods",
       task_template: "Find the root cause of {{item}} crashing.",
-      items: ["pod-a", "pod-b"],
+      response_form, items: ["pod-a", "pod-b"],
       reduce_prompt: "Group the causes into network/storage/other.",
     });
 
@@ -258,7 +271,7 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
     const tool = createSpawnSubagentTool(makeRefs(executor));
     const r = await tool.execute("g6", {
       description: "x",
-      items: ["pod-a", "pod-b"],
+      response_form, items: ["pod-a", "pod-b"],
       reduce_prompt: "summarize",
       run_in_background: false,
     });
@@ -313,7 +326,7 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
 
     await tool.execute(
       "g-live",
-      { description: "x", items: ["pod-a", "pod-b"], reduce_prompt: "summarize", run_in_background: false },
+      { description: "x", response_form, items: ["pod-a", "pod-b"], reduce_prompt: "summarize", run_in_background: false },
       undefined,
       (update) => updates.push(update),
     );
@@ -345,7 +358,7 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
       ],
     }));
     const tool = createSpawnSubagentTool(makeRefs(executor));
-    const r = await tool.execute("g7", { description: "x", items: ["pod-a", "pod-b"] });
+    const r = await tool.execute("g7", { description: "x", response_form, items: ["pod-a", "pod-b"] });
     const mv = JSON.parse(text(r));
     expect(mv.reduce_summary).toBeUndefined();
     expect(mv.item_results).toEqual([
@@ -366,7 +379,7 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
       ],
     }));
     const tool = createSpawnSubagentTool(makeRefs(executor));
-    const r = await tool.execute("g8", { description: "x", items: ["a", "b"] });
+    const r = await tool.execute("g8", { description: "x", response_form, items: ["a", "b"] });
     const mv = JSON.parse(text(r));
     expect(mv.circuit_broken).toBe(true);
     expect(mv.status).toBe("failed");
@@ -382,7 +395,7 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
   it("runs batch mode when enabled (default)", async () => {
     const executor = vi.fn(async (): Promise<SubagentGroupResult> => ({ status: "launched", jobId: "j" }));
     const tool = createSpawnSubagentTool(makeRefs(executor));
-    await tool.execute("gg", { description: "x", task_template: "{{item}}", items: ["a", "b"] });
+    await tool.execute("gg", { description: "x", task_template: "{{item}}", response_form, items: ["a", "b"] });
     expect(executor).toHaveBeenCalled();
   });
 
@@ -392,7 +405,7 @@ describe("spawn_subagent tool — batch (map→reduce) path", () => {
     try {
       const executor = vi.fn(async (): Promise<SubagentGroupResult> => ({ status: "launched", jobId: "j" }));
       const tool = createSpawnSubagentTool(makeRefs(executor));
-      const r = await tool.execute("gg", { description: "x", task_template: "{{item}}", items: ["a", "b"] });
+      const r = await tool.execute("gg", { description: "x", task_template: "{{item}}", response_form, items: ["a", "b"] });
       expect(executor).not.toHaveBeenCalled();
       expect(text(r)).toMatch(/batch mode is disabled/i);
       expect(text(r)).toMatch(/one spawn_subagent call per target/i);

--- a/src/tools/workflow/spawn-subagent.ts
+++ b/src/tools/workflow/spawn-subagent.ts
@@ -187,7 +187,11 @@ export function createSpawnSubagentTool(
       "Every question needs an answer; a failure counts. Include a free-text field for actual failed commands, " +
       "observed failures, and core errors not to repeat; use 'Not applicable' for that field on success. " +
       "If supplied, synthesis fills the same form for the group." +
-      renderTierMenuForDescription(tierMenu),
+      renderTierMenuForDescription(tierMenu) +
+      "\n\nYou are supposed to lead to a conclusion using ONE dispatch of subagents, if not, you shall give a serious " +
+      "reason of why subagent utterly failed your expectation, or things you must do yourself before going to " +
+      "the next phase that you are looking at/answering user query, which is the design purpose. Trust your " +
+      "subagents, don't repeat faults.",
     parameters: Type.Object({
       response_form: Type.Array(Type.Object({
         name: Type.String({ description: "Unique field heading, without colons or newlines." }),

--- a/src/tools/workflow/spawn-subagent.ts
+++ b/src/tools/workflow/spawn-subagent.ts
@@ -169,13 +169,23 @@ export function createSpawnSubagentTool(
     renderCall: (_a, theme) => new Text(theme.fg("toolTitle", theme.bold("spawn_subagent")), 0, 0),
     renderResult: renderTextResult,
     description: buildDescription(isSubagentGroupEnabled(), backgroundAllowed) +
+      "\n\nDelegate work to be completed with explicit questions, not open-ended requests such as 'whatever this involves'. " +
+      "Sub-agents are smart but not all-knowing: they have no user-query context unless you provide it. " +
+      "Ask only questions whose failure can be explained concretely, so you know what proved infeasible. " +
+      "When a sub-agent returns, treat the delegated attempt as complete whether the answer contains faults " +
+      "or meets expectations. A completed attempt does not mean its conclusion is correct or the investigation succeeded. " +
+      "If the answer falls short, inspect where it went wrong from the returned failure details. Do NOT repeat " +
+      "its trajectory for ANY confirmation purpose, repeat its mistakes, or dispatch another sub-agent to " +
+      "compensate for an incompletely expressed first request. Report the result or concrete failure to the user. " +
       "\n\nREQUIRED response_form: define the questions every child must answer. Use free-text fields for " +
-      "facts/evidence/coverage and options for a single-choice decision (include an unknown option when needed). " +
+      "answers and concrete failure details, and options for a single-choice decision (include a failure or unknown option when needed). " +
       "Carry all target identifiers and known facts in the task briefing; the form defines the deliverable. " +
       "Children fill name + colon + newline + answer as plain text. Option keys are expanded to their " +
       "meaning in the returned summaries. Example: [{name:'cause', question:'What caused the failure?', " +
-      "options:{A:'Upstream service error',B:'Insufficient evidence'}}, {name:'evidence',question:'Exact time and evidence?'}]. " +
+      "options:{A:'Upstream service error',B:'Insufficient evidence'}}, {name:'failure_details',question:'On failure, quote actual commands, observed errors, and mistakes not to repeat. On success: Not applicable.'}]. " +
       "Omit reduce_prompt when the filled item forms already answer your task; synthesis costs another sub-agent run. " +
+      "Every question needs an answer; a failure counts. Include a free-text field for actual failed commands, " +
+      "observed failures, and core errors not to repeat; use 'Not applicable' for that field on success. " +
       "If supplied, synthesis fills the same form for the group." +
       renderTierMenuForDescription(tierMenu),
     parameters: Type.Object({

--- a/src/tools/workflow/spawn-subagent.ts
+++ b/src/tools/workflow/spawn-subagent.ts
@@ -41,8 +41,10 @@ import {
 } from "../../core/subagent-registry.js";
 import { renderTierMenuForDescription, type ChildModelOutcome } from "../../core/subagent-models.js";
 import { validateAndRenderGroupPlan } from "../../agentbox/subagent-group.js";
+import { validateResponseForm, type SubagentResponseField } from "../../core/subagent-response-form.js";
 
 interface SpawnSubagentParams {
+  response_form: SubagentResponseField[];
   description: string;
   task_template?: string;
   items: Array<string | Record<string, string>>;
@@ -166,10 +168,24 @@ export function createSpawnSubagentTool(
     label: "Spawn Sub-agent",
     renderCall: (_a, theme) => new Text(theme.fg("toolTitle", theme.bold("spawn_subagent")), 0, 0),
     renderResult: renderTextResult,
-    description:
-      buildDescription(isSubagentGroupEnabled(), backgroundAllowed) +
+    description: buildDescription(isSubagentGroupEnabled(), backgroundAllowed) +
+      "\n\nREQUIRED response_form: define the questions every child must answer. Use free-text fields for " +
+      "facts/evidence/coverage and options for a single-choice decision (include an unknown option when needed). " +
+      "Carry all target identifiers and known facts in the task briefing; the form defines the deliverable. " +
+      "Children fill name + colon + newline + answer as plain text. Option keys are expanded to their " +
+      "meaning in the returned summaries. Example: [{name:'cause', question:'What caused the failure?', " +
+      "options:{A:'Upstream service error',B:'Insufficient evidence'}}, {name:'evidence',question:'Exact time and evidence?'}]. " +
+      "Omit reduce_prompt when the filled item forms already answer your task; synthesis costs another sub-agent run. " +
+      "If supplied, synthesis fills the same form for the group." +
       renderTierMenuForDescription(tierMenu),
     parameters: Type.Object({
+      response_form: Type.Array(Type.Object({
+        name: Type.String({ description: "Unique field heading, without colons or newlines." }),
+        question: Type.String({ description: "Question to answer, including required facts and completion criteria." }),
+        options: Type.Optional(Type.Record(Type.String(), Type.String(), {
+          description: "Single-choice key-to-text mapping, e.g. A: Upstream service error. Omit for a fill-in answer.",
+        })),
+      }), { minItems: 1, description: "Required answer form for each item and optional synthesis. All answers return as plain text." }),
       description: Type.String({ description: "Short (3-5 word) label for the task or batch." }),
       task_template: Type.Optional(
         Type.String({
@@ -278,6 +294,9 @@ export function createSpawnSubagentTool(
       });
       if (!plan.ok) return errorResult(plan.error);
 
+      const formError = validateResponseForm(p.response_form);
+      if (formError) return errorResult(formError);
+
       // Conditional default (design §"Tool layer (single entry)"): a single item runs foreground (grab the result and
       // keep reasoning), a multi-item batch runs background (asymmetric harm — each side fits its own
       // failure mode). An explicit run_in_background always wins; the flag is force-false while gated.
@@ -336,6 +355,7 @@ export function createSpawnSubagentTool(
       const result = await executor(
         {
           description,
+          responseForm: p.response_form,
           renderedTasks: plan.tasks,
           reducePrompt,
           subagentType: type.agentType,


### PR DESCRIPTION
## Summary

Free-form sub-agent summaries can omit requested facts and force parent agents to repeat delegated work. Add parent-defined response forms so each child returns directly usable answers, reducing the need for follow-up delegation or an extra synthesis run.

### Solution

- Support fill-in and single-choice questions using plain-text `name:\nanswer` fields; expand choice keys to their meanings before parent delivery.
- Preserve complete filled answers across single, batch, synthesis, and background paths instead of clipping them into report capsules. Background batches without synthesis now deliver item answers rather than only a completion count.
- Mark missing, duplicate, or invalid answers explicitly, preserve valid fields, and do not launch an automatic repair run. Retain questions and raw answers for audit.

### Compatibility

**Breaking tool contract:** new `spawn_subagent` calls must include `response_form`. Update manually authored calls and integrations to supply at least one question. The result envelope is unchanged; `summary` and `reduce_summary` contain the filled plain-text answers. Model context limits still apply.

## Test Plan

- [x] Parser and tool contract tests, including choice expansion, multiline evidence, invalid answers, and long responses.
- [x] Runtime tests for foreground single/batch/synthesis and background single/batch delivery, including audit persistence and no automatic repair child.
- [x] `npm test`: 303 files passed; 6,749 tests passed, 2 skipped.
- [x] `npm run build` (TypeScript).
- [ ] Live workload latency and delegation-count comparison after deployment.
