### PR TITLE
Record model usage across chat, analysis and compiler execution

### DIFF
--- a/.github/workflows/kbc-ci.yml
+++ b/.github/workflows/kbc-ci.yml
@@ -4,10 +4,10 @@ name: KBC Box CI
 on:
   push:
     branches: [main]
-    paths: ["kbc/**", "src/core/**", "src/kbc/**", "package*.json", "tsconfig.json", ".dockerignore", ".github/workflows/kbc-ci.yml"]
+    paths: ["kbc/**", "src/core/**", "src/kbc/**", "package*.json", "patches/**", "scripts/install/**", "tsconfig.json", ".dockerignore", ".github/workflows/kbc-ci.yml"]
   pull_request:
     branches: [main]
-    paths: ["kbc/**", "src/core/**", "src/kbc/**", "package*.json", "tsconfig.json", ".dockerignore", ".github/workflows/kbc-ci.yml"]
+    paths: ["kbc/**", "src/core/**", "src/kbc/**", "package*.json", "patches/**", "scripts/install/**", "tsconfig.json", ".dockerignore", ".github/workflows/kbc-ci.yml"]
 
 # Least-privilege: this job only reads the repo (no PR writes, no packages).
 permissions:

--- a/Dockerfile.agentbox
+++ b/Dockerfile.agentbox
@@ -20,6 +20,8 @@ WORKDIR /app
 
 # Dependencies layer (cached unless package*.json changes)
 COPY package*.json ./
+COPY patches/ ./patches/
+COPY scripts/install/ ./scripts/install/
 RUN npm ci
 
 # Copy backend source only (AgentBox runtime graph: agentbox-main + core + tools + knowledge).
@@ -97,6 +99,8 @@ WORKDIR /app
 
 # Production deps (cached unless package*.json changes)
 COPY package*.json ./
+COPY patches/ ./patches/
+COPY scripts/install/ ./scripts/install/
 RUN npm ci --omit=dev
 
 # Copy compiled JS + skills + entrypoint (knowledge synced at runtime via bundle API)

--- a/Dockerfile.portal
+++ b/Dockerfile.portal
@@ -18,6 +18,8 @@ FROM node:22.19-slim AS backend-builder
 WORKDIR /app
 
 COPY package*.json ./
+COPY patches/ ./patches/
+COPY scripts/install/ ./scripts/install/
 RUN npm ci
 
 COPY tsconfig.json ./
@@ -34,6 +36,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY package*.json ./
+COPY patches/ ./patches/
+COPY scripts/install/ ./scripts/install/
 RUN npm ci --omit=dev
 
 # Backend JS

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -8,6 +8,8 @@ WORKDIR /app
 
 # Dependencies layer (cached unless package*.json changes)
 COPY package*.json ./
+COPY patches/ ./patches/
+COPY scripts/install/ ./scripts/install/
 RUN npm ci
 
 # Copy source and compile
@@ -26,6 +28,8 @@ WORKDIR /app
 
 # Production deps
 COPY package*.json ./
+COPY patches/ ./patches/
+COPY scripts/install/ ./scripts/install/
 RUN npm ci --omit=dev
 
 # Copy compiled JS

--- a/docs/design/model-usage-observations.md
+++ b/docs/design/model-usage-observations.md
@@ -5,12 +5,20 @@ and subscription models use the same observation contract. Routing retries
 create separate calls; HTTP retries hidden inside Pi remain one logical call.
 This is runtime consumption telemetry, not an invoice or remaining allowance.
 
+Chat, system-analysis sessions and compiler workers share this observation
+contract. Workload ownership is resolved by the consuming control plane from
+the authenticated session or capability run. Compiler sessions retain their
+native identity and executor role; they do not impersonate a chat Agent.
+
 ## Evidence and identity
 
 Each call has a UUID, immutable dispatch timestamp, session and trace identity,
 model configuration snapshot, routing attempt and agent/auxiliary kind.
 Started and finished observations share that identity. Failed, cancelled and
 auxiliary calls are observed independently of visible assistant messages.
+Request IDs group calls within a prompt. Chat uses the root trace when present;
+compiler roles use their turn ID. Parent-call identity is optional and is not
+inferred from temporal proximity.
 
 Existing SDK usage and timing envelopes retain their meaning. The optional
 llmCall.call_id joins a timeline entry to an observation. A separate
@@ -42,6 +50,29 @@ Limits: 8 KiB per observation, 128 observations / 512 KiB per batch, 64 MiB per
 AgentBox outbox. Flushes start after 250 ms; transport errors back off from 1 to
 30 seconds. Idle collectors send health every 30 seconds. Shutdown allows a
 3-second flush and retains anything still unacknowledged.
+
+## Compiler producers
+
+The Pi compiler uses the same recorder and patched provider evidence as
+AgentBox. The Claude adapter captures numeric usage from native message stream
+events, including cache read/write fields. It emits one completed observation
+per provider message, regardless of how many SDK content blocks represent that
+message. SDK-only messages remain missing evidence; interrupted streams retain
+partial evidence. Timing for Claude starts at the observed message start;
+SDK-internal HTTP retries before that event are not individually measured.
+
+Compiler observations bypass the bounded diagnostic queue. On receipt, Runtime
+writes them to `capability-usage-outbox/<run>` and retries
+`capability.recordModelUsage` independently of run completion. Startup recovers
+pending outboxes, including completed runs. The consumer authorizes the runtime
+against the persisted run and resolves catalog identity from its frozen role
+snapshot before using the shared fact store. A drained collector retires only
+after its final empty health report is acknowledged.
+
+The worker-to-Runtime SSE transport and ephemeral worker storage still bound
+coverage: a worker or connection failure before Runtime receives an observation
+can lose that observation. The product must expose incomplete collection and
+must not describe these measurements as complete provider billing records.
 
 ## Pinned SDK patch
 

--- a/docs/design/model-usage-observations.md
+++ b/docs/design/model-usage-observations.md
@@ -58,8 +58,10 @@ AgentBox. The Claude adapter captures numeric usage from native message stream
 events, including cache read/write fields. It emits one completed observation
 per provider message, regardless of how many SDK content blocks represent that
 message. SDK-only messages remain missing evidence; interrupted streams retain
-partial evidence. Timing for Claude starts at the observed message start;
-SDK-internal HTTP retries before that event are not individually measured.
+partial evidence. Claude records the initial turn dispatch before waiting for
+the provider, so an early failure remains a call with unknown usage. Subsequent
+model-loop calls start at their observed message start; SDK-internal HTTP
+retries before that event are not individually measured.
 
 Compiler observations bypass the bounded diagnostic queue. On receipt, Runtime
 writes them to `capability-usage-outbox/<run>` and retries

--- a/docs/design/model-usage-observations.md
+++ b/docs/design/model-usage-observations.md
@@ -1,0 +1,58 @@
+# Provider usage observations
+
+The AgentBox records one logical call at the Pi stream-function boundary. API
+and subscription models use the same observation contract. Routing retries
+create separate calls; HTTP retries hidden inside Pi remain one logical call.
+This is runtime consumption telemetry, not an invoice or remaining allowance.
+
+## Evidence and identity
+
+Each call has a UUID, immutable dispatch timestamp, session and trace identity,
+model configuration snapshot, routing attempt and agent/auxiliary kind.
+Started and finished observations share that identity. Failed, cancelled and
+auxiliary calls are observed independently of visible assistant messages.
+
+Existing SDK usage and timing envelopes retain their meaning. The optional
+llmCall.call_id joins a timeline entry to an observation. A separate
+providerUsageEvidence captures allowlisted numeric fields, presence, protocol
+and terminal/intermediate status. It never contains prompts, headers,
+credentials or arbitrary provider properties. Invalid non-numeric values become
+field names in invalidFields; their values are discarded.
+
+The upstream normalizer owns accounting. OpenAI-compatible and Responses input
+already includes cache tokens. Anthropic input excludes separately reported
+cache read/write tokens. Reasoning is an output subset. Missing fields remain
+missing; SDK-initialized zeroes are not evidence of reported usage.
+
+## Persistence
+
+The outbox lives under agent/usage-outbox, outside session transcript
+directories, partitioned by agent and pod identity. Atomic file writes retain
+unacknowledged observations across process restarts on the same storage.
+Removing an ephemeral volume can still lose data; stale collector health must
+not be presented as complete account coverage.
+
+The authenticated AgentBox persistence channel carries usage.record_calls.
+The Runtime verifies session ownership, forwards allowed observations to
+usage.recordCalls, and returns per-observation acknowledgments. Accepted and
+duplicate records are removed. Retryable records stay on disk; rejected and
+dropped counts remain in collector state.
+
+Limits: 8 KiB per observation, 128 observations / 512 KiB per batch, 64 MiB per
+AgentBox outbox. Flushes start after 250 ms; transport errors back off from 1 to
+30 seconds. Idle collectors send health every 30 seconds. Shutdown allows a
+3-second flush and retains anything still unacknowledged.
+
+## Pinned SDK patch
+
+scripts/install/pi-usage-patch.mjs patches Pi AI 0.85.1. The manifest verifies
+original and patched SHA-256 values before writing; repeat installation is
+idempotent. It follows the installed Pi dependency graph, including nested
+copies created for peer dependencies. Unexpected versions or source hashes
+fail install. The installer,
+manifest and patch ship in npm packages and every backend Docker install stage.
+
+For upgrades, inspect the actual parsers, regenerate the patch and hashes,
+and run parser fixtures, logical-call tests, clean install and packed-package
+install checks. Responses SSE and WebSocket share the patched finalization path.
+Do not derive missing evidence from SDK counters.

--- a/kbc/platform/pod/Dockerfile
+++ b/kbc/platform/pod/Dockerfile
@@ -3,6 +3,8 @@
 FROM node:22.19-slim AS pi-builder
 WORKDIR /pi-worker
 COPY package.json package-lock.json ./
+COPY patches/ ./patches/
+COPY scripts/install/ ./scripts/install/
 RUN npm ci
 COPY tsconfig.json ./
 COPY src/ ./src/

--- a/kbc/platform/pod/claude_engine.py
+++ b/kbc/platform/pod/claude_engine.py
@@ -199,7 +199,7 @@ class ClaudeAgentClient:
                             blocks.append({"type": "toolCall", "id": value["id"],
                                            "name": self._names.get(value["name"], value["name"]), "arguments": value["input"]})
                 elif kind == "ResultMessage":
-                    await self._usage_recorder.finish("error" if message.is_error else "success", self._turn_id)
+                    await self._usage_recorder.finish("cancelled" if self._aborted else "error" if message.is_error else "success", self._turn_id)
                     await self._flush_assistant()
                     await self._stop_tools()
                     data = {"outcome": "aborted" if self._aborted else "failed" if message.is_error else "completed",
@@ -234,7 +234,12 @@ class ClaudeAgentClient:
         await self._emit("model_request", {"call": 1, "model": self.config["model"]["id"], "provider": self.config["model"]["provider"]})
         await self._emit("model_envelope", {"manifest": {"system_prompt_sha256": hashlib.sha256(self.system_prompt.encode()).hexdigest(),
                                                        "tools": list(self.tools), "model": self.config["model"]["id"]}})
-        await self._client.query(message)
+        await self._usage_recorder.begin(self._turn_id)
+        try:
+            await self._client.query(message)
+        except Exception:
+            await self._usage_recorder.finish("error", self._turn_id)
+            raise
 
     async def receive_messages(self):
         while True:

--- a/kbc/platform/pod/claude_engine.py
+++ b/kbc/platform/pod/claude_engine.py
@@ -14,6 +14,7 @@ import uuid
 
 from agent_protocol import AgentEvent, AgentTransportError, EngineTool
 from execution_observation import ExecutionObserver
+from model_usage import ClaudeUsageRecorder
 
 
 def sdk_version() -> str:
@@ -33,6 +34,7 @@ class ClaudeAgentClient:
         self.max_model_calls = max_model_calls
         self.sdk_version = sdk_version()
         self._observations = ExecutionObserver(session_id, self.config)
+        self._usage_recorder = ClaudeUsageRecorder(session_id, self.config, self._observations)
         self._client = None
         self._reader = None
         self._state = None
@@ -145,6 +147,7 @@ class ClaudeAgentClient:
         if self._assistant is None:
             return
         message, self._assistant = self._assistant, None
+        await self._usage_recorder.record_unobserved(message["id"], self._turn_id)
         self._model_calls += 1
         self._usage = dict(self._message_usage)
         await self._emit("assistant", {
@@ -158,6 +161,7 @@ class ClaudeAgentClient:
                 kind = type(message).__name__
                 if kind == "StreamEvent":
                     event = message.event
+                    await self._usage_recorder.observe(event, self._turn_id)
                     if event.get("type") == "message_start":
                         await self._flush_assistant()
                         self._message_usage = dict((event.get("message") or {}).get("usage") or {})
@@ -195,6 +199,7 @@ class ClaudeAgentClient:
                             blocks.append({"type": "toolCall", "id": value["id"],
                                            "name": self._names.get(value["name"], value["name"]), "arguments": value["input"]})
                 elif kind == "ResultMessage":
+                    await self._usage_recorder.finish("error" if message.is_error else "success", self._turn_id)
                     await self._flush_assistant()
                     await self._stop_tools()
                     data = {"outcome": "aborted" if self._aborted else "failed" if message.is_error else "completed",
@@ -208,6 +213,7 @@ class ClaudeAgentClient:
             if not self._closing:
                 raise AgentTransportError("Claude SDK stream closed before the session was closed")
         except Exception as error:
+            await self._usage_recorder.finish("error", self._turn_id)
             # Background transport boundary: wake the consumer with a failure.
             self._failure = AgentTransportError(self._safe_error(error))
             await self._observations.emit("transport_error", {}, self._turn_id)
@@ -222,6 +228,7 @@ class ClaudeAgentClient:
         if not self._client or self._closing or not self._settled.is_set():
             raise AgentTransportError("Previous Claude turn has not settled or session is unavailable")
         self._turn_id = str(uuid.uuid4())
+        self._usage_recorder.seen.clear()
         self._settled.clear()
         self._aborted, self._tool_calls, self._model_calls, self._status = False, 0, 0, None
         await self._emit("model_request", {"call": 1, "model": self.config["model"]["id"], "provider": self.config["model"]["provider"]})

--- a/kbc/platform/pod/execution_observation.py
+++ b/kbc/platform/pod/execution_observation.py
@@ -43,6 +43,7 @@ class ExecutionObserver:
             "ready": ("sdk_version",),
             "model_request": ("call", "model", "provider"),
             "model_envelope": ("manifest",),
+            "model_usage": ("observation",),
             "assistant": ("llm_call", "stop_reason"),
             "tool_start": ("call_id", "name"),
             "tool_end": ("call_id", "name", "is_error"),

--- a/kbc/platform/pod/model_usage.py
+++ b/kbc/platform/pod/model_usage.py
@@ -1,0 +1,90 @@
+"""Provider-native Claude stream usage; SDK aggregate defaults are not evidence."""
+
+import uuid
+from datetime import datetime, timezone
+
+_FIELDS = ("input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens")
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ClaudeUsageRecorder:
+    def __init__(self, session_id, config, observer):
+        self.session_id, self.config, self.observer = session_id, config, observer
+        self.call = None
+        self.seen = set()
+        self.raw = {}
+        self.terminal = False
+        self.response_id = None
+        self.response_model = None
+
+    async def observe(self, event, turn_id):
+        kind = event.get("type")
+        if kind == "message_start":
+            await self.finish("incomplete", turn_id)
+            model = self.config["model"]
+            self.call = {
+                "schemaVersion": 1, "callId": str(uuid.uuid4()), "phase": "started",
+                "sessionId": self.session_id, "requestId": turn_id, "requestAt": _now(),
+                "kind": "agent", "executionRole": "root", "routingAttempt": 1,
+                "executorRole": self.config.get("role", "compile"),
+                "model": {"configId": "", "name": model.get("name", model["id"]),
+                          "sourceKind": "unknown", "sourceId": "", "sourceName": "",
+                          "requestedId": model["id"], "runtimeProvider": model["provider"]},
+            }
+            message = event.get("message") or {}
+            self.response_id, self.response_model = message.get("id"), message.get("model")
+            self.raw, self.terminal = {}, False
+            self._merge(message.get("usage"))
+            await self._emit(self.call, turn_id)
+        elif kind == "message_delta" and self.call:
+            self._merge(event.get("usage"))
+        elif kind == "message_stop" and self.call:
+            self.terminal = True
+            await self.finish("success", turn_id)
+
+    def _merge(self, usage):
+        if isinstance(usage, dict):
+            for key in _FIELDS:
+                if key in usage:
+                    # Preserve invalid numeric types as invalid markers, never
+                    # coerce them to zero or retain arbitrary provider content.
+                    self.raw[key] = usage[key] if type(usage[key]) in (int, float) else "invalid"
+
+    async def _emit(self, observation, turn_id):
+        await self.observer.emit("model_usage", {"observation": observation}, turn_id)
+
+    async def finish(self, outcome, turn_id):
+        if self.call is None:
+            return
+        call, self.call = self.call, None
+        call = {**call, "phase": "finished", "finishedAt": _now(), "outcome": outcome,
+                "usageEvidence": {"protocol": "anthropic", "providerUsagePresent": bool(self.raw),
+                                  "finality": "terminal" if self.terminal else "intermediate", "rawUsage": dict(self.raw)}}
+        if isinstance(self.response_id, str):
+            call["responseId"] = self.response_id[:256]
+        if isinstance(self.response_model, str):
+            call["responseModel"] = self.response_model[:200]
+        if isinstance(self.response_id, str):
+            self.seen.add(self.response_id)
+        await self._emit(call, turn_id)
+
+    async def record_unobserved(self, message_id, turn_id):
+        # A legacy SDK message can establish that a call happened, but its
+        # normalized usage is not raw provider evidence.
+        if message_id in self.seen or (self.call is not None and message_id == self.response_id):
+            return
+        model = self.config["model"]
+        at = _now()
+        observation = {"schemaVersion": 1, "callId": str(uuid.uuid4()), "phase": "finished",
+                       "sessionId": self.session_id, "requestId": turn_id, "requestAt": at, "finishedAt": at,
+                       "kind": "agent", "executionRole": "root", "routingAttempt": 1, "outcome": "incomplete",
+                       "executorRole": self.config.get("role", "compile"),
+                       "model": {"configId": "", "name": model.get("name", model["id"]),
+                                 "sourceKind": "unknown", "sourceId": "", "sourceName": "",
+                                 "requestedId": model["id"], "runtimeProvider": model["provider"]}}
+        if message_id:
+            self.seen.add(message_id)
+        await self._emit(observation, turn_id)

--- a/kbc/platform/pod/model_usage.py
+++ b/kbc/platform/pod/model_usage.py
@@ -20,25 +20,33 @@ class ClaudeUsageRecorder:
         self.response_id = None
         self.response_model = None
 
+    async def begin(self, turn_id):
+        await self.finish("incomplete", turn_id)
+        model = self.config["model"]
+        self.call = {
+            "schemaVersion": 1, "callId": str(uuid.uuid4()), "phase": "started",
+            "sessionId": self.session_id, "requestId": turn_id, "requestAt": _now(),
+            "kind": "agent", "executionRole": "root", "routingAttempt": 1,
+            "executorRole": self.config.get("role", "compile"),
+            "model": {"configId": "", "name": model.get("name", model["id"]),
+                      "sourceKind": "unknown", "sourceId": "", "sourceName": "",
+                      "requestedId": model["id"], "runtimeProvider": model["provider"]},
+        }
+        self.response_id, self.response_model = None, None
+        self.raw, self.terminal = {}, False
+        await self._emit(self.call, turn_id)
+
     async def observe(self, event, turn_id):
         kind = event.get("type")
         if kind == "message_start":
-            await self.finish("incomplete", turn_id)
-            model = self.config["model"]
-            self.call = {
-                "schemaVersion": 1, "callId": str(uuid.uuid4()), "phase": "started",
-                "sessionId": self.session_id, "requestId": turn_id, "requestAt": _now(),
-                "kind": "agent", "executionRole": "root", "routingAttempt": 1,
-                "executorRole": self.config.get("role", "compile"),
-                "model": {"configId": "", "name": model.get("name", model["id"]),
-                          "sourceKind": "unknown", "sourceId": "", "sourceName": "",
-                          "requestedId": model["id"], "runtimeProvider": model["provider"]},
-            }
+            # Reuse the initial dispatch record. Later model-loop messages
+            # start a new call when their provider boundary becomes visible.
+            if self.call is None or self.response_id is not None:
+                await self.begin(turn_id)
             message = event.get("message") or {}
             self.response_id, self.response_model = message.get("id"), message.get("model")
             self.raw, self.terminal = {}, False
             self._merge(message.get("usage"))
-            await self._emit(self.call, turn_id)
         elif kind == "message_delta" and self.call:
             self._merge(event.get("usage"))
         elif kind == "message_stop" and self.call:
@@ -75,6 +83,10 @@ class ClaudeUsageRecorder:
         # A legacy SDK message can establish that a call happened, but its
         # normalized usage is not raw provider evidence.
         if message_id in self.seen or (self.call is not None and message_id == self.response_id):
+            return
+        if self.call is not None and self.response_id is None:
+            self.response_id = message_id
+            await self.finish("incomplete", turn_id)
             return
         model = self.config["model"]
         at = _now()

--- a/kbc/platform/pod/pi_engine.py
+++ b/kbc/platform/pod/pi_engine.py
@@ -126,6 +126,7 @@ class PiAgentClient:
                 "cwd": self.cwd, "state_dir": self._state.name,
                 "system_prompt": self.system_prompt,
                 "model": self.config["model"], "api_key": self.config["api_key"],
+                "executor_role": self.config.get("role", "compile"),
                 "auth_header": self.config.get("auth_header", True),
                 "headers": self.config.get("headers", {}),
                 "thinking_level": self.config.get("thinking_level", "off"),
@@ -211,7 +212,7 @@ class PiAgentClient:
                     if task:
                         task.cancel()
                     continue
-                if kind not in {"activity", "assistant", "tool_start", "tool_end", "model_request", "model_envelope", "result"}:
+                if kind not in {"activity", "assistant", "tool_start", "tool_end", "model_request", "model_envelope", "model_usage", "result"}:
                     raise AgentTransportError("Pi worker returned an unknown event")
                 if kind == "result":
                     if frame.get("outcome") not in {"completed", "failed", "aborted"} or self._executions:

--- a/kbc/platform/pod/test_claude_engine.py
+++ b/kbc/platform/pod/test_claude_engine.py
@@ -107,6 +107,14 @@ async def test_selected_claude_executes_host_tools_and_records_observations(tmp_
         assert events[-1].data["outcome"] == "completed"
         assert events[-1].data["tool_calls"] == 2
         assert len(requests) == 3
+        usage = [e["data"]["observation"] for e in observed if e["kind"] == "model_usage"]
+        finished = [e for e in usage if e["phase"] == "finished"]
+        assert len(finished) == len(requests)
+        assert len({e["callId"] for e in finished}) == len(requests)
+        assert all(e["executorRole"] == "compile" for e in finished)
+        assert all(e["usageEvidence"]["finality"] == "terminal" for e in finished)
+        assert all(e["usageEvidence"]["rawUsage"]["input_tokens"] == 42 for e in finished)
+        assert all(e["usageEvidence"]["rawUsage"]["output_tokens"] == 8 for e in finished)
         assert {"ready", "model_request", "model_envelope", "assistant", "tool_start", "tool_end", "result"} <= {e["kind"] for e in observed}
         assert "fixture-private-key" not in json.dumps(observed)
         assert "Synthetic retention" not in json.dumps(observed)

--- a/kbc/platform/pod/test_image_permissions.sh
+++ b/kbc/platform/pod/test_image_permissions.sh
@@ -18,6 +18,7 @@ trap cleanup EXIT HUP INT TERM
 
 cp "$KBC_TEST_ROOT/package.json" "$KBC_TEST_ROOT/package-lock.json" "$KBC_TEST_ROOT/tsconfig.json" "$KBC_TEST_ROOT/.dockerignore" "$KBC_TEST_CONTEXT/"
 cp -R "$KBC_TEST_ROOT/src" "$KBC_TEST_ROOT/kbc" "$KBC_TEST_CONTEXT/"
+cp -R "$KBC_TEST_ROOT/patches" "$KBC_TEST_ROOT/scripts" "$KBC_TEST_CONTEXT/"
 
 # Reproduce a checkout/build context created under a restrictive umask. Docker
 # can read these files as the builder user, but USER kbc must not depend on the

--- a/kbc/platform/pod/test_model_usage.py
+++ b/kbc/platform/pod/test_model_usage.py
@@ -44,6 +44,16 @@ class ModelUsageTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(evidence["finality"], "intermediate")
         self.assertEqual(sink.events[-1]["outcome"], "error")
 
+    async def test_failure_before_provider_response_still_records_the_dispatch(self):
+        recorder, sink = self.make()
+        await recorder.begin("turn")
+        await recorder.finish("error", "turn")
+        self.assertEqual(len(sink.events), 2)
+        self.assertEqual(sink.events[0]["callId"], sink.events[1]["callId"])
+        self.assertEqual(sink.events[1]["outcome"], "error")
+        self.assertFalse(sink.events[1]["usageEvidence"]["providerUsagePresent"])
+        self.assertEqual(sink.events[1]["usageEvidence"]["rawUsage"], {})
+
     async def test_sdk_only_message_is_unknown_and_repeated_blocks_do_not_duplicate(self):
         recorder, sink = self.make()
         await recorder.record_unobserved("sdk-message", "turn")

--- a/kbc/platform/pod/test_model_usage.py
+++ b/kbc/platform/pod/test_model_usage.py
@@ -1,0 +1,63 @@
+import unittest
+
+from model_usage import ClaudeUsageRecorder
+
+
+class Sink:
+    def __init__(self):
+        self.events = []
+
+    async def emit(self, kind, data, turn_id):
+        self.events.append(data["observation"])
+
+
+class ModelUsageTests(unittest.IsolatedAsyncioTestCase):
+    def make(self):
+        sink = Sink()
+        recorder = ClaudeUsageRecorder("session", {"role": "judge", "model": {
+            "id": "example", "provider": "gateway", "name": "Example"}}, sink)
+        return recorder, sink
+
+    async def test_native_cache_usage_and_terminal_are_recorded_once(self):
+        recorder, sink = self.make()
+        await recorder.observe({"type": "message_start", "message": {"id": "response", "usage": {
+            "input_tokens": 3, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 20}}}, "turn")
+        await recorder.observe({"type": "message_delta", "usage": {"output_tokens": 5}}, "turn")
+        await recorder.observe({"type": "message_stop"}, "turn")
+        await recorder.record_unobserved("response", "turn")
+        await recorder.finish("success", "turn")
+        self.assertEqual(len(sink.events), 2)
+        self.assertEqual(sink.events[0]["callId"], sink.events[1]["callId"])
+        evidence = sink.events[1]["usageEvidence"]
+        self.assertEqual(evidence["protocol"], "anthropic")
+        self.assertEqual(evidence["finality"], "terminal")
+        self.assertEqual(evidence["rawUsage"], {"input_tokens": 3, "output_tokens": 5,
+                         "cache_read_input_tokens": 0, "cache_creation_input_tokens": 20})
+        self.assertEqual(sink.events[1]["executorRole"], "judge")
+
+    async def test_transport_failure_preserves_partial_evidence(self):
+        recorder, sink = self.make()
+        await recorder.observe({"type": "message_start", "message": {"id": "response", "usage": {"input_tokens": 0}}}, "turn")
+        await recorder.finish("error", "turn")
+        evidence = sink.events[-1]["usageEvidence"]
+        self.assertEqual(evidence["rawUsage"], {"input_tokens": 0})
+        self.assertEqual(evidence["finality"], "intermediate")
+        self.assertEqual(sink.events[-1]["outcome"], "error")
+
+    async def test_sdk_only_message_is_unknown_and_repeated_blocks_do_not_duplicate(self):
+        recorder, sink = self.make()
+        await recorder.record_unobserved("sdk-message", "turn")
+        await recorder.record_unobserved("sdk-message", "turn")
+        self.assertEqual(len(sink.events), 1)
+        self.assertNotIn("usageEvidence", sink.events[0])
+
+    async def test_request_contents_are_never_copied_into_evidence(self):
+        recorder, sink = self.make()
+        await recorder.observe({"type": "message_start", "message": {"usage": {
+            "input_tokens": "secret", "output_tokens": 0, "prompt": "private"}}}, "turn")
+        await recorder.observe({"type": "message_stop"}, "turn")
+        self.assertEqual(sink.events[-1]["usageEvidence"]["rawUsage"], {"input_tokens": "invalid", "output_tokens": 0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kbc/platform/pod/test_pi_engine.py
+++ b/kbc/platform/pod/test_pi_engine.py
@@ -80,10 +80,18 @@ async def allow(*_):
 
 async def test_real_worker_unicode_tool_and_observation(tmp_path):
     content = "故障恢复与编译检查。\n" * 12000
+    observed = []
+
+    async def observe(event):
+        observed.append(event)
     async with provider(lambda _, n: completion(tool=("Write", {"file_path": "page.md", "content": content}))
                         if n == 1 else completion("已写入")) as (config, requests):
         tools = FileTools(str(tmp_path), ["Write"], allow).tools()
-        async with client(tmp_path, config, tools) as instance:
+        with observe_sessions(observe):
+            instance = PiAgentClient(cwd=str(tmp_path), system_prompt="Use the supplied tools.",
+                                     session_id="fixture-session", model_config=config, tools=tools)
+        try:
+            await instance.connect()
             await instance.query("Write the page")
             events = await collect(instance)
             assert instance.sdk_version == "0.85.1"
@@ -95,6 +103,15 @@ async def test_real_worker_unicode_tool_and_observation(tmp_path):
             assert all(event["llm_call"]["model"]["id"] == "fixture-model" for event in assistants)
             assert "content" not in assistants[0]["content"][0]["arguments"]
             assert len(requests) == 2
+            finished = [e["data"]["observation"] for e in observed if e["kind"] == "model_usage"
+                        and e["data"]["observation"]["phase"] == "finished"]
+            assert len(finished) == len(requests)
+            assert len({e["callId"] for e in finished}) == len(requests)
+            assert all(e["executorRole"] == "compile" for e in finished)
+            assert all(e["usageEvidence"]["rawUsage"]["prompt_tokens"] == 20 for e in finished)
+            assert all(e["usageEvidence"]["rawUsage"]["completion_tokens"] == 5 for e in finished)
+        finally:
+            await instance.disconnect()
 
 
 async def test_cancellation_waits_for_host_tool_before_next_turn(tmp_path):

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,8 @@
         "dingtalk-stream-sdk-nodejs": "^2.0.4",
         "discord.js": "^14.16.0",
         "grammy": "^1.41.1"
-      }
+      },
+      "hasInstallScript": true
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.71.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "portal-web/dist/",
     "siclaw.mjs",
     "skills/",
-    "settings.example.json"
+    "settings.example.json",
+    "patches/",
+    "scripts/install/"
   ],
   "license": "Apache-2.0",
   "publishConfig": {
@@ -121,6 +123,7 @@
     "docker:push:ocr": "docker push siclaw/siclaw-ocr:latest",
     "docker:push:agentbox": "docker push siclaw/siclaw-agentbox:latest",
     "dev:cli": "tsx src/cli-main.ts",
-    "prebuild": "node --input-type=module -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true });\""
+    "prebuild": "node --input-type=module -e \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true });\"",
+    "postinstall": "node scripts/install/pi-usage-patch.mjs"
   }
 }

--- a/patches/pi-ai-0.85.1.json
+++ b/patches/pi-ai-0.85.1.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.85.1",
+  "files": [
+    {
+      "path": "dist/api/openai-completions.js",
+      "before": "1e2097ced37cf0e21aa5711297eecc77916de8a4ed81a9019bc7d97b22825fa3",
+      "after": "78536857d76a3b31169e133467ed469695c7c884f1212d5d7eedccf243bf8221"
+    },
+    {
+      "path": "dist/api/openai-responses-shared.js",
+      "before": "b5d9f001e97bfafa8dfeef2e292f923c39f77fa8aef014132bf3530760f222e3",
+      "after": "1fe40a253fb60edf9f372e4186d7d3efba14189ba5654203e539b64151ef1bee"
+    },
+    {
+      "path": "dist/api/anthropic-messages.js",
+      "before": "f748560c80fe91bb5736b62f6f34c5e2e2bfa224cd5eb959134ca903c226b604",
+      "after": "85fbdc6869e547444adcc005b80de9550e5c0542ac9388abe762b6444f66323c"
+    },
+    {
+      "path": "dist/api/usage-evidence.js",
+      "before": null,
+      "after": "f561ace2311d56aa0e132c8449ce5b1b6be2c2a0d7f41febfd3e893c0a492b6f"
+    }
+  ]
+}

--- a/patches/pi-ai-0.85.1.patch
+++ b/patches/pi-ai-0.85.1.patch
@@ -1,0 +1,104 @@
+--- dist/api/openai-completions.js
++++ dist/api/openai-completions.js
+@@ -1,3 +1,4 @@
++import { captureUsage, finishUsage } from "./usage-evidence.js";
+ import OpenAI from "openai";
+ import { calculateCost, clampThinkingLevel } from "../models.js";
+ import { formatProviderError, normalizeProviderError } from "../utils/error-body.js";
+@@ -376,6 +377,7 @@
+                     output.responseModel ||= chunk.model;
+                 }
+                 if (chunk.usage) {
++                    captureUsage(output, chunk.usage, "openai_compatible", (hasFinishReason || chunk.choices?.[0]?.finish_reason || chunk.choices?.length === 0) ? "terminal" : "intermediate");
+                     output.usage = parseChunkUsage(chunk.usage, model);
+                 }
+                 const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
+@@ -384,6 +386,7 @@
+                 // Fallback: some providers (e.g., Moonshot) return usage
+                 // in choice.usage instead of the standard chunk.usage
+                 if (!chunk.usage && choice.usage) {
++                    captureUsage(output, choice.usage, "openai_compatible", choice.finish_reason ? "terminal" : "intermediate");
+                     output.usage = parseChunkUsage(choice.usage, model);
+                 }
+                 if (choice.finish_reason) {
+--- dist/api/openai-responses-shared.js
++++ dist/api/openai-responses-shared.js
+@@ -1,3 +1,4 @@
++import { captureUsage, finishUsage } from "./usage-evidence.js";
+ import { calculateCost } from "../models.js";
+ import { shortHash } from "../utils/hash.js";
+ import { parseStreamingJson } from "../utils/json-parse.js";
+@@ -431,6 +432,7 @@
+         }
+     };
+     const finalizeResponse = (response) => {
++        captureUsage(output, response?.usage, model.api === "openai-codex-responses" ? "codex_responses" : "openai_responses", "terminal");
+         sawTerminalResponseEvent = true;
+         backfillReasoningSignatures(response.output ?? []);
+         if (response?.id) {
+@@ -641,6 +643,7 @@
+             throw new Error(`Error Code ${event.code}: ${event.message}` || "Unknown error");
+         }
+         else if (event.type === "response.failed") {
++            captureUsage(output, event.response?.usage, model.api === "openai-codex-responses" ? "codex_responses" : "openai_responses", "terminal");
+             sawTerminalResponseEvent = true;
+             output.rawStopReason = event.response?.status;
+             const error = event.response?.error;
+--- dist/api/anthropic-messages.js
++++ dist/api/anthropic-messages.js
+@@ -1,3 +1,4 @@
++import { captureUsage, finishUsage } from "./usage-evidence.js";
+ import Anthropic from "@anthropic-ai/sdk";
+ import { calculateCost } from "../models.js";
+ import { splitDeferredTools } from "../utils/deferred-tools.js";
+@@ -395,6 +396,7 @@
+             const blocks = output.content;
+             for await (const event of iterateAnthropicEvents(response, options?.signal)) {
+                 if (event.type === "message_start") {
++                    captureUsage(output, event.message?.usage, "anthropic", "intermediate");
+                     output.responseId = event.message.id;
+                     const transformations = event.message.input_transformations;
+                     if (Array.isArray(transformations))
+@@ -553,7 +555,11 @@
+                         }
+                     }
+                 }
++                else if (event.type === "message_stop") {
++                    finishUsage(output);
++                }
+                 else if (event.type === "message_delta") {
++                    captureUsage(output, event.usage, "anthropic", "intermediate", true);
+                     const transformations = event.input_transformations;
+                     if (Array.isArray(transformations))
+                         inputTransformations = transformations;
+--- dist/api/usage-evidence.js
++++ dist/api/usage-evidence.js
+@@ -0,0 +1,28 @@
++// Capture only allowlisted numeric evidence. No request, response text, or credentials.
++const paths = ["input_tokens", "output_tokens", "total_tokens", "prompt_tokens", "completion_tokens",
++ "cache_read_input_tokens", "cache_creation_input_tokens", "prompt_cache_hit_tokens", "cached_tokens",
++ "input_tokens_details.cached_tokens", "input_tokens_details.cache_write_tokens",
++ "output_tokens_details.reasoning_tokens", "output_tokens_details.thinking_tokens",
++ "prompt_tokens_details.cached_tokens", "prompt_tokens_details.cache_write_tokens",
++ "completion_tokens_details.reasoning_tokens"];
++export function captureUsage(output, raw, protocol, finality, merge = false) {
++ if (!raw || typeof raw !== "object") return;
++ const previous = merge ? output.providerUsageEvidence : undefined;
++ const clean = previous ? structuredClone(previous.rawUsage) : {};
++ const invalid = new Set(previous?.invalidFields ?? []);
++ for (const path of paths) {
++  const parts = path.split(".");
++  let value = raw;
++  for (const part of parts) value = value && typeof value === "object" ? value[part] : undefined;
++  if (value == null) continue;
++  let target = clean;
++  for (const part of parts.slice(0, -1)) target = target[part] ??= {};
++  if (typeof value !== "number" || !Number.isFinite(value)) {
++   invalid.add(path); delete target[parts.at(-1)];
++  } else { target[parts.at(-1)] = value; invalid.delete(path); }
++ }
++ output.providerUsageEvidence = { protocol, providerUsagePresent: true, finality, rawUsage: clean, invalidFields: [...invalid].sort() };
++}
++export function finishUsage(output) {
++ if (output.providerUsageEvidence) output.providerUsageEvidence = { ...output.providerUsageEvidence, finality: "terminal" };
++}

--- a/scripts/install/pi-usage-patch.mjs
+++ b/scripts/install/pi-usage-patch.mjs
@@ -1,0 +1,49 @@
+import { readFileSync, writeFileSync, existsSync, realpathSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parsePatch, applyPatch } from 'diff';
+const here = dirname(fileURLToPath(import.meta.url));
+// Peer dependencies can give pi-coding-agent its own pi-ai copy. Follow the
+// installed Pi dependency graph so the model registry and the direct stream
+// entry points receive the same verified patch, including packed installs.
+const piPackages = new Set(['@earendil-works/pi-ai', '@earendil-works/pi-agent-core', '@earendil-works/pi-coding-agent']);
+const visited = new Set();
+const roots = new Set();
+function visit(root) {
+ root = realpathSync(root);
+ if (visited.has(root)) return;
+ visited.add(root);
+ const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+ if (pkg.name === '@earendil-works/pi-ai') roots.add(root);
+ const require = createRequire(resolve(root, 'package.json'));
+ for (const name of Object.keys(pkg.dependencies ?? {}).filter(name => piPackages.has(name))) {
+  const parent = require.resolve.paths(name).find(path => existsSync(resolve(path, name, 'package.json')));
+  if (!parent) throw new Error(`Usage patch dependency missing: ${name}`);
+  visit(resolve(parent, name));
+ }
+}
+visit(resolve(here, '../..'));
+if (!roots.size) throw new Error('Usage patch found no pi-ai installation');
+const manifest = JSON.parse(readFileSync(resolve(here, '../../patches/pi-ai-0.85.1.json'), 'utf8'));
+const patches = parsePatch(readFileSync(resolve(here, '../../patches/pi-ai-0.85.1.patch'), 'utf8'));
+const hash = (s) => createHash('sha256').update(s).digest('hex');
+const writes = [];
+for (const root of roots) {
+ const version = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).version;
+ if (version !== manifest.version) throw new Error(`Usage patch requires pi-ai ${manifest.version}; found ${version}`);
+ for (const entry of manifest.files) {
+  const path = resolve(root, entry.path);
+  const old = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  if (hash(old) === entry.after) continue;
+  if (entry.before === null ? old !== '' : hash(old) !== entry.before) throw new Error(`Usage patch source mismatch: ${entry.path}`);
+  const patch = patches.find(p => p.newFileName === entry.path);
+  const next = applyPatch(old, patch);
+  if (next === false || hash(next) !== entry.after) throw new Error(`Usage patch verification failed: ${entry.path}`);
+  writes.push([path, next]);
+ }
+}
+// Validate every source before writing any file. Re-running repairs an interrupted install.
+for (const [path, content] of writes) writeFileSync(path, content);
+console.log(`Verified pi-ai ${manifest.version} usage evidence patch (${roots.size} installations, ${writes.length} files applied)`);

--- a/src/agentbox/http-server.test.ts
+++ b/src/agentbox/http-server.test.ts
@@ -235,6 +235,7 @@ function makeFakeSessionManager(ledgerDir = fs.mkdtempSync(path.join(os.tmpdir()
   return {
     sessions,
     getOrCreateCalls,
+    setUsageRole: vi.fn(),
     ledgerDir,
     userId: "u",
     agentId: "a",

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -1000,6 +1000,7 @@ export function createHttpServer(
       body.handoffSupported === true,
       parseHandoffPolicy(body.handoffPolicy),
     );
+    sessionManager.setUsageRole(managed.id, String(body.origin) === "delegation" ? "delegated" : "root");
     if (managed.mcpManager) {
       observedMcpServers = managed.mcpManager.getServerConnections();
     }

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -770,7 +770,10 @@ export class AgentBoxSessionManager {
       }
     }
     brain.llmCalls?.setUsageSink?.({
-      context: () => ({ sessionId, executionRole: role, traceId: traceId ?? tracingRecorder.getRootTraceId(sessionId) }),
+      context: () => {
+        const rootTrace = traceId ?? tracingRecorder.getRootTraceId(sessionId);
+        return { sessionId, executionRole: role, traceId: rootTrace, ...(rootTrace ? { requestId: rootTrace } : {}) };
+      },
       record: observation => this.usageOutbox!.record(observation),
     });
   }

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -1,3 +1,4 @@
+import { UsageOutbox } from "./usage-outbox.js";
 /**
  * AgentBox session manager
  *
@@ -747,6 +748,33 @@ export class AgentBoxSessionManager {
    * Get base session storage directory.
    * Reads userDataDir from settings.json.
    */
+  private usageOutbox?: UsageOutbox;
+  setUsageRole(sessionId: string, role: "root" | "delegated"): void {
+    const managed = this.sessions.get(sessionId);
+    if (managed) this.attachUsage(managed.brain, sessionId, role);
+  }
+  private attachUsage(brain: BrainSession, sessionId: string, role: "root" | "internal_subagent" | "delegated", traceId?: string): void {
+    if (!this.gatewayClient || !this.agentId) return;
+    if (!this.usageOutbox) {
+      // Agent identity partitions local spawners that share a user data directory.
+      const agentKey = Buffer.from(this.agentId + ":" + (process.env.SICLAW_POD_NAME || "local")).toString("hex");
+      try {
+        this.usageOutbox = new UsageOutbox(path.join(this.getBaseSessionDir(), "..", "usage-outbox", agentKey), async batch => {
+          const result = await this.gatewayClient!.sendDelegationPersistenceEvent({ type: "usage.record_calls", batch });
+          if (!result.ok || !result.usage) throw new Error("usage persistence unavailable");
+          return result.usage;
+        });
+      } catch {
+        console.warn("[model-usage] collector unavailable; usage coverage is unknown");
+        return;
+      }
+    }
+    brain.llmCalls?.setUsageSink?.({
+      context: () => ({ sessionId, executionRole: role, traceId: traceId ?? tracingRecorder.getRootTraceId(sessionId) }),
+      record: observation => this.usageOutbox!.record(observation),
+    });
+  }
+
   private getBaseSessionDir(): string {
     const config = loadConfig();
     const userDataDir = path.resolve(process.cwd(), config.paths.userDataDir);
@@ -2833,6 +2861,7 @@ export class AgentBoxSessionManager {
     child.sessionIdRef.current = childSessionId;
     const mailbox = this.subagentRuns.get(childSessionId)?.mailbox;
     mailbox?.attach(child.brain);
+    this.attachUsage(child.brain, childSessionId, "internal_subagent", mainTraceId);
 
     // ── Model selection: tier, or the parent's effective model ──────────────
     //
@@ -3599,6 +3628,7 @@ export class AgentBoxSessionManager {
 
     // Populate sessionIdRef so skill_call events can associate with this session
     result.sessionIdRef.current = id;
+    this.attachUsage(result.brain, id, "root");
 
     // New session: sync memory index, then purge stale investigations (chained to avoid race)
     if (isMemoryEnabled() && isNewSession && this._sharedMemoryIndexer) {
@@ -4223,6 +4253,8 @@ export class AgentBoxSessionManager {
       this.teardownTracing(id, managed);
       emitDiagnostic({ type: "session_released", sessionId: id });
     }
+
+    await this.usageOutbox?.close();
 
     // Close shared memory indexer
     if (this._sharedMemoryIndexer) {

--- a/src/agentbox/usage-outbox.test.ts
+++ b/src/agentbox/usage-outbox.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { UsageOutbox } from "./usage-outbox.js";
+import type { UsageBatch, UsageObservation } from "../shared/model-usage.js";
+const directories: string[] = [];
+const dir = () => { const d = mkdtempSync(join(tmpdir(), "usage-test-"));directories.push(d);return d; };
+afterEach(() => { vi.useRealTimers(); for (const d of directories.splice(0)) rmSync(d, { recursive: true, force: true }); });
+const event = (): UsageObservation => ({ schemaVersion: 1, callId: randomUUID(), phase: "started", sessionId: "session-1", requestAt: new Date().toISOString(), kind: "agent", executionRole: "root", routingAttempt: 1, model: { configId: "model-1", name: "Example", sourceKind: "api", sourceId: "model-1", sourceName: "Example", requestedId: "gpt-example", runtimeProvider: "example" } });
+it("replays durable events after restart and removes only acknowledged records", async () => {
+  const directory=dir();const a=event(),b=event();
+  const failed=new UsageOutbox(directory,async()=>{throw new Error("offline");});
+  failed.record(a);failed.record(b);await failed.close();
+  const batches: UsageBatch[]=[];
+  const replay=new UsageOutbox(directory,async batch=>{batches.push(batch);return {results:[{callId:a.callId,phase:a.phase,status:"accepted"}]};});
+  await replay.close();
+  expect(batches[0].observations).toHaveLength(2);
+  expect(readdirSync(directory).filter(n=>n.endsWith(".event.json"))).toHaveLength(1);
+});
+it("reports capacity loss after recovery instead of claiming complete collection", async () => {
+  const batches:UsageBatch[]=[];
+  const outbox=new UsageOutbox(dir(),async batch=>{batches.push(batch);return{results:[]};},1);
+  outbox.record(event());await outbox.close();
+  expect(batches[0].health?.dropped).toBe(1);
+  expect(batches[0].observations).toEqual([]);
+});
+it("flushes new observations promptly while an idle heartbeat is scheduled", async () => {
+  vi.useFakeTimers();
+  const batches: UsageBatch[] = [];
+  const outbox = new UsageOutbox(dir(), async batch => {
+    batches.push(batch);
+    return { results: batch.observations.map(o => ({ callId: o.callId, phase: o.phase, status: "accepted" as const })) };
+  });
+  await vi.advanceTimersByTimeAsync(250);
+  outbox.record(event());
+  await vi.advanceTimersByTimeAsync(250);
+  expect(batches).toHaveLength(1);
+  expect(batches[0].observations).toHaveLength(1);
+  await outbox.close();
+});

--- a/src/agentbox/usage-outbox.ts
+++ b/src/agentbox/usage-outbox.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { UsageBatch, UsageBatchResponse, UsageObservation } from "../shared/model-usage.js";
+
+interface State { collectorId: string; sessionId: string; dropped: number; rejected: number; lastSuccessAt?: string }
+/** Independent of session transcripts: handoff cleanup must not delete pending usage. */
+export class UsageOutbox {
+  private state: State;
+  private bytes = 0;
+  private files = new Map<string, number>();
+  private timer?: ReturnType<typeof setTimeout>;
+  private timerAt = 0;
+  private active?: Promise<void>;
+  private stopped = false;
+  private retryMs = 1000;
+  constructor(
+    private readonly directory: string,
+    private readonly send: (batch: UsageBatch) => Promise<UsageBatchResponse>,
+    private readonly maxBytes = 64 * 1024 * 1024,
+  ) {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    this.state = { collectorId: randomUUID(), sessionId: "", dropped: 0, rejected: 0 };
+    try {
+      const state = JSON.parse(readFileSync(join(directory, "state.json"), "utf8"));
+      if (typeof state.collectorId !== "string" || typeof state.sessionId !== "string" ||
+          !Number.isSafeInteger(state.dropped) || !Number.isSafeInteger(state.rejected)) throw new Error("invalid state");
+      this.state = state;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        this.state.dropped++;
+        console.warn("[model-usage] collector state damaged; coverage is degraded");
+      }
+    }
+    for (const name of readdirSync(directory)) {
+      if (!name.endsWith(".event.json")) continue;
+      const size = statSync(join(directory, name)).size;
+      this.files.set(name, size);
+      this.bytes += size;
+    }
+    this.saveState();
+    this.schedule(250);
+  }
+  private saveState(): void {
+    const temporary = join(this.directory, "state.tmp");
+    writeFileSync(temporary, JSON.stringify(this.state), { mode: 0o600, flush: true });
+    renameSync(temporary, join(this.directory, "state.json"));
+  }
+  record(observation: UsageObservation): void {
+    this.state.sessionId = observation.sessionId;
+    try {
+      const content = JSON.stringify(observation);
+      const size = Buffer.byteLength(content);
+      if (size > 8192 || this.bytes + size > this.maxBytes) {
+        this.state.dropped++;
+        this.saveState();
+        console.warn("[model-usage] outbox capacity exceeded; coverage is degraded");
+        return;
+      }
+      const name = `${Date.now()}-${observation.callId}-${observation.phase}.event.json`;
+      const path = join(this.directory, name);
+      writeFileSync(path + ".tmp", content, { mode: 0o600, flush: true });
+      renameSync(path + ".tmp", path);
+      this.bytes += size - (this.files.get(name) ?? 0);
+      this.files.set(name, size);
+      this.saveState();
+      this.schedule(250);
+    } catch {
+      this.state.dropped++;
+      try { this.saveState(); } catch { /* Retain the counter in memory for the next health report. */ }
+      console.warn("[model-usage] outbox write failed; coverage is degraded");
+    }
+  }
+  private schedule(ms: number): void {
+    if (this.stopped) return;
+    const at = Date.now() + ms;
+    if (this.timer && this.timerAt <= at) return;
+    clearTimeout(this.timer);
+    this.timerAt = at;
+    this.timer = setTimeout(() => { this.timer = undefined; void this.flush(); }, ms);
+    this.timer.unref();
+  }
+  private remove(name: string): void {
+    unlinkSync(join(this.directory, name));
+    this.bytes -= this.files.get(name) ?? 0;
+    this.files.delete(name);
+  }
+  flush(): Promise<void> {
+    if (this.active) return this.active;
+    this.active = this.flushBatch().finally(() => { this.active = undefined; });
+    return this.active;
+  }
+  private async flushBatch(): Promise<void> {
+    try {
+      const entries: { name: string; observation: UsageObservation }[] = [];
+      let size = 0;
+      for (const name of [...this.files.keys()].sort()) {
+        if ((this.files.get(name) ?? 0) > 8192) {
+          this.state.rejected++; this.saveState(); this.remove(name); continue;
+        }
+        if (entries.length >= 128 || size + (this.files.get(name) ?? 0) > 500 * 1024) break;
+        try {
+          const observation = JSON.parse(readFileSync(join(this.directory, name), "utf8")) as UsageObservation;
+          if (observation.schemaVersion !== 1 || typeof observation.callId !== "string" ||
+              !["started", "finished"].includes(observation.phase) || typeof observation.sessionId !== "string") throw new Error("invalid");
+          entries.push({ name, observation });
+          size += this.files.get(name) ?? 0;
+        } catch {
+          // Corrupt observations are counted, never silently replayed as valid data.
+          this.state.rejected++;
+          this.saveState();
+          this.remove(name);
+        }
+      }
+      const sessionId = this.state.sessionId || entries[0]?.observation.sessionId;
+      if (!sessionId) { this.schedule(30_000); return; }
+      const response = await this.send({ observations: entries.map(e => e.observation), health: {
+        ...this.state, sessionId, pending: this.files.size,
+        oldestAt: entries[0]?.observation.requestAt, capturedAt: new Date().toISOString(),
+      } });
+      if (!Array.isArray(response.results)) throw new Error("missing acknowledgments");
+      for (const entry of entries) {
+        const ack = response.results.find(a => a.callId === entry.observation.callId && a.phase === entry.observation.phase);
+        if (!ack || ack.status === "retryable") continue;
+        if (ack.status === "rejected") { this.state.rejected++; this.saveState(); }
+        if (["accepted", "duplicate", "rejected"].includes(ack.status)) this.remove(entry.name);
+      }
+      this.state.lastSuccessAt = new Date().toISOString();
+      this.saveState();
+      this.retryMs = 1000;
+      this.schedule(this.files.size ? 250 : 30_000);
+    } catch {
+      this.schedule(this.retryMs);
+      this.retryMs = Math.min(this.retryMs * 2, 30_000);
+    }
+  }
+  async close(): Promise<void> {
+    this.stopped = true;
+    clearTimeout(this.timer);
+    await Promise.race([this.flush(), new Promise<void>(resolve => {
+      const timer = setTimeout(resolve, 3000); timer.unref();
+    })]);
+  }
+}

--- a/src/agentbox/usage-outbox.ts
+++ b/src/agentbox/usage-outbox.ts
@@ -13,6 +13,8 @@ export class UsageOutbox {
   private timerAt = 0;
   private active?: Promise<void>;
   private stopped = false;
+  private drained?: () => void;
+  retireWhenDrained(callback: () => void): void { this.drained = callback; }
   private retryMs = 1000;
   constructor(
     private readonly directory: string,
@@ -114,6 +116,7 @@ export class UsageOutbox {
       }
       const sessionId = this.state.sessionId || entries[0]?.observation.sessionId;
       if (!sessionId) { this.schedule(30_000); return; }
+      const wasEmpty = this.files.size === 0;
       const response = await this.send({ observations: entries.map(e => e.observation), health: {
         ...this.state, sessionId, pending: this.files.size,
         oldestAt: entries[0]?.observation.requestAt, capturedAt: new Date().toISOString(),
@@ -128,7 +131,10 @@ export class UsageOutbox {
       this.state.lastSuccessAt = new Date().toISOString();
       this.saveState();
       this.retryMs = 1000;
-      this.schedule(this.files.size ? 250 : 30_000);
+      if (wasEmpty && this.files.size === 0 && this.drained) {
+        this.stopped = true; clearTimeout(this.timer); this.drained(); return;
+      }
+      this.schedule(this.files.size || this.drained ? 250 : 30_000);
     } catch {
       this.schedule(this.retryMs);
       this.retryMs = Math.min(this.retryMs * 2, 30_000);

--- a/src/core/__fixtures__/subagent-tier-wire.golden.json
+++ b/src/core/__fixtures__/subagent-tier-wire.golden.json
@@ -54,17 +54,21 @@
     "never appears on spawn_subagent, and both suites stay green. That is exactly",
     "how the first integration attempt failed."
   ],
-
   "config_getAgent": {
     "subagent_model_tiers": {
       "revision": "0000000000000000000000000000000000000000000000000000000000000000",
       "items": [
-        { "tier": "fast", "whenToUse": "查日志、读代码、翻配置这类只需要检索和摘要的活" },
-        { "tier": "deep", "whenToUse": "需要跨多个证据源做因果推断、或结论要直接给人看的活" }
+        {
+          "tier": "fast",
+          "whenToUse": "查日志、读代码、翻配置这类只需要检索和摘要的活"
+        },
+        {
+          "tier": "deep",
+          "whenToUse": "需要跨多个证据源做因果推断、或结论要直接给人看的活"
+        }
       ]
     }
   },
-
   "config_getModelBinding": {
     "binding": {
       "subagentTiers": {
@@ -85,22 +89,35 @@
                   "id": "gpt-4o-mini",
                   "name": "gpt-4o-mini",
                   "reasoning": false,
-                  "input": ["text"],
-                  "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+                  "input": [
+                    "text"
+                  ],
+                  "cost": {
+                    "input": 0,
+                    "output": 0,
+                    "cacheRead": 0,
+                    "cacheWrite": 0
+                  },
                   "compat": {
                     "maxTokensField": "max_tokens",
                     "supportsDeveloperRole": false,
                     "supportsUsageInStreaming": true
                   }
                 }
-              ]
+              ],
+              "usageIdentity": {
+                "configId": "model-example",
+                "name": "Example model",
+                "sourceKind": "api",
+                "sourceId": "model-example",
+                "sourceName": "Example model"
+              }
             }
           }
         ]
       }
     }
   },
-
   "_rules": [
     "revision is 64 lowercase hex characters (SHA-256), computed over the RAW tier",
     "mapping sorted by tier — NOT over the hydrated candidates. Hashing the",

--- a/src/core/brains/pi-agent-brain.ts
+++ b/src/core/brains/pi-agent-brain.ts
@@ -567,7 +567,9 @@ export class PiAgentBrain implements BrainSession {
   }
 
   registerProvider(name: string, config: Record<string, unknown>): void {
-    this.session.modelRuntime.registerProvider(name, config as any);
+    const { usageIdentity, ...providerConfig } = config;
+    this.session.modelRuntime.registerProvider(name, providerConfig as any);
+    this.llmCalls?.registerUsageIdentity(name, usageIdentity);
   }
 
   /**

--- a/src/core/llm-call-recorder.ts
+++ b/src/core/llm-call-recorder.ts
@@ -156,6 +156,7 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
   }
 
   private promptOpen = false;
+  private usageRequestId = "";
   private promptExplicit = false;
   private promptReceivedAt?: number;
   private round = 0;
@@ -177,6 +178,7 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
     // fires later from inside the routing runner and must not reset the rounds.
     if (this.promptOpen && this.promptExplicit && !opts?.explicit) return;
     this.promptOpen = true;
+    this.usageRequestId = randomUUID();
     this.promptExplicit = opts?.explicit === true;
     this.promptReceivedAt = receivedAt ?? this.now();
     this.round = 0;
@@ -301,7 +303,7 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
       const provider = call.modelProvider ?? "";
       const identity = this.usageIdentities.get(provider) ?? { configId: "", name: call.modelId ?? "",
         sourceKind: "unknown" as const, sourceId: "", sourceName: "" };
-      call.observation = { schemaVersion: 1, callId: randomUUID(), phase: "started", ...this.usageSink.context(),
+      call.observation = { schemaVersion: 1, callId: randomUUID(), phase: "started", requestId: this.usageRequestId, ...this.usageSink.context(),
         requestAt: iso(call.requestAt), kind: call.kind, routingAttempt: this.attempt,
         model: { ...identity, requestedId: call.modelId ?? "", runtimeProvider: provider } };
       this.emitUsage(call.observation);

--- a/src/core/llm-call-recorder.ts
+++ b/src/core/llm-call-recorder.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import type { UsageEvidence, UsageIdentity, UsageObservation, UsageSink } from "../shared/model-usage.js";
 /**
  * LLM call recorder — measures every provider request at the `streamFn`
  * boundary and stamps the result onto the assistant message as `llmCall`.
@@ -48,6 +50,7 @@ export interface LlmCallUsage {
 
 export interface LlmCallEnvelope {
   v: typeof LLM_CALL_ENVELOPE_VERSION;
+  call_id?: string;
   /** 1-based index of this model call within the prompt. Only `agent` calls consume rounds. */
   round: number;
   /** Model-routing attempt number the call belongs to (1 when routing never switched). */
@@ -105,6 +108,8 @@ interface InFlightCall {
   modelProvider?: string;
   modelId?: string;
   sealedEnvelope?: LlmCallEnvelope;
+  observation?: UsageObservation;
+  evidence?: UsageEvidence;
 }
 
 export interface LlmCallRecorderOptions {
@@ -118,6 +123,7 @@ export interface LlmCallRecorderOptions {
  * boundaries without reaching into the recorder's internals.
  */
 export interface LlmCallPromptBoundary {
+  setUsageSink?(sink: UsageSink): void;
   /** A new prompt was accepted at `receivedAt` (ms epoch). Resets rounds. */
   beginPrompt(receivedAt?: number, opts?: { explicit?: boolean }): void;
   /** The prompt finished (every terminal path). */
@@ -131,6 +137,23 @@ export interface LlmCallPromptBoundary {
 export class LlmCallRecorder implements LlmCallPromptBoundary {
   private readonly now: () => number;
   private readonly warn: (message: string) => void;
+
+  private usageSink?: UsageSink;
+  private usageIdentities = new Map<string, UsageIdentity>();
+  setUsageSink(sink: UsageSink): void { this.usageSink = sink; }
+  registerUsageIdentity(provider: string, value: unknown): void {
+    if (!value || typeof value !== "object") return;
+    const v = value as UsageIdentity;
+    if (!["api", "subscription", "unknown"].includes(v.sourceKind)) return;
+    // Copy only non-secret fields; provider configs also carry credentials.
+    const text = (v: unknown, max: number) => typeof v === "string" ? v.slice(0, max) : "";
+    this.usageIdentities.set(provider, { configId: text(v.configId, 128), name: text(v.name, 200),
+      sourceKind: v.sourceKind, sourceId: text(v.sourceId, 128), sourceName: text(v.sourceName, 200) });
+  }
+  private emitUsage(observation: UsageObservation): void {
+    try { this.usageSink?.record(observation); }
+    catch { this.warn("[model-usage] observation could not be queued"); }
+  }
 
   private promptOpen = false;
   private promptExplicit = false;
@@ -265,7 +288,7 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
       // layer (child sub-agent, synthetic notify). Rounds still start at 1.
       this.beginPrompt(this.now());
     }
-    return {
+    const call: InFlightCall = {
       kind: Array.isArray(context?.tools) ? "agent" : "aux",
       requestAt: this.now(),
       blocks: [],
@@ -274,6 +297,16 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
       modelProvider: typeof model?.provider === "string" ? model.provider : undefined,
       modelId: typeof model?.id === "string" ? model.id : undefined,
     };
+    if (this.usageSink) {
+      const provider = call.modelProvider ?? "";
+      const identity = this.usageIdentities.get(provider) ?? { configId: "", name: call.modelId ?? "",
+        sourceKind: "unknown" as const, sourceId: "", sourceName: "" };
+      call.observation = { schemaVersion: 1, callId: randomUUID(), phase: "started", ...this.usageSink.context(),
+        requestAt: iso(call.requestAt), kind: call.kind, routingAttempt: this.attempt,
+        model: { ...identity, requestedId: call.modelId ?? "", runtimeProvider: provider } };
+      this.emitUsage(call.observation);
+    }
+    return call;
   }
 
   private wrapStream(stream: any, call: InFlightCall): any {
@@ -327,6 +360,10 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
   }
 
   private observeEvent(call: InFlightCall, event: any): void {
+    const partial = event?.partial ?? event?.message ?? event?.error;
+    if (partial?.providerUsageEvidence) call.evidence = structuredClone(partial.providerUsageEvidence);
+    if (event?.type === "done") this.sealCall(call, event.message);
+    if (event?.type === "error") this.sealCall(call, event.error);
     const type = event?.type;
     if (typeof type !== "string") return;
     const at = this.now();
@@ -472,6 +509,7 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
 
     const envelope: LlmCallEnvelope = {
       v: LLM_CALL_ENVELOPE_VERSION,
+      ...(call.observation ? { call_id: call.observation.callId } : {}),
       round: 0,
       attempt: this.attempt,
       kind: call.kind,
@@ -494,6 +532,15 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
       tool_call_ids: call.toolCallIds,
     };
     call.sealedEnvelope = envelope;
+    if (call.observation) {
+      const reason = message?.stopReason;
+      this.emitUsage({ ...call.observation, phase: "finished", finishedAt: iso(responseEndAt),
+        outcome: reason === "aborted" ? "cancelled" : reason === "error" ? "error" : reason === "length" ? "incomplete" : "success",
+        finishReason: typeof message?.rawStopReason === "string" ? message.rawStopReason.slice(0, 64) : typeof reason === "string" ? reason.slice(0, 64) : undefined,
+        responseId: typeof message?.responseId === "string" ? message.responseId.slice(0, 256) : undefined,
+        responseModel: typeof message?.responseModel === "string" ? message.responseModel.slice(0, 200) : undefined,
+        usageEvidence: message?.providerUsageEvidence ?? call.evidence });
+    }
 
     if (call.kind === "aux") {
       this.pendingAux.push(envelope);

--- a/src/core/model-usage.test.ts
+++ b/src/core/model-usage.test.ts
@@ -36,6 +36,19 @@ describe("provider evidence from the pinned parsers", () => {
     await expect(processResponsesStream((async function* () { yield { type: "response.failed", response: { status: "failed", usage, error: { code: "fixture", message: "failure" } } }; })(), output, { push() {} } as any, { ...model, api: "openai-codex-responses" })).rejects.toThrow();
     expect(output.providerUsageEvidence.rawUsage).toEqual(usage);
   });
+  it.each([undefined, {}])("preserves absent and empty Responses usage through call recording: %j", async rawUsage => {
+    const output: any = { content: [], usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: {} } };
+    const response = { status: "completed", output: [], ...(rawUsage === undefined ? {} : { usage: rawUsage }) };
+    await processResponsesStream((async function* () { yield { type: "response.completed", response }; })(), output, { push() {} } as any, { ...model, api: "openai-codex-responses" });
+    const events: UsageObservation[] = [];
+    const recorder = new LlmCallRecorder({ warn() {} });
+    recorder.setUsageSink({ context: () => ({ sessionId: "session-example", executionRole: "root" }), record: event => events.push(event) });
+    await recorder.wrapStreamFn(() => ({ async result() { return output; } }))(model, context, {}).result();
+    expect(events.map(event => event.phase)).toEqual(["started", "finished"]);
+    if (rawUsage === undefined) expect(events[1].usageEvidence).toBeUndefined();
+    else expect(events[1].usageEvidence).toMatchObject({ providerUsagePresent: true, rawUsage: {} });
+    expect(JSON.stringify(events[1].usageEvidence ?? {})).not.toContain("input_tokens");
+  });
   it("merges cumulative Anthropic usage without adding repeated snapshots", async () => {
     const result: any = await drain(streamAnthropic({ ...model, api: "anthropic-messages", provider: "anthropic" }, context, { apiKey: "fixture", fetch: fetchEvents([
       { type: "message_start", message: { id: "response-example", role: "assistant", model: "example", content: [], usage: { input_tokens: 40, cache_read_input_tokens: 60, output_tokens: 0 } } },

--- a/src/core/model-usage.test.ts
+++ b/src/core/model-usage.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { stream as streamOpenAICompletions } from "../../node_modules/@earendil-works/pi-ai/dist/api/openai-completions.js";
+import { stream as streamAnthropic } from "../../node_modules/@earendil-works/pi-ai/dist/api/anthropic-messages.js";
+import { processResponsesStream } from "../../node_modules/@earendil-works/pi-ai/dist/api/openai-responses-shared.js";
+import { LlmCallRecorder } from "./llm-call-recorder.js";
+import type { UsageObservation } from "../shared/model-usage.js";
+
+const model: any = { id: "gpt-example", name: "Example", provider: "openai", api: "openai-completions",
+  baseUrl: "https://api.example.test/v1", reasoning: false, input: ["text"], contextWindow: 10000, maxTokens: 100,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } };
+const context: any = { messages: [{ role: "user", content: "test", timestamp: 1 }], tools: [] };
+const usage = { input_tokens: 100, output_tokens: 20, total_tokens: 120, input_tokens_details: { cached_tokens: 60 }, output_tokens_details: { reasoning_tokens: 10 } };
+function fetchEvents(events: any[], named = false): typeof fetch {
+  return (async () => new Response(events.map(e => (named ? `event: ${e.type}\n` : "") + `data: ${JSON.stringify(e)}\n\n`).join("") +
+    (named ? "" : "data: [DONE]\n\n"), { headers: { "content-type": "text/event-stream" } })) as typeof fetch;
+}
+async function drain(stream: any) { for await (const _ of stream) { /* consume terminal event */ } return stream.result(); }
+describe("provider evidence from the pinned parsers", () => {
+  it("captures compatible inclusive input without changing legacy cache-exclusive usage", async () => {
+    const result: any = await drain(streamOpenAICompletions(model, context, { apiKey: "fixture", fetch: fetchEvents([
+      { id: "response-example", choices: [{ delta: { content: "ok" }, finish_reason: "stop" }] },
+      { choices: [], usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120, prompt_tokens_details: { cached_tokens: 60 } } },
+    ]) }));
+    expect(result.providerUsageEvidence.rawUsage.prompt_tokens).toBe(100);
+    expect(result.providerUsageEvidence.finality).toBe("terminal");
+    expect(result.usage.input).toBe(40);
+  });
+  it.each(["openai-responses", "openai-codex-responses"])("captures %s through the shared SSE/WebSocket processor", async api => {
+    const output: any = { content: [], usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: {} } };
+    await processResponsesStream((async function* () { yield { type: "response.completed", response: { id: "response-example", status: "completed", output: [], usage } }; })(), output, { push() {} } as any, { ...model, api });
+    expect(output.providerUsageEvidence).toMatchObject({ finality: "terminal", rawUsage: usage, protocol: api === "openai-codex-responses" ? "codex_responses" : "openai_responses" });
+    expect(output.usage.input).toBe(40);
+  });
+  it("retains reported usage on failed Responses", async () => {
+    const output: any = { content: [], usage: {} };
+    await expect(processResponsesStream((async function* () { yield { type: "response.failed", response: { status: "failed", usage, error: { code: "fixture", message: "failure" } } }; })(), output, { push() {} } as any, { ...model, api: "openai-codex-responses" })).rejects.toThrow();
+    expect(output.providerUsageEvidence.rawUsage).toEqual(usage);
+  });
+  it("merges cumulative Anthropic usage without adding repeated snapshots", async () => {
+    const result: any = await drain(streamAnthropic({ ...model, api: "anthropic-messages", provider: "anthropic" }, context, { apiKey: "fixture", fetch: fetchEvents([
+      { type: "message_start", message: { id: "response-example", role: "assistant", model: "example", content: [], usage: { input_tokens: 40, cache_read_input_tokens: 60, output_tokens: 0 } } },
+      { type: "message_delta", delta: {}, usage: { output_tokens: 5 } },
+      { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 20 } },
+      { type: "message_stop" },
+    ], true) }));
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.providerUsageEvidence).toMatchObject({ finality: "terminal", rawUsage: { input_tokens: 40, cache_read_input_tokens: 60, output_tokens: 20 } });
+  });
+  it("keeps missing evidence absent and sanitizes invalid optional strings", async () => {
+    const missing: any = await drain(streamOpenAICompletions(model, context, { apiKey: "fixture", fetch: fetchEvents([
+      { choices: [{ delta: {}, finish_reason: "stop" }] },
+    ]) }));
+    expect(missing.providerUsageEvidence).toBeUndefined();
+    const bad: any = await drain(streamOpenAICompletions(model, context, { apiKey: "fixture", fetch: fetchEvents([
+      { choices: [{ delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 0, completion_tokens: 0, prompt_tokens_details: { cached_tokens: "private-value" }, extra: "private-value" } },
+    ]) }));
+    expect(JSON.stringify(bad.providerUsageEvidence)).not.toContain("private-value");
+    expect(bad.providerUsageEvidence.invalidFields).toEqual(["prompt_tokens_details.cached_tokens"]);
+    expect(bad.providerUsageEvidence.rawUsage).toEqual({ prompt_tokens: 0, completion_tokens: 0, prompt_tokens_details: {} });
+  });
+});
+describe("independent logical call observations", () => {
+  it("retains failed attempts and trailing auxiliary calls under their dispatch identity", async () => {
+    const events: UsageObservation[] = [];
+    const recorder = new LlmCallRecorder({ warn() {} });
+    let trace = "trace-a";
+    recorder.setUsageSink({ context: () => ({ sessionId: "session-example", traceId: trace, executionRole: "root" }), record: o => events.push(o) });
+    recorder.registerUsageIdentity("openai", { configId: "config-a", name: "Example", sourceKind: "api", sourceId: "config-a", sourceName: "Example", apiKey: "private-value" });
+    recorder.beginPrompt();recorder.beginAttempt(1);
+    expect(() => recorder.wrapStreamFn(() => { throw new Error("fixture failure"); })(model, context, {})).toThrow();
+    recorder.rollbackAttempt();recorder.beginAttempt(2);
+    const stream = recorder.wrapStreamFn(() => ({ async result() { return { stopReason: "stop", providerUsageEvidence: { protocol: "codex_responses", providerUsagePresent: true, finality: "terminal", rawUsage: usage } }; } }))(model, { messages: [] }, {});
+    trace = "trace-b";
+    await stream.result();await stream.result();recorder.endPrompt();
+    expect(events.map(e => [e.phase, e.kind, e.routingAttempt])).toEqual([["started","agent",1],["finished","agent",1],["started","aux",2],["finished","aux",2]]);
+    expect(events[1].outcome).toBe("error");
+    expect(events[3].traceId).toBe("trace-a");
+    expect(new Set(events.map(e => e.callId)).size).toBe(2);
+    expect(JSON.stringify(events)).not.toContain("private-value");
+  });
+});

--- a/src/core/pi-sdk.contract.test.ts
+++ b/src/core/pi-sdk.contract.test.ts
@@ -16,6 +16,7 @@ import { createPiExecutionSession } from "./pi-execution.js";
 import { summarizeWithFallback } from "./compaction.js";
 import { resolveSessionThinkingLevel } from "./session-thinking.js";
 import { skillsHandler, knowledgeHandler } from "../agentbox/sync-handlers.js";
+import type { UsageObservation } from "../shared/model-usage.js";
 
 // Exercise installed Pi packages through the real HTTP serializer and agent loop.
 // Only the network boundary is replaced; no SDK classes or events are mocked.
@@ -100,7 +101,7 @@ async function createFixture(
   });
   cleanups.push(() => session.dispose());
   const brain = new PiAgentBrain(session, new Map(), llmCallRecorder);
-  return { brain, session, sessionManager, model, services, modelRuntime, onModelEnvelope, modelEnvelopeInspectionRef, sessionStarts };
+  return { brain, session, sessionManager, model, services, modelRuntime, onModelEnvelope, modelEnvelopeInspectionRef, sessionStarts, llmCallRecorder };
 }
 
 function resultTool(execute = vi.fn(async () => ({
@@ -114,6 +115,21 @@ function resultTool(execute = vi.fn(async () => ({
 }
 
 describe("installed Pi SDK contract", () => {
+  it("records provider evidence through the coding-agent's installed SDK dependency", async () => {
+    mockNetwork(() => completion({ content: "Completed." }));
+    const { brain, llmCallRecorder } = await createFixture();
+    const observations: UsageObservation[] = [];
+    llmCallRecorder.setUsageSink({
+      context: () => ({ sessionId: "session-example", executionRole: "root" }),
+      record: observation => observations.push(observation),
+    });
+    await brain.prompt("Confirm readiness.");
+    expect(observations.map(o => o.phase)).toEqual(["started", "finished"]);
+    expect(observations[1].usageEvidence).toMatchObject({
+      protocol: "openai_compatible", finality: "terminal", providerUsagePresent: true,
+      rawUsage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 },
+    });
+  });
   it("retains the requested default effort when a reasoning model is bound after bootstrap", async () => {
     const requests = mockNetwork(() => completion({ content: "Completed." }));
     const { brain, session, services, modelRuntime } = await createFixture();

--- a/src/core/subagent-tier-wire-contract.test.ts
+++ b/src/core/subagent-tier-wire-contract.test.ts
@@ -173,7 +173,7 @@ describe("the fixture PAYLOAD is pinned, so cross-repo drift is detectable", () 
    * same way lands on the same string; in Go, unmarshalling into a map and
    * re-marshalling sorts the keys for you.
    */
-  const EXPECTED_PAYLOAD_SHA256 = "de8aa805a00228e637f47d7480940f89361ba35de255ae9e8f76d6c2c31b7e4e";
+  const EXPECTED_PAYLOAD_SHA256 = "3c237cbf0702ed0bd3d7012af1126595329d181d2e8ac101c7db25b844995d13";
 
   it("has not drifted without the digest being updated", () => {
     const actual = crypto.createHash("sha256")

--- a/src/gateway/capability/execution-observation.ts
+++ b/src/gateway/capability/execution-observation.ts
@@ -1,3 +1,5 @@
+import { recordCapabilityUsage } from "./model-usage.js";
+import type { UsageObservation } from "../../shared/model-usage.js";
 import type { FrontendWsClient } from "../frontend-ws-client.js";
 import { CAPABILITY_PERSIST_EXECUTION_OBSERVATION } from "./contract.js";
 
@@ -59,6 +61,16 @@ export class ExecutionObservationRelay {
   }
 
   enqueue(observation: ExecutionObservation | undefined): void {
+    if (!this.closing && observation?.version === 1 && observation.kind === "model_usage") {
+      const usage = observation.data?.observation as UsageObservation | undefined;
+      if (!usage || usage.schemaVersion !== 1 || !/^[0-9a-f-]{36}$/i.test(usage.callId) ||
+          !["started", "finished"].includes(usage.phase) || typeof usage.sessionId !== "string") {
+        this.reportGap(); return;
+      }
+      try { recordCapabilityUsage(this.frontend, this.runId, usage); }
+      catch { this.reportGap(); }
+      return;
+    }
     if (this.closing || !observation || observation.version !== 1 ||
         this.queue.length + (this.pending ? 1 : 0) >= 128 ||
         Buffer.byteLength(JSON.stringify(observation)) > 64 * 1024) {

--- a/src/gateway/capability/model-usage.test.ts
+++ b/src/gateway/capability/model-usage.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { ExecutionObservationRelay } from "./execution-observation.js";
+import type { UsageBatch, UsageObservation } from "../../shared/model-usage.js";
+
+const configuration = vi.hoisted(() => ({ paths: { userDataDir: "" } }));
+vi.mock("../../core/config.js", () => ({ loadConfig: () => configuration }));
+beforeEach(() => { configuration.paths.userDataDir = mkdtempSync(path.join(tmpdir(), "compiler-usage-")); vi.useFakeTimers(); });
+afterEach(() => { vi.useRealTimers(); rmSync(configuration.paths.userDataDir, { recursive: true, force: true }); });
+
+it("persists compiler usage independently of the diagnostic queue and retries after run completion", async () => {
+  let attempts = 0;
+  const request = vi.fn(async (_method: string, params: { run_id: string; batch: UsageBatch }) => {
+    if (++attempts === 1) throw new Error("temporary control-plane outage");
+    return { results: params.batch.observations.map(o => ({ callId: o.callId, phase: o.phase, status: "accepted" })) };
+  });
+  const relay = new ExecutionObservationRelay({ request } as any, "run-123");
+  const observation: UsageObservation = { schemaVersion: 1, callId: randomUUID(), phase: "finished", sessionId: "compiler-session",
+    requestId: "turn-1", executorRole: "judge", executionRole: "root", requestAt: new Date().toISOString(), finishedAt: new Date().toISOString(),
+    kind: "agent", routingAttempt: 1, outcome: "success", model: { configId: "", name: "Example", sourceId: "", sourceName: "",
+      sourceKind: "unknown", requestedId: "example", runtimeProvider: "gateway" },
+    usageEvidence: { protocol: "openai_responses", finality: "terminal", providerUsagePresent: true, rawUsage: { input_tokens: 12, output_tokens: 3 } } };
+  relay.enqueue({ version: 1, id: randomUUID(), kind: "model_usage", session_id: observation.sessionId, turn_id: "turn-1",
+    observed_at: new Date().toISOString(), role: "judge", model_id: "example", provider: "gateway", data: { observation } });
+  await relay.close();
+  const directory = path.join(configuration.paths.userDataDir, "capability-usage-outbox", "run-123");
+  expect(readdirSync(directory).some(name => name.endsWith(".event.json"))).toBe(true);
+  await vi.advanceTimersByTimeAsync(1600);
+  expect(request.mock.calls.every(([method]) => method === "capability.recordModelUsage")).toBe(true);
+  expect(request.mock.calls[1][1].batch.observations[0]).toEqual(observation);
+  expect(readdirSync(directory).some(name => name.endsWith(".event.json"))).toBe(false);
+  await vi.runAllTimersAsync();
+  expect(request.mock.calls.at(-1)?.[1].batch.health?.pending).toBe(0);
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/src/gateway/capability/model-usage.ts
+++ b/src/gateway/capability/model-usage.ts
@@ -1,0 +1,38 @@
+import path from "node:path";
+import { existsSync, readdirSync } from "node:fs";
+import { UsageOutbox } from "../../agentbox/usage-outbox.js";
+import { loadConfig } from "../../core/config.js";
+import type { UsageBatchResponse, UsageObservation } from "../../shared/model-usage.js";
+import type { FrontendWsClient } from "../frontend-ws-client.js";
+
+const collectors = new WeakMap<FrontendWsClient, Map<string, UsageOutbox>>();
+function root(): string { return path.resolve(loadConfig().paths.userDataDir, "capability-usage-outbox"); }
+
+function collector(frontend: FrontendWsClient, runId: string): UsageOutbox {
+  if (!/^[a-zA-Z0-9_-]{1,64}$/.test(runId)) throw new Error("Invalid usage run identity");
+  let runs = collectors.get(frontend);
+  if (!runs) { runs = new Map(); collectors.set(frontend, runs); }
+  const active = runs.get(runId);
+  if (active) return active;
+  const outbox = new UsageOutbox(path.join(root(), runId), async batch =>
+    await frontend.request("capability.recordModelUsage", { run_id: runId, batch }) as UsageBatchResponse);
+  runs.set(runId, outbox);
+  // Final delivery keeps retrying after the compiler finishes. Once the empty
+  // health report is acknowledged, release the collector's timer and memory.
+  outbox.retireWhenDrained(() => { if (runs!.get(runId) === outbox) runs!.delete(runId); });
+  return outbox;
+}
+
+export function recordCapabilityUsage(frontend: FrontendWsClient, runId: string, observation: UsageObservation): void {
+  collector(frontend, runId).record(observation);
+}
+
+/** Replay pending records even when their originating run already completed. */
+export function recoverCapabilityUsage(frontend: FrontendWsClient): void {
+  const directory = root();
+  if (!existsSync(directory)) return;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !/^[a-zA-Z0-9_-]{1,64}$/.test(entry.name)) continue;
+    if (readdirSync(path.join(directory, entry.name)).some(name => name.endsWith(".event.json"))) collector(frontend, entry.name);
+  }
+}

--- a/src/gateway/internal-api.test.ts
+++ b/src/gateway/internal-api.test.ts
@@ -1462,3 +1462,24 @@ describe("handleMetricsFlush", () => {
     expect(errors).toBe(1);
   });
 });
+
+
+describe("model usage persistence ownership", () => {
+  it("forwards owned sessions and acknowledges foreign or unresolved sessions separately", async () => {
+    sessionRegistry.remember("parent-1", "user-1", "agent-1");
+    sessionRegistry.remember("parent-other", "user-2", "agent-2");
+    sessionRegistry.setResolver(async id => id === "parent-other" ? { userId: "user-2", agentId: "agent-2" } : null);
+    frontend.responses.set("usage.recordCalls", { results: [{ callId: "call-own", phase: "started", status: "accepted" }] });
+    const res = new FakeRes();
+    const observations = [{ callId: "call-own", sessionId: "parent-1", phase: "started" },
+      { callId: "call-foreign", sessionId: "parent-other", phase: "started" },
+      { callId: "call-missing", sessionId: "usage-unknown", phase: "started" }];
+    try {
+      await handleDelegationEvents(asReq(new FakeReq(JSON.stringify({ type: "usage.record_calls", batch: { observations } }))), asRes(res), identity, frontend as unknown as FrontendWsClient);
+      expect(res.statusCode).toBe(200);
+      expect(frontend.calls).toHaveLength(1);
+      expect(frontend.calls[0].params.observations).toEqual([observations[0]]);
+      expect(JSON.parse(res.body).usage.results.map((r: any) => r.status)).toEqual(["accepted", "rejected", "retryable"]);
+    } finally { sessionRegistry.setResolver(undefined); }
+  });
+});

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -179,6 +179,11 @@ async function validateDelegationEventActor(
   identity: CertificateIdentity,
 ): Promise<{ status: number; error: string } | null> {
   switch (event.type) {
+    case "usage.record_calls": {
+      if (!event.batch || !Array.isArray(event.batch.observations) || event.batch.observations.length > 128 ||
+          Buffer.byteLength(JSON.stringify(event.batch)) > 512 * 1024) return { status: 400, error: "invalid usage batch" };
+      return null;
+    }
     case "delegation.ensure_session": {
       if (!event.userId) return { status: 400, error: "delegation.ensure_session requires userId" };
       if (!agentMatchesIdentity(event.agentId, identity)) return { status: 403, error: "delegation agent mismatch" };
@@ -766,6 +771,26 @@ export async function handleDelegationEvents(
     let response: DelegationPersistenceResponse = { ok: true };
 
     switch (event.type) {
+      case "usage.record_calls": {
+        const ownership = new Map<string, "allowed" | "rejected" | "retryable">();
+        const sessionIds = new Set(event.batch.observations.map(o => o.sessionId));
+        if (event.batch.health) sessionIds.add(event.batch.health.sessionId);
+        for (const sessionId of sessionIds) {
+          if (!sessionId) { ownership.set(sessionId, "rejected"); continue; }
+          const owner = await sessionRegistry.get(sessionId);
+          ownership.set(sessionId, !owner ? "retryable" : await sessionBelongsToIdentity(sessionId, identity) ? "allowed" : "rejected");
+        }
+        const observations = event.batch.observations.filter(o => ownership.get(o.sessionId) === "allowed");
+        const health = event.batch.health && ownership.get(event.batch.health.sessionId) === "allowed" ? event.batch.health : undefined;
+        const usage: NonNullable<DelegationPersistenceResponse["usage"]> = observations.length || health
+          ? await frontendClient.request("usage.recordCalls", { observations, health }) : { results: [] };
+        for (const o of event.batch.observations) {
+          const status = ownership.get(o.sessionId);
+          if (status === "rejected" || status === "retryable") usage.results.push({ callId: o.callId, phase: o.phase, status, reason: "session_unavailable" });
+        }
+        response = { ok: true, usage };
+        break;
+      }
       case "delegation.ensure_session": {
         await frontendClient.request("chat.ensureSession", {
           session_id: event.sessionId,

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -32,6 +32,7 @@ import type { AgentBoxManager } from "./agentbox/manager.js";
 import { AgentBoxClient, type PromptOptions } from "./agentbox/client.js";
 import { getBoxProfile } from "./agentbox/box-profile.js";
 import { buildSpawnEnv } from "./agentbox/spawn-env.js";
+import { recoverCapabilityUsage } from "./capability/model-usage.js";
 import { CapabilityRunManager } from "./capability/run-manager.js";
 import { acquireCapabilityBox } from "./capability/box-acquire.js";
 import { driveCapabilitySession } from "./capability/session-driver.js";
@@ -1431,6 +1432,7 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
 
   // Recover AFTER ensureCapabilitySession exists — onAdopt re-attaches through it.
   const unsubscribeCapabilityReconnect = frontendClient.onConnected?.(() => capabilityRunManager.reconcile());
+  recoverCapabilityUsage(frontendClient);
   void capabilityRunManager.recover();
   capabilityRunManager.startWatchdog();
   // Capability-box orphan GC: a box is live iff its run is tracked and

--- a/src/kbc/pi-worker-protocol.ts
+++ b/src/kbc/pi-worker-protocol.ts
@@ -19,6 +19,7 @@ export interface WorkerInit {
   system_prompt: string;
   model: Model<Api>;
   api_key: string;
+  executor_role?: string;
   auth_header?: boolean;
   headers?: ProviderHeaders;
   thinking_level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
@@ -54,6 +55,7 @@ export function parseWorkerInput(value: unknown): WorkerInput {
       for (const key of ["session_id", "cwd", "state_dir", "api_key"]) text(key);
       text("system_prompt", true);
       if (frame.auth_header !== undefined && typeof frame.auth_header !== "boolean") throw new Error("Invalid auth header mode");
+      if (frame.executor_role !== undefined && (typeof frame.executor_role !== "string" || frame.executor_role.length > 32)) throw new Error("Invalid executor role");
       const model = frame.model;
       if (!model || typeof model !== "object" ||
           !["id", "provider", "api", "baseUrl"].every(key => typeof model[key] === "string" && model[key].trim()) ||

--- a/src/kbc/pi-worker.ts
+++ b/src/kbc/pi-worker.ts
@@ -163,7 +163,12 @@ export class PiCompilerWorker {
       guards,
       onModelEnvelope: manifest => this.emit("model_envelope", { manifest }),
     });
-    const { session } = this.execution;
+    const { session, llmCallRecorder } = this.execution;
+    llmCallRecorder.setUsageSink({
+      context: () => ({ sessionId: config.session_id, requestId: this.active?.id,
+        executionRole: "root", executorRole: config.executor_role ?? "compile" }),
+      record: observation => this.emit("model_usage", { observation }),
+    });
     const stream = session.agent.streamFunction;
     session.agent.streamFunction = (requestedModel, context, options) => {
       if (this.calls >= config.max_model_calls) throw new Error("KBC_MODEL_CALL_BUDGET_EXCEEDED");

--- a/src/shared/delegation-persistence.ts
+++ b/src/shared/delegation-persistence.ts
@@ -1,3 +1,4 @@
+import type { UsageBatch, UsageBatchResponse } from "./model-usage.js";
 // Type-only import (erased at runtime; src/shared already type-imports from src/core elsewhere,
 // and tool-registry does not import shared → no cycle). Keeps the group item-status snapshot
 // precisely typed on the wire.
@@ -157,6 +158,7 @@ export interface ChannelDeliverMessagePayload {
 }
 
 export type DelegationPersistenceEvent =
+  | { type: "usage.record_calls"; batch: UsageBatch }
   | {
       type: "delegation.ensure_session";
       sessionId: string;
@@ -175,6 +177,7 @@ export type DelegationPersistenceEvent =
   | { type: "channel.deliver_message"; message: ChannelDeliverMessagePayload };
 
 export interface DelegationPersistenceResponse {
+  usage?: UsageBatchResponse;
   ok: boolean;
   id?: string;
 }

--- a/src/shared/model-usage.ts
+++ b/src/shared/model-usage.ts
@@ -19,6 +19,9 @@ export interface UsageObservation {
   phase: "started" | "finished";
   sessionId: string;
   traceId?: string;
+  requestId?: string;
+  parentCallId?: string;
+  executorRole?: string;
   requestAt: string;
   finishedAt?: string;
   kind: "agent" | "aux";
@@ -46,6 +49,6 @@ export interface UsageBatchResponse {
   results: { callId: string; phase: string; status: "accepted" | "duplicate" | "rejected" | "retryable"; reason?: string }[];
 }
 export interface UsageSink {
-  context(): Pick<UsageObservation, "sessionId" | "traceId" | "executionRole">;
+  context(): Pick<UsageObservation, "sessionId" | "traceId" | "executionRole" | "requestId" | "parentCallId" | "executorRole">;
   record(observation: UsageObservation): void;
 }

--- a/src/shared/model-usage.ts
+++ b/src/shared/model-usage.ts
@@ -1,0 +1,51 @@
+/** Numeric provider evidence is independent of the legacy SDK usage envelope. */
+export interface UsageEvidence {
+  protocol: string;
+  providerUsagePresent: boolean;
+  finality: "terminal" | "intermediate" | "missing";
+  rawUsage: Record<string, unknown>;
+  invalidFields?: string[];
+}
+export interface UsageIdentity {
+  configId: string;
+  name: string;
+  sourceKind: "api" | "subscription" | "unknown";
+  sourceId: string;
+  sourceName: string;
+}
+export interface UsageObservation {
+  schemaVersion: 1;
+  callId: string;
+  phase: "started" | "finished";
+  sessionId: string;
+  traceId?: string;
+  requestAt: string;
+  finishedAt?: string;
+  kind: "agent" | "aux";
+  executionRole: "root" | "internal_subagent" | "delegated";
+  routingAttempt: number;
+  outcome?: "success" | "error" | "cancelled" | "incomplete";
+  finishReason?: string;
+  responseModel?: string;
+  responseId?: string;
+  model: UsageIdentity & { requestedId: string; runtimeProvider: string };
+  usageEvidence?: UsageEvidence;
+}
+export interface UsageHealth {
+  collectorId: string;
+  sessionId: string;
+  pending: number;
+  rejected: number;
+  dropped: number;
+  oldestAt?: string;
+  lastSuccessAt?: string;
+  capturedAt: string;
+}
+export interface UsageBatch { observations: UsageObservation[]; health?: UsageHealth }
+export interface UsageBatchResponse {
+  results: { callId: string; phase: string; status: "accepted" | "duplicate" | "rejected" | "retryable"; reason?: string }[];
+}
+export interface UsageSink {
+  context(): Pick<UsageObservation, "sessionId" | "traceId" | "executionRole">;
+  record(observation: UsageObservation): void;
+}


### PR DESCRIPTION
Record independent model-call observations for chat, analysis, routing attempts, compaction and compiler roles. Capture provider-native numeric evidence before normalization and preserve missing fields across supported API and subscription models. SDK-only usage remains unknown, and interruption outcomes remain distinct.

AgentBox delivers through its durable outbox. Compiler observations bypass the diagnostic queue, enter a durable Runtime outbox and retry independently of run completion. The consuming control plane owns workload, Agent, user, repository/profile and frozen model attribution.

Validation: TypeScript build, focused parser/recording tests and compiler measurement tests passed. Broader regressions retain previously reproduced self-check failures. Integration checks used synthetic inputs for real chat, analysis and knowledge compilation, reconciling recorded evidence and attribution. Deploy the paired ingestion backend before the execution components.

Coverage begins with instrumented dispatches. Compiler delivery before Runtime receipt, surviving outbox storage and SDK-internal HTTP retries remain boundaries. This measures observed token consumption; invoice pricing and remaining subscription allowance are separate.
