### PR TITLE
fix(capability): never roll a live kbc box mid-run; stamp watchdog closes

### DIFF
--- a/src/gateway/capability/box-acquire.test.ts
+++ b/src/gateway/capability/box-acquire.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { acquireCapabilityBox, type CapabilityBoxAcquirer } from "./box-acquire.js";
+
+class FakeManager implements CapabilityBoxAcquirer {
+  calls: string[] = [];
+  live: { endpoint: string } | undefined;
+  constructor(live?: { endpoint: string }) {
+    this.live = live;
+  }
+  async getAsync(agentId: string, profile?: string) {
+    this.calls.push(`getAsync:${agentId}:${profile}`);
+    return this.live;
+  }
+  async getOrCreateWithDisposition(agentId: string, config: { profile: string }) {
+    this.calls.push(`getOrCreateWithDisposition:${agentId}:${config.profile}`);
+    return { handle: { endpoint: "https://new-box:3000" }, created: true };
+  }
+  async getOrCreate(agentId: string, config: { profile: string }) {
+    this.calls.push(`getOrCreate:${agentId}:${config.profile}`);
+    return { endpoint: "https://new-box:3000" };
+  }
+}
+
+describe("acquireCapabilityBox", () => {
+  it("reuses the run's live box as-is and never enters acquisition (no image roll mid-run)", async () => {
+    const mgr = new FakeManager({ endpoint: "https://kbc-box-run1:3000" });
+    const got = await acquireCapabilityBox(mgr, "run1", "kb-compile", "org1");
+    expect(got).toEqual({ endpoint: "https://kbc-box-run1:3000", created: false });
+    expect(mgr.calls).toEqual(["getAsync:run1:kb-compile"]);
+  });
+
+  it("spawns through acquisition only when no live box exists, reporting the disposition", async () => {
+    const mgr = new FakeManager(undefined);
+    const got = await acquireCapabilityBox(mgr, "run2", "kb-compile", "org1");
+    expect(got).toEqual({ endpoint: "https://new-box:3000", created: true });
+    expect(mgr.calls).toEqual(["getAsync:run2:kb-compile", "getOrCreateWithDisposition:run2:kb-compile"]);
+  });
+
+  it("falls back to getOrCreate (treated as creator) for managers without disposition", async () => {
+    const mgr = new FakeManager(undefined);
+    (mgr as Partial<CapabilityBoxAcquirer>).getOrCreateWithDisposition = undefined;
+    const got = await acquireCapabilityBox(mgr, "run3", "kb-compile");
+    expect(got).toEqual({ endpoint: "https://new-box:3000", created: true });
+    expect(mgr.calls).toEqual(["getAsync:run3:kb-compile", "getOrCreate:run3:kb-compile"]);
+  });
+});

--- a/src/gateway/capability/box-acquire.ts
+++ b/src/gateway/capability/box-acquire.ts
@@ -1,0 +1,70 @@
+/**
+ * Box acquisition for capability runs (kb-compile and friends).
+ *
+ * A capability run's box is SINGLE-USE and keyed by the runId: the pod's identity
+ * is the run. That makes it fundamentally different from a chat agent's pool,
+ * and the difference matters on one path — acquisition. `getOrCreate*` compares
+ * a running box against the image the profile would spawn today and ROLLS a box
+ * it judges stale (markStaleBoxesDraining / getOrCreateK8s rollReason): the old
+ * pod is marked draining, a replacement comes up, and the caller is handed the
+ * replacement. For a chat pool that is a rolling upgrade. For a kbc box it is
+ * abandoning the run it is executing: the relay attaches to an empty replacement,
+ * the old pod is deleted at the drain deadline, and whatever the compile still
+ * had to emit — the candidate commit included — dies with it.
+ *
+ * 2026-09-07 incident: a siclaw release restarted the runtime; boot recovery
+ * re-attached a live compile run through acquisition, the box was rolled for its
+ * (unchanged) image, the run idled on the new pod and the watchdog closed it as
+ * "done" two hours later. The knowledge base showed "ready to generate" with no
+ * trace of the failure.
+ *
+ * Rule: a LIVE box for this run is reused as-is, regardless of image, cert
+ * freshness or anything else acquisition would roll on. Only a missing/dead box
+ * goes through spawn. Image changes reach kbc boxes the way they always did —
+ * every run is a new pod.
+ */
+
+export interface CapabilityBoxHandleLike {
+  endpoint: string;
+}
+
+export interface CapabilityBoxAcquirer {
+  /** The run's live box, if one is running right now. Never spawns, never rolls. */
+  getAsync(agentId: string, profile?: string): Promise<CapabilityBoxHandleLike | undefined>;
+  getOrCreateWithDisposition?(
+    agentId: string,
+    config: { profile: string; orgId?: string },
+  ): Promise<{ handle: CapabilityBoxHandleLike; created: boolean }>;
+  getOrCreate(
+    agentId: string,
+    config: { profile: string; orgId?: string },
+  ): Promise<CapabilityBoxHandleLike>;
+}
+
+export interface CapabilityBoxAcquisition {
+  endpoint: string;
+  /** true only when THIS call spawned the box (so failed setup may dispose of it). */
+  created: boolean;
+}
+
+export async function acquireCapabilityBox(
+  manager: CapabilityBoxAcquirer,
+  runId: string,
+  profile: string,
+  orgId?: string,
+): Promise<CapabilityBoxAcquisition> {
+  const live = await manager.getAsync(runId, profile);
+  if (live?.endpoint) {
+    return { endpoint: live.endpoint, created: false };
+  }
+  // Compatibility for embedded managers/test doubles built before acquisition
+  // disposition existed. The concrete manager always reports it; an older
+  // implementation is conservatively treated as the creator so failed setup
+  // retains the historical cleanup behavior.
+  if (typeof manager.getOrCreateWithDisposition === "function") {
+    const acquired = await manager.getOrCreateWithDisposition(runId, { profile, orgId });
+    return { endpoint: acquired.handle.endpoint, created: acquired.created };
+  }
+  const handle = await manager.getOrCreate(runId, { profile, orgId });
+  return { endpoint: handle.endpoint, created: true };
+}

--- a/src/gateway/capability/run-manager.test.ts
+++ b/src/gateway/capability/run-manager.test.ts
@@ -580,8 +580,24 @@ describe("CapabilityRunManager", () => {
     clock = 7000; // past idleTtl
     expect(await mgr.reapStale()).toEqual([runId]);
     expect(stopped).toEqual([runId]); // box still stopped (resource hygiene)
-    // ...but the outcome is a normal session end, not a failure.
-    expect(be.persists().at(-1)?.params).toMatchObject({ run_id: runId, status: "done" });
+    // ...but the outcome is a normal session end, not a failure — stamped with
+    // WHY the runtime (not the box) wrote it, so a consumer whose operation is
+    // still open can tell an undriven run from a finished one.
+    expect(be.persists().at(-1)?.params).toMatchObject({
+      run_id: runId,
+      status: "done",
+      checkpoint: { close_reason: "idle_timeout" },
+    });
+  });
+
+  it("a done the box itself emits carries no close_reason", async () => {
+    const be = new FakeBackend();
+    const mgr = new CapabilityRunManager(be);
+    const { runId } = await mgr.startRun({ profile: "kb-compile", orgId: "o1" });
+    await mgr.endRun(runId, "done");
+    const last = be.persists().at(-1)?.params;
+    expect(last).toMatchObject({ run_id: runId, status: "done" });
+    expect(last?.checkpoint?.close_reason).toBeUndefined();
   });
 
   it("onAdopt fires once per NEWLY adopted run — never for runs already tracked", async () => {

--- a/src/gateway/capability/run-manager.ts
+++ b/src/gateway/capability/run-manager.ts
@@ -52,6 +52,13 @@ export interface CapabilityRunRecord {
   commandReceipts: CapabilityCommandReceipt[];
   /** Sanitized machine-readable terminal failure; never user/tool content. */
   failure?: CapabilityRunFailure;
+  /**
+   * Why a "done" was written by the RUNTIME rather than the box (e.g.
+   * `idle_timeout`: the watchdog closed a resting run). Absent for a done the
+   * box itself emitted. A consumer whose operation is still open when such a
+   * done arrives can tell "the box finished" from "nobody was driving the run".
+   */
+  closeReason?: string;
   /** Wall-clock ms of the last DATA event; drives the stale-run watchdog. */
   lastActivityMs: number;
   /**
@@ -576,6 +583,12 @@ export class CapabilityRunManager {
           message: "runtime_stale:watchdog",
         });
       } else {
+        // An idle run closed by the watchdog is a normal session end for a
+        // conversation at rest — but for a compile whose operation never
+        // committed, it means the run was left undriven (its box was rolled or
+        // the relay never came back). Stamp the reason so the consumer can say
+        // which, instead of a bare "ended without committing".
+        rec.closeReason = "idle_timeout";
         await this.endRun(runId, outcome);
       }
       reaped.push(runId);
@@ -642,6 +655,7 @@ export class CapabilityRunManager {
       ...(rec.messageIds.length > 0 ? { message_ids: rec.messageIds } : {}),
       ...(rec.commandReceipts.length > 0 ? { command_receipts: rec.commandReceipts } : {}),
       ...(rec.failure ? { failure: rec.failure } : {}),
+      ...(rec.closeReason ? { close_reason: rec.closeReason } : {}),
     };
     const state: CapabilityRunState = {
       run_id: rec.runId,

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -28,6 +28,7 @@ import { AgentBoxClient, type PromptOptions } from "./agentbox/client.js";
 import { getBoxProfile } from "./agentbox/box-profile.js";
 import { buildSpawnEnv } from "./agentbox/spawn-env.js";
 import { CapabilityRunManager } from "./capability/run-manager.js";
+import { acquireCapabilityBox } from "./capability/box-acquire.js";
 import { driveCapabilitySession } from "./capability/session-driver.js";
 import { asFailureToken } from "./capability/failure.js";
 import { driveTestSession, shouldRelayTestSession } from "./capability/test-relay.js";
@@ -1215,18 +1216,12 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
         created: false,
       };
     }
-    // Compatibility for embedded managers/test doubles built before acquisition
-    // disposition existed. The concrete manager always reports it; an older
-    // implementation is conservatively treated as the creator so failed setup
-    // retains the historical cleanup behavior.
-    const manager = agentBoxManager as AgentBoxManager & {
-      getOrCreateWithDisposition?: AgentBoxManager["getOrCreateWithDisposition"];
-    };
-    const acquired = typeof manager.getOrCreateWithDisposition === "function"
-      ? await manager.getOrCreateWithDisposition(runId, { profile, orgId })
-      : { handle: await manager.getOrCreate(runId, { profile, orgId }), created: true };
+    // A live box for this run is reused as-is; only a missing box is spawned.
+    // Routing a live kbc box through acquisition rolls it on a stale image and
+    // abandons the run it is executing — see box-acquire.ts for the incident.
+    const acquired = await acquireCapabilityBox(agentBoxManager, runId, profile, orgId);
     return {
-      client: new AgentBoxClient(acquired.handle.endpoint, 30000, agentBoxTlsOptions),
+      client: new AgentBoxClient(acquired.endpoint, 30000, agentBoxTlsOptions),
       created: acquired.created,
     };
   };


### PR DESCRIPTION
## Problem

A capability run's box is single-use and keyed by the run id, but `capabilityBoxClient` routed every (re)attach through `agentBoxManager` acquisition. That path compares the running box against the profile's current image and **rolls** it when stale (`getOrCreateK8s` rollReason → `markStaleBoxesDraining`): the old pod is marked draining, a replacement is spawned, and the relay attaches to the empty replacement. For a kbc box this abandons the compile it is executing — the old pod is deleted at `DRAIN_DEADLINE_MS` and its pending candidate commit is lost (`_flush_on_shutdown` only drains to a live relay).

**2026-09-07 incident (prod, kb `660ed03c…`)**: the v0.3.17 release restarted the runtime at 13:41Z; boot recovery (`onAdopt`) re-attached a live compile run through acquisition; the box was rolled for its image (the release changed nothing under `kbc/`); the run idled on the new pod; the watchdog closed it as `done` at 15:42Z (`idleTtlMs` = 2h). Sicore recorded the operation as failed, but the page showed "documents ready, generate" with no trace of it.

## Fix

- `capabilityBoxClient` reuses the run's **live** box as-is (`getAsync`) and only spawns when no box exists. The rule lives in `acquireCapabilityBox` (`src/gateway/capability/box-acquire.ts`) so it is unit-tested against a fake manager. Image changes still reach kbc boxes the way they always did: every run is a new pod.
- The watchdog stamps `close_reason: "idle_timeout"` into the run checkpoint when **it** writes the `done`, so a consumer whose operation is still open can tell an undriven run from one the box finished. A `done` emitted by the box carries no `close_reason`. Sicore side consumes it in the companion MR (error message on the failed operation + a visible `compile_failed` phase).

## Verification

- `vitest run src/gateway/capability`: 95 passed (3 new in `box-acquire.test.ts`, 1 new + 1 extended in `run-manager.test.ts`). `capability-metrics.test.ts` fails to load locally only because my linked `node_modules` lacks `prom-client`; unrelated to this change.
- `tsc --noEmit`: no errors in touched files (remaining errors are missing local deps).
- Not yet exercised against a real rollout; the reproduction requires a kbc run in flight during a runtime restart.
