### PR TITLE
fix(runtime): preserve native read pages without artifact truncation

### DIFF
--- a/docs/design/2026-09-09-subagent-acceptance-and-output-recovery.md
+++ b/docs/design/2026-09-09-subagent-acceptance-and-output-recovery.md
@@ -43,6 +43,11 @@ wrapper establishes an AsyncLocalStorage invocation context, including detached 
 Command stdout is sanitized/projected and stderr redacted by the existing pipeline *before*
 full-output retention. The wrapper captures that sanitized text before the 8,000-character
 preview cut. MCP and other tool results use the same scoped artifact mechanism.
+The native pi-coding-agent `read` tool is exempt from artifact wrapping: its bounded,
+consecutive pages and continuation notices are returned unchanged. Existing injected
+path checks still apply. Archiving a read page and replacing its middle with a preview
+would invalidate native continuation semantics; reading an artifact to completion also
+would not establish that the original file had been read to completion.
 
 Files live under the session's `.tool-results/<hash(agentId,sessionId)>` directory. Direct
 read/write/grep/bash access remains blocked; recovery tools accept opaque IDs, never paths.

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -74,3 +74,13 @@ Skills can be used in several ways:
 - from webhook-triggered workflows
 
 This makes them a good fit for turning repeated incident response habits into reusable, reviewable runbooks.
+
+
+## Reading Skill Instructions
+
+Skill files and their references use pi-coding-agent's native `read` behavior.
+Each text read returns up to 2,000 lines or 50 KiB, with a line offset for continuing
+when more content remains. Siclaw preserves these pages and continuation notices;
+it does not replace them with an 8,000-character head/tail preview. Existing file
+access restrictions still apply. A successful first page does not imply that the
+entire file or its references have been read.

--- a/src/core/tool-result-artifact.test.ts
+++ b/src/core/tool-result-artifact.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Type } from "@sinclair/typebox";
+import { createReadTool } from "@earendil-works/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   ToolResultArtifactStore,
@@ -302,5 +303,83 @@ describe("formatUnrecoverableToolResult", () => {
     expect(rendered).toContain("cannot be recovered");
     expect(rendered).toContain("HEAD-");
     expect(rendered).toContain("-TAIL_ERROR");
+  });
+});
+
+
+describe("native read through artifact capture", () => {
+  let cwd: string;
+  let artifacts: ToolResultArtifactStore;
+
+  beforeEach(async () => {
+    cwd = await fs.mkdtemp(path.join(os.tmpdir(), "siclaw-native-read-"));
+    artifacts = new ToolResultArtifactStore({
+      rootDir: path.join(cwd, "artifacts"),
+      getScope: () => ({ agentId: "agent", sessionId: "session" }),
+      // Reading an authorized file must not depend on artifact storage capacity.
+      maxArtifactBytes: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(cwd, { recursive: true, force: true });
+  });
+
+  function read() {
+    return withToolResultArtifactCapture(createReadTool(cwd), artifacts, 4096);
+  }
+
+  it("returns a Skill over 8000 characters intact, including its middle", async () => {
+    const content = `${"step: inspect evidence\n".repeat(230)}MANDATORY MIDDLE GUIDANCE\n${"步骤：验证证据\n".repeat(650)}`;
+    expect(content.length).toBeGreaterThan(8000);
+    await fs.writeFile(path.join(cwd, "SKILL.md"), content);
+    const result = await read().execute("skill", { path: "SKILL.md" }, undefined, undefined, undefined);
+    expect(result.content).toEqual([{ type: "text", text: content }]);
+    expect(getToolResultArtifactReference(result.details)).toBeNull();
+  });
+
+  it.each([
+    { title: "line limit", count: 2300, width: 10 },
+    { title: "byte limit", count: 900, width: 100 },
+  ])("preserves consecutive pages and native continuation at the $title", async ({ count, width }) => {
+    const lines = Array.from({ length: count }, (_, index) => `${index + 1}: ${"x".repeat(width)}`);
+    await fs.writeFile(path.join(cwd, "source.ts"), lines.join("\n"));
+    const tool = read();
+    let offset = 1;
+    const collected: string[] = [];
+    for (let page = 0; page < 10; page++) {
+      const result = await tool.execute(`page-${page}`, { path: "source.ts", offset }, undefined, undefined, undefined);
+      const text = result.content.filter((item) => item.type === "text").map((item) => item.text).join("\n");
+      expect(text).not.toContain("artifact_id:");
+      expect(text).not.toContain("preview middle omitted");
+      const notice = /\n\n\[Showing lines \d+-\d+ of \d+.*Use offset=(\d+) to continue\.\]$/;
+      const match = text.match(notice);
+      collected.push(...text.replace(notice, "").split("\n"));
+      if (!match) break;
+      const nextOffset = Number(match[1]);
+      expect(nextOffset).toBeGreaterThan(offset);
+      expect(collected).toEqual(lines.slice(0, nextOffset - 1));
+      offset = nextOffset;
+    }
+    expect(offset).toBeGreaterThan(1);
+    expect(collected).toEqual(lines);
+  });
+
+  it("retains explicit line ranges and continuation notices", async () => {
+    await fs.writeFile(path.join(cwd, "source.ts"), "one\ntwo\nthree\nfour");
+    const result = await read().execute("range", { path: "source.ts", offset: 2, limit: 2 }, undefined, undefined, undefined);
+    expect(result.content).toEqual([{ type: "text", text: "two\nthree\n\n[1 more lines in file. Use offset=4 to continue.]" }]);
+  });
+
+  it("keeps the injected file access restriction in effect", async () => {
+    const tool = createReadTool(cwd, {
+      operations: {
+        access: async () => { throw new Error("read denied by path policy"); },
+        readFile: async () => { throw new Error("must not read a denied file"); },
+      },
+    });
+    const wrapped = withToolResultArtifactCapture(tool, artifacts, 4096);
+    await expect(wrapped.execute("denied", { path: "private.txt" }, undefined, undefined, undefined))
+      .rejects.toThrow("read denied by path policy");
   });
 });

--- a/src/core/tool-result-artifact.ts
+++ b/src/core/tool-result-artifact.ts
@@ -484,6 +484,11 @@ export function withToolResultArtifactCapture(
   store: ToolResultArtifactStore,
   minBytes = DEFAULT_CAPTURE_MIN_BYTES,
 ): ToolDefinition {
+  // Native read already bounds each page and supplies line-based continuation.
+  // Replacing a page with a head/tail preview loses its middle while retaining
+  // the next-page offset. Preserve the tool, including injected path checks.
+  if (tool.name === "read") return tool;
+
   const originalExecute = tool.execute.bind(tool) as ToolDefinition["execute"];
   return {
     ...tool,


### PR DESCRIPTION
## Summary

Skill and code reads over 8,000 characters were replaced by head/tail artifact previews even when pi-coding-agent had returned a complete native page. This could omit instructions or code in the middle while retaining a continuation offset that skipped past the missing content.

Return the native `read` tool unchanged from artifact wrapping, preserving its injected path restrictions, content, and line-based pagination. Add regressions using the actual pi read tool and document the behavior. Other tool-result artifact handling is unchanged.

## Test Plan

- [x] Full runtime test suite: 328 files passed; 7,052 tests passed, 2 skipped.
- [x] Native-read regressions cover a Skill above 8,000 characters, line/byte-limited continuation, explicit line ranges, and denied file access.
- [x] TypeScript check (`tsc --noEmit`) and build (`tsc`) pass.
- [ ] Deployment smoke test with a long Skill in LocalSpawner/K8sSpawner; not performed locally.

## Architecture Checklist

- [x] Existing path checks remain in effect; no new shell execution or artifact-access bypass.
- No new tool protocol, database schema, or deployment configuration.

## General Checklist

- [x] Focused on native read preservation, with tests and documentation.
- [x] Conventional commit; no unrelated changes.
