### PR TITLE
fix(gateway): persist top-level tool execution failures

### DIFF
--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -1048,6 +1048,30 @@ describe("consumeAgentSse — tool execution", () => {
     expect(updateCalls[0].outcome).toBe("error");
   });
 
+  it.each([true, false])("persists top-level tool failures with start frame present=%s", async (hasStart) => {
+    const events = [
+      ...(hasStart ? [{ type: "tool_execution_start", toolCallId: "failed-read", toolName: "grep", args: {} }] : []),
+      { type: "tool_execution_end", toolCallId: "failed-read", toolName: "grep", isError: true,
+        result: { content: [{ type: "text", text: "Search executable is unavailable" }] } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    const row = hasStart ? updateCalls[0] : appendCalls.find((call) => call.role === "tool");
+    expect(row).toMatchObject({ outcome: "error", content: "Search executable is unavailable" });
+  });
+
+  it("keeps blocked precedence and does not infer failure from output text", async () => {
+    const events = [
+      { type: "tool_execution_start", toolCallId: "blocked", toolName: "one", args: {} },
+      { type: "tool_execution_end", toolCallId: "blocked", toolName: "one", isError: true,
+        result: { content: [], details: { blocked: true } } },
+      { type: "tool_execution_start", toolCallId: "ok", toolName: "two", args: {} },
+      { type: "tool_execution_end", toolCallId: "ok", toolName: "two", isError: false,
+        result: { content: [{ type: "text", text: "Error handling documentation" }] } },
+    ];
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    expect(updateCalls.map((call) => call.outcome)).toEqual(["blocked", "success"]);
+  });
+
   it("persists tool details as metadata (dropping blocked/error flags that are surfaced via outcome)", async () => {
     // Tools can attach a rich `details` object to their result; the UI
     // consumes it on history reload. Verify the structured payload survives

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -831,7 +831,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
 
         let outcome: "success" | "error" | "blocked" = "success";
         if (toolResult?.details?.blocked) outcome = "blocked";
-        else if (toolResult?.details?.error) outcome = "error";
+        else if (evt.isError === true || toolResult?.details?.error) outcome = "error";
 
         const pendingCall = shiftPending(pendingToolCalls, toolCallKey(evt, toolName));
         const eventToolset = typeof evt.toolset === "string" && evt.toolset.length > 0


### PR DESCRIPTION
When a tool ends with `isError: true` and no `result.details.error`, the live execution reports a failure but the stored tool message records success. Persist the event's error flag so reloaded traces and error counts reflect the execution outcome. Keep blocked outcomes authoritative and continue treating successful text containing the word "Error" as success.

Regression tests cover both updating a tool message created by a start frame and appending a result when that frame is absent. Both error cases failed before the fix and pass afterward.

Validation: 96 focused SSE consumer tests passed; the full suite passed with 7,067 tests and 2 skips across 328 files; `npx tsc --noEmit` and `npm run build` passed. This changes newly persisted outcomes; it does not rewrite historical traces.
