### PR TITLE
Retain bounded lifecycle evidence for capability containers

### DIFF
--- a/docs/design/capability-container-evidence.md
+++ b/docs/design/capability-container-evidence.md
@@ -1,0 +1,26 @@
+# Capability container evidence
+
+Kubernetes KB runs emit bounded status-only observations through the optional
+`capability.observeContainer` frontend RPC. Deploy a compatible receiver before
+the emitter to retain snapshots after Pod deletion. Older receivers still get
+the safe `[capability-container]` Runtime log records when persistence fails.
+
+The observation identifies the run/profile and Pod UID, namespace, node, image
+identity and every regular, init and ephemeral container's current/previous exit
+status. It excludes environment, arguments, annotations, messages and log content.
+The receiver must authorize against the authenticated Runtime and stored run;
+Pod labels alone are not authority. Evidence storage must not update execution
+state or heartbeat time.
+
+A namespace informer records additions, updates and deletions. Before explicit
+cleanup, the last cached snapshot is also recorded without delaying deletion.
+One RPC is in flight at a time, with a 3 second transport deadline. Pending and
+reconnect backlogs each retain at most 256 observations; acknowledged dedupe
+retains at most 1024 keys. Connection recovery replays failed snapshots after
+run reconciliation. Shutdown waits only for the active request and reports any
+dropped backlog; it does not drain minutes of queued diagnostics.
+
+These are observations, not a Kubernetes audit journal. A Runtime crash before
+acknowledgement can lose its in-memory backlog; retained Runtime logs remain the
+second evidence source. A watch that never observed a short-lived Pod cannot
+reconstruct its container status afterward.

--- a/src/gateway/agentbox/k8s-spawner.ts
+++ b/src/gateway/agentbox/k8s-spawner.ts
@@ -11,6 +11,7 @@ import type { BoxSpawner } from "./spawner.js";
 import type { AgentBoxConfig, AgentBoxHandle, AgentBoxInfo, AgentBoxStatus } from "./types.js";
 import { getBoxProfile } from "./box-profile.js";
 import { CertificateManager } from "../security/cert-manager.js";
+import { observeContainerLifecycle, type ContainerObservation } from "../capability/container-evidence.js";
 import {
   certExpiryLabel,
   certificateNeedsRenewal,
@@ -203,6 +204,19 @@ export class K8sSpawner implements BoxSpawner {
   private coreApi: k8s.CoreV1Api;
   private config: Required<Omit<K8sSpawnerConfig, "persistence" | "nodeSelector">> & Pick<K8sSpawnerConfig, "persistence" | "nodeSelector">;
   private certManager: CertificateManager | null = null;
+  private containerObserver?: ReturnType<typeof observeContainerLifecycle>;
+
+  observeContainers(send: (observation: ContainerObservation) => Promise<unknown>): { retry(): void; stop(): Promise<void> } {
+    if (this.containerObserver) throw new Error("container observation already started");
+    this.containerObserver = observeContainerLifecycle(this.kc, this.coreApi, this.config.namespace, this.config.labelPrefix, send);
+    return {
+      retry: () => this.containerObserver?.retry(),
+      stop: async () => {
+        await this.containerObserver?.stop();
+        this.containerObserver = undefined;
+      },
+    };
+  }
 
   constructor(config?: K8sSpawnerConfig) {
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -1083,6 +1097,8 @@ export class K8sSpawner implements BoxSpawner {
     const { namespace, labelPrefix } = this.config;
 
     console.log(`[k8s-spawner] Stopping pod: ${boxId}`);
+
+    this.containerObserver?.beforeStop(boxId);
 
     try {
       await this.coreApi.deleteNamespacedPod({ name: boxId, namespace });

--- a/src/gateway/agentbox/spawner.ts
+++ b/src/gateway/agentbox/spawner.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AgentBoxConfig, AgentBoxHandle, AgentBoxInfo } from "./types.js";
+import type { ContainerObservation } from "../capability/container-evidence.js";
 
 export interface BoxSpawner {
   /** Spawner name */
@@ -37,6 +38,9 @@ export interface BoxSpawner {
    * Clean up resources
    */
   cleanup(): Promise<void>;
+
+  /** K8s-only, read-only lifecycle evidence. Stop the observer before transport shutdown. */
+  observeContainers?(send: (observation: ContainerObservation) => Promise<unknown>): { retry(): void; stop(): Promise<void> };
 
   /**
    * Fingerprint of the CA the spawner currently issues mTLS certs from, if the

--- a/src/gateway/capability/container-evidence.test.ts
+++ b/src/gateway/capability/container-evidence.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as k8s from "@kubernetes/client-node";
+import { containerObservation, ContainerEvidenceQueue, observeContainerLifecycle } from "./container-evidence.js";
+
+const watch = vi.hoisted(() => ({ handlers: new Map<string, (pod: unknown) => void>(), start: vi.fn(async () => {}), stop: vi.fn(async () => {}), get: vi.fn() }));
+vi.mock("@kubernetes/client-node", () => ({ makeInformer: () => ({ ...watch, on: (event: string, cb: (pod: unknown) => void) => watch.handlers.set(event, cb) }) }));
+
+function pod(): k8s.V1Pod {
+  return {
+    metadata: { name: "compile-1", namespace: "work", uid: "pod-1", labels: { "test/agent": "run-1", "test/boxType": "kb-compile" }, annotations: { secret: "private" } },
+    spec: { nodeName: "node-1", containers: [{ name: "compiler", image: "box:rev1", env: [{ name: "SECRET", value: "private" }] }], initContainers: [{ name: "init", image: "init:rev1" }], ephemeralContainers: [{ name: "debug", image: "debug:rev1" }] },
+    status: { phase: "Failed", message: "private", containerStatuses: [{ name: "compiler", image: "box:rev1", imageID: "containerd://sha256:abc", ready: false, restartCount: 2,
+      state: { terminated: { exitCode: 137, reason: "OOMKilled", message: "private", finishedAt: new Date("2026-09-11T01:00:00Z") } },
+      lastState: { terminated: { exitCode: 1, reason: "Error" } } }], initContainerStatuses: [{ name: "init", ready: true, restartCount: 0, image: "init:rev1", imageID: "sha256:def", state: { terminated: { exitCode: 0, reason: "Completed" } } }] },
+  };
+}
+const flush = async () => { for (let i = 0; i < 6; i++) await Promise.resolve(); };
+afterEach(() => { vi.restoreAllMocks(); vi.useRealTimers(); watch.handlers.clear(); watch.start.mockReset().mockResolvedValue(); watch.get.mockReset(); });
+
+describe("container evidence", () => {
+  it("keeps all container roles, previous exits and immutable image/Pod identities without content", () => {
+    const snapshot = containerObservation(pod(), "deleted", "test")!;
+    expect(snapshot).toMatchObject({ run_id: "run-1", pod_uid: "pod-1", source: "deleted", node_name: "node-1" });
+    expect(snapshot.containers.map((c) => c.role)).toEqual(["container", "init", "ephemeral"]);
+    expect(snapshot.containers[0]).toMatchObject({ restart_count: 2, image_id: "containerd://sha256:abc", termination: { exit_code: 137, reason: "OOMKilled" }, last_termination: { exit_code: 1 } });
+    expect(JSON.stringify(snapshot)).not.toMatch(/private|SECRET|message|annotations/);
+    const replaced = pod(); replaced.metadata!.uid = "pod-2";
+    expect(containerObservation(replaced, "observed", "test")!.pod_uid).toBe("pod-2");
+    replaced.metadata!.labels!["test/boxType"] = "agent";
+    expect(containerObservation(replaced, "observed", "test")).toBeUndefined();
+  });
+
+  it("deduplicates only acknowledged persistence and allows retry on a later observation", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const send = vi.fn().mockRejectedValueOnce(new Error("disconnected")).mockResolvedValueOnce({ observed: false }).mockResolvedValue({ observed: true });
+    const queue = new ContainerEvidenceQueue(send);
+    const snapshot = containerObservation(pod(), "deleted", "test")!;
+    for (let i = 0; i < 4; i++) { queue.record(snapshot); await flush(); }
+    expect(send).toHaveBeenCalledTimes(3);
+    await queue.close();
+  });
+
+  it("replays an outage snapshot after reconnect even when its Pod was deleted", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const send = vi.fn().mockRejectedValueOnce(new Error("disconnected")).mockResolvedValue({ observed: true });
+    const queue = new ContainerEvidenceQueue(send);
+    const snapshot = containerObservation(pod(), "deleted", "test")!;
+    queue.record(snapshot); await flush();
+    queue.retry(); await flush();
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenLastCalledWith(snapshot);
+    queue.retry(); await flush();
+    expect(send).toHaveBeenCalledTimes(2);
+    await queue.close();
+  });
+
+  it("pumps reconnect evidence queued between drain completion and its finalizer", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    let acknowledge!: (value: unknown) => void;
+    const send = vi.fn().mockRejectedValueOnce(new Error("offline"))
+      .mockImplementationOnce(() => new Promise((resolve) => { acknowledge = resolve; }))
+      .mockResolvedValue({ observed: true });
+    const queue = new ContainerEvidenceQueue(send);
+    const old = containerObservation(pod(), "deleted", "test")!;
+    queue.record(old); await flush();
+    queue.record({ ...old, pod_uid: "new-pod" });
+    acknowledge({ observed: true });
+    queueMicrotask(() => queue.retry());
+    await flush(); await flush();
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenLastCalledWith(old);
+    await queue.close();
+  });
+
+  it("logs a bounded backlog and shutdown waits only for the active request", async () => {
+    const logs = vi.spyOn(console, "info").mockImplementation(() => {});
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    let complete!: (result: unknown) => void;
+    const send = vi.fn(() => new Promise((resolve) => { complete = resolve; }));
+    const queue = new ContainerEvidenceQueue(send);
+    for (let i = 0; i < 300; i++) queue.record({ ...containerObservation(pod(), "observed", "test")!, pod_uid: `pod-${i}` });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveBeenCalledWith("[capability-container] queue full", expect.any(String));
+    expect(logs).toHaveBeenCalledTimes(300);
+    const closed = queue.close(); complete({ observed: true }); await closed;
+    expect(send).toHaveBeenCalledTimes(1);
+    queue.record(containerObservation(pod(), "deleted", "test")!);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("observes deletion and captures stopping without waiting for persistence", async () => {
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const send = vi.fn(async () => ({ observed: true }));
+    const observer = observeContainerLifecycle({} as k8s.KubeConfig, {} as k8s.CoreV1Api, "work", "test", send);
+    watch.get.mockReturnValue(pod());
+    expect(observer.beforeStop("compile-1")).toBeUndefined();
+    await flush();
+    watch.handlers.get("delete")!(pod()); await flush();
+    expect(send.mock.calls.map(([s]) => (s as unknown as { source: string }).source)).toEqual(["stopping", "deleted"]);
+    await observer.stop();
+  });
+
+  it("handles rejected watch starts and cancels reconnect on shutdown", async () => {
+    vi.useFakeTimers(); vi.spyOn(console, "error").mockImplementation(() => {});
+    watch.start.mockRejectedValueOnce(new Error("watch unavailable"));
+    const observer = observeContainerLifecycle({} as k8s.KubeConfig, {} as k8s.CoreV1Api, "work", "test", vi.fn());
+    await flush();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(watch.start).toHaveBeenCalledTimes(2);
+    watch.handlers.get("error")!(new Error("expired"));
+    await observer.stop(); await vi.advanceTimersByTimeAsync(5000);
+    expect(watch.start).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/capability/container-evidence.ts
+++ b/src/gateway/capability/container-evidence.ts
@@ -1,0 +1,201 @@
+import * as k8s from "@kubernetes/client-node";
+import { createHash } from "node:crypto";
+
+export const CAPABILITY_OBSERVE_CONTAINER = "capability.observeContainer";
+
+export interface ContainerTermination {
+  reason: string;
+  exit_code: number;
+  signal: number;
+  started_at?: string;
+  finished_at?: string;
+}
+
+export interface ContainerObservation {
+  run_id: string;
+  profile: string;
+  source: "observed" | "deleted" | "stopping";
+  namespace: string;
+  pod_name: string;
+  pod_uid: string;
+  node_name?: string;
+  phase: string;
+  reason?: string;
+  deletion_timestamp?: string;
+  containers: Array<{
+    name: string;
+    role: "container" | "init" | "ephemeral";
+    image: string;
+    image_id?: string;
+    restart_count: number;
+    state: "waiting" | "running" | "terminated" | "unknown";
+    waiting_reason?: string;
+    termination?: ContainerTermination;
+    last_termination?: ContainerTermination;
+  }>;
+}
+
+function timestamp(value: Date | undefined): string | undefined {
+  return value ? new Date(value).toISOString() : undefined;
+}
+
+function termination(value: k8s.V1ContainerStateTerminated | undefined): ContainerTermination | undefined {
+  return value ? {
+    reason: value.reason ?? "", exit_code: value.exitCode, signal: value.signal ?? 0,
+    started_at: timestamp(value.startedAt), finished_at: timestamp(value.finishedAt),
+  } : undefined;
+}
+
+/** Project status only. Never retain PodSpec env/args, annotations or messages. */
+export function containerObservation(pod: k8s.V1Pod, source: ContainerObservation["source"], prefix: string): ContainerObservation | undefined {
+  const profile = pod.metadata?.labels?.[`${prefix}/boxType`];
+  const runId = pod.metadata?.labels?.[`${prefix}/agent`];
+  if (!profile?.startsWith("kb-") || !runId || !pod.metadata?.uid || !pod.metadata.name || !pod.metadata.namespace) return;
+  const groups = [
+    { role: "container" as const, specs: pod.spec?.containers, statuses: pod.status?.containerStatuses },
+    { role: "init" as const, specs: pod.spec?.initContainers, statuses: pod.status?.initContainerStatuses },
+    { role: "ephemeral" as const, specs: pod.spec?.ephemeralContainers, statuses: pod.status?.ephemeralContainerStatuses },
+  ];
+  return {
+    run_id: runId, profile, source, namespace: pod.metadata.namespace,
+    pod_name: pod.metadata.name, pod_uid: pod.metadata.uid, node_name: pod.spec?.nodeName,
+    phase: pod.status?.phase ?? "Unknown", reason: pod.status?.reason,
+    deletion_timestamp: timestamp(pod.metadata.deletionTimestamp),
+    containers: groups.flatMap(({ role, specs, statuses }) => (specs ?? []).map((spec) => {
+      const status = statuses?.find((s) => s.name === spec.name);
+      return {
+        name: spec.name, role, image: spec.image ?? "", image_id: status?.imageID,
+        restart_count: status?.restartCount ?? 0,
+        state: status?.state?.terminated ? "terminated" as const : status?.state?.waiting ? "waiting" as const : status?.state?.running ? "running" as const : "unknown" as const,
+        waiting_reason: status?.state?.waiting?.reason,
+        termination: termination(status?.state?.terminated), last_termination: termination(status?.lastState?.terminated),
+      };
+    })),
+  };
+}
+
+/** A bounded queue keeps a watch burst from creating unbounded pending RPCs. */
+export class ContainerEvidenceQueue {
+  private pending = new Map<string, ContainerObservation>();
+  private failed = new Map<string, ContainerObservation>();
+  private acknowledged = new Map<string, true>();
+  private draining?: Promise<void>;
+  private closed = false;
+  private inFlight?: string;
+
+  constructor(private readonly send: (observation: ContainerObservation) => Promise<unknown>) {}
+
+  record(observation: ContainerObservation): void {
+    if (this.closed) return;
+    const key = createHash("sha256").update(JSON.stringify(observation)).digest("hex");
+    if (this.acknowledged.has(key) || this.pending.has(key) || this.inFlight === key) return;
+    console.info("[capability-container]", JSON.stringify(observation));
+    if (!this.pending.has(key) && this.pending.size >= 256) {
+      // This is evidence loss, not a successful observation. Keep a log that
+      // central logging can retain even while the consumer store is overloaded.
+      console.error("[capability-container] queue full", JSON.stringify(observation));
+      return;
+    }
+    this.failed.delete(key);
+    this.pending.set(key, observation);
+    this.pump();
+  }
+
+  private pump() {
+    if (this.closed || this.draining || this.pending.size === 0) return;
+    this.draining = this.drain().finally(() => {
+      this.draining = undefined;
+      // A reconnect may enqueue between drain completion and this microtask.
+      this.pump();
+    });
+  }
+
+  private async drain() {
+    while (this.pending.size > 0) {
+      const [key, observation] = this.pending.entries().next().value!;
+      this.pending.delete(key);
+      this.inFlight = key;
+      try {
+        const result = await this.send(observation);
+        // Another Runtime may own this run, or its initial write may still be
+        // in flight. Only an explicit stored acknowledgement enables dedupe.
+        if ((result as { observed?: boolean } | null)?.observed === true) this.acknowledged.set(key, true);
+        else this.retainForReconnect(key, observation);
+        if (this.acknowledged.size > 1024) this.acknowledged.delete(this.acknowledged.keys().next().value!);
+      } catch (error) {
+        // Diagnostic transport is a top-level boundary, independent of running
+        // work. Failed observations are not deduplicated on a later relist.
+        this.retainForReconnect(key, observation);
+        console.error("[capability-container] persistence failed", observation.run_id, error);
+      } finally {
+        this.inFlight = undefined;
+      }
+    }
+  }
+
+  private retainForReconnect(key: string, observation: ContainerObservation) {
+    if (this.closed) return;
+    if (this.failed.size >= 256) {
+      console.error("[capability-container] reconnect backlog full", observation.run_id);
+      this.failed.delete(this.failed.keys().next().value!);
+    }
+    this.failed.set(key, observation);
+  }
+
+  retry() {
+    const snapshots = [...this.failed.values()];
+    this.failed.clear();
+    for (const snapshot of snapshots) this.record(snapshot);
+  }
+
+  async close() {
+    this.closed = true;
+    // Each queued snapshot was already logged. Shutdown waits only for the
+    // active RPC (the transport imposes a 3s deadline), never the whole backlog.
+    if (this.pending.size) console.error("[capability-container] shutdown dropped pending persistence", this.pending.size);
+    this.pending.clear();
+    this.failed.clear();
+    await this.draining;
+  }
+}
+
+export function observeContainerLifecycle(kc: k8s.KubeConfig, api: k8s.CoreV1Api, namespace: string, prefix: string,
+  send: (observation: ContainerObservation) => Promise<unknown>) {
+  const selector = `${prefix}/app=agentbox,${prefix}/boxType in (kb-compile,kb-compile-codex,kb-compile-pi,kb-test)`;
+  const informer = k8s.makeInformer<k8s.V1Pod>(kc, `/api/v1/namespaces/${encodeURIComponent(namespace)}/pods`,
+    () => api.listNamespacedPod({ namespace, labelSelector: selector }), selector);
+  const queue = new ContainerEvidenceQueue(send);
+  let closed = false;
+  let reconnect: ReturnType<typeof setTimeout> | undefined;
+  const record = (pod: k8s.V1Pod, source: ContainerObservation["source"]) => {
+    const observation = containerObservation(pod, source, prefix);
+    if (observation) queue.record(observation);
+  };
+  informer.on("add", (pod) => { void record(pod, "observed"); });
+  informer.on("update", (pod) => { void record(pod, "observed"); });
+  informer.on("delete", (pod) => { void record(pod, "deleted"); });
+  const onError = (error: unknown) => {
+    console.error("[capability-container] Kubernetes watch interrupted", error);
+    if (!closed && !reconnect) {
+      // Kubernetes watches disconnect/expire; the informer resumes its
+      // resource version and relists after expiration.
+      reconnect = setTimeout(() => { reconnect = undefined; if (!closed) void informer.start().catch(onError); }, 5_000);
+      reconnect.unref();
+    }
+  };
+  informer.on("error", onError);
+  void informer.start().catch(onError);
+  return {
+    retry: () => queue.retry(),
+    beforeStop: (podName: string) => {
+      const pod = informer.get(podName, namespace);
+      if (pod) record(pod, "stopping");
+    },
+    stop: async () => {
+      closed = true;
+      clearTimeout(reconnect);
+      await informer.stop();
+      await queue.close();
+    },
+  };
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -31,6 +31,7 @@ import { getBoxProfile } from "./agentbox/box-profile.js";
 import { buildSpawnEnv } from "./agentbox/spawn-env.js";
 import { CapabilityRunManager } from "./capability/run-manager.js";
 import { acquireCapabilityBox } from "./capability/box-acquire.js";
+import { CAPABILITY_OBSERVE_CONTAINER } from "./capability/container-evidence.js";
 import { driveCapabilitySession } from "./capability/session-driver.js";
 import { asFailureToken } from "./capability/failure.js";
 import { driveTestSession, shouldRelayTestSession } from "./capability/test-relay.js";
@@ -1520,7 +1521,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
   };
 
   // Recover AFTER ensureCapabilitySession exists — onAdopt re-attaches through it.
-  const unsubscribeCapabilityReconnect = frontendClient.onConnected?.(() => capabilityRunManager.reconcile());
+  let retryContainerEvidence: (() => void) | undefined;
+  const unsubscribeCapabilityReconnect = frontendClient.onConnected?.(async () => {
+    await capabilityRunManager.reconcile();
+    retryContainerEvidence?.();
+  });
   void capabilityRunManager.recover();
   capabilityRunManager.startWatchdog();
   // Capability-box orphan GC: a box is live iff its run is tracked and
@@ -2950,6 +2955,10 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     console.error("[runtime] Failed to start HTTPS server:", err);
   }
 
+  const containerObservation = spawner?.observeContainers?.((observation) =>
+    frontendClient.request(CAPABILITY_OBSERVE_CONTAINER, observation, 3_000));
+  retryContainerEvidence = () => containerObservation?.retry();
+
   // ── Server handle ────────────────────────────────────────
   const runtimeServer: RuntimeServer = {
     httpServer,
@@ -2959,6 +2968,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     agentBoxTlsOptions,
     credentialService,
     async close() {
+      await containerObservation?.stop();
       metricsAggregator?.destroy();
       unsubscribeCapabilityReconnect?.();
       // Before frontendClient.close(): the acknowledged terminal for a delegated turn


### PR DESCRIPTION
When a knowledge execution Pod disappears, its exit reason and image identity are lost with it. The Runtime now observes safe lifecycle snapshots and reports them to the frontend receiver, while keeping Pod cleanup independent of telemetry delivery.

Snapshots include Pod/container identity, image IDs, restart counts and current/previous exit status. The queue, reconnect backlog and deduplication are bounded; failed deliveries replay after reconnect and safe snapshots are also logged. No environment, command, annotation, termination message or log contents are exported. A crash before acknowledgement still requires retained logs.

Validation: TypeScript checks and the full Runtime suite pass (7,112 tests, two skips); the integration fixture also passes 110 focused container, spawner and evidence-lookup tests. Regressions cover delivery failure, reconnect replay and a drain-finalizer race. Kubernetes validation retained Pod identity, init-container exit 0 and main-container exit 137 through automatic orphan cleanup and a same-name replacement; exit 137 was deliberate, not a simulated OOM claim. The bounded history exposed truncation and did not change the stored terminal lifecycle or heartbeat.

Deployment requires the additive receiver support before enabling this emitter. The diagnostic receiver was tested separately against its actual database representation.
