### PR TITLE
fix(kbc): keep evidence references consistent with frozen sources

### DIFF
--- a/kbc/platform/pod/compile_box.py
+++ b/kbc/platform/pod/compile_box.py
@@ -2955,6 +2955,29 @@ async def _post_turn_selfcheck(run) -> str | None:
             if restored_pages:
                 after = incremental.page_hashes(workdir)
                 incr_violations = incremental.integrity_violations(incr["before"], after, editable)
+    # First restore unauthorized body edits above. Only then apply deterministic
+    # identity changes globally: an unchanged Raw path/content can have a new
+    # source id after delete/reupload, outside the semantic changeset.
+    identity_before = incremental.page_hashes(workdir)
+    identity_fixes = selfcheck.normalize_evidence_source_ids(workdir)
+    if identity_fixes:
+        identity_after = incremental.page_hashes(workdir)
+        for fix in identity_fixes:
+            page = fix["page"]
+            if (incr and page not in editable and page not in incr_violations
+                    and page in incr["before"]):
+                # Preserve the exact restored prose as the next repair turn's
+                # baseline, with only the machine-owned source ids advanced.
+                # Do not widen editable/repair_pages or excuse failed restores.
+                incr["before"][page] = identity_after[page]
+                incr.setdefault("before_bytes", {})[page] = (
+                    Path(workdir) / "candidate" / page).read_bytes()
+            if (turn_format_guard and turn_format_guard.get("before", {}).get(page)
+                    == identity_before.get(page)):
+                # Identity-only repair is not a migration of inherited format.
+                turn_format_guard["before"][page] = identity_after[page]
+        after = identity_after
+        key = selfcheck.state_key(workdir)
     # Mechanical provenance repair belongs before Layer-1 and before the model
     # repair budget. It is deliberately scoped to pages already editable in an
     # incremental turn; ordinary guarded owner edits are limited to pages that
@@ -2968,9 +2991,8 @@ async def _post_turn_selfcheck(run) -> str | None:
             turn_format_guard.get("before") or {}, current))
     mechanical_fixes = selfcheck.normalize_body_source_annotations(
         workdir, allowed_pages=mechanical_allowed)
-    # Same seam, same scope: stamp sources[].id from the frozen manifest and
-    # derive one okf:evidence marker per section from the (source:) tags the
-    # model wrote, so knowledge_cite lands on a section's own originals.
+    # Section attribution remains scoped: derive markers from the (source:)
+    # tags the model wrote only on pages authorized for content changes.
     mechanical_fixes = mechanical_fixes + selfcheck.attribute_evidence_sections(
         workdir, allowed_pages=mechanical_allowed)
     if mechanical_fixes:
@@ -2986,6 +3008,9 @@ async def _post_turn_selfcheck(run) -> str | None:
         producer_stamps = sorted(set(producer_stamps) | set(mechanical_stamps))
         after = incremental.page_hashes(workdir)
         key = selfcheck.state_key(workdir)
+    # Identity-only repairs do not change generated.by/at or enlist untouched
+    # pages into a producer metadata migration, but remain visible in the audit.
+    mechanical_fixes = identity_fixes + mechanical_fixes
     run._selfcheck_key = key
     report = selfcheck.run_layer1(workdir)
     pending_stamp_failures = dict(

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -23,6 +23,7 @@ import posixpath
 import re
 import unicodedata
 import uuid
+from collections.abc import Collection
 from datetime import date, datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -220,14 +221,27 @@ def _explicit_external_source(resource: str) -> bool:
     managed-source namespace. Bare values remain a legacy compatibility case
     when (and only when) they exactly match the current Raw inventory.
     """
-    value = posixpath.normpath(resource.strip().replace("\\", "/"))
+    value = resource.strip().replace("\\", "/")
+    # Filesystem normalization collapses URI separators (https:// -> https:/).
+    # Recognize schemes before interpreting the value as a path.
+    if re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", value):
+        return True
+    value = posixpath.normpath(value)
     lowered = value.lower()
     return (
-        "://" in value
-        or lowered.startswith(("mailto:", "urn:", "doi:"))
-        or value.startswith(("/", "../"))
+        value.startswith(("/", "../"))
         or lowered.startswith("references/")
     )
+
+
+def _managed_source_entry(resource: str, managed_sources: Collection[str] | None) -> str:
+    """Resolve explicit Raw paths or exact legacy inventory matches only."""
+    if _explicit_external_source(resource):
+        return ""
+    entry = _norm_source_entry(resource)
+    if _explicit_managed_source(resource) or (managed_sources is not None and entry in managed_sources):
+        return entry
+    return ""
 
 
 def parse_okf_sources(
@@ -256,20 +270,12 @@ def parse_okf_sources(
             resource = item.get("resource")
             if not isinstance(resource, str):
                 continue
-            if _explicit_managed_source(resource):
-                entry = _norm_source_entry(resource)
-                if entry:
-                    resources.append(entry)
-                continue
-            if _explicit_external_source(resource):
-                continue
             # Clean v0.2 packages use an explicit managed namespace. Preserve
             # the old bare-path dialect only when it exactly identifies a Raw
             # inventory entry; every other value is an OKF scope descriptor.
-            if managed_sources is not None:
-                entry = _norm_source_entry(resource)
-                if entry in managed_sources:
-                    resources.append(entry)
+            entry = _managed_source_entry(resource, managed_sources)
+            if entry:
+                resources.append(entry)
     return resources, derived, has_key
 
 
@@ -2051,6 +2057,7 @@ def _stamp_source_ids_text(
     frontmatter = "".join(lines[1:end])
     try:
         root = yaml.compose(frontmatter, Loader=yaml.SafeLoader)
+        tokens = list(yaml.scan(frontmatter, Loader=yaml.SafeLoader))
     except yaml.YAMLError:
         return None
     if not isinstance(root, yaml.MappingNode):
@@ -2075,8 +2082,9 @@ def _stamp_source_ids_text(
                 id_pair = (key, value)
         if resource_pair is None or not isinstance(resource_pair[1], yaml.ScalarNode):
             continue
-        entry = _norm_source_entry(resource_pair[1].value)
-        wanted = manifest_ids.get(entry)
+        resource = resource_pair[1].value
+        entry = _norm_source_entry(resource)
+        wanted = manifest_ids.get(_managed_source_entry(resource, manifest_ids))
         existing = None
         if id_pair is not None and isinstance(id_pair[1], yaml.ScalarNode):
             candidate = id_pair[1].value.strip()
@@ -2094,7 +2102,10 @@ def _stamp_source_ids_text(
         ids[entry] = wanted
         if id_pair is None and item.flow_style:
             insert_at = item.end_mark.index - 1
-            prefix = " " if frontmatter[:insert_at].rstrip().endswith(",") else ", "
+            # Scanner tokens exclude comments, including comments following a
+            # trailing comma. Text suffix checks would insert a second comma.
+            previous = next(token for token in reversed(tokens) if token.end_mark.index <= insert_at)
+            prefix = " " if isinstance(previous, yaml.tokens.FlowEntryToken) else ", "
             edits.append((insert_at, insert_at, f"{prefix}id: {json.dumps(wanted)}"))
         elif id_pair is None:
             key_node, value_node = resource_pair
@@ -2114,6 +2125,10 @@ def _stamp_source_ids_text(
     for start, finish, replacement in sorted(edits, key=lambda edit: edit[0], reverse=True):
         frontmatter = frontmatter[:start] + replacement + frontmatter[finish:]
     if edits:
+        try:
+            yaml.safe_load(frontmatter)
+        except yaml.YAMLError:
+            return None  # Never persist invalid YAML from a lossless splice.
         text = lines[0] + frontmatter + "".join(lines[end:])
     return text, ids
 
@@ -2129,7 +2144,8 @@ def _remap_evidence_source_ids(text: str, original: str, manifest_ids: dict[str,
             continue
         old, resource = source.get("id"), source.get("resource")
         if isinstance(old, str) and isinstance(resource, str):
-            destinations.setdefault(old.strip(), set()).add(manifest_ids.get(_norm_source_entry(resource)))
+            entry = _managed_source_entry(resource, manifest_ids)
+            destinations.setdefault(old.strip(), set()).add(manifest_ids.get(entry))
     stamped_fm, _, _ = parse_okf_frontmatter(text)
     stamped_ids = {source.get("id") for source in (stamped_fm or {}).get("sources", [])
                    if isinstance(source, dict) and isinstance(source.get("id"), str)}
@@ -2158,6 +2174,7 @@ def _remap_evidence_source_ids(text: str, original: str, manifest_ids: dict[str,
 def trusted_evidence_violations(workdir: str, pages: dict[str, dict]) -> list[dict]:
     """Check Raw evidence against frozen identity, not only page-local ids."""
     manifest_ids = load_manifest_source_ids(workdir)
+    managed_sources = set(source_inventory(workdir)) | manifest_ids.keys()
     violations = []
     for rel, page in sorted(pages.items()):
         fm, body, error = parse_okf_frontmatter(page.get("text", ""))
@@ -2177,8 +2194,8 @@ def trusted_evidence_violations(workdir: str, pages: dict[str, dict]) -> list[di
             source_id, resource = source.get("id"), source.get("resource")
             if not isinstance(source_id, str) or not isinstance(resource, str) or source_id.strip() not in used:
                 continue
-            entry = _norm_source_entry(resource)
-            if _explicit_external_source(resource):
+            entry = _managed_source_entry(resource, managed_sources)
+            if not entry:
                 continue  # External citation declarations are inspected by the package boundary.
             if manifest_ids.get(entry) != source_id.strip():
                 violations.append({"page": rel, "kind": "evidence_source_mapping",

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -2033,8 +2033,8 @@ def _stamp_source_ids_text(
 ) -> tuple[str, dict[str, str]] | None:
     """Return ``(text with sources[].id stamped, resource → id)``.
 
-    ``None`` means the frontmatter cannot be rewritten losslessly (flow-style
-    rows, invalid YAML, no block ``sources`` sequence); such a page is left for
+    ``None`` means the frontmatter cannot be rewritten losslessly (invalid
+    YAML or no ``sources`` sequence); such a page is left for
     the normal OKF lint and keeps page-wide citations. An existing id that
     agrees with the manifest is kept; one that disagrees is replaced — the
     frozen manifest, not the model, owns source ids, and a stray id would fail
@@ -2053,17 +2053,17 @@ def _stamp_source_ids_text(
         root = yaml.compose(frontmatter, Loader=yaml.SafeLoader)
     except yaml.YAMLError:
         return None
-    if not isinstance(root, yaml.MappingNode) or root.flow_style:
+    if not isinstance(root, yaml.MappingNode):
         return None
     sources_node = next((value for key, value in root.value
                          if isinstance(key, yaml.ScalarNode) and key.value == "sources"), None)
-    if not isinstance(sources_node, yaml.SequenceNode) or sources_node.flow_style:
+    if not isinstance(sources_node, yaml.SequenceNode):
         return None
     newline = "\r\n" if "\r\n" in text else "\n"
     ids: dict[str, str] = {}
     edits: list[tuple[int, int, str]] = []
     for item in sources_node.value:
-        if not isinstance(item, yaml.MappingNode) or item.flow_style:
+        if not isinstance(item, yaml.MappingNode):
             return None
         resource_pair = id_pair = None
         for key, value in item.value:
@@ -2092,7 +2092,11 @@ def _stamp_source_ids_text(
             # row tells the model what to fix). Leave the row out of the map.
             continue
         ids[entry] = wanted
-        if id_pair is None:
+        if id_pair is None and item.flow_style:
+            insert_at = item.end_mark.index - 1
+            prefix = " " if frontmatter[:insert_at].rstrip().endswith(",") else ", "
+            edits.append((insert_at, insert_at, f"{prefix}id: {json.dumps(wanted)}"))
+        elif id_pair is None:
             key_node, value_node = resource_pair
             finish = max(_yaml_terminal_end(key_node), _yaml_terminal_end(value_node))
             line_end = frontmatter.find("\n", finish)
@@ -2112,6 +2116,74 @@ def _stamp_source_ids_text(
     if edits:
         text = lines[0] + frontmatter + "".join(lines[end:])
     return text, ids
+
+
+def _remap_evidence_source_ids(text: str, original: str, manifest_ids: dict[str, str]) -> str:
+    """Repair only ids whose original page declaration identifies one Raw path."""
+    fm, _, error = parse_okf_frontmatter(original)
+    if error or not fm:
+        return text
+    destinations: dict[str, set[str | None]] = {}
+    for source in fm.get("sources", []):
+        if not isinstance(source, dict):
+            continue
+        old, resource = source.get("id"), source.get("resource")
+        if isinstance(old, str) and isinstance(resource, str):
+            destinations.setdefault(old.strip(), set()).add(manifest_ids.get(_norm_source_entry(resource)))
+    stamped_fm, _, _ = parse_okf_frontmatter(text)
+    stamped_ids = {source.get("id") for source in (stamped_fm or {}).get("sources", [])
+                   if isinstance(source, dict) and isinstance(source.get("id"), str)}
+    remap = {old: next(iter(values)) for old, values in destinations.items()
+             if len(values) == 1 and None not in values and next(iter(values)) in stamped_ids}
+    edits = []
+    for match in _EVIDENCE_MARKER_RE.finditer(_markdown_prose(text)):
+        try:
+            marker = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue  # Structural lint reports the original malformed marker.
+        if not isinstance(marker, dict) or not isinstance(marker.get("sources"), list):
+            continue
+        sources = marker["sources"]
+        if not all(isinstance(value, str) for value in sources):
+            continue
+        updated = [remap.get(value.strip(), value) for value in sources]
+        if updated != sources and len(set(updated)) == len(updated):
+            marker["sources"] = updated
+            edits.append((match.start(1), match.end(1), json.dumps(marker, separators=(",", ":"))))
+    for start, end, value in reversed(edits):
+        text = text[:start] + value + text[end:]
+    return text
+
+
+def trusted_evidence_violations(workdir: str, pages: dict[str, dict]) -> list[dict]:
+    """Check Raw evidence against frozen identity, not only page-local ids."""
+    manifest_ids = load_manifest_source_ids(workdir)
+    violations = []
+    for rel, page in sorted(pages.items()):
+        fm, body, error = parse_okf_frontmatter(page.get("text", ""))
+        if error or not fm:
+            continue
+        used = set()
+        for match in _EVIDENCE_MARKER_RE.finditer(_markdown_prose(body)):
+            try:
+                marker = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(marker, dict) and isinstance(marker.get("sources"), list):
+                used.update(value.strip() for value in marker["sources"] if isinstance(value, str))
+        for source in fm.get("sources", []):
+            if not isinstance(source, dict):
+                continue
+            source_id, resource = source.get("id"), source.get("resource")
+            if not isinstance(source_id, str) or not isinstance(resource, str) or source_id.strip() not in used:
+                continue
+            entry = _norm_source_entry(resource)
+            if _explicit_external_source(resource):
+                continue  # External citation declarations are inspected by the package boundary.
+            if manifest_ids.get(entry) != source_id.strip():
+                violations.append({"page": rel, "kind": "evidence_source_mapping",
+                                   "detail": f"Source {source_id!r} for {resource!r} does not match the frozen source manifest; restore the exact Raw resource and its id in both page sources and evidence markers."})
+    return violations
 
 
 def _marker_id(marker_json: str) -> str | None:
@@ -2323,7 +2395,8 @@ def attribute_evidence_sections(
         stamped = _stamp_source_ids_text(text, manifest_ids)
         if stamped is None or not stamped[1]:
             continue
-        updated, stats, _ = _attribute_page_text(stamped[0], stamped[1])
+        rebound = _remap_evidence_source_ids(stamped[0], text, manifest_ids)
+        updated, stats, _ = _attribute_page_text(rebound, stamped[1])
         if updated == text:
             continue
         _write_text_atomic(path, updated)
@@ -2818,20 +2891,22 @@ def candidate_tree_hash(workdir: str) -> str | None:
 
 
 def state_key(workdir: str) -> str | None:
-    """Idempotency key for the self-check trigger: candidate tree + exclusions
-    file. Covers EXCLUSIONS.json explicitly because a repair that only adds
+    """Idempotency key for the self-check trigger: candidate tree, exclusions,
+    and frozen source manifest. Covers EXCLUSIONS.json explicitly because a repair that only adds
     exclusions (no candidate edits) must still trigger a re-check — otherwise
     the report would stay 'repairing' forever. None = nothing to check yet."""
     tree = candidate_tree_hash(workdir)
     if tree is None:
         return None
     h = hashlib.sha256(tree.encode())
-    excl = Path(workdir) / EXCLUSIONS_PATH
-    if excl.is_file():
-        try:
-            h.update(excl.read_bytes())
-        except OSError:
-            pass
+    for relative in (EXCLUSIONS_PATH, AUTHORING_MANIFEST_PATH):
+        path = Path(workdir) / relative
+        h.update(relative.encode())
+        if path.is_file():
+            try:
+                h.update(path.read_bytes())
+            except OSError:
+                pass
     return h.hexdigest()
 
 
@@ -2854,6 +2929,8 @@ def run_layer1(workdir: str) -> dict:
     exclusions, exclusion_errors = load_exclusions(workdir)
     cov = coverage(workdir, pages, exclusions)
     lint = lint_candidate(pages, exclusion_errors)
+    lint["violations"].extend(trusted_evidence_violations(workdir, pages))
+    lint["ok"] = not lint["violations"]
     over_broad = detect_over_broad_exclusions(workdir, exclusions)
     previous = read_selfcheck(workdir) or {}
     media_verify = previous.get("media_verify")

--- a/kbc/platform/pod/selfcheck.py
+++ b/kbc/platform/pod/selfcheck.py
@@ -2364,16 +2364,47 @@ def _attribute_page_text(
     return "".join(out), stats, unattributed
 
 
+
+def normalize_evidence_source_ids(workdir: str) -> list[dict[str, object]]:
+    """Rebind source identities across the draft without changing attribution.
+
+    A source row may be recreated with identical path/content, so the new
+    frozen identity also applies to pages outside an incremental changeset.
+    Only source-id scalars and existing marker source lists are rewritten.
+    """
+    fixes: list[dict[str, object]] = []
+    candidate = Path(workdir) / "candidate"
+    manifest_ids = load_manifest_source_ids(workdir)
+    if not manifest_ids or not candidate.is_dir():
+        return fixes
+    for path in sorted(candidate.rglob("*.md")):
+        rel = path.relative_to(candidate).as_posix()
+        if _is_reserved_page(rel):
+            continue
+        try:
+            text = path.read_bytes().decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue  # Existing Layer-1 read/format diagnostics own these errors.
+        stamped = _stamp_source_ids_text(text, manifest_ids)
+        if stamped is None:
+            continue
+        updated = _remap_evidence_source_ids(stamped[0], text, manifest_ids)
+        if updated != text:
+            _write_text_atomic(path, updated)
+            fixes.append({"rule": "evidence_source_ids_rebound", "page": rel})
+    return fixes
+
+
 def attribute_evidence_sections(
     workdir: str,
     allowed_pages: set[str] | None = None,
 ) -> list[dict[str, object]]:
     """Stamp ``sources[].id`` and machine evidence markers on candidate pages.
 
-    Runs at the same seam and under the same page scope as
-    ``normalize_body_source_annotations``: incremental turns touch only pages
-    already editable, so this can never become a whole-library rewrite behind
-    an owner's scoped edit. Returns one audit record per rewritten page.
+    Section attribution stays within the same page scope as
+    ``normalize_body_source_annotations``. The driver separately rebinds source
+    identities across the draft with ``normalize_evidence_source_ids``.
+    Returns one audit record per rewritten page.
     """
     fixes: list[dict[str, object]] = []
     candidate = Path(workdir) / "candidate"

--- a/kbc/platform/pod/test_compile_box.py
+++ b/kbc/platform/pod/test_compile_box.py
@@ -6931,6 +6931,7 @@ async def main():
     await test_incremental_integrity_guard()
     await test_incremental_guard_rearms_on_ledger_repair()
     await test_incremental_violation_auto_restored()
+    await test_incremental_rebinds_untouched_source_ids_without_widening_body_scope()
     await test_unconverged_files_residual_ticket()
     await test_exact_source_alias_is_repaired_before_l1_budget()
     await test_incremental_grandfathers_untouched_format_debt()
@@ -7799,6 +7800,66 @@ async def test_the_runtime_owns_the_dispatch_round_not_the_model():
         await client.close()
         td.cleanup()
     print("✓ dispatch round is stamped by the runtime; a wrong or missing echo cannot mislead it")
+
+
+async def test_incremental_rebinds_untouched_source_ids_without_widening_body_scope():
+    """Recreated Raw identity is metadata repair, including across repair turns."""
+    import incremental
+    import selfcheck
+
+    for needs_repair in (False, True):
+        with tempfile.TemporaryDirectory() as td:
+            wd = Path(td)
+            for folder in ("raw", "candidate", "authoring"):
+                (wd / folder).mkdir()
+            (wd / "raw/changed.md").write_text("Changed source.")
+            (wd / "raw/stable.md").write_text("Unchanged source bytes.")
+            (wd / "authoring/manifest.yaml").write_text(
+                "sources:\n  - id: changed-source\n    path: changed.md\n"
+                "  - id: current-source\n    path: stable.md\n")
+            (wd / "candidate/index.md").write_text(
+                '---\nokf_version: "0.2"\n---\n# Index\n- [A](a.md)\n- [C](c.md)\n')
+            a = ('---\ntype: Guide\ntitle: Changed\nlabels:\n'
+                 '  - facet: topic\n    value: changed\nsources:\n'
+                 '  - resource: raw/changed.md\n    id: changed-source\n---\nA fact.\n')
+            # Inherited format debt must remain grandfathered: rekeying may
+            # not enlist this untouched page into a labels/format migration.
+            c = ('---\ntype: Guide\ntitle: Stable\nsources:\n'
+                 '  - resource: raw/stable.md\n    id: old-source\n---\n'
+                 '<!-- okf:evidence {"id":"stable.section","sources":["old-source"]} -->\n'
+                 '## Stable\nKeep this prose and its attribution exactly.\n')
+            expected = c.replace('id: old-source', 'id: "current-source"').replace(
+                '"sources":["old-source"]', '"sources":["current-source"]')
+            (wd / "candidate/a.md").write_text(a)
+            (wd / "candidate/c.md").write_text(c)
+            (wd / "authoring/RAW_CHANGES.json").write_text(json.dumps({
+                "modified": ["changed.md"], "added": [], "deleted": []}))
+            run = compile_box.CompileRun("source-rekey", td, 1)
+            run.client = _FakeSDKClient()
+            await compile_box._start_incremental(run, "Update changed source", strict=True)
+            assert run._incr_pending["changeset"]["affected_pages"] == ["a.md"]
+            if needs_repair:
+                (wd / "raw/orphan.md").write_text("Unaccounted input.")
+            # Even a simultaneous unauthorized body edit must be restored;
+            # the identity repair is never a blanket exemption for this page.
+            (wd / "candidate/c.md").write_text(c + "Unauthorized body edit.\n")
+            repair = await compile_box._post_turn_selfcheck(run)
+            assert (wd / "candidate/c.md").read_text() == expected
+            report = selfcheck.read_selfcheck(td)
+            assert not any(v["kind"] == "evidence_source_mapping" for v in report["lint"]["violations"])
+            assert report["incremental"]["restored_pages"] == ["c.md"]
+            if needs_repair:
+                assert repair and "orphan.md" in repair
+                assert "c.md" not in run._incr_pending["repair_pages"]
+                assert run._incr_pending["before_bytes"]["c.md"] == expected.encode()
+                (wd / "authoring/EXCLUSIONS.json").write_text(json.dumps([
+                    {"pattern": "orphan.md", "reason": "Live operational data"}]))
+                (wd / "candidate/c.md").write_text(expected + "Another unauthorized edit.\n")
+                repair = await compile_box._post_turn_selfcheck(run)
+                assert (wd / "candidate/c.md").read_text() == expected
+            assert repair is None
+            assert selfcheck.read_selfcheck(td)["state"] == "passed"
+            assert run._l1_repairs_used == 0
 
 
 if __name__ == "__main__":

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -2856,6 +2856,9 @@ def main():
     test_evidence_identity_repair_preserves_ambiguous_and_unstamped_ids()
     test_frozen_identity_change_invalidates_selfcheck_key()
     test_flow_source_rows_and_authored_markers_repair_together()
+    test_frozen_identity_check_preserves_unmanaged_resources()
+    test_flow_source_id_insertion_preserves_comments_and_yaml()
+    test_source_identity_rewrite_rejects_invalid_yaml_atomically()
     test_attribution_reports_oversized_pages()
     test_spaced_markdown_links()
     test_media_verify_helpers()
@@ -3027,6 +3030,81 @@ def test_flow_source_rows_and_authored_markers_repair_together():
             assert selfcheck._okf_evidence_violations("guide.md", fm, body) == []
             assert selfcheck.trusted_evidence_violations(td, {"guide.md": {"text": result}}) == []
             assert selfcheck.attribute_evidence_sections(td) == []
+
+
+def test_frozen_identity_check_preserves_unmanaged_resources():
+    resources = (
+        "https://example.com/manual", "s3://bucket/manual", "urn:manual:v1",
+        "references/manual.md", "package/manual.md", "Service API scope",
+    )
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        # Even a colliding Raw-relative path must not capture an external URI
+        # or an explicitly package-owned references/ resource.
+        collisions = ("https:/example.com/manual", "references/manual.md")
+        rows = [{"path": path, "id": f"raw-{i}"} for i, path in enumerate(collisions)]
+        rows.append({"path": "managed.md", "id": "managed"})
+        _mk(base, "authoring/manifest.yaml", json.dumps({"sources": rows}))
+        for row in rows:
+            _mk(base, "raw/" + row["path"], "Managed source.")
+        for resource in resources:
+            page = ('---\ntype: Guide\nsources: [{resource: ' + json.dumps(resource)
+                    + ', id: external}]\n---\n'
+                    '<!-- okf:evidence {"id":"section","sources":["external"]} -->\nFact.\n')
+            _mk(base, "candidate/page.md", page)
+            assert selfcheck.trusted_evidence_violations(td, {"page.md": {"text": page}}) == [], resource
+            assert selfcheck.parse_okf_sources(page, set(collisions))[0] == [], resource
+            assert selfcheck.normalize_evidence_source_ids(td) == [], resource
+            assert (base / "candidate/page.md").read_text() == page
+        # A mixed page still keeps external evidence in its section fallback;
+        # namespace checking changes identity ownership, not attribution.
+        mixed = ('---\ntype: Guide\nsources: [{resource: raw/managed.md, id: managed}, '
+                 '{resource: https://example.com/manual, id: external}]\n---\n## Guide\nA fact.\n')
+        _mk(base, "candidate/page.md", mixed)
+        selfcheck.attribute_evidence_sections(td)
+        result = (base / "candidate/page.md").read_text()
+        assert '"sources":["managed","external"]' in result, result
+        for resource in ("raw/managed.md", "drop/managed.md", "managed.md", "raw/missing.md"):
+            page = ('---\nsources: [{resource: ' + resource + ', id: wrong}]\n---\n'
+                    '<!-- okf:evidence {"id":"section","sources":["wrong"]} -->\nFact.\n')
+            assert selfcheck.trusted_evidence_violations(td, {"page.md": {"text": page}}), resource
+
+
+def test_flow_source_id_insertion_preserves_comments_and_yaml():
+    rows = (
+        '{resource: raw/a.md, # Original document\n}',
+        '{resource: raw/a.md # Original document\n}',
+        '{resource: raw/a.md, note: "comma, # literal", # Original document\n}',
+    )
+    for row in rows:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            _mk(base, "authoring/manifest.yaml", 'sources: [{id: current, path: a.md}]\n')
+            page = f'---\ntype: Guide\nsources: [{row}]\n---\n## Guide\nKeep this body.\n'
+            fm_before, body_before, error = selfcheck.parse_okf_frontmatter(page)
+            assert error is None
+            _mk(base, "candidate/page.md", page)
+            selfcheck.normalize_evidence_source_ids(td)
+            result = (base / "candidate/page.md").read_text()
+            fm_after, body_after, error = selfcheck.parse_okf_frontmatter(result)
+            assert error is None, result
+            fm_before["sources"][0]["id"] = "current"
+            assert fm_after == fm_before
+            assert body_after == body_before and "# Original document" in result
+            assert selfcheck.normalize_evidence_source_ids(td) == []
+
+
+def test_source_identity_rewrite_rejects_invalid_yaml_atomically():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _mk(base, "authoring/manifest.yaml", 'sources: [{id: current, path: a.md}]\n')
+        # Replacing this scalar would also remove an anchor used elsewhere.
+        page = ('---\nsources: [{resource: raw/a.md, id: &shared old}]\n'
+                'other: *shared\n---\nKeep this body.\n')
+        assert selfcheck.parse_okf_frontmatter(page)[2] is None
+        _mk(base, "candidate/page.md", page)
+        assert selfcheck.normalize_evidence_source_ids(td) == []
+        assert (base / "candidate/page.md").read_text() == page
 
 
 if __name__ == "__main__":

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -2953,3 +2953,76 @@ def test_source_id_stamping_handles_bare_and_non_scalar_ids():
         q = (base / "candidate" / "q.md").read_text()
         assert "id: [x]" in q and "okf:evidence" not in q, q
     print("OK  source id stamping: bare id gets a space; non-scalar id is not cited")
+
+
+def test_authored_evidence_ids_follow_frozen_source_identity():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _mk(base, "authoring/manifest.yaml", 'sources:\n  - id: current-source\n    path: guide.md\n')
+        _mk(base, "raw/guide.md", "A source.")
+        page = ('---\ntype: guide\ntitle: Guide\nsources:\n'
+                '  - resource: raw/guide.md\n    id: old-source\n---\n'
+                '<!-- okf:evidence {"id":"owner.section","sources":["old-source"]} -->\n'
+                '## Guide\nA fact.\n'
+                '```html\n<!-- okf:evidence {"id":"example","sources":["old-source"]} -->\n```\n')
+        _mk(base, "candidate/guide.md", page)
+        selfcheck.attribute_evidence_sections(td)
+        result = (base / "candidate/guide.md").read_text()
+        fm, body, _ = selfcheck.parse_okf_frontmatter(result)
+        assert selfcheck._okf_evidence_violations("guide.md", fm, body) == []
+        assert '"sources":["current-source"]' in result
+        assert '"id":"example","sources":["old-source"]' in result
+        assert selfcheck.attribute_evidence_sections(td) == []
+
+
+def test_trusted_evidence_check_rejects_self_consistent_unknown_id():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _mk(base, "authoring/manifest.yaml", 'sources:\n  - id: current-source\n    path: guide.md\n')
+        page = ('---\ntype: guide\ntitle: Guide\nsources: [{resource: raw/guide.md, id: invented-source}]\n---\n'
+                '<!-- okf:evidence {"id":"section","sources":["invented-source"]} -->\nA fact.\n')
+        pages = {"guide.md": {"text": page}}
+        fm, body, _ = selfcheck.parse_okf_frontmatter(page)
+        assert selfcheck._okf_evidence_violations("guide.md", fm, body) == []
+        problems = selfcheck.trusted_evidence_violations(td, pages)
+        assert len(problems) == 1
+        assert problems[0]["kind"] == "evidence_source_mapping"
+        assert "invented-source" in problems[0]["detail"]
+
+
+def test_evidence_identity_repair_preserves_ambiguous_and_unstamped_ids():
+    page = ('---\nsources:\n'
+            '  - resource: raw/a.md\n    id: old\n'
+            '  - resource: raw/b.md\n    id: old\n---\n'
+            '<!-- okf:evidence {"id":"section","sources":["old"]} -->\nFact.\n')
+    assert selfcheck._remap_evidence_source_ids(page, page, {"a.md": "a", "b.md": "b"}) == page
+    flow = ('---\nsources: [{resource: raw/a.md, id: old}]\n---\n'
+            '<!-- okf:evidence {"id":"section","sources":["old"]} -->\nFact.\n')
+    assert selfcheck._remap_evidence_source_ids(flow, flow, {"a.md": "a"}) == flow
+
+
+def test_frozen_identity_change_invalidates_selfcheck_key():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _mk(base, "candidate/page.md", "A page.")
+        _mk(base, "authoring/manifest.yaml", 'sources: [{id: first, path: a.md}]\n')
+        before = selfcheck.state_key(td)
+        _mk(base, "authoring/manifest.yaml", 'sources: [{id: second, path: a.md}]\n')
+        assert selfcheck.state_key(td) != before
+
+
+def test_flow_source_rows_and_authored_markers_repair_together():
+    for row in ('{resource: raw/guide.md, id: old-source}', '{resource: raw/guide.md}', '{resource: raw/guide.md,}'):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            _mk(base, "authoring/manifest.yaml", 'sources: [{id: current-source, path: guide.md}]\n')
+            _mk(base, "raw/guide.md", "A source.")
+            marker = '<!-- okf:evidence {"id":"section","sources":["old-source"]} -->\n' if 'id:' in row else ''
+            _mk(base, "candidate/guide.md", f'---\ntype: guide\nsources: [{row}]\n---\n{marker}## Guide\nA fact.\n')
+            selfcheck.attribute_evidence_sections(td)
+            result = (base / "candidate/guide.md").read_text()
+            fm, body, error = selfcheck.parse_okf_frontmatter(result)
+            assert not error and fm["sources"][0]["id"] == "current-source", result
+            assert selfcheck._okf_evidence_violations("guide.md", fm, body) == []
+            assert selfcheck.trusted_evidence_violations(td, {"guide.md": {"text": result}}) == []
+            assert selfcheck.attribute_evidence_sections(td) == []

--- a/kbc/platform/pod/test_selfcheck.py
+++ b/kbc/platform/pod/test_selfcheck.py
@@ -2851,6 +2851,11 @@ def main():
     test_deterministic_body_source_normalization()
     test_attribute_evidence_sections_derives_markers_from_statement_tags()
     test_attribute_evidence_sections_without_manifest_is_inert()
+    test_authored_evidence_ids_follow_frozen_source_identity()
+    test_trusted_evidence_check_rejects_self_consistent_unknown_id()
+    test_evidence_identity_repair_preserves_ambiguous_and_unstamped_ids()
+    test_frozen_identity_change_invalidates_selfcheck_key()
+    test_flow_source_rows_and_authored_markers_repair_together()
     test_attribution_reports_oversized_pages()
     test_spaced_markdown_links()
     test_media_verify_helpers()
@@ -2898,10 +2903,6 @@ def main():
     test_ticket_kind_gate_and_claim_identity()
     test_file_ticket_record_supersedes_by_claim_and_normalizer_never_guesses()
     print("ALL OK  test_selfcheck")
-
-
-if __name__ == "__main__":
-    main()
 
 
 def test_attribution_pairs_lines_by_newline_and_keeps_the_page_tail():
@@ -3026,3 +3027,7 @@ def test_flow_source_rows_and_authored_markers_repair_together():
             assert selfcheck._okf_evidence_violations("guide.md", fm, body) == []
             assert selfcheck.trusted_evidence_violations(td, {"guide.md": {"text": result}}) == []
             assert selfcheck.attribute_evidence_sections(td) == []
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Draft source IDs could be corrected from the frozen manifest while authored evidence markers kept old IDs. Flow-style source rows also skipped identity stamping. Recreated source identities on otherwise unchanged Raw paths could remain on pages outside an incremental changeset.

Rebind declarations and authored markers across the draft when the Raw resource has an unambiguous frozen identity. Run this after restoring unauthorized body edits, and advance only the identity-normalized baseline for untouched pages. Section attribution remains scoped; identity repair does not broaden model edit permissions or migrate inherited format debt. Later repair turns retain the corrected identities while still restoring out-of-scope body edits.

Check Raw evidence against the frozen manifest during self-check and include manifest changes in the check key, so internally consistent but untrusted IDs enter repair before publication.

Recognize external URI schemes before path normalization and use the same managed-resource boundary for coverage, identity stamping, marker remapping, and frozen-ID validation. Preserve external/package resource declarations and mixed-page attribution. Flow mapping insertion reads YAML tokens so trailing commas followed by comments stay valid, and rewritten frontmatter must parse before any page is saved.

Validation:
- CI script entrypoints (`test_compile_box.py`, `test_selfcheck.py`, `test_incremental.py`) pass, with the new regressions wired into their runners.
- Compile-box, self-check and incremental suites: 221 passed; two failures reproduced unchanged on clean main (212 passed): charset corruption line numbering and self-check wiring idempotency.
- Added regression coverage for external and package resources, Raw-name collisions, mixed attribution, commented flow mappings, and atomic rejection of unsafe anchor rewrites.
- The incremental regression covers recreated identity on an untouched page, simultaneous unauthorized body edits, inherited format debt, and a subsequent repair turn.
- Cross-repository smoke: feed the actual consumer frozen manifest into the compiler, process the scoped incremental turn, synchronize its generated pages, and verify readiness plus successful publication through the consumer service.

These checks establish the corrected code paths; they do not reconstruct a specific production draft history.
