### PR TITLE
feat(mcp): report per-server connection outcomes and add mcp.probe

### DIFF
--- a/docs/design/mcp-connection-observability.md
+++ b/docs/design/mcp-connection-observability.md
@@ -1,0 +1,87 @@
+---
+title: "MCP Connection Observability"
+sidebarTitle: "MCP Connection Observability"
+description: "How a box reports whether each configured MCP server was actually reached, and how the Runtime dials one config on demand."
+---
+
+# MCP Connection Observability
+
+> **Purpose**: A configured MCP server that failed to connect used to leave one
+> `console.error` line inside the AgentBox and nothing anywhere else. The control
+> plane saw the configured names on `/api/sync-status` and reported them as
+> "installed"; a developer whose MCP URL pointed at a web page saw a green tag
+> for weeks and an agent that never had the tools. This document fixes the
+> contract that closes that gap.
+
+## 1. Two facts, two fields
+
+`/api/sync-status` (`BoxSyncStatus`, schema v4) now carries two different facts
+about MCP:
+
+| Field | Says | Source |
+|---|---|---|
+| `mcp.names` | the server's config was **written into the box** | keys of the materialized `mcpServers` config |
+| `mcp.servers[]` | the server was **dialled**, and what happened | `McpClientManager.getServerConnections()` |
+
+`mcp.servers` is **absent** on a box that predates v4 or has not created a
+session since it started, and **`[]`** on a box that reported and had nothing
+configured. A consumer must not read absence as "all connected" — that is the
+exact false green this exists to remove.
+
+Each entry (`ObservedMcpServer`):
+
+```ts
+{ name, transport, state: "connected" | "failed", toolCount, toolNames,
+  durationMs, observedAt, error?: { kind, httpStatus?, contentType?, message } }
+```
+
+## 2. The error vocabulary is owned here
+
+`classifyMcpConnectError` (`src/core/mcp-client.ts`) maps whatever the MCP SDK
+throws into a closed set: `invalid_config, dns, connection_refused, timeout,
+tls, auth, not_found, not_mcp, http, protocol, unknown`. Sicore stores and
+renders the kind; it never re-classifies. `not_found` + `contentType:
+"text/html"` is the signature of a page URL pasted as an MCP endpoint, and is
+why the HTML case gets its own handling: the message is reduced to `HTML page:
+<title>` instead of carrying a 15 KB response body.
+
+## 3. When the box records it
+
+`observedMcpServers` is captured when a session is **created** (after
+`getOrCreate`), not when a turn succeeds. A server that fails to connect is the
+observation a developer needs, and it must survive the turn that follows also
+failing — e.g. the model rejecting an oversized tool list. `/api/sync-status`
+prefers the newest live session's manager (an MCP reload invalidates sessions,
+so the newest one reflects the current config) and falls back to the snapshot.
+
+## 4. Replica consensus
+
+`agent.syncStatus` includes `{name, state, toolCount, errorKind}` per server in
+the replica identity. Two boxes with identical config where one reached a
+server and the other did not are serving different toolsets, so they are
+`consistent: false` and the flat `mcp.servers` is withheld; per-box outcomes
+stay in `observations`. Timing, tool names and message text are evidence, not
+identity, and are ignored.
+
+## 5. `mcp.probe` — dial one config from the Runtime
+
+The Runtime exposes an RPC `mcp.probe { server, timeoutMs? }` that builds a
+single-server `McpClientManager`, initializes it with a bounded timeout, and
+returns the same `McpServerConnection` shape a box reports. It runs on the
+Runtime — the network position of the boxes it spawns, and the place
+per-runtime address overrides are meaningful — never on the control plane.
+
+`stdio` servers are refused (`invalid_config`): probing one would execute an
+arbitrary command in the Runtime process, and a box start already observes them.
+
+## 6. Source-of-truth map
+
+| Question | Where |
+|---|---|
+| Was a server reached, and why not | `McpClientManager.getServerConnections()` |
+| Error classification | `classifyMcpConnectError` |
+| Wire shape / normalization | `src/shared/agentbox-sync-status.ts` |
+| Box report | `src/agentbox/http-server.ts` `/api/sync-status` |
+| Replica consensus, flat aggregate | `src/gateway/server.ts` `agent.syncStatus` |
+| On-demand probe | `src/gateway/server.ts` `mcp.probe` |
+| Control-plane storage and console | sicore `internal/siclaw/mcpobs` |

--- a/docs/design/mcp-session-lifecycle.md
+++ b/docs/design/mcp-session-lifecycle.md
@@ -158,6 +158,14 @@ on Toggle-off / Delete, etc.
 
 ---
 
+## 6a. Connection outcomes are reported, not swallowed
+
+A server that fails to connect during the per-session `McpClientManager`
+initialization is recorded per server (`getServerConnections()`) and reported on
+`/api/sync-status` as `mcp.servers`, alongside the configured names. See
+[MCP Connection Observability](mcp-connection-observability.md) for the wire
+contract and the `mcp.probe` RPC.
+
 ## 7. When this contract must be revisited
 
 Reopen this doc if any of the following becomes true:

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -32,6 +32,7 @@ import {
   readBoxSyncStatus,
   type KnowledgeSyncHandler,
 } from "./sync-handlers.js";
+import type { ObservedMcpServer } from "../shared/agentbox-sync-status.js";
 import { GATEWAY_SYNC_DESCRIPTORS, type AgentBoxSyncHandler, type GatewaySyncType } from "../shared/gateway-sync.js";
 import { detectLanguage } from "../shared/detect-language.js";
 import { stripLanguageDirective } from "../shared/strip-language-directive.js";
@@ -653,6 +654,14 @@ export function createHttpServer(
     candidatesRevision: string | null;
     observedAt: string;
   } | null = null;
+  /**
+   * Per-server MCP connection outcome from the most recent session that
+   * initialized MCP in this box. Recorded when the session is CREATED, not when
+   * a turn succeeds: a server that fails to connect is exactly the observation
+   * a developer needs, and it must not disappear because the turn that followed
+   * also failed (e.g. the model rejecting an oversized tool list).
+   */
+  let observedMcpServers: ObservedMcpServer[] | null = null;
   if (sessionManager.credentialBroker) {
     perServerHandlers.cluster = createClusterHandler(sessionManager.credentialBroker);
     perServerHandlers.host = createHostHandler(sessionManager.credentialBroker);
@@ -808,11 +817,21 @@ export function createHttpServer(
    * intended to send.
    */
   addRoute("GET", "/api/sync-status", async (_req, res) => {
+    const inventory = readBoxSyncStatus({
+      knowledgeDir: sessionManager.knowledgeDir,
+      knowledgeHandler: perServerKnowledgeHandler,
+    });
+    // Prefer a live session's manager over the last recorded snapshot: an MCP
+    // reload invalidates sessions, so the newest session is the one built from
+    // the current config. Fall back to the snapshot when every session has been
+    // released, and to "no servers field" when this box never initialized MCP.
+    const liveManager = sessionManager.list()
+      .filter((session) => session.mcpManager)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0]?.mcpManager;
+    const servers = liveManager ? liveManager.getServerConnections() : observedMcpServers;
     sendJson(res, 200, {
-      ...readBoxSyncStatus({
-        knowledgeDir: sessionManager.knowledgeDir,
-        knowledgeHandler: perServerKnowledgeHandler,
-      }),
+      ...inventory,
+      mcp: { ...inventory.mcp, ...(servers ? { servers } : {}) },
       model: observedModel,
       harness: observedHarness,
       tiers: observedTiers,
@@ -916,6 +935,9 @@ export function createHttpServer(
       delegation,
       body.userId,
     );
+    if (managed.mcpManager) {
+      observedMcpServers = managed.mcpManager.getServerConnections();
+    }
     if (!managed._promptDone || managed._promptInflight) {
       // _promptInflight covers the synthetic-parent-prompt path that may
       // be holding the brain even when _promptDone has already flipped

--- a/src/core/mcp-client-connections.test.ts
+++ b/src/core/mcp-client-connections.test.ts
@@ -1,0 +1,160 @@
+/**
+ * McpClientManager connection observations.
+ *
+ * Until these existed a server that failed to connect left one console.error
+ * and nothing else: the control plane saw the configured names and reported
+ * "installed" for a server no session had ever reached. These tests pin the
+ * per-server outcome the manager now keeps, and the error classification the
+ * control plane renders, against real HTTP endpoints rather than a mocked SDK
+ * so the shape the SDK actually throws is what gets classified.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { McpClientManager, classifyMcpConnectError } from "./mcp-client.js";
+
+type Responder = (req: http.IncomingMessage, body: string, res: http.ServerResponse) => void;
+
+const servers: http.Server[] = [];
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => { s.closeAllConnections(); s.close(() => r()); })));
+});
+
+async function listen(responder: Responder): Promise<string> {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => responder(req, body, res));
+  });
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+}
+
+/** The smallest streamable-http MCP server the SDK client will complete a handshake with. */
+const fakeMcpServer = (tools: string[]): Responder => (req, body, res) => {
+  if (req.method !== "POST") {
+    res.writeHead(405).end();
+    return;
+  }
+  const msg = JSON.parse(body);
+  if (msg.id === undefined) { // notification
+    res.writeHead(202).end();
+    return;
+  }
+  const result = msg.method === "initialize"
+    ? { protocolVersion: msg.params?.protocolVersion ?? "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "fake", version: "0" } }
+    : msg.method === "tools/list"
+      ? { tools: tools.map((name) => ({ name, inputSchema: { type: "object", properties: {} } })) }
+      : undefined;
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(result !== undefined
+    ? { jsonrpc: "2.0", id: msg.id, result }
+    : { jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "Method not found" } }));
+};
+
+const HTML_404 = `<!DOCTYPE html><html lang="zh-CN"><head><title>Simate</title></head><body><h2>页面不存在</h2></body></html>`;
+
+describe("classifyMcpConnectError", () => {
+  it("recognises an HTML 404 page as not_found with a text/html hint and a stripped message", () => {
+    const err = Object.assign(new Error(`Streamable HTTP error: Error POSTing to endpoint: ${HTML_404}`), { code: 404 });
+    expect(classifyMcpConnectError(err)).toEqual({
+      kind: "not_found", httpStatus: 404, contentType: "text/html", message: "HTML page: Simate",
+    });
+  });
+
+  it("recognises an HTML body with no status as not_mcp", () => {
+    const err = new Error(`Error POSTing to endpoint: ${HTML_404}`);
+    expect(classifyMcpConnectError(err)).toMatchObject({ kind: "not_mcp", contentType: "text/html" });
+    expect(classifyMcpConnectError(err).httpStatus).toBeUndefined();
+  });
+
+  it("maps 401/403 to auth and other statuses to http", () => {
+    expect(classifyMcpConnectError(Object.assign(new Error("Unauthorized"), { code: 401 })).kind).toBe("auth");
+    expect(classifyMcpConnectError(Object.assign(new Error("Forbidden"), { code: 403 })).kind).toBe("auth");
+    expect(classifyMcpConnectError(Object.assign(new Error("Bad Gateway"), { code: 502 }))).toEqual({
+      kind: "http", httpStatus: 502, message: "Bad Gateway",
+    });
+  });
+
+  it("maps system error codes to dns / connection_refused / timeout", () => {
+    expect(classifyMcpConnectError(Object.assign(new Error("getaddrinfo ENOTFOUND nowhere"), { code: "ENOTFOUND" })).kind).toBe("dns");
+    expect(classifyMcpConnectError(new TypeError("fetch failed", { cause: { code: "ECONNREFUSED" } })).kind).toBe("connection_refused");
+    expect(classifyMcpConnectError(Object.assign(new Error("aborted"), { name: "AbortError" })).kind).toBe("timeout");
+    expect(classifyMcpConnectError(new Error("connect ETIMEDOUT 10.0.0.1:443 — timed out")).kind).toBe("timeout");
+  });
+
+  it("caps the message and never stores a raw HTML body", () => {
+    const err = new Error(`x${"y".repeat(2_000)}`);
+    const out = classifyMcpConnectError(err);
+    expect(out.message.length).toBeLessThanOrEqual(300);
+    const html = classifyMcpConnectError(new Error(`<html><body>${"z".repeat(5_000)}</body></html>`));
+    expect(html.message).toBe("HTML page");
+  });
+});
+
+describe("McpClientManager.getServerConnections", () => {
+  it("records a connected server with its tool inventory and a failed one with a classified error", async () => {
+    const good = await listen(fakeMcpServer(["ping", "echo"]));
+    const bad = await listen((_req, _body, res) => {
+      res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(HTML_404);
+    });
+    const manager = new McpClientManager({
+      mcpServers: {
+        devops: { transport: "streamable-http", url: good },
+        siverse: { transport: "streamable-http", url: bad },
+      },
+    });
+    try {
+      await manager.initialize();
+      const connections = manager.getServerConnections();
+      expect(connections.map((c) => [c.name, c.state, c.toolCount])).toEqual([
+        ["devops", "connected", 2],
+        ["siverse", "failed", 0],
+      ]);
+      expect(connections[0].toolNames).toEqual(["echo", "ping"]);
+      expect(connections[0].transport).toBe("streamable-http");
+      expect(connections[0].error).toBeUndefined();
+      expect(connections[1].error).toMatchObject({ kind: "not_found", httpStatus: 404, contentType: "text/html" });
+      expect(connections[1].error?.message).toBe("HTML page: Simate");
+      for (const c of connections) {
+        expect(c.observedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(c.durationMs).toBeGreaterThanOrEqual(0);
+      }
+      // Tools of the failed server never reach the model; the connected one's do.
+      expect(manager.getTools().map((t) => t.name)).toEqual(["mcp__devops__ping", "mcp__devops__echo"]);
+    } finally {
+      await manager.shutdown();
+    }
+  });
+
+  it("records an unknown transport as an invalid_config failure instead of skipping silently", async () => {
+    const manager = new McpClientManager({ mcpServers: { odd: { transport: "carrier-pigeon" } as any } });
+    await manager.initialize();
+    expect(manager.getServerConnections()).toEqual([
+      expect.objectContaining({ name: "odd", state: "failed", toolCount: 0, error: { kind: "invalid_config", message: 'unknown transport "carrier-pigeon"' } }),
+    ]);
+  });
+
+  it("records connection_refused when nothing listens on the port", async () => {
+    const closed = http.createServer();
+    await new Promise<void>((r) => closed.listen(0, "127.0.0.1", () => r()));
+    const port = (closed.address() as AddressInfo).port;
+    await new Promise<void>((r) => closed.close(() => r()));
+    const manager = new McpClientManager({
+      mcpServers: { gone: { transport: "streamable-http", url: `http://127.0.0.1:${port}/mcp` } },
+    });
+    await manager.initialize();
+    expect(manager.getServerConnections()[0]).toMatchObject({ name: "gone", state: "failed", error: { kind: "connection_refused" } });
+  });
+
+  it("returns copies so a caller cannot mutate the manager's record", async () => {
+    const manager = new McpClientManager({ mcpServers: { odd: { transport: "nope" } as any } });
+    await manager.initialize();
+    const first = manager.getServerConnections();
+    first[0].state = "connected";
+    first[0].toolNames.push("x");
+    expect(manager.getServerConnections()[0]).toMatchObject({ state: "failed", toolNames: [] });
+  });
+});

--- a/src/core/mcp-client-connections.test.ts
+++ b/src/core/mcp-client-connections.test.ts
@@ -159,6 +159,39 @@ describe("McpClientManager.getServerConnections", () => {
   });
 });
 
+describe("McpClientManager closes clients that fail after the transport is up", () => {
+  it("closes the SSE stream when tools/list returns a protocol error", async () => {
+    let sseOpened = 0;
+    let sseClosed = 0;
+    const url = await listen((req, body, res) => {
+      if (req.method === "GET") { // the SDK opens the server→client SSE stream after initialize
+        sseOpened++;
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(":\n\n");
+        // res.close fires when the client tears the stream down; req.close would
+        // fire as soon as the (empty) request body is read.
+        res.on("close", () => { sseClosed++; });
+        return;
+      }
+      const msg = JSON.parse(body);
+      if (msg.method === "tools/list") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ jsonrpc: "2.0", id: msg.id, error: { code: -32603, message: "tools/list exploded" } }));
+        return;
+      }
+      fakeMcpServer([])(req, body, res);
+    });
+    const manager = new McpClientManager({ mcpServers: { flaky: { transport: "streamable-http", url } } });
+    await manager.initialize();
+    expect(manager.getServerConnections()[0]).toMatchObject({ name: "flaky", state: "failed", error: { kind: "protocol" } });
+    expect(manager.getTools()).toEqual([]);
+    // Wait for the server to observe the client going away.
+    for (let i = 0; i < 50 && sseClosed < sseOpened; i++) await new Promise((r) => setTimeout(r, 20));
+    expect(sseOpened).toBeGreaterThan(0);
+    expect(sseClosed).toBe(sseOpened);
+  });
+});
+
 describe("McpClientManager.shutdown during initialize", () => {
   it("closes a connection that completes after shutdown instead of leaking it", async () => {
     let handshakes = 0;

--- a/src/core/mcp-client-connections.test.ts
+++ b/src/core/mcp-client-connections.test.ts
@@ -158,3 +158,27 @@ describe("McpClientManager.getServerConnections", () => {
     expect(manager.getServerConnections()[0]).toMatchObject({ state: "failed", toolNames: [] });
   });
 });
+
+describe("McpClientManager.shutdown during initialize", () => {
+  it("closes a connection that completes after shutdown instead of leaking it", async () => {
+    let handshakes = 0;
+    const url = await listen((req, body, res) => {
+      const msg = JSON.parse(body);
+      if (msg.method === "initialize") handshakes++;
+      // Answer slowly so shutdown() can land while the SDK is still dialling.
+      setTimeout(() => fakeMcpServer(["ping"])(req, body, res), 300);
+    });
+    const manager = new McpClientManager({ mcpServers: { slow: { transport: "streamable-http", url } } });
+    const init = manager.initialize();
+    await new Promise((r) => setTimeout(r, 50));
+    await manager.shutdown();
+    await init;
+    expect(handshakes).toBe(1);
+    expect(manager.getTools()).toEqual([]);
+    expect(manager.getServerConnections()).toEqual([
+      expect.objectContaining({ name: "slow", state: "failed", toolCount: 0, error: { kind: "timeout", message: "connection completed after the manager was shut down" } }),
+    ]);
+    // Nothing left to close: a second shutdown is a no-op rather than a second disconnect.
+    await manager.shutdown();
+  });
+});

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -112,6 +112,141 @@ interface ManagedMcpClient {
 }
 
 // ---------------------------------------------------------------------------
+// Connection observations
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a configured MCP server could not be connected, as a closed vocabulary
+ * the control plane can render and aggregate without parsing free text.
+ *
+ *   invalid_config     the entry itself is unusable (unknown transport, bad URL)
+ *   dns                the host does not resolve
+ *   connection_refused TCP-level refusal
+ *   timeout            connect or handshake did not finish in time
+ *   tls                certificate / TLS negotiation failed
+ *   auth               HTTP 401/403 from the endpoint
+ *   not_found          HTTP 404 — usually a URL that points at something that
+ *                      is not an MCP endpoint (a web page, a wrong path)
+ *   not_mcp            the endpoint answered, but with something that is not an
+ *                      MCP response (an HTML page, a non-JSON body)
+ *   http               any other HTTP status the transport rejected
+ *   protocol           MCP-level failure after transport (initialize/listTools)
+ *   unknown            nothing above matched
+ */
+export type McpConnectErrorKind =
+  | "invalid_config"
+  | "dns"
+  | "connection_refused"
+  | "timeout"
+  | "tls"
+  | "auth"
+  | "not_found"
+  | "not_mcp"
+  | "http"
+  | "protocol"
+  | "unknown";
+
+export interface McpConnectError {
+  kind: McpConnectErrorKind;
+  /** HTTP status when the transport surfaced one. */
+  httpStatus?: number;
+  /** Hint about what the endpoint actually returned, e.g. "text/html". */
+  contentType?: string;
+  /** Short, HTML-stripped, length-capped message. Never a full response body. */
+  message: string;
+}
+
+/**
+ * One configured server's connection outcome, as observed by the process that
+ * actually dialled it. `toolCount` is 0 for a failed server by construction.
+ */
+export interface McpServerConnection {
+  name: string;
+  transport: string;
+  state: "connected" | "failed";
+  toolCount: number;
+  toolNames: string[];
+  durationMs: number;
+  observedAt: string;
+  error?: McpConnectError;
+}
+
+const MCP_CONNECT_ERROR_MESSAGE_MAX = 300;
+
+function looksLikeHtml(text: string): boolean {
+  return /^\s*<(?:!doctype\s+html|html[\s>])/i.test(text) || /<\/html>\s*$/i.test(text);
+}
+
+/** Collapse an error message to something safe to store and show. */
+function compactErrorMessage(raw: string): string {
+  let text = raw;
+  if (looksLikeHtml(text) || /<[a-z][^>]*>/i.test(text)) {
+    const title = /<title[^>]*>([^<]*)<\/title>/i.exec(text)?.[1]?.trim();
+    text = title ? `HTML page: ${title}` : "HTML page";
+  }
+  text = text.replace(/\s+/g, " ").trim();
+  return text.length > MCP_CONNECT_ERROR_MESSAGE_MAX
+    ? `${text.slice(0, MCP_CONNECT_ERROR_MESSAGE_MAX - 1)}…`
+    : text;
+}
+
+/**
+ * Classify a connection failure into {@link McpConnectError}.
+ *
+ * The SDK's `StreamableHTTPError` / `SseError` carry the HTTP status in `.code`
+ * and often the raw response body in the message. A body that is an HTML page
+ * is the signature of "this URL is not an MCP endpoint" — the exact mistake a
+ * platform MCP owner makes by pasting a page URL — so it gets its own kind even
+ * when the status is missing.
+ */
+export function classifyMcpConnectError(err: unknown): McpConnectError {
+  const anyErr = err as any;
+  const rawMessage: string = typeof anyErr?.message === "string" ? anyErr.message : String(err);
+  const message = compactErrorMessage(rawMessage);
+  const code = anyErr?.code;
+  let httpStatus: number | undefined;
+  if (typeof code === "number" && code >= 100 && code <= 599) {
+    httpStatus = code;
+  } else {
+    const m = /\b(?:HTTP\s+)?(?:status|code)\s*[:=]?\s*(\d{3})\b/i.exec(rawMessage)
+      ?? /\bHTTP\s+(\d{3})\b/.exec(rawMessage);
+    if (m) httpStatus = Number(m[1]);
+  }
+  const html = looksLikeHtml(rawMessage) || /<html[\s>]/i.test(rawMessage);
+  const base: Omit<McpConnectError, "kind"> = {
+    message,
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    ...(html ? { contentType: "text/html" } : {}),
+  };
+
+  const sysCode: string = typeof code === "string"
+    ? code
+    : typeof anyErr?.cause?.code === "string" ? anyErr.cause.code : "";
+  if (sysCode === "ENOTFOUND" || sysCode === "EAI_AGAIN" || /getaddrinfo/i.test(rawMessage)) {
+    return { kind: "dns", ...base };
+  }
+  if (sysCode === "ECONNREFUSED" || /ECONNREFUSED/.test(rawMessage)) {
+    return { kind: "connection_refused", ...base };
+  }
+  if (sysCode === "ETIMEDOUT" || anyErr?.name === "AbortError" || /timed? ?out/i.test(rawMessage)) {
+    return { kind: "timeout", ...base };
+  }
+  if (/^(?:ERR_TLS|CERT_|UNABLE_TO_VERIFY|SELF_SIGNED|DEPTH_ZERO)/.test(sysCode) || /certificate|\bTLS\b|\bSSL\b/i.test(rawMessage)) {
+    return { kind: "tls", ...base };
+  }
+  if (httpStatus === 401 || httpStatus === 403) return { kind: "auth", ...base };
+  if (httpStatus === 404) return { kind: "not_found", ...base };
+  if (html || /unexpected token|not valid JSON|invalid json/i.test(rawMessage)) {
+    return { kind: "not_mcp", ...base };
+  }
+  if (httpStatus !== undefined) return { kind: "http", ...base };
+  if (/^(?:McpError|ProtocolError)$/.test(anyErr?.name ?? "") || /MCP error|protocol/i.test(rawMessage)) {
+    return { kind: "protocol", ...base };
+  }
+  return { kind: "unknown", ...base };
+}
+
+// ---------------------------------------------------------------------------
 // MCP inputSchema handling
 // ---------------------------------------------------------------------------
 
@@ -251,6 +386,13 @@ export class McpClientManager {
   private clients: ManagedMcpClient[] = [];
   private tools: ToolDefinition[] = [];
   private config: McpServersConfig;
+  /**
+   * Per-server connection outcome from the last `initialize()`. Kept alongside
+   * the successful clients precisely because failures used to vanish into a
+   * console.error: the control plane then saw the configured names, could not
+   * tell a connected server from a dead one, and reported both as "installed".
+   */
+  private connections: McpServerConnection[] = [];
 
   constructor(config: McpServersConfig) {
     this.config = config;
@@ -261,6 +403,7 @@ export class McpClientManager {
    */
   async initialize(): Promise<void> {
     const entries = Object.entries(this.config.mcpServers);
+    this.connections = [];
     if (entries.length === 0) return;
 
     // Lazy-import the SDK (only when actually used)
@@ -270,16 +413,24 @@ export class McpClientManager {
     const { StreamableHTTPClientTransport } = await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
 
     for (const [serverName, serverConfig] of entries) {
+      const startedAt = Date.now();
+      // Auto-detect transport when not explicitly set: url → streamable-http, command → stdio
+      const cfg = serverConfig as any;
+      const detectedTransport: string = cfg.transport
+        ?? (cfg.url ? "streamable-http" : cfg.command ? "stdio" : "");
+      const recordFailure = (error: McpConnectError) => {
+        this.connections.push({
+          name: serverName, transport: detectedTransport, state: "failed",
+          toolCount: 0, toolNames: [], durationMs: Date.now() - startedAt,
+          observedAt: new Date().toISOString(), error,
+        });
+      };
       try {
         const client = new Client(
           { name: `siclaw-mcp-${serverName}`, version: "1.0.0" },
         );
 
         let transport: any;
-        // Auto-detect transport when not explicitly set: url → streamable-http, command → stdio
-        const cfg = serverConfig as any;
-        const detectedTransport: string = cfg.transport
-          ?? (cfg.url ? "streamable-http" : cfg.command ? "stdio" : "");
         const stdioEnv = detectedTransport === "stdio"
           ? mergeMcpStdioEnv(cfg.env, process.env, isBundledCreateChartCommand(cfg.command, cfg.args))
           : undefined;
@@ -309,6 +460,10 @@ export class McpClientManager {
             break;
           default:
             console.warn(`[mcp-client] Unknown transport for "${serverName}": ${detectedTransport}`);
+            recordFailure({
+              kind: "invalid_config",
+              message: `unknown transport "${detectedTransport}"`,
+            });
             continue;
         }
 
@@ -334,12 +489,43 @@ export class McpClientManager {
         }
 
         this.clients.push({ serverName, client, transport });
+        this.connections.push({
+          name: serverName, transport: detectedTransport, state: "connected",
+          toolCount: mcpTools.length,
+          toolNames: mcpTools.map((t: any) => String(t.name)).sort(),
+          durationMs: Date.now() - startedAt,
+          observedAt: new Date().toISOString(),
+        });
       } catch (err) {
-        console.error(`[mcp-client] Failed to connect to "${serverName}":`, err);
+        const error = classifyMcpConnectError(err);
+        // The classified line is what an operator greps for; the raw error keeps
+        // the full detail (it can be a whole response body) on the next line.
+        console.error(
+          `[mcp-client] Failed to connect to "${serverName}" (${detectedTransport}): ${error.kind}` +
+          (error.httpStatus !== undefined ? ` http=${error.httpStatus}` : "") +
+          (error.contentType ? ` content-type=${error.contentType}` : "") +
+          ` — ${error.message}`,
+        );
+        console.error(`[mcp-client] Raw error for "${serverName}":`, err);
+        recordFailure(error);
       }
     }
 
     console.log(`[mcp-client] Initialized ${this.clients.length} servers, ${this.tools.length} tools total`);
+  }
+
+  /**
+   * Connection outcome of every configured server from the last `initialize()`,
+   * in configuration order. Failed servers are present with `state: "failed"`
+   * and a classified error; this is the list a box reports upstream so the
+   * control plane can show "configured but not connected" instead of "installed".
+   */
+  getServerConnections(): McpServerConnection[] {
+    return this.connections.map((item) => ({
+      ...item,
+      toolNames: [...item.toolNames],
+      ...(item.error ? { error: { ...item.error } } : {}),
+    }));
   }
 
   /**

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -393,6 +393,13 @@ export class McpClientManager {
    * tell a connected server from a dead one, and reported both as "installed".
    */
   private connections: McpServerConnection[] = [];
+  /**
+   * Set by shutdown(). initialize() checks it after every await so a connection
+   * that completes AFTER the manager was shut down — a probe that timed out, a
+   * session released while a slow server was still dialling — is closed on the
+   * spot instead of being registered into a list nobody will close again.
+   */
+  private disposed = false;
 
   constructor(config: McpServersConfig) {
     this.config = config;
@@ -404,6 +411,7 @@ export class McpClientManager {
   async initialize(): Promise<void> {
     const entries = Object.entries(this.config.mcpServers);
     this.connections = [];
+    this.disposed = false;
     if (entries.length === 0) return;
 
     // Lazy-import the SDK (only when actually used)
@@ -468,11 +476,19 @@ export class McpClientManager {
         }
 
         await client.connect(transport);
+        if (this.disposed) {
+          await this.closeLate(serverName, client, startedAt, detectedTransport);
+          continue;
+        }
         console.log(`[mcp-client] Connected to "${serverName}" (${detectedTransport})`);
         const serverImplementationName = client.getServerVersion()?.name;
 
         // Discover tools
         const { tools: mcpTools } = await client.listTools();
+        if (this.disposed) {
+          await this.closeLate(serverName, client, startedAt, detectedTransport);
+          continue;
+        }
         console.log(`[mcp-client] "${serverName}" provides ${mcpTools.length} tools: ${mcpTools.map((t: any) => t.name).join(", ")}`);
 
         for (const mcpTool of mcpTools) {
@@ -514,6 +530,21 @@ export class McpClientManager {
     console.log(`[mcp-client] Initialized ${this.clients.length} servers, ${this.tools.length} tools total`);
   }
 
+  /** Close a connection that completed after shutdown() and record why it is not usable. */
+  private async closeLate(serverName: string, client: any, startedAt: number, transport: string): Promise<void> {
+    console.warn(`[mcp-client] "${serverName}" connected after the manager was shut down; closing it`);
+    try {
+      await client.close();
+    } catch (err) {
+      console.warn(`[mcp-client] Error closing late connection to "${serverName}":`, err);
+    }
+    this.connections.push({
+      name: serverName, transport, state: "failed", toolCount: 0, toolNames: [],
+      durationMs: Date.now() - startedAt, observedAt: new Date().toISOString(),
+      error: { kind: "timeout", message: "connection completed after the manager was shut down" },
+    });
+  }
+
   /**
    * Connection outcome of every configured server from the last `initialize()`,
    * in configuration order. Failed servers are present with `state: "failed"`
@@ -546,6 +577,7 @@ export class McpClientManager {
    * Shutdown all MCP client connections.
    */
   async shutdown(): Promise<void> {
+    this.disposed = true;
     for (const { serverName, client } of this.clients) {
       try {
         await client.close();

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -426,6 +426,10 @@ export class McpClientManager {
       const cfg = serverConfig as any;
       const detectedTransport: string = cfg.transport
         ?? (cfg.url ? "streamable-http" : cfg.command ? "stdio" : "");
+      // Set once the transport is up, so the catch below can close a client
+      // whose listTools() failed: the SSE stream is open by then, and a client
+      // that never reached this.clients is otherwise closed by nobody.
+      let connected: any = null;
       const recordFailure = (error: McpConnectError) => {
         this.connections.push({
           name: serverName, transport: detectedTransport, state: "failed",
@@ -476,6 +480,7 @@ export class McpClientManager {
         }
 
         await client.connect(transport);
+        connected = client;
         if (this.disposed) {
           await this.closeLate(serverName, client, startedAt, detectedTransport);
           continue;
@@ -524,6 +529,11 @@ export class McpClientManager {
         );
         console.error(`[mcp-client] Raw error for "${serverName}":`, err);
         recordFailure(error);
+        if (connected) {
+          try { await connected.close(); } catch (closeErr) {
+            console.warn(`[mcp-client] Failed to close "${serverName}" after a failed handshake:`, closeErr);
+          }
+        }
       }
     }
 

--- a/src/gateway/server-mcp-probe.test.ts
+++ b/src/gateway/server-mcp-probe.test.ts
@@ -1,0 +1,120 @@
+/**
+ * mcp.probe RPC — dial one MCP server config from the Runtime and report the
+ * outcome in the box's connection-observation shape.
+ *
+ * Exercised against real local HTTP endpoints so the probe classifies what the
+ * MCP SDK actually throws, the same way a box does at session start.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+vi.mock("./chat-repo.js", () => ({
+  validTraceId: (v: unknown) => (typeof v === "string" && /^[0-9a-f]{32}$/.test(v) ? v : undefined),
+  warnTraceBindFailure: vi.fn(),
+  ensureChatSession: vi.fn(async () => {}),
+  appendMessage: vi.fn(async () => "msg-id"),
+  bindMessageTraceId: vi.fn(async () => {}),
+  updateMessage: vi.fn(async () => {}),
+  incrementMessageCount: vi.fn(async () => {}),
+}));
+
+const { startRuntime } = await import("./server.js");
+
+const servers: http.Server[] = [];
+type Responder = (req: http.IncomingMessage, body: string, res: http.ServerResponse) => void;
+async function listen(responder: Responder): Promise<string> {
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => { body += chunk; });
+    req.on("end", () => responder(req, body, res));
+  });
+  servers.push(server);
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  return `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+}
+const fakeMcpServer = (tools: string[]): Responder => (req, body, res) => {
+  if (req.method !== "POST") { res.writeHead(405).end(); return; }
+  const msg = JSON.parse(body);
+  if (msg.id === undefined) { res.writeHead(202).end(); return; }
+  const result = msg.method === "initialize"
+    ? { protocolVersion: msg.params?.protocolVersion ?? "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "fake", version: "0" } }
+    : msg.method === "tools/list"
+      ? { tools: tools.map((name) => ({ name, inputSchema: { type: "object", properties: {} } })) }
+      : undefined;
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(result !== undefined
+    ? { jsonrpc: "2.0", id: msg.id, result }
+    : { jsonrpc: "2.0", id: msg.id, error: { code: -32601, message: "Method not found" } }));
+};
+
+async function bootRuntime() {
+  return startRuntime({
+    config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
+    agentBoxManager: {
+      setCertManager: vi.fn(), setSpawnEnvResolver: vi.fn(), setPersistenceResolver: vi.fn(),
+      getAsync: vi.fn(), getOrCreate: vi.fn(), list: vi.fn(async () => []), cleanup: vi.fn(async () => {}),
+    } as any,
+    frontendClient: { request: vi.fn(async () => ({})), onCommand: vi.fn(), emitEvent: vi.fn(), close: vi.fn() } as any,
+    credentialService: {} as any,
+  });
+}
+
+let server: Awaited<ReturnType<typeof startRuntime>> | undefined;
+afterEach(async () => {
+  if (server) await server.close();
+  server = undefined;
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => { s.closeAllConnections(); s.close(() => r()); })));
+});
+
+describe("mcp.probe RPC", () => {
+  it("reports a reachable MCP endpoint as connected with its tool inventory", async () => {
+    const url = await listen(fakeMcpServer(["siclaw_investigate", "siclaw_get_task"]));
+    server = await bootRuntime();
+    const probe = server.rpcMethods.get("mcp.probe")!;
+    const out: any = await probe({ server: { name: "siverse", transport: "streamable-http", url } }, { sendEvent: vi.fn() } as any);
+    expect(out.ok).toBe(true);
+    expect(out.probe).toMatchObject({
+      name: "siverse", transport: "streamable-http", state: "connected", toolCount: 2,
+      toolNames: ["siclaw_get_task", "siclaw_investigate"],
+    });
+    expect(out.probe.error).toBeUndefined();
+  });
+
+  it("reports a URL that answers with an HTML 404 page as not_found / text/html", async () => {
+    const url = await listen((_req, _body, res) => {
+      res.writeHead(404, { "Content-Type": "text/html" });
+      res.end("<!DOCTYPE html><html><head><title>Simate</title></head><body>页面不存在</body></html>");
+    });
+    server = await bootRuntime();
+    const probe = server.rpcMethods.get("mcp.probe")!;
+    const out: any = await probe({ server: { name: "siverse", url } }, { sendEvent: vi.fn() } as any);
+    expect(out.probe).toMatchObject({
+      name: "siverse", transport: "streamable-http", state: "failed", toolCount: 0,
+      error: { kind: "not_found", httpStatus: 404, contentType: "text/html", message: "HTML page: Simate" },
+    });
+  });
+
+  it("refuses to probe a stdio server from the Runtime", async () => {
+    server = await bootRuntime();
+    const probe = server.rpcMethods.get("mcp.probe")!;
+    const out: any = await probe({ server: { name: "chart", transport: "stdio", command: "/bin/echo" } }, { sendEvent: vi.fn() } as any);
+    expect(out.probe).toMatchObject({ name: "chart", transport: "stdio", state: "failed", error: { kind: "invalid_config" } });
+  });
+
+  it("gives up with a timeout when the endpoint never answers", async () => {
+    const url = await listen(() => { /* hold the request open */ });
+    server = await bootRuntime();
+    const probe = server.rpcMethods.get("mcp.probe")!;
+    const started = Date.now();
+    const out: any = await probe({ server: { name: "slow", url }, timeoutMs: 1_000 }, { sendEvent: vi.fn() } as any);
+    expect(Date.now() - started).toBeLessThan(5_000);
+    expect(out.probe).toMatchObject({ name: "slow", state: "failed", error: { kind: "timeout" } });
+  });
+
+  it("rejects a request without a server name", async () => {
+    server = await bootRuntime();
+    const probe = server.rpcMethods.get("mcp.probe")!;
+    await expect(probe({ server: { url: "http://127.0.0.1:1/mcp" } }, { sendEvent: vi.fn() } as any)).rejects.toThrow("server.name required");
+  });
+});

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -513,3 +513,74 @@ describe("agent.promptInspection RPC", () => {
     });
   });
 });
+
+describe("agent.syncStatus RPC — MCP connection outcomes", () => {
+  const connected = { name: "devops", transport: "streamable-http", state: "connected", toolCount: 2, toolNames: ["a", "b"], durationMs: 10, observedAt: "2026-09-07T09:44:58.000Z" };
+  const failed = { name: "siverse", transport: "streamable-http", state: "failed", toolCount: 0, toolNames: [], durationMs: 5, observedAt: "2026-09-07T09:45:00.000Z",
+    error: { kind: "not_found", httpStatus: 404, contentType: "text/html", message: "HTML page: Simate" } };
+
+  it("surfaces per-server outcomes in the flat aggregate when every box agrees", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://b2" },
+    ];
+    for (const endpoint of ["https://b1", "https://b2"]) {
+      getJsonByEndpoint.set(endpoint, async () => ({
+        ...defaultSyncStatus,
+        schemaVersion: 4,
+        mcp: { names: ["devops", "siverse"], servers: [connected, failed] },
+      }));
+    }
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+    await expect(syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any)).resolves.toMatchObject({
+      consistent: true,
+      mcp: { names: ["devops", "siverse"], servers: [connected, failed] },
+      observations: [
+        { boxId: "b1", status: { mcp: { servers: [connected, failed] } } },
+        { boxId: "b2", status: { mcp: { servers: [connected, failed] } } },
+      ],
+    });
+  });
+
+  it("treats the same config with a different connection outcome as inconsistent and withholds the flat servers", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://b2" },
+    ];
+    getJsonByEndpoint.set("https://b1", async () => ({
+      ...defaultSyncStatus, schemaVersion: 4,
+      mcp: { names: ["devops", "siverse"], servers: [connected, failed] },
+    }));
+    getJsonByEndpoint.set("https://b2", async () => ({
+      ...defaultSyncStatus, schemaVersion: 4,
+      mcp: { names: ["devops", "siverse"], servers: [connected, { ...failed, state: "connected", toolCount: 5, error: undefined }] },
+    }));
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+    const out: any = await syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any);
+    expect(out.consistent).toBe(false);
+    expect(out.mcp).toEqual({ names: ["devops", "siverse"] });
+    expect(out.observations[0].status.mcp.servers[1].state).toBe("failed");
+    expect(out.observations[1].status.mcp.servers[1].state).toBe("connected");
+  });
+
+  it("ignores timing and message differences between replicas", async () => {
+    listReturns = [
+      { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+      { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://b2" },
+    ];
+    getJsonByEndpoint.set("https://b1", async () => ({
+      ...defaultSyncStatus, schemaVersion: 4, mcp: { names: ["siverse"], servers: [failed] },
+    }));
+    getJsonByEndpoint.set("https://b2", async () => ({
+      ...defaultSyncStatus, schemaVersion: 4,
+      mcp: { names: ["siverse"], servers: [{ ...failed, durationMs: 900, observedAt: "2026-09-07T10:00:00.000Z", error: { ...failed.error, message: "HTML page" } }] },
+    }));
+    server = await bootRuntime();
+    const syncStatus = server.rpcMethods.get("agent.syncStatus")!;
+    const out: any = await syncStatus({ agentId: "preview" }, { sendEvent: vi.fn() } as any);
+    expect(out.consistent).toBe(true);
+    expect(out.mcp.servers).toHaveLength(1);
+  });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -2362,8 +2362,12 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       return { ok: true, probe };
     } finally {
       if (timer) clearTimeout(timer);
-      // Best-effort: a hung transport must not keep the Runtime's probe pending.
-      void manager.shutdown().catch(() => {});
+      // Awaited, not fire-and-forget: shutdown() marks the manager disposed so a
+      // connection that completes after the timeout is closed by initialize()
+      // itself instead of leaking into a list nobody will close again.
+      await manager.shutdown().catch((err) => {
+        console.warn(`[rpc] mcp.probe: shutdown of "${name}" failed:`, err);
+      });
     }
   });
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -79,6 +79,7 @@ import {
   type BoxSyncObservation,
   type BoxSyncStatus,
 } from "../shared/agentbox-sync-status.js";
+import { McpClientManager, type McpConnectErrorKind, type McpServerConnection } from "../core/mcp-client.js";
 import { clearAgentMemory } from "./memory-cleanup.js";
 import {
   handleSettings,
@@ -2236,6 +2237,15 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       knowledge: [...(status.knowledge?.repos ?? [])].sort((a, b) => a.id.localeCompare(b.id)),
       skills: [...(status.skills?.names ?? [])].sort(),
       mcp: [...(status.mcp?.names ?? [])].sort(),
+      // Connection outcome is part of what a replica IS: two boxes with the same
+      // config where one reached a server and the other did not are serving
+      // different toolsets. Timing, tool names and error text are evidence, not
+      // identity, so only name/state/toolCount/error kind participate.
+      mcpServers: status.mcp?.servers
+        ? [...status.mcp.servers]
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((s) => ({ name: s.name, state: s.state, toolCount: s.toolCount, errorKind: s.error?.kind ?? null }))
+        : null,
       harness: status.harness ? {
         agentType: status.harness.agentType,
         systemPromptTemplate: status.harness.systemPromptTemplate,
@@ -2290,7 +2300,13 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       // the old verifier in sync_pending rather than producing a false success.
       knowledge: first.knowledge ?? { syncedAt: null, repos: [] },
       skills: first.skills ?? { names: [] },
-      mcp: first.mcp ?? { names: [] },
+      // `servers` follows the harness/model gate: per-box outcomes live in
+      // `observations`; the flat view only claims a connection state every
+      // running box agrees on.
+      mcp: {
+        names: first.mcp?.names ?? [],
+        ...(consistent && first.mcp?.servers ? { servers: first.mcp.servers } : {}),
+      },
       harness: consistent ? (first.harness ?? null) : null,
       model: consistent ? (first.model ?? null) : null,
       // Same gate as the two above: a tier observation is proof only when every
@@ -2298,6 +2314,57 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       // walking `observations` would otherwise have no way to see tier state at all.
       tiers: consistent ? (first.tiers ?? null) : null,
     };
+  });
+
+  // mcp.probe — dial ONE MCP server config from this Runtime and report the
+  // outcome in the same shape a box reports after initializing MCP.
+  //
+  // This exists so a platform MCP owner can learn "your URL returns an HTML
+  // page" when they SAVE the config, instead of after an agent somewhere fails
+  // to connect and nobody surfaces it. It runs here rather than in the control
+  // plane on purpose: the Runtime is where the config will actually be used, it
+  // shares the network position of the boxes it spawns, and per-runtime address
+  // overrides only make sense when the runtime itself resolves them.
+  //
+  // stdio servers are refused: probing one would execute an arbitrary command in
+  // the Runtime process, and a box start already reports their outcome.
+  rpcMethods.set("mcp.probe", async (params) => {
+    const server = params.server as Record<string, unknown> | undefined;
+    if (!server || typeof server.name !== "string" || server.name.trim() === "") {
+      throw new Error("server.name required");
+    }
+    const name = server.name;
+    const transport = typeof server.transport === "string" && server.transport !== ""
+      ? server.transport
+      : typeof server.url === "string" ? "streamable-http" : typeof server.command === "string" ? "stdio" : "";
+    const startedAt = Date.now();
+    const failed = (kind: McpConnectErrorKind, message: string): McpServerConnection => ({
+      name, transport, state: "failed", toolCount: 0, toolNames: [],
+      durationMs: Date.now() - startedAt, observedAt: new Date().toISOString(),
+      error: { kind, message },
+    });
+    if (transport === "stdio") {
+      return { ok: true, probe: failed("invalid_config", "stdio servers run inside the AgentBox and are not probed from the Runtime") };
+    }
+    const requested = Number(params.timeoutMs);
+    const timeoutMs = Number.isFinite(requested) ? Math.min(Math.max(Math.trunc(requested), 1_000), 30_000) : 10_000;
+    const manager = new McpClientManager({ mcpServers: { [name]: { ...server, transport } as any } });
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = new Promise<"timeout">((resolve) => { timer = setTimeout(() => resolve("timeout"), timeoutMs); });
+    try {
+      const outcome = await Promise.race([manager.initialize().then(() => "done" as const), timedOut]);
+      if (outcome === "timeout") {
+        return { ok: true, probe: failed("timeout", `no MCP handshake within ${timeoutMs}ms`) };
+      }
+      const probe = manager.getServerConnections().find((item) => item.name === name)
+        ?? failed("unknown", "probe produced no observation");
+      console.log(`[rpc] mcp.probe: "${name}" (${transport}) → ${probe.state}${probe.error ? ` ${probe.error.kind}` : ` ${probe.toolCount} tools`}`);
+      return { ok: true, probe };
+    } finally {
+      if (timer) clearTimeout(timer);
+      // Best-effort: a hung transport must not keep the Runtime's probe pending.
+      void manager.shutdown().catch(() => {});
+    }
   });
 
   // agent.promptInspection — explicit sensitive audit of one resident session.

--- a/src/shared/agentbox-sync-status.test.ts
+++ b/src/shared/agentbox-sync-status.test.ts
@@ -104,3 +104,64 @@ describe("tiers observation", () => {
     }
   });
 });
+
+describe("mcp.servers observation", () => {
+  it("leaves `servers` absent when the box did not send it (v3 box or MCP never initialized)", () => {
+    const status = normalizeBoxSyncStatus(payload({ mcp: { names: ["devops"] } }));
+    expect(status.mcp).toEqual({ names: ["devops"] });
+    expect("servers" in status.mcp).toBe(false);
+  });
+
+  it("keeps an empty `servers` array distinct from an absent one", () => {
+    const status = normalizeBoxSyncStatus(payload({ mcp: { names: [], servers: [] } }));
+    expect(status.mcp.servers).toEqual([]);
+  });
+
+  it("preserves a connected and a failed server with the classified error", () => {
+    const status = normalizeBoxSyncStatus(payload({
+      mcp: {
+        names: ["devops", "siverse"],
+        servers: [
+          { name: "devops", transport: "streamable-http", state: "connected", toolCount: 2,
+            toolNames: ["get_change_detail", "list_change_records"], durationMs: 361, observedAt: "2026-09-07T09:44:58.643Z" },
+          { name: "siverse", transport: "streamable-http", state: "failed", toolCount: 0, toolNames: [], durationMs: 20,
+            observedAt: "2026-09-07T09:45:00.168Z",
+            error: { kind: "not_found", httpStatus: 404, contentType: "text/html", message: "HTML page: Simate" } },
+        ],
+      },
+    }));
+    expect(status.mcp.servers).toEqual([
+      { name: "devops", transport: "streamable-http", state: "connected", toolCount: 2,
+        toolNames: ["get_change_detail", "list_change_records"], durationMs: 361, observedAt: "2026-09-07T09:44:58.643Z" },
+      { name: "siverse", transport: "streamable-http", state: "failed", toolCount: 0, toolNames: [], durationMs: 20,
+        observedAt: "2026-09-07T09:45:00.168Z",
+        error: { kind: "not_found", httpStatus: 404, contentType: "text/html", message: "HTML page: Simate" } },
+    ]);
+  });
+
+  it("drops entries without a name or a recognised state and never invents a connection", () => {
+    const status = normalizeBoxSyncStatus(payload({
+      mcp: {
+        names: ["a", "b", "c"],
+        servers: [
+          { transport: "sse", state: "connected" },
+          { name: "b", state: "pending" },
+          { name: "c", state: "failed" },
+        ],
+      },
+    }));
+    expect(status.mcp.servers).toEqual([
+      // A failed server without an explanation still reports failed, with an
+      // `unknown` error rather than a fabricated success.
+      { name: "c", transport: "", state: "failed", toolCount: 0, toolNames: [], durationMs: 0, observedAt: "",
+        error: { kind: "unknown", message: "" } },
+    ]);
+  });
+
+  it("maps an unrecognised error kind to unknown instead of leaking free text into the vocabulary", () => {
+    const status = normalizeBoxSyncStatus(payload({
+      mcp: { names: ["x"], servers: [{ name: "x", state: "failed", error: { kind: "weird", message: "boom" } }] },
+    }));
+    expect(status.mcp.servers?.[0].error).toEqual({ kind: "unknown", message: "boom" });
+  });
+});

--- a/src/shared/agentbox-sync-status.ts
+++ b/src/shared/agentbox-sync-status.ts
@@ -22,8 +22,41 @@ export interface ObservedKnowledgeRepo {
  * consumer needs the version to tell that apart from a v2 box, which says nothing
  * either way. Without it, "this box is not tiering" and "this box is too old to
  * say" are the same observation.
+ *
+ * 4 adds `mcp.servers`. `mcp.names` was — and still is — the keys of the
+ * materialized config, which says a server was WRITTEN TO DISK and nothing
+ * about whether it was ever reached. `servers` is the per-server connection
+ * outcome from the process that dialled them. A v4 box reports it whenever a
+ * session has initialized MCP; a v3 box cannot, so a consumer must not read an
+ * absent `servers` as "all connected".
  */
-export const AGENT_SYNC_STATUS_SCHEMA_VERSION = 3;
+export const AGENT_SYNC_STATUS_SCHEMA_VERSION = 4;
+
+/** Closed vocabulary shared with core/mcp-client.ts; see McpConnectErrorKind. */
+export type ObservedMcpErrorKind =
+  | "invalid_config" | "dns" | "connection_refused" | "timeout" | "tls"
+  | "auth" | "not_found" | "not_mcp" | "http" | "protocol" | "unknown";
+
+/**
+ * One configured MCP server as the box actually experienced it. A failed
+ * server carries `toolCount: 0` and a classified `error`; the message is short
+ * and HTML-stripped by the producer, never a response body.
+ */
+export interface ObservedMcpServer {
+  name: string;
+  transport: string;
+  state: "connected" | "failed";
+  toolCount: number;
+  toolNames: string[];
+  durationMs: number;
+  observedAt: string;
+  error?: {
+    kind: ObservedMcpErrorKind;
+    httpStatus?: number;
+    contentType?: string;
+    message: string;
+  };
+}
 
 export interface BoxSyncStatus {
   /** Preserve the box-reported version during rolling upgrades. */
@@ -33,7 +66,16 @@ export interface BoxSyncStatus {
     repos: ObservedKnowledgeRepo[];
   };
   skills: { names: string[] };
-  mcp: { names: string[] };
+  mcp: {
+    /** Configured server names (materialized config keys). */
+    names: string[];
+    /**
+     * Per-server connection outcome from the most recent MCP initialization
+     * in this box. Absent on a box that has not initialized MCP yet (no
+     * session created since start) or that predates v4.
+     */
+    servers?: ObservedMcpServer[];
+  };
   /** Harness configuration that completed the latest successful turn. */
   harness?: {
     agentType: string;
@@ -95,6 +137,56 @@ function strings(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === "string");
 }
 
+const OBSERVED_MCP_ERROR_KINDS: ReadonlySet<string> = new Set<ObservedMcpErrorKind>([
+  "invalid_config", "dns", "connection_refused", "timeout", "tls",
+  "auth", "not_found", "not_mcp", "http", "protocol", "unknown",
+]);
+
+/**
+ * Normalize `mcp` from a box. `servers` is kept only when the box sent an array:
+ * an absent field must stay absent so the consumer can tell "v3 box, cannot say"
+ * from "v4 box, nothing configured" (empty array).
+ */
+export function normalizeObservedMcp(mcp: Record<string, unknown> | null): BoxSyncStatus["mcp"] {
+  const names = strings(mcp?.names);
+  if (!Array.isArray(mcp?.servers)) return { names };
+  const servers = mcp.servers.flatMap((item): ObservedMcpServer[] => {
+    const server = record(item);
+    if (!server || typeof server.name !== "string") return [];
+    const state = server.state === "connected" || server.state === "failed" ? server.state : null;
+    if (!state) return [];
+    const error = record(server.error);
+    const kind = typeof error?.kind === "string" && OBSERVED_MCP_ERROR_KINDS.has(error.kind)
+      ? error.kind as ObservedMcpErrorKind
+      : "unknown";
+    return [{
+      name: server.name,
+      transport: typeof server.transport === "string" ? server.transport : "",
+      state,
+      toolCount: typeof server.toolCount === "number" && Number.isFinite(server.toolCount)
+        ? Math.max(0, Math.trunc(server.toolCount))
+        : 0,
+      toolNames: strings(server.toolNames),
+      durationMs: typeof server.durationMs === "number" && Number.isFinite(server.durationMs)
+        ? Math.max(0, Math.trunc(server.durationMs))
+        : 0,
+      observedAt: typeof server.observedAt === "string" ? server.observedAt : "",
+      // A failed server without an error object still gets one: the state is the
+      // fact, the error is the explanation, and a missing explanation is itself
+      // worth showing rather than silently turning the entry into "connected".
+      ...(state === "failed"
+        ? { error: {
+            kind,
+            ...(typeof error?.httpStatus === "number" ? { httpStatus: error.httpStatus } : {}),
+            ...(typeof error?.contentType === "string" ? { contentType: error.contentType } : {}),
+            message: typeof error?.message === "string" ? error.message : "",
+          } }
+        : {}),
+    }];
+  });
+  return { names, servers };
+}
+
 /** Normalize an independently released AgentBox's JSON before Runtime uses it. */
 export function normalizeBoxSyncStatus(value: unknown): BoxSyncStatus {
   const root = record(value);
@@ -139,7 +231,7 @@ export function normalizeBoxSyncStatus(value: unknown): BoxSyncStatus {
       repos,
     },
     skills: { names: strings(record(root.skills)?.names) },
-    mcp: { names: strings(record(root.mcp)?.names) },
+    mcp: normalizeObservedMcp(record(root.mcp)),
     ...(harness && typeof harness.agentType === "string"
       ? { harness: {
           agentType: harness.agentType,


### PR DESCRIPTION
## Why

A configured MCP server that failed to connect left one `console.error` inside the AgentBox and nothing else. `/api/sync-status` reported the configured names (config keys), so Sicore showed every server as "installed" — including a platform MCP whose URL pointed at a web page. Its agents never had the tools and nobody could see why without reading a Pod log.

## What

- `McpClientManager` keeps a per-server connection outcome and exposes `getServerConnections()`: `connected` with tool inventory, or `failed` with a classified error (`classifyMcpConnectError`: `invalid_config | dns | connection_refused | timeout | tls | auth | not_found | not_mcp | http | protocol | unknown`, plus `httpStatus` / `contentType` / a short stripped message). An HTML body is reduced to `HTML page: <title>` instead of a 15 KB response.
- `BoxSyncStatus` schema **v4**: `mcp.servers[]` next to `mcp.names`. Absent = old box / MCP not initialized yet; `[]` = reported, nothing configured. The normalizer keeps those apart.
- The box records outcomes when a session is **created**, so a server that failed to connect is visible even if the turn that followed also failed (e.g. the model rejecting an oversized tool list). `/api/sync-status` prefers the newest live session's manager.
- `agent.syncStatus`: connection outcomes (name/state/toolCount/errorKind) are part of the replica identity; the flat `mcp.servers` is only published when every running box agrees.
- New Runtime RPC **`mcp.probe { server, timeoutMs? }`** dials one server config from the Runtime and returns the same outcome shape. Runs on the Runtime on purpose (network position of the boxes, per-runtime address overrides). `stdio` is refused.
- Design note: `docs/design/mcp-connection-observability.md`; cross-reference in `mcp-session-lifecycle.md`.

Sicore counterpart (stores the outcomes, shows them on the harness panel and the MCP page, adds a "Test connection" probe and Dev MCP tools) is in a separate MR.

## Tests

- `src/core/mcp-client-connections.test.ts` — real local HTTP endpoints: connected server, HTML 404 → `not_found`/`text/html`, connection refused, unknown transport, copies.
- `src/shared/agentbox-sync-status.test.ts` — v4 normalization.
- `src/gateway/server-sync-status.test.ts` — consensus with/without agreeing outcomes.
- `src/gateway/server-mcp-probe.test.ts` — probe happy path, HTML 404, stdio refusal, timeout, validation.
- Full `vitest run`: 6784 passed; 5 failures in `server-chat-abort.test.ts` / `node-logs-skill-scripts.test.ts` pass when run alone on both this branch and `origin/main` (load-dependent, unrelated).
