### PR TITLE
fix(tools): align preview errors and persisted tool outcomes

### DIFF
--- a/docs/completion/2026-09-10-remove-tui.md
+++ b/docs/completion/2026-09-10-remove-tui.md
@@ -362,3 +362,37 @@ Final compatibility check: single-message detail preserves legacy JSON text up
 to the same byte budget, so malformed structured metadata can still fall back.
 Oversized detail text is suppressed. The 259 affected Portal checks and backend
 build passed after this adjustment.
+
+### Remaining boundary: tool budget and storage budget
+
+The tool now checks the shared 1 MiB serialized UTF-8 ceiling before returning
+its result to the model or capturing an output artifact. This prevents previews
+above that ceiling from claiming they can be viewed or copied. It does **not**
+make tool acceptance a guarantee that the host will persist the package.
+
+For MySQL, `preparePreviewWrite` uses this per-message limit, in bytes:
+
+```text
+max(1024, min(1048576, floor(max_allowed_packet / 2) - otherBytes - 32768))
+otherBytes = utf8Bytes(content) + utf8Bytes(tool_input)
+```
+
+With a 1 MiB packet and small content/input, a 600 KiB preview can pass the tool
+check and still be omitted by the writer. With a 4 MiB packet and the same small
+columns, the shared 1 MiB ceiling is the tighter limit. The earlier 4 MiB
+database acceptance did not exercise the first case. The 1/4 MiB packet unit
+cases in `src/portal/skill-preview-storage.test.ts` cover both writer outcomes;
+they do not establish live-model agreement under the smaller packet limit.
+
+On a late omission, the writer replaces the history metadata and content with
+an omission notice, but it cannot retract a success summary already delivered
+to the model in the current turn. Metadata added downstream and expansion
+during redaction can also cause a late omission. These remain known limits of
+the model/panel consistency fix.
+
+Closing the capacity gap requires the host to derive a conservative effective
+preview budget and pass it through Runtime configuration to AgentBox, reserving
+space for the other columns, envelope metadata and escaping. AgentBox must not
+import the database layer to discover that budget. The host still needs its
+write-time guard for capacity changes and unexpected expansion. This budget
+propagation is follow-up work, not implemented by the shared-ceiling check.

--- a/docs/design/2026-08-02-error-surfacing-contract.md
+++ b/docs/design/2026-08-02-error-surfacing-contract.md
@@ -153,6 +153,13 @@ consumer behaviour on the strength of it.
 
 ## Consequences
 
+Tool-call failures have two representations: the event's `isError` flag for a
+thrown failure, and `result.details.error` for a returned tool error. Either
+must persist as `outcome: error` in Web and channel history, even if the other
+flag is absent or false. An explicit `details.blocked` retains the more specific
+`blocked` outcome. These are individual tool outcomes, not failed-turn render
+signals; they must not manufacture a `stream_error` for the whole turn.
+
 - Adding a render path for a new error-shaped event means asking whether it is
   a fact or an instruction. If a consumer must decide *whether* to show
   something, the decision belongs in `sse-consumer.ts`, where suppression and

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -553,6 +553,13 @@ Conditions are declared in each tool's `registration`, not in agent-factory:
 | `memory_search`, `memory_get` | `available` | `(refs) => !!refs.memoryIndexer` | Depends on indexer instance |
 | `knowledge_search` | `available` | `(refs) => !!refs.knowledgeIndexer` | Hybrid index over this Agent's mounted knowledge |
 
+Skill draft previews share the chat metadata budget of 1 MiB, measured as
+serialized UTF-8 JSON (including file projections and escaping). A package
+that exceeds it returns an error and an `omitted` preview notice to the model
+before artifact capture. A recoverable tool-output artifact does not promise
+that a chat panel can display its files. Accepted previews retain complete
+files in metadata; history loading and redaction still enforce their own bounds.
+
 ### allowedTools — Built-in and File-Tool Availability Axis
 
 `allowedTools` is the control over registry tools and framework file tools after

--- a/docs/design/tools.md
+++ b/docs/design/tools.md
@@ -553,12 +553,16 @@ Conditions are declared in each tool's `registration`, not in agent-factory:
 | `memory_search`, `memory_get` | `available` | `(refs) => !!refs.memoryIndexer` | Depends on indexer instance |
 | `knowledge_search` | `available` | `(refs) => !!refs.knowledgeIndexer` | Hybrid index over this Agent's mounted knowledge |
 
-Skill draft previews share the chat metadata budget of 1 MiB, measured as
+Skill draft previews enforce a shared ceiling of 1 MiB, measured as
 serialized UTF-8 JSON (including file projections and escaping). A package
 that exceeds it returns an error and an `omitted` preview notice to the model
 before artifact capture. A recoverable tool-output artifact does not promise
-that a chat panel can display its files. Accepted previews retain complete
-files in metadata; history loading and redaction still enforce their own bounds.
+that a chat panel can display its files. Passing this check keeps full files in
+the tool details; it does not confirm persistence. The host may impose a lower
+MySQL packet budget, and later metadata or redaction expansion can exceed the
+remaining budget. Those paths can still omit the preview after the model has
+seen a success summary. See the [preview budget boundary](../completion/2026-09-10-remove-tui.md#remaining-boundary-tool-budget-and-storage-budget)
+for the effective limit and the configuration work needed to close that gap.
 
 ### allowedTools — Built-in and File-Tool Availability Axis
 

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -4396,6 +4396,23 @@ describe("collectChannelResponse — audit persistence", () => {
     expect(toolRows.map((m) => m.outcome)).toEqual(["error", "blocked"]);
   });
 
+  it.each(["tool_execution_end", "tool_end"])("persists thrown tool failures from %s in channel history", async (type) => {
+    const events = [
+      { type: "tool_execution_start", toolName: "spawn_subagent", toolCallId: "bad-handle", args: { resume: "invalid" } },
+      { type, toolName: "spawn_subagent", toolCallId: "bad-handle", isError: true,
+        result: { content: [{ type: "text", text: "Invalid subagent handle" }] } },
+      { type: "tool_execution_start", toolName: "lookup", toolCallId: "bad-lookup", args: {} },
+      { type, toolName: "lookup", toolCallId: "bad-lookup", isError: true,
+        result: { content: [{ type: "text", text: "Lookup failed" }], details: { error: false } } },
+      { type: "tool_execution_start", toolName: "blocked", toolCallId: "blocked", args: {} },
+      { type, toolName: "blocked", toolCallId: "blocked", isError: true, result: { content: [], details: { blocked: true } } },
+    ];
+    await collectChannelResponse(fakeClient(events), "s-error", "lark", { persist: { agentId: "a1" } });
+    const rows = appendMessageMock.mock.calls.map(c => c[0] as any).filter(m => m.role === "tool");
+    expect(rows.map(m => m.outcome)).toEqual(["error", "error", "blocked"]);
+    expect(rows.slice(0, 2).map(m => m.content)).toEqual(["Invalid subagent handle", "Lookup failed"]);
+  });
+
   it("keeps invocation toolsets stable for out-of-order same-name calls", async () => {
     const events = [
       { type: "tool_execution_start", toolCallId: "a", toolName: "query", toolset: "mcp:cluster-a", args: { q: "a" } },

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -9,7 +9,7 @@ import { ConversationClient, supportsConversations } from "../conversation-clien
 
 import { AssistantItemStream } from "../assistant-item-stream.js";
 import { assistantTextBlocks } from "../../shared/assistant-items.js";
-import { persistableToolDetails, traceVisualIds } from "../../shared/tool-result-metadata.js";
+import { persistableToolDetails, toolResultOutcome, traceVisualIds } from "../../shared/tool-result-metadata.js";
 import type { AgentBoxManager } from "../agentbox/manager.js";
 import { AgentBoxClient, type PromptOptions } from "../agentbox/client.js";
 import type { ChannelHandler } from "../channel-manager.js";
@@ -3385,9 +3385,7 @@ export async function collectChannelResponse(
           const resultText = Array.isArray(ev.result?.content)
             ? ev.result.content.filter((c: any) => c?.type === "text").map((c: any) => c.text ?? "").join("")
             : "";
-          let outcome: "success" | "error" | "blocked" = "success";
-          if (ev.result?.details?.blocked) outcome = "blocked";
-          else if (ev.result?.details?.error) outcome = "error";
+          const outcome = toolResultOutcome(ev.result?.details, ev.isError);
           const key = toolKey(ev, name);
           const input = shiftQ(toolInputs, key) || "";
           const start = shiftQ(toolStarts, key);

--- a/src/gateway/sse-consumer.test.ts
+++ b/src/gateway/sse-consumer.test.ts
@@ -1031,7 +1031,7 @@ describe("consumeAgentSse — tool execution", () => {
   it("marks outcome=blocked when details.blocked is true", async () => {
     const events = [
       { type: "tool_execution_start", toolName: "dangerous", args: {} },
-      { type: "tool_execution_end", toolName: "dangerous",
+      { type: "tool_execution_end", toolName: "dangerous", isError: true,
         result: { content: [{ type: "text", text: "blocked" }], details: { blocked: true } } },
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
@@ -1041,11 +1041,25 @@ describe("consumeAgentSse — tool execution", () => {
   it("marks outcome=error when details.error is true", async () => {
     const events = [
       { type: "tool_execution_start", toolName: "t", args: {} },
-      { type: "tool_execution_end", toolName: "t",
+      { type: "tool_execution_end", toolName: "t", isError: false,
         result: { content: [{ type: "text", text: "oops" }], details: { error: true } } },
     ];
     await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
     expect(updateCalls[0].outcome).toBe("error");
+  });
+
+  it.each(["tool_execution_end", "tool_end"])("persists thrown tool failures from %s even without details.error", async (type) => {
+    const failures = ["Invalid subagent handle", "Handle index out of range", "Handle from another session", "Handle from another caller"];
+    const events = failures.flatMap((text, i) => [
+      { type: "tool_execution_start", toolName: "spawn_subagent", toolCallId: `call-${i}`, args: { resume: `invalid-${i}` } },
+      { type, toolName: "spawn_subagent", toolCallId: `call-${i}`, isError: true,
+        result: { content: [{ type: "text", text }], ...(i === 0 ? {} : { details: i === 1 ? {} : { error: false } }) } },
+    ]);
+    await consumeAgentSse({ client: mkClient(events), sessionId: "s", userId: "u", persistMessages: true });
+    const rows = JSON.parse(JSON.stringify(updateCalls));
+    expect(rows.map((row: any) => row.outcome)).toEqual(failures.map(() => "error"));
+    expect(rows.map((row: any) => row.content)).toEqual(failures);
+    expect(rows.map((row: any) => row.messageId)).toEqual(["msg-1", "msg-2", "msg-3", "msg-4"]);
   });
 
   it("persists tool details as metadata (dropping blocked/error flags that are surfaced via outcome)", async () => {

--- a/src/gateway/sse-consumer.ts
+++ b/src/gateway/sse-consumer.ts
@@ -15,7 +15,7 @@ import { randomUUID } from "node:crypto";
 import { AssistantItemStream } from "./assistant-item-stream.js";
 import { assistantTextBlocks, type AssistantItem } from "../shared/assistant-items.js";
 import type { ChatMessageMetadata } from "../shared/message-kinds.js";
-import { persistableToolDetails } from "../shared/tool-result-metadata.js";
+import { persistableToolDetails, toolResultOutcome } from "../shared/tool-result-metadata.js";
 import { ErrorCodes } from "../lib/error-envelope.js";
 import { AgentBoxClient } from "./agentbox/client.js";
 import { appendMessage, incrementMessageCount, updateMessage } from "./chat-repo.js";
@@ -796,9 +796,7 @@ export async function consumeAgentSse(opts: ConsumeAgentSseOptions): Promise<Sse
             .join("") ?? "";
         const toolName = (evt.toolName as string) || (evt.name as string) || "tool";
 
-        let outcome: "success" | "error" | "blocked" = "success";
-        if (toolResult?.details?.blocked) outcome = "blocked";
-        else if (toolResult?.details?.error) outcome = "error";
+        const outcome = toolResultOutcome(toolResult?.details, evt.isError);
 
         const pendingCall = shiftPending(pendingToolCalls, toolCallKey(evt, toolName));
         const eventToolset = typeof evt.toolset === "string" && evt.toolset.length > 0

--- a/src/portal/skill-preview-storage.test.ts
+++ b/src/portal/skill-preview-storage.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 import type { Db } from "../gateway/db.js";
 import { preparePreviewMessage } from "./skill-preview-storage.js";
+import { boundSkillPreviewMetadata, MAX_PREVIEW_METADATA_BYTES } from "../shared/skill-preview-storage.js";
 
 it.each([4, 16, 64])("bounds escaped writes for a %i MiB MySQL packet", async (packetMiB) => {
   const packet = packetMiB * 1024 * 1024;
@@ -9,4 +10,29 @@ it.each([4, 16, 64])("bounds escaped writes for a %i MiB MySQL packet", async (p
   await preparePreviewMessage(db, message);
   expect(message.metadata).toMatchObject({ skillPreview: { status: "omitted", reason: "size_limit" }, llm_round: 3 });
   expect(2 * (Buffer.byteLength(JSON.stringify(message.metadata)) + Buffer.byteLength(message.content)) + 65536).toBeLessThan(packet);
+});
+
+it.each([1, 4])("applies a %i MiB packet budget to previews below the tool-side ceiling", async (packetMiB) => {
+  const packet = packetMiB * 1024 * 1024;
+  const db = { driver: "mysql", query: async () => [[{ packet }], undefined] } as unknown as Db;
+  const summary = "Skill preview for 'packet-boundary'. Click View to inspect and copy.";
+  const metadata = { skillPreview: { skill: { name: "packet-boundary", specs: "x".repeat(600 * 1024) }, summary }, llm_round: 3 };
+  expect(Buffer.byteLength(JSON.stringify(metadata))).toBeLessThan(MAX_PREVIEW_METADATA_BYTES);
+  const accepted = boundSkillPreviewMetadata(metadata);
+  expect(accepted).toBe(metadata);
+  const message = { metadata: accepted, content: summary, tool_input: "{}" };
+
+  await preparePreviewMessage(db, message);
+
+  if (packetMiB === 1) {
+    expect(message.metadata).toMatchObject({ skillPreview: { status: "omitted", reason: "size_limit", name: "packet-boundary" }, llm_round: 3 });
+    expect(message.metadata.skillPreview).not.toHaveProperty("skill");
+    expect(message.content).toContain("Generate a smaller preview");
+    // A persistence downgrade cannot retract the success already given to the model.
+    expect(accepted).toBe(metadata);
+    expect(metadata.skillPreview.summary).toBe(summary);
+  } else {
+    expect(message.metadata).toBe(metadata);
+    expect(message.content).toBe(summary);
+  }
 });

--- a/src/shared/skill-preview-storage.ts
+++ b/src/shared/skill-preview-storage.ts
@@ -1,7 +1,19 @@
 /** Serialized UTF-8 budget, including JSON escaping and compatibility projections. */
 export const MAX_PREVIEW_METADATA_BYTES = 1024 * 1024;
 
-export function previewSummary(preview: any, reason: string, limitBytes = MAX_PREVIEW_METADATA_BYTES) {
+export interface OmittedSkillPreview {
+  status: "omitted";
+  reason: string;
+  name: string;
+  limitBytes: number;
+}
+
+/** Oversized sibling fields may be dropped along with the full package. */
+export interface OmittedPreviewMetadata extends Record<string, unknown> {
+  skillPreview: OmittedSkillPreview;
+}
+
+export function previewSummary(preview: any, reason: string, limitBytes = MAX_PREVIEW_METADATA_BYTES): OmittedSkillPreview {
   return {
     status: "omitted",
     reason,
@@ -11,13 +23,13 @@ export function previewSummary(preview: any, reason: string, limitBytes = MAX_PR
   };
 }
 
-/** Run before redaction so oversized packages never enter the regex pipeline. */
+/** Bound the package before redaction; omission does not preserve the input's shape. */
 export function boundSkillPreviewMetadata<T extends Record<string, unknown> | null | undefined>(
   metadata: T, limitBytes = MAX_PREVIEW_METADATA_BYTES,
-): T {
+): T | OmittedPreviewMetadata {
   if (!metadata?.skillPreview) return metadata;
   if (Buffer.byteLength(JSON.stringify(metadata), "utf8") <= limitBytes) return metadata;
-  const result: Record<string, unknown> = { skillPreview: previewSummary(metadata.skillPreview, "size_limit", limitBytes) };
+  const result: OmittedPreviewMetadata = { skillPreview: previewSummary(metadata.skillPreview, "size_limit", limitBytes) };
   // Keep small timeline fields even if an unexpected sibling also contains a
   // large payload. Removing the package alone must not defeat the byte limit.
   const priority = ["llm_round", "tool_call_id", "started_at", "model_route", "toolset_dispatch"];
@@ -26,5 +38,5 @@ export function boundSkillPreviewMetadata<T extends Record<string, unknown> | nu
     const candidate = { ...result, [key]: metadata[key] };
     if (Buffer.byteLength(JSON.stringify(candidate), "utf8") <= limitBytes) result[key] = metadata[key];
   }
-  return result as T;
+  return result;
 }

--- a/src/shared/tool-result-metadata.ts
+++ b/src/shared/tool-result-metadata.ts
@@ -1,5 +1,13 @@
 import { boundSkillPreviewMetadata, previewSummary } from "./skill-preview-storage.js";
 
+/** Thrown failures set the event flag; returned tool failures use details.error. */
+export function toolResultOutcome(details: unknown, isError: unknown): "success" | "error" | "blocked" {
+  const flags = details && typeof details === "object" && !Array.isArray(details)
+    ? details as Record<string, unknown> : undefined;
+  if (flags?.blocked) return "blocked";
+  return isError === true || flags?.error ? "error" : "success";
+}
+
 /** Preserve structured tool data across Web, IM, delegation and synthetic turns. */
 export function persistableToolDetails(
   details: unknown,

--- a/src/tools/workflow/skill-preview.test.ts
+++ b/src/tools/workflow/skill-preview.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { createSkillPreviewTool, registration } from "./skill-preview.js";
 import { ToolResultArtifactStore, withToolResultArtifactCapture } from "../../core/tool-result-artifact.js";
 import os from "node:os";
+import { persistableToolDetails } from "../../shared/tool-result-metadata.js";
+import { MAX_PREVIEW_METADATA_BYTES } from "../../shared/skill-preview-storage.js";
 
 /** Tests write to the real DRAFTS_BASE (.siclaw/user-data/skill-drafts/) under cwd,
  *  matching production behavior. Each test creates a unique subdirectory and
@@ -61,6 +63,35 @@ describe("skill_preview tool", () => {
       expect(details.skillPreview.skill.specs).toBe(specs);
       expect(details.skillPreview.skill.files.find((f: any) => f.path === "SKILL.md").content).toBe(specs);
       expect(details.skillPreview.skill.files.find((f: any) => f.path === "scripts/check.sh").content).toBe(script);
+      expect(fs.existsSync(testSkillDir)).toBe(false);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it.each([
+    ["ascii", "x".repeat(1_150_000)],
+    ["utf8", "界".repeat(400_000)],
+    ["escaped JSON", '"'.repeat(550_000)],
+  ])("reports an omitted %s preview to the model before artifact capture", async (_kind, reference) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "siclaw-preview-limit-"));
+    const store = new ToolResultArtifactStore({ rootDir: root, getScope: () => ({ agentId: "a", sessionId: "s" }) });
+    writeSkill("---\nname: oversized-preview\ndescription: Preview limit regression\n---\n# Draft\n");
+    fs.mkdirSync(path.join(testSkillDir, "references"));
+    fs.writeFileSync(path.join(testSkillDir, "references", "notes.txt"), reference + "END_OF_OVERSIZED_REFERENCE");
+    try {
+      await store.initialize();
+      const wrapped = withToolResultArtifactCapture(tool, store, 4096);
+      const result = await wrapped.execute("preview-limit", { dir: testSkillDir }, undefined, {} as any);
+      const text = result.content.filter(b => b.type === "text").map(b => b.text).join("");
+      const modelResult = JSON.parse(text);
+      expect(modelResult).toMatchObject({ error: true, status: "omitted", reason: "size_limit", limitBytes: MAX_PREVIEW_METADATA_BYTES });
+      expect(modelResult.summary).toContain("smaller preview");
+      expect(text).not.toContain("Click View");
+      expect(text).not.toContain("END_OF_OVERSIZED_REFERENCE");
+      expect(result.details).toHaveProperty("error", true);
+      expect(result.details).not.toHaveProperty("toolResultArtifact");
+      const saved = persistableToolDetails(result.details);
+      expect(saved?.skillPreview).toMatchObject({ status: "omitted", reason: modelResult.reason, name: modelResult.name });
+      expect(saved?.skillPreview).not.toHaveProperty("skill");
       expect(fs.existsSync(testSkillDir)).toBe(false);
     } finally { fs.rmSync(root, { recursive: true, force: true }); }
   });

--- a/src/tools/workflow/skill-preview.ts
+++ b/src/tools/workflow/skill-preview.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveUnderDir } from "../../shared/path-utils.js";
 import { collectSkillDirectoryFiles, parseSingleSkillPackage } from "../../shared/skill-package.js";
+import { boundSkillPreviewMetadata } from "../../shared/skill-preview-storage.js";
 
 const DRAFTS_BASE = path.resolve(process.cwd(), ".siclaw/user-data/skill-drafts");
 
@@ -121,12 +122,25 @@ description: >-
           skill: { ...parsed, type },
           summary: `Skill preview for '${parsed.name}'. Click View to inspect and copy.`,
         };
+        // Decide whether the panel can retain the package before the model sees
+        // a success summary or artifact capture replaces it with a text preview.
+        const details = boundSkillPreviewMetadata({ skillPreview: result });
+        if ("status" in details.skillPreview && details.skillPreview.status === "omitted") {
+          return {
+            content: [{ type: "text", text: JSON.stringify({
+              ...details.skillPreview,
+              error: true,
+              summary: "Skill preview could not be saved because the package exceeds the preview storage limit. Generate a smaller preview; these files are not available to view or copy in the chat panel.",
+            }) }],
+            details: { ...details, error: true },
+          };
+        }
 
         return {
           content: [{ type: "text", text: JSON.stringify(result) }],
           // Chat persists details independently of the model's bounded text.
-          // Large previews must remain usable after artifact capture and reload.
-          details: { skillPreview: result },
+          // Accepted previews remain complete after artifact capture and reload.
+          details,
         };
       } finally {
         // Always clean up draft directory

--- a/src/tools/workflow/skill-preview.ts
+++ b/src/tools/workflow/skill-preview.ts
@@ -122,8 +122,8 @@ description: >-
           skill: { ...parsed, type },
           summary: `Skill preview for '${parsed.name}'. Click View to inspect and copy.`,
         };
-        // Decide whether the panel can retain the package before the model sees
-        // a success summary or artifact capture replaces it with a text preview.
+        // Enforce the shared ceiling before model output and artifact capture.
+        // The host's packet budget or redaction may still require a later omission.
         const details = boundSkillPreviewMetadata({ skillPreview: result });
         if ("status" in details.skillPreview && details.skillPreview.status === "omitted") {
           return {
@@ -139,7 +139,7 @@ description: >-
         return {
           content: [{ type: "text", text: JSON.stringify(result) }],
           // Chat persists details independently of the model's bounded text.
-          // Accepted previews remain complete after artifact capture and reload.
+          // Keep full files here; persistence applies its own remaining limits.
           details,
         };
       } finally {


### PR DESCRIPTION
## Summary

Skill previews above the shared 1 MiB metadata ceiling told the model that files were available even when chat storage omitted them. Enforce that serialized UTF-8 ceiling before returning the tool result, so these oversized packages report an error to the model as well as the panel.

Thrown tool errors, including rejected subagent resumes, also appeared as successful calls in history. Web and channel persistence now honor both the event error flag and returned tool errors, preserving the more specific blocked outcome.

The metadata helper now returns an explicit union of the original metadata and an omission marker; it no longer claims that an omitted package or dropped sibling fields preserve the input type.

**Remaining boundary:** a smaller MySQL packet, added metadata or redaction expansion can still cause a later persistence omission after the model receives a success summary. The boundary document records the effective packet budget, the 1/4 MiB cases and the follow-up needed to propagate a conservative host budget to AgentBox. This PR does not implement that configuration flow.

## Test Plan

- [x] Seven original regression cases fail before the fix and pass afterward; two additional cases cover lower packet budgets. Latest targeted run: 422 tests.
- [x] Full suite: 7,495 passed, one skipped; TypeScript checks, return-type contract checks and builds pass.
- [x] Build and deploy both Runtime and AgentBox images in an isolated Kubernetes test environment; verify image digests and compiled file checksums.
- [x] Real model calls: normal and oversized previews; invalid, out-of-range, cross-parent, cross-user and conflicting-parameter subagent resumes; persisted outcomes and absence of rejected-call side effects.
- [x] Browser: complete text and empty-file copying, binary handling, reload, lazy detail retrieval, and recovery from an injected HTTP 503.
- [x] Recreate the test AgentBox and resume the same child with its original context; inject expiry into only the synthetic ticket and verify rejection without child changes.

Deployment checks cover commit c352eb54. The review follow-up changes types, comments, documentation and tests; its emitted runtime JavaScript is identical when comments are removed, so the test deployment was retained.

Channel behavior is covered by consumer tests; no live messaging-channel delivery was exercised. The initial full-suite run before the review follow-up reported two asynchronous fixture errors; the affected file and a full rerun passed. This change does not modify that fixture path.
