### PR TITLE
runtime: reconnect a lost box event stream before failing the run

### DIFF
--- a/src/gateway/capability/capability-metrics.ts
+++ b/src/gateway/capability/capability-metrics.ts
@@ -37,3 +37,9 @@ export const capabilityRelayFailuresTotal = new Counter({
   help: "Capability box event relays that ended with an error",
   registers: [federationSelfRegistry],
 });
+
+export const capabilityRelayReconnectsTotal = new Counter({
+  name: "siclaw_gateway_capability_relay_reconnects_total",
+  help: "Capability box event stream reconnects (stream lost while the box was still alive)",
+  registers: [federationSelfRegistry],
+});

--- a/src/gateway/capability/session-driver.test.ts
+++ b/src/gateway/capability/session-driver.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { driveCapabilitySession } from "./session-driver.js";
-import { CAPABILITY_EVENT, CAPABILITY_PERSIST_ARTIFACTS } from "./contract.js";
+import { CapabilityRunManager } from "./run-manager.js";
+import { CAPABILITY_EVENT, CAPABILITY_PERSIST_ARTIFACTS, CAPABILITY_PERSIST_RUN_STATE } from "./contract.js";
 
 // Fake box client that yields a fixed sequence of box events over streamPath.
 function fakeClient(events: any[]) {
@@ -521,10 +522,70 @@ describe("driveCapabilitySession — bounded stream reconnect", () => {
         throw new Error("connection closed by peer");
       },
     } as any;
-    // endRun("done") is sticky in the real manager; mirror it for the check.
-    mgr.endRun.mockImplementation(async () => { mgr.get.mockReturnValue({ status: "done" }); });
+    // The real manager DROPS the record after persisting the terminal state.
+    mgr.endRun.mockImplementation(async () => { mgr.get.mockReturnValue(undefined); });
     await driveCapabilitySession({ client, runId: "r1", frontendClient: fakeFrontend(), manager: mgr, reconnect: alive });
     expect(mgr.endRun).toHaveBeenCalledTimes(1);
     expect(mgr.endRun).toHaveBeenCalledWith("r1", "done");
+  });
+});
+
+describe("driveCapabilitySession — reconnect against the real run manager", () => {
+  const noDelay = { baseDelayMs: 0, maxDelayMs: 0, isBoxAlive: async () => true };
+  const frontend = () => ({ emitEvent: vi.fn(), request: vi.fn().mockResolvedValue({ ok: true }) }) as any;
+
+  it.each(["done", "error"])("does not replay after %s was persisted and the live record dropped", async (eventType) => {
+    const fe = frontend();
+    const manager = new CapabilityRunManager(fe);
+    const id = `settled-${eventType}`;
+    await manager.startRun({ runId: id, profile: "kb-compile", orgId: "t" });
+    const paths: string[] = [];
+    const health = vi.fn().mockResolvedValue(true);
+    const client = {
+      async *streamPath(path: string) {
+        paths.push(path);
+        if (paths.length === 1) {
+          yield { type: eventType };
+          expect(manager.get(id)).toBeUndefined(); // endRun dropped the record
+          throw new Error("socket reset after terminal, before end");
+        }
+        yield { type: "end" };
+      },
+    } as any;
+    await driveCapabilitySession({ client, runId: id, frontendClient: fe, manager, reconnect: { ...noDelay, isBoxAlive: health } });
+    const persisted = fe.request.mock.calls.filter((c: any[]) => c[0] === CAPABILITY_PERSIST_RUN_STATE).map((c: any[]) => c[1].status);
+    expect(persisted).toEqual(["running", eventType === "done" ? "done" : "failed"]);
+    expect(paths).toEqual([`/events/${id}`]);
+    expect(health).not.toHaveBeenCalled();
+  });
+
+  it.each(["probe", "backoff"])("does not reopen after the run settles during the %s", async (stage) => {
+    const fe = frontend();
+    const manager = new CapabilityRunManager(fe);
+    const id = `settle-during-${stage}`;
+    await manager.startRun({ runId: id, profile: "kb-compile", orgId: "t" });
+    const paths: string[] = [];
+    let settling: Promise<void> | undefined;
+    const client = {
+      async *streamPath(path: string) {
+        paths.push(path);
+        if (paths.length === 1) throw new Error("temporary stream reset");
+        yield { type: "end" };
+      },
+    } as any;
+    await driveCapabilitySession({
+      client, runId: id, frontendClient: fe, manager,
+      reconnect: {
+        ...noDelay, baseDelayMs: 20, maxDelayMs: 20,
+        isBoxAlive: async () => {
+          if (stage === "probe") await manager.endRun(id, "done");
+          else setTimeout(() => { settling = manager.endRun(id, "done"); }, 0);
+          return true;
+        },
+      },
+    });
+    await settling;
+    expect(paths).toEqual([`/events/${id}`]);
+    expect(manager.get(id)).toBeUndefined();
   });
 });

--- a/src/gateway/capability/session-driver.test.ts
+++ b/src/gateway/capability/session-driver.test.ts
@@ -451,3 +451,80 @@ describe("driveCapabilitySession — box event → capability wire mapping", () 
     });
   });
 });
+
+describe("driveCapabilitySession — bounded stream reconnect", () => {
+  const alive = { baseDelayMs: 0, maxDelayMs: 0, isBoxAlive: async () => true };
+
+  it("re-opens the stream with replay when it breaks while the box is alive", async () => {
+    const paths: string[] = [];
+    let call = 0;
+    const client = {
+      async *streamPath(path: string) {
+        paths.push(path);
+        if (call++ === 0) {
+          yield { type: "log", text: "before the drop" };
+          throw new Error("socket hang up");
+        }
+        yield { type: "log", text: "after reconnect" };
+        yield { type: "end" };
+      },
+    } as any;
+    const fe = fakeFrontend();
+    const mgr = fakeManager();
+    mgr.get.mockReturnValue({ status: "running" });
+    await driveCapabilitySession({ client, runId: "r1", frontendClient: fe, manager: mgr, reconnect: alive });
+    expect(paths).toEqual(["/events/r1", "/events/r1?replay=1"]);
+    expect(emits(fe).filter((e: any) => e.type === "log").map((e: any) => e.payload.text)).toEqual(["before the drop", "after reconnect"]);
+    expect(mgr.endRun).toHaveBeenCalledWith("r1", "done");
+  });
+
+  it("gives up immediately when the box no longer answers", async () => {
+    const paths: string[] = [];
+    const client = {
+      async *streamPath(path: string) {
+        paths.push(path);
+        throw new Error("ECONNRESET");
+      },
+    } as any;
+    const mgr = fakeManager();
+    mgr.get.mockReturnValue({ status: "running" });
+    await expect(driveCapabilitySession({
+      client, runId: "r1", frontendClient: fakeFrontend(), manager: mgr,
+      reconnect: { ...alive, isBoxAlive: async () => false },
+    })).rejects.toThrow("ECONNRESET");
+    expect(paths).toEqual(["/events/r1"]);
+    expect(mgr.endRun).not.toHaveBeenCalled(); // the caller fails the run (relay_failed)
+  });
+
+  it("fails the relay once the attempt budget is spent", async () => {
+    const paths: string[] = [];
+    const client = {
+      async *streamPath(path: string) {
+        paths.push(path);
+        throw new Error("still broken");
+      },
+    } as any;
+    const mgr = fakeManager();
+    mgr.get.mockReturnValue({ status: "running" });
+    await expect(driveCapabilitySession({
+      client, runId: "r1", frontendClient: fakeFrontend(), manager: mgr,
+      reconnect: { ...alive, maxAttempts: 2 },
+    })).rejects.toThrow("still broken");
+    expect(paths).toEqual(["/events/r1", "/events/r1?replay=1", "/events/r1?replay=1"]);
+  });
+
+  it("ignores a stream error after the run already settled", async () => {
+    const mgr = fakeManager();
+    const client = {
+      async *streamPath(_path: string) {
+        yield { type: "done" };
+        throw new Error("connection closed by peer");
+      },
+    } as any;
+    // endRun("done") is sticky in the real manager; mirror it for the check.
+    mgr.endRun.mockImplementation(async () => { mgr.get.mockReturnValue({ status: "done" }); });
+    await driveCapabilitySession({ client, runId: "r1", frontendClient: fakeFrontend(), manager: mgr, reconnect: alive });
+    expect(mgr.endRun).toHaveBeenCalledTimes(1);
+    expect(mgr.endRun).toHaveBeenCalledWith("r1", "done");
+  });
+});

--- a/src/gateway/capability/session-driver.ts
+++ b/src/gateway/capability/session-driver.ts
@@ -29,6 +29,7 @@ import {
   isTerminalCapabilityStatus,
 } from "./contract.js";
 import { structuredBoxFailure } from "./failure.js";
+import { capabilityRelayReconnectsTotal } from "./capability-metrics.js";
 
 interface BoxEvent {
   type: string;
@@ -67,7 +68,37 @@ export interface DriveCapabilitySessionOptions {
   manager: CapabilityRunManager;
   /** Re-attaching to a live box after relay/runtime loss: request full replay. */
   replayWorkspace?: boolean;
+  /** Bounded reconnect of the box event stream (see driveCapabilitySession). */
+  reconnect?: Partial<StreamReconnectPolicy>;
 }
+
+export interface StreamReconnectPolicy {
+  /** Reconnect attempts per run before the relay gives up and fails the run. */
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  /** Probe the box before reconnecting; a dead box is not worth waiting for. */
+  isBoxAlive: (client: AgentBoxClient) => Promise<boolean>;
+}
+
+// Six attempts with 2s→60s backoff is about three minutes of transport trouble
+// tolerated; the run-manager's data-stale watchdog still bounds a box that is
+// alive but silent. A box that answers /health is worth reconnecting to — the
+// alternative (relay_failed → stop the box) throws away the whole in-flight
+// batch for a broken TCP connection.
+export const defaultStreamReconnectPolicy: StreamReconnectPolicy = {
+  maxAttempts: 6,
+  baseDelayMs: 2_000,
+  maxDelayMs: 60_000,
+  isBoxAlive: async (client) => {
+    try {
+      await client.getJson("/health");
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
 
 /**
  * Relay the box event stream over the capability protocol until the box closes
@@ -81,14 +112,49 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
     frontendClient.emitEvent(CAPABILITY_EVENT, frame);
   };
 
-  // onComment: the box emits `: heartbeat` SSE comments between data events. A
-  // long read-only compile phase can be data-silent for >10min — the heartbeat
-  // must count as liveness (touchHeartbeat, the separate clock) or the watchdog
-  // reaps a healthy run and kills its box. It is deliberately NOT touch(): a box
-  // that ONLY heartbeats (a wedged turn) must still be reaped at dataStaleMs.
-  const eventPath = `/events/${runId}${opts.replayWorkspace ? "?replay=1" : ""}`;
-  for await (const raw of client.streamPath(eventPath, { onComment: () => manager.touchHeartbeat(runId) })) {
-    const evt = raw as BoxEvent;
+  const policy: StreamReconnectPolicy = { ...defaultStreamReconnectPolicy, ...opts.reconnect };
+  let replay = opts.replayWorkspace === true;
+  let attempts = 0;
+  for (;;) {
+    // onComment: the box emits `: heartbeat` SSE comments between data events. A
+    // long read-only compile phase can be data-silent for >10min — the heartbeat
+    // must count as liveness (touchHeartbeat, the separate clock) or the watchdog
+    // reaps a healthy run and kills its box. It is deliberately NOT touch(): a box
+    // that ONLY heartbeats (a wedged turn) must still be reaped at dataStaleMs.
+    const eventPath = `/events/${runId}${replay ? "?replay=1" : ""}`;
+    try {
+      for await (const raw of client.streamPath(eventPath, { onComment: () => manager.touchHeartbeat(runId) })) {
+        await relayBoxEvent(raw as BoxEvent);
+      }
+      return; // clean close: the box ended the stream
+    } catch (err) {
+      // A stream error after the run already settled (done/error consumed, or the
+      // record dropped at a terminal) has nothing left to relay — do not turn it
+      // into a relay_failed that stops a box which is already finished.
+      const rec = manager.get(runId);
+      if (rec && isTerminalCapabilityStatus(rec.status)) {
+        console.warn(`[capability] run=${runId} box stream error after terminal status; ignoring`);
+        return;
+      }
+      attempts++;
+      if (attempts > policy.maxAttempts || !(await policy.isBoxAlive(client))) {
+        throw err;
+      }
+      const delay = Math.min(policy.baseDelayMs * 2 ** (attempts - 1), policy.maxDelayMs);
+      capabilityRelayReconnectsTotal.inc();
+      console.warn(
+        `[capability] run=${runId} box stream lost (${attempts}/${policy.maxAttempts}), box alive; ` +
+          `reconnecting with replay in ${delay}ms: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      // Re-attach semantics: ask for the workspace replay so a sync batch that
+      // was in flight when the connection broke is delivered again (the
+      // consumer accepts duplicate ACKs; persistArtifacts is idempotent).
+      replay = true;
+    }
+  }
+
+  async function relayBoxEvent(evt: BoxEvent): Promise<void> {
     // ANY box event means the box is alive → bump activity so the watchdog never
     // reaps an actively-working run (e.g. a long compile emitting only `log`).
     // touch() is in-memory only (no persist), so it is cheap to call every event.

--- a/src/gateway/capability/session-driver.ts
+++ b/src/gateway/capability/session-driver.ts
@@ -115,6 +115,10 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
   const policy: StreamReconnectPolicy = { ...defaultStreamReconnectPolicy, ...opts.reconnect };
   let replay = opts.replayWorkspace === true;
   let attempts = 0;
+  // Only TRANSPORT errors (the stream itself) are retried. An error thrown while
+  // relaying an event — e.g. the artifact persist loop giving up because the run
+  // was cancelled or reaped — is a relay decision and must fail the run as before.
+  let relayError: unknown;
   for (;;) {
     // onComment: the box emits `: heartbeat` SSE comments between data events. A
     // long read-only compile phase can be data-silent for >10min — the heartbeat
@@ -124,22 +128,30 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
     const eventPath = `/events/${runId}${replay ? "?replay=1" : ""}`;
     try {
       for await (const raw of client.streamPath(eventPath, { onComment: () => manager.touchHeartbeat(runId) })) {
-        await relayBoxEvent(raw as BoxEvent);
+        try {
+          await relayBoxEvent(raw as BoxEvent);
+        } catch (err) {
+          relayError = err;
+          throw err;
+        }
       }
       return; // clean close: the box ended the stream
     } catch (err) {
-      // A stream error after the run already settled (done/error consumed, or the
-      // record dropped at a terminal) has nothing left to relay — do not turn it
-      // into a relay_failed that stops a box which is already finished.
-      const rec = manager.get(runId);
-      if (rec && isTerminalCapabilityStatus(rec.status)) {
-        console.warn(`[capability] run=${runId} box stream error after terminal status; ignoring`);
+      if (relayError !== undefined) throw err;
+      // A stream error after the run already settled has nothing left to relay
+      // — do not turn it into a relay_failed that stops a box which is already
+      // finished. endRun() DROPS the live record once the terminal state is
+      // persisted, so "no record" is the normal settled case, not an unknown.
+      if (runSettled()) {
+        console.warn(`[capability] run=${runId} box stream error after the run settled; ignoring`);
         return;
       }
       attempts++;
       if (attempts > policy.maxAttempts || !(await policy.isBoxAlive(client))) {
         throw err;
       }
+      // The probe awaited; the run may have been cancelled or finished meanwhile.
+      if (runSettled()) return;
       const delay = Math.min(policy.baseDelayMs * 2 ** (attempts - 1), policy.maxDelayMs);
       capabilityRelayReconnectsTotal.inc();
       console.warn(
@@ -147,11 +159,19 @@ export async function driveCapabilitySession(opts: DriveCapabilitySessionOptions
           `reconnecting with replay in ${delay}ms: ${err instanceof Error ? err.message : String(err)}`,
       );
       await new Promise((resolve) => setTimeout(resolve, delay));
+      // Same check after the backoff: never reopen a stream for a settled run.
+      if (runSettled()) return;
       // Re-attach semantics: ask for the workspace replay so a sync batch that
       // was in flight when the connection broke is delivered again (the
       // consumer accepts duplicate ACKs; persistArtifacts is idempotent).
       replay = true;
     }
+  }
+
+  /** True once the run is terminal or its live record is gone (endRun drops it). */
+  function runSettled(): boolean {
+    const rec = manager.get(runId);
+    return !rec || isTerminalCapabilityStatus(rec.status);
   }
 
   async function relayBoxEvent(evt: BoxEvent): Promise<void> {


### PR DESCRIPTION
## Why

The Runtime↔box relay is a single SSE connection with no reconnect. A transport error (SSE drop, apiserver-side proxy hiccup) ended the run as `relay_failed`, and the relay's `finally` stopped the box — throwing away the in-flight batch of a healthy box. The 2026-09-10 harness review ranked this the second stability risk after plan-less recovery.

## What

- `driveCapabilitySession` wraps the stream in a bounded reconnect loop: on a stream error, if the run is not already terminal and the box still answers `/health`, wait (2s→60s backoff, 6 attempts) and re-open `/events/:runId?replay=1` so an in-flight sync batch is delivered again (persistArtifacts is idempotent; duplicate ACKs are accepted). A dead box or a spent budget rethrows, so the caller's `relay_failed` path is unchanged. A stream error after the run already settled is ignored (no spurious relay_failed on a finished run).
- Policy is injectable (`reconnect` option) for tests; production uses the defaults.
- New counter `siclaw_gateway_capability_relay_reconnects_total`.

## Tests

`session-driver.test.ts`: reconnect with replay relays events from both connections; dead box gives up immediately; attempt budget exhausted rethrows; error after terminal is ignored. Capability suite: 100 passed.

Companion: sicore MR !1180 (recovery modes / breaker classes / sweeps) and siclaw #586 (plan-less `compile.resume`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)