### PR TITLE
feat(integration): unify Siclaw caller contract and plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "description": "Siclaw SRE agent: MCP server + the siclaw-brief skill (caller contract v1)"
+  },
+  "name": "siclaw",
+  "owner": {
+    "name": "SciTiX Siclaw",
+    "url": "https://github.com/scitix/siclaw"
+  },
+  "plugins": [
+    {
+      "description": "Delegate SRE investigations to a hosted Siclaw agent with a well-formed brief",
+      "name": "siclaw",
+      "source": "./plugins/siclaw",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -175,6 +175,22 @@ All configuration happens through the web UI:
 - Manage users and roles in **Users**
 - Schedule recurring investigations in **My Tasks**
 
+## Use Siclaw from Claude Code
+
+Talk to a hosted Siclaw agent from Claude Code with one plugin: it registers
+the remote MCP server and ships the `siclaw-brief` skill that teaches how to brief the
+agent (see [plugins/siclaw/README.md](plugins/siclaw/README.md)).
+
+```bash
+export SICLAW_CONTROL_PLANE_URL="https://control-plane.example.com" # no trailing slash
+export SICLAW_A2A_KEY=sk-...          # agent API key from the control plane
+claude plugin marketplace add scitix/siclaw
+claude plugin install siclaw@siclaw
+```
+
+Codex and other clients: drop [`siclaw-brief.md`](siclaw-brief.md) into your skills
+directory and register `https://<control-plane-host>/api/v1/mcp` with your own MCP client.
+
 ## Documentation
 
 - [Getting Started](https://docs.siclaw.ai/start/getting-started)

--- a/docs/a2a-integration-guide.md
+++ b/docs/a2a-integration-guide.md
@@ -17,7 +17,18 @@ Three things, nothing else:
 1. **An Agent Card URL** — describes the agent, its skills, capabilities, and the
    base URL for all operations.
 2. **An API key** — `Authorization: Bearer sk-...`. The key is bound to one agent.
-3. **A natural-language problem** — e.g. "pods in kube-system keep restarting on node X".
+3. **A brief** — preferably the structured form (caller contract v1): a data part
+   with `mediaType: application/vnd.siclaw.brief+json` carrying `target`,
+   `time_window {start, end}` (absolute UTC), `open_question`, and optionally
+   `scope`, `known_facts`, `already_checked`, `side_evidence`, `assumptions`,
+   `constraints`; plus `message.metadata.caller_product` naming the product that
+   composes the request. `target` is the entity the investigation must explain —
+   not a suspected cause, not a side observation, not a step. A plain text part
+   (`"pods in kube-system keep restarting on node X"`) still works but is answered
+   with `MISSING_TARGET` warnings. Field reference and examples: the the control plane
+   product doc `/docs/siclaw/a2a-integration` ("How to brief Siclaw") and the
+   Agent Card's `skills[0].examples`, which are complete request bodies. The
+   response's `task.metadata.brief` echoes what the control plane understood; read it.
 
 Base path (all routes are per-agent, because one Portal can host many agents):
 

--- a/mcp/a2a-mcp-adapter/README.md
+++ b/mcp/a2a-mcp-adapter/README.md
@@ -233,3 +233,31 @@ there is just multiple client configurations, one per agent — no alias multipl
 is needed. This local stdio adapter exists for clients that inject credentials from
 env/files rather than per-request headers, and it is where named-key aliasing
 applies.
+
+## Caller contract and the Claude Code plugin
+
+The remote endpoint and this adapter accept the same **caller contract** (v1):
+a structured brief with `target`, `time_window`, `open_question`, optional
+`known_facts` / `already_checked` / `side_evidence` / `assumptions` /
+`constraints`, and a `caller_product`. The contract, its `target` definition and
+the intake warnings are documented in the the control plane product docs
+(`/docs/siclaw/a2a-integration`, "How to brief Siclaw") and taught to the model
+by the `siclaw-brief` skill.
+
+This adapter still sends the model's `question` as a plain text part, i.e. the
+**legacy** form: the control plane accepts it, but answers with `MISSING_TARGET` /
+`MISSING_CALLER` warnings and Siclaw's sub-agents get no anchor. For Claude Code,
+prefer the plugin in this repository, which registers the remote endpoint and
+ships the skill:
+
+```bash
+export SICLAW_CONTROL_PLANE_URL="https://control-plane.example.com" # no trailing slash
+export SICLAW_A2A_KEY=sk-...
+claude plugin marketplace add scitix/siclaw
+claude plugin install siclaw@siclaw
+```
+
+Codex users of this adapter should install the bare skill
+(`siclaw-brief.md` at the repository root → `~/.codex/skills/siclaw-brief/SKILL.md`)
+so the model knows how to phrase the brief even though the adapter forwards it as
+text.

--- a/mcp/a2a-mcp-adapter/src/server.test.ts
+++ b/mcp/a2a-mcp-adapter/src/server.test.ts
@@ -50,6 +50,10 @@ describe("MCP server", () => {
 
     expect(client.getInstructions()).toContain("call siclaw_wait_task");
     expect(client.getInstructions()).toContain("Never resubmit the same question");
+    expect(client.getInstructions()).toContain("self-contained brief");
+    expect(client.getInstructions()).toContain("Siclaw owns investigation scoping");
+    expect(client.getInstructions()).not.toContain("first ask it to list its bound clusters");
+    expect(client.getInstructions()).not.toContain("submit independent hypotheses concurrently");
 
     const listed = await client.listTools();
     expect(listed.tools.map((tool) => tool.name)).toEqual([

--- a/mcp/a2a-mcp-adapter/src/server.ts
+++ b/mcp/a2a-mcp-adapter/src/server.ts
@@ -5,7 +5,9 @@ import type { AgentRouter } from "./router.js";
 import { buildToolDefinitions, createToolHandler } from "./tools.js";
 
 const BASE_INSTRUCTIONS = [
-  "Use siclaw_investigate for operational questions that require the configured Siclaw SRE agent.",
+  "Use siclaw_investigate to delegate operational diagnosis to the configured Siclaw SRE agent.",
+  "Give Siclaw a self-contained brief with the user's goal, observed symptoms, known facts and identifiers, relevant time facts, checks already performed and their results, the unresolved question, and explicit user constraints. Separate known facts from assumptions or uncertain context.",
+  "Do not invent or prescribe data sources, query ranges, tool calls, hypotheses, investigation steps, or execution order unless the user explicitly requires a method. Siclaw owns investigation scoping, planning, evidence selection and correlation, execution order, and stopping conditions.",
   "When it returns a non-terminal task, keep the current turn open and call siclaw_wait_task with the same task_id until terminal, unless the user requests fire-and-forget, asks to stop, or the overall investigation deadline is exhausted.",
   "Never resubmit the same question merely because a task is still working.",
   "Use siclaw_list_tasks to recover server-side tasks after a client restart.",

--- a/mcp/a2a-mcp-adapter/src/tools.test.ts
+++ b/mcp/a2a-mcp-adapter/src/tools.test.ts
@@ -68,6 +68,18 @@ describe("tool contract", () => {
     expect(list.description).toMatch(/aggregates tasks from every configured agent/);
   });
 
+  it("delegates investigation planning to Siclaw and asks callers for a factual brief", () => {
+    const defs = buildToolDefinitions(singleRouter());
+    const investigate = defs.find((tool) => tool.name === "siclaw_investigate")!;
+    expect(investigate.description).toContain("Do not prescribe the investigation plan");
+    expect(investigate.description).toContain("Siclaw chooses");
+
+    const question = investigate.inputSchema.properties.question as { description: string };
+    expect(question.description).toContain("checks already performed and their results");
+    expect(question.description).toContain("Clearly separate facts from assumptions");
+    expect(question.description).toContain("Siclaw plans and conducts the investigation");
+  });
+
   it("submits and waits for a bounded investigation and tags the agent", async () => {
     const api = fakeApi();
     const handle = createToolHandler(singleRouter(api));

--- a/mcp/a2a-mcp-adapter/src/tools.ts
+++ b/mcp/a2a-mcp-adapter/src/tools.ts
@@ -41,7 +41,7 @@ export function buildToolDefinitions(router: AgentRouter) {
     {
       name: "siclaw_investigate",
       description:
-        "Ask the configured Siclaw SRE agent to investigate an operational question. This creates an asynchronous ControlPlane A2A task. Reuse context_id to continue the same investigation. If the returned task is not terminal, do not submit it again: call siclaw_wait_task until it finishes unless the user explicitly requested fire-and-forget. The A2A key selected by \"agent\" fixes which Siclaw agent is used."
+        "Delegate an operational problem to the configured Siclaw SRE agent. Pass a self-contained brief with the caller's relevant background, known facts, prior checks and results, unresolved question, and explicit user constraints. Do not prescribe the investigation plan: Siclaw chooses the data sources, query scope, tools, evidence chain, execution order, and stopping conditions. This creates an asynchronous ControlPlane A2A task. Reuse context_id to continue the same investigation. If the returned task is not terminal, do not submit it again: call siclaw_wait_task until it finishes unless the user explicitly requested fire-and-forget. The A2A key selected by \"agent\" fixes which Siclaw agent is used."
         + ` ${hint}${requireAgent}`,
       inputSchema: {
         type: "object",
@@ -49,7 +49,7 @@ export function buildToolDefinitions(router: AgentRouter) {
           question: {
             type: "string",
             minLength: 1,
-            description: "The concrete operational question for Siclaw, including relevant target names and time window when known.",
+            description: "A self-contained delegation brief for Siclaw: the user's goal, observed symptoms, known facts and target identifiers, relevant time facts, checks already performed and their results, the unresolved question, and explicit user constraints. Clearly separate facts from assumptions or uncertain context. Do not add data-source choices, query ranges, tool calls, hypotheses, investigation steps, or execution order that the user did not explicitly require; Siclaw plans and conducts the investigation.",
           },
           agent,
           context_id: {

--- a/plugins/siclaw/.claude-plugin/plugin.json
+++ b/plugins/siclaw/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "author": {
+    "name": "SciTiX Siclaw",
+    "url": "https://github.com/scitix/siclaw"
+  },
+  "description": "Investigate infrastructure problems through a Siclaw SRE agent (control-plane /api/v1/mcp) and brief it the way its contract expects",
+  "displayName": "Siclaw",
+  "homepage": "https://github.com/scitix/siclaw",
+  "keywords": [
+    "sre",
+    "kubernetes",
+    "gpu",
+    "diagnostics",
+    "siclaw"
+  ],
+  "name": "siclaw",
+  "repository": "https://github.com/scitix/siclaw",
+  "version": "1.0.0"
+}

--- a/plugins/siclaw/.mcp.json
+++ b/plugins/siclaw/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "siclaw": {
+      "headers": {
+        "Authorization": "Bearer ${SICLAW_A2A_KEY}"
+      },
+      "type": "http",
+      "url": "${SICLAW_CONTROL_PLANE_URL}/api/v1/mcp"
+    }
+  }
+}

--- a/plugins/siclaw/README.md
+++ b/plugins/siclaw/README.md
@@ -1,0 +1,42 @@
+# Siclaw plugin for Claude Code
+
+Delegate SRE investigations to a hosted Siclaw agent, and brief it the
+way its caller contract (v1) expects. The plugin ships two things:
+
+- an MCP server declaration pointing at `${SICLAW_CONTROL_PLANE_URL}/api/v1/mcp` (tools:
+  siclaw_investigate / wait_task / get_task / cancel_task / list_tasks), and
+- the `siclaw-brief` skill, which teaches how to fill the structured brief
+  (target, time_window, open_question, …) and how to read Siclaw's echo.
+
+## Install
+
+```bash
+export SICLAW_CONTROL_PLANE_URL="https://control-plane.example.com" # origin, without a trailing slash
+export SICLAW_A2A_KEY=sk-...   # your agent API key, from your control-plane self-service page
+claude plugin marketplace add scitix/siclaw
+claude plugin install siclaw@siclaw
+```
+
+Set the origin to the control plane that issued your Agent key. Restart Claude Code
+(or open a new session). The origin and key are read from your shell environment.
+An explicitly generated deployment URL takes precedence over the origin variable.
+
+If your Claude Code build does not expand environment variables in plugin MCP
+configuration, register the server directly instead and keep the skill:
+
+```bash
+claude mcp add --transport http -s user siclaw "${SICLAW_CONTROL_PLANE_URL}/api/v1/mcp" \
+  --header "Authorization: Bearer $SICLAW_A2A_KEY"
+```
+
+## Codex and other clients
+
+Copy `siclaw-brief.md` (repository root) into your skills directory
+(`~/.codex/skills/siclaw-brief/SKILL.md`) or paste it into your agent's
+system prompt. Register the MCP server with your client's own mechanism.
+
+## Regenerating
+
+This directory is generated from the control-plane contract source
+(`internal/siclaw/a2a/brief`, command `go run ./tools/siclaw-plugin`). Do not
+edit these files by hand; change the contract and regenerate.

--- a/plugins/siclaw/skills/siclaw-brief/SKILL.md
+++ b/plugins/siclaw/skills/siclaw-brief/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: siclaw-brief
+description: How to brief the Siclaw SRE agent (siclaw_investigate) — fill target / time_window / open_question, keep side evidence and assumptions out of the target, declare caller_product, then read the understood/warnings echo before waiting. Load before any siclaw_investigate call.
+when_to_use: The user asks to investigate, diagnose, troubleshoot or root-cause an infrastructure, Kubernetes, GPU, network, storage, model-gateway or service problem and a Siclaw MCP server (siclaw_investigate) is available; or the user says 排查 / 诊断 / 告警 / 根因 / siclaw.
+metadata:
+  contract_version: "1"
+  source: caller contract (generated — do not edit)
+---
+
+# Briefing Siclaw (caller contract v1)
+
+Siclaw is an investigator, not a script runner. You hand it a **brief**; it owns
+the plan (data sources, queries, order, stopping conditions). Your job is to make
+the brief unambiguous about one thing above all: **what the alert is about**.
+
+## The fields of `siclaw_investigate`
+
+| Field | Required | Fill with |
+|---|---|---|
+| `target` | **yes** | The entity this investigation must explain — one line: entity kind + the identifiers that pin it down + the observed symptom. It is what the alert or question is ABOUT. It is NOT a suspected cause (→ assumptions), NOT something you happened to notice (→ side_evidence), and NOT an investigation step (→ open_question, or leave it out). Example: "vendor=aws model=claude-fable-5 external TPOT>2s/token alert". Not: "Bedrock/Novita upstream timeouts (Novita is side evidence; Bedrock overload is an assumption)". |
+| `time_window` | **yes** | Absolute UTC window the question is about, RFC 3339 (e.g. 2026-09-03T01:45:00Z → 2026-09-03T02:30:00Z). Never relative words. |
+| `open_question` | **yes** | The unresolved question Siclaw must answer, stated as a question about the target — not as steps to run. |
+| `caller_product` | **yes** | The product composing this request — the one you are running in — e.g. claude-code, codex, cursor, feishu-bot. Required for usage attribution; not the model name. |
+| `scope` | no | Identifiers already known: cluster (name or id), namespace, workloads (pod/deployment names). Optional. |
+| `known_facts` | no | Verified facts, one per item, with numbers and timestamps. Optional. |
+| `already_checked` | no | Data sources or checks already done and their result; Siclaw will not repeat them. Optional. |
+| `side_evidence` | no | Things noticed that are NOT the target (other vendors, other models, neighbouring symptoms). They inform but must not redirect the investigation. Optional. |
+| `assumptions` | no | Suspected causes or uncertain context, clearly separated from known_facts. Optional. |
+| `constraints` | no | Explicit user constraints: read-only, no changes, scope limits, deadlines. Optional. |
+| `freshness_note` | no | Anything about evidence age (events past TTL, pods replaced). The control plane fills this in when the window is older than 24h. Optional. |
+| `context_id` | no | Optional context_id from a prior task to continue the same Siclaw investigation session. |
+| `question` | no | DEPRECATED free-text brief. Prefer the structured fields; a text-only brief is accepted but returns MISSING_TARGET / MISSING_QUESTION warnings and gives Siclaw's sub-agents no anchor. |
+
+`target`, `time_window` and `open_question` are required *together*: sending some structured fields but missing one of them is rejected with the missing names. `question` alone still works (legacy) but returns MISSING_TARGET warnings and gives Siclaw's sub-agents no anchor — do not use it for new calls.
+
+## What `target` means
+
+> The entity this investigation must explain — one line: entity kind + the identifiers that pin it down + the observed symptom. It is what the alert or question is ABOUT. It is NOT a suspected cause (→ assumptions), NOT something you happened to notice (→ side_evidence), and NOT an investigation step (→ open_question, or leave it out).
+
+| | Example | Why |
+|---|---|---|
+| Good | `vendor=aws model=claude-fable-5 external TPOT>2s/token alert` | entity + identifiers + symptom |
+| Good | `node cetus-c-013 GPU#3 Xid 79 alert` | same shape |
+| Bad | `Bedrock/Novita upstream timeouts (Novita is side evidence; Bedrock overload is an assumption)` | the vendor you *noticed* is side_evidence; the cause you *suspect* is an assumption |
+| Bad | `did the three model-api pods restart?` | that is a step, not the object; it belongs in open_question or nowhere |
+
+## Three things never to do
+
+1. **Do not promote side evidence into the target or the question.** Anything you
+   saw that is not the alert object (another vendor, another model, a neighbouring
+   symptom) goes into `side_evidence`. Siclaw and its sub-agents treat that list
+   as context, never as a lead.
+2. **Do not prescribe the investigation.** No "first run kubectl…, then check
+   events". State what is unresolved; Siclaw decides how to find out.
+3. **Do not use relative time.** "Last night" is not a window. Give `time_window`
+   as absolute UTC RFC 3339. If the window is older than a day, expect a
+   STALE_WINDOW warning: Kubernetes events are past TTL, pods may have been replaced,
+   logs rotated — ask Siclaw to report "evidence unavailable" rather than "no anomaly".
+
+## `caller_product`
+
+Always pass the product you are running in, for example: `claude-code` / `codex` / `cursor` / `feishu-bot` / `siclaw`
+(other values are accepted and stored as declared). This is how usage is attributed;
+it is not the model name.
+
+## After the call: read the echo before you wait
+
+The result carries `understood` (the brief the control plane understood: target, window, caller)
+and `warnings`. Check them before calling `siclaw_wait_task`:
+
+| Warning | Meaning | Do |
+|---|---|---|
+| `MISSING_TARGET` | no target field (legacy text brief) | resend with the structured fields |
+| `MISSING_WINDOW` | no absolute UTC window found | add time_window |
+| `MISSING_QUESTION` | no open_question field | state the unresolved question |
+| `MISSING_CALLER` | caller_product not declared | pass the product you run in |
+| `UNKNOWN_CALLER` | caller_product not in the known table | fine if intentional; check spelling |
+| `LEGACY_QUESTION` | free-text `question` used | migrate to structured fields |
+| `CONTRADICTORY_CHECKED` | a source is described as both checked and not checked | fix already_checked / open_question |
+| `SIDE_EVIDENCE_IN_TARGET` | a side_evidence entity appears in target/open_question | move it out of the target |
+| `STALE_WINDOW` | window ended more than 24h ago | expect evidence gaps; ask for 'unavailable' not 'no anomaly' |
+| `RELATIVE_TIME` | relative time words without absolute timestamps | give RFC 3339 UTC |
+| `PRESCRIBED_PLAN` | the brief dictates steps or commands | state the question, drop the steps |
+| `OVERSIZE` | brief over 16 KiB | reference bulk evidence instead of pasting it |
+
+If `understood.target` is not what you meant, cancel (`siclaw_cancel_task`) and resend a
+corrected brief — do not let a misread brief run for minutes.
+
+## Following up and challenging
+
+- Continue the same investigation with `context_id` from the previous task; do not
+  restate the whole brief, add the new fact or the new question.
+- While a task is working, call `siclaw_wait_task` repeatedly; never resubmit the
+  same brief because it is slow.
+- When the report arrives, check that its conclusion is about **your target**. A
+  report that pivots to a side_evidence entity has drifted — say so in the follow-up
+  and restate the target.
+- Ask for the evidence chain, not just the verdict: which source, which time, which
+  identifier. "Looks right" is not verified.

--- a/siclaw-brief.md
+++ b/siclaw-brief.md
@@ -1,0 +1,99 @@
+---
+name: siclaw-brief
+description: How to brief the Siclaw SRE agent (siclaw_investigate) — fill target / time_window / open_question, keep side evidence and assumptions out of the target, declare caller_product, then read the understood/warnings echo before waiting. Load before any siclaw_investigate call.
+when_to_use: The user asks to investigate, diagnose, troubleshoot or root-cause an infrastructure, Kubernetes, GPU, network, storage, model-gateway or service problem and a Siclaw MCP server (siclaw_investigate) is available; or the user says 排查 / 诊断 / 告警 / 根因 / siclaw.
+metadata:
+  contract_version: "1"
+  source: caller contract (generated — do not edit)
+---
+
+# Briefing Siclaw (caller contract v1)
+
+Siclaw is an investigator, not a script runner. You hand it a **brief**; it owns
+the plan (data sources, queries, order, stopping conditions). Your job is to make
+the brief unambiguous about one thing above all: **what the alert is about**.
+
+## The fields of `siclaw_investigate`
+
+| Field | Required | Fill with |
+|---|---|---|
+| `target` | **yes** | The entity this investigation must explain — one line: entity kind + the identifiers that pin it down + the observed symptom. It is what the alert or question is ABOUT. It is NOT a suspected cause (→ assumptions), NOT something you happened to notice (→ side_evidence), and NOT an investigation step (→ open_question, or leave it out). Example: "vendor=aws model=claude-fable-5 external TPOT>2s/token alert". Not: "Bedrock/Novita upstream timeouts (Novita is side evidence; Bedrock overload is an assumption)". |
+| `time_window` | **yes** | Absolute UTC window the question is about, RFC 3339 (e.g. 2026-09-03T01:45:00Z → 2026-09-03T02:30:00Z). Never relative words. |
+| `open_question` | **yes** | The unresolved question Siclaw must answer, stated as a question about the target — not as steps to run. |
+| `caller_product` | **yes** | The product composing this request — the one you are running in — e.g. claude-code, codex, cursor, feishu-bot. Required for usage attribution; not the model name. |
+| `scope` | no | Identifiers already known: cluster (name or id), namespace, workloads (pod/deployment names). Optional. |
+| `known_facts` | no | Verified facts, one per item, with numbers and timestamps. Optional. |
+| `already_checked` | no | Data sources or checks already done and their result; Siclaw will not repeat them. Optional. |
+| `side_evidence` | no | Things noticed that are NOT the target (other vendors, other models, neighbouring symptoms). They inform but must not redirect the investigation. Optional. |
+| `assumptions` | no | Suspected causes or uncertain context, clearly separated from known_facts. Optional. |
+| `constraints` | no | Explicit user constraints: read-only, no changes, scope limits, deadlines. Optional. |
+| `freshness_note` | no | Anything about evidence age (events past TTL, pods replaced). The control plane fills this in when the window is older than 24h. Optional. |
+| `context_id` | no | Optional context_id from a prior task to continue the same Siclaw investigation session. |
+| `question` | no | DEPRECATED free-text brief. Prefer the structured fields; a text-only brief is accepted but returns MISSING_TARGET / MISSING_QUESTION warnings and gives Siclaw's sub-agents no anchor. |
+
+`target`, `time_window` and `open_question` are required *together*: sending some structured fields but missing one of them is rejected with the missing names. `question` alone still works (legacy) but returns MISSING_TARGET warnings and gives Siclaw's sub-agents no anchor — do not use it for new calls.
+
+## What `target` means
+
+> The entity this investigation must explain — one line: entity kind + the identifiers that pin it down + the observed symptom. It is what the alert or question is ABOUT. It is NOT a suspected cause (→ assumptions), NOT something you happened to notice (→ side_evidence), and NOT an investigation step (→ open_question, or leave it out).
+
+| | Example | Why |
+|---|---|---|
+| Good | `vendor=aws model=claude-fable-5 external TPOT>2s/token alert` | entity + identifiers + symptom |
+| Good | `node cetus-c-013 GPU#3 Xid 79 alert` | same shape |
+| Bad | `Bedrock/Novita upstream timeouts (Novita is side evidence; Bedrock overload is an assumption)` | the vendor you *noticed* is side_evidence; the cause you *suspect* is an assumption |
+| Bad | `did the three model-api pods restart?` | that is a step, not the object; it belongs in open_question or nowhere |
+
+## Three things never to do
+
+1. **Do not promote side evidence into the target or the question.** Anything you
+   saw that is not the alert object (another vendor, another model, a neighbouring
+   symptom) goes into `side_evidence`. Siclaw and its sub-agents treat that list
+   as context, never as a lead.
+2. **Do not prescribe the investigation.** No "first run kubectl…, then check
+   events". State what is unresolved; Siclaw decides how to find out.
+3. **Do not use relative time.** "Last night" is not a window. Give `time_window`
+   as absolute UTC RFC 3339. If the window is older than a day, expect a
+   STALE_WINDOW warning: Kubernetes events are past TTL, pods may have been replaced,
+   logs rotated — ask Siclaw to report "evidence unavailable" rather than "no anomaly".
+
+## `caller_product`
+
+Always pass the product you are running in, for example: `claude-code` / `codex` / `cursor` / `feishu-bot` / `siclaw`
+(other values are accepted and stored as declared). This is how usage is attributed;
+it is not the model name.
+
+## After the call: read the echo before you wait
+
+The result carries `understood` (the brief the control plane understood: target, window, caller)
+and `warnings`. Check them before calling `siclaw_wait_task`:
+
+| Warning | Meaning | Do |
+|---|---|---|
+| `MISSING_TARGET` | no target field (legacy text brief) | resend with the structured fields |
+| `MISSING_WINDOW` | no absolute UTC window found | add time_window |
+| `MISSING_QUESTION` | no open_question field | state the unresolved question |
+| `MISSING_CALLER` | caller_product not declared | pass the product you run in |
+| `UNKNOWN_CALLER` | caller_product not in the known table | fine if intentional; check spelling |
+| `LEGACY_QUESTION` | free-text `question` used | migrate to structured fields |
+| `CONTRADICTORY_CHECKED` | a source is described as both checked and not checked | fix already_checked / open_question |
+| `SIDE_EVIDENCE_IN_TARGET` | a side_evidence entity appears in target/open_question | move it out of the target |
+| `STALE_WINDOW` | window ended more than 24h ago | expect evidence gaps; ask for 'unavailable' not 'no anomaly' |
+| `RELATIVE_TIME` | relative time words without absolute timestamps | give RFC 3339 UTC |
+| `PRESCRIBED_PLAN` | the brief dictates steps or commands | state the question, drop the steps |
+| `OVERSIZE` | brief over 16 KiB | reference bulk evidence instead of pasting it |
+
+If `understood.target` is not what you meant, cancel (`siclaw_cancel_task`) and resend a
+corrected brief — do not let a misread brief run for minutes.
+
+## Following up and challenging
+
+- Continue the same investigation with `context_id` from the previous task; do not
+  restate the whole brief, add the new fact or the new question.
+- While a task is working, call `siclaw_wait_task` repeatedly; never resubmit the
+  same brief because it is slow.
+- When the report arrives, check that its conclusion is about **your target**. A
+  report that pivots to a side_evidence entity has drifted — say so in the follow-up
+  and restate the target.
+- Ask for the evidence chain, not just the verdict: which source, which time, which
+  identifier. "Looks right" is not verified.


### PR DESCRIPTION
External callers can install the Siclaw plugin, provide a self-contained factual investigation brief, and use the existing asynchronous task contract. Siclaw owns investigation planning, evidence selection and stopping conditions while honoring explicit user constraints.

- Ship the plugin marketplace, MCP configuration and generated siclaw-brief skill, including the standalone skill copy.
- Align the stdio MCP adapter instructions and tool schema with the caller's factual brief and Siclaw's investigation responsibility.
- Document installation, authentication, structured intake and the legacy free-text adapter path.

This PR consolidates #534 into the plugin distribution change. Generated distribution remains owned by the upstream control-plane brief contract.

Validation: the current-main MCP adapter build and all 57 tests passed, including real stdio/HTTP fixtures. Plugin and marketplace validation passed; six generated distribution files match the updated control-plane generator. The public package reads SICLAW_CONTROL_PLANE_URL and SICLAW_A2A_KEY from the caller environment; the companion generator preserves explicit fixed-origin builds. An authenticated first-install and real remote investigation remain live acceptance work.
