### PR TITLE
Forward the IM sender type on chat.ensureSession

### DIFF
--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1861,7 +1861,7 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
   const persistedText = redactImageUrlsInText(effectiveText);
   let promptMessageId: string;
   try {
-    await ensureChatSession(sessionId, agentId, binding.createdBy, persistedText, persistedText, "channel", undefined, { senderExternalId, channelId });
+    await ensureChatSession(sessionId, agentId, binding.createdBy, persistedText, persistedText, "channel", undefined, { senderExternalId, channelId, senderType });
     promptMessageId = await appendMessage({
       sessionId,
       role: "user",

--- a/src/gateway/chat-repo.ts
+++ b/src/gateway/chat-repo.ts
@@ -150,7 +150,7 @@ export async function ensureChatSession(
   sessionId: string, agentId: string, userId: string,
   title?: string, preview?: string, origin?: string,
   lineage?: ChatSessionLineageInput,
-  opts?: { senderExternalId?: string | null; channelId?: string | null },
+  opts?: { senderExternalId?: string | null; channelId?: string | null; senderType?: string | null },
 ): Promise<void> {
   const payload: Record<string, unknown> = {
     session_id: sessionId, agent_id: agentId, user_id: userId,
@@ -167,6 +167,14 @@ export async function ensureChatSession(
   // Each gated on != null so web/api/a2a callers leave the payload unchanged.
   if (opts?.senderExternalId != null) payload.sender_external_id = opts.senderExternalId;
   if (opts?.channelId != null) payload.channel_id = opts.channelId;
+  // The provider's own sender kind ("user" / "bot" / …), forwarded VERBATIM —
+  // no mapping, no default, absent rather than empty when the event carried
+  // none. Upstream stores it on the session so a usage count can tell a person
+  // from a machine: an allowlisted or open-tier bot otherwise writes a row
+  // indistinguishable from an unbound human's. Only providers that classify
+  // senders send this (Feishu today), and "absent" must stay distinguishable
+  // from "user" — which is why this is gated on != null like the two above.
+  if (opts?.senderType != null) payload.sender_type = opts.senderType;
   await getClient().request("chat.ensureSession", payload);
 }
 


### PR DESCRIPTION
## What

Forward the IM provider's sender classification (`sender_type`) on `chat.ensureSession`, so the control plane can persist it alongside the sender's open_id.

## Why

Feishu labels every sender `user` or `bot`, and the gateway already reads that value — it goes out on `channel.resolveBinding`, where the access decision consumes it. The RPC that writes the session row is a different one and never saw it.

The consequence is downstream: a bot that is allowlisted, or that talks to an agent on an open access tier, writes a session row **indistinguishable from an unbound human's** — no owning account, just an open_id. Anything counting people then counts the bot as one, and on an agent nobody else talks to, as *the* one.

## How

The queue context already carried `senderType` for the access path, so this only widens the `ensureSession` payload — no new extraction, no new parsing.

Forwarded **verbatim**: no mapping, no default, and absent rather than empty when the event carried none. Only providers that classify senders send it (Feishu today), and "absent" has to stay distinguishable from `"user"` — a reader that folds the two together would call every unclassified sender a person. Hence the `!= null` gate, matching the two audit dimensions beside it.

## Deploy order

**Control plane first.** With it deployed and this not, the field is simply absent and the reader falls back to its other signals, so no window misclassifies anyone. The reverse order just wastes a release — the value arrives with nowhere to go.

## Test

`npx tsc --noEmit` clean; 2553 tests across the touched areas pass. Rebased on `main` (`3df6ccad`).
