### PR TITLE
fix: preserve source citations through final answer delivery

### DIFF
--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -2588,6 +2588,37 @@ describe("handleLarkMessage — streaming card flow", () => {
     expect(appendMessageMock.mock.calls.filter(([row]) => row.role === "assistant")).toHaveLength(0);
   });
 
+  it("renders forwarded runtime citations once in the final card", async () => {
+    supportsConversationsMock.mockResolvedValue(true);
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    appendMessageMock.mockResolvedValue("original-user-row");
+    const sources = Array.from({ length: 8 }, (_, i) => ({
+      title: `Source ${i + 1}`, url: `https://example.com/source-${i + 1}`,
+    }));
+    const answer = "Answer\n\n### Original sources\n\n" + sources
+      .map(source => `- [${source.title}](${source.url})`).join("\n");
+    let receive: (data: unknown) => void = () => {};
+    const frontend = {
+      connected: true,
+      subscribe: vi.fn((_channel: string, handler: (data: unknown) => void) => { receive = handler; return vi.fn(); }),
+      request: vi.fn(async (method: string, input: any) => {
+        if (method === "conversation.start") {
+          for (const event of [
+            { type: "knowledge_sources", sources },
+            { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: answer }] } },
+            { type: "prompt_done" },
+          ]) receive({ sessionId: input.sessionId, requestId: input.userMessageId, event });
+          return { sessionId: input.sessionId };
+        }
+        return {};
+      }),
+    };
+    const lark = makeCardAwareLarkClient();
+    await handleLarkMessage(makeTextEvent("Explain the sources"), lark, "lark", makeAgentBoxManager() as any, undefined, frontend as any);
+    const content = lark.cardkit.v1.cardElement.content.mock.calls.at(-1)?.[0].data.content;
+    expect(content).toBe(answer);
+  });
+
   function makeCardAwareLarkClient() {
     return {
       im: {

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -3936,6 +3936,24 @@ describe("collectResponse — SSE event flattening", () => {
     expect(text).toContain("[GPU Runbook](https://docs.feishu.cn/wiki/a)");
   });
 
+  it.each([false, true])("keeps sources in the delivered channel answer after commentary (re-cite: %s)", async (recite) => {
+    const sources = [{ title: "Runbook", url: "https://example.com/runbook" }];
+    const events = [
+      { type: "knowledge_sources", sources },
+      { type: "message_end", message: { role: "assistant", stopReason: "toolUse", content: [
+        { type: "text", text: "Checking nodes.", textSignature: JSON.stringify({ v: 1, id: "progress", phase: "commentary" }) },
+      ] } },
+      { type: "tool_execution_end", toolName: "lookup", result: { content: [] } },
+      ...(recite ? [{ type: "knowledge_sources", sources }] : []),
+      { type: "message_end", message: { role: "assistant", stopReason: "stop", content: [
+        { type: "text", text: "All nodes are healthy.", textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }) },
+      ] } },
+    ];
+    const result = await collectChannelResponse(fakeClient(events), "s-citations");
+    expect(result.text).toContain(sources[0].url);
+    expect(result.text.split(sources[0].url)).toHaveLength(2);
+  });
+
   it("discards a failed primary's knowledge sources before rendering the fallback answer", async () => {
     const events = [
       { type: "model_route_start", candidateCount: 2 },

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -3107,7 +3107,7 @@ export interface ChannelPersistContext {
 }
 
 export async function collectChannelResponse(
-  client: Pick<AgentBoxClient, "streamEvents">,
+  client: Pick<AgentBoxClient, "streamEvents"> & { readonly conversationEvents?: boolean },
   sessionId: string,
   logPrefix = "lark",
   options: { includeImages?: boolean; onMilestone?: (text: string) => void; onActivity?: (text: string) => void; persist?: ChannelPersistContext; locale?: LarkLocale; throwOnError?: boolean } = {},
@@ -3321,7 +3321,10 @@ export async function collectChannelResponse(
           });
         }
       }
-      if (ev.type === "knowledge_sources") {
+      // Conversation events already passed through the destination runtime's
+      // SSE consumer, which appended citations to message_end. Only raw
+      // AgentBox streams need this channel to render their source list.
+      if (ev.type === "knowledge_sources" && !client.conversationEvents) {
         pendingKnowledgeSources = ev.sources;
       }
 

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -3151,14 +3151,8 @@ export async function collectChannelResponse(
   let lastRowContent = "";
   let lastRowMetadata: Record<string, unknown> = {};
   let pendingKnowledgeSources: unknown = null;
-  // Same contract as sse-consumer: the citations appended to THIS assistant row
-  // ride on its metadata for feedback attribution.
-  let pendingRowCitations: KnowledgeSourceCitation[] = [];
-  // URLs already rendered into an assistant reply this stream (= one turn).
-  // Append only the not-yet-rendered delta and keep pending, so an intermediate
-  // narration turn no longer steals the references off the final answer, nor
-  // duplicates them across bubbles when the model cites twice.
-  const renderedKnowledgeSourceUrls = new Set<string>();
+  // Keep the source union for the final delivered answer; an intermediate
+  // message must not consume references needed by a later reply.
 
   // ── Audit persistence (opt-in) ──────────────────────────────────────────
   // Mirrors the field mapping in sse-consumer.ts so a channel transcript looks
@@ -3243,7 +3237,6 @@ export async function collectChannelResponse(
         lastAssistantMessageId = null;
         parts.length = 0;
         pendingKnowledgeSources = null;
-        renderedKnowledgeSourceUrls.clear();
         assistantItems.begin();
       }
       if (!persist && ev.type === "item/completed" && ev.item?.type === "agentMessage" && ev.dbMessageId) lastAssistantMessageId = String(ev.dbMessageId);
@@ -3269,8 +3262,6 @@ export async function collectChannelResponse(
 
       if (ev.type === "model_route_start" || ev.type === "model_route_rollback") {
         pendingKnowledgeSources = null;
-        renderedKnowledgeSourceUrls.clear();
-        pendingRowCitations = [];
         if (ev.type === "model_route_rollback") {
           // The failed call is NOT dropped here: the switch notice that follows a
           // rollback is its carrier. Only the user-visible error goes, because a
@@ -3457,22 +3448,19 @@ export async function collectChannelResponse(
         const rowEnvelope = isModelCallRowEnvelope(envelope, ev.message?.stopReason)
           ? redactLlmCallEnvelope(envelope, redact)
           : undefined;
-        let turnText = assistantTextBlocks(ev.message).map(block => block.text).join("");
+        const textBlocks = assistantTextBlocks(ev.message);
+        let turnText = textBlocks.map(block => block.text).join("");
+        let rowCitations: KnowledgeSourceCitation[] = [];
         // The SHARED rule, not a second copy of it. The local re-derivation read
         // only `blocks`, so a recovered turn whose final message carries STRING
         // content looked like no output — the error stayed pending and a terminal
         // error_response was written over a successful answer.
         if (pendingError && messageProducedOutput(ev.message)) await flushRecoveredLlmCalls();
-        if (pendingKnowledgeSources && turnText.trim() && ev.message?.stopReason !== "error") {
-          const freshSources = normalizeKnowledgeSourceCitations(pendingKnowledgeSources)
-            .filter((source) => !renderedKnowledgeSourceUrls.has(source.url));
-          if (freshSources.length > 0) {
-            turnText = appendKnowledgeSourceCitations(turnText, freshSources);
-            for (const source of freshSources) renderedKnowledgeSourceUrls.add(source.url);
-            pendingRowCitations = freshSources;
-          }
-          // Keep pending: a later assistant message this turn may carry sources
-          // cited after this one; the rendered-set prevents any double-append.
+        const isProgress = ev.message?.stopReason === "toolUse" || ev.awaitingBackgroundJobs === true || ev.awaitingSubagents === true;
+        if (pendingKnowledgeSources && turnText.trim() && ev.message?.stopReason !== "error" && !isProgress &&
+            textBlocks.some(block => block.phase !== "commentary" && block.text.trim())) {
+          rowCitations = normalizeKnowledgeSourceCitations(pendingKnowledgeSources);
+          turnText = appendKnowledgeSourceCitations(turnText, rowCitations);
         }
         if (turnText) {
           lastAssistantText = turnText;
@@ -3496,9 +3484,8 @@ export async function collectChannelResponse(
           // is not a card and must leave the id alone.
           const rowMetadata = {
             ...(rowEnvelope ? { llm_call: rowEnvelope } : {}),
-            ...(pendingRowCitations.length > 0 ? { knowledge_citations: knowledgeCitationsMetadata(pendingRowCitations) } : {}),
+            ...(rowCitations.length > 0 ? { knowledge_citations: knowledgeCitationsMetadata(rowCitations) } : {}),
           };
-          pendingRowCitations = [];
           const rowId = await persistRow({
             sessionId,
             role: "assistant",

--- a/src/gateway/conversation-client.ts
+++ b/src/gateway/conversation-client.ts
@@ -16,6 +16,7 @@ export async function supportsConversations(frontend: FrontendWsClient): Promise
 /** Observe a logical request at the control plane. This client never starts a
  * destination AgentBox locally and never receives the destination's credentials. */
 export class ConversationClient {
+  /** Events already processed by the destination runtime, including citations. */
   readonly conversationEvents = true;
   private events: unknown[] = [];
   private wake?: () => void;

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -2,6 +2,7 @@ import { appendMessage } from "./chat-repo.js";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { consumeAgentSse } from "./sse-consumer.js";
 import { AgentBoxClient } from "./agentbox/client.js";
+import { appendKnowledgeSourceCitations } from "../shared/knowledge-citations.js";
 
 // ── Mock chat-repo ──────────────────────────────────────
 // Replace the module-scoped appendMessage/incrementMessageCount so tests run
@@ -100,6 +101,42 @@ describe("consumeAgentSse — type-less extra events", () => {
 });
 
 describe("consumeAgentSse — assistant message flow", () => {
+  it("keeps attribution when a raw answer already contains the registered footer", async () => {
+    const sources = [{ title: "Runbook", url: "https://example.com/runbook", repoId: "repo-1" }];
+    const answer = appendKnowledgeSourceCitations("Answer", sources);
+    const result = await consumeAgentSse({
+      client: mkClient([
+        { type: "knowledge_sources", sources },
+        { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: answer }] } },
+      ]),
+      sessionId: "s", userId: "u", persistMessages: true,
+    });
+    expect(result.resultText).toBe(answer);
+    expect(appendCalls[0].content).toBe(answer);
+    expect(appendCalls[0].metadata.knowledge_citations.repo_ids).toEqual(["repo-1"]);
+  });
+
+  it("preserves citations when a conversation forwards already-consumed runtime events", async () => {
+    const sources = Array.from({ length: 8 }, (_, i) => ({
+      title: `Source ${i + 1}`, url: `https://example.com/source-${i + 1}`,
+    }));
+    const forwarded: any[] = [];
+    const original = await consumeAgentSse({
+      client: mkClient([
+        { type: "knowledge_sources", sources },
+        { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "Answer" }] } },
+      ]),
+      sessionId: "s", userId: "u", onEvent: event => forwarded.push(event),
+    });
+    const result = await consumeAgentSse({
+      client: Object.assign(mkClient(forwarded), { conversationEvents: true }),
+      sessionId: "s", userId: "u", persistMessages: false,
+    });
+    expect(original.resultText.match(/### Original sources/g)).toHaveLength(1);
+    expect(original.resultText).toContain("Source 8");
+    expect(result.resultText).toBe(original.resultText);
+  });
+
   it("appends registered knowledge sources to the final answer event and result", async () => {
     const events = [
       { type: "knowledge_sources", sources: [{ title: "GPU Runbook", url: "https://docs.feishu.cn/wiki/a" }] },

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -101,6 +101,47 @@ describe("consumeAgentSse — type-less extra events", () => {
 });
 
 describe("consumeAgentSse — assistant message flow", () => {
+  it.each([false, true])("keeps sources in the delivered final answer after commentary (re-cite: %s)", async (recite) => {
+    const sources = [{ title: "Runbook", url: "https://example.com/runbook", repoId: "repo-1" }];
+    const events = [
+      { type: "knowledge_sources", sources },
+      { type: "message_end", message: { role: "assistant", stopReason: "toolUse", content: [
+        { type: "text", text: "Checking nodes.", textSignature: JSON.stringify({ v: 1, id: "progress", phase: "commentary" }) },
+      ] } },
+      { type: "tool_execution_end", toolName: "lookup", result: { content: [] } },
+      ...(recite ? [{ type: "knowledge_sources", sources }] : []),
+      { type: "message_end", message: { role: "assistant", stopReason: "stop", content: [
+        { type: "text", text: "All nodes are healthy.", textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }) },
+      ] } },
+    ];
+    const result = await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    expect(result.resultText).toContain(sources[0].url);
+    expect(result.resultText.split(sources[0].url)).toHaveLength(2);
+    expect(appendCalls.at(-1).metadata.knowledge_citations.repo_ids).toEqual(["repo-1"]);
+  });
+
+  it("attaches citations to the final native item and bills the model call only once", async () => {
+    const sources = [{ title: "Runbook", url: "https://example.com/runbook", repoId: "repo-1", page: "runbook.md" }];
+    const result = await consumeAgentSse({
+      client: mkClient([
+        { type: "knowledge_sources", sources },
+        { type: "message_end", message: { role: "assistant", stopReason: "stop", llmCall: mkEnvelope(), content: [
+          { type: "text", text: "Checks complete.", textSignature: JSON.stringify({ v: 1, id: "progress", phase: "commentary" }) },
+          { type: "text", text: "All nodes are healthy.", textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }) },
+        ] } },
+      ]), sessionId: "s", userId: "u", persistMessages: true,
+    });
+    expect(result.resultText).toContain(sources[0].url);
+    expect(appendCalls).toHaveLength(2);
+    expect(appendCalls[0].metadata.knowledge_citations).toBeUndefined();
+    expect(appendCalls[1].content).toBe(result.resultText);
+    expect(appendCalls[1].metadata.knowledge_citations).toEqual({
+      repo_ids: ["repo-1"], pages: [{ repo_id: "repo-1", page: "runbook.md", url: sources[0].url }],
+    });
+    expect(appendCalls.filter(row => row.metadata.llm_call)).toHaveLength(1);
+    expect(appendCalls[0].metadata.llm_call).toBeDefined();
+  });
+
   it("keeps attribution when a raw answer already contains the registered footer", async () => {
     const sources = [{ title: "Runbook", url: "https://example.com/runbook", repoId: "repo-1" }];
     const answer = appendKnowledgeSourceCitations("Answer", sources);
@@ -151,10 +192,9 @@ describe("consumeAgentSse — assistant message flow", () => {
     expect((seen.filter(e => e.type === "message_end")[0].message.content[0].text as string)).toBe(result.resultText);
   });
 
-  it("renders each source exactly once across a turn's messages, never duplicating the union", async () => {
-    // Consumers assign (not merge) knowledge_sources. Cite A, narrate (that
-    // message renders A), then cite the growing union [A, B]: the final message
-    // must append ONLY B — the old code re-appended [A, B] and A showed twice.
+  it("includes the registered source union once in each independently delivered answer", async () => {
+    // Legacy messages have no phase. An earlier answer may render A, but the
+    // final answer still needs the complete registered union [A, B].
     const a = "https://docs.feishu.cn/wiki/a";
     const b = "https://docs.feishu.cn/wiki/b";
     const events = [
@@ -170,14 +210,13 @@ describe("consumeAgentSse — assistant message flow", () => {
     expect(narration).toContain(a);
     expect(narration).not.toContain(b);
     expect(final).toContain(b);
-    expect(final).not.toContain(a); // A was already rendered on the narration — not repeated
+    expect(final.split(a)).toHaveLength(2);
+    expect(final.split(b)).toHaveLength(2);
   });
 
   it("does not lose references when a zero-fresh re-cite follows an intermediate message", async () => {
-    // Cite A, narrate (renders A), re-cite A right before the final answer.
-    // The source must still be present in the transcript exactly once — the old
-    // code nulled pending on the narration and the re-cite emitted nothing, so
-    // it vanished entirely.
+    // An earlier message must not consume the final answer's sources, even
+    // when re-citing A adds no fresh sources to the turn's union.
     const a = "https://docs.feishu.cn/wiki/a";
     const events = [
       { type: "knowledge_sources", sources: [{ title: "A", url: a }] },
@@ -186,9 +225,9 @@ describe("consumeAgentSse — assistant message flow", () => {
       { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "final answer" }] } },
     ];
     const seen: any[] = [];
-    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", onEvent: (event) => seen.push(event) });
-    const combined = `${seen.filter(e => e.type === "message_end")[0].message.content[0].text}\n${seen.filter(e => e.type === "message_end")[1].message.content[0].text}`;
-    expect(combined.split(a).length - 1).toBe(1); // present exactly once, not lost, not doubled
+    const result = await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", onEvent: (event) => seen.push(event) });
+    expect(result.resultText.split(a)).toHaveLength(2);
+    expect(seen.filter(e => e.type === "message_end")[1].message.content[0].text).toBe(result.resultText);
   });
 
   it("resets citation state at the user-message turn boundary so a source can re-render next turn", async () => {
@@ -1520,7 +1559,7 @@ describe("consumeAgentSse — onEvent callback", () => {
 });
 
 describe("consumeAgentSse — knowledge citation attribution", () => {
-  it("persists the cited repos/pages on the assistant row that rendered them, exactly once per turn", async () => {
+  it("persists all cited repos/pages on each answer row that renders them", async () => {
     const a = "https://docs.feishu.cn/wiki/a";
     const b = "https://docs.feishu.cn/wiki/b";
     const events = [
@@ -1540,15 +1579,18 @@ describe("consumeAgentSse — knowledge citation attribution", () => {
     const rows = appendCalls.filter((r) => r.role === "assistant");
     expect(rows).toHaveLength(2);
     expect(rows[0].metadata.llm_call).toMatchObject({ round: 1 });
-    // First row carries A; second row carries only the delta (B). Attribution
-    // mirrors the rendered text: each source lands on exactly one row.
+    // Attribution mirrors each independently delivered answer: A on the first,
+    // and the complete registered union [A, B] on the second.
     expect(rows[0].metadata.knowledge_citations).toEqual({
       repo_ids: ["repo-1"],
       pages: [{ repo_id: "repo-1", page: "repos/kb-1/a.md", url: a, claim: "A says so." }],
     });
     expect(rows[1].metadata.knowledge_citations).toEqual({
-      repo_ids: ["repo-2"],
-      pages: [{ repo_id: "repo-2", page: "repos/kb-2/b.md", url: b, evidence: "ev.b" }],
+      repo_ids: ["repo-1", "repo-2"],
+      pages: [
+        { repo_id: "repo-1", page: "repos/kb-1/a.md", url: a, claim: "A says so." },
+        { repo_id: "repo-2", page: "repos/kb-2/b.md", url: b, evidence: "ev.b" },
+      ],
     });
     // A row without citations carries no attribution key at all.
     const plain = [

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -13,7 +13,7 @@
 
 import { randomUUID } from "node:crypto";
 import { AssistantItemStream } from "./assistant-item-stream.js";
-import type { AssistantItem } from "../shared/assistant-items.js";
+import { assistantTextBlocks, type AssistantItem } from "../shared/assistant-items.js";
 import type { ChatMessageMetadata } from "../shared/message-kinds.js";
 import { ErrorCodes } from "../lib/error-envelope.js";
 import { AgentBoxClient } from "./agentbox/client.js";
@@ -436,18 +436,8 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
   let isRoutingTurn = false;
   let routingCommitted = false;
   let pendingKnowledgeSources: unknown = null;
-  // Citations rendered into the assistant row being committed — persisted on
-  // that row's metadata as `knowledge_citations`, so feedback on the row can be
-  // attributed to the cited repos/pages. Exactly the delta appended to the text.
-  let pendingRowCitations: KnowledgeSourceCitation[] = [];
-  // URLs already rendered into an assistant message THIS TURN. Consumers ASSIGN
-  // (not merge) the knowledge_sources event, and a source must appear exactly
-  // once per turn. Nulling pending after the first ended message lost the
-  // references when the model narrated or re-cited before its final answer
-  // (zero-fresh re-cite emits nothing), and duplicated them across bubbles when
-  // it cited twice. Instead keep pending and append only the not-yet-rendered
-  // delta to each message; reset at the user-message turn boundary.
-  const renderedKnowledgeSourceUrls = new Set<string>();
+  // Keep the registered union until the user turn ends. Each independently
+  // delivered answer needs its sources even if an earlier message cited them.
   const pendingAssistantOps: Array<() => Promise<void>> = [];
   const pendingErrorOps: Array<() => Promise<void>> = [];
   const flushOps = async (ops: Array<() => Promise<void>>) => {
@@ -507,8 +497,6 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
     pendingErrorOps.length = 0;
     pendingFailedLlmCalls = [];
     pendingKnowledgeSources = null;
-    renderedKnowledgeSourceUrls.clear();
-    pendingRowCitations = [];
     pendingStreamError = null;
     errorMessage = "";
   };
@@ -669,7 +657,6 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         assistantContent = currentMsgText = resultText = taskReportText = "";
         assistantItems.begin();
         pendingKnowledgeSources = null;
-        renderedKnowledgeSourceUrls.clear();
       }
 
       // A ConversationClient observes output already rendered by the owning
@@ -926,12 +913,9 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           // once per LLM round-trip: a turn that calls tools emits several, and
           // flushing on those would defeat the in-turn suppression entirely.
           await flushTerminalError();
-          // Same boundary retires the previous turn's citation state, so a
-          // source rendered last turn never suppresses this turn's identical
-          // citation and stale pending never leaks onto the new answer.
+          // Retire the previous turn's source union so stale references never
+          // leak onto an answer to the new user input.
           pendingKnowledgeSources = null;
-          renderedKnowledgeSourceUrls.clear();
-          pendingRowCitations = [];
         }
         if (message?.role === "user" && onUserMessageStarted) {
           // The echoed text, so the caller can check the echo against the row it expects —
@@ -1118,30 +1102,24 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
               .map((c) => c.text ?? "")
               .join("");
           }
-          if (pendingKnowledgeSources && message.stopReason !== "error") {
-            const base = extracted || currentMsgText || assistantContent;
+          let rowCitations: KnowledgeSourceCitation[] = [];
+          let citationContentIndex: number | undefined;
+          const textBlocks = assistantTextBlocks(message);
+          const answerBlock = [...textBlocks].reverse().find(block => block.phase !== "commentary" && block.text.trim());
+          const isProgress = message.stopReason === "toolUse" || evt.awaitingBackgroundJobs === true || evt.awaitingSubagents === true;
+          if (pendingKnowledgeSources && message.stopReason !== "error" && !isProgress &&
+              (answerBlock || textBlocks.length === 0)) {
+            const base = answerBlock?.text || extracted || currentMsgText || assistantContent;
             if (base.trim()) {
-              // Append only sources not already rendered this turn, and do NOT
-              // null pending: a later message may carry sources cited after this
-              // one, while the rendered-set stops any source appearing twice.
-              const freshSources = normalizeKnowledgeSourceCitations(pendingKnowledgeSources)
-                .filter((source) => !renderedKnowledgeSourceUrls.has(source.url));
-              if (freshSources.length > 0) {
-                const cited = appendKnowledgeSourceCitations(base, freshSources);
-                if (cited !== base) {
-                  extracted = cited;
-                  assistantContent = cited;
-                  if (Array.isArray(message.content)) {
-                    const parts = message.content.map(part => ({ ...part }));
-                    const lastText = [...parts].reverse().find(part => part.type === "text");
-                    if (lastText) lastText.text += cited.slice(base.length);
-                    message.content = parts;
-                  } else message.content = cited;
-                }
-                // An identical footer may already exist; attribution still
-                // belongs to this row even when rendering is a no-op.
-                for (const source of freshSources) renderedKnowledgeSourceUrls.add(source.url);
-                pendingRowCitations = freshSources;
+              rowCitations = normalizeKnowledgeSourceCitations(pendingKnowledgeSources);
+              if (rowCitations.length > 0) {
+                const cited = appendKnowledgeSourceCitations(base, rowCitations);
+                citationContentIndex = answerBlock?.index ?? 0;
+                if (Array.isArray(message.content) && answerBlock) {
+                  message.content = message.content.map((part, index) =>
+                    index === answerBlock.index ? { ...part, text: cited } : part);
+                } else message.content = cited;
+                extracted = assistantTextBlocks(message).map(block => block.text).join("");
               }
             }
           }
@@ -1170,7 +1148,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
           // ── 落库:按 assistant item 分行,这一轮调用的账挂在第一行 ──
           // 上游按「一次模型调用一行 + 一条 thinking 行」落库,本分支按「一个
           // assistant item 一行」落库 —— 同一批文本的两种切法。合并规则:行按 item
-          // 切,envelope / citations / model_route 只挂第一行(一轮调用只结算一次账),
+          // 切,envelope / model_route 只挂第一行(一轮调用只结算一次账),
           // 没产出任何文本的纯工具轮仍然留一条空行来承载 envelope。
           const rowEnvelope = isModelCallRowEnvelope(envelope, message.stopReason)
             ? redactLlmCallEnvelope(envelope, (text) => redactText(text, redactionConfig))
@@ -1186,9 +1164,9 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
               ...(rowEnvelope ? { llm_call: rowEnvelope } : {}),
               ...(!rowEnvelope && envelope && envelope.round > 0 ? { llm_round: envelope.round } : {}),
               ...(currentModelRouteMetadata ? { model_route: currentModelRouteMetadata } : {}),
-              ...(pendingRowCitations.length > 0 ? { knowledge_citations: knowledgeCitationsMetadata(pendingRowCitations) } : {}),
             };
-            pendingRowCitations = [];
+            const citationMetadata = rowCitations.length > 0
+              ? { knowledge_citations: knowledgeCitationsMetadata(rowCitations) } : {};
             const rows: { content: string; item?: AssistantItem; metadata: Record<string, unknown> }[] =
               itemRows.length > 0
                 ? itemRows.map(({ item, cleaned }, index) => ({
@@ -1196,6 +1174,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
                     item,
                     metadata: {
                       ...(index === 0 ? headMetadata : {}),
+                      ...(item.contentIndex === citationContentIndex ? citationMetadata : {}),
                       phase: item.phase ?? phase,
                       assistant_item: { ...item, text: undefined, status: "completed" },
                     } as Record<string, unknown>,

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -94,7 +94,7 @@ const HANDOFF_PAIRED_CLOSERS = new Set([
 ]);
 
 export interface ConsumeAgentSseOptions {
-  client: Pick<AgentBoxClient, "streamEvents">;
+  client: Pick<AgentBoxClient, "streamEvents"> & { readonly conversationEvents?: boolean };
   sessionId: string;
   userId: string;
   /**
@@ -672,7 +672,10 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
         renderedKnowledgeSourceUrls.clear();
       }
 
-      if (eventType === "knowledge_sources") {
+      // A ConversationClient observes output already rendered by the owning
+      // runtime. Re-registering its sources would append them a second time
+      // when scheduled tasks consume the forwarded message_end.
+      if (eventType === "knowledge_sources" && !client.conversationEvents) {
         pendingKnowledgeSources = (evt as Record<string, unknown>).sources;
       }
 
@@ -1134,9 +1137,11 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
                     if (lastText) lastText.text += cited.slice(base.length);
                     message.content = parts;
                   } else message.content = cited;
-                  for (const source of freshSources) renderedKnowledgeSourceUrls.add(source.url);
-                  pendingRowCitations = freshSources;
                 }
+                // An identical footer may already exist; attribution still
+                // belongs to this row even when rendering is a no-op.
+                for (const source of freshSources) renderedKnowledgeSourceUrls.add(source.url);
+                pendingRowCitations = freshSources;
               }
             }
           }

--- a/src/shared/knowledge-citations.test.ts
+++ b/src/shared/knowledge-citations.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from "vitest";
 import { appendKnowledgeSourceCitations, normalizeKnowledgeSourceCitations, knowledgeCitationsMetadata } from "./knowledge-citations.js";
 
 describe("knowledge source citation rendering", () => {
-  it.each(["Answer", "结论"])("does not append an identical source footer twice: %s", (answer) => {
+  it.each([
+    ["Answer", "Source"],
+    ["结论", "Source"],
+    ["Answer", "来源"],
+    ["结论", "来源"],
+  ])("does not append an identical source footer twice: %s / %s", (answer, title) => {
     const sources = Array.from({ length: 8 }, (_, i) => ({
-      title: `Source ${i + 1}`, url: `https://example.com/source-${i + 1}`,
+      title: `${title} ${i + 1}`, url: `https://example.com/source-${i + 1}`,
     }));
     const rendered = appendKnowledgeSourceCitations(answer, sources);
     expect(appendKnowledgeSourceCitations(rendered, sources)).toBe(rendered);

--- a/src/shared/knowledge-citations.test.ts
+++ b/src/shared/knowledge-citations.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it } from "vitest";
 import { appendKnowledgeSourceCitations, normalizeKnowledgeSourceCitations, knowledgeCitationsMetadata } from "./knowledge-citations.js";
 
 describe("knowledge source citation rendering", () => {
+  it.each(["Answer", "结论"])("does not append an identical source footer twice: %s", (answer) => {
+    const sources = Array.from({ length: 8 }, (_, i) => ({
+      title: `Source ${i + 1}`, url: `https://example.com/source-${i + 1}`,
+    }));
+    const rendered = appendKnowledgeSourceCitations(answer, sources);
+    expect(appendKnowledgeSourceCitations(rendered, sources)).toBe(rendered);
+    expect(appendKnowledgeSourceCitations(`${rendered}\n`, sources)).toBe(`${rendered}\n`);
+    // A URL in ordinary answer text must not suppress the trusted footer.
+    expect(appendKnowledgeSourceCitations(`See ${sources[0].url}`, sources)).toContain("### Original sources");
+  });
+
   it("deduplicates, caps and appends trusted source links", () => {
     const sources = [
       { title: "GPU Runbook", url: "https://docs.feishu.cn/wiki/a" },

--- a/src/shared/knowledge-citations.ts
+++ b/src/shared/knowledge-citations.ts
@@ -101,9 +101,13 @@ export function appendKnowledgeSourceCitations(text: string, value: unknown): st
     const destination = source.url.replaceAll("(", "%28").replaceAll(")", "%29");
     return `- [${source.title.replace(/[\[\]]/g, "")}](${destination})`;
   });
-  const footer = `\n\n### ${heading}\n\n${lines.join("\n")}`;
+  const sourceList = lines.join("\n");
+  const trimmedText = text.trimEnd();
   // A relayed or pre-rendered answer can already carry this exact footer.
-  // Match the complete generated block, not arbitrary URLs in answer prose.
-  if (text.trimEnd().endsWith(footer)) return text;
-  return `${text.trimEnd()}${footer}`;
+  // Source titles can change language detection after the first append, so
+  // recognize either supported heading while matching the complete source list.
+  if (["参考原文", "Original sources"].some((existingHeading) =>
+    trimmedText.endsWith(`\n\n### ${existingHeading}\n\n${sourceList}`),
+  )) return text;
+  return `${trimmedText}\n\n### ${heading}\n\n${sourceList}`;
 }

--- a/src/shared/knowledge-citations.ts
+++ b/src/shared/knowledge-citations.ts
@@ -101,5 +101,9 @@ export function appendKnowledgeSourceCitations(text: string, value: unknown): st
     const destination = source.url.replaceAll("(", "%28").replaceAll(")", "%29");
     return `- [${source.title.replace(/[\[\]]/g, "")}](${destination})`;
   });
-  return `${text.trimEnd()}\n\n### ${heading}\n\n${lines.join("\n")}`;
+  const footer = `\n\n### ${heading}\n\n${lines.join("\n")}`;
+  // A relayed or pre-rendered answer can already carry this exact footer.
+  // Match the complete generated block, not arbitrary URLs in answer prose.
+  if (text.trimEnd().endsWith(footer)) return text;
+  return `${text.trimEnd()}${footer}`;
 }


### PR DESCRIPTION
## Summary

Knowledge answers could show duplicate references after a conversation relay, lose references after intermediate commentary, or persist citation attribution on the commentary row instead of the final answer.

The destination runtime owns citation rendering for relayed events. Direct consumers retain the registered source union for each independently delivered answer and skip known progress messages. Citation metadata follows the text item containing the references; the model-call billing envelope remains on one row. The shared renderer recognizes identical complete footers under either supported heading, including mixed-language answers and source titles.

## Test Plan

- [x] Reproduced the duplicate footer, mixed-language footer, missing final sources, and misplaced native-item attribution before their respective fixes.
- [x] 367 focused tests passed across citation rendering, SSE consumption, Feishu collection, and native-item persistence.
- [x] `npm test`: 328 files passed; 7,064 tests passed, 2 skipped.
- [x] `npx tsc --noEmit` and `npm run build` passed.
- [ ] Live deployment and Feishu acceptance.
