### PR TITLE
Export shared compiler checks and authoring standards for local agents

### DIFF
--- a/kbc/tools/AUTHORING_KIT.md
+++ b/kbc/tools/AUTHORING_KIT.md
@@ -1,0 +1,31 @@
+# Local authoring kit
+
+Export the compiler's deterministic checker and its reading standards for a local
+coding-agent workspace:
+
+```sh
+python3 kbc/tools/authoring_kit.py /path/to/workspace/.local-kb --locale en
+```
+
+The kit contains the actual `selfcheck.py`, its source classification module,
+compiler playbook/role, constitution, OKF citation guidance and consumer role.
+`kit-manifest.json` records every file's SHA256 and the supported OKF version.
+`local-consumer-role.md` adapts only the original consumer role's workspace path
+to `candidate/`; the original role is retained separately.
+
+A platform integration can combine this kit with a pinned workspace containing
+`raw/`, `candidate/`, `authoring/` and `eval/`, then import
+`checker/selfcheck.py` and call `run_layer1(workspace)`. The checker needs Python
+3.11+ and PyYAML. Use a fresh Python process with only the checker directory added
+to its import path; source content should never supply executable modules.
+
+Use compiler instructions as content/quality standards. Cloud-only tools named
+in the compiler role require adaptation to the local platform workflow. Local
+consumer experiments should receive question text and Wiki access without
+reference answers or Raw, then be assessed separately against those sources.
+
+Local reports are development evidence. Proposal review, canonical versioning,
+platform verification and publication remain the integrating platform's job.
+Use a Siclaw checkout aligned with that platform's compiler release: matching OKF
+versions alone does not prove matching compiler builds. The exporter preserves
+existing kit files; create a new workspace when updating compiler versions.

--- a/kbc/tools/authoring_kit.py
+++ b/kbc/tools/authoring_kit.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Export compiler checker code and reading standards for local KB authoring.
+
+The destination may already contain a platform workspace's baseline files. Every
+kit file is created exclusively; existing checker/standards files are preserved.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+POD = REPO / "kbc/platform/pod"
+
+
+def export_kit(destination: Path, locale="en") -> dict:
+    if locale not in {"en", "zh"}:
+        raise ValueError("locale must be en or zh")
+    sources = {
+        "checker/selfcheck.py": POD / "selfcheck.py",
+        "checker/source_kinds.py": POD / "source_kinds.py",
+        "checker/prompts/zh/test_role.md": POD / "prompts/zh/test_role.md",
+        "standards/playbook.md": POD / f"prompts/{locale}/playbook.md",
+        "standards/compiler-role.md": POD / f"prompts/{locale}/box_role.md",
+        "standards/consumer-role.md": POD / f"prompts/{locale}/test_role.md",
+        "standards/constitution.md": REPO / "kbc/constitution.md",
+        "standards/okf-evidence-citations.md": REPO / "docs/design/okf-evidence-citations.md",
+    }
+    bodies = {rel: source.read_bytes() for rel, source in sources.items()}
+    # Preserve the authoritative consumer role too. Only its workspace path
+    # changes in the local adaptation, which is hashed independently.
+    bodies["standards/local-consumer-role.md"] = bodies["standards/consumer-role.md"].replace(
+        b".siclaw/knowledge/", b"candidate/")
+    manifest = {"format": 1, "locale": locale, "okf_version": "0.2",
+                "files": {rel: hashlib.sha256(body).hexdigest() for rel, body in bodies.items()}}
+    bodies["kit-manifest.json"] = (json.dumps(manifest, indent=2) + "\n").encode()
+    # Preflight all destinations so an existing kit is not partially updated.
+    for rel in bodies:
+        target = destination
+        if target.is_symlink():
+            raise ValueError("Kit destination must not be a symlink")
+        for part in Path(rel).parts:
+            target /= part
+            if target.is_symlink():
+                raise ValueError(f"Kit path must not be a symlink: {rel}")
+        if target.exists():
+            raise FileExistsError(f"Kit file already exists: {rel}")
+    for rel, body in bodies.items():
+        target = destination / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("xb") as output:
+            output.write(body)
+    return manifest
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("destination", type=Path)
+    parser.add_argument("--locale", choices=("en", "zh"), default="en")
+    args = parser.parse_args()
+    print(json.dumps(export_kit(args.destination, args.locale), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/kbc/tools/test_authoring_kit.py
+++ b/kbc/tools/test_authoring_kit.py
@@ -1,0 +1,47 @@
+"""Exported kits retain the actual compiler checks and prompt bytes."""
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import authoring_kit
+
+
+@pytest.mark.parametrize("locale", ["en", "zh"])
+def test_kit_matches_compiler_sources_and_runs_real_check(tmp_path, locale):
+    kit = tmp_path / "kit"
+    manifest = authoring_kit.export_kit(kit, locale)
+    assert manifest["okf_version"] == "0.2"
+    for rel, sha in manifest["files"].items():
+        assert hashlib.sha256((kit / rel).read_bytes()).hexdigest() == sha
+    assert (kit / "checker/selfcheck.py").read_bytes() == (authoring_kit.POD / "selfcheck.py").read_bytes()
+    assert (kit / "standards/playbook.md").read_bytes() == (authoring_kit.POD / f"prompts/{locale}/playbook.md").read_bytes()
+    assert b"candidate/" in (kit / "standards/local-consumer-role.md").read_bytes()
+    workspace = tmp_path / "workspace"
+    (workspace / "candidate").mkdir(parents=True)
+    (workspace / "raw").mkdir()
+    (workspace / "raw/source.md").write_text("# Source\nA supported fact.\n")
+    (workspace / "candidate/index.md").write_text('---\nokf_version: "0.2"\n---\n# Index\n- [Guide](guide.md) - facts\n')
+    (workspace / "candidate/guide.md").write_text('---\ntype: concept\nsources:\n  - resource: raw/source.md\n---\n# Guide\nA supported fact.\n')
+    code = "import sys,json; sys.path.insert(0,sys.argv[1]); import selfcheck; print(json.dumps(selfcheck.run_layer1(sys.argv[2])))"
+    result = subprocess.run([sys.executable, "-I", "-c", code, str(kit / "checker"), str(workspace)], check=True, capture_output=True, text=True)
+    report = json.loads(result.stdout)
+    assert report["coverage"]["closed"] and report["lint"]["ok"], report
+
+
+def test_export_preserves_existing_files_and_refuses_symlinks(tmp_path):
+    kit = tmp_path / "kit"
+    authoring_kit.export_kit(kit)
+    sentinel = kit / "standards/playbook.md"
+    sentinel.write_text("local content")
+    with pytest.raises(FileExistsError):
+        authoring_kit.export_kit(kit)
+    assert sentinel.read_text() == "local content"
+    linked = tmp_path / "linked"
+    linked.symlink_to(kit)
+    with pytest.raises(ValueError, match="symlink"):
+        authoring_kit.export_kit(linked)


### PR DESCRIPTION
Local coding agents need the same reading and output standards as the knowledge compiler. Add a small exporter that packages the existing deterministic checker, source classification, compiler playbook, constitution, OKF citation guidance and consumer role with content checksums.

The original consumer role is preserved alongside a local workspace path adaptation. Platform-specific checkout, proposal and publication workflows remain outside this reusable kit. Existing destination files are preserved.

Validation: 3 exporter tests pass, including execution of the real copied checker for both locales. The unchanged compiler selfcheck suite has 83 passes and 2 pre-existing failures (`test_charset_corruption_detection`, `test_wiring`), reproduced on main.

Usage: `kbc/tools/AUTHORING_KIT.md`.
