### PR TITLE
Apply versioned shared Agent model selections at dispatch

### DIFF
--- a/docs/design/agent-model-selections.md
+++ b/docs/design/agent-model-selections.md
@@ -1,0 +1,48 @@
+# Shared Agent model selection
+
+The control plane owns a shared Agent's model selection. A selection version is
+a non-negative safe integer, independent of the release and model fingerprint.
+It distinguishes repeated selections such as A → B → A within one release.
+
+## Dispatch contract
+
+A `chat.send` carrying `modelSelectionVersion` resolves its binding after taking
+the turn lock, on every turn. The current binding owns the model, routing policy,
+sub-agent candidates and Agent Addendum. A caller's earlier routing or Addendum
+must not override that binding. Control planes that omit `binding.systemPrompt`
+continue to supply the current Addendum through `config.getAgent`.
+
+If the current binding cannot be resolved, the turn reports an error before
+prompt dispatch. Reusing the caller's older binding could silently undo an
+acknowledged selection. An uncontended lock does not prove that the caller's
+binding is current: a save may commit after the caller resolved it but before
+Runtime dispatches it. Reload notifications are therefore an optimization, not
+the source of next-turn correctness.
+
+Callers without selection metadata retain their existing prompt and routing
+behavior. Already dispatched turns retain their captured configuration.
+
+## Rollout and observations
+
+1. Upgrade Runtime and AgentBox to support versioned selection metadata.
+2. Upgrade the complete control-plane deployment so `config.getModelBinding`
+   returns the version, including zero, before selection writes or versioned
+   reload notifications are enabled. Do not serve selection-aware traffic from
+   mixed old and new control-plane replicas.
+3. Enable the selection interface after those prerequisites are satisfied.
+
+Bindings without a version represent legacy version zero. They cannot
+acknowledge a reload expecting a nonzero version. Invalid version types produce
+an input error; mismatched valid identities produce a stale-binding error.
+
+An older AgentBox cannot prove it ran a nonzero selection. During a mixed box
+rollout, an unversioned observation and a nonzero observation remain
+inconsistent, even if their release and model fingerprint match. Do not turn
+missing evidence into a successful consistency receipt. Recycle old boxes
+through normal operations after their active work finishes, and obtain a real
+turn observation from the upgraded boxes. A reload acknowledgement alone is
+not that observation.
+
+Once a box has observed a nonzero selection, a later versionless prompt cannot
+replace that evidence. This protects against delayed legacy traffic; new
+selection-aware entrypoints must forward the version.

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -446,6 +446,7 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
       modelId: "gpt-4",
       releaseId: "release-2",
       modelFingerprint: "fingerprint-2",
+      modelSelectionVersion: 3,
       systemPromptTemplate: "You are the personal preview.",
     });
     expect(prompt.status).toBe(200);
@@ -457,6 +458,7 @@ describe("http-server — /health + /api/sessions + /api/models", () => {
       modelFingerprint: "fingerprint-2",
     });
     expect(new Date(after.data.model.observedAt).toString()).not.toBe("Invalid Date");
+    expect(after.data.model.modelSelectionVersion).toBe(3);
     expect(after.data.harness).toMatchObject({
       agentType: "sre",
       systemPromptTemplate: "You are the personal preview.",

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -1498,6 +1498,8 @@ export function createHttpServer(
         const ranIntendedModel = intendedCandidate !== undefined
           && result?.activeCandidateKey === intendedCandidate;
         if (ranIntendedModel && body.releaseId && body.modelFingerprint
+          // Versionless callers are legacy version zero. They cannot certify a
+          // newer selection, even if they happen to use the same model again.
           && (body.modelSelectionVersion ?? 0) >= (observedModel?.modelSelectionVersion ?? 0)) {
           observedModel = {
             releaseId: body.releaseId,

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -112,6 +112,8 @@ interface PromptRequestBody {
   modelId?: string;
   releaseId?: string;
   modelFingerprint?: string;
+  /** Monotonic Agent configuration selection, independent of release identity. */
+  modelSelectionVersion?: number;
   systemPromptTemplate?: string;
   modelConfig?: Record<string, unknown>;
   modelRouting?: ModelRoutePolicy;
@@ -661,7 +663,7 @@ export function createHttpServer(
   // Updated only after a turn completes successfully. A reload ACK means the
   // next turn is prepared; this state is the stronger evidence that a box has
   // actually run with the published model binding.
-  let observedModel: { releaseId: string; modelFingerprint: string; observedAt: string } | null = null;
+  let observedModel: { releaseId: string; modelFingerprint: string; modelSelectionVersion: number; observedAt: string } | null = null;
   let observedHarness: {
     agentType: string;
     /** Request-scoped Agent prompt; the resource loader adds platform instructions. */
@@ -1495,10 +1497,12 @@ export function createHttpServer(
           : undefined;
         const ranIntendedModel = intendedCandidate !== undefined
           && result?.activeCandidateKey === intendedCandidate;
-        if (ranIntendedModel && body.releaseId && body.modelFingerprint) {
+        if (ranIntendedModel && body.releaseId && body.modelFingerprint
+          && (body.modelSelectionVersion ?? 0) >= (observedModel?.modelSelectionVersion ?? 0)) {
           observedModel = {
             releaseId: body.releaseId,
             modelFingerprint: body.modelFingerprint,
+            modelSelectionVersion: body.modelSelectionVersion ?? 0,
             observedAt: new Date().toISOString(),
           };
         }

--- a/src/agentbox/model-reload-sdk.test.ts
+++ b/src/agentbox/model-reload-sdk.test.ts
@@ -1,0 +1,36 @@
+import { expect, it, vi } from "vitest";
+import { ExtensionRunner, wrapRegisteredTool } from "@earendil-works/pi-coding-agent";
+import { modelHandler } from "./sync-handlers.js";
+import { AgentBoxSessionManager } from "./session.js";
+
+it("model-only invalidation preserves the SDK tool runner until the captured turn ends", async () => {
+  const runner = Object.create(ExtensionRunner.prototype);
+  runner.extensions = [];
+  runner.runtime = { flagValues: new Map(), getActiveTools: () => ["probe"], invalidate: vi.fn() };
+  let finish!: (value: any) => void;
+  const tool = wrapRegisteredTool({ definition: {
+    name: "probe", description: "Probe", parameters: {},
+    execute: () => new Promise((resolve) => { finish = resolve; }),
+  } } as any, runner);
+  const managed = {
+    _invalidated: false, _promptDone: false, _promptInflight: Promise.resolve(),
+    _promptDoneCallbacks: new Set<() => void>(),
+  };
+  const manager = Object.create(AgentBoxSessionManager.prototype);
+  manager.sessions = new Map([["busy", managed]]);
+  manager.scheduleRelease = vi.fn();
+  const reload = vi.fn(async () => runner.invalidate());
+  const pending = tool.execute("first", {}, undefined, undefined);
+  await modelHandler.postReload!({ sessions: [{ brain: { reload }, invalidate: () => manager.invalidate("busy") }] } as any);
+  expect(managed._invalidated).toBe(true);
+  expect(manager.scheduleRelease).not.toHaveBeenCalled();
+  expect(reload).not.toHaveBeenCalled();
+  finish({ content: [{ type: "text", text: "success" }] });
+  await expect(pending).resolves.toMatchObject({ content: [{ text: "success" }] });
+  const nextTool = tool.execute("second", {}, undefined, undefined);
+  finish({ content: [{ type: "text", text: "next tool succeeded" }] });
+  await expect(nextTool).resolves.toMatchObject({ content: [{ text: "next tool succeeded" }] });
+  managed._promptDone = true;
+  for (const callback of managed._promptDoneCallbacks) callback();
+  expect(manager.scheduleRelease).toHaveBeenCalledWith("busy", 0);
+});

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -71,7 +71,7 @@ vi.mock("../core/agent-factory.js", async () => {
       abort: behavior.abort ?? (async () => {}),
       steer: behavior.steer ?? (async () => {}),
       clearQueue: () => ({ steering: [], followUp: [] }),
-      getModel: () => null,
+      getModel: behavior.getModel ?? (() => null),
       // Overridable, unchanged defaults. Model SETUP is where a provider exception
       // is raised, and a factory that could only vary prompt/abort/steer could not
       // express that at all: every failure arrived as `findModel → null`, whose
@@ -80,7 +80,7 @@ vi.mock("../core/agent-factory.js", async () => {
       setModel: behavior.setModel ?? (async () => {}),
       findModel: behavior.findModel ?? (() => null),
       getContextUsage: () => null,
-      getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, cost: 0 }),
+      getSessionStats: behavior.getSessionStats ?? (() => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, cost: 0 })),
       registerProvider: behavior.registerProvider ?? (() => {}),
     };
   }
@@ -147,6 +147,7 @@ import { saveSessionKnowledge } from "../memory/session-summarizer.js";
 import * as subagentRegistry from "../core/subagent-registry.js";
 import { getSubagentConcurrency } from "../core/subagent-registry.js";
 import { ConcurrencyLimiter } from "../core/concurrency-limiter.js";
+import { onDiagnostic, type DiagnosticEvent } from "../shared/diagnostic-events.js";
 
 // ── Test setup ────────────────────────────────────────────────────────
 
@@ -1071,6 +1072,34 @@ describe("AgentBoxSessionManager — Stop / abort latches", () => {
     } finally {
       attachSpy.mockRestore(); startSpy.mockRestore(); endSpy.mockRestore(); detachSpy.mockRestore();
     }
+  });
+
+  it.each([false, true])("records child token usage once even when execution fails (%s)", async (fails) => {
+    const mgr = new AgentBoxSessionManager() as any;
+    const before = { tokens: { input: 10, output: 5, cacheRead: 20, cacheWrite: 0, total: 35 }, cost: 0.01 };
+    const after = { tokens: { input: 110, output: 35, cacheRead: 70, cacheWrite: 0, total: 215 }, cost: 0.03 };
+    let stats = before;
+    const events: DiagnosticEvent[] = [];
+    const unsubscribe = onDiagnostic((event) => events.push(event));
+    (globalThis as any).__fakeBrainFactories.push((emitter: any) => ({
+      getSessionStats: () => stats,
+      getModel: () => ({ id: "fast-model", provider: "provider-b" }),
+      prompt: async () => {
+        stats = after;
+        if (fails) throw new Error("provider failed after usage");
+        emitter.emit("event", { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "done" }] } });
+      },
+    }));
+    try {
+      await mgr.runSpawnedSubagent({ spawnId: "s1", parentSessionId: "parent", parentAgentId: "a1", description: "d", prompt: "do x", userId: "u1" }, { childSessionId: "child-usage" });
+      const usage = events.filter((event) => event.type === "prompt_complete");
+      expect(usage).toHaveLength(1);
+      expect(usage[0]).toMatchObject({
+        sessionId: "child-usage", prev: before, curr: after,
+        model: { id: "fast-model", provider: "provider-b" }, userId: "u1",
+        outcome: fails ? "error" : "completed",
+      });
+    } finally { unsubscribe(); }
   });
 
   it("#1 stopSessionJobs re-sweep catches a job registered after the first sweep", () => {

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -2777,6 +2777,7 @@ export class AgentBoxSessionManager {
     // startPrompt (else startPrompt takes the id-only branch). Both self-gate on tracing state.
     tracingRecorder.attach(childSessionId, child.brain, { userId: request.userId, agentId });
     tracingRecorder.startPrompt(childSessionId, request.prompt, request.userId, mainTraceId, spawnSpanContext);
+    const previousUsage = child.brain.getSessionStats();
 
     // Cancellation: stopRequested is set by either the parent's abort signal
     // (main "stop" button → the spawn_subagent tool's signal) or job_stop.
@@ -3060,6 +3061,19 @@ export class AgentBoxSessionManager {
     // so no child trace is left open. endPrompt stays outside the try so it runs before the
     // terminal persist, mirroring the main-prompt ordering.
     tracingRecorder.endPrompt(childSessionId, status === "done" ? "completed" : "error");
+    // Internal children bypass HTTP /prompt and own separate session histories.
+    // Their usage is absent from the parent's delta, so account for it here once,
+    // including consumed tokens on failed or cancelled work.
+    emitDiagnostic({
+      type: "prompt_complete",
+      sessionId: childSessionId,
+      prev: previousUsage,
+      curr: child.brain.getSessionStats(),
+      model: child.brain.getModel(),
+      durationMs: Date.now() - startedAt,
+      outcome: status === "done" ? "completed" : "error",
+      userId: request.userId,
+    });
     try {
       const bundle = buildDelegateSummaryBundle(redactText(finalText, redactionConfig));
       const durationMs = Date.now() - startedAt;

--- a/src/gateway/agent-model-binding.ts
+++ b/src/gateway/agent-model-binding.ts
@@ -13,6 +13,8 @@ export interface ResolvedModelBinding {
   releaseId?: string;
   /** Digest of the immutable model snapshot in that Release. */
   modelFingerprint?: string;
+  /** Monotonic Agent configuration selection, independent of release identity. */
+  modelSelectionVersion?: number;
   modelProvider: string;
   modelId: string;
   modelConfig: {

--- a/src/gateway/agentbox/client.ts
+++ b/src/gateway/agentbox/client.ts
@@ -65,6 +65,8 @@ export interface PromptOptions {
   releaseId?: string;
   /** Fingerprint of the release model snapshot for runtime observation. */
   modelFingerprint?: string;
+  /** Monotonic Agent configuration selection, independent of release identity. */
+  modelSelectionVersion?: number;
   /** Agent ID (for logging/context) */
   agentId?: string;
   /** Agent-owned Addendum (legacy wire field name). */

--- a/src/gateway/channels/dingtalk.test.ts
+++ b/src/gateway/channels/dingtalk.test.ts
@@ -6,6 +6,7 @@ import {
   resetConversationSessionsForTest,
 } from "./dingtalk.js";
 import { sessionRegistry } from "../session-registry.js";
+import { sessionTurnLocks } from "../session-turn-lock.js";
 import { buildMarkdownMessage, DINGTALK_TITLE, sanitizeMarkdownForDingTalk } from "./dingtalk-card.js";
 
 const supportsConversationsMock = vi.hoisted(() => vi.fn());
@@ -473,6 +474,49 @@ describe("handleDingTalkMessage — routing to AgentBox", () => {
     expect(promptArg.modelConfig).toEqual(modelConfig);
     expect(promptArg.modelRouting).toEqual(modelRouting);
     sessionRegistry.forget(promptArg.sessionId);
+  });
+
+  it.each(["binding", "separate", "cleared"])("refreshes the model and %s Addendum after a queued turn acquires its lock", async (promptSource) => {
+    resolveBindingMock.mockResolvedValue({ agentId: "agent-selection", bindingId: "b1" });
+    promptMock.mockResolvedValue({ sessionId: "channel-selection" });
+    streamEventsMock.mockImplementation(async function* () { /* empty */ });
+    let selectionVersion = 1;
+    const frontend = { request: vi.fn(async (method: string) => {
+      if (method === "config.getModelBinding") {
+        return { binding: {
+          modelProvider: "provider", modelId: `model-${selectionVersion}`,
+          modelSelectionVersion: selectionVersion,
+          ...(promptSource === "binding" ? { systemPrompt: `BOUND ADDENDUM ${selectionVersion}` } : {}),
+          ...(promptSource === "cleared" && selectionVersion === 2 ? { systemPrompt: "" } : {}),
+        } };
+      }
+      return { system_prompt: `SEPARATE ADDENDUM ${selectionVersion}` };
+    }) };
+    const mgr = makeAgentBoxManager("agent-selection");
+    const message = makeDownstream("hi", { conversationType: "1", conversationId: "selection-chat" });
+    await handleDingTalkMessage(message, "ch", mgr as any, undefined, frontend as any);
+    const sessionId = promptMock.mock.calls[0][0].sessionId as string;
+    const release = await sessionTurnLocks.acquire(sessionId);
+    const acquire = vi.spyOn(sessionTurnLocks, "acquire");
+    promptMock.mockClear();
+    const queued = handleDingTalkMessage(message, "ch", mgr as any, undefined, frontend as any);
+    try {
+      await vi.waitFor(() => expect(acquire).toHaveBeenCalledWith(sessionId));
+      expect(promptMock).not.toHaveBeenCalled();
+      selectionVersion = 2;
+      release();
+      await queued;
+      expect(promptMock).toHaveBeenCalledWith(expect.objectContaining({
+        modelId: "model-2", modelSelectionVersion: 2,
+        systemPromptTemplate: promptSource === "binding" ? "BOUND ADDENDUM 2"
+          : promptSource === "cleared" ? "" : "SEPARATE ADDENDUM 2",
+      }));
+    } finally {
+      release();
+      await queued;
+      acquire.mockRestore();
+      sessionRegistry.forget(sessionId);
+    }
   });
 
   it("does not pass userId into the AgentBox prompt payload", async () => {

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -316,7 +316,6 @@ export async function handleDingTalkMessage(
   let releaseTurn: (() => void) | undefined;
   try {
     const remoteConversation = frontendClient ? await supportsConversations(frontendClient) : false;
-    const systemPromptTemplate = !remoteConversation ? await resolveAgentSystemPrompt(agentId, frontendClient) : undefined;
     // Audit: persist the session + inbound user message so DingTalk sessions are
     // visible in the audit (they were previously invisible — no chat_messages at
     // all). origin="channel" unifies IM channels alongside Web/API/A2A. user_id =
@@ -353,6 +352,10 @@ export async function handleDingTalkMessage(
       client = new AgentBoxClient(handle.endpoint, 120_000, tlsOptions);
     }
     const modelBinding = !remoteConversation && frontendClient ? await resolveAgentModelBinding(agentId, frontendClient) : null;
+    // Resolve the Addendum with the model after the turn lock. The binding owns
+    // an explicit value, including an empty string that clears the old prompt.
+    const systemPromptTemplate = remoteConversation ? undefined
+      : modelBinding?.systemPrompt ?? await resolveAgentSystemPrompt(agentId, frontendClient);
     const promptOpts: PromptOptions = {
       text,
       agentId,

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -317,7 +317,6 @@ export async function handleDingTalkMessage(
   try {
     const remoteConversation = frontendClient ? await supportsConversations(frontendClient) : false;
     const systemPromptTemplate = !remoteConversation ? await resolveAgentSystemPrompt(agentId, frontendClient) : undefined;
-    const modelBinding = !remoteConversation && frontendClient ? await resolveAgentModelBinding(agentId, frontendClient) : null;
     // Audit: persist the session + inbound user message so DingTalk sessions are
     // visible in the audit (they were previously invisible — no chat_messages at
     // all). origin="channel" unifies IM channels alongside Web/API/A2A. user_id =
@@ -353,6 +352,7 @@ export async function handleDingTalkMessage(
       sessionTurnLocks.noteBox(sessionId, handle.boxId, handle.endpoint);
       client = new AgentBoxClient(handle.endpoint, 120_000, tlsOptions);
     }
+    const modelBinding = !remoteConversation && frontendClient ? await resolveAgentModelBinding(agentId, frontendClient) : null;
     const promptOpts: PromptOptions = {
       text,
       agentId,

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -362,6 +362,7 @@ export async function handleDingTalkMessage(
       modelId: modelBinding?.modelId,
       releaseId: modelBinding?.releaseId,
       modelFingerprint: modelBinding?.modelFingerprint,
+      modelSelectionVersion: modelBinding?.modelSelectionVersion,
       modelConfig: modelBinding?.modelConfig,
       modelRouting: modelBinding?.modelRouting,
       subagentTiers: modelBinding?.subagentTiers,

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -2057,6 +2057,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       modelId: modelBinding?.modelId,
       releaseId: modelBinding?.releaseId,
       modelFingerprint: modelBinding?.modelFingerprint,
+      modelSelectionVersion: modelBinding?.modelSelectionVersion,
       modelConfig: modelBinding?.modelConfig,
       modelRouting: modelBinding?.modelRouting,
       subagentTiers: modelBinding?.subagentTiers,

--- a/src/gateway/server-agent-release-reload.test.ts
+++ b/src/gateway/server-agent-release-reload.test.ts
@@ -41,11 +41,11 @@ afterEach(async () => {
   reloadCalls.length = 0;
 });
 
-async function boot(running = true) {
+async function boot(running = true, frontendClient = fakeFrontendClient()) {
   server = await startRuntime({
     config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
     agentBoxManager: fakeAgentBoxManager(running),
-    frontendClient: fakeFrontendClient(),
+    frontendClient,
     credentialService: {} as any,
   });
   return server.rpcMethods.get("agent.reload")!;
@@ -90,6 +90,23 @@ describe("agent.reload release model identity", () => {
 });
 
 describe("agent.reload model selection within one release", () => {
+  it.each(["3", null, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])("rejects invalid version %s as an input error", async (modelSelectionVersion) => {
+    const frontend = fakeFrontendClient();
+    const reload = await boot(true, frontend);
+    await expect(reload({ agentId: "agent-1", resources: ["model"], modelSelectionVersion })).rejects.toThrow("modelSelectionVersion must be a non-negative safe integer");
+    expect(frontend.request).not.toHaveBeenCalledWith("config.getModelBinding", expect.anything());
+    expect(reloadCalls).toEqual([]);
+  });
+
+  it("requires control-plane version support before acknowledging nonzero selections", async () => {
+    const frontend = fakeFrontendClient();
+    frontend.request.mockResolvedValue({ binding: { ...binding, modelSelectionVersion: undefined } });
+    const reload = await boot(true, frontend);
+    await expect(reload({ agentId: "agent-1", resources: ["model"], modelSelectionVersion: 1 })).rejects.toThrow(/model selection version/);
+    expect(reloadCalls).toEqual([]);
+    await expect(reload({ agentId: "agent-1", resources: ["model"], modelSelectionVersion: 0 })).resolves.toMatchObject({ preparedModelSelectionVersion: 0 });
+  });
+
   it("rejects an old A -> B -> A receipt even when the model fingerprint matches", async () => {
     const reload = await boot();
     await expect(reload({agentId: "agent-1", resources: ["model"], releaseId: "release-2", modelFingerprint: "fingerprint-2", modelSelectionVersion: 1})).rejects.toThrow(/model selection version/);

--- a/src/gateway/server-agent-release-reload.test.ts
+++ b/src/gateway/server-agent-release-reload.test.ts
@@ -13,6 +13,7 @@ const { startRuntime } = await import("./server.js");
 const binding = {
   releaseId: "release-2",
   modelFingerprint: "fingerprint-2",
+  modelSelectionVersion: 3,
   modelProvider: "openai",
   modelId: "gpt-4",
   modelConfig: { name: "openai", baseUrl: "", apiKey: "", api: "openai-responses", authHeader: true, models: [] },
@@ -85,5 +86,15 @@ describe("agent.reload release model identity", () => {
     }) as any;
     expect(result).toMatchObject({ boxes: 0, preparedReleaseId: "release-2" });
     expect(reloadCalls).toEqual([]);
+  });
+});
+
+describe("agent.reload model selection within one release", () => {
+  it("rejects an old A -> B -> A receipt even when the model fingerprint matches", async () => {
+    const reload = await boot();
+    await expect(reload({agentId: "agent-1", resources: ["model"], releaseId: "release-2", modelFingerprint: "fingerprint-2", modelSelectionVersion: 1})).rejects.toThrow(/model selection version/);
+    expect(reloadCalls).toEqual([]);
+    const prepared = await reload({agentId: "agent-1", resources: ["model"], releaseId: "release-2", modelFingerprint: "fingerprint-2", modelSelectionVersion: 3});
+    expect(prepared).toMatchObject({preparedModelSelectionVersion: 3, preparedModelFingerprint: "fingerprint-2"});
   });
 });

--- a/src/gateway/server-chat-subagent-tiers.test.ts
+++ b/src/gateway/server-chat-subagent-tiers.test.ts
@@ -19,6 +19,7 @@
  * and asserts on the PromptOptions the box actually receives.
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
+import { buildRedactionConfigForModelConfig } from "./output-redactor.js";
 
 vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
@@ -174,4 +175,6 @@ it("resolves the latest shared model at dispatch and keeps the independent fast 
   expect(promptCalls[0]).toMatchObject(binding);
   expect(promptCalls[0].modelRouting).toBeUndefined();
   expect(frontend.request).toHaveBeenCalledWith("config.getModelBinding", { agentId: "a" });
+  await waitFor(() => vi.mocked(buildRedactionConfigForModelConfig).mock.calls.length > 0);
+  expect(buildRedactionConfigForModelConfig).toHaveBeenLastCalledWith(binding.modelConfig);
 });

--- a/src/gateway/server-chat-subagent-tiers.test.ts
+++ b/src/gateway/server-chat-subagent-tiers.test.ts
@@ -178,3 +178,58 @@ it("resolves the latest shared model at dispatch and keeps the independent fast 
   await waitFor(() => vi.mocked(buildRedactionConfigForModelConfig).mock.calls.length > 0);
   expect(buildRedactionConfigForModelConfig).toHaveBeenLastCalledWith(binding.modelConfig);
 });
+
+it.each(["CURRENT ADDENDUM", "", null, undefined])("refreshes the caller-stamped prompt with the dispatched binding (%s)", async (systemPrompt) => {
+  const frontend = fakeFrontendClient();
+  const binding = {
+    modelProvider: "provider-b", modelId: "model-b", modelConfig: {},
+    modelSelectionVersion: 2, systemPrompt,
+  };
+  frontend.request.mockImplementation(async (method: string) => method === "config.getModelBinding"
+    ? { binding } : { system_prompt: "CURRENT SEPARATE ADDENDUM" });
+  server = await bootRuntime(frontend);
+  await server.rpcMethods.get("chat.send")!({
+    agentId: "a", userId: "u", text: "hi", sessionId: "prompt-refresh",
+    modelSelectionVersion: 1, systemPrompt: "STALE CALLER ADDENDUM",
+  }, { sendEvent: vi.fn() });
+  await waitFor(() => promptCalls.length > 0);
+  expect(promptCalls[0]).toMatchObject({
+    modelId: "model-b",
+    systemPromptTemplate: systemPrompt ?? "CURRENT SEPARATE ADDENDUM",
+  });
+});
+
+it("preserves explicit prompts for callers without selection metadata", async () => {
+  server = await bootRuntime();
+  await server.rpcMethods.get("chat.send")!({
+    agentId: "a", userId: "u", text: "hi", sessionId: "legacy-prompt",
+    systemPrompt: "CALLER ADDENDUM",
+  }, { sendEvent: vi.fn() });
+  await waitFor(() => promptCalls.length > 0);
+  expect(promptCalls[0].systemPromptTemplate).toBe("CALLER ADDENDUM");
+});
+
+it("fails a versioned turn explicitly when current binding resolution fails", async () => {
+  const frontend = fakeFrontendClient();
+  const context = { sendEvent: vi.fn() };
+  frontend.request.mockImplementation(async (method: string) => {
+    if (method === "config.getModelBinding") throw new Error("control plane unavailable");
+    return { found: false };
+  });
+  server = await bootRuntime(frontend);
+  await server.rpcMethods.get("chat.send")!({
+    agentId: "a", userId: "u", text: "hi", sessionId: "binding-failure",
+    modelSelectionVersion: 0, modelProvider: "old-provider", modelId: "old-model", modelConfig: {},
+  }, context);
+  await waitFor(() => context.sendEvent.mock.calls.some((call) => call[1]?.event?.type === "stream_error"));
+  expect(promptCalls).toHaveLength(0);
+  expect(context.sendEvent.mock.calls.some((call) => call[1]?.event?.type === "prompt_done")).toBe(true);
+});
+
+it.each(["3", null, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])("rejects malformed chat selection version %s before dispatch", async (modelSelectionVersion) => {
+  server = await bootRuntime();
+  await expect(server.rpcMethods.get("chat.send")!({
+    agentId: "a", userId: "u", text: "hi", modelSelectionVersion,
+  }, { sendEvent: vi.fn() })).rejects.toThrow("modelSelectionVersion must be a non-negative safe integer");
+  expect(promptCalls).toHaveLength(0);
+});

--- a/src/gateway/server-chat-subagent-tiers.test.ts
+++ b/src/gateway/server-chat-subagent-tiers.test.ts
@@ -24,6 +24,7 @@ vi.mock("./chat-repo.js", () => ({
   ensureChatSession: vi.fn(async () => {}),
   appendMessage: vi.fn(async () => "msg-id"),
   bindMessageTraceId: vi.fn(async () => {}),
+  validTraceId: (value: unknown) => typeof value === "string" ? value : undefined,
   updateMessage: vi.fn(async () => {}),
   incrementMessageCount: vi.fn(async () => {}),
 }));
@@ -82,11 +83,11 @@ function fakeAgentBoxManager() {
   } as any;
 }
 
-async function bootRuntime() {
+async function bootRuntime(frontendClient = fakeFrontendClient()) {
   return startRuntime({
     config: { port: 0, internalPort: 0, host: "127.0.0.1", serverUrl: "", portalSecret: "" } as any,
     agentBoxManager: fakeAgentBoxManager(),
-    frontendClient: fakeFrontendClient(),
+    frontendClient,
     credentialService: {} as any,
   });
 }
@@ -152,4 +153,25 @@ describe("startRuntime — chat.send forwards sub-agent tier candidates", () => 
     // key the caller never set would misreport a clear as a decision.
     expect("subagentTiers" in promptCalls[0]).toBe(true);
   });
+});
+
+
+it("resolves the latest shared model at dispatch and keeps the independent fast tier", async () => {
+  const frontend = fakeFrontendClient();
+  const binding = {
+    modelProvider: "provider-b", modelId: "model-b", modelConfig: { apiKey: "test-key" },
+    releaseId: "release-1", modelFingerprint: "fingerprint-b", modelSelectionVersion: 2,
+    subagentTiers: TIERS,
+  };
+  frontend.request.mockImplementation(async (method: string) => method === "config.getModelBinding" ? { binding } : { found: false });
+  server = await bootRuntime(frontend);
+  await server.rpcMethods.get("chat.send")!({
+    agentId: "a", userId: "u", text: "hi", sessionId: "S3",
+    modelProvider: "provider-a", modelId: "model-a", modelSelectionVersion: 1,
+    modelRouting: { enabled: true },
+  }, { sendEvent: vi.fn() });
+  await waitFor(() => promptCalls.length > 0);
+  expect(promptCalls[0]).toMatchObject(binding);
+  expect(promptCalls[0].modelRouting).toBeUndefined();
+  expect(frontend.request).toHaveBeenCalledWith("config.getModelBinding", { agentId: "a" });
 });

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -585,12 +585,12 @@ describe("agent.syncStatus RPC — MCP connection outcomes", () => {
   });
 });
 
-it("distinguishes model selections even when release and fingerprint repeat", async () => {
+it.each([1, undefined])("does not certify an older or unversioned box (%s) as the current selection", async (oldVersion) => {
   listReturns = [
     { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
     { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://b2" },
   ];
-  for (const [endpoint, version] of [["https://b1", 1], ["https://b2", 3]] as const) {
+  for (const [endpoint, version] of [["https://b1", oldVersion], ["https://b2", 3]] as const) {
     getJsonByEndpoint.set(endpoint, async () => ({ ...defaultSyncStatus,
       model: { releaseId: "release", modelFingerprint: "same-model", modelSelectionVersion: version, observedAt: "2026-09-11T00:00:00Z" },
     }));
@@ -598,7 +598,7 @@ it("distinguishes model selections even when release and fingerprint repeat", as
   server = await bootRuntime();
   const result = await server.rpcMethods.get("agent.syncStatus")!({ agentId: "preview" }, { sendEvent: vi.fn() } as any);
   expect(result).toMatchObject({ consistent: false, model: null, observations: [
-    { status: { model: { modelSelectionVersion: 1 } } },
+    { status: { model: { releaseId: "release", modelFingerprint: "same-model" } } },
     { status: { model: { modelSelectionVersion: 3 } } },
   ] });
 });

--- a/src/gateway/server-sync-status.test.ts
+++ b/src/gateway/server-sync-status.test.ts
@@ -584,3 +584,21 @@ describe("agent.syncStatus RPC — MCP connection outcomes", () => {
     expect(out.mcp.servers).toHaveLength(1);
   });
 });
+
+it("distinguishes model selections even when release and fingerprint repeat", async () => {
+  listReturns = [
+    { boxId: "b1", agentId: "preview", status: "running", endpoint: "https://b1" },
+    { boxId: "b2", agentId: "preview", status: "running", endpoint: "https://b2" },
+  ];
+  for (const [endpoint, version] of [["https://b1", 1], ["https://b2", 3]] as const) {
+    getJsonByEndpoint.set(endpoint, async () => ({ ...defaultSyncStatus,
+      model: { releaseId: "release", modelFingerprint: "same-model", modelSelectionVersion: version, observedAt: "2026-09-11T00:00:00Z" },
+    }));
+  }
+  server = await bootRuntime();
+  const result = await server.rpcMethods.get("agent.syncStatus")!({ agentId: "preview" }, { sendEvent: vi.fn() } as any);
+  expect(result).toMatchObject({ consistent: false, model: null, observations: [
+    { status: { model: { modelSelectionVersion: 1 } } },
+    { status: { model: { modelSelectionVersion: 3 } } },
+  ] });
+});

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -809,6 +809,11 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     if (!agentId || !userId || !text) {
       throw new Error("agentId, userId, and text are required");
     }
+    if (params.modelSelectionVersion !== undefined
+      && (typeof params.modelSelectionVersion !== "number"
+        || !Number.isSafeInteger(params.modelSelectionVersion) || params.modelSelectionVersion < 0)) {
+      throw new Error("modelSelectionVersion must be a non-negative safe integer");
+    }
     // Refuse rather than accept a turn this process will not be around to finish. The
     // caller can place it on a Runtime that will.
     if (shuttingDown) {
@@ -1056,6 +1061,9 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           promptOpts.modelFingerprint = binding.modelFingerprint;
           promptOpts.modelSelectionVersion = binding.modelSelectionVersion;
           promptOpts.subagentTiers = binding.subagentTiers;
+          // A caller-stamped Addendum belongs to its old binding too. An absent
+          // Addendum is resolved below for control planes with a separate RPC.
+          promptOpts.systemPromptTemplate = binding.systemPrompt ?? undefined;
         }
 
         // Agent-Addendum precedence for the box session. An explicit
@@ -2263,6 +2271,12 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const wantsModel = resourceTypes.includes("model");
     const expectedReleaseId = params.releaseId as string | undefined;
     const expectedModelFingerprint = params.modelFingerprint as string | undefined;
+    const expectedModelSelectionVersion = params.modelSelectionVersion;
+    if (expectedModelSelectionVersion !== undefined
+      && (typeof expectedModelSelectionVersion !== "number"
+        || !Number.isSafeInteger(expectedModelSelectionVersion) || expectedModelSelectionVersion < 0)) {
+      throw new Error("modelSelectionVersion must be a non-negative safe integer");
+    }
     let preparedReleaseId = "";
     let preparedModelFingerprint = "";
     let preparedModelSelectionVersion = 0;
@@ -2272,14 +2286,14 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       preparedReleaseId = binding.releaseId ?? "";
       preparedModelFingerprint = binding.modelFingerprint ?? "";
       preparedModelSelectionVersion = binding.modelSelectionVersion ?? 0;
-      if (params.modelSelectionVersion !== undefined && params.modelSelectionVersion !== preparedModelSelectionVersion) {
-        throw new Error("model selection version does not match expected Agent configuration");
-      }
       if (expectedReleaseId && preparedReleaseId !== expectedReleaseId) {
         throw new Error(`model binding release ${preparedReleaseId || "<empty>"} does not match expected ${expectedReleaseId}`);
       }
       if (expectedModelFingerprint && preparedModelFingerprint !== expectedModelFingerprint) {
         throw new Error(`model binding fingerprint ${preparedModelFingerprint || "<empty>"} does not match expected ${expectedModelFingerprint}`);
+      }
+      if (expectedModelSelectionVersion !== undefined && expectedModelSelectionVersion !== preparedModelSelectionVersion) {
+        throw new Error("model selection version does not match expected Agent configuration");
       }
     }
 

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -1205,7 +1205,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           warnTraceBindFailure("prompt", promptResult.sessionId, promptMessageId!, bindErr);
         });
 
-        const redactionConfig = buildRedactionConfigForModelConfig(modelConfig);
+        const redactionConfig = buildRedactionConfigForModelConfig(promptOpts.modelConfig);
         const abortCtrl = turnAbort;
         const promptDoneEvent = () => ({
           type: "prompt_done",

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -913,6 +913,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       modelId: params.modelId as string | undefined,
       releaseId: params.releaseId as string | undefined,
       modelFingerprint: params.modelFingerprint as string | undefined,
+      modelSelectionVersion: params.modelSelectionVersion as number | undefined,
       systemPromptTemplate: params.systemPrompt as string | undefined,
       mode: params.mode as string | undefined,
       origin: origin as PromptOptions["origin"],
@@ -1041,6 +1042,21 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           releaseTurn = await sessionTurnLocks.acquire(sessionId);
         }
         throwIfStoppedBeforePrompt();
+
+        // Resolve selection-aware bindings at dispatch, after acquiring the turn
+        // lock. A save while this request waited must affect this new turn.
+        if (promptOpts.modelSelectionVersion !== undefined) {
+          const binding = await resolveAgentModelBinding(agentId, frontendClient);
+          if (!binding) throw new Error(`model binding unavailable for agent ${agentId}`);
+          promptOpts.modelProvider = binding.modelProvider;
+          promptOpts.modelId = binding.modelId;
+          promptOpts.modelConfig = binding.modelConfig;
+          promptOpts.modelRouting = binding.modelRouting;
+          promptOpts.releaseId = binding.releaseId;
+          promptOpts.modelFingerprint = binding.modelFingerprint;
+          promptOpts.modelSelectionVersion = binding.modelSelectionVersion;
+          promptOpts.subagentTiers = binding.subagentTiers;
+        }
 
         // Agent-Addendum precedence for the box session. An explicit
         // params.systemPrompt (the portal-standalone path stamps it from the
@@ -2249,11 +2265,16 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     const expectedModelFingerprint = params.modelFingerprint as string | undefined;
     let preparedReleaseId = "";
     let preparedModelFingerprint = "";
+    let preparedModelSelectionVersion = 0;
     if (wantsModel) {
       const binding = await resolveAgentModelBinding(agentId, frontendClient);
       if (!binding) throw new Error(`model binding unavailable for agent ${agentId}`);
       preparedReleaseId = binding.releaseId ?? "";
       preparedModelFingerprint = binding.modelFingerprint ?? "";
+      preparedModelSelectionVersion = binding.modelSelectionVersion ?? 0;
+      if (params.modelSelectionVersion !== undefined && params.modelSelectionVersion !== preparedModelSelectionVersion) {
+        throw new Error("model selection version does not match expected Agent configuration");
+      }
       if (expectedReleaseId && preparedReleaseId !== expectedReleaseId) {
         throw new Error(`model binding release ${preparedReleaseId || "<empty>"} does not match expected ${expectedReleaseId}`);
       }
@@ -2273,7 +2294,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       console.log(`[rpc] agent.reload: no active boxes for agent=${agentId}, skipping`);
       return {
         ok: true, reloaded: [], skipped: resourceTypes, boxes: 0,
-        preparedReleaseId, preparedModelFingerprint,
+        preparedReleaseId, preparedModelFingerprint, preparedModelSelectionVersion,
       };
     }
 
@@ -2304,7 +2325,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
     console.log(`[rpc] agent.reload: agent=${agentId} boxes=${targets.length} reloaded=[${reloaded}] failed=[${failed}]`);
     return {
       ok: true, reloaded, failed, boxes: targets.length,
-      preparedReleaseId, preparedModelFingerprint,
+      preparedReleaseId, preparedModelFingerprint, preparedModelSelectionVersion,
     };
   });
 
@@ -2396,6 +2417,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
       model: status.model ? {
         releaseId: status.model.releaseId,
         modelFingerprint: status.model.modelFingerprint,
+        modelSelectionVersion: status.model.modelSelectionVersion ?? 0,
       } : null,
       // Sub-agent tiering is part of what a replica IS, so it belongs here for the
       // same reason `model` does. Without it two boxes serving different tier state

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -309,6 +309,7 @@ export class TaskCoordinator {
           modelId: binding.modelId,
           releaseId: binding.releaseId,
           modelFingerprint: binding.modelFingerprint,
+          modelSelectionVersion: binding.modelSelectionVersion,
           modelConfig: binding.modelConfig,
           modelRouting: binding.modelRouting,
           subagentTiers: binding.subagentTiers,

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -287,14 +287,14 @@ export class TaskCoordinator {
           resultText = consumed.resultText;
         } finally { clearTimeout(timer); client.close(); }
       } else {
-        const binding = await resolveAgentModelBinding(agentId, this.frontendClient);
-        if (!binding) throw new Error(`Agent ${agentId} has no valid model binding`);
-
         // One pod per agent — shared across users who call the agent.
         // Caller/task-owner attribution flows to Upstream via the session registry.
         sessionRegistry.remember(sessionId, userId, agentId);
         // One turn at a time for this task's session — see session-turn-lock.ts.
         releaseTurn = await sessionTurnLocks.acquire(sessionId);
+        const binding = await resolveAgentModelBinding(agentId, this.frontendClient);
+        if (!binding) throw new Error(`Agent ${agentId} has no valid model binding`);
+
         const handle = await this.manager.getOrCreate(agentId, { persistence: binding.persistence }, sessionId);
         sessionTurnLocks.noteBox(sessionId, handle.boxId, handle.endpoint);
         const client = new AgentBoxClient(handle.endpoint, 30_000, this.tlsOptions);

--- a/src/shared/__tests__/model-switch-usage.test.ts
+++ b/src/shared/__tests__/model-switch-usage.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, expect, it } from "vitest";
+import { AgentSession } from "@earendil-works/pi-coding-agent";
+import { processResponsesStream } from "@earendil-works/pi-ai/api/openai-responses-shared";
+import { emitDiagnostic } from "../diagnostic-events.js";
+import { metricsRegistry } from "../metrics.js";
+
+beforeEach(() => metricsRegistry.resetMetrics());
+
+async function response(modelId: string, input: number, cached: number, output: number, reasoning: number) {
+  const model = { id: modelId, provider: "test", cost: { input: 2, output: 8, cacheRead: 0.2, cacheWrite: 0 } };
+  const message: any = { role: "assistant", content: [], model: modelId, provider: "test", stopReason: "stop" };
+  async function* events() {
+    yield { type: "response.completed", response: { status: "completed", output: [], usage: {
+      input_tokens: input, input_tokens_details: { cached_tokens: cached },
+      output_tokens: output, output_tokens_details: { reasoning_tokens: reasoning }, total_tokens: input + output,
+    } } };
+  }
+  await processResponsesStream(events() as any, message, { push: () => {} } as any, model as any);
+  return message;
+}
+
+function stats(entries: any[]) {
+  // Exercise the installed SDK's accounting across a restored session, without
+  // provider calls. Compacted entries still belong to the billable history.
+  return AgentSession.prototype.getSessionStats.call({
+    sessionManager: { getEntries: () => entries }, getContextUsage: () => undefined,
+  } as any);
+}
+
+function record(sessionId: string, model: string, before: ReturnType<typeof stats>, after: ReturnType<typeof stats>) {
+  emitDiagnostic({ type: "prompt_complete", sessionId, prev: before, curr: after,
+    model: { id: model, provider: "test" } as any, durationMs: 1, outcome: "completed" });
+}
+
+it("keeps cached and reasoning tokens disjoint across model changes and restored history", async () => {
+  const history: any[] = [];
+  const empty = stats(history);
+  const first = await response("model-a", 100, 60, 30, 20);
+  expect(first.usage).toMatchObject({ input: 40, cacheRead: 60, output: 30, reasoning: 20, totalTokens: 130 });
+  history.push({ type: "message", message: first });
+  const afterA = stats(history);
+  expect(afterA.tokens.total).toBe(130); // Reasoning is already included in output.
+  record("parent", "model-a", empty, afterA);
+
+  const restored = structuredClone(history);
+  const beforeB = stats(restored);
+  restored.push({ type: "message", message: await response("model-b", 200, 100, 40, 10) });
+  const afterB = stats(restored);
+  expect(afterB.tokens.total).toBe(370);
+  record("parent", "model-b", beforeB, afterB);
+
+  const child = [{ type: "message", message: await response("fast-model", 50, 10, 20, 5) }];
+  record("child", "fast-model", stats([]), stats(child));
+  // A later parent turn reuses its own history, excluding the child's tokens.
+  expect(stats(restored).tokens.total).toBe(370);
+  const samples = (await metricsRegistry.getMetricsAsJSON()).find((metric) => metric.name === "siclaw_tokens_total")!.values;
+  const byModel = (id: string) => samples.filter((sample) => sample.labels.model === id).reduce((sum, sample) => sum + sample.value, 0);
+  expect(byModel("model-a")).toBe(130);
+  expect(byModel("model-b")).toBe(240);
+  expect(byModel("fast-model")).toBe(70);
+});
+
+it("retains compacted history and charges a recorded compaction only once", async () => {
+  const message = await response("model-a", 100, 60, 30, 20);
+  const compact = await response("model-a", 50, 0, 10, 0);
+  const history = [{ type: "message", message }, { type: "compaction", usage: compact.usage }];
+  expect(stats(history).tokens.total).toBe(190);
+  expect(stats(structuredClone(history)).tokens.total).toBe(190);
+});

--- a/src/shared/agentbox-sync-status.ts
+++ b/src/shared/agentbox-sync-status.ts
@@ -90,6 +90,7 @@ export interface BoxSyncStatus {
   model?: {
     releaseId: string;
     modelFingerprint: string;
+    modelSelectionVersion?: number;
     observedAt: string;
   } | null;
   /**
@@ -250,6 +251,7 @@ export function normalizeBoxSyncStatus(value: unknown): BoxSyncStatus {
       ? { model: {
           releaseId: model.releaseId,
           modelFingerprint: model.modelFingerprint,
+          ...(typeof model.modelSelectionVersion === "number" ? { modelSelectionVersion: model.modelSelectionVersion } : {}),
           observedAt: typeof model.observedAt === "string" ? model.observedAt : "",
         } }
       : root.model === null ? { model: null } : {}),


### PR DESCRIPTION
Shared Agent model changes take effect at the next dispatch while a running turn keeps its captured configuration. Carry the optional selection version through prompts, reload preparation and observed box status, including A-to-B-to-A changes within one release.

Resolve selection-aware chat bindings after acquiring the turn lock on every turn. The dispatched binding owns the model, routing, fast sub-agent candidates, output redaction and Agent Addendum; a caller-stamped old prompt is replaced too. If the current binding cannot be resolved, fail explicitly before dispatch instead of silently using an older selection. Callers without selection metadata retain their existing prompt and routing behavior. Validate version types at RPC boundaries before checking staleness. Direct DingTalk turns also resolve the Addendum after acquiring the session lock, preferring the binding value, including an explicit empty prompt; control planes using config.getAgent retain that current lookup.

The companion control plane sends model-only invalidation for preference changes. A regression exercises real SDK tool wrappers to verify pending and subsequent tools remain usable until that turn ends. Reject stale reload receipts and prevent older completed turns from replacing newer model observations.

Internal spawned children also report their own token and cost deltas to the existing metrics path. Previously they bypassed HTTP prompt accounting and were missing from totals. Child and parent histories stay separate. Accounting regressions cover success/failure, cached and reasoning tokens, next-turn model changes, restored history and recorded compaction. Cost still depends on supplied model prices; this change does not provide billing reconciliation.

Rollout: upgrade Runtime and AgentBox first, then every control-plane replica so `config.getModelBinding` returns a selection version (including zero), before enabling selection writes or versioned reloads. Old bindings represent version zero and cannot acknowledge nonzero selections. Mixed old/new boxes can report inconsistent evidence until old boxes finish active work, are recycled normally and provide versioned real-turn observations. Missing version evidence must not certify a later A-to-B-to-A selection. Details: `docs/design/agent-model-selections.md`.

Validation: 487 focused tests pass across DingTalk, Lark, chat dispatch, reload, sync status, HTTP, real SDK busy-session handling and usage accounting. Two additional internal-child usage tests pass for successful and failed execution. The three real-lock DingTalk regressions first reproduced the old Addendum with the new model and now pass, covering binding-provided, separately resolved and cleared prompts. Runtime and AgentBox TypeScript checks pass. No real-provider or deployed browser acceptance was performed.
