### PR TITLE
fix(tasks): preserve task names across status updates

### DIFF
--- a/docs/completion/2026-09-11-task-title-preservation.md
+++ b/docs/completion/2026-09-11-task-title-preservation.md
@@ -1,0 +1,24 @@
+# Preserve task names across status updates
+
+A status-only `task_update` can contain an empty `subject` placeholder. The ledger
+previously persisted that value as a rename, leaving both completed and active
+plan rows without text.
+
+The ledger now ignores blank title updates while accepting nonblank renames.
+Batch and single-item tool schemas document the same behavior. Runtime history
+recovery and Portal replay retain the last known title for the same task without
+crossing delete/reset boundaries or modifying source events. The Portal displays
+`Task #ID` if no title is available in loaded history.
+
+Validation:
+
+- Regression tests failed before the fix for ledger mutation, tool snapshots,
+  and history recovery.
+- 60 tests across the ledger, task tools, history recovery, task events and task
+  coordinator pass.
+- Portal plan tests: 3 files / 17 tests pass.
+- Runtime TypeScript build and Portal production build pass.
+- `git diff --check` passes; no production dependencies were added.
+
+The change has not been deployed. It does not rewrite existing persisted data;
+recovering an old title requires an earlier valid event in the loaded history.

--- a/docs/completion/2026-09-11-task-title-preservation.md
+++ b/docs/completion/2026-09-11-task-title-preservation.md
@@ -20,5 +20,16 @@ Validation:
 - Runtime TypeScript build and Portal production build pass.
 - `git diff --check` passes; no production dependencies were added.
 
-The change has not been deployed. It does not rewrite existing persisted data;
-recovering an old title requires an earlier valid event in the loaded history.
+The production Runtime and Portal images built from `9735b22b` were also tested in
+an isolated Kubernetes namespace. Executing the compiled task tools inside the
+Runtime container preserved titles for single empty-title and batched whitespace
+updates, including the emitted snapshots. Historical damaged events were written
+through the Portal Runtime RPC into a temporary database. The production Portal
+displayed the original completed, active and pending task names before and after
+a browser reload.
+
+The temporary namespace and port forwards were removed after acceptance. This
+was a tool and persisted-history integration test using synthetic events, not a
+live model evaluation. No existing deployment or persisted conversation was
+modified. Recovering an old title still requires an earlier valid event in the
+loaded history.

--- a/docs/design/2026-05-29-subagents-background-task-ledger.md
+++ b/docs/design/2026-05-29-subagents-background-task-ledger.md
@@ -377,6 +377,19 @@ that the Portal/Gateway DB owns sessions and chat history; AgentBox state is dis
   is persisted too. On refresh, the Jobs bar reloads running + recently-finished jobs and **reattaches to
   live progress** via SSE; `job_output` streams resume from the persisted offset.
 
+### Task titles during status updates
+
+A task title is non-empty at creation and cannot be cleared by `task_update`.
+Models may fill unused optional strings with empty placeholders, including in
+batch updates. An omitted, empty or whitespace-only subject keeps the current
+title; a nonblank subject renames it. Other optional fields retain their existing
+clearing semantics.
+
+When replaying legacy events, a blank title reuses the last nonblank title for
+that task within the current plan. Delete and reset events end that recovery
+scope. Replay does not rewrite stored events. If no title is available in the
+loaded history, the plan panel displays `Task #ID` instead of an empty row.
+
 ### In-flight work across refresh
 - A running sub-agent/job keeps executing in the AgentBox during a refresh (the client disconnecting does
   not abort it; background work uses an independent abort controller — §7). A session with live background

--- a/portal-web/src/components/plan/PlanPanel.test.tsx
+++ b/portal-web/src/components/plan/PlanPanel.test.tsx
@@ -1,0 +1,19 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { expect, it } from "vitest"
+import { PlanPanel } from "./PlanPanel"
+import type { PilotMessage } from "../chat/types"
+
+const task = (subject: string, status = "pending"): PilotMessage => ({
+  id: `event-${status}`, role: "user", content: "", timestamp: "0",
+  metadata: { kind: "task_event", action: "upsert", task: { id: "7", subject, status } },
+} as PilotMessage)
+
+it("shows the known title after a blank completion snapshot, including history replay", () => {
+  const messages = JSON.parse(JSON.stringify([task("Inspect request timing"), task("", "completed")]))
+  expect(renderToStaticMarkup(createElement(PlanPanel, { messages }))).toContain("Inspect request timing")
+})
+
+it("shows a task ID rather than an empty row when the title is unavailable", () => {
+  expect(renderToStaticMarkup(createElement(PlanPanel, { messages: [task("", "in_progress")] }))).toContain("Task #7")
+})

--- a/portal-web/src/components/plan/PlanPanel.tsx
+++ b/portal-web/src/components/plan/PlanPanel.tsx
@@ -24,7 +24,7 @@ function ProgressRow({ task }: { task: PlanTaskView }) {
       </span>
       <div className="min-w-0 flex-1">
         <p className={`text-[13px] leading-snug ${done ? "text-muted-foreground" : "text-foreground"}`}>
-          {task.subject}
+          {task.subject.trim() || `Task #${task.id}`}
         </p>
         {task.group === "blocked" && task.blockedBy.length > 0 && (
           <p className="text-[10px] text-muted-foreground/60">

--- a/portal-web/src/components/plan/foldPlan.test.ts
+++ b/portal-web/src/components/plan/foldPlan.test.ts
@@ -81,3 +81,17 @@ describe("foldPlan", () => {
     expect(plan[0].owner).toBe("sub-agent-1")
   })
 })
+
+it("recovers titles from older events when status snapshots have blank names", () => {
+  const created = ev("upsert", { task: { id: "7", subject: "Inspect request timing", status: "pending" } });
+  const started = ev("upsert", { task: { id: "7", subject: "", status: "in_progress", activeForm: "" } });
+  const renamed = ev("upsert", { task: { id: "7", subject: "Verify timing evidence", status: "in_progress" } });
+  const completed = ev("upsert", { task: { id: "7", subject: " \t", status: "completed" } });
+  expect(foldPlan([created, started])[0]).toMatchObject({ subject: "Inspect request timing", group: "in_progress" });
+  const history = JSON.parse(JSON.stringify([created, started, renamed, completed]));
+  expect(foldPlan(history)[0]).toMatchObject({ subject: "Verify timing evidence", group: "completed" });
+  expect(history[3].metadata.task.subject).toBe(" \t");
+  for (const boundary of [ev("reset"), ev("delete", { taskId: "7" })]) {
+    expect(foldPlan([created, boundary, completed])[0].subject).toBe("");
+  }
+});

--- a/portal-web/src/components/plan/foldPlan.ts
+++ b/portal-web/src/components/plan/foldPlan.ts
@@ -69,7 +69,10 @@ export function foldPlan(messages: PilotMessage[]): PlanTaskView[] {
       const t = ev.task
       map.set(String(t.id), {
         id: String(t.id),
-        subject: t.subject,
+        // Old status updates sometimes persisted a blank title. Retain the
+        // last real name until delete/reset, while accepting explicit renames.
+        subject: typeof t.subject === "string" && t.subject.trim()
+          ? t.subject : map.get(String(t.id))?.subject ?? "",
         description: t.description,
         status: t.status,
         owner: t.owner,

--- a/src/agentbox/task-ledger-recovery.test.ts
+++ b/src/agentbox/task-ledger-recovery.test.ts
@@ -21,3 +21,22 @@ it("does not erase a local plan when history has no valid plan events", () => {
   expect(restoreTaskLedgerFromHistory("s", [{ metadata: "bad json" }])).toBe(false);
   expect(getOrCreateLedger("s").size).toBe(1);
 });
+
+it("recovers the last nonblank title from legacy snapshots without mutating history", () => {
+  const created = upsert("7");
+  const completed = { metadata: { ...created.metadata, task: { ...created.metadata.task, subject: " \t", status: "completed" } } };
+  const messages = [created, { metadata: JSON.stringify(completed.metadata) }];
+  const before = JSON.stringify(messages);
+  restoreTaskLedgerFromHistory("s", messages);
+  expect(getOrCreateLedger("s").get("7")).toMatchObject({ subject: "Check nodes", status: "completed" });
+  expect(JSON.stringify(messages)).toBe(before);
+});
+
+it("does not recover a title from a deleted or reset plan", () => {
+  for (const boundary of [{ action: "delete", taskId: "7" }, { action: "reset" }]) {
+    const blank = upsert("7");
+    blank.metadata.task.subject = "";
+    restoreTaskLedgerFromHistory("s", [upsert("7"), { metadata: { kind: "task_event", taskListId: "s", ...boundary } }, blank]);
+    expect(getOrCreateLedger("s").get("7")?.subject).toBe("");
+  }
+});

--- a/src/agentbox/task-ledger-recovery.ts
+++ b/src/agentbox/task-ledger-recovery.ts
@@ -16,7 +16,13 @@ export function restoreTaskLedgerFromHistory(sessionId: string, messages: Array<
     else if (e.action === "upsert" && e.task && typeof e.task.id === "string" &&
       typeof e.task.subject === "string" && typeof e.task.description === "string" &&
       ["pending", "in_progress", "completed"].includes(e.task.status) && Array.isArray(e.task.blockedBy)) {
-      tasks.set(e.task.id, e.task);
+      // Older status snapshots may have overwritten a valid title with "".
+      // Recover only within this task's lifetime; reset/delete clear the map.
+      const previous = tasks.get(e.task.id);
+      tasks.set(e.task.id, {
+        ...e.task,
+        subject: e.task.subject.trim() ? e.task.subject : previous?.subject ?? "",
+      });
       highWater = Math.max(highWater, Number(e.task.id) || 0);
       found = true;
     }

--- a/src/core/task-ledger.test.ts
+++ b/src/core/task-ledger.test.ts
@@ -122,3 +122,17 @@ describe("TaskLedger", () => {
     expect(a).not.toBe(c);
   });
 });
+
+it("keeps the task title through blank status updates while allowing a real rename", () => {
+  const ledger = new TaskLedger();
+  ledger.create({ subject: "Inspect request timing", description: "Check the trace", owner: "worker" });
+  for (const subject of ["", " \t\n", undefined]) {
+    expect(ledger.update("1", { subject, status: "in_progress" })).toMatchObject({
+      subject: "Inspect request timing", status: "in_progress",
+    });
+  }
+  expect(ledger.update("1", { subject: "Verify timing evidence", status: "completed", owner: "" })).toMatchObject({
+    subject: "Verify timing evidence", status: "completed", owner: "",
+  });
+  expect(ledger.update("1", { subject: "", status: "completed" })?.subject).toBe("Verify timing evidence");
+});

--- a/src/core/task-ledger.ts
+++ b/src/core/task-ledger.ts
@@ -65,7 +65,9 @@ export class TaskLedger {
   update(id: string, patch: UpdateTaskPatch): LedgerTask | null {
     const task = this.tasks.get(id);
     if (!task) return null;
-    if (patch.subject !== undefined) task.subject = patch.subject;
+    // Status-only model calls may fill optional strings with empty placeholders.
+    // A task title cannot be cleared; a nonblank value still performs a rename.
+    if (patch.subject?.trim()) task.subject = patch.subject;
     if (patch.description !== undefined) task.description = patch.description;
     if (patch.activeForm !== undefined) task.activeForm = patch.activeForm;
     if (patch.status !== undefined) task.status = patch.status;

--- a/src/tools/workflow/task-tools.test.ts
+++ b/src/tools/workflow/task-tools.test.ts
@@ -237,3 +237,24 @@ describe("task tools — batch form", () => {
     expect((r as any).details?.error).toBeUndefined();
   });
 });
+
+it("preserves titles in emitted snapshots for padded batch and single status updates", async () => {
+  resetLedgers();
+  const events: any[] = [];
+  const emit = (event: any) => events.push(JSON.parse(JSON.stringify(event)));
+  await createTaskCreateTool(TLID, emit).execute("create", { tasks: [
+    { subject: "Inspect request timing", description: "Read the trace" },
+    { subject: "Compare control request", description: "Match the input" },
+  ] });
+  const update = createTaskUpdateTool(TLID, emit);
+  await update.execute("batch", { updates: [
+    { id: "1", status: "completed", subject: "", description: "", activeForm: "", owner: "", addBlockedBy: [] },
+    { id: "2", status: "in_progress", subject: "", description: "", activeForm: "", owner: "", addBlockedBy: [] },
+  ], id: "", status: "pending", subject: "" });
+  expect(events.slice(2).map(event => [event.task.subject, event.task.status])).toEqual([
+    ["Inspect request timing", "completed"], ["Compare control request", "in_progress"],
+  ]);
+  await update.execute("single", { id: "2", status: "completed", subject: " \t" });
+  expect(events.at(-1).task.subject).toBe("Compare control request");
+  expect(text(await createTaskGetTool(TLID).execute("get", { id: "2" }))).toContain("Compare control request");
+});

--- a/src/tools/workflow/task-tools.ts
+++ b/src/tools/workflow/task-tools.ts
@@ -64,7 +64,7 @@ const TaskStatusLiteral = Type.Union([
 const TaskUpdateItem = Type.Object({
   id: Type.String({ description: "The task id returned by task_create" }),
   status: Type.Optional(TaskStatusLiteral),
-  subject: Type.Optional(Type.String()),
+  subject: Type.Optional(Type.String({ description: "Non-empty new title; omitted or blank keeps the current title" })),
   description: Type.Optional(Type.String()),
   activeForm: Type.Optional(Type.String()),
   owner: Type.Optional(Type.String()),
@@ -256,7 +256,7 @@ export function createTaskUpdateTool(taskListId: string, emit?: SessionEventEmit
       // Single-update form: the common case, and what rides along with a real tool call.
       id: Type.Optional(Type.String()),
       status: Type.Optional(TaskStatusLiteral),
-      subject: Type.Optional(Type.String()),
+      subject: Type.Optional(Type.String({ description: "Non-empty new title; omitted or blank keeps the current title" })),
       description: Type.Optional(Type.String()),
       activeForm: Type.Optional(Type.String()),
       owner: Type.Optional(Type.String()),


### PR DESCRIPTION
A status-only `task_update` with an empty or whitespace `subject` could erase the task name, leaving completed and active plan rows blank. Preserve the existing title for these updates while allowing explicit nonblank renames. Runtime recovery and Portal replay retain the last known title within the same task lifetime; untitled history falls back to `Task #ID`.

Validation: 60 Runtime tests and 17 Portal tests pass, along with both production builds. The compiled task tools and the production Portal were deployed in an isolated Kubernetes namespace. Single and batch updates preserved emitted names, and damaged historical events written through Runtime RPC displayed the correct names before and after browser reload. The temporary namespace and port forwards were removed after acceptance.

This does not rewrite persisted history. Recovering a previous title requires an earlier valid event in the loaded history. No live model evaluation was performed.
