### PR TITLE
Record every LLM call with its provenance intact

### DIFF
--- a/docs/design/2026-09-12-token-cost-analysis.zh-CN.md
+++ b/docs/design/2026-09-12-token-cost-analysis.zh-CN.md
@@ -1,0 +1,963 @@
+# siclaw Token 成本分析与优化方案
+
+> **修订 r6（2026-09-13）** —— 基线 `origin/main` @ `946e0675`。
+> **P0 已实现**，含接收端与事实表；实现记录与剩余缺口见 **§7.8.9**。
+> **P0 方案定稿见 §7.8**，五项决策与三处补正均已并入。
+> r1 有多处实质错误已被推翻，逐条列于「修订记录」。**r1 的诊断路径不可执行，勿按 r1 实施。**
+>
+> **r3 相对 r2 的改动**：①「子代理历史无可回灌」过满，改为「可回灌范围待查」（pi 的 JSONL 另有一份，且无正文的 assistant 也能带 usage）；② `PI_CACHE_RETENTION=long` 不等于直接拿到 24h（分支可能发 `ttl=30m`）；③「50 item = 50 次前缀 write」撤回为「前缀复用率未知」。
+
+## 修订记录：r1 被推翻的结论
+
+| r1 的说法 | 实际 | 证据 |
+|---|---|---|
+| 「数据完整，只缺聚合」「无需新增采集」「历史不丢」 | **错。** subagent 走独立持久化路径，assistant 行的 metadata 只有 `phase`/`stop_reason`/`assistant_item`，**没有 `llm_call`**；且 `if (text)` 守卫使无正文的调用不落行。**头号怀疑对象恰恰在 Portal 侧无数据可查**（r3 补正：pi 的 JSONL 另有一份完整 assistant 消息且可携带 usage，可回灌范围见 §7.7 待查清单）| `session.ts:2921-2945` |
+| §3.1 的 SQL 能区分三个假说 | **错。** `round` 是 **prompt 内**轮次、每个 prompt 重置，故「rnd=1 多」只说明 prompt 多，不能证明 subagent 多；首轮 `since_prev_ms` 是准备耗时而非距上次提问的间隔 | `llm-call-recorder.ts:49` |
+| 「写一次要读 ≥2 次才回本」 | **算错了。** 写 1.25 + 读 0.1 = **1.35 < 2.0**，**一次复用即回本**。故 write 高本身不等于赔钱，只有在几乎没有对应 read 时才是 | 算术 |
+| 「有独立 cache_write 计费项 ⇒ Anthropic 风格或自建计费」 | **不成立。** OpenAI 官方对 GPT-5.6 及以后模型亦有 cache-write 计价 | OpenAI 文档 |
+| `tool-result-context-guard` 原地改写 ⇒「不改共享对象则前缀恒定」 | **前提与结论都错。** `context-pruning` 本就只返回请求视图（复制数组 + 构造新消息）；而且只要**发出去的历史**变了，缓存照样受影响 | `context-pruning.ts:142` |
+| 后台通知无合并窗口，50 item = 最多 50 次 `runPrompt` | **错。** group 在 reduce 后算**一次**完成；独立通知路径另有 600ms 合并窗口 | `background-work-turn.ts:78-79`、`session.ts:312` |
+| 台账语义「强制」每个 milestone 拆成独立回合 | **过度推断。** 工具明确支持「完成上一项 + 下一次独立工具调用」同批提交；禁止提前宣告验证成功 ≠ 禁止批量 | `task-tools.ts:259` |
+| 每轮固定开销 17,100 tokens | **低估，需重测。** 只统计了 description 与嵌套 description 字符串，未计 schema 结构本身（`task_create` 实际 1,047 vs 记为 141；`task_update` 1,411 vs 141），也未计文件/artifact 工具、运行时追加 prompt 与新增的 `run_script` |
+| 「没有任何 token 读取能力」 | **写过满。** 已有 `siclaw_tokens_total{type,provider,model,user_id}` 与 `siclaw_cost_usd_total` Prometheus counter；缺的是**调用明细与下钻**，不是全部能力 | `shared/metrics.ts:75-88` |
+| §7.4「token 挂在没有主人的子会话上」 | **错。** 子会话建会话时即写入 `request.userId`，有主人。真正的缺口是**没有 token 数据**，不是归属 | `session.ts:2829` |
+| 「292K tokens 重复计费」 | **口径不严。** 那是按假定前缀推算的累计输入量，其中命中缓存的部分不按 input 单价计费，不能直接当作损失额 |
+
+**因此顺序改为：补齐采集与计费口径 → 测量真实请求与缓存复用 → 再决定 TTL / 裁剪 / 子会话优化。** `C > B > A` 现在只是待验证假设，三者可以同时成立，且尚未排除服务端路由、缓存淘汰与断点等外部原因。
+
+---
+
+> 分析基线：`origin/main` @ `946e0675`（2026-09-12）
+> 依赖库：`@earendil-works/pi-ai` **0.85.1**（注意：本地 `node_modules` 仍是 0.80.7，行号会对不上，本文引用的是 0.85.1）
+> 线上协议：**OpenAI Responses**（`openai-responses`）
+
+---
+
+## 背景
+
+模型服务方的计费显示 siclaw 消耗异常，且统计里 **cache_write 占比特别高**。
+
+本文回答三件事：钱花在哪、cache_write 高说明什么、怎么改。
+
+**文档分两部分**：
+
+- **§1–§6 诊断与止血** —— 账的构成、cache_write 偏高的三个假说、定位方法与降本方案。
+- **§7 Token 可观测性建设** —— 要新建的能力：provider/model 维度的开发者 dashboard、按用户的管理员视图。含四个需要 review 的设计决策。
+
+**需要先说明的**：
+
+1. **§2.3 的三个假说目前都未被证实**，且**可以同时成立**；也尚未排除服务端路由漂移、缓存淘汰、断点策略等客户端观测不到的原因。在补齐采集（§3.0b）之前，任何一条都不足以支撑改代码。
+2. 所有 `file:line` 引用基于 **`origin/main` @ `946e0675`**。若在落后的本地工作区核对会对不上行号。
+3. pi 系列依赖引用 **0.85.1**（`package.json` 声明值）。本地 `node_modules` 若仍是 0.80.7，行号同样对不上。
+
+---
+
+## 一、成本结构
+
+### 1.1 每轮固定开销 ≳ 17,100 tokens（**低估，需重测**）
+
+每一次模型往返都要重发 system prompt + 全部工具定义。下表**只统计了 description 与嵌套的 description 字符串，未计 schema 结构本身**，因此是下界：
+
+| 工具 | 下表记为 | 实际 `JSON.stringify(parameters)` |
+|---|---:|---:|
+| `task_create` | 141 | **1,047** |
+| `task_update` | 141 | **1,411** |
+
+另漏计：实际启用的文件工具与 artifact 工具、运行时追加的 prompt（PROFILE / 知识目录 / 引用说明）、以及最新 main 新增的 `run_script`。
+
+**重测方式**：在 `pi-execution.ts:52` 的 `inspectModelEnvelope` 处直接量真实 payload——它本就对 system + tools schema 做 sha256 指纹，加一个长度统计即可，比逐文件数字符串准确。
+
+字符数（SRE agent，web 模式）：
+
+| 组成 | 字符 | ~tokens |
+|---|---:|---:|
+| system prompt | 12,779 | 3,200 |
+| **工具定义（30 个 siclaw 工具）** | **55,551** | **13,900** |
+| MCP 工具 | **无上限** | 视配置 |
+| **合计（不含 MCP）** | **68,330** | **~17,100** |
+
+**工具块是 system prompt 的 4.3 倍。** 优化 prompt 措辞的收益远小于压缩工具描述。
+
+按 agent type 的差异：
+
+| Agent type | 工具数 | 工具字符 | prompt 字符 | ~tokens |
+|---|---:|---:|---:|---:|
+| **sre**（默认） | 30 | 55,551 | 12,779 | **~17,100** |
+| coordinator | 6 | 8,331 | 9,084 | ~4,350 |
+| knowledge_qa | 2 | 2,601 | 6,767 | ~2,340 |
+
+### 1.2 最肥的工具描述
+
+| 工具 | desc | param | 合计 | 位置 |
+|---|---:|---:|---:|---|
+| `node_exec` | 6,823 | 1,168 | **7,991** | `cmd-exec/node-exec.ts:101` |
+| `spawn_subagent` | 5,268 | 1,174 | **6,442** | `workflow/spawn-subagent.ts:166` |
+| `manage_schedule` | 3,064 | 473 | 3,537 | `workflow/manage-schedule.ts:27` |
+| `task_create` | 3,175 | 141 | 3,316 | `workflow/task-tools.ts:126` |
+| `host_exec` | 2,211 | 1,009 | 3,220 | `cmd-exec/host-exec.ts:112` |
+| `task_update` | 2,980 | 141 | 3,121 | `workflow/task-tools.ts:224` |
+
+具体的水分：
+
+- **`node_exec`** 内嵌一份 1,573 字符的命令白名单散文（`:128-142`），重复 `command-sets.ts` 的内容。枚举不该进 description，而且会与真正的执行源静默漂移。另有约 2,000 字符是示例，含一段 6 行的 tcpdump/curl 演练。
+- **`spawn_subagent`** 5,268 字符的描述里是三个完整示例 + 一篇写 task 模板的教程，而 `subagent_type` 菜单**只有一个选项**（`general-purpose`，`subagent-registry.ts:159-172`）。
+- **`BACKGROUND_EXEC_DESCRIPTION`** 596 字符被内联进 7 个工具（`background-launch.ts:10`），源码层面是 DRY 的，但模型每轮读同一段话 **7 遍 = 4,172 字符**。
+- **8 个 `*_exec` / `*_script` 工具共 18,871 字符**，实际只有 2 个契约。
+- **`task_create` + `task_update` = 6,437 字符**，外加 system prompt 里 2,027 字符的 Planning 段。同文件里 `task_list` 82 字符、`task_get` 33 字符——说明正确的标定尺度本来就存在。
+
+### 1.3 为什么一直没被发现
+
+三个测量盲区叠在一起：
+
+| 盲区 | 位置 | 后果 |
+|---|---|---|
+| 预算检查只量 system prompt（阈值 20,000 字符），**不量工具块** | `prompt-inspection.ts:220-223` | 55K 字符的工具定义从不触发任何告警 |
+| 成本表硬编码全零 `{input:0, output:0, cacheRead:0, cacheWrite:0}` | `model-compat.ts:474` | siclaw 自报花费**永远是 $0** |
+| Portal `/admin/dashboard/usage` 只 `COUNT(*)` 消息条数 | `siclaw-api.ts:3619` | token 数据记了三个月没人聚合 |
+
+**主会话的数据一直在记**——`chat_messages.metadata.llm_call.usage` 有 `input / output / reasoning / cache_read / cache_write`（`llm-call-recorder.ts:38-45`），另有 Prometheus 的 `siclaw_tokens_total` / `siclaw_cost_usd_total`（`shared/metrics.ts:75-88`）。
+
+缺的是**调用级下钻**与**覆盖完整性**：subagent 既不落库也不进 counter（§3.0b），成本曲线又因零价格表恒为 0。所以真实账单只能靠外部反查。
+
+### 1.4 往返次数：×17
+
+2026-08 全量实测（1540 条 trace，40321 次工具调用）：
+
+- 平均 **17.1 次模型往返 / 对话**
+- **77% 的往返只发 1 个工具调用**
+- 模型往返占墙上时间 75%，工具执行仅 25%
+
+17.1 × 17,100 ≈ **292K tokens 的累计输入量**（仅固定前缀部分，未计历史累积与 tool result）。
+
+> ⚠️ **这是累计输入量，不是损失额。** 其中命中缓存的部分按 cache_read 单价（约 0.1×）计费，不能直接当作"重复计费"或可节省金额——r1 此处口径不严。真实损失取决于缓存复用率，而那正是当前测不出来的（§3.0b）。
+
+往返被系统性放大的四处：
+
+| 来源 | 位置 | 机制 |
+|---|---|---|
+| ~~后台完成通知无合并窗口~~ **已撤回** | `background-work-turn.ts:78-79`、`session.ts:312` | r1 称"50 item = 最坏 50 次 `runPrompt`"，**错**。group 在 reduce 后算**一次**完成；独立通知路径另有 `NOTIFICATION_COALESCE_MS = 600` 合并窗口。仅多个**互相独立**的 spawn / 后台 bash 才各自唤醒 |
+| ~~台账语义强制拆回合~~ **已撤回** | `task-tools.ts:259` | r1 称语义"禁止批量"，**过度推断**。工具明确支持"完成上一项 + 下一次独立工具调用"同批提交；禁止提前宣告未到达的验证结果 ≠ 禁止批量，也不必然新增独立回合 |
+| fallback 候选数无上限 | `model-routing.ts:455` | 只去重不限量；`empty_response` 在 `DEFAULT_FALLBACK_ON` 里，一次空响应重跑**整个 agentic loop** |
+| `task_output` 教模型翻页读全量 | `task-output.ts:39` | "follow next_offset until complete"，8MB ÷ 32KB = **256 次往返**，无上限提示 |
+
+台账那条代码里已有自述（`task-tools.ts:29-39`）：*"9841 task_\* calls, 96% of them the only tool call in their turn"*——**但那是数组批量落地之前的历史观测**。批量形式已经就位，当前是否仍独占回合，需要按现版本重新取数，不能沿用旧结论。
+
+> **本节整体存疑**：17.1 次往返来自 2026-08 的实测，此后代码已有多次相关改动。§1.4 保留的两条（fallback、`task_output` 翻页）也只是**可能路径**，未在当前版本实测其发生频率。
+
+### 1.5 output 侧：thinking 默认 high
+
+`session-thinking.ts:8` 的 `?? "high"` 是**无配置时的兜底**，不是"全部强制 high"——r1 此处写过满。模型级设置（`getModelThinkingLevel`）优先，且 pi 会按模型能力 clamp。实际生效档位需按 provider/model 逐个确认，不能假定全线 high。
+
+Responses 协议下 reasoning token 计入 `max_output_tokens`，而 `DEFAULT_MAX_TOKENS = 16384`（`model-compat.ts:158`）——reasoning 与正文抢同一预算。另外 `params.include = ["reasoning.encrypted_content"]`（`openai-responses.js:262`），这些加密 reasoning 内容会累积进历史并每轮重发。
+
+---
+
+## 二、cache_write 偏高说明什么
+
+### 2.1 回本点在哪（r1 此处算错，已更正）
+
+以常见的 1.25× / 0.1× 计（**实际单价必须以所用模型服务方的计费规则为准**，见 §6）：
+
+| | 相对 input |
+|---|---|
+| cache write | **1.25×** |
+| cache read | **0.1×** |
+| 普通 input | 1.0× |
+
+**回本点在一次复用。** 同一前缀用 n 次：
+
+- 不缓存：`n × 1.0`
+- 缓存：`1.25 + (n−1) × 0.1`
+- n=2 时 **1.35 < 2.0**，已经回本；打平点约 n≈1.28。
+
+> **r1 在此处写成"要读 ≥2 次才回本"并据此断言"比不用缓存还贵 25%"，是算术错误。** 结论应更正为：
+>
+> **write 高本身不是问题，只有当它几乎没有对应的 read 时才是。** 判据是 `cache_read / cache_write` 的比值，而非 write 的绝对值。write 随流量增长是正常的。
+
+另外，**不能从"存在独立的 cache_write 计费项"推断计费风格**——OpenAI 官方对 GPT-5.6 及以后模型同样有 cache-write 计价。
+
+### 2.2 协议层面缓存标记是发出去的（但这不证明链路正常）
+
+需要澄清一个容易搞错的点：Responses 与 Completions 两条路径行为不同。
+
+| | `openai-completions` | `openai-responses`（线上用这条） |
+|---|---|---|
+| 缓存标记 | 仅 `provider==="openrouter"` 且 `model.id` 以 `anthropic/` 开头才发（`:601`、`:1000`） | **`prompt_cache_key` 无条件发**（`:230`） |
+| siclaw 是否需要配置 | 需要 `cacheControlFormat`，而全仓未设 | 不需要 |
+
+所以"缓存标记没发出去"这个猜测**不适用于线上**。`prompt_cache_key` 取 `options.sessionId`，由 pi 自己管理（`agent-session.js:697,2691`），有值。
+
+但 `store: false`（`:233`），无 `previous_response_id`，**每轮仍然全量重发**。
+
+> ⚠️ **发送了 cache key ≠ 缓存链路正常。** 网关是否识别、上游是否命中、是否发生路由漂移或提前淘汰，都不是客户端能从发送动作推断的。另外 pi 0.85.1 的 `long` 分支并非只有一种形态——可能发 `24h`，也可能发 `prompt_cache_options.ttl=30m`，取决于 compat 判断，改配置前需实际抓一次请求确认。
+
+### 2.3 三个假说
+
+写多读少，只可能是缓存建完就失效了。三种失效方式，都在 siclaw 侧。
+
+**优先级依据**（2026-09-12 经上游控制面的平台概览接口取得，7 天窗口）：
+
+| 观测 | 数值 | 对假说的影响 |
+|---|---|---|
+| a2a 入口占比 | **786 / 1128 = 70%** | 主流量是程序连续调用，非人在回路 → **假说 A 权重大幅下调** |
+| 每 prompt 工具调用数 | **49832 / 1128 ≈ 44** | 单次任务往返极多，放大一切固定开销 |
+| 每 trace 的 `sessionCount` | **9~16**（`rootCount` 恒为 1） | 每次任务派生十几个子会话 → **假说 C 权重最高** |
+| SRE 类型占比 | 1019 prompts / 47118 toolCalls | 成本几乎全部集中在 SRE agent（即 §1.1 中最重的那个 17K 配置） |
+
+> ⚠️ **这些只是"值得优先排查"的次序，不是结论。** 三个假说**可以同时成立**，上表也没有排除服务端路由漂移、缓存淘汰、缓存断点策略等客户端看不见的原因。更关键的是：权重最高的 C **当前根本没有数据可查**（§3.0b）。
+>
+> **`C > B > A` 仅作排查假设使用；补齐采集前不要据此改代码。**
+
+---
+
+**假说 A — TTL 太短，撑不过调用间隔**（权重已下调）
+
+`PI_CACHE_RETENTION` 全仓从未设置 → `resolveCacheRetention` 返回 `"short"` → `prompt_cache_retention` 为 `undefined`（`openai-responses.js:230-231`）。
+
+SRE 排障是人在回路的节奏：agent 给一批结果 → 人看几分钟 → 再问下一个。每次停顿超过保留期，下一轮就要重新 write 整个 17K 前缀。
+
+`supportsLongCacheRetention` 默认 `true`（`:55`）。但 **`long` 分支并非只有一种形态**：可能发 `prompt_cache_retention: "24h"`，也可能发 `prompt_cache_options.ttl=30m`，取决于 compat 判断（`supportsExplicitPromptCacheMode`）。**改配置前必须抓一次真实请求确认实际发的是哪种**，并确认网关是否识别该字段。
+
+**假说 B — 前缀每轮被自己改写**
+
+`context-pruning.ts` 挂在 `"context"` 事件上，**每次 LLM 调用前都跑**。context 超 `SOFT_TRIM_RATIO = 0.3`（`:7`）就改写历史里最老的 tool result，超 `HARD_CLEAR_RATIO = 0.5`（`:10`）直接清空。
+
+裁剪本身幂等，所以前缀不会整体失效；但只要 ratio 持续高于 30%，每轮都可能在历史前部新增一处改写，该点之后的缓存前缀作废。
+
+两处裁剪器的行为**不同**，r1 把它们混为一谈了：
+
+| | 是否改写共享对象 | 对缓存的影响 |
+|---|---|---|
+| `context-pruning.ts` | **否**——`messages.slice()` + 构造新消息，只返回本次请求视图（`:142`起） | **仍有影响**：缓存看的是发出去的内容 |
+| `tool-result-context-guard.ts` | **是**——`applyMessageMutationInPlace` 用 `Object.assign` 原地改写（`:248`） | 影响持续到后续轮次 |
+
+> ⚠️ **两个纠正**：
+> 1. r1 提出的修法「改成只影响请求视图，前缀就恒定」不成立——`context-pruning` 本来就只改视图，而**只要发给模型的历史变了，缓存照样失效**。
+> 2. **"持续出现 write" 不能证明这条假说**：每轮正常追加 assistant + tool result 本身就会产生新的 cache write。要证实需要能观测「同一前缀被复用了几次」，当前数据做不到。
+
+**假说 C — 每个 subagent 是独立 session，前缀各写一遍**
+
+`session.ts:2706` 每个 child 走 `createSiclawSession` → 新 sessionId → 新 `prompt_cache_key`。每个 child 继承约 12K tokens 的工具定义（`allowedTools` 全量继承，仅屏蔽 `task_*` 与 `spawn_subagent`）。
+
+> ⚠️ **r1 写"一次 50 item 的 batch = 50 次独立的前缀 write"，这个数字不能这么用。** 它假定每个 child 都完整写一遍前缀且都没命中，而：
+> - 并发上限是 10，且 child 的前缀与父**部分重合**（公共 system 段、共享工具），共同前缀部分仍可能命中；
+> - `prompt_cache_key` 相同与否只影响路由分区，**命中取决于前缀内容**；
+> - **整条假说本身尚未被任何数据证实**（§3.0b：subagent 在 Portal 侧没有 `llm_call`）。
+>
+> 正确表述：**每个 child 是独立会话、独立缓存生命周期，其前缀复用率未知**。具体损失需等 P0 计量。
+
+---
+
+## 三、诊断
+
+### 3.0 现有工具拿不到 token 数据
+
+2026-09-12 实测 `siclaw-dev` MCP 三个接口，**均无 token 维度**：
+
+| 接口 | 返回什么 | token |
+|---|---|---|
+| 控制面 trace 列表接口 | `messageCount` / `contentChars` / `toolCallCount` | ❌ |
+| 控制面 trace 消息接口 | 投影结构，**字段中没有 `metadata`** | ❌ |
+| 控制面平台概览接口 | sessions / prompts / toolCalls / distinctUsers | ❌ |
+
+但**已有** Prometheus 指标可用（r1 漏了这一层）：
+
+```
+siclaw_tokens_total{type, provider, model, user_id}
+siclaw_cost_usd_total{provider, model, user_id}
+```
+
+见 `shared/metrics.ts:75-88`。所以"完全没有 token 读取能力"的说法不成立——**缺的是调用级明细与下钻**，不是全部能力。注意 `cost` counter 只在 `dCost > 0` 时累加（`metrics.ts:197`），而 Portal 托管模型的价格表硬编码为零（`model-compat.ts:474`），所以**成本那条曲线对这批模型恒为 0**：指标名存，值实亡。
+
+### 3.0b 致命缺口：subagent 根本没有 token 数据
+
+`chat_messages.metadata.llm_call` 只覆盖主会话。**subagent 走的是另一条持久化路径**（`session.ts:2921-2945`）：
+
+- assistant 行的 metadata 只有 `phase` / `stop_reason` / `error_message` / `assistant_item`，**没有 `llm_call`**；
+- 且被 `if (text)` 守卫——**没有正文的模型调用连行都不落**。
+
+主会话侧也不完整：压缩调用挂在 `aux_calls` 里、被路由丢弃的挂在 `discarded_llm_calls` 里，都需要展开；而**一次 prompt 结尾处的 aux 调用没有后续 agent 调用来承载，会直接丢失**。
+
+**后果**：§2.3 里权重最高的假说 C（subagent 各写一遍前缀）**在 Portal 侧恰恰是唯一查不到的**。
+
+> **r3 补正**：这不等于历史彻底丢失。pi 的 `SessionManager` 会把完整 assistant 消息写入 JSONL，**且无正文的 assistant 也能携带 usage**（0.85.1 已合成验证）。所以 r1 的「历史不丢」与 r2 的「无可回灌」**都过满**——可回灌范围取决于 session dir 的存储位置与保留策略，见 §7.7 的待查清单。
+
+**必须先补采集，才谈得上定位。**
+
+### 3.1 定位 SQL（r1 版本无效，此处说明为什么）
+
+> ⚠️ **r1 给的 SQL 不能区分三个假说，不要执行。** 两个语义误读：
+>
+> 1. **`round` 是 prompt 内轮次，每个 prompt 从 1 重新开始**（`llm-call-recorder.ts:49`："index of this model call **within the prompt**"）。因此"`rnd=1` 占绝大多数"只说明 prompt 多，**不能推出 subagent 多**。
+> 2. **首轮的 `since_prev_ms` 是准备耗时**（`request_at − prompt_received_at`），不是距上次用户提问的间隔，拿它判 TTL 过期是错的。
+>
+> 更根本的是：**秒级间隔持续出现 write 也不能证明前缀被裁剪**——正常追加历史（每轮新增 assistant + tool result）同样会产生新的 cache write。三个假说**可以同时成立**，且都未排除服务端路由漂移、缓存淘汰、断点策略等客户端看不见的原因。
+
+补齐采集后，真正能分辨的口径应当是：
+
+- **按「同一前缀被复用了几次」而非按 round 聚合** —— 需要请求级的前缀指纹或稳定的会话键；
+- **read/write 比值**，而非 write 绝对值（§2.1）；
+- **区分主会话与子会话**，两者的缓存生命周期完全不同。
+
+以下 SQL 仅可用于**主会话的量级摸底**，不能用于结论：
+
+```sql
+SELECT
+  CAST(JSON_EXTRACT(metadata,'$.llm_call.round') AS UNSIGNED) AS rnd,
+  COUNT(*) calls,
+  ROUND(AVG(CAST(JSON_EXTRACT(metadata,'$.llm_call.usage.cache_write') AS UNSIGNED))) avg_write,
+  ROUND(AVG(CAST(JSON_EXTRACT(metadata,'$.llm_call.usage.cache_read')  AS UNSIGNED))) avg_read,
+  ROUND(AVG(CAST(JSON_EXTRACT(metadata,'$.llm_call.since_prev_ms')     AS UNSIGNED))) avg_gap_ms
+FROM chat_messages
+WHERE metadata LIKE '%llm_call%' AND created_at >= NOW() - INTERVAL 7 DAY
+GROUP BY rnd ORDER BY rnd LIMIT 20;
+```
+
+**能读出什么**：主会话的 `cache_read / cache_write` 比值（§2.1 的判据）、以及 input 的量级。
+
+**不能读出什么**：subagent 的任何数据（§3.0b）、TTL 是否过期、前缀是否被裁剪打碎。r1 的判读表基于错误的 `round` 语义，已删除。
+
+### 3.2 按会话来源拆分（覆盖面受限，勿据此下结论）
+
+> ⚠️ 因 §3.0b，`subagent` 行**查不到任何 token**。该查询只能说明各 origin 的**主会话**分布，不能用来证伪或坐实假说 C。补齐采集后此查询才有意义。
+
+```sql
+SELECT COALESCE(s.origin,'web') AS origin,
+       COUNT(*) calls,
+       COUNT(DISTINCT s.id) sessions,
+       SUM(CAST(JSON_EXTRACT(m.metadata,'$.llm_call.usage.cache_write') AS UNSIGNED)) cache_write,
+       SUM(CAST(JSON_EXTRACT(m.metadata,'$.llm_call.usage.cache_read')  AS UNSIGNED)) cache_read
+FROM chat_messages m
+JOIN chat_sessions s ON m.session_id = s.id
+WHERE m.metadata LIKE '%llm_call%' AND m.created_at >= NOW() - INTERVAL 7 DAY
+GROUP BY COALESCE(s.origin,'web')
+ORDER BY cache_write DESC;
+```
+
+### 3.3 总量视图（确认量级）
+
+> ⚠️ 此查询同样不完整：漏掉 subagent（§3.0b）、`aux_calls` 中的压缩调用、`discarded_llm_calls` 中被路由丢弃的调用，以及 prompt 结尾无后续 agent 调用承载的 aux。另外 **Responses 的 `reasoning` 是 `output` 的子集**，两列不可相加。
+
+```sql
+SELECT DATE(created_at) day, COUNT(*) calls,
+       SUM(CAST(JSON_EXTRACT(metadata,'$.llm_call.usage.input')       AS UNSIGNED)) input_tok,
+       SUM(CAST(JSON_EXTRACT(metadata,'$.llm_call.usage.cache_read')  AS UNSIGNED)) cache_read,
+       SUM(CAST(JSON_EXTRACT(metadata,'$.llm_call.usage.cache_write') AS UNSIGNED)) cache_write,
+       SUM(CAST(JSON_EXTRACT(metadata,'$.llm_call.usage.output')      AS UNSIGNED)) output_tok,
+       SUM(CAST(JSON_EXTRACT(metadata,'$.llm_call.usage.reasoning')   AS UNSIGNED)) reasoning_tok
+FROM chat_messages
+WHERE metadata LIKE '%llm_call%' AND created_at >= NOW() - INTERVAL 7 DAY
+GROUP BY DATE(created_at);
+```
+
+---
+
+## 四、优化方案
+
+> **执行顺序已按 review 意见改写。** r1 让 §4.1–4.3 依据一次 SQL"择一优先"，但那个 SQL 判不了（§3.1），而权重最高的假说根本无数据（§3.0b）。**正确顺序是：**
+>
+> **① 补齐采集与计费口径（§7）→ ② 测量真实请求体积与缓存复用率 → ③ 再决定 TTL / 裁剪 / 子会话优化。**
+>
+> **§4.4、§4.6 与 §7 可以立即动手**（它们不依赖假说成立）；**§4.1–4.3 与 §4.5 必须等测量结果**。
+
+### 4.1 【假说 A · 待测量】缓存保留期改 long
+
+一行环境变量，`prompt_cache_retention` 由 undefined 变为长保留。
+
+两个前提未确认：**(a)** pi 0.85.1 的 `long` 有条件分支，可能发 `24h`，也可能发 `prompt_cache_options.ttl=30m`，改之前需实际抓一次请求确认发的是哪种；**(b)** 需确认所用的模型网关认不认这个 Responses 字段（§6）。
+
+另外 a2a 占 70% 意味着调用间隔通常很短，TTL 过期作为主因的可能性本来就偏低。
+
+### 4.2 【假说 B · 待测量】裁剪阈值（r1 的修法有误）
+
+> **r1 的修法「改成只影响请求视图、不改写共享对象，前缀就恒定」是错的**：`context-pruning` 本来就只改视图（`:142`起），而缓存看的是**发出去的历史**——只要内容变了照样失效。
+
+可考虑的方向仍是抬高 `SOFT_TRIM_RATIO`（当前 `0.3`），但：
+
+- **不能只动 soft 不动 hard**：soft 提到 0.65–0.7 而 `HARD_CLEAR_RATIO` 留在 0.5，会让 hard 先于 soft 触发，两段裁剪的触发关系被颠倒。要改就两个一起重新设计。
+- 收益前提是"缓存复用被裁剪打断"确实在发生，而这**当前测不出来**（正常追加历史同样产生 write）。
+
+`tool-result-context-guard.ts` 的 in-place 改写（`:248`）是另一回事，它的影响会延续到后续轮次，可以单独评估。
+
+### 4.3 【假说 C · 待测量】降低 subagent 的前缀成本
+
+### 4.3 【假说 C】降低 subagent 的前缀成本
+
+两个方向：
+
+- 给 child 传更窄的 `allowedTools`（当前是全量继承，`session.ts:2721`）。child 大多只需要少数几个工具——**这一条不依赖假说成立**，缩小 payload 本身就有收益。
+- 让同一个 batch 的 child 共享 `prompt_cache_key`——它们的前缀本来就完全相同。需先确认网关侧按该 key 做亲和。
+
+**但"每个 child 各写一遍前缀"当前无法验证**（§3.0b），能省多少要等采集补齐。
+
+### 4.4 压缩工具描述（无条件做）
+
+优先级从高到低：
+
+| 动作 | 省字符 |
+|---|---:|
+| `node_exec` 删掉白名单散文（枚举不该进 description） | ~1,600 |
+| `spawn_subagent` 教程砍到菜单（只有一个选项） | ~3,000 |
+| `BACKGROUND_EXEC_DESCRIPTION` 收敛，不再 7 份内联 | ~3,500 |
+| `task_create` / `task_update` 向同文件的 `task_list` 看齐 | ~3,000 |
+| 8 个 exec/script 工具归并为 2 个契约的表述 | ~6,000 |
+
+保守砍掉 40%（约 22K 字符 ≈ 5,500 tokens），按 17.1 轮计 **≈ 每次对话省 94K tokens**，且每个 subagent 同样受益。
+
+### 4.5 thinking 默认降档
+
+`session-thinking.ts:8` 的 `?? "high"` 改为 `"medium"` 或按 agent type 区分。SRE 排障未必需要 high，而它同时吃掉 `max_output_tokens` 预算。
+
+### 4.6 补上测量（防止回潮）
+
+- `prompt-inspection.ts` 的预算检查纳入工具块，否则瘦身完还会长回来；
+- `model-compat.ts:474` 的成本表填真实单价，让 siclaw 能自报花费；
+- Portal 加一个 token 聚合视图，数据本来就在库里（`/admin/dashboard/usage` 当前只 `COUNT(*)`）；
+- 上游控制面的 trace 消息接口投影补回 `metadata`（见 §3.0），否则每次排查都要直连数据库。
+
+### 4.7 需要架构改动的
+
+| 动作 | 位置 |
+|---|---|
+| ~~`BackgroundWorkTurn.next()` 加合并窗口~~ **已撤回**——group 已合并为一次完成，独立路径已有 600ms 窗口 | `background-work-turn.ts:78-79`、`session.ts:312` |
+| fallback 候选数加上限（如 3） | `model-routing.ts:455` |
+| MCP 工具注入加预算与截断（当前无上限、绕过 `allowedTools`） | `mcp-client.ts:637-648`、`tool-append.ts:19-20` |
+| `cluster_list` 加分页/截断（当前不走 `postExecSecurity`，无界 pretty-print JSON） | `query/cluster-list.ts:157` |
+
+---
+
+## 五、不是问题的部分
+
+避免误伤，以下几处已经做得对：
+
+- **skill 是懒加载的**：28 个 skill 的 SKILL.md 共 224KB，但只索引 frontmatter **7KB**（`agent-factory.ts:262-266`）。32 倍的节省已经在位——这正是工具描述该学的模式。
+- **tool result 体积管得很紧**：`processToolOutput` 统一 8,000 字符截断（头 3,000 + 尾 3,000，`tool-render.ts:11-13`），唯一调用点在 `security-pipeline.ts:167`，是所有 exec 工具的强制出口。超出部分转 artifact 按需取。
+- **`k8s_inspect` 是预算控制的模范**：`MAX_TOTAL_CHARS = 7_000`，刻意低于 8,000，并有 `worstCaseChars()` 从 relation 表算上界 + 测试盯着。它本身就是为省往返而生的。
+
+---
+
+## 六、未确认的前提
+
+无法从代码确定，需要业务侧确认后才能定优先级：
+
+1. **模型服务方的 cache write / read 实际单价是多少？** §2.1 用的 1.25× / 0.1× 是常见值，**不是实测单价**。
+   > r1 曾据"存在独立 cache_write 项"推断是 Anthropic 风格或自建计费，**这个推断不成立**——OpenAI 官方对 GPT-5.6 及以后模型同样有 cache-write 计价。单价必须查实际计费规则，回本点（§2.1）随单价变化。
+
+2. **网关的缓存链路是否真的工作？** 客户端发出 `prompt_cache_key` 不能证明任何事——网关是否识别、上游是否命中、是否发生路由漂移或提前淘汰，都要在网关侧确认。
+
+3. **网关认不认 `prompt_cache_retention`？** 它是 OpenAI Responses 的字段。另需确认 pi 0.85.1 在你们这条 compat 分支上**实际发的是 `24h` 还是 `prompt_cache_options.ttl=30m`**——抓一次真实请求即可。
+
+---
+
+## 七、Token 可观测性建设
+
+**已有的能力**：`siclaw_tokens_total{type,provider,model,user_id}` 与 `siclaw_cost_usd_total` 两个 Prometheus counter（`shared/metrics.ts:75-88`）。所以本章**不是从零建设**——r1 写"没有任何 token 读取能力"过满，已更正。
+
+**缺的是**：调用级明细与下钻能力（counter 无法按会话/请求回溯，也无法回答"同一前缀复用了几次"），以及 §7.2 那三个采集缺口导致的**覆盖不全**——subagent 的消耗既不在 counter 里，也不在库里。
+
+### 7.1 目标
+
+| 视图 | 受众 | 维度 |
+|---|---|---|
+| 开发者平台 dashboard | 平台开发者 | 按 **provider / model** 的 token 与成本统计 |
+| 管理员视图 | 管理员 | 按**用户**（平台用户 + 渠道用户）的 token 消耗 |
+| 排查视图 | SRE / 开发 | 按 round / origin 下钻，即 §3 的诊断能力常态化 |
+
+指标口径统一为五项：`input` / `output` / `reasoning` / `cache_read` / `cache_write`，外加派生的**缓存命中率**与**成本**。
+
+### 7.2 数据来源：envelope 够用，但**采集路径不完整**（r1 此处错误）
+
+`LlmCallEnvelope`（`llm-call-recorder.ts`）本身携带了所需字段：
+
+| 需要的维度 | envelope 中的位置 |
+|---|---|
+| 五项 token | `usage.{input,output,reasoning,cache_read,cache_write}` |
+| provider / model | `model.{provider,id,response_model}` |
+| 轮次 / 间隔 | `round`（**prompt 内**轮次，每 prompt 重置）、`since_prev_ms`（首轮为准备耗时） |
+| 重试 / 附属 | `attempt`、`aux_calls`（压缩调用） |
+
+**但落库路径有三个缺口，必须先补**：
+
+| 缺口 | 位置 | 后果 |
+|---|---|---|
+| **subagent 不落 `llm_call`** | `session.ts:2921-2945` | 子会话 token **完全缺失**；且 `if (text)` 守卫使无正文的调用不落行 |
+| `aux_calls` / `discarded_llm_calls` 需展开 | `sse-consumer.ts` | 压缩调用与被路由丢弃的调用不计入，低估用量 |
+| prompt 末尾的 aux 无承载 | 同上 | 没有后续 agent 调用来挂载，**直接丢失** |
+
+> **r1 写的"不需要新增采集，只需要新增存储与读取"是错的，已撤回。** 正确表述是：**先补采集，再谈聚合**。至于回灌：Portal 侧确实没有 subagent 的 `llm_call`，但 pi 的 JSONL 里另有一份（r3 补正），**可回灌范围待查**，见 §7.7。
+
+**统计口径注意**：Responses 的 `reasoning` 是 `output` 的**子集**，五项不可直接相加；展示与求和时需明确口径，否则 output 会被重复计算。
+
+### 7.3 决策一：聚合方式（需 review）
+
+| 方案 | 改动量 | 问题 |
+|---|---|---|
+| A. 直接 `JSON_EXTRACT` 查 `chat_messages` | 零 | `metadata` 是 TEXT，配合 `LIKE '%llm_call%'` 即全表扫。当前 7 天就有 ~5 万条工具消息，不可持续 |
+| **B. 新建 `llm_calls` 事实表，写入时同步落** | 中 | **推荐**。一次模型调用一行，维度列独立成列可索引 |
+| C. 在 B 之上加日粒度 rollup | 小 | dashboard 查 rollup，排查查事实表 |
+
+建议 **B + C**：事实表保证可下钻，rollup 保证 dashboard 快。A 仅用于本次一次性定位（§3）。
+
+事实表的最小列集：
+
+```
+llm_calls(
+  id, org_id, user_id, session_id, message_id,
+  agent_id, agent_type, session_origin,
+  provider, model_id, api_type,
+  round, attempt, since_prev_ms,
+  input_tokens, output_tokens, reasoning_tokens,
+  cache_read_tokens, cache_write_tokens,
+  cost_micros,                    -- 见 7.5
+  occurred_at
+)
+```
+
+索引至少覆盖 `(org_id, occurred_at)`、`(provider, model_id, occurred_at)`、`(user_id, occurred_at)`。
+
+### 7.4 决策二：归属维度（r1 的前提有误）
+
+> **r1 称"token 会挂在没有主人的子会话上"，错。** 子会话建会话时即写入 `request.userId`（`session.ts:2829`），**有主人**。真正的缺口是那些会话**没有 token 数据**（§7.2），不是归属丢失。
+
+归属仍需设计，但要解决的是另一组问题：
+
+| 维度 | 说明 |
+|---|---|
+| **用户** | 子会话已带 `user_id`，直接可用 |
+| **根请求关联** | 需要把子会话的消耗归拢到发起它的那次请求上，才能回答"这一次排障花了多少钱" |
+| **入口归属** | `PARENT_ATTRIBUTED_ORIGINS` 解决的是入口口径；注意 **`task`（定时任务）不在该列表**——它本身就是独立入口，无父可继承 |
+| **调用去重** | 同一次调用可能经多个事件抵达，事实表需要稳定的去重键（参考 `llmCallEnvelopeKey` 的构造） |
+| **缺失 usage** | provider 未返回 usage 时要显式标记，不能记 0 混入统计 |
+| **渠道发送者** | 见 §7.6 |
+
+另注意 `adapter.ts` 有 HTTP + WS 两套镜像查询，改一处不够；孤儿行（父已删除）需要显式处理，不能落进任何用户的账。
+
+**仅在 SSE 写入点旁 double-write 是不够的**——那条路径本身就漏了 subagent（§7.2）。采集点应当放在更靠近 `llm-call-recorder` 的位置，或在子会话持久化路径上同步补写。
+
+### 7.5 决策三：成本单价（需 review）
+
+当前 `model-compat.ts:474` 的成本表硬编码全零，所以 `getSessionStats().cost` 对所有 Portal 托管模型永远返回 $0。
+
+单价存哪里有两种选择：
+
+| 方案 | 问题 |
+|---|---|
+| `model_entries` 加价格列 | 简单，但价格变更后历史数据会被按新价重算 |
+| **独立 `model_pricing` 表，带生效时间** | **推荐**。历史账单按当时单价计算，价格调整可追溯 |
+
+单价需要区分四档：`input` / `output` / `cache_read` / `cache_write`——正是 §2.1 那张表，缺任何一档都算不出 cache 是省钱还是赔钱。
+
+建议事实表落库时即算出 `cost_micros` 冻结下来，而非查询时 join 价格表：一来避免历史重算，二来 dashboard 不必每次做区间匹配。
+
+### 7.6 决策四：渠道用户的身份（需 review · 有硬约束）
+
+需求里的"飞书用户"不能直接复用平台用户 id —— 渠道消息的发送者未必绑定过平台账号。现有的渠道审计已经确立了口径：以 **sender 的渠道原生标识（open_id + channel_id）** 归属，不引入外部平台的用户 id。
+
+> ⚠️ **上游仓库约束**：`github.com/scitix/siclaw` 内不得出现上游控制面的产品名、内部仓库路径或内部表名。涉及该侧的表述一律用中性词（如 "Upstream mode"）。本功能的列名与文案需遵守。
+
+因此用户维度实际是两类主体，dashboard 需要分别呈现而非强行合并：
+
+- **平台用户**：`chat_sessions.user_id`
+- **渠道用户**：渠道原生 sender 标识，可能无对应平台账号
+
+### 7.7 落地顺序
+
+0. **先补采集**（§7.2 的三个缺口）：subagent 路径落 `llm_call`、展开 `aux_calls` / `discarded_llm_calls`、处理 prompt 末尾无承载的 aux。**这是前置条件，跳过它后面全部失真。**
+1. 建 `llm_calls` 事实表（`migrate.ts` 需同时兼容 MySQL 与 SQLite，禁用 `JSON` 列类型），采集点见 §7.4 末段
+2. 补 `model_pricing` 与 `cost_micros` 计算；同时修正 `model-compat.ts:474` 的零成本表，让现有 `siclaw_cost_usd_total` 也恢复有效
+3. 开发者平台 dashboard：provider / model 维度
+4. 管理员视图：两类用户主体
+5. rollup 表 + 排查下钻视图
+6. 回填：**可回灌范围待定，先查再定**。Portal 侧确实没有 subagent 的 `llm_call`，但 **pi 的 SessionManager 会把完整 assistant 消息写入 JSONL，且无正文的 assistant 也能携带 usage**（0.85.1 已合成验证）。所以 r1 的"历史不丢"与 r2 的"无可回灌"**都过满**。
+
+   待查清单（P0 的一部分）：
+   - `SessionManager.create(process.cwd())`（`agent-factory.ts:427`）的 session dir 实际落在哪，是否在 NFS/PVC 上——注意它与 `userDataDir`（`:468`）是分别计算的，不一定同路径；
+   - agentbox pod 回收后 JSONL 是否留存、保留多久；
+   - 历史覆盖率（多少比例的会话还能找到 JSONL）。
+
+   查清之前，回填规模不做承诺；回填后的数据必须标注覆盖范围，避免被当作全量
+
+### 7.8 P0 方案定稿（已对齐，可开工）
+
+经两轮 review 对齐，P0 = **完整调用采集 + 固定样例计量报告**。Dashboard、价格表、rollup 全部后置。
+
+#### 7.8.1 采集架构：core 只产事件，Runtime 负责持久化
+
+在 recorder / 执行适配边界统一生成调用记录，AgentBox 经 `GatewayClient` 交给 Runtime 落库——**core 不直接写数据库**。
+
+**aux、无正文、失败调用独立结算**，不再等待下一条聊天消息承载（这正是 §7.2 第三个缺口"prompt 末尾的 aux 无承载"的解法）。
+
+#### 7.8.2 `round`/`attempt` 不能当唯一 ID —— 必须新增 `call_id`
+
+> ⚠️ r3 早先写"用 `round`/`attempt` 关联 usage"是错的：
+> - `round` **每个 prompt 重置**（`llm-call-recorder.ts:49`）；
+> - **aux 调用的 `round` 为 0**，多条 aux 无法互相区分。
+
+正确做法：
+
+| 标识 | 用途 |
+|---|---|
+| **`call_id`（新增，稳定唯一）** | 关联 session、prompt、父／根请求；**投递重试按它去重** |
+| 底层 HTTP 重试 | **另记为网络尝试**，不与 `call_id` 混淆 |
+
+#### 7.8.2b 记录结构（第 1 步产物）
+
+**设计原则：来源在产生处显式记录，不做事后推断。**
+
+> ⚠️ 早先提议用 `stop_reason === "pending"` + 「该 session 是否 handoff 过」推断来源，**已作废**。两个反例（Pi 0.85.1 合成验证）：
+> - **未返回 usage 也能正常结束为 `stop_reason: "stop"`**，异常路径还会变成 `error`/`aborted` —— 查 `pending` 会漏判；
+> - **重建不只由 handoff 触发**。`session.ts:3193-3210` 的分支表明：会话被驱逐（`evictedSessions`）、或本地历史缺失（`!hasRestorableSessionContext`，**pod 重启后的常态**）都会从控制面重建。且**同一 session 内可能混有重建消息与其后的真实调用** —— 按 session 判断必然出错，**只能逐消息／逐调用标记**。
+
+```ts
+interface LlmCallRecord {
+  // ── 身份：call_id 对应一次真实调用的生命周期 ──
+  call_id: string;              // 稳定唯一；投递重试按它去重
+  session_id: string;
+  prompt_id: string;            // 一次 prompt（含其多轮）
+  root_request_id?: string;     // 根请求，跨父子关联
+  parent_call_id?: string;      // 发起该 subagent 的调用
+
+  // ── 分类：round/attempt 仅供诊断，不作标识 ──
+  kind: "agent" | "aux";
+  round: number;                // prompt 内轮次，每 prompt 重置；aux 为 0
+  attempt: number;              // 模型路由尝试
+  network_attempts: number;     // 底层 HTTP 重试，独立计，不产生新 call_id
+
+  // ── 模型 ──
+  provider: string;
+  model_id: string;
+  api_type: string;
+
+  // ── usage：状态与来源分开，token 可空，一律存服务端原值 ──
+  usage_status: "reported" | "partial" | "missing" | "unknown";
+  usage_source: "provider" | "sdk_default" | "rehydrated" | "unknown";
+  reported_fields: string[];    // 服务端实际报告了哪些字段（按该 API 的契约判定）
+  input_tokens_total:  number | null;  // 原值；Responses 下含 cached + cache-write
+  output_tokens_total: number | null;  // 原值；含 reasoning
+  reasoning_tokens:    number | null;
+  cache_read_tokens:   number | null;
+  cache_write_tokens:  number | null;
+
+  // ── 请求快照：缓存与裁剪验证的依据 ──
+  request_snapshot: {
+    prompt_cache_key: string | null;
+    cache_retention_sent: "none" | "24h" | "ttl_30m" | null;  // null = 未发送该字段
+    model_settings: Record<string, unknown>;   // thinking level、max_tokens 等
+    system_sha256: string;
+    tools_sha256: string;
+    history_prefix_sha256: string;   // 历史前缀指纹，用于识别裁剪/改写
+    history_message_count: number;
+  };
+
+  // ── 请求计量：三个口径互不替代 ──
+  payload_bytes: number | null;            // 真实请求体字节
+  payload_tokens_estimated: number | null; // 本地估算
+
+  // ── 时间 ──
+  request_at: string;
+  response_end_at: string;
+  since_prev_ms: number | null;  // 首轮为准备耗时，非距上次提问
+
+  // ── 归属 ──
+  org_id: string; user_id: string | null;
+  agent_id: string; agent_type: string; session_origin: string;
+
+  // ── 成本：P0 阶段一律 null（单价未核实）──
+  cost_micros: null;
+}
+```
+
+**三组语义的判定规则**：
+
+| 字段 | 规则 |
+|---|---|
+| `usage_source` | 响应适配层按**服务端是否报告**打 `provider` / `sdk_default`；恢复路径（`writeRehydratedSession`）打 `rehydrated`；历史无标记则 `unknown` |
+| `usage_status` | 按**该 provider/API 的字段契约**判定「全」，**不能固定要求五项都在**——不同 API 报告的字段集本就不同。全 → `reported`；部分 → `partial`；SDK 占位 → `missing`；来源不可信 → `unknown`。⚠️ **空的 `reported_fields` 自身区分不了 `missing` 与 `unknown`**，必须结合 `usage_source` 的采集证据 |
+| token 字段 | **明确报告的零保留为 `0`**；未报告一律 `null`。`null ≠ 0` 是本设计的核心约束 |
+
+**派生值走共享 helper，不靠各消费方记纪律**：
+
+```
+output_non_reasoning_tokens = output_tokens_total - reasoning_tokens
+input_tokens_uncached       = input_tokens_total - cache_read_tokens - cache_write_tokens  // 仅 Responses
+```
+
+**任一输入为 `null`，派生结果即为 `null`。** 正确聚合放进共享实现 + 测试，避免「不可相加」变成每个消费方得记住的口头约定。
+
+> ⚠️ **`usage.input` 在两个协议下语义不同，这是必须存原值的硬理由**：
+> - **Responses**：pi 已扣除缓存部分 —— `input: Math.max(0, input_tokens - cachedTokens - cacheWriteTokens)`（`openai-responses-shared.js:441-445`，注释原文 "OpenAI includes cached and cache-write tokens in input_tokens, so subtract both"）。那个 `Math.max(0, …)` 钳制**又是一个零的来源**。
+> - **Anthropic**：`usage.input = input_tokens` 直接赋值（`anthropic-messages.js:409`），原始值本就不含 cache。
+>
+> 直接存 pi 的 `usage.input` 会得到「未缓存输入」而非「总输入」，且跨协议不可比。
+
+**重建消息不是调用**：`writeRehydratedSession` 产出的合成 assistant 消息**不分配 `call_id`、不入事实表**——否则虚增调用数。
+
+> ⚠️ **但也不能反推丢了多少调用**：一条工具结果同样会生成合成 assistant，**消息数 ≠ 原始调用数**。覆盖率报告只记「排除的重建消息数／会话数」，**无法确认的调用数保持 `unknown`**，不做估算。
+
+#### 7.8.3 缺失语义进 schema —— 以及 pi 的全零陷阱
+
+`usage_status` 四态：`reported` / `partial` / `missing` / `unknown`；token 字段**可空**；报告同步展示覆盖率。
+
+> ⚠️ **pi 0.85.1 在发请求之前就把 usage 初始化为全零**（`openai-responses.js:94-101`，此时 `stopReason: "pending"`）。因此：
+> - **不能只检查 `message.usage` 是否存在**——它总是存在；
+> - **不能把全零直接判成缺失**——`cache_read = 0` 是完全可能的真实值。
+>
+> 必须在**响应适配层**保留"服务端是否报告、哪些字段实际存在"的信息。
+>
+> **全零共有三个来源**（见 §7.8.7）：pi 的请求前初始化、handoff 后 `ZERO_USAGE` 重建、以及真实的零值。三者在数据里无法自动区分，**无法判定来源的一律标 `unknown`，不得填零**。
+
+#### 7.8.4 保留现有变更回调，并行新增逐调用计量回调
+
+现有 `onModelEnvelope`（哈希变化时触发）**不改语义**——它有明确的现存契约：KBC worker 用它发送 `model_envelope` 事件，SDK 契约测试要求"两次请求、一次变更回调"。外部日志消费者未知，P0 没有必要动它。
+
+计量走**新增的逐调用回调**。
+
+#### 7.8.5 验证：双层，且网关测试不需要真实集群
+
+| 层 | 覆盖 | 方式 |
+|---|---|---|
+| **离线夹具** | 主／子会话、aux、失败、重试、取消、缺失 usage、去重与关联 | 复用现有测试设施 |
+
+**必须覆盖的五个反例**（都来自 Pi 0.85.1 合成验证，每一个都能让朴素实现判错）：
+
+1. **正常结束但无 usage** —— `stop_reason: "stop"` 配全零 usage，不能判成 `reported`
+2. **失败／取消后的初始化零** —— `error` / `aborted` 同样带全零
+3. **无 handoff 的重建** —— 驱逐或本地历史缺失即可触发
+4. **重建与真实调用混合在同一 session** —— 证明按 session 判断不可行
+5. **明确报告的 `cache_read = 0`** —— 必须保留为 `0`，不得转成 `null` 或判为缺失
+| **真实网关** | 冷／热缓存、历史追加、裁剪 | **固定合成输入 + 合成工具定义**，打真实网关 |
+
+缓存参数有**三种**形态需覆盖，不是两种：pi 默认 `short` 时**根本不发**这两个字段；`long` 分支才可能发 `prompt_cache_retention: "24h"` 或 `prompt_cache_options.ttl=30m`。离线夹具覆盖全部三种，真实请求验证当前走哪条。
+
+> ⚠️ **网关返回成功只说明它接受了请求，不能证明兑现了 TTL。** 短期重复请求也只验证当时命中。
+
+真实 SRE 剧本留给后续的任务质量与 `run_script` 收益评估，**不进 P0**。
+
+#### 7.8.6 交付物
+
+1. 固定夹具
+2. 网关探测脚本
+3. **机器可读结果**
+4. 报告：记录版本／配置／覆盖率
+
+可重复脚本是硬要求——否则后续改动（如 `defer_loading`）无法证明收益。
+
+#### 7.8.7 JSONL 回灌：路径已确定，剩余为部署侧待查
+
+child **不走** factory 的默认 `SessionManager.create()`，而是显式传入 `continueRecent(cwd, childSessionDir)`（`session.ts:2683`）。目录由代码确定：
+
+```
+resolve(process.cwd(), config.paths.userDataDir)/agent/sessions/<childSessionId>
+```
+
+（`session.ts:755-774` 的 `getBaseSessionDir()` + `getSessionDir()`）
+
+**K8s 侧代码事实**：
+
+- `userDataDir` 默认 `.siclaw/user-data`，可被 `SICLAW_USER_DATA_DIR` 覆盖（`config.ts:259,401`）
+- agentbox pod 显式设 `PI_CODING_AGENT_DIR = .siclaw/user-data/agent`（`k8s-spawner.ts:590`）——pi 目录确实在 user-data 之下
+- `user-data` 卷在 PVC 与 `emptyDir` 之间二选一（`k8s-spawner.ts:726-730`）
+
+> ⚠️ **r4 据此写成"一个全局二元开关"，错了。** 决策是**逐 agent**的（`k8s-spawner.ts:706-713`，注释原文 "Persistence decision is per-agent"）：
+>
+> ```ts
+> const wantsPersistence = boxConfig.persistence ?? !!this.config.persistence?.enabled;
+> const persistenceEnabled = wantsPersistence && !!persistenceClaimName;
+> ```
+>
+> 全局关闭时单个 agent 仍可挂 PVC，反之亦可显式关闭。**必须查目标 Pod 的实际 volume / mount / subPath**，而且**当前配置不代表历史配置**。
+
+#### 存储可用 ≠ 数据可信（本轮最重要的一条）
+
+即使 JSONL 文件在，里面的 usage 也**可能是占位零**：
+
+| 全零的来源 | 位置 | 含义 |
+|---|---|---|
+| pi 发请求**之前**的初始化 | `openai-responses.js:94-101` | 服务端从未报告 |
+| **handoff 后从控制面重建** | `session-rehydrate.ts:84,148,172` 的 `ZERO_USAGE` | 原始记录**已被删除**后重建的历史 |
+| 真实的零值 | — | `cache_read = 0` 完全合法 |
+
+handoff 会调 `removeCachedSessionTranscript()`（`session.ts:3151`，调用点 `:3202`、`:4070`）删掉旧 JSONL，之后重建的 assistant 消息带 `ZERO_USAGE`。
+
+**所以回灌必须做来源核验**：三种全零在文件里长得一样，含义完全不同。无法判定来源的一律标 `unknown`（§7.8.3），**不得填零**。
+
+反向的一条也成立：**使用 `emptyDir` 的 Pod 只要尚未删除，数据仍可提取**——不是"关了 persistence 就一定没有"。
+
+#### 已从代码排除的一项
+
+r4 担心 `scheduleToolOutputCleanup`（`session.ts:768`）会清掉 JSONL——**可以排除**。`sweepSessionToolOutputs` 只进入 `<session>/.tool-results` 子目录（`tool-output-cleanup.ts:20-21`），不碰会话 JSONL；每个 base 只注册一次，启动清扫后每十分钟跑一次，其 24 小时窗口是 tool-result 产物的保留期，不是 JSONL 的。
+
+**剩余待查（需要生产环境）**：
+
+1. 目标 Pod 的**实际** volume / mount / subPath（逐 agent，且历史配置可能不同）
+2. 抽样核验：文件里的 usage 是原始记录还是 `ZERO_USAGE` 重建
+3. 历史文件的实际覆盖率
+
+顺序建议：**先查配置 → 再抽样 → 最后才谈覆盖率普查**。但来源与覆盖率核验不可取消。
+
+
+#### 7.8.8 两项不阻塞 P0 的前提
+
+| 项 | 处理 |
+|---|---|
+| 实际单价未核实 | **先只记 token，成本字段留"未知"**，不因缺价格而阻塞采集 |
+| 网关缓存链路是否工作 | **它是实测结果，不是前提**。注意：短期重复请求只能验证当时命中，**不能证明网关兑现了长期 TTL** |
+
+### 7.8.9 P0 实现记录
+
+分支 `worktree-token-metering-p0`，基线 `946e0675`。经多轮 review 修订，根仓库全量 **373 文件 / 7592 测试通过**、portal-web **32 文件 / 280 测试通过**，两侧 `tsc --noEmit` 均干净。
+
+#### 落地文件
+
+| 文件 | 作用 |
+|---|---|
+| `src/shared/llm-call-record.ts` | 记录结构、协议契约表、派生 helper、一致性校验 |
+| `src/shared/llm-call-validation.ts` | 线上契约，发送与接收共用 |
+| `src/core/raw-usage-observer.ts` | HTTP 层原始 usage 观察 + 最终请求指纹 |
+| `src/core/llm-call-recorder.ts` | 注入 fetch、产出 measurement（**附加式**） |
+| `src/shared/session-rehydrate.ts` | 重建消息打 `rehydrated` 标记 |
+| `src/agentbox/llm-call-dispatcher.ts` | 批量投递：有界队列、重试、交付统计 |
+| `src/agentbox/session.ts` | 主/子会话接线 + 四条关闭路径收尾 + 子代理继承请求关联 |
+| `src/agentbox/http-server.ts` | 把 `turnId` 绑成该轮的请求关联 |
+| `src/gateway/channels/{lark,dingtalk}.ts`、`task-coordinator.ts` | 在入口铸稳定 turn id（此前这三条路一个都没带） |
+| `src/gateway/llm-call-api.ts` | 接收端：校验、归属解析、持久化 |
+| `src/portal/llm-call-repo.ts` | 按 `call_id` 幂等写入 |
+| `src/portal/llm-usage-repo.ts` | 读取端聚合：按 provider×模型 / 按用户，服务端排序 |
+| `src/portal/siclaw-api.ts` | `GET /metrics/token-usage`（admin） |
+| `portal-web/…/TokenUsageCard.tsx`、`useMetrics.ts` | Portal 上的用量表（四列 + 可排序 + 覆盖率） |
+| `src/portal/migrate.ts` | `llm_calls` 事实表 + 3 个索引 |
+| `scripts/smoke/token-cache-probe.mjs` | 网关探测脚本（三种 retention 形态） |
+
+#### 采集为何在 HTTP 层
+
+`streamFn` 边界只能看到 pi 归一化后的 usage，而 pi 在请求发出前就把 `input`/`output`/`cacheRead`/`cacheWrite` 初始化为全零且类型必填——**"报了 0"与"没报"在那里不可区分**。`reasoning?` 也不是可用信号（实测未报告时被填为 `0`）。
+
+因此改用 `options.fetch`（pi 公开入参）：逐调用组合、不替换调用方自带的 fetch、tee 响应体、**原始字节原样交给 SDK**，只在自己那份上解析。
+
+#### 三值语义与四种零
+
+| 概念 | 取值 |
+|---|---|
+| `usage_source` | `provider` / `sdk_default`（读到了，确实没有）/ `rehydrated` / `unknown`（没读到或未插桩）|
+| token 字段 | `number`（含明确报告的 `0`）或 `null`（未报告）。**`null ≠ 0`** |
+| `request_snapshot.cache_retention_sent` | 字段缺失=未采集；`null`=采集了且确认未发送；`"24h"`/`"ttl_30m"`/`"none"` |
+
+已知会产生全零的四条路径：pi 的请求前初始化、`session-rehydrate` 的 `ZERO_USAGE`、`Math.max(0,…)` 钳制、真实的零。它们在数据里长得一样，所以来源**在产生处打标**，不做事后推断。
+
+#### review 修订记录（各轮暴露的实际缺陷）
+
+| 问题 | 修法 |
+|---|---|
+| 时序竞态：seal 同步、观察异步 | measurement 等待观察，250ms 宽限后降级 `unknown` |
+| 重试只记首次响应 | 每次 attempt 独立 latch + 编号；取**最后发起**的那次 |
+| Anthropic input/cache 被丢弃 | 按**字段合并**而非整体覆盖（`message_start` 与 `message_delta` 各带一半）|
+| 观察失败被记成"服务端未报" | 三态 `outcome`，失败归 `unknown` |
+| 延迟记录串到下一个 prompt | `promptId` 在 `openCall` 时快照 |
+| SSE 按行拆分 | 按空行分帧，帧内多个 `data:` 按规范拼接 |
+| 坏帧被已读 usage 掩盖 | 有坏帧或**无终态标记**即 `failed`，values 保留作证据 |
+| 瞬时发送失败永久丢批 | 确认前不出队，退避重试 3 次 |
+| 上限没约束在途批次 | 单队列单消费循环，`queue + inFlight` 统一计数 |
+| 空队列 flush 后永久卡死 | 空队列不进入 draining 状态 |
+| `close` 无时间上限 | 墙钟预算 5s，超时部分计入 `dropped` 并清空 |
+| 预算信号晚于它要限制的等待 | `close` 设置截止时刻的**同时**就挂定时器：在 close 之前开始的发送没有 deadline 可挂定时器、只挂在 cutoff 闩上，而 close 自己的 `await drain()` 等的正是那次发送——把信号放在循环之后，等于让限制者等待被限制者（实测 5s 预算跑到 9s） |
+| 并发收尾丢尾部 | 按 session 共享同一个收尾 Promise |
+| 收尾漏掉未结束的调用 | `activeCalls` 跟踪，先等调用再等 measurement |
+| 指纹取自 SDK 输入 context | 改取**最终请求 body**（`onPayload` 可改写 instructions）|
+
+#### 主子关联：一次用户请求的完整开销
+
+子代理的调用本来就是这套计量要补的那块（Portal 从没见过它们），但"补上了行"不等于"能按请求汇总"——还得知道**哪些行属于同一次请求**。
+
+契约有三条，每条都对应一种实际会算错的形态：
+
+**一、关联由生产方带，绝不在接收端推。** 只有 box 知道一次调用服务的是哪个 turn。接收端能拿到的只有会话血缘，而一段对话里的多次请求共用同一个会话——按血缘推会把整段对话折成一个 id。所以 `root_request_id` 走 measurement 本身，接收端只在生产方**没带**时写 `null`（旧版 box），不自己造。
+
+**一之二、两个问题，两个字段。** `root_request_id` 只回答"这些调用属于同一次请求"，回答不了"是**哪一次模型调用**派发了这个 child"。后者是 `parent_call_id`，同样由生产方带：tool-call id 命名的是工具调用、不是产生它的那次 LLM 调用；会话血缘更看不出一个 turn 的哪一轮做了派发。取值是**刚封口的那次 agent 调用**——它的 tool 正在执行，正是派发者；aux 调用（摘要之类）不发工具，跳过，否则会指认一个不可能派发的调用。下一轮开始就会覆盖它，所以必须在 dispatch 那一刻同步读。
+
+**二、复用 `turnId`，不另造协议字段。** `turnId` 已经是"一次被接受的 prompt 执行"的标识，且**跨 model-routing 重试保持不变**——重试是同一次用户请求换个候选模型，正是需要归到一起的情况。再造一个 id 只会多出一个要对齐的东西。
+
+**二之二、id 在入口铸，不在 client 铸。** `chat.send`（web / api / a2a 都走它）本来就会补 `turnId`，但飞书、钉钉、定时任务是**直接调 `AgentBoxClient`** 的，此前一个 id 都没带——这些入口的每一次调用（含子代理）都落成无关联的行。补在 client 里是错的：**一个 turnId 命名一个 turn，而 client 是每次 attempt 调一遍**，`promptWithBusyRetry` 会重试，那样一条消息会裂成两个关联。所以在构造 `promptOpts` 处铸，重试复用同一个对象。定时任务直接用已有的 `runId`——它本来就命名这次执行，这样计量行与运维看的那条 run 记录天然对齐。
+
+> 仍有一处没覆盖：上游模式下走 `ConversationClient → conversation.start` 的那条路，turn 身份由控制面派发时决定，不在本仓库内。
+
+**三、子代理在 dispatch 时刻快照继承，不事后回读父会话。** 与 trace id 完全同一个理由：后台子代理可能在父 prompt 结束、甚至父会话已释放之后才启动，那时回读得到的要么是空，要么是另一次请求的值。因此捕获点在 `createSpawnSubagentExecutor`（父 turn 还活着），随 `SubagentDispatchContext` 一路传到每个 child。
+
+三种刻意留 `null` 的情况（都是"不知道"而不是"没有"）：
+
+| 情况 | 为什么是 `null` |
+|---|---|
+| 旧版 box 不带该字段 | 加性上线的代价，不能靠猜补齐 |
+| 上游模式下走控制面 `conversation.start` 的 turn | turn 身份在控制面那侧决定，本仓库看不到 |
+| synthetic turn（后台任务完成后唤醒父会话） | 它不属于任何一次用户请求；且通知会**合并**，一个 turn 可能同时回应来自不同请求的多个 job。开销仍归到 session/agent/user，只是不折进某一次请求 |
+| id 超过列宽（64 字符） | 截断会把不同请求的调用**串到一起**；宁可丢关联也不丢测量——行照写，只是 `root_request_id` 为空，并 warn 一次 |
+
+#### 读取端：聚合的三条纪律
+
+采集侧花了很大力气把"报了 0"和"没报"分开，而**聚合正是这些区分被重新抹掉的地方**。所以下面三条不是各调用方自己注意，是写进 `llm-usage-repo.ts` 的：
+
+**一、`SUM(col)` 会跳过 NULL。** 一个字段只有一半调用报了，`SUM` 照样给出一个**看起来像总数**的数。所以每个字段都返回 `{total, reportedCalls}` 两个值，页面拿 `reportedCalls` 和该行的 `calls` 一比就知道这个和的分母是多少；不等时标星号并在 hover 里写明"N 次中的 M 次"。全都没报时 `total` 是 `null`、渲染成 `—`，**绝不写 0**。
+
+**二、不可信的行排除在外，且把排除了多少说出来。** `sdk_default` / `rehydrated` / `unknown` 的行全是零，混进 SUM 会静默拉低每个数字。它们不参与求和，单独计数，接口返回 `coverage: {trustworthy, excluded}`，卡片上直接显示 `7/10 measured`——否则一份覆盖不全的统计和完整的长得一模一样。
+
+**三、"总 token"在不同协议下是不同的算式。** openai-responses 的 `input_tokens` **已经包含** cache 部分，anthropic-messages 不包含。五列一视同仁地加，会在前者上把每个缓存 token 数两遍、在后者上少数。所以聚合**按 `api_type` 分组**，再逐组调 `billableTokens()`——那条规则在 `llm-call-record.ts` 里只有一份，不在 SQL 里再答一遍。一个 actor 的调用跨了协议时打 `mixedProtocols` 标记；其中任何一片算不出来，整个 actor 的总数就是 `null`，不拿已知的那部分冒充总数。
+
+补充两条：
+
+- **排序在服务端。** 结果是**截断**的，把返回的那一页在浏览器里重排会排错行——"cache write 最高的 50 个"不等于"总量最高的 50 个里 cache write 最高的"。`sort` 参数支持 `billable / input / output / cacheRead / cacheWrite / calls`，截断在排序**之后**。
+- **算不出总数的行排最后，不当 0。** 它不是"最便宜的那个"，是"算不出来的那个"——按 0 排会把一个可能很贵的对象沉到底，而那正是这张表要找的东西。
+
+actor 维度要**沿父会话取身份**：`sender_external_id` 只盖在渠道会话上，子代理的子会话没有。注意不能逐列 COALESCE——子会话**有自己的 origin**（`subagent`），COALESCE 永远取不到父的。判断要先问"这个会话该用谁的身份"（复用 `PARENT_ATTRIBUTED_ORIGINS`），再整体从那一侧读列。
+
+#### 仍未完成
+
+| 项 | 说明 |
+|---|---|
+| **端到端验证** | 接收端只有单元测试，未跑过真实 box → Runtime；Portal 那张表也只跑过 SSR 渲染断言，没在浏览器里看过真实数据 |
+| **上游模式控制台的审计页** | 本轮做的是 **siclaw Portal** 的 Metrics。上游模式下控制台是另一套前端，它的数据得先让 `llmCall.persist` 在那侧落库——两件事 |
+| **`org_id`** | 事实表已有该列，缺的是**可信来源**：`chat_sessions` 无此列，而 LocalSpawner 证书里的 `default` 是占位符，填进去等于造一个假租户。按 review 结论先留空——这确实使"按组织汇总"暂不可用，但它是数据缺口，不是本次实现的遗留 |
+| **成本** | `cost_micros` 恒为 `null`——单价未核实，错误的成本比缺失更糟 |
+| **回灌** | 范围仍取决于 §7.8.7 的部署侧待查项 |
+
+#### 部署顺序（三段，不可颠倒）
+
+数据流是 **AgentBox → Runtime → 数据库持有方**，所以升级必须**逆着数据流**走：接收方先就位，发送方最后。
+
+| 次序 | 组件 | 内容 | 为什么必须在前 |
+|---|---|---|---|
+| **1** | 数据库持有方（控制面 / Portal） | `llm_calls` DDL + 索引；`llmCall.persist` handler | Runtime 转发无处可去时会 500，且 DDL 未就位时 handler 本身报错 |
+| **2** | Runtime | `/api/internal/llm-call-measurements` 路由、校验、鉴权、RPC 转发 | 早于 AgentBox，否则投递撞 404 |
+| **3** | AgentBox | recorder / observer / dispatcher / 会话接线 | 最后开采集，前两段已能接住 |
+
+**混合版本期间的行为**（每一段都设计成可降级）：
+
+| 组合 | 结果 |
+|---|---|
+| 新 AgentBox + 旧 Runtime | 投递 404 → dispatcher 重试耗尽 → 计入 `siclaw_metering_unconfirmed_total`。**不影响对话** |
+| 新 Runtime + 旧数据库持有方 | `llmCall.persist` method-not-found → 500 → 同上 |
+| 旧 AgentBox + 新 Runtime/DB | 不产出计量，表为空。无副作用 |
+
+**验收**（按段做，不要等全部上完再看）：
+
+1. 第 1 段后：确认表与三个索引存在
+2. 第 2 段后：手工 POST 一个合法批次，期望 200 + `inserted`；用**另一个 agent 的证书**打同一 session，期望 **403**
+3. 第 3 段后：跑一轮真实对话，查 `llm_calls` 是否有 `usage_source='provider'` 的行，以及 `unconfirmed` counter 是否为 0
+4. 第 3 段后：跑一轮**带子代理**的对话，确认父与子的行共享同一个 `root_request_id`，且子的 `parent_call_id` 等于父那一轮的 `call_id`——前者是"一次请求花了多少"的判据，后者是"哪一次调用派发的"，两个都要看
+5. 第 3 段后：从**飞书**和**定时任务**各跑一轮，确认 `root_request_id` 非空——这两条路是直连 AgentBoxClient 的，不经过 `chat.send` 的 turnId 补值
+
+**回滚**：逆序回退（AgentBox → Runtime → 控制面）。**表和数据不必回滚**——写入幂等，旧版本不读它，留着即可。只有确认不再启用时才 DROP。
+
+⚠️ `imagePullPolicy: Always` **只在 pod CREATE 时拉取**：存量 pod 继续跑旧代码，拿存量会话验证等于没验证。
+
+### 7.9 顺带解决的问题
+
+该事实表建成后，§3.0 的控制面取数缺口可由它直接回答，不必再给 trace 消息接口的投影补 `metadata`（那会把大量无关字段一起暴露）。§4.6 的"补上测量"亦由本章覆盖。
+
+---
+
+## 附：部署影响
+
+§4.2–4.5 涉及的文件（`src/core/`、`src/tools/`）都在 **agentbox 镜像**里。改完需要：重建 agentbox 镜像 → 更新 `SICLAW_AGENTBOX_IMAGE` → 回收 pod。
+
+注意 `imagePullPolicy: Always` 只在 pod **CREATE** 时拉取，存量 pod 会继续跑旧代码——拿存量会话验证等于没验证。
+
+§4.1 若走环境变量，需确认该变量能透传进 agentbox 容器。

--- a/docs/design/2026-09-12-token-efficiency-comparison.zh-CN.md
+++ b/docs/design/2026-09-12-token-efficiency-comparison.zh-CN.md
@@ -1,0 +1,264 @@
+# Token 效率三方对比：siclaw / Claude Code / codex
+
+> **修订 r3（经两轮 review）** —— r1 有多处源码误读会把实现带偏，逐条列于下方。**§7 的清单不可按 r1 直接落地。**
+>
+> **r3 相对 r2 的改动**：① codex 的 Code Mode 只完整渲染 `enabled_tools`，r2 写成「enabled + deferred 全部嵌入」是修过头了；② P0 的「最终请求计量」拆成三个口径，并指出现有哈希是变更事件流而非每轮记录；③ MCP 预算区分「描述截取」与「spec 准入」两种策略，不可并列抄数字；④ `defer_loading` 的「ROI 最高」撤回；⑤ cache key 表述限定模型版本，且不反推为完全零命中。
+>
+> 对比基线：siclaw `origin/main` @ `946e0675`；Claude Code 源码 `~/project/claude-code-init`；codex 源码 `~/project/codex`（Rust）。
+> 姊妹文档：`2026-09-12-token-cost-analysis.zh-CN.md`（siclaw 自身的成本诊断）。
+
+> ⚠️ **对标来源的时效限定**：`claude-code-init` 是 **2026-03 的非官方历史快照**，不代表 Claude Code 当前产品默认行为。快照中多项能力挂在 feature gate 后（聚合预算默认关闭、MCP 可用 `alwaysLoad` 退出延迟、自动阈值有字符估算 fallback）。引用其设计思路可以，**不能当作"业界现状"或默认配置**。
+
+## 修订记录：r1 被推翻的结论
+
+| r1 的说法 | 实际 | 证据 |
+|---|---|---|
+| codex 工具描述仅 **4,207 字符**，据此得出"胖 prompt 优于多个工具描述" | **数字误导，结论不成立。** 4,207 只是静态 handler spec 字面量；Code Mode 下 `build_exec_tool_description` 把 **`enabled_tools`** 的描述与 schema 生成的 TypeScript 声明动态嵌入 `exec` 的 description（**r3 再修正**：r2 写成「enabled + deferred 全部嵌入」是修过头了——`deferred_tools` 只贡献一个发现提示段与共享类型判断，测试明确断言延迟工具标题不进初始描述）。而且**工具定义同样参与缓存**，挪进 system prompt 本身没有缓存优势。三方应比较**最终渲染请求**，静态字面量不可比 | `code-mode-protocol/src/description.rs:261` |
+| "codex 子代理继承父 cache key，是假说 C 的直接答案、配置级改动" | **引用错 + 逻辑错。** `{source}:{parent_thread_id}` 仅走 `SessionSource::Internal` 分支；Guardian 用的是派生的 `guardian:{parent_thread_id}`，**不是父会话原 key**；普通会话回退自己的 `session_id`。更根本的是：**`prompt_cache_key` 是路由分区提示，命中取决于前缀内容**——siclaw 父子的工具集（child 屏蔽 `task_*`/`spawn_subagent`）与 prompt（带 addendum）本就不同，**统一 key 不保证命中**（且作用按模型版本而异；亦不能反推为完全零命中——共同前缀仍可能复用）| `codex-rs/core/src/client.rs:491` |
+| `defer_loading` 可无条件启用，收益等同 Claude Code 的"工具只占一个名字" | **两件事被混为一谈。** Claude Code 的 ToolSearch 是**客户端**实现，延迟工具只留 `tool.name`；OpenAI 的 `defer_loading` 是**服务端**特性，**名称和 description 仍进入上下文，主要推迟参数 schema**。要省成员工具描述需设计 namespace/MCP 分组。且官方要求模型支持（GPT-5.4+）并配置 `tool_search`，codex 另有模型/provider 能力检查 | OpenAI tool-search 文档 |
+| "裁剪决定冻结"可直接替换 `context-pruning` | **目标不同，直接套用会耗尽容量。** Claude 冻结的是**结果首次进入上下文时的预算处理**；siclaw pruning 是**随历史增长清理旧结果**。若首次"不裁剪"也永久冻结，近期受保护的结果此后无法清理，最终仍会触发其他 guard 或压缩。须把"首次结果预算"与"后续历史压缩"分开设计 | — |
+| 缓存断裂检测器能把"猜三个假说"变成"读输出" | **过满。** 它是**变化检测**：持续 `cache_read=0`、大量单轮子会话都不会触发"比上次下降"；只比较 system/tools 也看不到历史消息裁剪。参考实现自己保留了"可能 TTL / 可能服务端 / 未知原因"三档 | — |
+| siclaw"无缓存断裂检测""`spawn_subagent` description 运行时拼装是缓存杀手" | **均不成立。** siclaw **已有**最终 payload 的 system/tools sha256 记录，且只在哈希变化时 log；`buildDescription()` 在工具对象构造时调用一次，**同一 session 内稳定**，运行时拼装 ≠ 每轮变化。另已有工具可用性过滤、整体 context guard，最新 main 的 `run_script` 还提供脚本内并发与聚合 | `pi-execution.ts:48-60`、`model-envelope.ts:74-88`、`spawn-subagent.ts:167` |
+| siclaw"统一 8,000 字符上限"，建议"超限统一报错" | **都不成立。** 8,000 是**普通执行结果预览路径**的阈值，artifact 回读、其他工具、脚本 SDK 数据路径各有限制。Claude 那个实验只针对 **Read 超限**场景，不能推广到已执行完的命令或 MCP 查询——统一丢结果报错会增加重跑。应比较**完整任务成本**，并保留 artifact 引用与受控回读 | — |
+| codex MCP 预算 8K/spec、64K 总计适用于全部 MCP | **仅适用于 agent-plugin MCP**（`agent_plugin_bytes` 只对 `is_agent_plugin()` 的 server 累加） | `core/src/mcp_tool_exposure.rs:99` |
+
+**执行顺序据此改为**：补齐采集与**最终请求计量** → 验证现有 `run_script` 聚合效果 → 做**带能力检查的**工具搜索试点 → 按实测处理前缀变化。**共享 key、冻结裁剪、放宽结果上限降级为实验项。**
+
+---
+
+## 结论先行
+
+**siclaw 有改进空间，但差距不在"描述写太长"，也不像 r1 说的那么一边倒。**
+
+三家每轮都重发全部历史，**没有一家有传输层的增量协议**（codex 的 WebSocket delta 是唯一例外，见 §4）。所以：
+
+> **token 节省 = 缓存命中率工程，不是传输量工程。**
+
+siclaw 缺的主要是**缓存稳定性的制度化**（分区、边界、破坏需申报）和**按需加载**。但要修正 r1 的两处夸大：
+
+- siclaw **已经有**最终 payload 的 system/tools sha256 记录（`pi-execution.ts:48-60`）、工具可用性过滤、整体 context guard，以及最新 main 的 `run_script` 脚本内并发聚合。**不是白纸一张。**
+- `defer_loading` **不是**"开了就等于 Claude Code 那套"：它是服务端特性，**名称和 description 仍进上下文，主要推迟参数 schema**；还需模型支持（GPT-5.4+）与 `tool_search` 配置。收益需按 namespace/MCP 分组设计后实测，不能因同协议就全量开启。
+
+---
+
+## 一、三方基础数据
+
+> ⚠️ **这张表的字符数不可直接横比**——三者的统计口径不同，且都不是最终渲染请求的实测值。**要得出可比结论，必须抓三方的真实 payload 计量。** 详见每行脚注。
+
+| | siclaw (SRE) | Claude Code | codex |
+|---|---:|---:|---:|
+| 模型可见工具数 | **30**（全量注入） | ~22（默认）**+ 26 个延迟** | 2（Code Mode，7/9 模型）ᴬ |
+| 工具 description 字符 | 55,551 ᴮ | 60,905 ᴰ | 4,207 ᴬ |
+| system prompt 字符 | 12,779 | ~25,889 源码 / 实发 12–20K | 20,903（default.md）|
+| 单次工具结果上限 | 8,000 字符 ᶜ | Bash 30,000 字符 / Read 25,000 tok | 10,000 tokens |
+| 每轮结果聚合上限 | 无 | 200,000 字符（**默认关闭的 gate 后**）| — |
+| 延迟加载工具 | 无 | ToolSearch（客户端，**只留名字**）| `defer_loading`（服务端，**仍留 name+desc**）|
+| MCP 描述上限 | **无** | 2,048 字符 | 8 KB/spec、64 KB 总计（**仅 agent-plugin MCP**）|
+| 子代理缓存 | 独立 key | 共享父的 rendered prompt + 替换状态 | Internal 分支用派生 key，**非父原 key** |
+| 缓存断裂检测 | **已有 payload 哈希**，未接 usage | 有，按维度归因 | 有 telemetry |
+| 并行工具调用 | 默认 | **大力鼓励**（4 处提示）| **新模型禁用**，改 Code Mode |
+
+**ᴬ** codex 的 2 个工具 / 4,207 字符**只是静态 handler spec 字面量**。Code Mode 下 `build_exec_tool_description`（`description.rs:301`）把 **`enabled_tools`** 的描述与 schema 生成的 TS 声明动态嵌入 `exec` 的 description，真实上下文成本远高于此；`deferred_tools` 只贡献一个发现提示段，不完整渲染。
+**ᴮ** siclaw 的 55,551 是**下界**——只统计 description 与嵌套 description，未计 schema 结构（`task_create` 实测 141 vs 实际 1,047）。见成本分析文档 §1.1。
+**ᶜ** 8,000 只是**普通执行结果预览路径**的阈值，artifact 回读、其他工具、脚本 SDK 数据路径各有限制，不是统一上限。
+**ᴰ** 条件拼装的工具（Bash / Agent / Grep）按全分支计，单次会话实际渲染更少。
+
+---
+
+## 二、工具体积：两种策略，以及一个不可比的数字
+
+**Claude Code：肥描述 + 延迟加载。** 单个 `BashTool` 12,184 字符、`AgentTool` 11,274、`TodoWriteTool` 9,401——比 siclaw 最肥的 `node_exec`（7,991）还大。但它有逃生阀：
+
+`ToolSearchTool/prompt.ts:115-117` 的核心就三行——
+```ts
+export function formatDeferredToolLine(tool: Tool): string {
+  return tool.name
+}
+```
+
+延迟的工具**只占一个名字**，没有 description、没有 schema。模型需要时调 `ToolSearch` 把完整 schema 取回，编码与静态列表完全一致。**26 个内置工具标了 `shouldDefer`，MCP 工具一律强制延迟**，自动触发阈值是上下文窗口的 10%（真实 token 计数，非估算）。
+
+例外都写了理由：Agent 工具不延迟，因为"必须第一轮可用，不能藏在一次 ToolSearch 往返后面"。**延迟与否按往返成本逐个论证。**
+
+**codex：静态 spec 很瘦，但真实成本不在那里。** 静态字面量确实是一行：
+
+- `exec_command` — 80 字符："Runs a command in a PTY, returning output or a session ID for ongoing interaction."
+- `apply_patch` — 108 字符
+- 全部 handler spec 合计 4,207 字符
+
+> ⚠️ **r1 据此得出"胖 prompt 优于 N 个工具描述"，这个结论已撤回。** 两个理由：
+> 1. Code Mode 下 `build_exec_tool_description`（`description.rs:301`）把 **`enabled_tools`** 的描述、以及 schema 生成的 TypeScript 声明动态嵌入 `exec` 的 description——工具内容并没有消失，只是换了个位置。（**r3 再修正**：`deferred_tools` 只贡献一个发现提示段与共享类型判断，并不完整渲染；r2 把两者并列是修过头了。）
+> 2. **工具定义同样参与缓存**。把内容从 tools 字段挪进 system prompt，本身没有缓存优势。
+>
+> 真正可比的只有**最终渲染请求**的计量，静态字面量不可比。
+
+**siclaw 的位置**：描述肥度接近 Claude Code，但没有按需加载机制；**30 个工具无条件全量注入，MCP 无上限、无截断、还绕过 `allowedTools`**——最后这条是三家里唯一没有任何 MCP 预算约束的。
+
+---
+
+## 三、缓存稳定性：制度化程度的差距
+
+Claude Code 把"前缀逐字节稳定"当成一等工程约束，建了五层机制。逐条对照 siclaw：
+
+| Claude Code 的机制 | siclaw 现状 |
+|---|---|
+| **system prompt 分区 + 哨兵边界**：静态段在前（可跨 org 全局缓存），动态段在后，注释写死 "Do not remove or reorder"（`prompts.ts:105-115, 560-576`） | 无分区概念 |
+| **破坏缓存要在代码里申报理由**：`systemPromptSection()` 默认 memoize，想每轮重算必须调 `DANGEROUS_uncachedSystemPromptSection(name, compute, _reason)`。全仓只有一个 DANGEROUS 调用（`systemPromptSections.ts:20-38`）| 无此约束 |
+| **runtime 布尔挪到边界之后**：前缀里每多一个开关 = 2^N 个前缀哈希变体（`prompts.ts:343-351`）| 条件拼接散在 prompt 组装里 |
+| **易变内容改尾部 delta**：MCP instructions 不回头改 system prompt，而是尾部追加一条持久 attachment，按 server 名字 diff（`mcpInstructionsDelta.ts:29-60`）| 无 |
+| **tool schema 按 session memoize**：注释直说工具定义在服务端 position 2，**任何字节变化炸掉整个 ~11K token 工具块及下游全部**（`toolSchemaCache.ts:3-11`）| **已等效满足**：`buildDescription()` 在工具对象构造时调用一次，同一 session 内稳定（`spawn-subagent.ts:167`）。r1 称其为缓存杀手，错误。真正要防的是**跨 session 的非必要漂移**与把环境态（集群列表、连接状态）写进 description |
+
+还有两条 sticky 锁存，代价都标了价：beta header 一旦发过就整个 session 继续发（一次翻转 ~50–70K tokens，`claude.ts:1405-1442`）；1h TTL 资格在 bootstrap 锁死（~20K/次，`claude.ts:403-413`）。
+
+**codex 的同类做法**：合成 tool output 的 UUID 命名空间被硬编码，注释写"改这个值会改变模型可见 ID 并使 prompt cache 失效"（`normalize.rs:18-19`）；"Responses Lite" 把 instructions 和 tools 移进 input 数组，ID 用内容寻址的 UUIDv5，**相同内容 ⇒ 相同 ID ⇒ 前缀跨重试与恢复会话字节稳定**（`client.rs:770-802`）。
+
+### 对照 siclaw 的两个已知问题
+
+1. **`context-pruning` 每轮从完整历史重新裁剪**。Claude Code 的对应设计是**决定冻结**（`toolResultStorage.ts:372-412`）。
+
+   > ⚠️ **但不能直接替换 siclaw 的 pruning——两者目标不同。** Claude 冻结的是**结果首次进入上下文时的预算处理**；siclaw pruning 是**随历史增长清理旧结果**。若首次"不裁剪"也永久冻结，近期受保护的结果此后无法清理，最终仍会触发其他 guard 或压缩。
+   >
+   > 正确做法是**拆成两层**：「首次结果预算」（可冻结）与「后续历史压缩」（必须可持续回收），并补齐容量耗尽、恢复与证据回读规则。降级为**实验项**。
+
+2. **每个 subagent 独立 session、独立 cache key**。
+
+   > ⚠️ **r1 称"共享 cache key 是假说 C 的直接答案、配置级改动"，两处都错。**
+   >
+   > - **引用错**：codex 的 `{source}:{parent_thread_id}` 仅走 `SessionSource::Internal` 分支；Guardian 用的是派生的 `guardian:{parent_thread_id}`，**不是父会话原 key**；普通会话回退自己的 `session_id`（`client.rs:491-503`）。
+   > - **逻辑错**：`prompt_cache_key` 的作用按**模型版本**而异（OpenAI 文档区分 GPT-5.6 前后行为），准确的结论是**同 key 不保证命中**——命中仍取决于前缀内容。siclaw 的 child 屏蔽了 `task_*`/`spawn_subagent`、system prompt 还带 addendum，所以**统一 key 不足以带来命中**；但也**不能推成完全零命中**——父子的共同前缀（公共 system 段、共享工具）仍可能复用，收益取决于**共同前缀有多长**，这需要实测。
+   >
+   > Claude Code 的做法之所以成立，是因为它连**内容**一起对齐：`renderedSystemPrompt` 在 turn 开始时冻结给 fork 复用，`contentReplacementState` **克隆**，保证 fork 与父产出相同的 wire 前缀（`Tool.ts:301-323`）。**要抄就得抄这一整套，不是只改个 key。** 降级为实验项。
+
+---
+
+## 四、Responses API 特有的机会（附启用前提）
+
+siclaw 走 `openai-responses`，与 codex 同协议。codex 用到的 Responses 原生省 token 能力：
+
+| 能力 | codex 怎么用 | siclaw |
+|---|---|---|
+| **`defer_loading: true`** | 服务端延迟加载工具定义，MCP 默认延迟（`features/lib.rs:220-223`）；模型调 `tool_search` 按需取回（默认一次 8 个）。codex 另有模型/provider 能力检查，且用的是客户端执行的搜索 | 未使用 |
+| **`prompt_cache_key`** | = session id，**刻意冻结**，有测试保证"跨模型/effort 切换都不变"（`prompt_caching.rs:543,811`）| pi 自动设为 sessionId |
+
+> ⚠️ **`defer_loading` 的语义不等于 Claude Code 的 ToolSearch，r1 把两者混为一谈了：**
+>
+> | | Claude Code ToolSearch | OpenAI `defer_loading` |
+> |---|---|---|
+> | 实现层 | **客户端** | **服务端** |
+> | 延迟的工具在上下文里剩什么 | **只剩 `tool.name`** | **name + description 仍在**，主要推迟**参数 schema** |
+>
+> 所以在 Responses 上启用它，**省的是 schema 不是描述**。要省成员工具的描述，需要设计 **namespace / MCP 分组**。
+>
+> 前提还有：官方要求模型支持（**GPT-5.4 及以后**）并配置 `tool_search`。**不能因为协议相同就全量开启**——须先验证实际服务、fallback 行为与子模型，做带能力检查的试点。
+| **`previous_response_id` + delta input** | **WebSocket 上**只发增量；**服务端返回的 items 算作已知基线，永不重传**（`client.rs:1220-1257`）| `store:false`，每轮全量重发 |
+| 服务端压缩 | `compact_remote_v2.rs` | 无 |
+
+> **注意一个被我先前猜错的点**：codex **也是 `store: false`**（`client.rs:855`），同样拒绝了 stateful HTTP 路线。它的 delta 走的是 **Responses-over-WebSocket**——`previous_response_id` 只出现在 `responses_websocket.rs`，在 `responses.rs` 里**从不出现**。所以"改成 `store: true` 就能省"这个想法两家都没采纳，不要照搬。
+
+> ⚠️ **r1 称 `defer_loading` 是「ROI 最高的一项」「codex 已用成无条件默认」，两句都已撤回。** 它省的是**参数 schema**而非 name+description；需模型支持（GPT-5.4+）与 `tool_search` 配置，codex 另有模型/provider 能力检查。收益必须先按 namespace / MCP 分组设计、再用 P0 的计量实测，**不能凭同协议就判定 ROI**。
+
+---
+
+## 五、结果截断：口径需先对齐再比较
+
+| | 单次上限 | 策略 |
+|---|---|---|
+| siclaw | 8,000 字符（头 3,000 + 尾 3,000）**——仅普通执行结果预览路径** | 超出转 artifact，可受控回读 |
+| Claude Code | Bash 30,000 字符、Read 25,000 tokens、Grep 250 条 | 逐工具设定 + 50K 落盘 + 2KB 预览 + 每轮聚合 200K（**默认关闭的 gate 后**）|
+| codex | 10,000 tokens（≈40,000 字符）| 中间截断 50/50 头尾，标注 "…N tokens truncated…" |
+
+> ⚠️ **r1 说 siclaw"统一 8,000、三家最严"，不成立。** 8,000 只覆盖普通执行结果的预览路径；artifact 回读、其他工具、脚本 SDK 数据路径各有自己的限制。要比较得先把各路径列全。
+
+关于"报错比截断更省"（`FileReadTool/limits.ts:1-14`）：
+
+> ⚠️ **那个实验只针对 Read 超限场景**——用户显式指定了超出字节上限的读取，报错能逼模型重新收窄再读。**不能推广到已经执行完的命令或 MCP 查询**：结果已经产生，丢掉它报错只会导致重跑，总成本更高。
+>
+> siclaw 现有的 **artifact 引用 + 受控回读**在这类场景下比"报错"更合适，应保留。要评估就比较**完整任务成本**（含重跑），而不是单次结果的字节数。
+
+仍然成立的一条：**每轮聚合预算**。单个结果都没超限，但一轮 10 个并行 × 40K = 400K。siclaw 没有这一层——不过 Claude Code 那边它也在一个默认关闭的 gate 后面，属可选设计而非业界默认。
+
+---
+
+## 六、并发策略：两家结论相反
+
+- **Claude Code 大力鼓励并行**：全局 system prompt、Bash 描述、Agent 描述、Explore 子代理 prompt 四处都讲。而且不是抽象建议——git/PR 流程被写成**预先并行化的编号步骤**（"Run the following bash commands in parallel"）。
+- **codex 对新模型直接禁用并行工具调用**（`client.rs:853`，`!model_info.use_responses_lite`），改用 **Code Mode**：并发发生在 JS 脚本内部（`await Promise.all([...])`），而不是 N 个并行 `function_call`。
+
+Code Mode 里有个对 siclaw 特别有价值的设计：**`store(key, value)` / `load(key)` 让中间值跨 `exec` 调用持久化，完全不经过模型上下文**。对可观测性查询这类"取大量数据、只要结论"的场景，这是结构性的省法。
+
+还有 `// @exec: {"max_output_tokens": 1000}` 首行 pragma——**让模型自己设定本次调用的输出预算**。
+
+---
+
+## 七、siclaw 可执行清单（r2 · 已按 review 重排）
+
+> r1 把"共享 key""冻结裁剪""放宽结果上限"列为可直接落地项，都是误读。**这三项降级为实验项**，且顺序改为：**先计量 → 验证已有能力 → 带能力检查的试点 → 按实测处理前缀变化。**
+
+### P0 · 补齐计量（前置条件，其余全部依赖它）
+
+**1. 补齐调用 usage 采集**。成本分析文档 §3.0b：subagent 完全没有 `llm_call`，`aux_calls` / `discarded_llm_calls` 未展开。**不补这个，后面任何改动都无法验证收益。**
+
+**2. 最终请求计量**（**不是「加个长度统计」那么简单**）。三个口径必须分开记，谁都不能替谁：
+
+| 口径 | 含义 |
+|---|---|
+| **payload 字节数** | 真实发出的请求体大小 |
+| **token 估算** | 本地估算值，用于预算判断 |
+| **服务端 usage** | provider 返回的权威计费值 |
+
+两个现成的坑：
+- 现有 `inspectModelEnvelope` **只在哈希变化时才 log**（`pi-execution.ts:56-59` 的 `if`）——它是**变更事件流，不是每轮记录**，无法与每轮 usage 对齐。必须改成每轮落一条，并用**调用 / 尝试 ID**（`round`、`attempt`）关联到对应的 usage。
+- 它的 system 哈希来自**提取后拼接的文本**，既不等于真实 payload 字节，也不覆盖完整历史结构。
+
+**3. 把已有的 envelope 哈希接上 usage**。siclaw 已有变化检测的一半（`model-envelope.ts:74-88`），缺的是与 `cache_read` 关联。
+
+> ⚠️ **但检测器解决不了全部归因**（r1 此处过满）：持续 `cache_read=0`、大量单轮子会话都不会触发"比上次下降"；只比较 system/tools 也看不到历史消息裁剪。
+>
+> 需要一并记录：**历史前缀变化、调用间隔、cache key、模型配置**；输出要区分「相关变化」与「已确认原因」，并保留「可能 TTL / 可能服务端 / 未知」三档——参考实现自己就是这么做的。
+
+### P1 · 先验证已有能力，再谈新建
+
+**4. 验证 `run_script` 的脚本内并发与聚合效果**。最新 main 已提供，与 codex Code Mode 的 `store`/`load` 思路同源（中间值不进上下文）。**先测它覆盖了多少场景，再决定是否需要别的机制**——避免重复建设。
+
+**5. MCP 预算**。三家里 siclaw 是唯一没有任何 MCP 预算约束的，这条**不依赖任何假说**。
+
+> ⚠️ **但两家的数字是两种策略，不能并列当参考值直接抄**：
+> - Claude Code 的 **2,048 是描述截取**（超出部分截断，工具仍可用）；
+> - codex 的 **8KB/spec、64KB 总计是准入门槛**（超限**隐藏**该 spec），且**仅适用于 agent-plugin 来源**。
+>
+> siclaw 要设计的是**完整预算**，至少覆盖：描述、参数 schema、**重复的 server context**（当前 `serverDescription` 会被 prepend 到该 server 的每个工具，N 个工具就是 N 份）、工具数量、以及总量上限。先量再定阈值。
+
+### P2 · 带能力检查的试点
+
+**6. 工具搜索 / `defer_loading` 试点**。**不能无条件启用**：
+- 需模型支持（GPT-5.4+）+ 配置 `tool_search`，并验证实际服务、fallback 与子模型行为；
+- **省的是参数 schema，不是 name + description**——要省成员工具描述得设计 namespace / MCP 分组；
+- 先在 MCP 与低频工具（`manage_schedule` 3,537、`skill_preview` 1,747）上试点，按 P0 的计量看真实收益。
+
+**7. system prompt 分区 + 哨兵边界**，静态在前动态在后；section 注册表默认 memoize，破坏缓存需显式申报理由。这条不依赖外部能力，是纯内部纪律。
+
+### P3 · 实验项（需要先设计，不可直接照搬）
+
+**8. 结果预算分层**。把「首次结果预算」（可冻结）与「后续历史压缩」（必须可持续回收）拆开，补齐容量耗尽、恢复与证据回读规则。**直接用"冻结"替换现有 pruning 会导致近期结果无法清理。**
+
+**9. 子代理缓存复用**。要抄就抄 Claude Code 的一整套（冻结 rendered prompt + 克隆替换状态使前缀内容对齐），**只统一 `prompt_cache_key` 无效**——父子前缀本就不同。
+
+**10. 重估结果上限**。先列全各路径（预览 8,000 / artifact 回读 / 脚本 SDK）的实际限制，按**完整任务成本**（含重跑）评估，保留 artifact 引用与受控回读。**不要统一改成超限报错。**
+
+**11. 裁剪要告知模型**。若 P3-8 落地，需在 prompt 里说明"旧结果会被清理，重要信息请写进回复"，否则模型会引用已消失的内容（`prompts.ts:836-841`）。
+
+---
+
+## 八、两个反直觉的点
+
+1. **message 级 cache breakpoint 只用 1 个，不是 4 个**（`claude.ts:3078-3088`）。多打不等于多命中——多余 marker 会让服务端保护一个永远不会被 resume 的 KV page，纯浪费。
+
+2. **压缩摘要请求本身应该走 fork 复用主线程前缀**。Claude Code 实测该项从 **98% cache miss** 变为命中，占全队 `cache_creation` 的 0.76%（**~38B tokens/天**，`compact.ts:432-436`）。坑也标了：别给这个 fork 设 `maxOutputTokens`，它会 clamp thinking budget，而 thinking config 在 cache key 里。
+
+---
+
+## 附：证据来源与限度
+
+- siclaw 侧数据来自 `946e0675` 实测，工具字符数为**下界**（见成本分析文档 §1.1 的修订说明）。
+- Claude Code / codex 侧为源码阅读结论，字符数由脚本统计模板字面量得出，条件拼装的工具（Bash / Agent / Grep）按全分支计，实际渲染更少。
+- **未做的**：三方的真实请求抓包对比、siclaw 改造后的收益实测。本文给的是机制差距，不是收益承诺。

--- a/portal-web/src/components/metrics/TokenUsageCard.test.tsx
+++ b/portal-web/src/components/metrics/TokenUsageCard.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest"
+import { renderToStaticMarkup } from "react-dom/server"
+import { TokenUsageCard } from "./TokenUsageCard"
+import type { TokenUsageData, UsageActor, UsageGroup } from "../../hooks/useMetrics"
+
+// portal-web ships no DOM environment, so this asserts the RENDER CONTRACT via
+// react-dom/server. That is the right level here anyway: every rule under test
+// is about what a number on screen claims, not about interaction.
+
+const totals = (total: number | null, reportedCalls: number) => ({ total, reportedCalls })
+
+const group = (over: Partial<UsageGroup> = {}): UsageGroup => ({
+  provider: "example-gateway", modelId: "gpt-5", apiType: "openai-responses",
+  calls: 2,
+  input: totals(3_000, 2), output: totals(300, 2), reasoning: totals(null, 0),
+  cacheRead: totals(500, 2), cacheWrite: totals(600, 2),
+  billable: 3_300,
+  ...over,
+})
+
+const actor = (over: Partial<UsageActor> = {}): UsageActor => ({
+  kind: "user", id: "user-a", calls: 2,
+  input: totals(3_000, 2), output: totals(300, 2),
+  cacheRead: totals(500, 2), cacheWrite: totals(600, 2),
+  billable: 3_300, mixedProtocols: false,
+  ...over,
+})
+
+const data = (over: Partial<TokenUsageData> = {}): TokenUsageData => ({
+  from: "2026-09-01T00:00:00.000Z", to: "2026-09-13T00:00:00.000Z",
+  sort: "billable",
+  models: [group()], actors: [actor()],
+  coverage: { trustworthy: 2, excluded: 0 },
+  ...over,
+})
+
+const render = (d: TokenUsageData | null, sort: TokenUsageData["sort"] = "billable") =>
+  renderToStaticMarkup(
+    <TokenUsageCard data={d} loading={false} rangeLabel="last 7d" sort={sort} onSort={() => {}} />,
+  )
+
+describe("TokenUsageCard", () => {
+  it("shows a dash for a field nothing reported — never a zero", () => {
+    // The collection side kept "reported 0" and "never reported" apart through
+    // the whole pipeline; painting the second as 0 here would undo it at the
+    // last step, and the reader would take it as a measured fact.
+    const html = render(data({
+      models: [group({ cacheWrite: totals(null, 0), billable: null })],
+      actors: [],
+    }))
+    expect(html).toContain("—")
+    expect(html).toContain("No call in this row reported this field")
+  })
+
+  it("keeps a reported zero as 0, distinct from the dash", () => {
+    const html = render(data({
+      models: [group({ cacheRead: totals(0, 2), cacheWrite: totals(null, 0) })],
+      actors: [],
+    }))
+    expect(html).toContain(">0<")   // the reported zero renders as a number
+    expect(html).toContain("—")     // the unreported field does not
+  })
+
+  it("marks a sum taken over fewer calls than the row has", () => {
+    // Otherwise a partial sum is visually identical to a complete one.
+    const html = render(data({
+      models: [group({ calls: 5, cacheWrite: totals(600, 1) })],
+      actors: [],
+    }))
+    expect(html).toContain("Summed over 1 of 5 calls")
+    expect(html).toContain("summed over only the calls that reported that")
+  })
+
+  it("says so when an unpriceable total is unknown rather than zero", () => {
+    const html = render(data({ models: [group({ billable: null })], actors: [] }))
+    expect(html).toContain("the total is unknown")
+  })
+
+  it("states coverage when calls were excluded from the figures", () => {
+    const html = render(data({ coverage: { trustworthy: 7, excluded: 3 } }))
+    expect(html).toContain("7/10 measured")
+  })
+
+  it("breaks users out with the four token columns", () => {
+    const html = render(data({ actors: [actor({ id: "ou_alice", kind: "channel" })] }))
+    expect(html).toContain("By user")
+    expect(html).toContain("ou_alice")
+    expect(html).toContain("channel sender")
+    for (const label of ["Input", "Output", "Cache write", "Cache read"]) {
+      expect(html).toContain(label)
+    }
+  })
+
+  it("flags an actor whose calls span protocols that bill cache differently", () => {
+    const html = render(data({ actors: [actor({ mixedProtocols: true })] }))
+    expect(html).toContain("bill cache differently")
+  })
+
+  it("marks the active sort column, so the ranking basis is visible", () => {
+    const html = render(data(), "cacheWrite")
+    // The heading carries the marker; which column it sits on is what tells the
+    // reader what the rows are ordered by.
+    expect(html).toMatch(/Cache write<span[^>]*>↓<\/span>/)
+  })
+
+  it("says the window is empty rather than rendering an empty table", () => {
+    const html = render(data({ models: [], actors: [] }))
+    expect(html).toContain("No measured calls in this window")
+  })
+})

--- a/portal-web/src/components/metrics/TokenUsageCard.tsx
+++ b/portal-web/src/components/metrics/TokenUsageCard.tsx
@@ -1,0 +1,207 @@
+import type { TokenFieldTotals, TokenUsageData, UsageSortKey } from "../../hooks/useMetrics"
+
+/**
+ * Token spend per provider × model, and per actor.
+ *
+ * Two rendering rules carry the whole point of the pipeline behind this:
+ *
+ *   - A field nothing reported shows "—", never 0. The collection side went to
+ *     some length to keep those apart; painting a dash as a zero here would
+ *     undo it at the last step.
+ *   - A number summed over FEWER calls than the row has says so. Otherwise a
+ *     partial sum is indistinguishable from a complete one.
+ */
+
+const COLUMNS: { key: UsageSortKey; label: string; hint: string }[] = [
+  { key: "input", label: "Input", hint: "prompt tokens as the provider reported them" },
+  { key: "output", label: "Output", hint: "completion tokens, reasoning included" },
+  { key: "cacheWrite", label: "Cache write", hint: "tokens written into the prompt cache" },
+  { key: "cacheRead", label: "Cache read", hint: "tokens served from the prompt cache" },
+  { key: "billable", label: "Charged", hint: "per-protocol total; cache is inside input on some APIs" },
+  { key: "calls", label: "Calls", hint: "model calls with provider-reported usage" },
+]
+
+function fmtTokens(n: number | null): string {
+  if (n === null) return "—"
+  if (n < 1_000) return String(n)
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`
+  return `${(n / 1_000_000).toFixed(2)}M`
+}
+
+/** A cell that can say "nothing reported" and "reported by only some calls". */
+function TokenCell({ value, calls }: { value: TokenFieldTotals; calls: number }) {
+  const missing = value.total === null
+  const partial = !missing && value.reportedCalls < calls
+  return (
+    <div
+      className={`text-right tabular-nums ${missing ? "text-muted-foreground/50" : "text-foreground"}`}
+      title={
+        missing
+          ? "No call in this row reported this field — not the same as zero"
+          : partial
+          ? `Summed over ${value.reportedCalls} of ${calls} calls; the rest never reported this field`
+          : undefined
+      }
+    >
+      {fmtTokens(value.total)}
+      {partial && <span className="text-amber-500 ml-0.5">*</span>}
+    </div>
+  )
+}
+
+function SortableHead({
+  column, active, onSort,
+}: {
+  column: { key: UsageSortKey; label: string; hint: string }
+  active: UsageSortKey
+  onSort: (key: UsageSortKey) => void
+}) {
+  const isActive = active === column.key
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(column.key)}
+      title={column.hint}
+      className={`text-right text-[11px] hover:text-foreground transition-colors ${
+        isActive ? "text-foreground font-medium" : "text-muted-foreground"
+      }`}
+    >
+      {column.label}
+      {isActive && <span className="ml-0.5">↓</span>}
+    </button>
+  )
+}
+
+const GRID = "grid grid-cols-[minmax(9rem,1.6fr)_repeat(6,minmax(4.25rem,0.7fr))] gap-x-3 gap-y-1.5 text-[11px] items-center"
+
+export function TokenUsageCard({
+  data, loading, rangeLabel, sort, onSort,
+}: {
+  data: TokenUsageData | null
+  loading: boolean
+  rangeLabel: string
+  sort: UsageSortKey
+  onSort: (key: UsageSortKey) => void
+}) {
+  const models = data?.models ?? []
+  const actors = data?.actors ?? []
+  const coverage = data?.coverage
+  const anyPartial =
+    models.some((g) => [g.input, g.output, g.cacheRead, g.cacheWrite].some((f) => f.total !== null && f.reportedCalls < g.calls)) ||
+    actors.some((a) => [a.input, a.output, a.cacheRead, a.cacheWrite].some((f) => f.total !== null && f.reportedCalls < a.calls))
+
+  return (
+    <div className="border border-border rounded-lg bg-card p-4">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div>
+          <h3 className="text-sm font-semibold tracking-tight">Token usage</h3>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            Per call, sub-agents included · {rangeLabel}
+          </p>
+        </div>
+        {coverage && coverage.excluded > 0 && (
+          <span
+            title={`${coverage.excluded} call(s) excluded: the provider reported no usage, or its provenance could not be established. Including them would count their placeholder zeros as real.`}
+            className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-amber-500/40 text-amber-500 select-text"
+          >
+            {coverage.trustworthy}/{coverage.trustworthy + coverage.excluded} measured
+          </span>
+        )}
+      </div>
+
+      {loading && !data ? (
+        <p className="text-[11px] text-muted-foreground py-6 text-center">Loading…</p>
+      ) : models.length === 0 && actors.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground py-6 text-center">
+          No measured calls in this window.
+        </p>
+      ) : (
+        <>
+          <div className={GRID}>
+            <div className="text-muted-foreground">Provider · model</div>
+            {COLUMNS.map((c) => (
+              <SortableHead key={c.key} column={c} active={sort} onSort={onSort} />
+            ))}
+            {models.map((g) => (
+              <Row
+                key={`${g.provider}/${g.modelId}/${g.apiType}`}
+                label={g.modelId}
+                sub={`${g.provider} · ${g.apiType}`}
+                row={g}
+              />
+            ))}
+          </div>
+
+          <div className="mt-4 pt-3 border-t border-border">
+            <h4 className="text-[11px] font-semibold text-foreground mb-2">By user</h4>
+            {actors.length === 0 ? (
+              <p className="text-[11px] text-muted-foreground py-2">No attributable calls in this window.</p>
+            ) : (
+              <div className={GRID}>
+                <div className="text-muted-foreground">User</div>
+                {COLUMNS.map((c) => (
+                  <SortableHead key={c.key} column={c} active={sort} onSort={onSort} />
+                ))}
+                {actors.map((a) => (
+                  <Row
+                    key={`${a.kind}:${a.id}`}
+                    label={a.id}
+                    sub={a.kind === "channel" ? "channel sender" : "platform user"}
+                    row={a}
+                    note={a.mixedProtocols ? "Calls span protocols that bill cache differently" : undefined}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {anyPartial && (
+            <p className="text-[10px] text-muted-foreground mt-3">
+              <span className="text-amber-500">*</span> summed over only the calls that reported that
+              field — hover for the count.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function Row({
+  label, sub, row, note,
+}: {
+  label: string
+  sub: string
+  note?: string
+  row: {
+    calls: number
+    input: TokenFieldTotals
+    output: TokenFieldTotals
+    cacheRead: TokenFieldTotals
+    cacheWrite: TokenFieldTotals
+    billable: number | null
+  }
+}) {
+  return (
+    <>
+      <div className="min-w-0" title={note}>
+        <div className="truncate font-medium text-foreground">
+          {label}
+          {note && <span className="text-amber-500 ml-1">†</span>}
+        </div>
+        <div className="truncate text-[10px] text-muted-foreground">{sub}</div>
+      </div>
+      <TokenCell value={row.input} calls={row.calls} />
+      <TokenCell value={row.output} calls={row.calls} />
+      <TokenCell value={row.cacheWrite} calls={row.calls} />
+      <TokenCell value={row.cacheRead} calls={row.calls} />
+      <div
+        className={`text-right tabular-nums ${row.billable === null ? "text-muted-foreground/50" : "text-foreground font-medium"}`}
+        title={row.billable === null ? "A component this protocol charges for was never reported, so the total is unknown" : undefined}
+      >
+        {fmtTokens(row.billable)}
+      </div>
+      <div className="text-right tabular-nums text-muted-foreground">{row.calls}</div>
+    </>
+  )
+}

--- a/portal-web/src/hooks/useMetrics.ts
+++ b/portal-web/src/hooks/useMetrics.ts
@@ -593,3 +593,86 @@ export function useChannelSenders(
 
   return { senders, loading }
 }
+
+// ── Token usage (the llm_calls fact table) ───────────────
+//
+// Separate from useSummary on purpose: that one reads message metadata, which
+// never covered sub-agent calls. These figures come from the per-call fact
+// table, so they include spend Portal previously could not see at all.
+
+/** A sum, plus how many calls actually reported the field it sums. */
+export interface TokenFieldTotals {
+  /** null = no call in this group reported the field. NOT the same as 0. */
+  total: number | null
+  reportedCalls: number
+}
+
+export interface UsageGroup {
+  provider: string
+  modelId: string
+  apiType: string
+  calls: number
+  input: TokenFieldTotals
+  output: TokenFieldTotals
+  reasoning: TokenFieldTotals
+  cacheRead: TokenFieldTotals
+  cacheWrite: TokenFieldTotals
+  /** Charged tokens, computed per protocol; null when not computable. */
+  billable: number | null
+}
+
+export interface UsageActor {
+  kind: "user" | "channel"
+  id: string
+  calls: number
+  input: TokenFieldTotals
+  output: TokenFieldTotals
+  cacheRead: TokenFieldTotals
+  cacheWrite: TokenFieldTotals
+  billable: number | null
+  /** This actor's calls span protocols that bill cache differently. */
+  mixedProtocols: boolean
+}
+
+export type UsageSortKey = "billable" | "input" | "output" | "cacheRead" | "cacheWrite" | "calls"
+
+export interface TokenUsageData {
+  from: string
+  to: string
+  sort: UsageSortKey
+  models: UsageGroup[]
+  actors: UsageActor[] | null
+  /** How much of the window these figures actually cover. */
+  coverage: { trustworthy: number; excluded: number }
+}
+
+/**
+ * Sorting is a SERVER round-trip, never a client-side re-sort.
+ *
+ * The result is capped, so re-ordering the returned page would rank the wrong
+ * rows: the top 50 by total tokens is not the set containing the top 50 by
+ * cache write.
+ */
+export function useTokenUsage(
+  range: TimeRange,
+  sort: UsageSortKey = "billable",
+): { data: TokenUsageData | null; loading: boolean; refresh: () => void } {
+  const [data, setData] = useState<TokenUsageData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const paramsRef = useRef({ range, sort })
+  paramsRef.current = { range, sort }
+
+  const fetchOnce = useCallback(() => {
+    setLoading(true)
+    const { range: r, sort: s } = paramsRef.current
+    const { fromMs, toMs } = resolveRange(r)
+    const q = new URLSearchParams({ from: String(fromMs), to: String(toMs), sort: s })
+    return api<TokenUsageData>(`/siclaw/metrics/token-usage?${q.toString()}`)
+      .then((d) => { setData(d); setLoading(false) })
+      .catch(() => setLoading(false))
+  }, [])
+
+  useEffect(() => { fetchOnce() }, [range.from, range.to, sort, fetchOnce])
+
+  return { data, loading, refresh: fetchOnce }
+}

--- a/portal-web/src/pages/Metrics.tsx
+++ b/portal-web/src/pages/Metrics.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo, useState } from "react"
 import { Loader2, RefreshCw } from "lucide-react"
-import { useSummary, useTiming, useUsers, useChannels, useChannelSenders, rangeLabel, ENTRY_LABELS, DEFAULT_RANGE, type EntryMode, type TimeRange } from "../hooks/useMetrics"
+import { useSummary, useTiming, useTokenUsage, useUsers, useChannels, useChannelSenders, rangeLabel, ENTRY_LABELS, DEFAULT_RANGE, type EntryMode, type TimeRange, type UsageSortKey } from "../hooks/useMetrics"
 import { KpiCards } from "../components/metrics/KpiCards"
 import { TrendChart } from "../components/metrics/TrendChart"
 import { TimingStatsCard } from "../components/metrics/TimingStatsCard"
+import { TokenUsageCard } from "../components/metrics/TokenUsageCard"
 import { AuditTable } from "../components/metrics/AuditTable"
 import { SessionTable } from "../components/metrics/SessionTable"
 import { GrafanaFrame } from "../components/metrics/GrafanaFrame"
@@ -24,6 +25,10 @@ export function Metrics() {
   const [senderId, setSenderId] = useState<string>("")     // exact channel sender open_id/staffId (channel entry only)
   const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_RANGE)
   const [entry, setEntry] = useState<EntryMode>("all")     // entry-form axis, shared across tabs
+  // Ranking metric for the token tables. Held here (not in the card) because it
+  // drives a REFETCH: the result is capped server-side, so re-sorting what came
+  // back would rank the wrong rows.
+  const [usageSort, setUsageSort] = useState<UsageSortKey>("billable")
 
   // The "who" axis is origin-aware. Channel actors are open_ids, NOT portal
   // users, so the portal-user filter does not apply on the channel entry (it
@@ -45,14 +50,19 @@ export function Metrics() {
   // an individual — so summary/timing are fetched without a user filter.
   const { data: summary, loading: summaryLoading, refresh: refreshSummary } = useSummary(timeRange, null, entry)
   const { data: timing, loading: timingLoading, refresh: refreshTiming } = useTiming(timeRange, null, entry)
+  const { data: tokenUsage, loading: tokenUsageLoading, refresh: refreshTokenUsage } = useTokenUsage(timeRange, usageSort)
 
   const [spinning, setSpinning] = useState(false)
   const handleRefresh = useCallback(() => {
     setSpinning(true)
-    Promise.all([Promise.resolve(refreshSummary()), Promise.resolve(refreshTiming())]).finally(() => {
+    Promise.all([
+      Promise.resolve(refreshSummary()),
+      Promise.resolve(refreshTiming()),
+      Promise.resolve(refreshTokenUsage()),
+    ]).finally(() => {
       setTimeout(() => setSpinning(false), 600)
     })
-  }, [refreshSummary, refreshTiming])
+  }, [refreshSummary, refreshTiming, refreshTokenUsage])
 
   const selectedUsername = useMemo(() => {
     if (!userId) return null
@@ -190,6 +200,18 @@ export function Metrics() {
                 ) : (
                   <TimingStatsCard data={timing} rangeLabel={rLabel} entryLabel={ENTRY_LABELS[entry]} entry={entry} />
                 )}
+
+                {/* Token spend from the per-call fact table. Deliberately NOT
+                    entry-filtered: the entry axis is a property of the session,
+                    while these rows are attributed per actor across every path
+                    a sub-agent's calls take. */}
+                <TokenUsageCard
+                  data={tokenUsage}
+                  loading={tokenUsageLoading}
+                  rangeLabel={rLabel}
+                  sort={usageSort}
+                  onSort={setUsageSort}
+                />
               </>
             )}
           </section>

--- a/scripts/smoke/token-cache-probe.mjs
+++ b/scripts/smoke/token-cache-probe.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Gateway cache probe — the online half of the P0 metering verification.
+ *
+ * Sends a FIXED synthetic prompt through the real gateway several times and
+ * reports what the provider says about caching each time. No cluster, no SRE
+ * scenario, no model-quality judgement: the payload is deliberately boring and
+ * identical across runs, because the only variable under study is the cache.
+ *
+ * It answers three questions the offline fixtures structurally cannot:
+ *
+ *   1. Which cache-retention shape does this deployment actually send?
+ *      pi's default `short` sends NEITHER field; `long` may send
+ *      `prompt_cache_retention: "24h"` OR `prompt_cache_options.ttl=30m`,
+ *      depending on a compat branch. Guessing is not allowed — we read the body.
+ *   2. Does a warm repeat actually report cache reads, i.e. is the gateway's
+ *      cache path wired at all?
+ *   3. Does appending to the history keep the prefix warm, and does rewriting
+ *      an old message kill it?
+ *
+ * ⚠️ A 200 means the gateway ACCEPTED the request. It does not mean the cache
+ * worked, and a warm hit minutes apart does not prove a long TTL was honoured —
+ * that needs a probe separated by longer than the short-TTL window.
+ *
+ * Usage:
+ *   SICLAW_PROBE_BASE_URL=https://gateway.example/v1 \
+ *   SICLAW_PROBE_API_KEY=...                          \
+ *   SICLAW_PROBE_MODEL=gpt-5                          \
+ *   node scripts/smoke/token-cache-probe.mjs [--json out.json]
+ *
+ * Exits non-zero only on a transport/config failure — an absent cache is a
+ * RESULT to be reported, not an error.
+ */
+
+const BASE_URL = process.env.SICLAW_PROBE_BASE_URL;
+const API_KEY = process.env.SICLAW_PROBE_API_KEY;
+const MODEL = process.env.SICLAW_PROBE_MODEL ?? "gpt-5";
+const RETENTION = process.env.SICLAW_PROBE_RETENTION ?? "";
+
+if (!BASE_URL || !API_KEY) {
+  console.error("Set SICLAW_PROBE_BASE_URL and SICLAW_PROBE_API_KEY. Nothing was sent.");
+  process.exit(2);
+}
+
+/** Padding large enough to clear the minimum any prefix cache will bother with. */
+const FILLER = "The quick brown fox jumps over the lazy dog. ".repeat(200);
+
+const baseInput = [
+  { role: "system", content: `You are a fixture. Reply with the single word OK.\n${FILLER}` },
+  { role: "user", content: "Say OK." },
+];
+
+/**
+ * Build the retention fields exactly as pi would for a given mode, so the probe
+ * measures the shapes the runtime can actually emit rather than invented ones.
+ */
+function retentionFields(mode) {
+  if (mode === "24h") return { prompt_cache_retention: "24h" };
+  if (mode === "ttl_30m") return { prompt_cache_options: { ttl: "30m" } };
+  return {}; // pi's default `short` sends neither
+}
+
+async function probe(label, { input, cacheKey, retentionMode }) {
+  const body = {
+    model: MODEL,
+    input,
+    store: false,
+    max_output_tokens: 16,
+    ...(cacheKey ? { prompt_cache_key: cacheKey } : {}),
+    ...retentionFields(retentionMode),
+  };
+  const startedAt = Date.now();
+  const response = await fetch(`${BASE_URL.replace(/\/$/, "")}/responses`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${API_KEY}` },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let usage = null;
+  try {
+    usage = JSON.parse(text)?.usage ?? null;
+  } catch { /* keep raw below */ }
+
+  const cachedTokens = usage?.input_tokens_details?.cached_tokens;
+  return {
+    label,
+    ok: response.ok,
+    status: response.status,
+    elapsed_ms: Date.now() - startedAt,
+    sent_retention_fields: Object.keys(retentionFields(retentionMode)),
+    prompt_cache_key: cacheKey ?? null,
+    // Absent is recorded as null, never 0 — the same rule the records follow.
+    input_tokens: typeof usage?.input_tokens === "number" ? usage.input_tokens : null,
+    output_tokens: typeof usage?.output_tokens === "number" ? usage.output_tokens : null,
+    cached_tokens: typeof cachedTokens === "number" ? cachedTokens : null,
+    usage_reported: usage !== null,
+    ...(response.ok ? {} : { error_excerpt: text.slice(0, 300) }),
+  };
+}
+
+const results = [];
+const key = `siclaw-probe-${Date.now()}`;
+
+// 1. Cold: first time this prefix is seen.
+results.push(await probe("cold", { input: baseInput, cacheKey: key, retentionMode: RETENTION }));
+// 2. Warm: byte-identical repeat — the only run that can show a cache read.
+results.push(await probe("warm_identical", { input: baseInput, cacheKey: key, retentionMode: RETENTION }));
+// 3. Append: prefix unchanged, one message added.
+results.push(await probe("warm_appended", {
+  input: [...baseInput, { role: "user", content: "And again." }],
+  cacheKey: key,
+  retentionMode: RETENTION,
+}));
+// 4. Rewrite: an OLD message changed — the prefix should be dead.
+results.push(await probe("rewritten_prefix", {
+  input: [{ role: "system", content: `Different system prompt.\n${FILLER}` }, ...baseInput.slice(1)],
+  cacheKey: key,
+  retentionMode: RETENTION,
+}));
+// 5. No cache key at all — isolates what the key itself contributes.
+results.push(await probe("no_cache_key", { input: baseInput, cacheKey: null, retentionMode: RETENTION }));
+
+const warm = results.find((r) => r.label === "warm_identical");
+const report = {
+  probed_at: new Date().toISOString(),
+  model: MODEL,
+  retention_mode: RETENTION || "default(short: sends neither field)",
+  results,
+  findings: {
+    gateway_reports_usage: results.some((r) => r.usage_reported),
+    // Explicitly three-valued: null means the gateway never reported the field,
+    // which is different from reporting a zero.
+    cache_read_observed: warm?.cached_tokens === null ? null : (warm?.cached_tokens ?? 0) > 0,
+    caveat: "A 200 only means the request was accepted. A warm hit here does NOT prove a long TTL was honoured; that needs a repeat separated by more than the short-TTL window.",
+  },
+};
+
+const jsonFlag = process.argv.indexOf("--json");
+if (jsonFlag !== -1 && process.argv[jsonFlag + 1]) {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(process.argv[jsonFlag + 1], JSON.stringify(report, null, 2));
+  console.log(`Wrote ${process.argv[jsonFlag + 1]}`);
+} else {
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (!results.every((r) => r.ok)) process.exit(1);

--- a/src/agentbox-main.ts
+++ b/src/agentbox-main.ts
@@ -159,6 +159,23 @@ async function main() {
     }
     await debugPodCache.evictAll();
     await sessionManager.closeAll();
+    // Second, SMALL flush after closeAll: metering teardown increments its
+    // counter inside closeAll, i.e. after the flush above — so a delivery gap
+    // discovered during shutdown reached the local registry but never the
+    // federation, which is precisely when it matters most. closeAll is already
+    // time-bounded per session, so this adds one bounded request, not a stall.
+    if (federationFlushEnabled) {
+      try {
+        const client = new GatewayClient({ gatewayUrl: config.server.gatewayUrl });
+        await client.sendMetricsFlush({
+          incarnation: processIncarnation,
+          prom: await getMetricsAsJSON(),
+          ...(process.env.SICLAW_POD_NAME ? { boxId: process.env.SICLAW_POD_NAME } : {}),
+        });
+      } catch (err) {
+        console.warn("[agentbox] Post-teardown metrics flush failed (continuing shutdown):", err);
+      }
+    }
     server.close();
     // Flush + shut down tracing last (forceFlush is capped at 3s internally so a
     // dead in-network backend cannot stall SIGTERM past the K8s grace period).

--- a/src/agentbox/gateway-client.ts
+++ b/src/agentbox/gateway-client.ts
@@ -12,6 +12,8 @@ import fs from "node:fs";
 import path from "node:path";
 import type { DelegationPersistenceEvent, DelegationPersistenceResponse } from "../shared/delegation-persistence.js";
 import type { MetricsFlushPayload } from "../shared/metrics-types.js";
+import type { LlmCallMeasurementBatch } from "../shared/llm-call-record.js";
+import { LLM_CALL_MEASUREMENTS_PATH } from "../shared/llm-call-validation.js";
 import type { DelegateRequest, DelegateResponse, DelegatesResponse } from "../shared/agent-delegate.js";
 import { SESSION_HISTORY_PATH, type SessionHistoryResponse } from "../shared/session-history.js";
 import { HANDOFF_TARGETS_PATH, HANDOFF_SEARCH_PATH, type HandoffSearchQuery, type HandoffSearchResponse, type HandoffTargetsResponse } from "../shared/agent-handoff.js";
@@ -175,6 +177,17 @@ export class GatewayClient {
    */
   async sendMetricsFlush(payload: MetricsFlushPayload): Promise<void> {
     await this.request("/api/internal/metrics-flush", "POST", payload);
+  }
+
+  /**
+   * Hand completed LLM-call measurements to the Runtime for persistence.
+   *
+   * Core produces measurements; the Runtime owns the database. Batched because
+   * a busy turn settles several calls in quick succession, and idempotent on
+   * `call_id` so a delivery retry cannot double-count a call.
+   */
+  async sendLlmCallMeasurements(payload: LlmCallMeasurementBatch): Promise<void> {
+    await this.request(LLM_CALL_MEASUREMENTS_PATH, "POST", payload);
   }
 
   /**

--- a/src/agentbox/http-server.ts
+++ b/src/agentbox/http-server.ts
@@ -1075,6 +1075,11 @@ export function createHttpServer(
     // fast double-submit cannot start a second prompt on the same brain.
     managed._promptDone = false;
     managed._aborted = false;
+    // Bind this turn's calls to the user request BEFORE the first one opens.
+    // `turnId` already identifies one accepted prompt execution and survives
+    // model-routing retries, which is exactly the correlation metering needs — so
+    // no second id is minted for it.
+    managed.brain.llmCalls?.setRootRequestId(body.turnId ?? null);
     // LLM-call timeline: the prompt is accepted NOW. Everything between here and
     // the first provider request (model setup, media preflight, language
     // detection, routing preflight) is round 1's `since_prev_ms` (= setup).

--- a/src/agentbox/llm-call-dispatcher.test.ts
+++ b/src/agentbox/llm-call-dispatcher.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from "vitest";
+import { LlmCallMeasurementDispatcher } from "./llm-call-dispatcher.js";
+import type { LlmCallMeasurement } from "../shared/llm-call-record.js";
+
+const measurement = (callId: string): LlmCallMeasurement => ({
+  call_id: callId,
+  prompt_id: "p1",
+  kind: "agent",
+  round: 1,
+  attempt: 1,
+  network_attempts: 1,
+  provider: "example-gateway",
+  model_id: "gpt-5",
+  api_type: "openai-responses",
+  usage_status: "reported",
+  usage_source: "provider",
+  reported_fields: ["input", "output"],
+  input_tokens_total: 10,
+  output_tokens_total: 5,
+  reasoning_tokens: null,
+  cache_read_tokens: 0,
+  cache_write_tokens: null,
+  payload_bytes: 100,
+  payload_tokens_estimated: 25,
+  request_snapshot: {
+    model_settings: {},
+    system_sha256: "s",
+    tools_sha256: "t",
+    history_prefix_sha256: "h",
+    history_message_count: 1,
+  },
+  request_at: "2026-09-12T00:00:00.000Z",
+  response_end_at: "2026-09-12T00:00:01.000Z",
+  since_prev_ms: null,
+  cost_micros: null,
+  inconsistencies: [],
+});
+
+describe("LlmCallMeasurementDispatcher", () => {
+  it("batches rather than sending one request per call", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send });
+
+    for (let i = 0; i < 5; i++) d.record(measurement(`c${i}`));
+    expect(send).not.toHaveBeenCalled();   // still buffered
+
+    await d.flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0].measurements).toHaveLength(5);
+    expect(send.mock.calls[0][0].session_id).toBe("s1");
+  });
+
+  it("flushes automatically once the batch fills", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send });
+
+    for (let i = 0; i < 16; i++) d.record(measurement(`c${i}`));
+    await d.flush();
+    expect(send).toHaveBeenCalled();
+    expect(send.mock.calls[0][0].measurements).toHaveLength(16);
+  });
+
+  it("never lets a delivery failure reach the caller", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("runtime down"));
+    const warn = vi.fn();
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send, warn, sleep: async () => {} });
+
+    d.record(measurement("c1"));
+    await expect(d.flush()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    expect(d.stats().dropped).toBe(1);
+  });
+
+  it("retries a transient failure instead of losing the batch", async () => {
+    // The failure mode that mattered: first send fails, Runtime recovers, and
+    // the measurements must still arrive rather than being gone for good.
+    const send = vi.fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue(undefined);
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send, sleep: async () => {} });
+
+    d.record(measurement("c1"));
+    await d.flush();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(d.stats().delivered).toBe(1);
+    expect(d.stats().dropped).toBe(0);
+  });
+
+  it("reports a delivery gap that a coverage statement can read", async () => {
+    const send = vi.fn().mockRejectedValue(new Error("down"));
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send, sleep: async () => {} });
+    d.record(measurement("c1"));
+    await d.flush();
+
+    const stats = d.stats();
+    expect(stats.dropped).toBe(1);
+    expect(stats.failedBatches).toBe(1);
+    expect(stats.delivered).toBe(0);
+  });
+
+  it("bounds EVERYTHING it holds, including batches awaiting acknowledgement", async () => {
+    // The earlier cap counted only the pending buffer while dispatched batches
+    // accumulated outside it, so 1024 records produced zero drops.
+    let release: () => void = () => {};
+    const firstSendHangs = new Promise<void>((r) => { release = r; });
+    let calls = 0;
+    const send = vi.fn().mockImplementation(async () => {
+      if (++calls === 1) await firstSendHangs;
+    });
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send, sleep: async () => {} });
+
+    for (let i = 0; i < 1_024; i++) d.record(measurement(`c${i}`));
+    // With the first send still in flight, the cap must already have bitten.
+    expect(d.stats().dropped).toBeGreaterThan(0);
+    expect(d.stats().pending).toBeLessThanOrEqual(512);
+
+    release();
+    await d.flush();
+  });
+
+  it("does not send the same measurement twice across concurrent flushes", async () => {
+    const seen: string[] = [];
+    const send = vi.fn().mockImplementation(async (batch: any) => {
+      for (const m of batch.measurements) seen.push(m.call_id);
+      await new Promise((r) => setTimeout(r, 5));
+    });
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send });
+
+    d.record(measurement("a"));
+    const first = d.flush();
+    d.record(measurement("b"));
+    const second = d.flush();
+    await Promise.all([first, second]);
+
+    expect(seen.sort()).toEqual(["a", "b"]);   // each exactly once
+  });
+
+  it("flushes what is pending on close", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send });
+    d.record(measurement("c1"));
+    await d.close();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds a send that STARTED BEFORE close, not only ones begun after it", async () => {
+    // The hard case: with no deadline set yet, such a send arms no timer and is
+    // parked on the cutoff latch alone — while close's own `await drain()` is
+    // waiting on that same send. Signalling after the loop would make the bound
+    // wait on the thing it bounds.
+    let releaseSend: () => void = () => {};
+    const send = vi.fn(() => new Promise<void>((r) => { releaseSend = r; }));
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send });
+
+    for (let i = 0; i < 16; i++) d.record(measurement(`c${i}`)); // fills a batch ⇒ drains now
+    await Promise.resolve();
+    expect(send).toHaveBeenCalledTimes(1);                        // in flight, unresolved
+
+    const startedAt = Date.now();
+    await d.close(30);
+    const elapsed = Date.now() - startedAt;
+
+    // Generous upper bound: the point is that it returns on the budget rather
+    // than on the send. Before the fix this waited for `releaseSend`.
+    expect(elapsed).toBeLessThan(2_000);
+    expect(d.stats().dropped).toBe(16);   // counted as lost, not left as pending
+    expect(d.stats().pending).toBe(0);
+    releaseSend();                        // the abandoned request may still land
+  });
+
+  it("is a no-op when nothing is pending", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const d = new LlmCallMeasurementDispatcher({ sessionId: "s1", send });
+    await d.flush();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/src/agentbox/llm-call-dispatcher.ts
+++ b/src/agentbox/llm-call-dispatcher.ts
@@ -1,0 +1,315 @@
+/**
+ * Ships LLM-call measurements from a box to the Runtime.
+ *
+ * Core produces measurements at the provider boundary and knows nothing about
+ * databases; this is the seam where they leave the box. Metering must never be
+ * able to fail a user's turn, so nothing here ever throws at the caller.
+ *
+ * Three properties the first version got wrong, each for the same underlying
+ * reason — it treated "handed to a promise" as "delivered":
+ *
+ *   1. A batch was removed from the buffer BEFORE the send, so a transient
+ *      failure lost it permanently. Entries now stay queued until the Runtime
+ *      has acknowledged them, and a failed batch is retried with backoff.
+ *   2. The size cap counted only the pending buffer, while dispatched-but-
+ *      unacknowledged batches piled up in a promise chain outside it. There is
+ *      now ONE queue and one drain loop, so the cap bounds everything in flight.
+ *   3. Losses were recorded in a private counter nobody could read. Delivery
+ *      gaps are now reportable (`stats()`), because a coverage report that
+ *      cannot see them would present incomplete data as complete.
+ */
+
+import type { LlmCallMeasurement } from "../shared/llm-call-record.js";
+
+/** Measurements per delivery. */
+const BATCH_SIZE = 16;
+/** Idle delay before draining a partial batch. */
+const FLUSH_INTERVAL_MS = 2_000;
+/**
+ * Total measurements held — queued AND awaiting acknowledgement. Past this the
+ * OLDEST are dropped: a Runtime outage must not become a memory leak, and newer
+ * measurements are the ones still worth having.
+ */
+const MAX_QUEUED = 512;
+/** Attempts per batch before it is declared undeliverable. */
+const MAX_SEND_ATTEMPTS = 3;
+/** Base backoff; doubles per attempt. */
+const RETRY_BASE_MS = 200;
+/**
+ * Wall-clock budget for teardown delivery. Comfortably inside a pod's default
+ * termination grace, so a slow Runtime delays shutdown rather than preventing it.
+ */
+const CLOSE_DEADLINE_MS = 5_000;
+
+export interface LlmCallDispatcherDeps {
+  sessionId: string;
+  send: (batch: { session_id: string; measurements: LlmCallMeasurement[] }) => Promise<void>;
+  warn?: (message: string) => void;
+  /** Injectable for tests; real callers use the default timer. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable clock so a test can drive the close deadline deterministically. */
+  now?: () => number;
+}
+
+/** What was delivered and what was lost — the basis of a coverage statement. */
+export interface DeliveryStats {
+  delivered: number;
+  /** Measurements discarded: queue overflow, or a batch that exhausted retries. */
+  dropped: number;
+  /** Still queued or being retried. */
+  pending: number;
+  /** Batches that failed every attempt. */
+  failedBatches: number;
+}
+
+/** A promise that can be resolved from outside, used as a one-way latch. */
+function deferredFalse(): { promise: Promise<boolean>; resolve: (v: boolean) => void } {
+  let resolve: (v: boolean) => void = () => {};
+  const promise = new Promise<boolean>((r) => { resolve = r; });
+  // Nothing rejects it, and an unobserved resolution is fine.
+  return { promise, resolve };
+}
+
+export class LlmCallMeasurementDispatcher {
+  private queue: LlmCallMeasurement[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private draining: Promise<void> | null = null;
+  /** Batch taken from the queue and awaiting acknowledgement; counted by the cap. */
+  private inFlight: LlmCallMeasurement[] = [];
+  private delivered = 0;
+  private dropped = 0;
+  private failedBatches = 0;
+  private closed = false;
+  /** Wall-clock cutoff for teardown delivery; the drain loop honours it too. */
+  private closeDeadline: number | null = null;
+
+  constructor(private readonly deps: LlmCallDispatcherDeps) {}
+
+  /** Queue one measurement. Never throws; never blocks the caller. */
+  record(measurement: LlmCallMeasurement): void {
+    if (this.closed) { this.dropped += 1; return; }
+    this.queue.push(measurement);
+    // The cap covers EVERYTHING held, in-flight included — counting only the
+    // queue let dispatched-but-unacknowledged batches push the real total past
+    // the limit. In-flight rows are never dropped: they may yet be delivered.
+    const excess = this.held - MAX_QUEUED;
+    if (excess > 0) {
+      // Drop from the FRONT of the queue: the oldest are the least likely to
+      // still matter, and dropping the newest would hide an ongoing problem.
+      this.dropped += this.queue.splice(0, Math.min(excess, this.queue.length)).length;
+    }
+    if (this.queue.length >= BATCH_SIZE) { void this.drain(); return; }
+    this.scheduleDrain();
+  }
+
+  /** Delivery accounting, so a report can state coverage rather than assume it. */
+  stats(): DeliveryStats {
+    return {
+      delivered: this.delivered,
+      dropped: this.dropped,
+      pending: this.held,
+      failedBatches: this.failedBatches,
+    };
+  }
+
+  /** Drain everything currently queued. Safe to call concurrently. */
+  async flush(): Promise<void> {
+    await this.drain();
+  }
+
+  /**
+   * Final drain under a WALL-CLOCK budget, then refuse further records.
+   *
+   * A pass count is not a time bound: one drain empties the whole queue, so 512
+   * measurements at 16 per batch and 4s per send is 128 seconds — every request
+   * inside the client's own timeout, the total far past a pod's termination
+   * grace. Teardown needs its own deadline.
+   *
+   * Whatever misses it is COUNTED AS DROPPED and discarded. The alternative is
+   * leaving rows on a dispatcher the session has already released — unreachable,
+   * never retried, yet still counted as `pending`, which would let a coverage
+   * report overstate what was delivered.
+   */
+  async close(deadlineMs = CLOSE_DEADLINE_MS): Promise<void> {
+    this.clearTimer();
+    const now = () => (this.deps.now ? this.deps.now() : Date.now());
+    // Published so the RUNNING drain loop can see it too. Checking the clock only
+    // around `await drain()` bounds nothing: one drain empties the entire queue,
+    // so 512 rows at 4s per batch took 128 seconds while every individual send
+    // stayed inside the client's own timeout.
+    this.closeDeadline = now() + deadlineMs;
+    // Arm the cutoff HERE, before awaiting anything.
+    //
+    // A send that started BEFORE close() had no deadline to arm a timer against,
+    // so it is parked on the cutoff latch alone — and `await this.drain()` below
+    // returns that very drain's promise. Signalling only after the loop therefore
+    // makes the signal wait on precisely the wait it exists to bound: measured at
+    // 5s budget / 9s actual, with 16 rows still pending at the 5s mark. Every
+    // caller of close() is a teardown path (release, sub-agent settle, closeAll),
+    // so the overrun is paid by shutdown.
+    const cutoffTimer = setTimeout(() => { this.signalCutoff(); }, Math.max(0, deadlineMs));
+    cutoffTimer.unref?.();
+    try {
+      while (this.held > 0 && now() < this.closeDeadline) {
+        const before = this.held;
+        await this.drain();
+        // No progress while still inside the budget ⇒ the Runtime is refusing;
+        // spinning would burn the remaining grace for nothing.
+        if (this.held >= before) break;
+      }
+    } finally {
+      clearTimeout(cutoffTimer);
+    }
+    this.closed = true;
+    this.clearTimer();
+    // Idempotent: releases anything still parked if the loop exited first.
+    this.signalCutoff();
+    const abandoned = this.held;
+    if (abandoned > 0) {
+      this.queue = [];
+      this.inFlight = [];
+      this.dropped += abandoned;
+      this.deps.warn?.(
+        `[llm-call-dispatcher] abandoned ${abandoned} measurement(s) at close: delivery budget exhausted`,
+      );
+    }
+  }
+
+  /**
+   * True when `work` finishes first, false when the close deadline does.
+   *
+   * With no deadline set (ordinary operation) this is a plain await. A rejected
+   * send still propagates, so only the TIMEOUT branch becomes a value.
+   */
+  private async raceDeadline(work: Promise<unknown>): Promise<boolean> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      if (this.closeDeadline !== null) {
+        const clock = this.deps.now ? this.deps.now() : Date.now();
+        const remaining = this.closeDeadline - clock;
+        if (remaining <= 0) { void work.catch(() => {}); return false; }
+        timer = setTimeout(() => { this.signalCutoff(); }, remaining);
+        timer.unref?.();
+      }
+      // Always race the cutoff signal, even with no deadline YET: a send that
+      // began before `close()` was called would otherwise never learn of the
+      // deadline it later acquired, and a 5s close returned at 9s waiting on it.
+      const finished = await Promise.race([work.then(() => true), this.cutoff.promise]);
+      if (!finished) void work.catch(() => {});
+      return finished;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  /** Wake every in-flight wait: the teardown budget is spent. */
+  private signalCutoff(): void {
+    this.cutoff.resolve(false);
+  }
+
+  /** A latch the deadline flips; all waiters observe it, whenever they started. */
+  private cutoff = deferredFalse();
+
+  private clearTimer(): void {
+    if (this.timer !== null) { clearTimeout(this.timer); this.timer = null; }
+  }
+
+  /** Everything this dispatcher is holding: queued plus awaiting acknowledgement. */
+  private get held(): number {
+    return this.queue.length + this.inFlight.length;
+  }
+
+  /** Arm the idle timer, unless one is already pending or a drain is running. */
+  private scheduleDrain(): void {
+    if (this.closed || this.timer !== null || this.draining) return;
+    if (this.queue.length === 0) return;
+    this.timer = setTimeout(() => { this.timer = null; void this.drain(); }, FLUSH_INTERVAL_MS);
+    this.timer.unref?.();
+  }
+
+  /**
+   * The single consumer. Only one runs at a time, so a batch cannot be sent
+   * twice and `held` is the whole of what we retain.
+   */
+  private drain(): Promise<void> {
+    if (this.draining) return this.draining;
+    this.clearTimer();
+    // Nothing to do: return WITHOUT entering the draining state. Setting it here
+    // parked an already-resolved promise in `this.draining` — the loop never
+    // awaited, so its cleanup ran before the assignment — and every later drain
+    // then short-circuited on it, silently stopping delivery for good.
+    if (this.queue.length === 0) return Promise.resolve();
+    const task = (async () => {
+      try {
+        while (this.queue.length > 0) {
+          // Honour a teardown deadline BETWEEN batches: close must be able to
+          // stop a drain that would otherwise run the whole backlog past the
+          // pod's termination grace.
+          if (this.closeDeadline !== null) {
+            const clock = this.deps.now ? this.deps.now() : Date.now();
+            if (clock >= this.closeDeadline) break;
+          }
+          // TAKE the batch out of the queue and hold it in `inFlight`, so the
+          // cap still counts it and a front-drop cannot delete rows that are
+          // mid-send. Removing by count later could splice a DIFFERENT batch
+          // that had since moved to the front.
+          this.inFlight = this.queue.splice(0, BATCH_SIZE);
+          const ok = await this.sendWithRetry(this.inFlight);
+          if (ok) {
+            this.delivered += this.inFlight.length;
+          } else {
+            this.dropped += this.inFlight.length;
+            this.failedBatches += 1;
+            this.inFlight = [];
+            break; // stop hammering a Runtime that is clearly unavailable
+          }
+          this.inFlight = [];
+        }
+      } finally {
+        // Safe to clear unconditionally: the guard above admits one drain at a
+        // time, and the loop always awaits, so this runs after the assignment.
+        this.draining = null;
+        this.inFlight = [];
+        // Anything left — a failed batch's successors, or records that arrived
+        // mid-drain — must get another chance, or the queue silently stalls.
+        this.scheduleDrain();
+      }
+    })();
+    this.draining = task;
+    return task;
+  }
+
+  private async sendWithRetry(measurements: LlmCallMeasurement[]): Promise<boolean> {
+    const sleep = this.deps.sleep ?? ((ms: number) => new Promise<void>((r) => { setTimeout(r, ms).unref?.(); }));
+    const clock = () => (this.deps.now ? this.deps.now() : Date.now());
+    for (let attempt = 1; attempt <= MAX_SEND_ATTEMPTS; attempt++) {
+      // The deadline has to bound the SENDS too, not just the gaps between
+      // batches: three retries against a 5s-timeout Runtime ran 15.6s past a
+      // close that was supposed to cap at 5s.
+      if (this.closeDeadline !== null && clock() >= this.closeDeadline) return false;
+      try {
+        // RACE the send against the deadline. Checking the clock beforehand
+        // bounds nothing once we are inside `await send()`: two 4s batches ran a
+        // 5s close out to 8s. Losing the race abandons the WAIT, not necessarily
+        // the request — it may still land, and the receiver is idempotent on
+        // call_id, so a late arrival is harmless.
+        const sent = await this.raceDeadline(
+          this.deps.send({ session_id: this.deps.sessionId, measurements }),
+        );
+        return sent;
+      } catch (error) {
+        // Do not spend the remaining grace on a backoff we cannot afford.
+        if (this.closeDeadline !== null && clock() >= this.closeDeadline) return false;
+        if (attempt === MAX_SEND_ATTEMPTS) {
+          this.deps.warn?.(
+            `[llm-call-dispatcher] gave up on ${measurements.length} measurement(s) after ${attempt} attempts: ` +
+            (error instanceof Error ? error.message : String(error)),
+          );
+          return false;
+        }
+        await sleep(RETRY_BASE_MS * 2 ** (attempt - 1));
+      }
+    }
+    return false;
+  }
+}

--- a/src/agentbox/session.test.ts
+++ b/src/agentbox/session.test.ts
@@ -82,13 +82,34 @@ vi.mock("../core/agent-factory.js", async () => {
       getContextUsage: () => null,
       getSessionStats: () => ({ tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, cost: 0 }),
       registerProvider: behavior.registerProvider ?? (() => {}),
+      // Enough of the metering boundary to observe what a spawn hands its child.
+      // Kept stateful rather than a spy: the claim under test is that the value a
+      // call is recorded under is the one bound when it opened.
+      llmCalls: (() => {
+        let rootRequestId: string | null = null;
+        let parentCallId: string | null = null;
+        let toolDispatchCallId: string | null = null;
+        return {
+          setRootRequestId(id: string | null | undefined) { rootRequestId = id || null; },
+          getRootRequestId() { return rootRequestId; },
+          setParentCallId(id: string | null | undefined) { parentCallId = id || null; },
+          getParentCallId() { return parentCallId; },
+          getToolDispatchCallId() { return toolDispatchCallId; },
+          /** Test-only: stand in for "a round just sealed". */
+          __setToolDispatchCallId(id: string | null) { toolDispatchCallId = id; },
+          beginPrompt() {}, endPrompt() {}, beginAttempt() {}, rollbackAttempt() {},
+        };
+      })(),
     };
   }
   return {
     createSiclawSession: async (opts: any) => {
       g.__createSessionCalls.push(opts);
+      const brain = createFakeBrain();
+      g.__createdBrains = g.__createdBrains ?? [];
+      g.__createdBrains.push(brain);
       return {
-        brain: createFakeBrain(),
+        brain,
         session: { sessionId: "fake-session" },
         sessionIdRef: { current: "" },
         kubeconfigRef: opts.kubeconfigRef,
@@ -1329,6 +1350,67 @@ describe("AgentBoxSessionManager — spawn_subagent batch (foreground)", () => {
       expect(call[1]?.childSessionId).toMatch(/^[0-9a-f-]{36}$/);
     }
     expect(new Set(runSpy.mock.calls.map((call: any[]) => call[1]?.childSessionId)).size).toBe(4);
+  });
+
+  it("threads the parent's request correlation to every child, snapshotted once at dispatch", async () => {
+    // A sub-agent's spend is the parent request's spend — that is the gap this
+    // metering work exists to close. Captured at dispatch for the same reason the
+    // trace ids are: a background child can start after the parent turn is over.
+    const mgr = new AgentBoxSessionManager() as any;
+    const parent = await mgr.getOrCreate("p1", "web");
+    parent.brain.llmCalls.setRootRequestId("turn-parent");
+    parent.brain.llmCalls.__setToolDispatchCallId("call-round-2");
+    const runSpy = vi.spyOn(mgr, "runSpawnedSubagent").mockImplementation(async (_request: any, opts: any) => {
+      // The parent moving on mid-batch must not reach a child already dispatched.
+      parent.brain.llmCalls.setRootRequestId("turn-later");
+      parent.brain.llmCalls.__setToolDispatchCallId("call-round-3");
+      return { status: "done", summary: "ok", childSessionId: opts.childSessionId, toolCalls: 0, durationMs: 1 };
+    });
+
+    await mgr.createSpawnSubagentExecutor()(baseReq({ reducePrompt: "Summarize" }), undefined, undefined);
+
+    expect(runSpy).toHaveBeenCalledTimes(4); // 3 map + 1 reduce
+    for (const call of runSpy.mock.calls) {
+      expect(call[1]?.rootRequestId).toBe("turn-parent");
+      // Which request they share, and which call dispatched them, are separate
+      // facts — a shared root alone cannot name the dispatcher.
+      expect(call[1]?.parentCallId).toBe("call-round-2");
+    }
+    await mgr.closeAll();
+  });
+
+  it("records null when the parent bound no request, rather than inventing one for the child", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    await mgr.getOrCreate("p1", "web");
+    const runSpy = vi.spyOn(mgr, "runSpawnedSubagent").mockImplementation(async (_r: any, opts: any) => ({
+      status: "done", summary: "ok", childSessionId: opts.childSessionId, toolCalls: 0, durationMs: 1,
+    }));
+
+    await mgr.createSpawnSubagentExecutor()(baseReq({ renderedTasks: [{ item: "pod-a", prompt: "Check pod-a" }] }), undefined, undefined);
+
+    expect(runSpy.mock.calls[0][1]?.rootRequestId).toBeNull();
+    await mgr.closeAll();
+  });
+
+  it("the child adopts the inherited correlation, so its own calls bill to the parent request", async () => {
+    const mgr = new AgentBoxSessionManager() as any;
+    const parent = await mgr.getOrCreate("p1", "web");
+    parent.brain.llmCalls.setRootRequestId("turn-parent");
+    parent.brain.llmCalls.__setToolDispatchCallId("call-round-7");
+    pushPromptDrivenBrains(1);
+    const before = ((globalThis as any).__createdBrains ?? []).length;
+
+    await mgr.createSpawnSubagentExecutor()(
+      baseReq({ renderedTasks: [{ item: "pod-a", prompt: "Check pod-a" }] }),
+      undefined,
+      undefined,
+    );
+
+    const childBrains = ((globalThis as any).__createdBrains ?? []).slice(before);
+    expect(childBrains).toHaveLength(1);
+    expect(childBrains[0].llmCalls.getRootRequestId()).toBe("turn-parent");
+    expect(childBrains[0].llmCalls.getParentCallId()).toBe("call-round-7");
+    await mgr.closeAll();
   });
 
   it("does not expose the reduce session until its execution slot is acquired", async () => {

--- a/src/agentbox/session.ts
+++ b/src/agentbox/session.ts
@@ -109,6 +109,8 @@ import {
   type TierSelectionSource,
 } from "../core/subagent-models.js";
 import type { GatewayClient } from "./gateway-client.js";
+import { LlmCallMeasurementDispatcher } from "./llm-call-dispatcher.js";
+import { recordMeteringLoss } from "../shared/metrics.js";
 import { extractToolResultId } from "../core/message-utils.js";
 // topic-consolidator import removed — consolidation disabled
 
@@ -117,7 +119,26 @@ import { extractToolResultId } from "../core/message-utils.js";
  * `mainTraceId` stamps chat_messages.trace_id (DB audit); `spawnSpanContext` nests the child
  * ROOT under the parent's spawn_subagent tool span (Langfuse). Both undefined when tracing is off.
  */
-type SubagentTraceContext = { mainTraceId?: string; spawnSpanContext?: SpanContext };
+/**
+ * What a spawn captures from its parent AT DISPATCH, while the parent turn is
+ * still live.
+ *
+ * Trace ids and the metering correlation are captured together because they
+ * share one hazard: a background child can start after its parent's prompt has
+ * ended, so anything re-read later resolves against a turn that is over.
+ */
+type SubagentDispatchContext = {
+  mainTraceId?: string;
+  spawnSpanContext?: SpanContext;
+  /** The user request this whole spawn serves; children inherit it verbatim. */
+  rootRequestId?: string | null;
+  /**
+   * The parent's LLM call that issued this spawn. Tells "which model call
+   * dispatched this child" apart from "which request they both belong to" —
+   * `rootRequestId` alone can only answer the second.
+   */
+  parentCallId?: string | null;
+};
 
 export interface ManagedSession {
   id: string;
@@ -396,6 +417,69 @@ async function abortBrainBestEffort(
 
 export class AgentBoxSessionManager {
   private sessions = new Map<string, ManagedSession>();
+  /**
+   * Metering dispatchers, one per session id (main and sub-agent alike).
+   *
+   * Held here so release can flush the tail: the last calls of a turn settle
+   * after the stream ends, and a dispatcher dropped on the floor takes exactly
+   * the measurements that describe how the turn finished.
+   */
+  private _measurementDispatchers = new Map<string, LlmCallMeasurementDispatcher>();
+  /** Bounded "wait for outstanding measurements" per session; see finishMetering. */
+  private _measurementSettlers = new Map<string, () => Promise<void>>();
+  /** In-flight metering teardown per session, so concurrent callers share it. */
+  private _meteringFinish = new Map<string, Promise<void>>();
+
+  /**
+   * Close out metering for one session, in the only order that works:
+   * wait for the recorder to hand over what is still in flight, THEN drain the
+   * delivery queue.
+   *
+   * Reversing it loses the tail. A turn's last calls settle after its stream has
+   * ended — the observation branch is still reading a teed body — so draining
+   * first empties a queue those measurements have not reached yet.
+   *
+   * Every teardown path must call this: release, close, closeAll and sub-agent
+   * completion alike. A path that skips it both loses the data and leaks a map
+   * entry per session.
+   */
+  private finishMetering(sessionId: string): Promise<void> {
+    // Concurrent callers SHARE one completion, they do not race it. Deleting the
+    // settler up front and letting a second caller skip straight to closing the
+    // dispatcher is how release + closeAll together lost the tail: the second
+    // call found no settler, waited for nothing, and closed the queue before the
+    // first call's measurements had been handed over.
+    const existing = this._meteringFinish.get(sessionId);
+    if (existing) return existing;
+
+    const task = (async () => {
+      const settle = this._measurementSettlers.get(sessionId);
+      if (settle) await settle().catch(() => {});
+      const dispatcher = this._measurementDispatchers.get(sessionId);
+      if (dispatcher) {
+        await dispatcher.close().catch(() => {});
+        // Report the delivery gap before the dispatcher is dropped. Without
+        // this the only record of a loss dies with the object: 1,024 produced
+        // and 512 delivered looked exactly like 512 produced, so a coverage
+        // report could not tell under-collection from reduced spend.
+        const stats = dispatcher.stats();
+        if (stats.dropped > 0) {
+          console.warn(
+            `[agentbox-session] metering gap for ${sessionId}: delivered=${stats.delivered} ` +
+            `dropped=${stats.dropped} failedBatches=${stats.failedBatches}`,
+          );
+          recordMeteringLoss(stats.dropped);
+        }
+      }
+      // Removed only once the work is done, so a late caller still joins the
+      // in-flight completion rather than starting a second, shorter one.
+      this._measurementSettlers.delete(sessionId);
+      this._measurementDispatchers.delete(sessionId);
+    })();
+    this._meteringFinish.set(sessionId, task);
+    void task.finally(() => { this._meteringFinish.delete(sessionId); });
+    return task;
+  }
   // Retain the launching request owner until notification, even if Stop/handoff
   // replaces the session's current request before a late child/process exit.
   private backgroundWorkOwners = new Map<string, BackgroundWorkTurn>();
@@ -1041,9 +1125,23 @@ export class AgentBoxSessionManager {
       // ensureToolSpan resolves the ONE spawn_subagent tool span; every child (collapse / map /
       // reduce) nests under it (spawnSpanContext) and shares the DB trace_id (mainTraceId).
       // ⚠️ Never re-capture per child with a derived `${groupId}#i` id — that mints phantom spans.
-      const traceCtx = {
+      const dispatchCtx: SubagentDispatchContext = {
         mainTraceId: tracingRecorder.getRootTraceId(request.parentSessionId),
         spawnSpanContext: tracingRecorder.ensureToolSpan(request.parentSessionId, request.spawnId, "spawn_subagent"),
+        // Captured here for the same reason as the trace ids: a background child
+        // can start after the parent's prompt has ended, and the parent session
+        // may not even be resident by then. Null when the parent never set one
+        // (an older caller) — never a value invented for the child.
+        // Every hop optional on purpose: reading a correlation must never be able
+        // to break a spawn, and a brain without a recorder is an ordinary state
+        // (metering off, or a session built by a harness).
+        rootRequestId:
+          this.sessions.get(request.parentSessionId)?.brain?.llmCalls?.getRootRequestId() ?? null,
+        // The round now executing its tools IS the dispatcher. Read here, before
+        // any await, for the same reason as everything else in this snapshot:
+        // the parent's next round would overwrite it.
+        parentCallId:
+          this.sessions.get(request.parentSessionId)?.brain?.llmCalls?.getToolDispatchCallId() ?? null,
       };
 
       // Tier plan captured ONCE, here, for the same reason the trace context is:
@@ -1071,7 +1169,7 @@ export class AgentBoxSessionManager {
           spawnId: request.spawnId,
           tierPlan,
         };
-        if (childReq.runInBackground) return this.startBackgroundSubagent(childReq, traceCtx);
+        if (childReq.runInBackground) return this.startBackgroundSubagent(childReq, dispatchCtx);
         // Already aborted before we even queue (e.g. the whole turn was cancelled): don't
         // acquire a slot or spin up a throwaway child session — short-circuit cleanly.
         if (signal?.aborted) {
@@ -1108,7 +1206,7 @@ export class AgentBoxSessionManager {
           // Flip a previously-queued card to "running" immediately on slot acquisition,
           // before the child's first tool call emits progress (avoids a stale "Queued").
           onProgress?.({ status: "running", toolCalls: 0, steps: [] });
-          return this.runSpawnedSubagent(childReq, { ...traceCtx }, onProgress, signal);
+          return this.runSpawnedSubagent(childReq, { ...dispatchCtx }, onProgress, signal);
         }));
       }
 
@@ -1121,7 +1219,7 @@ export class AgentBoxSessionManager {
       const plannedRequest: SpawnSubagentGroupRequest = { ...request, tierPlan };
 
       if (plannedRequest.runInBackground) {
-        return this.startBackgroundSubagentGroup(plannedRequest, traceCtx);
+        return this.startBackgroundSubagentGroup(plannedRequest, dispatchCtx);
       }
       // Already aborted before we queue anything (whole turn cancelled): short-circuit
       // without creating any child session — every item is skipped.
@@ -1144,7 +1242,7 @@ export class AgentBoxSessionManager {
       // separate throttled group_progress emitter instead.
       const throttled = onProgress ? throttleTrailing(onProgress, GROUP_PROGRESS_THROTTLE_MS) : undefined;
       try {
-        return await this.runSubagentGroup(plannedRequest, throttled?.call, signal, traceCtx);
+        return await this.runSubagentGroup(plannedRequest, throttled?.call, signal, dispatchCtx);
       } finally {
         throttled?.cancel();
       }
@@ -1174,7 +1272,7 @@ export class AgentBoxSessionManager {
     request: SpawnSubagentGroupRequest,
     onProgress?: (progress: SubagentGroupProgress) => void,
     signal?: AbortSignal,
-    traceCtx?: SubagentTraceContext,
+    dispatchCtx?: SubagentDispatchContext,
   ): Promise<SubagentGroupReport> {
     const startedAt = Date.now();
     const groupId = request.spawnId;
@@ -1286,7 +1384,7 @@ export class AgentBoxSessionManager {
           emit("map");
           return this.runSpawnedSubagent(
             childReq,
-            { ...traceCtx, childSessionId },
+            { ...dispatchCtx, childSessionId },
             (progress) => {
               const activity = progress.activity?.trim();
               if (!activity || activity === state.activity) return;
@@ -1409,7 +1507,7 @@ export class AgentBoxSessionManager {
             emit("reduce");
             return this.runSpawnedSubagent(
               reduceReq,
-              { ...traceCtx, childSessionId: reduceChildSessionId },
+              { ...dispatchCtx, childSessionId: reduceChildSessionId },
               undefined,
               userAbort.signal,
             );
@@ -1497,7 +1595,7 @@ export class AgentBoxSessionManager {
         ...(r.tierOutcome ? { tier: persistableTierOutcome(r.tierOutcome) } : {}),
       })),
       durationMs,
-      traceId: traceCtx?.mainTraceId,
+      traceId: dispatchCtx?.mainTraceId,
     });
 
     return {
@@ -1555,7 +1653,7 @@ export class AgentBoxSessionManager {
    * (reusing type "subagent" + isGroup), returns "launched" immediately, and notifies the
    * parent on completion. Background work blocks session release until it finishes.
    */
-  private startBackgroundSubagentGroup(request: SpawnSubagentGroupRequest, traceCtx?: SubagentTraceContext): SubagentGroupResult {
+  private startBackgroundSubagentGroup(request: SpawnSubagentGroupRequest, dispatchCtx?: SubagentDispatchContext): SubagentGroupResult {
     this.registerBackgroundWork(request.parentSessionId, request.spawnId);
     const jobId = request.spawnId;
     const controller = new AbortController();
@@ -1587,7 +1685,7 @@ export class AgentBoxSessionManager {
         summaryTruncated: false,
         itemStatuses: request.renderedTasks.map((_, i) => ({ index: i, status: "skipped" as GroupItemStatus })),
         durationMs: 0,
-        traceId: traceCtx?.mainTraceId,
+        traceId: dispatchCtx?.mainTraceId,
       });
       void this.notifyParent(request.parentSessionId, jobId, {
         taskId: jobId,
@@ -1627,7 +1725,7 @@ export class AgentBoxSessionManager {
     // (unknown event type ignored) and no-ops when persistence isn't wired (gatewayClient absent).
     const onProgress = this.makeGroupProgressEmitter(request.parentSessionId, jobId);
 
-    void this.runSubagentGroup(request, onProgress.emit, controller.signal, traceCtx)
+    void this.runSubagentGroup(request, onProgress.emit, controller.signal, dispatchCtx)
       .then(async (report) => {
         await this.persistSubagentJobOutput(jobId, JSON.stringify(report));
         onProgress.settle();
@@ -1901,7 +1999,7 @@ export class AgentBoxSessionManager {
    * "launched"; on completion notifyParent injects a <task_notification> into the
    * parent model. Background work blocks session release until it finishes.
    */
-  private startBackgroundSubagent(request: SpawnSubagentRequest, traceCtx?: SubagentTraceContext): SpawnSubagentResult {
+  private startBackgroundSubagent(request: SpawnSubagentRequest, dispatchCtx?: SubagentDispatchContext): SpawnSubagentResult {
     this.registerBackgroundWork(request.parentSessionId, request.spawnId);
     const childSessionId = randomUUID();
     const jobId = request.spawnId;
@@ -1954,7 +2052,7 @@ export class AgentBoxSessionManager {
               scope: request.prompt,
               toolCalls: 0,
               durationMs: 0,
-              traceId: traceCtx?.mainTraceId,
+              traceId: dispatchCtx?.mainTraceId,
             });
           } catch { /* best-effort */ }
         })();
@@ -1996,7 +2094,7 @@ export class AgentBoxSessionManager {
     // "launched" immediately; queueing delays the child's start, never the tool call.
     const sessionLim = this.sessionSubagentLimiter(request.parentSessionId);
     void sessionLim.run(() => this.podSubagentLimiter.run(() =>
-      this.runSpawnedSubagent(request, { childSessionId, jobId, ...traceCtx })))
+      this.runSpawnedSubagent(request, { childSessionId, jobId, ...dispatchCtx })))
       .then(async (res) => {
         if (res.status !== "launched") await this.persistSubagentJobOutput(jobId, res.fullSummary ?? res.summary);
         const job = this.jobs.get(jobId);
@@ -2232,6 +2330,13 @@ export class AgentBoxSessionManager {
         managed._routeBrainEventsThroughExtra = effectivePolicy !== undefined;
         let latestModelRouteSwitch: Extract<ModelRouteEvent, { type: "model_route_switch" }> | null = null;
         let currentModelRouteMetadata: Record<string, unknown> | null = null;
+        // A synthetic turn belongs to NO user request, so it carries none. Two
+        // reasons this is not merely conservative: the recorder would otherwise
+        // keep whatever the last real prompt bound — a request that has since
+        // finished — and notifications COALESCE, so one turn can answer jobs from
+        // several different requests. Its spend stays attributed to the session,
+        // agent and user; it is simply not folded into one request.
+        managed.brain.llmCalls?.setRootRequestId(null);
         managed.brain.llmCalls?.beginPrompt(Date.now(), { explicit: true });
         const handleRouteEvent = (event: ModelRouteEvent): void => {
           if (event.type === "model_route_attempt" && event.status === "started") {
@@ -2665,7 +2770,7 @@ export class AgentBoxSessionManager {
    */
   private async runSpawnedSubagent(
     request: SpawnSubagentRequest,
-    opts?: { childSessionId?: string; jobId?: string; mainTraceId?: string; spawnSpanContext?: SpanContext },
+    opts?: { childSessionId?: string; jobId?: string } & SubagentDispatchContext,
     onProgress?: (progress: SpawnSubagentProgress) => void,
     signal?: AbortSignal,
   ): Promise<SpawnSubagentResult> {
@@ -2704,7 +2809,22 @@ export class AgentBoxSessionManager {
      */
     const sharedMcpManager = this.sessions.get(request.parentSessionId)?.mcpManager;
 
+    // A sub-agent's calls are the parent request's spend, and they are the ones
+    // Portal never saw — metering them is the whole point of this work.
+    const childDispatcher = this.gatewayClient
+      ? new LlmCallMeasurementDispatcher({
+          sessionId: childSessionId,
+          send: (batch) => this.gatewayClient!.sendLlmCallMeasurements(batch),
+          warn: (message) => console.warn(message),
+        })
+      : undefined;
+    if (childDispatcher) this._measurementDispatchers.set(childSessionId, childDispatcher);
+
     const child = await createSiclawSession({
+      onLlmCallMeasurement: childDispatcher ? (m) => childDispatcher.record(m) : undefined,
+      onLlmCallSettler: childDispatcher
+        ? (settle) => this._measurementSettlers.set(childSessionId, settle)
+        : undefined,
       mcpManager: sharedMcpManager,
       sessionManager: childSessionManager,
       kubeconfigRef,
@@ -2733,6 +2853,11 @@ export class AgentBoxSessionManager {
       // never sees spawn_subagent (no recursion).
     });
     child.sessionIdRef.current = childSessionId;
+    // A sub-agent's spend belongs to the request that spawned it. Inherited from
+    // the dispatch snapshot rather than re-read from the parent, which may have
+    // finished its turn (or been released) before a background child starts.
+    child.brain?.llmCalls?.setRootRequestId(opts?.rootRequestId ?? null);
+    child.brain?.llmCalls?.setParentCallId(opts?.parentCallId ?? null);
 
     // ── Model selection: tier, or the parent's effective model ──────────────
     //
@@ -3033,6 +3158,10 @@ export class AgentBoxSessionManager {
     } finally {
       if (childTimer) clearTimeout(childTimer);
       unsubscribe();
+      // A child session ends here and nowhere else — it never reaches release()
+      // or close(). Without this its measurements are lost and its map entries
+      // accumulate for the life of the box.
+      await this.finishMetering(childSessionId);
       // Shut down only connections this child opened. A manager shared with the
       // parent outlives every child and is torn down with the parent session.
       if (child.mcpManager && child.mcpManager !== sharedMcpManager) {
@@ -3524,7 +3653,23 @@ export class AgentBoxSessionManager {
       : undefined;
 
     const scriptInfo = effectiveMode === "web" && !delegation && gc ? await gc.scriptSandboxInfo() : undefined;
+    // Metering rides the Runtime link: without a gateway there is nowhere to
+    // deliver, and turning observation on would cost work nothing can read.
+    const measurementDispatcher = gc
+      ? new LlmCallMeasurementDispatcher({
+          sessionId: id,
+          send: (batch) => gc.sendLlmCallMeasurements(batch),
+          warn: (message) => console.warn(message),
+        })
+      : undefined;
+    if (measurementDispatcher) this._measurementDispatchers.set(id, measurementDispatcher);
     const result = await createSiclawSession({
+      onLlmCallMeasurement: measurementDispatcher
+        ? (measurement) => measurementDispatcher.record(measurement)
+        : undefined,
+      onLlmCallSettler: measurementDispatcher
+        ? (settle) => this._measurementSettlers.set(id, settle)
+        : undefined,
       scriptExecutor: scriptInfo?.enabled ? (request, _sessionId, signal) => gc!.runScript(request, id, signal) : undefined,
       scriptSandboxInfo: scriptInfo,
       sessionManager: frameworkSessionManager,
@@ -3990,6 +4135,7 @@ export class AgentBoxSessionManager {
   }
 
   async release(sessionId: string): Promise<void> {
+    await this.finishMetering(sessionId);
     const managed = this.sessions.get(sessionId);
     if (!managed) {
       // Not resident — but a handed-away session still has to lose its on-disk
@@ -4118,6 +4264,9 @@ export class AgentBoxSessionManager {
    * are still NOT destroyed (they belong to the AgentBox).
    */
   async close(sessionId: string): Promise<void> {
+    // Before anything else, and regardless of residency: a session closed
+    // without a resident entry can still have measurements queued.
+    await this.finishMetering(sessionId);
     const managed = this.sessions.get(sessionId);
     if (managed) {
       console.log(`[agentbox-session] Closing session: ${sessionId}`);
@@ -4179,6 +4328,14 @@ export class AgentBoxSessionManager {
     // from emitting a duplicate session_released for the same session.
     const snapshot = new Map(this.sessions);
     this.sessions.clear();
+
+    // SIGTERM exits straight after this, so an unflushed dispatcher is a
+    // guaranteed loss. Settle every session's metering first, in parallel and
+    // bounded — each finishMetering already caps its own waits.
+    await Promise.all(
+      [...new Set([...this._measurementSettlers.keys(), ...this._measurementDispatchers.keys()])]
+        .map((id) => this.finishMetering(id)),
+    );
 
     for (const [id, managed] of snapshot) {
       if (managed._releaseTimer) {

--- a/src/core/agent-factory.ts
+++ b/src/core/agent-factory.ts
@@ -35,6 +35,7 @@ import {
   type AgentContextManifest,
 } from "./agent-context.js";
 import type { AgentType } from "./agent-types.js";
+import type { LlmCallMeasurement } from "../shared/llm-call-record.js";
 import contextPruningExtension from "./extensions/context-pruning.js";
 import compactionSafeguardExtension from "./extensions/compaction-safeguard.js";
 import memoryFlushExtension from "./extensions/memory-flush.js";
@@ -105,6 +106,19 @@ export interface CreateSiclawSessionOpts {
   allowedTools?: string[] | null;
   /** Agent kind used by the shared context compiler. Legacy standalone callers default to SRE. */
   agentType?: AgentType;
+  /**
+   * Per-call metering sink. Core produces the measurement and hands it over;
+   * the caller owns attribution and persistence. Omitting it leaves metering off.
+   */
+  onLlmCallMeasurement?: (measurement: LlmCallMeasurement) => void;
+  /**
+   * Receives a bounded "wait for outstanding measurements" function.
+   *
+   * Teardown needs it: a turn's final calls settle AFTER the stream ends, so a
+   * release that only drains the delivery queue drains an empty one and loses
+   * precisely the measurements describing how the turn finished.
+   */
+  onLlmCallSettler?: (settle: () => Promise<void>) => void;
   /** False when the control plane could not prove the Agent's type/capability policy. */
   harnessResolved?: boolean;
   /** Persisted Agent-owned addendum; built-in type contracts are compiled separately. */
@@ -917,6 +931,7 @@ export async function createSiclawSession(
     model: configuredModel,
     thinkingLevel: resolveSessionThinkingLevel(services.settingsManager, configuredModel),
     customTools,
+    onLlmCallMeasurement: opts?.onLlmCallMeasurement,
     onModelEnvelope: (manifest) => {
       console.log(`[model-envelope] ${JSON.stringify({
         agentType: compiledContext.harness.agentType,
@@ -932,6 +947,9 @@ export async function createSiclawSession(
       return toolset ? [[tool.name, toolset] as const] : [];
     }),
   );
+  // Hand the settler out before the brain wraps the recorder away: teardown is
+  // the only caller, and it has no other route to it.
+  opts?.onLlmCallSettler?.(() => llmCallRecorder.settleMeasurements());
   const brain: BrainSession = new PiAgentBrain(session, toolsetsByName, llmCallRecorder);
   const getSkillSnapshot = () => {
     const currentSkills = loader.getSkills().skills;

--- a/src/core/llm-call-metering.test.ts
+++ b/src/core/llm-call-metering.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Offline fixtures for the P0 metering path.
+ *
+ * These drive the real recorder through a scripted stream and a scripted fetch,
+ * so they exercise the whole chain — instrumented fetch → raw observation →
+ * provenance → measurement — without a network or a model.
+ *
+ * Every case here is one of the counter-examples that made the design what it
+ * is. They all share a shape: something produces zeros, and a naive reader would
+ * bank them as "this call was free".
+ */
+
+import { describe, it, expect } from "vitest";
+import { LlmCallRecorder } from "./llm-call-recorder.js";
+import type { LlmCallMeasurement } from "../shared/llm-call-record.js";
+
+/** A stream that yields nothing and settles with `finalMessage`. */
+function streamOf(finalMessage: any) {
+  return {
+    async result() { return finalMessage; },
+    [Symbol.asyncIterator]() {
+      return {
+        async next() { return { done: true as const, value: undefined }; },
+        async return() { return { done: true as const, value: undefined }; },
+        async throw() { return { done: true as const, value: undefined }; },
+      };
+    },
+  };
+}
+
+/** Body of a Responses SSE stream whose terminal event carries `usage`. */
+const sseWithUsage = (usage: unknown): string =>
+  `data: ${JSON.stringify({ type: "response.completed", response: { usage } })}\n\ndata: [DONE]\n\n`;
+
+/** An SSE stream that never reports usage at all. */
+const sseWithoutUsage = (): string =>
+  `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "hi" })}\n\ndata: [DONE]\n\n`;
+
+interface Harness {
+  recorder: LlmCallRecorder;
+  measurements: LlmCallMeasurement[];
+  /** Runs one call whose HTTP response body is `body`; omit to leave fetch uninstrumented-by-the-caller. */
+  call(body: string | null, finalMessage?: any, context?: any): Promise<void>;
+}
+
+function harness(options: { instrument?: boolean } = {}): Harness {
+  const measurements: LlmCallMeasurement[] = [];
+  const recorder = new LlmCallRecorder({
+    ...(options.instrument === false ? {} : { onMeasurement: (m) => measurements.push(m) }),
+    newCallId: (() => { let n = 0; return () => `id-${++n}`; })(),
+  });
+
+  const call: Harness["call"] = async (body, finalMessage = {}, context = { tools: [], messages: [] }) => {
+    const base = (_model: any, _context: any, opts: any) => {
+      // Exercise the injected fetch exactly as the SDK would.
+      if (body !== null && opts?.fetch) {
+        void opts.fetch("https://provider.invalid/v1/responses").then((r: Response) => r.text());
+      }
+      return streamOf({ api: "openai-responses", provider: "example-gateway", model: "gpt-5", ...finalMessage });
+    };
+    const wrapped = recorder.wrapStreamFn(base as any);
+    const stream = wrapped({ provider: "example-gateway", id: "gpt-5" }, context, {
+      fetch: body === null ? undefined : async () => new Response(body, { status: 200 }),
+    });
+    await stream.result();
+    await new Promise((r) => setTimeout(r, 0)); // let the observer branch settle
+  };
+
+  return { recorder, measurements, call };
+}
+
+describe("metering: provenance of every zero", () => {
+  it("records provider-reported figures, keeping an explicit zero as a zero", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({
+      input_tokens: 1_000,
+      output_tokens: 200,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 50 },
+    }));
+
+    expect(h.measurements).toHaveLength(1);
+    const m = h.measurements[0];
+    expect(m.usage_source).toBe("provider");
+    expect(m.usage_status).toBe("reported");
+    expect(m.cache_read_tokens).toBe(0);         // reported zero survives as 0
+    expect(m.input_tokens_total).toBe(1_000);
+    expect(m.reasoning_tokens).toBe(50);
+    expect(m.inconsistencies).toEqual([]);
+  });
+
+  it("1. a call that settles normally without usage is `missing`, not zeros", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithoutUsage(), { stopReason: "stop" });
+
+    const m = h.measurements[0];
+    expect(m.usage_source).toBe("sdk_default");
+    expect(m.usage_status).toBe("missing");
+    // The decisive assertion: unreported figures are null, never 0.
+    expect(m.input_tokens_total).toBeNull();
+    expect(m.output_tokens_total).toBeNull();
+    expect(m.cache_read_tokens).toBeNull();
+  });
+
+  it("2. an aborted call leaves nulls rather than initialisation zeros", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithoutUsage(), { stopReason: "aborted" });
+
+    const m = h.measurements[0];
+    expect(m.usage_status).toBe("missing");
+    expect(m.output_tokens_total).toBeNull();
+  });
+
+  it("3. a transport that never calls fetch is `unknown`, which is not `missing`", async () => {
+    // Nothing was observed, so we cannot claim the provider stayed silent —
+    // `missing` would be an assertion we have no basis for. The measurement
+    // waits out the observation grace period and then settles as unknown.
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(null);
+    await new Promise((r) => setTimeout(r, 300)); // > OBSERVATION_GRACE_MS
+
+    const m = h.measurements[0];
+    expect(m.usage_source).toBe("unknown");
+    expect(m.usage_status).toBe("unknown");
+    expect(m.input_tokens_total).toBeNull();
+  });
+
+  it("4. partial reports are marked partial and keep the fields that did arrive", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 17 }));
+
+    const m = h.measurements[0];
+    expect(m.usage_source).toBe("provider");
+    expect(m.usage_status).toBe("partial");
+    expect(m.reported_fields).toEqual(["input"]);
+    expect(m.input_tokens_total).toBe(17);
+    // pi would have shown 0 here; the raw observation says "never sent".
+    expect(m.reasoning_tokens).toBeNull();
+  });
+
+  it("5. contradictory figures are surfaced, not clamped away", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({
+      input_tokens: 100,
+      output_tokens: 10,
+      input_tokens_details: { cached_tokens: 120 },
+      output_tokens_details: { reasoning_tokens: 20 },
+    }));
+
+    const m = h.measurements[0];
+    expect(m.inconsistencies.map((p) => p.field).sort()).toEqual(["cache_vs_input", "reasoning_vs_output"]);
+    // The raw values are preserved as evidence rather than normalised.
+    expect(m.output_tokens_total).toBe(10);
+    expect(m.reasoning_tokens).toBe(20);
+  });
+});
+
+describe("metering: identity and correlation", () => {
+  it("gives each call its own call_id while holding prompt_id steady", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 1 }));
+    await h.call(sseWithUsage({ input_tokens: 2 }));
+
+    const [a, b] = h.measurements;
+    expect(a.call_id).not.toBe(b.call_id);
+    expect(a.prompt_id).toBe(b.prompt_id);
+  });
+
+  it("never emits an empty prompt_id", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 1 }));
+    expect(h.measurements[0].prompt_id).not.toBe("");
+  });
+
+  it("counts transport retries without minting extra call_ids", async () => {
+    const measurements: LlmCallMeasurement[] = [];
+    const recorder = new LlmCallRecorder({ onMeasurement: (m) => measurements.push(m) });
+    recorder.beginPrompt();
+
+    let attempts = 0;
+    const base = (_m: any, _c: any, opts: any) => {
+      // Two HTTP attempts inside ONE logical call.
+      void (async () => {
+        await opts.fetch("https://provider.invalid").then((r: Response) => r.text());
+        await opts.fetch("https://provider.invalid").then((r: Response) => r.text());
+      })();
+      return streamOf({ api: "openai-responses", provider: "example-gateway", model: "gpt-5" });
+    };
+    const wrapped = recorder.wrapStreamFn(base as any);
+    const stream = wrapped({ provider: "example-gateway", id: "gpt-5" }, { tools: [], messages: [] }, {
+      fetch: async () => {
+        attempts += 1;
+        return new Response(sseWithUsage({ input_tokens: attempts * 10 }), { status: 200 });
+      },
+    });
+    await stream.result();
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(measurements).toHaveLength(1);
+    expect(measurements[0].network_attempts).toBeGreaterThanOrEqual(1);
+  });
+
+  it("marks aux calls distinctly from agent calls", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    // No `tools` on the context ⇒ auxiliary (compaction/summarisation) call.
+    await h.call(sseWithUsage({ input_tokens: 5 }), {}, { messages: [] });
+
+    expect(h.measurements[0].kind).toBe("aux");
+  });
+});
+
+describe("metering: the FINAL attempt decides", () => {
+  /** Drives one call whose fetch answers differently per attempt. */
+  async function callWithAttempts(bodies: Array<{ body: string; delayMs?: number }>) {
+    const measurements: LlmCallMeasurement[] = [];
+    const recorder = new LlmCallRecorder({ onMeasurement: (m) => measurements.push(m) });
+    recorder.beginPrompt();
+
+    let n = 0;
+    // Retries happen while the SDK is still trying to obtain a response, i.e.
+    // BEFORE the stream settles — so every attempt is started by seal time.
+    const base = async (_m: any, _c: any, opts: any) => {
+      for (let i = 0; i < bodies.length; i++) {
+        await opts.fetch("https://provider.invalid").then((r: Response) => r.text()).catch(() => {});
+      }
+      return streamOf({ api: "openai-responses", provider: "example-gateway", model: "gpt-5" });
+    };
+    const stream = await recorder.wrapStreamFn(base as any)(
+      { provider: "example-gateway", id: "gpt-5" },
+      { tools: [], messages: [] },
+      {
+        fetch: async () => {
+          const spec = bodies[Math.min(n++, bodies.length - 1)];
+          if (spec.delayMs) await new Promise((r) => setTimeout(r, spec.delayMs));
+          return new Response(spec.body, { status: 200 });
+        },
+      },
+    );
+    await stream.result();
+    await new Promise((r) => setTimeout(r, 400)); // past the observation grace
+    return measurements;
+  }
+
+  it("does not let an earlier success stand in for a final unreadable attempt", async () => {
+    const measurements = await callWithAttempts([
+      { body: sseWithUsage({ input_tokens: 500 }) },     // attempt 1 succeeded
+      { body: 'data: {"type":"response.compl\n\n' },     // attempt 2 broke
+    ]);
+    // Reporting 500 here would quote a response the SDK discarded.
+    expect(measurements[0].usage_source).toBe("unknown");
+    expect(measurements[0].input_tokens_total).toBeNull();
+  });
+
+  it("waits for a slow final attempt rather than recording the 503 before it", async () => {
+    const measurements = await callWithAttempts([
+      { body: "upstream unavailable" },                                  // 503-ish, unparseable
+      { body: sseWithUsage({ input_tokens: 77, output_tokens: 3 }), delayMs: 80 },
+    ]);
+    expect(measurements[0].usage_source).toBe("provider");
+    expect(measurements[0].input_tokens_total).toBe(77);
+    expect(measurements[0].network_attempts).toBe(2);
+  });
+});
+
+describe("metering: request snapshot", () => {
+  it("separates history growth from history rewriting", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    const shared = [{ role: "user", content: "a" }, { role: "assistant", content: "b" }];
+
+    // Growth: same prefix, one more message appended.
+    await h.call(sseWithUsage({ input_tokens: 1 }), {}, { tools: [], messages: [...shared] });
+    await h.call(sseWithUsage({ input_tokens: 1 }), {}, { tools: [], messages: [...shared, { role: "user", content: "c" }] });
+    // Rewrite: an OLD message changed — the cache prefix is dead.
+    await h.call(sseWithUsage({ input_tokens: 1 }), {}, {
+      tools: [],
+      messages: [{ role: "user", content: "a" }, { role: "assistant", content: "REWRITTEN" }, { role: "user", content: "c" }],
+    });
+
+    const [grow1, grow2, rewrite] = h.measurements.map((m) => m.request_snapshot);
+    // First call's prefix is just the user turn; second call's prefix is the two
+    // shared messages — different, but each is a stable extension.
+    expect(grow2.history_message_count).toBe(3);
+    expect(rewrite.history_message_count).toBe(3);
+    // Same length, different prefix ⇒ this is the signal that matters.
+    expect(rewrite.history_prefix_sha256).not.toBe(grow2.history_prefix_sha256);
+    expect(grow1.history_prefix_sha256).toBeTruthy();
+  });
+
+  it("fingerprints system prompt and tools separately", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 1 }), {}, { tools: [{ name: "bash" }], messages: [], systemPrompt: "S1" });
+    await h.call(sseWithUsage({ input_tokens: 1 }), {}, { tools: [{ name: "bash" }], messages: [], systemPrompt: "S2" });
+
+    const [a, b] = h.measurements.map((m) => m.request_snapshot);
+    expect(a.tools_sha256).toBe(b.tools_sha256);      // tools unchanged
+    expect(a.system_sha256).not.toBe(b.system_sha256); // prompt changed
+  });
+});
+
+describe("metering is strictly additive", () => {
+  it("produces nothing and instruments no fetch when no sink is configured", async () => {
+    const h = harness({ instrument: false });
+    h.recorder.beginPrompt();
+
+    let sawInjectedFetch = false;
+    const base = (_m: any, _c: any, opts: any) => {
+      sawInjectedFetch = typeof opts?.fetch === "function" && opts.fetch.name !== "boundFetch";
+      return streamOf({ api: "openai-responses", provider: "example-gateway", model: "gpt-5" });
+    };
+    const wrapped = h.recorder.wrapStreamFn(base as any);
+    await wrapped({ provider: "example-gateway", id: "gpt-5" }, { tools: [], messages: [] }, {}).result();
+
+    expect(h.measurements).toHaveLength(0);
+    expect(sawInjectedFetch).toBe(false);
+  });
+});
+
+describe("metering: which user request a call served", () => {
+  it("carries the bound request across rounds and routing retries", async () => {
+    const h = harness();
+    h.recorder.setRootRequestId("turn-abc");
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+    // A routing retry is the SAME user request on another candidate.
+    h.recorder.beginAttempt(2);
+    await h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+
+    expect(h.measurements.map((m) => m.root_request_id)).toEqual(["turn-abc", "turn-abc"]);
+    // …while staying distinct calls, so the correlation groups them rather than
+    // collapsing two real calls into one row.
+    expect(new Set(h.measurements.map((m) => m.call_id)).size).toBe(2);
+  });
+
+  it("records null when nothing bound a request, rather than inventing one", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+
+    expect(h.measurements[0].root_request_id).toBeNull();
+  });
+
+  it("drops an unstorable id instead of truncating it, and keeps the measurement", async () => {
+    const h = harness();
+    h.recorder.setRootRequestId("x".repeat(65));
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+
+    // A prefix would join calls from different requests; null says we could not
+    // carry the correlation. Either way the usage figures still land.
+    expect(h.measurements[0].root_request_id).toBeNull();
+    expect(h.measurements[0].input_tokens_total).toBe(10);
+  });
+
+  it("names the call whose tools are running, so a spawn can record its dispatcher", async () => {
+    const h = harness();
+    h.recorder.beginPrompt();
+    expect(h.recorder.getToolDispatchCallId()).toBeNull();   // nothing has sealed yet
+
+    await h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+    const firstRound = h.recorder.getToolDispatchCallId();
+    expect(firstRound).toBe(h.measurements[0].call_id);
+
+    // The NEXT round replaces it — which is exactly why a spawn must read this
+    // synchronously at dispatch rather than later.
+    await h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+    expect(h.recorder.getToolDispatchCallId()).toBe(h.measurements[1].call_id);
+    expect(h.recorder.getToolDispatchCallId()).not.toBe(firstRound);
+  });
+
+  it("does not let an aux call stand in as the dispatcher", async () => {
+    // A summarisation issues no tools; naming it would attribute the spawn to a
+    // call that could not have made it.
+    const h = harness();
+    h.recorder.beginPrompt();
+    await h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+    const agentCall = h.recorder.getToolDispatchCallId();
+
+    await h.call(sseWithUsage({ input_tokens: 5, output_tokens: 1 }), {}, { systemPrompt: "summarise", messages: [] });
+
+    expect(h.measurements[1].kind).toBe("aux");
+    expect(h.recorder.getToolDispatchCallId()).toBe(agentCall);
+  });
+
+  it("stamps a sub-agent's calls with the call that spawned it", async () => {
+    const child = harness();
+    child.recorder.setParentCallId("call-parent-round-2");
+    child.recorder.beginPrompt();
+    await child.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+
+    expect(child.measurements[0].parent_call_id).toBe("call-parent-round-2");
+    // A parent's own calls have no dispatcher.
+    const parent = harness();
+    parent.recorder.beginPrompt();
+    await parent.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+    expect(parent.measurements[0].parent_call_id).toBeNull();
+  });
+
+  it("keeps the request a call opened under, not one rebound mid-flight", async () => {
+    const h = harness();
+    h.recorder.setRootRequestId("turn-1");
+    h.recorder.beginPrompt();
+    const started = h.call(sseWithUsage({ input_tokens: 10, output_tokens: 1 }));
+    h.recorder.setRootRequestId("turn-2");
+    await started;
+
+    expect(h.measurements[0].root_request_id).toBe("turn-1");
+  });
+});

--- a/src/core/llm-call-recorder.ts
+++ b/src/core/llm-call-recorder.ts
@@ -22,6 +22,68 @@
  * timing — a reader that wants a different number derives it from these.
  */
 
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  MAX_CORRELATION_ID_LENGTH,
+  resolveUsageStatus,
+  validateUsageConsistency,
+  type LlmCallMeasurement,
+  type LlmRequestSnapshot,
+  type UsageField,
+  type UsageSource,
+} from "../shared/llm-call-record.js";
+import { instrumentFetchForUsage, type RawUsageObservation } from "./raw-usage-observer.js";
+
+const sha256 = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+/**
+ * How long a measurement waits for the raw-usage branch before giving up.
+ *
+ * The branch reads a teed copy of a body the SDK has already consumed, so it is
+ * normally microseconds behind. The cap exists so a stuck read degrades to
+ * `unknown` instead of leaking a pending timer per call.
+ */
+const OBSERVATION_GRACE_MS = 250;
+
+/** Budget-only estimate; a real tokenizer is not worth the dependency here. */
+const APPROX_BYTES_PER_TOKEN = 4;
+
+/** Ceiling on how long teardown waits for outstanding measurements. */
+const MEASUREMENT_SETTLE_MS = 1_000;
+
+/**
+ * Fingerprint the request as the model will see it.
+ *
+ * `history_prefix_sha256` covers every message EXCEPT the newest one, which is
+ * what separates "history merely grew" (prefix stable, cache still usable) from
+ * "history was rewritten or pruned" (prefix changed, cache prefix dead) — the
+ * distinction the whole cache investigation turns on.
+ *
+ * `prompt_cache_key` and the retention shape are left null here: both are set
+ * inside the SDK's request builder, below this boundary. A later step can lift
+ * them off the outgoing request body.
+ */
+function snapshotRequest(context: any): LlmRequestSnapshot {
+  const messages: unknown[] = Array.isArray(context?.messages) ? context.messages : [];
+  const prefix = messages.slice(0, Math.max(0, messages.length - 1));
+  const systemPrompt = typeof context?.systemPrompt === "string" ? context.systemPrompt : "";
+  let toolsText = "[]";
+  let prefixText = "[]";
+  try { toolsText = JSON.stringify(context?.tools ?? []); } catch { toolsText = "[unserialisable]"; }
+  try { prefixText = JSON.stringify(prefix); } catch { prefixText = "[unserialisable]"; }
+  return {
+    // prompt_cache_key / cache_retention_sent are deliberately ABSENT here:
+    // this function has not inspected any request. The fetch observation fills
+    // them in, and only then does a null mean "was not sent".
+    model_settings: {},
+    system_sha256: sha256(systemPrompt),
+    tools_sha256: sha256(toolsText),
+    history_prefix_sha256: sha256(prefixText),
+    history_message_count: messages.length,
+  };
+}
+
 export const LLM_CALL_ENVELOPE_VERSION = 1 as const;
 
 export type LlmCallKind = "agent" | "aux";
@@ -97,6 +159,46 @@ export interface LlmCallEnvelope {
 interface InFlightCall {
   kind: LlmCallKind;
   requestAt: number;
+  /** Identifies this call for its whole lifecycle; transport retries reuse it. */
+  callId: string;
+  /**
+   * The prompt this call belongs to, captured at open time.
+   *
+   * Must NOT be read from the recorder when the measurement finally settles: a
+   * call that waits out its observation grace period can outlive its prompt, and
+   * reading the live value then files it under whatever prompt started next.
+   */
+  promptId: string;
+  /** Snapshotted with the call, for the same reason `promptId` is. */
+  rootRequestId: string | null;
+  /** Likewise: a sub-agent's spawning call, fixed for this recorder's lifetime. */
+  parentCallId: string | null;
+  /**
+   * Per-attempt observations, keyed by attempt number.
+   *
+   * Keyed rather than collapsed to "the best so far" because the LAST attempt is
+   * the outcome, whatever it says: a final attempt whose body failed to parse
+   * must report `failed`, not inherit an earlier attempt's success.
+   */
+  attemptObservations: Map<number, RawUsageObservation>;
+  /** Resolves per attempt once its observation has settled. */
+  attemptWaits: Map<number, Promise<void>>;
+  /** Transport-level retries observed for this one call. */
+  networkAttempts: number;
+  /** Request shape as sent — the evidence cache and pruning checks read. */
+  requestSnapshot: LlmRequestSnapshot;
+  /** True once this call's options were instrumented (distinguishes "no fetch" from "not wired"). */
+  instrumented?: boolean;
+  /** Releases this call from `activeCalls`; cleared once used. */
+  settleActive?: () => void;
+  /**
+   * Wire protocol, snapshotted at open time.
+   *
+   * An abandoned stream has no final message to read `api` from, so a call that
+   * ended early recorded `api_type: ""` — which resolves to `unknown` and
+   * discards a perfectly good usage report that had already arrived.
+   */
+  apiType?: string;
   headersAt?: number;
   firstTokenAt?: number;
   blocks: LlmCallBlock[];
@@ -111,6 +213,14 @@ export interface LlmCallRecorderOptions {
   now?: () => number;
   /** Diagnostic sink; defaults to console.warn. */
   warn?: (message: string) => void;
+  /**
+   * Per-call metering sink. When absent the recorder behaves exactly as before —
+   * no fetch is instrumented and no measurement is produced — so this stays an
+   * additive capability rather than a change to the existing envelope contract.
+   */
+  onMeasurement?: (measurement: LlmCallMeasurement) => void;
+  /** Stable id generator; injectable so tests can pin call_ids. */
+  newCallId?: () => string;
 }
 
 /**
@@ -118,6 +228,19 @@ export interface LlmCallRecorderOptions {
  * boundaries without reaching into the recorder's internals.
  */
 export interface LlmCallPromptBoundary {
+  /**
+   * Bind subsequent calls to a user request. Optional: a caller that never sets
+   * it yields a null correlation, which is honest — the alternative, deriving
+   * one at the receiver from session lineage, collapsed every request in a
+   * conversation into a single id.
+   */
+  setRootRequestId(id: string | null | undefined): void;
+  /** The bound request, so a spawn can snapshot it while the parent turn is live. */
+  getRootRequestId(): string | null;
+  /** The call whose tools are running — a spawn records it as its children's parent. */
+  getToolDispatchCallId(): string | null;
+  /** Bind this recorder's calls to the call that spawned this sub-agent. */
+  setParentCallId(id: string | null | undefined): void;
   /** A new prompt was accepted at `receivedAt` (ms epoch). Resets rounds. */
   beginPrompt(receivedAt?: number, opts?: { explicit?: boolean }): void;
   /** The prompt finished (every terminal path). */
@@ -131,10 +254,28 @@ export interface LlmCallPromptBoundary {
 export class LlmCallRecorder implements LlmCallPromptBoundary {
   private readonly now: () => number;
   private readonly warn: (message: string) => void;
+  private readonly onMeasurement?: (measurement: LlmCallMeasurement) => void;
+  private readonly newCallId: () => string;
+  /** Measurement tasks not yet handed to the sink; awaited by `settleMeasurements`. */
+  private readonly pendingMeasurements = new Set<Promise<void>>();
+  /** Calls that have opened but not yet sealed — they have no measurement YET. */
+  private readonly activeCalls = new Set<Promise<void>>();
 
   private promptOpen = false;
   private promptExplicit = false;
   private promptReceivedAt?: number;
+  /** One accepted prompt execution — spans its rounds, aux calls and route retries. */
+  private promptId = "";
+  /** The user request these prompts serve; a sub-agent inherits its parent's. */
+  private rootRequestId: string | null = null;
+  private warnedOversizedRootRequestId = false;
+  /**
+   * The agent call that most recently finished — i.e. the one whose tool calls
+   * are executing right now. A spawn snapshots it as its children's parent.
+   */
+  private lastAgentCallId: string | null = null;
+  /** Set on a sub-agent's recorder: the call that spawned it. Never derived. */
+  private parentCallId: string | null = null;
   private round = 0;
   private attempt = 1;
   private attemptStartRound = 0;
@@ -145,14 +286,70 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
   constructor(options: LlmCallRecorderOptions = {}) {
     this.now = options.now ?? (() => Date.now());
     this.warn = options.warn ?? ((message) => console.warn(message));
+    this.onMeasurement = options.onMeasurement;
+    this.newCallId = options.newCallId ?? (() => randomUUID());
   }
 
   // ── Prompt / attempt boundaries ────────────────────────────────────────
+
+  /**
+   * Bind this recorder's calls to a user request.
+   *
+   * Optional by design: an older caller that never sets it produces records with
+   * a null correlation, which is honest. Inventing one at the receiver from
+   * session lineage was the previous attempt, and it collapsed every request in
+   * a long conversation into a single id.
+   */
+  setRootRequestId(id: string | null | undefined): void {
+    if (!id) {
+      this.rootRequestId = null;
+      return;
+    }
+    if (id.length > MAX_CORRELATION_ID_LENGTH) {
+      // Storing a prefix would correlate calls from different requests. Drop the
+      // correlation, keep the measurements, and say so once — silence here would
+      // look identical to a box that never supported the field.
+      if (!this.warnedOversizedRootRequestId) {
+        this.warnedOversizedRootRequestId = true;
+        console.warn(
+          `[llm-call-recorder] root request id longer than ${MAX_CORRELATION_ID_LENGTH} characters; ` +
+          "recording these calls without a request correlation",
+        );
+      }
+      this.rootRequestId = null;
+      return;
+    }
+    this.rootRequestId = id;
+  }
+
+  getRootRequestId(): string | null {
+    return this.rootRequestId;
+  }
+
+  /**
+   * The call whose tools are executing — what a spawn records as its children's
+   * parent, read synchronously at dispatch.
+   *
+   * Not substitutable by a tool-call id (that names the tool invocation, not the
+   * LLM call that produced it) nor by session lineage (which cannot say WHICH of
+   * a turn's calls did the spawning). Null before the first round seals.
+   */
+  getToolDispatchCallId(): string | null {
+    return this.lastAgentCallId;
+  }
+
+  /** Bind this recorder's calls to the call that spawned this sub-agent. */
+  setParentCallId(id: string | null | undefined): void {
+    this.parentCallId = id && id.length <= MAX_CORRELATION_ID_LENGTH ? id : null;
+  }
 
   beginPrompt(receivedAt?: number, opts?: { explicit?: boolean }): void {
     // An explicit open (HTTP receipt) wins over the brain's implicit one, which
     // fires later from inside the routing runner and must not reset the rounds.
     if (this.promptOpen && this.promptExplicit && !opts?.explicit) return;
+    // A route retry stays inside the same prompt execution, so the id is minted
+    // here and not per attempt.
+    if (!this.promptOpen) this.promptId = this.newCallId();
     this.promptOpen = true;
     this.promptExplicit = opts?.explicit === true;
     this.promptReceivedAt = receivedAt ?? this.now();
@@ -223,7 +420,7 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
       const call = recorder.openCall(model, context);
       let maybeStream: any;
       try {
-        maybeStream = baseFn(model, context, options);
+        maybeStream = baseFn(model, context, recorder.instrumentOptions(options, call));
       } catch (error) {
         recorder.sealFailedCall(call, error);
         throw error;
@@ -268,12 +465,252 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
     return {
       kind: Array.isArray(context?.tools) ? "agent" : "aux",
       requestAt: this.now(),
+      callId: this.newCallId(),
+      promptId: this.promptId,
+      rootRequestId: this.rootRequestId,
+      parentCallId: this.parentCallId,
+      networkAttempts: 0,
+      apiType: typeof model?.api === "string" ? model.api : undefined,
+      ...this.trackActiveCall(),
+      attemptObservations: new Map(),
+      attemptWaits: new Map(),
+      requestSnapshot: snapshotRequest(context),
       blocks: [],
       openBlocks: new Map(),
       toolCallIds: [],
       modelProvider: typeof model?.provider === "string" ? model.provider : undefined,
       modelId: typeof model?.id === "string" ? model.id : undefined,
     };
+  }
+
+  /**
+   * Turn one sealed call into a metering measurement.
+   *
+   * The usage numbers come from the RAW observation, not from pi's normalised
+   * object: a field the provider never sent is left `null` here, where the
+   * normalised object would have shown a zero indistinguishable from a real one.
+   * With no observation at all (uninstrumented transport) the source is
+   * `unknown` and every figure is null — deliberately not zero.
+   */
+  private emitMeasurement(call: InFlightCall, envelope: LlmCallEnvelope, message: any): void {
+    const sink = this.onMeasurement;
+    if (!sink) return;
+    // Wait for the observation branch, but never hold the turn hostage to it:
+    // a stalled read yields `unknown`, which is honest, rather than blocking.
+    const task = (async () => {
+      // Wait for EVERY attempt that was started, not merely the first to answer.
+      // By seal time the SDK has stopped retrying, so the set is complete.
+      const waits = [...call.attemptWaits.values()];
+      if (waits.length > 0) {
+        await Promise.race([
+          Promise.all(waits),
+          new Promise<void>((resolve) => setTimeout(resolve, OBSERVATION_GRACE_MS).unref?.()),
+        ]);
+      }
+      this.finishMeasurement(sink, call, envelope, message);
+    })();
+    // Tracked so teardown can wait for it. A turn's last calls settle AFTER the
+    // stream ends, so a release that only drains the dispatcher's queue flushes
+    // an empty queue and loses exactly the measurements describing how the turn
+    // finished.
+    this.pendingMeasurements.add(task);
+    void task.finally(() => { this.pendingMeasurements.delete(task); });
+  }
+
+  /**
+   * Wait for in-flight measurements to be handed to the sink.
+   *
+   * Bounded: teardown must not hang on a stuck observation. What does not
+   * settle in time is simply not reported, which is the honest outcome.
+   */
+  async settleMeasurements(timeoutMs = MEASUREMENT_SETTLE_MS): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    const remaining = () => Math.max(0, deadline - Date.now());
+    // Calls still in flight come FIRST: a measurement only enters
+    // `pendingMeasurements` once its call has sealed, so waiting on that set
+    // alone returns instantly while a request is mid-flight — and the records it
+    // is about to produce then arrive after the dispatcher has already closed.
+    if (this.activeCalls.size > 0) {
+      await Promise.race([
+        Promise.allSettled([...this.activeCalls]),
+        new Promise<void>((resolve) => { setTimeout(resolve, remaining()).unref?.(); }),
+      ]);
+    }
+    if (this.pendingMeasurements.size === 0) return;
+    await Promise.race([
+      Promise.allSettled([...this.pendingMeasurements]),
+      new Promise<void>((resolve) => { setTimeout(resolve, remaining()).unref?.(); }),
+    ]);
+  }
+
+  /**
+   * The observation that describes this call's outcome: the HIGHEST-numbered
+   * attempt that reported back.
+   *
+   * Not "the best" — a final attempt that failed to parse is the truth about the
+   * call, and letting an earlier success stand in its place would report numbers
+   * from a response the SDK discarded.
+   */
+  /**
+   * Register a call as active and hand back the fields that track it.
+   *
+   * Resolved by `markCallSettled` on every exit path — success, failure, abort —
+   * so teardown can wait for a request that is still in flight instead of
+   * concluding there is nothing to wait for.
+   */
+  private trackActiveCall(): { settleActive: () => void } {
+    let settleActive = (): void => {};
+    const gate = new Promise<void>((resolve) => { settleActive = resolve; });
+    this.activeCalls.add(gate);
+    const done = (): void => { this.activeCalls.delete(gate); settleActive(); };
+    return { settleActive: done };
+  }
+
+  /**
+   * Mark a call no longer in flight. Idempotent.
+   *
+   * Must be reached on EVERY exit — sealed, failed, or abandoned. A call that is
+   * never sealed (an aborted stream) would otherwise sit in `activeCalls`
+   * forever, and every later teardown would burn its full settle budget waiting
+   * on a call that is never coming back.
+   */
+  /**
+   * Seal a call whose stream was abandoned before settling.
+   *
+   * The call really happened — the request went out, and its usage may already
+   * have been observed — so it earns a record like any other, marked `aborted`.
+   * Releasing `activeCalls` without sealing (as an earlier fix did) stops
+   * teardown from hanging but discards the call entirely.
+   *
+   * Idempotent: a stream that already sealed normally is left alone.
+   */
+  private sealAbandonedCall(call: InFlightCall): void {
+    if (call.sealedEnvelope) { this.markCallSettled(call); return; }
+    this.sealCall(call, { stopReason: "aborted" });
+  }
+
+  private markCallSettled(call: InFlightCall): void {
+    call.settleActive?.();
+    call.settleActive = undefined;
+  }
+
+  private finalObservation(call: InFlightCall): RawUsageObservation | undefined {
+    // Only the LAST attempt that was STARTED describes this call. Falling back
+    // to the highest attempt that happened to report would, when the final
+    // attempt's observation times out, quote an earlier response the SDK had
+    // already discarded — and do it while looking confident.
+    if (call.networkAttempts === 0) return undefined;
+    return call.attemptObservations.get(call.networkAttempts);
+  }
+
+  private finishMeasurement(
+    sink: (measurement: LlmCallMeasurement) => void,
+    call: InFlightCall,
+    envelope: LlmCallEnvelope,
+    message: any,
+  ): void {
+    // Prefer the final message, fall back to the protocol captured at open time:
+    // an abandoned call has no message but its protocol was never in doubt.
+    const apiType = (typeof message?.api === "string" && message.api) || call.apiType || "";
+    const observation = this.finalObservation(call);
+    const reported: UsageField[] = observation?.outcome === "reported" ? [...observation.reported_fields] : [];
+    // Three distinct situations, three distinct verdicts. Collapsing the first
+    // two into `sdk_default` would assert "the provider reported nothing" on the
+    // strength of our own failure to read.
+    const source: UsageSource =
+      // Not wired, or wired but the attempt never reported back — either way we
+      // did not observe it, so claiming provider silence is unfounded.
+      observation === undefined ? "unknown"
+      : observation.outcome === "failed" ? "unknown" // we could not read it
+      : observation.outcome === "no_usage" ? "sdk_default" // read it; genuinely none
+      : "provider";
+    const value = (field: UsageField): number | null => {
+      const v = observation?.values[field];
+      return typeof v === "number" ? v : null;
+    };
+
+    const usage = {
+      input_tokens_total: value("input"),
+      output_tokens_total: value("output"),
+      reasoning_tokens: value("reasoning"),
+      cache_read_tokens: value("cache_read"),
+      cache_write_tokens: value("cache_write"),
+    };
+
+    const measurement: LlmCallMeasurement = {
+      call_id: call.callId,
+      prompt_id: call.promptId,
+      root_request_id: call.rootRequestId,
+      parent_call_id: call.parentCallId,
+      // This recorder sits in the agent loop, so every call it measures is
+      // conversational by construction. A non-conversational producer (a
+      // compile box, say) builds its measurements elsewhere and names its own
+      // workload — which is exactly why the field is not derived downstream.
+      workload: "conversation",
+      kind: call.kind,
+      round: envelope.round,
+      attempt: envelope.attempt,
+      network_attempts: call.networkAttempts,
+      provider: envelope.model.provider ?? "",
+      model_id: envelope.model.id ?? "",
+      api_type: apiType,
+      usage_status: resolveUsageStatus(apiType, reported, source),
+      usage_source: source,
+      reported_fields: reported,
+      ...usage,
+      // Measured at the fetch boundary, which sits AFTER the SDK built the
+      // request — so these are the bytes and cache fields actually sent.
+      payload_bytes: observation?.request_bytes ?? null,
+      payload_tokens_estimated: observation?.request_bytes === undefined
+        ? null
+        : Math.ceil(observation.request_bytes / APPROX_BYTES_PER_TOKEN),
+      request_snapshot: {
+        ...call.requestSnapshot,
+        // Fingerprints of the request AS SENT override the context-derived ones:
+        // onPayload can rewrite the final instructions, so a context hash reads
+        // "unchanged" across exactly the change that would break the cache.
+        ...(observation?.request_fingerprint ?? {}),
+        // `cache_retention_sent: null` means "neither field was sent". It must
+        // only be claimed once a request was actually inspected; an unobserved
+        // call leaves the whole `request_cache` absent instead.
+        ...(observation?.request_cache ?? {}),
+      },
+      request_at: envelope.request_at,
+      response_end_at: envelope.response_end_at,
+      since_prev_ms: envelope.since_prev_ms ?? null,
+      cost_micros: null,
+      inconsistencies: validateUsageConsistency({ api_type: apiType, ...usage }),
+    };
+    try { sink(measurement); } catch (error) {
+      this.warn(`[llm-call-recorder] measurement sink failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Compose a per-call `options.fetch` that observes the provider's raw usage.
+   *
+   * Composed, not replaced: a caller that already supplied a fetch keeps it.
+   * Only the LAST observation is kept — a transport retry within one call
+   * reports on its own response, and the surviving attempt is the truth.
+   */
+  private instrumentOptions(options: any, call: InFlightCall): any {
+    if (!this.onMeasurement) return options;
+    call.instrumented = true;
+    const settle = new Map<number, () => void>();
+    const fetchImpl = instrumentFetchForUsage(
+      options?.fetch,
+      (observation, attempt) => {
+        call.attemptObservations.set(attempt, observation);
+        settle.get(attempt)?.();
+      },
+      (attempt) => {
+        // Registered when the attempt STARTS, so sealing waits for an attempt
+        // whose observation has not come back yet instead of concluding early.
+        call.networkAttempts = Math.max(call.networkAttempts, attempt);
+        call.attemptWaits.set(attempt, new Promise<void>((resolve) => settle.set(attempt, resolve)));
+      },
+    );
+    return { ...(options ?? {}), fetch: fetchImpl };
   }
 
   private wrapStream(stream: any, call: InFlightCall): any {
@@ -294,10 +731,22 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
               throw error;
             }
           },
-          return: async (value?: unknown) =>
-            iterator.return?.(value) ?? { done: true as const, value: undefined },
-          throw: async (error?: unknown) =>
-            iterator.throw?.(error) ?? { done: true as const, value: undefined },
+          // An abandoned stream (abort, break out of the loop) never seals, so
+          // release the call here too — otherwise it sits in `activeCalls` for
+          // the life of the recorder and makes every later teardown wait out its
+          // full settle budget for a call that will never arrive.
+          // An abandoned stream must be SEALED, not merely released. Clearing
+          // `activeCalls` alone stops teardown from hanging but throws the call
+          // away: a request that went out and whose usage we already observed
+          // would be recorded nowhere at all.
+          return: async (value?: unknown) => {
+            this.sealAbandonedCall(call);
+            return iterator.return?.(value) ?? { done: true as const, value: undefined };
+          },
+          throw: async (error?: unknown) => {
+            this.sealAbandonedCall(call);
+            return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+          },
         };
       };
     }
@@ -494,10 +943,18 @@ export class LlmCallRecorder implements LlmCallPromptBoundary {
       tool_call_ids: call.toolCallIds,
     };
     call.sealedEnvelope = envelope;
+    this.markCallSettled(call);
+    this.emitMeasurement(call, envelope, message);
 
     if (call.kind === "aux") {
       this.pendingAux.push(envelope);
     } else {
+      // The tools of this round are about to run, and this is the call that
+      // asked for them. Recorded on SEAL rather than on open: the next round's
+      // call must not already have overwritten it while a tool is dispatching.
+      // Aux calls are skipped because they issue no tools — letting a
+      // summarisation slip in here would name the wrong dispatcher.
+      this.lastAgentCallId = call.callId;
       this.round += 1;
       envelope.round = this.round;
       if (this.round === 1 && this.promptReceivedAt !== undefined) {

--- a/src/core/pi-execution.ts
+++ b/src/core/pi-execution.ts
@@ -11,12 +11,19 @@ import {
 } from "./model-envelope.js";
 import { createGuardRegistry, installGuardPipeline, type GuardRegistry } from "./guard-pipeline.js";
 import { LlmCallRecorder } from "./llm-call-recorder.js";
+import type { LlmCallMeasurement } from "../shared/llm-call-record.js";
 
 export interface PiExecutionOptions extends Omit<CreateAgentSessionFromServicesOptions, "noTools" | "tools" | "excludeTools"> {
   /** Harness-owned guards. Omission retains the standard message/tool guards. */
   guards?: GuardRegistry;
   /** Receives hashes and counts, never prompt or tool contents. */
   onModelEnvelope?: (manifest: ModelEnvelopeManifest) => void;
+  /**
+   * Per-call metering sink. Supplying it turns on raw-usage observation for
+   * this session; omitting it leaves the recorder in its pre-metering behaviour
+   * (no fetch instrumented, no measurement produced).
+   */
+  onLlmCallMeasurement?: (measurement: LlmCallMeasurement) => void;
 }
 
 /**
@@ -29,7 +36,7 @@ export interface PiExecutionOptions extends Omit<CreateAgentSessionFromServicesO
  * guards and per-request recorder below it.
  */
 export async function createPiExecutionSession(options: PiExecutionOptions) {
-  const { guards, onModelEnvelope, ...sessionOptions } = options;
+  const { guards, onModelEnvelope, onLlmCallMeasurement, ...sessionOptions } = options;
   const result = await createAgentSessionFromServices({
     ...sessionOptions,
     // Every harness supplies its own bounded tools. Never enable SDK built-ins
@@ -62,7 +69,7 @@ export async function createPiExecutionSession(options: PiExecutionOptions) {
 
   // Recorder stays closest to the provider: input/output guard work belongs to
   // setup/tool time rather than network latency. Preserve this wrapper order.
-  const llmCallRecorder = new LlmCallRecorder();
+  const llmCallRecorder = new LlmCallRecorder({ onMeasurement: onLlmCallMeasurement });
   session.agent.streamFunction = llmCallRecorder.wrapStreamFn(session.agent.streamFunction);
   installGuardPipeline(guards ?? createGuardRegistry(options.model?.contextWindow ?? 128_000), {
     agent: session.agent,

--- a/src/core/raw-usage-observer.test.ts
+++ b/src/core/raw-usage-observer.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractUsageFields,
+  findUsageInBody,
+  instrumentFetchForUsage,
+  readRequestCacheFacts,
+} from "./raw-usage-observer.js";
+
+const sse = (...events: unknown[]): string =>
+  events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("") + "data: [DONE]\n\n";
+
+const streamOf = (body: string): ReadableStream<Uint8Array> => {
+  const bytes = new TextEncoder().encode(body);
+  return new ReadableStream({
+    start(controller) {
+      const mid = Math.floor(bytes.length / 2);
+      controller.enqueue(bytes.slice(0, mid));
+      controller.enqueue(bytes.slice(mid));
+      controller.close();
+    },
+  });
+};
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("extractUsageFields", () => {
+  it("records only keys the server actually sent", () => {
+    const observation = extractUsageFields({ input_tokens: 17 });
+    expect(observation.outcome).toBe("reported");
+    expect(observation.reported_fields).toEqual(["input"]);
+    expect(observation.values).toEqual({ input: 17 });
+    // The decisive property: unreported fields are ABSENT, not zero.
+    expect(observation.values.output).toBeUndefined();
+    expect(observation.values.reasoning).toBeUndefined();
+  });
+
+  it("keeps an explicitly reported zero", () => {
+    const observation = extractUsageFields({
+      input_tokens: 500,
+      output_tokens: 20,
+      input_tokens_details: { cached_tokens: 0 },
+    });
+    expect(observation.reported_fields.sort()).toEqual(["cache_read", "input", "output"]);
+    expect(observation.values.cache_read).toBe(0);
+  });
+
+  it("reads the nested Responses shape", () => {
+    const observation = extractUsageFields({
+      input_tokens: 1_000,
+      output_tokens: 300,
+      input_tokens_details: { cached_tokens: 800 },
+      output_tokens_details: { reasoning_tokens: 120 },
+    });
+    expect(observation.values).toEqual({ input: 1_000, output: 300, cache_read: 800, reasoning: 120 });
+  });
+
+  it("reads the flat Anthropic shape", () => {
+    const observation = extractUsageFields({
+      input_tokens: 50,
+      output_tokens: 10,
+      cache_read_input_tokens: 900,
+      cache_creation_input_tokens: 40,
+    });
+    expect(observation.values.cache_read).toBe(900);
+    expect(observation.values.cache_write).toBe(40);
+  });
+
+  it("reports no_usage — not failure — for a payload carrying none", () => {
+    expect(extractUsageFields({}).outcome).toBe("no_usage");
+    expect(extractUsageFields(undefined).outcome).toBe("no_usage");
+    expect(extractUsageFields({ input_tokens: "17" }).outcome).toBe("no_usage");
+  });
+});
+
+describe("findUsageInBody", () => {
+  it("reads usage from a plain JSON response", () => {
+    expect(findUsageInBody(JSON.stringify({ usage: { input_tokens: 5, output_tokens: 6 } })).values)
+      .toEqual({ input: 5, output: 6 });
+  });
+
+  it("reads usage from the terminal SSE event", () => {
+    const body = sse(
+      { type: "response.created", response: {} },
+      { type: "response.completed", response: { usage: { input_tokens: 9, output_tokens: 3 } } },
+    );
+    expect(findUsageInBody(body).values).toEqual({ input: 9, output: 3 });
+  });
+
+  it("MERGES Anthropic's split usage instead of letting the last event win", () => {
+    // message_start carries input + both cache figures; message_delta carries
+    // only the running output. Replacing wholesale threw input and cache away.
+    const body = sse(
+      { type: "message_start", message: { usage: { input_tokens: 100, cache_read_input_tokens: 1_000, cache_creation_input_tokens: 200 } } },
+      { type: "content_block_delta", delta: { text: "hi" } },
+      { type: "message_delta", usage: { output_tokens: 20 } },
+    );
+    const observation = findUsageInBody(body);
+    expect(observation.outcome).toBe("reported");
+    expect(observation.values).toEqual({ input: 100, cache_read: 1_000, cache_write: 200, output: 20 });
+  });
+
+  it("lets a later cumulative value win for the same field", () => {
+    const body = sse(
+      { type: "message_delta", usage: { output_tokens: 5 } },
+      { type: "message_delta", usage: { output_tokens: 42 } },
+    );
+    expect(findUsageInBody(body).values.output).toBe(42);
+  });
+
+  it("distinguishes a readable stream with no usage from an unreadable body", () => {
+    // Read it, found none → a positive finding.
+    expect(findUsageInBody(sse({ type: "response.output_text.delta", delta: "hi" })).outcome).toBe("no_usage");
+    // Could not parse anything → we do not know.
+    expect(findUsageInBody("<html>502 Bad Gateway</html>").outcome).toBe("failed");
+    expect(findUsageInBody("{not json").outcome).toBe("failed");
+  });
+
+  it("parses a legitimately multi-line data frame", () => {
+    // SSE joins several `data:` lines within ONE frame into a single document.
+    // Splitting per line turned this valid event into unparseable fragments.
+    const body = 'data: {"type":"response.completed",\ndata: "response":{"usage":{"input_tokens":8}}}\n\n';
+    const observation = findUsageInBody(body);
+    expect(observation.outcome).toBe("reported");
+    expect(observation.values.input).toBe(8);
+  });
+
+  it("does not call a partially unreadable stream `no_usage`", () => {
+    // A valid opening event followed by a broken one: part of the stream is
+    // unaccounted for, so we cannot assert the provider reported nothing.
+    const body = 'data: {"type":"response.created","response":{}}\n\ndata: {"type":"response.compl\n\n';
+    expect(findUsageInBody(body).outcome).toBe("failed");
+  });
+
+  it("keeps usage seen before a broken frame, but does NOT call the read complete", () => {
+    // Protocols that send running totals (Anthropic) make an early snapshot
+    // indistinguishable from the final figure, so a broken later frame means we
+    // may be holding a partial count. Keep it as evidence; refuse to bank it.
+    const body =
+      'data: {"type":"response.completed","response":{"usage":{"input_tokens":4}}}\n\ndata: {"brok\n\n';
+    const observation = findUsageInBody(body);
+    expect(observation.outcome).toBe("failed");
+    expect(observation.values.input).toBe(4);   // preserved as evidence
+  });
+
+  it("does not call a stream complete when its final cumulative frame broke", () => {
+    // Anthropic's shape: opening totals arrive, the closing usage frame is cut.
+    const body =
+      'data: {"type":"message_start","message":{"usage":{"input_tokens":100,"output_tokens":1}}}\n\n' +
+      'data: {"type":"message_delta","usage":{"output_toke\n\n';
+    const observation = findUsageInBody(body);
+    expect(observation.outcome).toBe("failed");
+    expect(observation.values.input).toBe(100);
+  });
+
+  it("ignores comment and event-only frames without calling them failures", () => {
+    const body = ': keep-alive\n\nevent: ping\n\ndata: {"usage":{"input_tokens":2}}\n\ndata: [DONE]\n\n';
+    expect(findUsageInBody(body)).toMatchObject({ outcome: "reported", values: { input: 2 } });
+  });
+
+  it("does not call a stream complete when it ends without a terminal marker", () => {
+    // pi reports this as a missing message_stop. The opening usage object looks
+    // complete on its own, which is exactly why the marker has to be checked.
+    const body =
+      'data: {"type":"message_start","message":{"usage":{"input_tokens":100,"output_tokens":0}}}\n\n' +
+      'data: {"type":"content_block_delta","delta":{"text":"hi"}}\n\n';
+    const observation = findUsageInBody(body);
+    expect(observation.outcome).toBe("failed");
+    expect(observation.values.input).toBe(100);   // kept as evidence
+  });
+
+  it("accepts a stream closed by its protocol's terminal event", () => {
+    const body =
+      'data: {"type":"message_start","message":{"usage":{"input_tokens":100}}}\n\n' +
+      'data: {"type":"message_delta","usage":{"output_tokens":20}}\n\n' +
+      'data: {"type":"message_stop"}\n\n';
+    expect(findUsageInBody(body)).toMatchObject({ outcome: "reported", values: { input: 100, output: 20 } });
+  });
+
+  it("survives a truncated trailing event", () => {
+    const body = `data: {"type":"response.completed","response":{"usage":{"input_tokens":7}}}\n\ndata: {"trunca`;
+    expect(findUsageInBody(body).values).toEqual({ input: 7 });
+  });
+});
+
+describe("readRequestCacheFacts", () => {
+  it("reads the key and each retention shape as actually sent", () => {
+    expect(readRequestCacheFacts(JSON.stringify({ prompt_cache_key: "k", prompt_cache_retention: "24h" })))
+      .toEqual({ prompt_cache_key: "k", cache_retention_sent: "24h" });
+    expect(readRequestCacheFacts(JSON.stringify({ prompt_cache_options: { ttl: "30m" } })))
+      .toEqual({ prompt_cache_key: null, cache_retention_sent: "ttl_30m" });
+    // pi's default `short` sends neither field — null, having looked.
+    expect(readRequestCacheFacts(JSON.stringify({ model: "gpt-5" })))
+      .toEqual({ prompt_cache_key: null, cache_retention_sent: null });
+  });
+
+  it("returns undefined when there was no body to inspect", () => {
+    expect(readRequestCacheFacts(undefined)).toBeUndefined();
+    expect(readRequestCacheFacts("{not json")).toBeUndefined();
+  });
+});
+
+describe("instrumentFetchForUsage", () => {
+  it("passes the body through byte-exact while observing usage", async () => {
+    const body = sse({ type: "response.completed", response: { usage: { input_tokens: 11, output_tokens: 2 } } });
+    let seen: any;
+    const wrapped = instrumentFetchForUsage(
+      async () => new Response(streamOf(body), { status: 200, headers: { "content-type": "text/event-stream" } }),
+      (o) => { seen = o; },
+    );
+
+    const response = await wrapped("https://example.invalid/v1/responses");
+    expect(await response.text()).toBe(body);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    await settle();
+    expect(seen).toMatchObject({ outcome: "reported", values: { input: 11, output: 2 } });
+  });
+
+  it("does not corrupt multi-byte characters split across chunks", async () => {
+    const body = `data: {"type":"response.completed","response":{"usage":{"input_tokens":3},"text":"排障中文——测试"}}\n\n`;
+    const wrapped = instrumentFetchForUsage(async () => new Response(streamOf(body), { status: 200 }), () => {});
+    expect(await (await wrapped("https://example.invalid")).text()).toBe(body);
+  });
+
+  it("composes on top of a caller-supplied fetch instead of replacing it", async () => {
+    let calledBase = false;
+    const wrapped = instrumentFetchForUsage(
+      async () => { calledBase = true; return new Response(JSON.stringify({ usage: { input_tokens: 1 } })); },
+      () => {},
+    );
+    await wrapped("https://example.invalid");
+    expect(calledBase).toBe(true);
+  });
+
+  it("reports no_usage for a readable stream that carries none", async () => {
+    let seen: any;
+    const wrapped = instrumentFetchForUsage(
+      async () => new Response(streamOf(sse({ type: "response.output_text.delta", delta: "x" })), { status: 200 }),
+      (o) => { seen = o; },
+    );
+    await (await wrapped("https://example.invalid")).text();
+    await settle();
+    expect(seen.outcome).toBe("no_usage");
+  });
+
+  it("never lets an observer error escape into the call", async () => {
+    const wrapped = instrumentFetchForUsage(
+      async () => new Response(JSON.stringify({ usage: { input_tokens: 1 } })),
+      () => { throw new Error("sink exploded"); },
+    );
+    const response = await wrapped("https://example.invalid");
+    await expect(response.text()).resolves.toContain("input_tokens");
+  });
+
+  it("observes EVERY attempt made through the SAME wrapper", async () => {
+    // The real retry path: pi retries inside one logical call, reusing the fetch
+    // it was given. A wrapper-level latch silently dropped attempt 2 onwards.
+    const observations: any[] = [];
+    const attempts: number[] = [];
+    let n = 0;
+    const wrapped = instrumentFetchForUsage(
+      async () => {
+        n += 1;
+        return n === 1
+          ? new Response("upstream unavailable", { status: 503 })
+          : new Response(JSON.stringify({ usage: { input_tokens: 77 } }), { status: 200 });
+      },
+      (o) => { observations.push(o); },
+      () => { attempts.push(1); },
+    );
+
+    await (await wrapped("https://example.invalid")).text();   // 503
+    await (await wrapped("https://example.invalid")).text();   // 200
+    await settle();
+
+    expect(attempts).toHaveLength(2);
+    expect(observations).toHaveLength(2);
+    // The successful retry's numbers must survive, not be masked by the 503.
+    expect(observations[1]).toMatchObject({ outcome: "reported", values: { input: 77 } });
+  });
+
+  it("counts an attempt even when the transport throws", async () => {
+    const attempts: number[] = [];
+    const observations: any[] = [];
+    const wrapped = instrumentFetchForUsage(
+      async () => { throw new Error("ECONNRESET"); },
+      (o) => { observations.push(o); },
+      () => { attempts.push(1); },
+    );
+    await expect(wrapped("https://example.invalid")).rejects.toThrow("ECONNRESET");
+    expect(attempts).toHaveLength(1);
+    expect(observations[0].outcome).toBe("failed");
+  });
+
+  it("carries request bytes and cache facts from the outgoing body", async () => {
+    let seen: any;
+    const body = JSON.stringify({ model: "gpt-5", prompt_cache_key: "sess-1", prompt_cache_retention: "24h" });
+    const wrapped = instrumentFetchForUsage(
+      async () => new Response(JSON.stringify({ usage: { input_tokens: 1 } })),
+      (o) => { seen = o; },
+    );
+    await (await wrapped("https://example.invalid", { method: "POST", body })).text();
+    await settle();
+
+    expect(seen.request_bytes).toBe(Buffer.byteLength(body, "utf8"));
+    expect(seen.request_cache).toEqual({ prompt_cache_key: "sess-1", cache_retention_sent: "24h" });
+  });
+});

--- a/src/core/raw-usage-observer.ts
+++ b/src/core/raw-usage-observer.ts
@@ -1,0 +1,403 @@
+/**
+ * Observes the provider's RAW usage report at the HTTP boundary.
+ *
+ * Why this exists: pi normalises usage into an object whose input/output/
+ * cacheRead/cacheWrite are REQUIRED and zero-filled before the request goes
+ * out. By the time a response reaches the streamFn boundary, "the provider
+ * reported 0" and "the provider reported nothing" are byte-identical, and the
+ * optional `reasoning` field is not a usable discriminator either (a fixture
+ * reporting only `input_tokens` came back with reasoning set to 0).
+ *
+ * The only place the truth still exists is the wire. pi accepts a per-call
+ * `options.fetch` (`FetchFunction`, a public input), so this module composes
+ * one: it tees the response body, hands the SDK the original bytes untouched,
+ * and parses its own copy.
+ *
+ * Three contracts this file must never break:
+ *
+ *   1. PASSTHROUGH IS EXACT. The SDK receives the original byte stream. We never
+ *      re-encode or re-chunk it — decoding happens only on our own branch of the
+ *      tee, with a streaming decoder.
+ *   2. OBSERVATION NEVER FAILS THE CALL. Any error yields an observation marked
+ *      `failed` and the request proceeds.
+ *   3. FAILURE IS NOT SILENCE. "We could not read the response" and "the server
+ *      reported no usage" are different facts and must not collapse into one:
+ *      only the latter licenses `missing`, the former is `unknown`.
+ */
+
+import { createHash } from "node:crypto";
+import type { UsageField } from "../shared/llm-call-record.js";
+
+/**
+ * What happened when we tried to read one response.
+ *
+ * `no_usage` is a POSITIVE finding — we read the body and it genuinely carried
+ * no usage. `failed` means we do not know, and the caller must not conclude the
+ * provider stayed silent.
+ */
+export type ObservationOutcome = "reported" | "no_usage" | "failed";
+
+/** What the server actually put on the wire for one HTTP attempt. */
+export interface RawUsageObservation {
+  outcome: ObservationOutcome;
+  /** Usage keys genuinely present — the basis for `reported_fields`. */
+  reported_fields: UsageField[];
+  /** Values as sent. A key absent here was not reported; it is NOT zero. */
+  values: Partial<Record<UsageField, number>>;
+  /** Bytes of the request body, when it could be measured. */
+  request_bytes?: number;
+  /** Cache-control fields as actually sent — evidence, not assumption. */
+  request_cache?: RequestCacheFacts;
+  /** Fingerprints of the request as it actually went out (hashes only). */
+  request_fingerprint?: ReturnType<typeof fingerprintRequestBody>;
+}
+
+/** Cache-related fields read off the OUTGOING request body. */
+export interface RequestCacheFacts {
+  /** `prompt_cache_key` as sent, or null when the field was absent. */
+  prompt_cache_key: string | null;
+  /** Which retention shape went out; null means neither field was present. */
+  cache_retention_sent: "none" | "24h" | "ttl_30m" | null;
+}
+
+export const OBSERVATION_FAILED: RawUsageObservation = Object.freeze({
+  outcome: "failed",
+  reported_fields: [],
+  values: {},
+});
+
+export const OBSERVATION_NO_USAGE: RawUsageObservation = Object.freeze({
+  outcome: "no_usage",
+  reported_fields: [],
+  values: {},
+});
+
+type FetchLike = (input: any, init?: any) => Promise<Response>;
+
+/**
+ * Merge usage fields from one event into an accumulator.
+ *
+ * Merging per FIELD rather than replacing wholesale is required by Anthropic's
+ * event protocol: `message_start` carries input and both cache figures while
+ * `message_delta` carries only the running output total. Taking "the last usage
+ * object" therefore threw input and cache away entirely.
+ *
+ * Later values win per field, since a cumulative counter's final reading is the
+ * one that counts.
+ */
+function mergeUsageInto(
+  target: Partial<Record<UsageField, number>>,
+  usage: unknown,
+): boolean {
+  if (!usage || typeof usage !== "object") return false;
+  const u = usage as Record<string, any>;
+  let found = false;
+
+  const take = (field: UsageField, ...candidates: unknown[]): void => {
+    for (const candidate of candidates) {
+      if (typeof candidate === "number" && Number.isFinite(candidate)) {
+        target[field] = candidate;
+        found = true;
+        return;
+      }
+    }
+  };
+
+  take("input", u.input_tokens, u.prompt_tokens);
+  take("output", u.output_tokens, u.completion_tokens);
+  take("reasoning", u.output_tokens_details?.reasoning_tokens, u.completion_tokens_details?.reasoning_tokens);
+  take("cache_read",
+    u.input_tokens_details?.cached_tokens,
+    u.prompt_tokens_details?.cached_tokens,
+    u.cache_read_input_tokens);
+  take("cache_write", u.cache_creation_input_tokens, u.input_tokens_details?.cache_write_tokens);
+  return found;
+}
+
+/** Read usage out of a single payload. Exposed for tests and direct callers. */
+export function extractUsageFields(usage: unknown): RawUsageObservation {
+  const values: Partial<Record<UsageField, number>> = {};
+  const found = mergeUsageInto(values, usage);
+  if (!found) return OBSERVATION_NO_USAGE;
+  return { outcome: "reported", reported_fields: Object.keys(values) as UsageField[], values };
+}
+
+/**
+ * Pull usage out of one decoded body.
+ *
+ * Handles a plain JSON response and an SSE stream without needing to know which
+ * was used. Across SSE events the fields are ACCUMULATED (see `mergeUsageInto`),
+ * not overwritten.
+ *
+ * A body we cannot make sense of at all returns `failed`, never `no_usage` —
+ * asserting the server said nothing requires having actually read it.
+ */
+export function findUsageInBody(body: string): RawUsageObservation {
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, any>;
+      return extractUsageFields(parsed.usage ?? parsed.response?.usage);
+    } catch {
+      return OBSERVATION_FAILED;
+    }
+  }
+
+  const values: Partial<Record<UsageField, number>> = {};
+  let sawUsage = false;
+  let parsedFrames = 0;
+  let badFrames = 0;
+  let sawTerminal = false;
+
+  for (const frame of splitSseFrames(body)) {
+    const payload = frameData(frame);
+    if (payload === null) continue;
+    if (payload === "[DONE]") { sawTerminal = true; continue; }
+    let event: Record<string, any>;
+    try {
+      event = JSON.parse(payload) as Record<string, any>;
+    } catch {
+      // A frame we could not parse is EVIDENCE OF A GAP, not something to skip.
+      // Ignoring it let a stream that broke mid-way read as "server said nothing".
+      badFrames += 1;
+      continue;
+    }
+    parsedFrames += 1;
+    // Anthropic nests opening totals under message_start.message.usage; OpenAI
+    // Responses puts them on response.usage. Merge from every known shape.
+    const merged =
+      mergeUsageInto(values, event.response?.usage) ||
+      mergeUsageInto(values, event.message?.usage) ||
+      mergeUsageInto(values, event.usage);
+    if (merged) sawUsage = true;
+    // The protocol's own end-of-stream marker. Without one the transport cut out
+    // mid-stream, and whatever totals we hold are an intermediate snapshot —
+    // which on Anthropic looks complete on its own, because message_start alone
+    // carries a full-looking usage object.
+    const type = typeof event.type === "string" ? event.type : "";
+    if (type === "message_stop" || type === "response.completed" || type === "response.incomplete") {
+      sawTerminal = true;
+    }
+  }
+
+  if (sawUsage) {
+    // Having SOME usage does not license `reported` when part of the stream was
+    // unreadable: Anthropic sends running totals, so a broken final frame means
+    // the figures we hold are an early snapshot, not the call's totals. Keep the
+    // values as evidence, but mark the read as failed so nothing banks them.
+    // Two ways a read can be incomplete, neither of which licenses `reported`:
+    //   - a frame we could not parse (a gap we can point at), or
+    //   - no terminal marker at all (the stream simply stopped; pi surfaces this
+    //     as a missing message_stop).
+    if (badFrames > 0 || !sawTerminal) {
+      return { outcome: "failed", reported_fields: Object.keys(values) as UsageField[], values };
+    }
+    return { outcome: "reported", reported_fields: Object.keys(values) as UsageField[], values };
+  }
+  // No usage found. Whether that is a finding or an admission depends on whether
+  // the body was fully readable: a malformed frame means part of the stream is
+  // unaccounted for, so we cannot claim the provider stayed silent.
+  // A stream that simply stopped tells us nothing about what the provider would
+  // have reported — `no_usage` is a claim only a COMPLETE read can support.
+  if (badFrames > 0 || parsedFrames === 0 || !sawTerminal) return OBSERVATION_FAILED;
+  return OBSERVATION_NO_USAGE;
+}
+
+/**
+ * Split an SSE body into frames.
+ *
+ * Frames are separated by a blank line, NOT by newline — a single frame may
+ * carry several `data:` lines that belong to one JSON document. Splitting per
+ * line broke those legitimately multi-line events into fragments, each of which
+ * then failed to parse.
+ */
+function splitSseFrames(body: string): string[] {
+  return body.split(/\r?\n\r?\n/).filter((frame) => frame.trim().length > 0);
+}
+
+/**
+ * The data payload of one frame: every `data:` line joined with newlines, per
+ * the SSE spec. Returns null for a frame carrying no data lines (comments,
+ * `event:`-only frames), which is an absence rather than a parse failure.
+ */
+function frameData(frame: string): string | null {
+  const parts: string[] = [];
+  for (const line of frame.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    parts.push(line.slice(5).replace(/^ /, ""));
+  }
+  if (parts.length === 0) return null;
+  const joined = parts.join("\n").trim();
+  return joined.length === 0 ? null : joined;
+}
+
+/**
+ * Fingerprint the request body as it ACTUALLY went out.
+ *
+ * The SDK's input context is not the final request: `onPayload` can rewrite the
+ * instructions after it, so two calls with identical context can put different
+ * bytes on the wire. A cache-stability analysis reading the context-derived hash
+ * would see "unchanged" across exactly the change that broke the cache.
+ *
+ * Hashes only — no request content is retained anywhere.
+ */
+export function fingerprintRequestBody(body: unknown): {
+  /** null = inspected the request and it carried no system prompt. */
+  system_sha256?: string | null;
+  tools_sha256?: string;
+  payload_sha256?: string;
+  model_settings?: Record<string, unknown>;
+} | undefined {
+  if (typeof body !== "string") return undefined;
+  const digest = (value: unknown): string =>
+    createHash("sha256").update(typeof value === "string" ? value : JSON.stringify(value ?? null)).digest("hex");
+  try {
+    const parsed = JSON.parse(body) as Record<string, any>;
+    // Each protocol puts the system prompt somewhere different:
+    //   Responses  → `instructions`
+    //   Anthropic  → `system`
+    //   Chat Compl → the leading system/developer MESSAGES
+    // Reading only the first two hashed an empty string for Chat Completions, so
+    // a changed prompt produced an unchanged fingerprint — silent on exactly the
+    // change a cache-stability check exists to catch.
+    let system: unknown = parsed.instructions ?? parsed.system;
+    if (system === undefined && Array.isArray(parsed.messages)) {
+      const leading = parsed.messages
+        .filter((m: any) => m?.role === "system" || m?.role === "developer")
+        .map((m: any) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)));
+      system = leading.length > 0 ? leading.join("\n") : undefined;
+    }
+    const settings: Record<string, unknown> = {};
+    for (const key of [
+      "model", "temperature", "store", "parallel_tool_calls",
+      // Output ceilings differ per protocol, and a request carries exactly one.
+      "max_output_tokens", "max_tokens", "max_completion_tokens",
+      // Reasoning controls: Responses uses `reasoning`, Anthropic `thinking`
+      // plus `output_config` — all three change request shape and cost.
+      "reasoning", "thinking", "output_config",
+    ]) {
+      if (parsed[key] !== undefined) settings[key] = parsed[key];
+    }
+    return {
+      // Explicit null, NOT an omitted key: this fingerprint is merged over the
+      // context-derived snapshot, so omitting it left the OLD hash in place and
+      // a request whose instructions were REMOVED looked unchanged.
+      system_sha256: system === undefined ? null : digest(system),
+      tools_sha256: digest(parsed.tools ?? []),
+      payload_sha256: digest(body),
+      model_settings: settings,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the cache-control facts off an outgoing request body. */
+export function readRequestCacheFacts(body: unknown): RequestCacheFacts | undefined {
+  if (typeof body !== "string") return undefined;
+  try {
+    const parsed = JSON.parse(body) as Record<string, any>;
+    const key = typeof parsed.prompt_cache_key === "string" ? parsed.prompt_cache_key : null;
+    let retention: RequestCacheFacts["cache_retention_sent"] = null;
+    if (parsed.prompt_cache_retention === "24h") retention = "24h";
+    else if (typeof parsed.prompt_cache_retention === "string") retention = "none";
+    else if (parsed.prompt_cache_options?.ttl === "30m") retention = "ttl_30m";
+    return { prompt_cache_key: key, cache_retention_sent: retention };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Byte length of a request body when it is measurable without consuming a stream. */
+function requestBodyBytes(init: any): number | undefined {
+  const body = init?.body;
+  if (typeof body === "string") return Buffer.byteLength(body, "utf8");
+  if (body instanceof Uint8Array) return body.byteLength;
+  return undefined;
+}
+
+/**
+ * Wrap a fetch so EVERY attempt it makes is observed.
+ *
+ * `base` is honoured rather than replaced. The sink fires once per HTTP
+ * attempt — a transport retry inside one logical call reports its own response,
+ * which is what lets the caller both count attempts and keep the surviving
+ * attempt's numbers.
+ */
+export function instrumentFetchForUsage(
+  base: FetchLike | undefined,
+  onObservation: (observation: RawUsageObservation, attempt: number) => void,
+  onAttempt?: (attempt: number) => void,
+): FetchLike {
+  const underlying: FetchLike = base ?? ((input: any, init?: any) => globalThis.fetch(input, init));
+  let attemptCounter = 0;
+
+  return async (input: any, init?: any): Promise<Response> => {
+    // Numbered so the caller can tell WHICH attempt each observation belongs to.
+    // Without it a late-arriving early attempt could overwrite the final one's
+    // result, which is exactly backwards: the last attempt is the outcome.
+    const attempt = ++attemptCounter;
+    onAttempt?.(attempt);
+    // Per-attempt latch: each HTTP attempt reports exactly once, but a second
+    // attempt through the SAME wrapper is not suppressed by the first.
+    let reported = false;
+    const requestFacts = readRequestCacheFacts(init?.body);
+    const requestFingerprint = fingerprintRequestBody(init?.body);
+    const requestBytes = requestBodyBytes(init);
+    const report = (observation: RawUsageObservation): void => {
+      if (reported) return;
+      reported = true;
+      const enriched: RawUsageObservation = {
+        ...observation,
+        ...(requestBytes === undefined ? {} : { request_bytes: requestBytes }),
+        ...(requestFacts === undefined ? {} : { request_cache: requestFacts }),
+        ...(requestFingerprint === undefined ? {} : { request_fingerprint: requestFingerprint }),
+      };
+      try { onObservation(enriched, attempt); } catch { /* metering must never break the call */ }
+    };
+
+    let response: Response;
+    try {
+      response = await underlying(input, init);
+    } catch (error) {
+      report(OBSERVATION_FAILED);
+      throw error;
+    }
+
+    if (!response.body) {
+      try {
+        report(findUsageInBody(await response.clone().text()));
+      } catch {
+        report(OBSERVATION_FAILED);
+      }
+      return response;
+    }
+
+    const [forSdk, forUs] = response.body.tee();
+    void (async () => {
+      const decoder = new TextDecoder("utf-8");
+      const reader = forUs.getReader();
+      let buffered = "";
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffered += decoder.decode(value, { stream: true });
+        }
+        buffered += decoder.decode();
+        report(findUsageInBody(buffered));
+      } catch {
+        // A read error is NOT evidence that the server reported nothing.
+        report(OBSERVATION_FAILED);
+      } finally {
+        try { reader.releaseLock(); } catch { /* already released */ }
+      }
+    })();
+
+    return new Response(forSdk, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}

--- a/src/gateway/channels/dingtalk.ts
+++ b/src/gateway/channels/dingtalk.ts
@@ -358,6 +358,10 @@ export async function handleDingTalkMessage(
       agentId,
       mode: "channel",
       sessionId,
+      // One id per turn, minted at the entry rather than in the client (which
+      // runs per attempt). Without it every call this turn makes — sub-agents
+      // included — is metered with no request correlation.
+      turnId: crypto.randomUUID(),
       modelProvider: modelBinding?.modelProvider,
       modelId: modelBinding?.modelId,
       releaseId: modelBinding?.releaseId,

--- a/src/gateway/channels/lark.test.ts
+++ b/src/gateway/channels/lark.test.ts
@@ -3706,6 +3706,31 @@ describe("handleLarkMessage — streaming card flow", () => {
     const last = lark.cardkit.v1.cardElement.content.mock.calls.at(-1)?.[0].data.content ?? "";
     expect(last).toContain("\u7ED3\u8BBA\u597D\u4E86");
     expect(last).not.toContain("409");
+
+    // One inbound message is ONE turn, even when it was queued behind a busy
+    // session first. A fresh id per attempt would split one request's metering
+    // across two correlations \u2014 which is why the id is minted at the entry and
+    // not inside the client.
+    const turnIds = promptMock.mock.calls.map((c: any[]) => c[0]?.turnId);
+    expect(turnIds[0]).toBeTruthy();
+    expect(turnIds[1]).toBe(turnIds[0]);
+  });
+
+  it("gives each inbound message its own turn id, so two requests do not merge", async () => {
+    resolveBindingMock.mockResolvedValue(makeBinding());
+    promptMock.mockResolvedValue({ sessionId: "s-1" });
+    streamEventsMock.mockImplementation(async function* () {
+      yield { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } };
+    });
+    const lark = makeCardAwareLarkClient();
+
+    await handleLarkMessage(makeTextEvent("\u4E00"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+    await handleLarkMessage(makeTextEvent("\u4E8C"), lark, "lark", makeAgentBoxManager("a1") as any, undefined, {} as any);
+
+    const turnIds = promptMock.mock.calls.map((c: any[]) => c[0]?.turnId);
+    expect(turnIds).toHaveLength(2);
+    expect(turnIds[0]).toBeTruthy();
+    expect(turnIds[1]).not.toBe(turnIds[0]);
   });
 
   it("shows a friendly busy notice when 409 persists past the retry window", async () => {

--- a/src/gateway/channels/lark.ts
+++ b/src/gateway/channels/lark.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { ConversationClient, supportsConversations } from "../conversation-client.js";
 /**
  * Lark (飞书) channel handler.
@@ -2053,6 +2055,12 @@ async function processQueuedLarkMessage(ctx: QueuedLarkMessageContext): Promise<
       agentId,
       mode: "channel",
       sessionId,
+      // Minted HERE, not inside the client: a turn id names one turn, while the
+      // client is called once per ATTEMPT — `promptWithBusyRetry` reuses this
+      // same object, so a queued-then-accepted message stays one turn. Without
+      // it a channel turn reaches the box with no id at all, and metering
+      // records every channel call — sub-agents included — uncorrelated.
+      turnId: randomUUID(),
       modelProvider: modelBinding?.modelProvider,
       modelId: modelBinding?.modelId,
       releaseId: modelBinding?.releaseId,

--- a/src/gateway/internal-api.ts
+++ b/src/gateway/internal-api.ts
@@ -142,6 +142,39 @@ async function sessionBelongsToIdentity(sessionId: string | null | undefined, id
  * Every `true` this returns is therefore either "no such session" or a comparison
  * against a row-sourced record. There is no third source.
  */
+/**
+ * May this certificate file records against this session?
+ *
+ * Accepts the session's OWNER or, for a delegated leg, its TARGET — the box that
+ * actually ran the turn is a legitimate reporter of what that turn cost. An
+ * unknown or non-authoritative session stays permissive for the same reason the
+ * owner check does: refusing on missing information would break legitimate
+ * traffic during a cache miss.
+ */
+export async function sessionReportableByIdentity(
+  sessionId: string | null | undefined,
+  identity: CertificateIdentity,
+): Promise<boolean> {
+  if (!sessionId) return false;
+  // FAIL CLOSED. This gate decides whether one agent may file spend against
+  // another's session, so "we could not establish ownership" must not read as
+  // "go ahead" — a non-authoritative cache entry or a failed lookup was enough
+  // to let a worker's certificate write to an owner's session.
+  let record = await sessionRegistry.get(sessionId).catch(() => undefined);
+  if (!record?.authoritative) {
+    try {
+      record = await sessionRegistry.refresh(sessionId);
+    } catch (err) {
+      console.warn(`[internal-api] could not establish ownership of ${sessionId}: ${String(err)}`);
+      return false;
+    }
+  }
+  if (!record?.authoritative) return false;
+  if (record.agentId === identity.agentId) return true;
+  // The delegated executor legitimately reports what its own turn cost.
+  return Boolean(record.targetAgentId && record.targetAgentId === identity.agentId);
+}
+
 async function sessionOwnedByIdentity(sessionId: string | null | undefined, identity: CertificateIdentity): Promise<boolean> {
   if (!sessionId) return true;
   const cached = await sessionRegistry.get(sessionId);

--- a/src/gateway/llm-call-api.ts
+++ b/src/gateway/llm-call-api.ts
@@ -1,0 +1,160 @@
+/**
+ * Receives LLM-call measurements from an AgentBox.
+ *
+ * The box produces measurements at the provider boundary and cannot write to the
+ * database (in K8s it is a different pod); this handler is the other half of
+ * that seam.
+ *
+ * Two properties it owes the sender:
+ *
+ *   1. IDEMPOTENCE. A delivery whose response was lost will be retried, so the
+ *      same `call_id` must be harmless the second time — enforced by the table's
+ *      primary key, not by the sender remembering.
+ *   2. HONEST FAILURE. A rejected batch returns a status the dispatcher can act
+ *      on. Answering 200 to something we did not store would let the box count
+ *      it delivered and a coverage report overstate itself.
+ *
+ * Attribution is resolved HERE, not trusted from the body: the box knows its
+ * session, but org/user/agent identity belongs to the Runtime, and a box must
+ * not be able to file measurements against someone else.
+ */
+
+import type http from "node:http";
+import { validateMeasurementBatch } from "../shared/llm-call-validation.js";
+import { persistLlmCallMeasurements } from "../portal/llm-call-repo.js";
+import type { Db } from "./db.js";
+import type { LlmCallAttribution } from "../shared/llm-call-record.js";
+
+/** Resolves the identities a box is not allowed to assert for itself. */
+export type AttributionResolver = (sessionId: string) => Promise<Omit<LlmCallAttribution, "session_id"> | null>;
+
+/**
+ * Read attribution straight off the session row.
+ *
+ * The in-memory registry only carries userId/agentId, and filing rows with the
+ * rest blank would leave the per-user and per-entry views — the ones this work
+ * exists to produce — unbuildable. One indexed lookup per BATCH (not per call)
+ * is a price worth paying for that.
+ *
+ * A sub-agent's rows carry the CHILD session's identities. Which user request
+ * they belong to is a separate fact, and one the box supplies on the
+ * measurement (`root_request_id` / `parent_call_id`) — see the note below on
+ * why `parent_session_id` cannot answer it.
+ */
+export async function resolveAttributionFromDb(
+  db: Db,
+  sessionId: string,
+): Promise<Omit<LlmCallAttribution, "session_id"> | null> {
+  const [rows] = (await db.query(
+    `SELECT s.agent_id, s.user_id, s.origin, s.target_agent_id,
+            owner.agent_type AS owner_type,
+            target.agent_type AS target_type
+       FROM chat_sessions s
+       LEFT JOIN agents owner  ON owner.id  = s.agent_id
+       LEFT JOIN agents target ON target.id = s.target_agent_id
+      WHERE s.id = ?`,
+    [sessionId],
+  )) as any;
+  const row = rows?.[0];
+  if (!row) return null;
+  // The executor when the leg was delegated, otherwise the owner — and the TYPE
+  // must describe the SAME agent. Joining on the owner while reporting the
+  // target produced agent_id=worker with agent_type=coordinator, which makes
+  // any per-type breakdown wrong in exactly the delegated case.
+  const executorIsTarget = Boolean(row.target_agent_id);
+  return {
+    org_id: "",
+    user_id: row.user_id ?? null,
+    agent_id: (executorIsTarget ? row.target_agent_id : row.agent_id) ?? "",
+    agent_type: (executorIsTarget ? row.target_type : row.owner_type) ?? "",
+    session_origin: row.origin ?? "web",
+    // NOT parent_session_id: one parent session spans many user requests, so
+    // using it would file every sub-call of every request under one id while
+    // the parent's own calls carry none. Session lineage is a different fact
+    // from request identity. Both correlations therefore come from the BOX, on
+    // the measurement itself; these two stay null so that an older box — which
+    // sends neither — records an honest absence rather than a lineage guess.
+    root_request_id: null,
+    parent_call_id: null,
+  };
+}
+
+/** Read a JSON body with a hard cap, decoding on the stream. */
+async function readJsonBody(req: http.IncomingMessage, maxBytes = 1024 * 1024): Promise<unknown> {
+  return await new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      // Byte length, not string length: a UTF-16 count lets CJK bodies run past
+      // the cap. Decoding happens once, at the end, over the whole buffer.
+      size += chunk.length;
+      if (size > maxBytes) { reject(new Error("body too large")); req.destroy(); return; }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      try { resolve(JSON.parse(Buffer.concat(chunks).toString("utf8"))); }
+      catch { reject(new Error("body is not valid JSON")); }
+    });
+    req.on("error", reject);
+  });
+}
+
+function send(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+/** Hands a validated batch to whoever owns persistence. */
+export type MeasurementPersister = (batch: {
+  session_id: string;
+  measurements: unknown[];
+}) => Promise<{ ok: boolean; error?: string; inserted?: number; duplicates?: number }>;
+
+/** Answers whether this certificate may file measurements against this session. */
+export type SessionAuthorizer = (sessionId: string) => Promise<boolean>;
+
+export async function handleLlmCallMeasurements(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  persist: MeasurementPersister,
+  authorize: SessionAuthorizer,
+): Promise<void> {
+  let body: unknown;
+  try {
+    body = await readJsonBody(req);
+  } catch (error) {
+    send(res, 400, { error: error instanceof Error ? error.message : "unreadable body" });
+    return;
+  }
+
+  const validation = validateMeasurementBatch(body);
+  if (!validation.ok || !validation.batch) {
+    // 400, not 200: a shape we refuse is a shape the sender should stop
+    // producing, and telling it "fine" hides a version skew during a rollout.
+    send(res, 400, { error: validation.error ?? "invalid batch" });
+    return;
+  }
+
+  const { session_id: sessionId, measurements } = validation.batch;
+  try {
+    // A VALID CERTIFICATE IS NOT AUTHORIZATION. Any box can present one, so
+    // without this a worker's certificate could file spend against an owner's
+    // session — resolving attribution from the database says who the session
+    // belongs to, never that this caller may write to it.
+    if (!(await authorize(sessionId))) {
+      send(res, 403, { error: "not authorized for this session" });
+      return;
+    }
+    const result = await persist({ session_id: sessionId, measurements });
+    if (!result.ok) {
+      send(res, result.error === "unknown session" ? 404 : 500, { error: result.error ?? "persist failed" });
+      return;
+    }
+    // `duplicates` is reported, not treated as an error — it is the expected
+    // outcome of a redelivery and useful for spotting a sender retrying too hard.
+    send(res, 200, result);
+  } catch (error) {
+    console.warn(`[llm-call-api] failed to persist ${measurements.length} measurement(s):`, error);
+    send(res, 500, { error: "persist failed" });
+  }
+}

--- a/src/gateway/server.ts
+++ b/src/gateway/server.ts
@@ -114,6 +114,9 @@ import { MetricsAggregator } from "./metrics-aggregator.js";
 import { PromFederationAggregator } from "./prom-federation-aggregator.js";
 import { LocalSpawner } from "./agentbox/local-spawner.js";
 import { sessionRegistry } from "./session-registry.js";
+import { handleLlmCallMeasurements } from "./llm-call-api.js";
+import { sessionReportableByIdentity } from "./internal-api.js";
+import { LLM_CALL_MEASUREMENTS_PATH } from "../shared/llm-call-validation.js";
 import { sessionTurnLocks } from "./session-turn-lock.js";
 import { pendingUserRows } from "./pending-user-rows.js";
 import { resolveAgentModelBinding, resolveAgentSystemPrompt } from "./agent-model-binding.js";
@@ -2920,6 +2923,23 @@ export async function startRuntime(opts: StartRuntimeOptions): Promise<RuntimeSe
           if (url === "/api/internal/delegation-events" && method === "POST") {
             if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
             handleDelegationEvents(req, res, identity, frontendClient);
+            return;
+          }
+
+          // Per-call token metering from an AgentBox. Attribution is resolved
+          // here from the session registry — a box may state its own session,
+          // never someone else's org/user/agent.
+          if (url === LLM_CALL_MEASUREMENTS_PATH && method === "POST") {
+            if (!identity) { res.writeHead(401, { "Content-Type": "application/json" }); res.end(JSON.stringify({ error: "Client certificate required" })); return; }
+            void handleLlmCallMeasurements(
+              req,
+              res,
+              // Persistence belongs to whoever owns the database. A standalone
+              // Runtime has none — it reaches it through this RPC — so calling
+              // getDb() here only ever worked in single-process local mode.
+              (batch) => frontendClient.request("llmCall.persist", batch),
+              (sessionId) => sessionReportableByIdentity(sessionId, identity),
+            );
             return;
           }
 

--- a/src/gateway/task-coordinator.ts
+++ b/src/gateway/task-coordinator.ts
@@ -305,6 +305,12 @@ export class TaskCoordinator {
           text: prompt,
           mode: "task",
           agentId,
+          // A scheduled run IS the request here, and `runId` already names it —
+          // using it means a metered call joins the run row an operator is
+          // already looking at, instead of a second id minted beside it. Empty
+          // when the run row could not be reserved: then there is no stable id
+          // to carry, and sending none is honest.
+          turnId: runId || undefined,
           modelProvider: binding.modelProvider,
           modelId: binding.modelId,
           releaseId: binding.releaseId,

--- a/src/portal/adapter-rpc.test.ts
+++ b/src/portal/adapter-rpc.test.ts
@@ -2489,7 +2489,7 @@ describe("buildAdapterRpcHandlers", () => {
       "config.getDelegates",
       "credential.list", "credential.get", "credential.checkAccess",
       "credential.resourceManifest", "credential.hostSearch",
-      "chat.getVisualLink", "chat.ensureSession", "chat.resolveSession", "chat.appendMessage", "chat.bindMessageTraceId", "chat.recordFeedback", "chat.updateMessage", "chat.updateDelegationToolMessage", "chat.getMessages",
+      "chat.getVisualLink", "chat.ensureSession", "chat.resolveSession", "chat.appendMessage", "chat.bindMessageTraceId", "chat.recordFeedback", "llmCall.persist", "chat.updateMessage", "chat.updateDelegationToolMessage", "chat.getMessages",
       "chat.recentDelegationSessions", "chat.sequenceMessage",
       "task.listActive", "task.getStatus", "task.list", "task.create",
       "task.update", "task.delete", "task.runRecord", "task.runStart",

--- a/src/portal/adapter.ts
+++ b/src/portal/adapter.ts
@@ -9,6 +9,9 @@ import { sandboxResolveHandler } from "./script-sandbox.js";
 import crypto from "node:crypto";
 import http from "node:http";
 import { getDb, type Db } from "../gateway/db.js";
+import { persistLlmCallMeasurements } from "./llm-call-repo.js";
+import { resolveAttributionFromDb } from "../gateway/llm-call-api.js";
+import type { LlmCallMeasurement } from "../shared/llm-call-record.js";
 import { buildUpsert, insertIgnorePrefix, safeParseJson, toSqlTimestamp } from "../gateway/dialect-helpers.js";
 // Shared with the gateway so both layers normalize the admission tier identically — a drift here
 // means the runtime treats a bot as open while this adapter refuses to bind it.
@@ -2885,6 +2888,29 @@ export function buildAdapterRpcHandlers(): Map<string, (params: any, agentId: st
   handlers.set("chat.recordFeedback", async (params) => {
     const db = getDb();
     return recordMessageFeedback(db, params);
+  });
+
+  /**
+   * Persist LLM-call measurements.
+   *
+   * Lives here because the DATABASE lives here: a standalone Runtime never
+   * initialises one and reaches persistence through this RPC. A handler that
+   * called `getDb()` on the Runtime side worked only in the single-process
+   * local mode, where Portal had already booted — and returned 500 anywhere else.
+   *
+   * Attribution is resolved here too, for the same reason: it needs the session
+   * row. Idempotent on `call_id`, so a redelivery is a no-op.
+   */
+  handlers.set("llmCall.persist", async (params) => {
+    const db = getDb();
+    const { session_id: sessionId, measurements } = params as {
+      session_id: string;
+      measurements: LlmCallMeasurement[];
+    };
+    const attribution = await resolveAttributionFromDb(db, sessionId);
+    if (!attribution) return { ok: false, error: "unknown session" };
+    const result = await persistLlmCallMeasurements(db, { session_id: sessionId, ...attribution }, measurements);
+    return { ok: true, ...result };
   });
 
   /**

--- a/src/portal/llm-call-repo.test.ts
+++ b/src/portal/llm-call-repo.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb, closeDb, getDb } from "../gateway/db.js";
+import { runPortalMigrations } from "./migrate.js";
+import { persistLlmCallMeasurements } from "./llm-call-repo.js";
+import type { LlmCallMeasurement, LlmCallAttribution } from "../shared/llm-call-record.js";
+
+const attribution: LlmCallAttribution = {
+  session_id: "sess-1", org_id: "org-1", user_id: "user-1",
+  agent_id: "agent-1", agent_type: "sre", session_origin: "web",
+  root_request_id: null, parent_call_id: null,
+};
+
+const measurement = (callId: string, over: Partial<LlmCallMeasurement> = {}): LlmCallMeasurement => ({
+  call_id: callId, prompt_id: "p1", kind: "agent",
+  round: 1, attempt: 1, network_attempts: 1,
+  provider: "example-gateway", model_id: "gpt-5", api_type: "openai-responses",
+  usage_status: "reported", usage_source: "provider",
+  reported_fields: ["input", "output"],
+  input_tokens_total: 1_000, output_tokens_total: 200,
+  reasoning_tokens: null, cache_read_tokens: 0, cache_write_tokens: null,
+  payload_bytes: 900, payload_tokens_estimated: 225,
+  request_snapshot: {
+    model_settings: {}, system_sha256: "s", tools_sha256: "t",
+    history_prefix_sha256: "h", history_message_count: 3,
+  },
+  request_at: "2026-09-13T00:00:00.000Z", response_end_at: "2026-09-13T00:00:01.000Z",
+  since_prev_ms: null, cost_micros: null, inconsistencies: [],
+  ...over,
+});
+
+describe("persistLlmCallMeasurements", () => {
+  beforeEach(async () => {
+    initDb("sqlite::memory:");
+    await runPortalMigrations();
+  });
+  afterEach(async () => { await closeDb(); });
+
+  it("writes a row per call", async () => {
+    const result = await persistLlmCallMeasurements(getDb(), attribution, [measurement("c1"), measurement("c2")]);
+    expect(result).toEqual({ inserted: 2, duplicates: 0 });
+  });
+
+  it("is idempotent on call_id — a redelivery cannot double-count", async () => {
+    // The sender holds no "already delivered" state, so this is the only place
+    // a retried batch can be made harmless.
+    await persistLlmCallMeasurements(getDb(), attribution, [measurement("c1")]);
+    const again = await persistLlmCallMeasurements(getDb(), attribution, [measurement("c1")]);
+    expect(again).toEqual({ inserted: 0, duplicates: 1 });
+
+    const [rows] = await getDb().query<Array<{ n: number }>>("SELECT COUNT(*) AS n FROM llm_calls");
+    expect(Number(rows[0].n)).toBe(1);
+  });
+
+  it("preserves NULL and 0 as different values", async () => {
+    // The whole pipeline exists to keep these apart: 0 is a reported zero,
+    // NULL is "the provider never said".
+    await persistLlmCallMeasurements(getDb(), attribution, [
+      measurement("c1", { cache_read_tokens: 0, cache_write_tokens: null, reasoning_tokens: null }),
+    ]);
+    const [rows] = await getDb().query<Array<Record<string, unknown>>>(
+      "SELECT cache_read_tokens, cache_write_tokens, reasoning_tokens FROM llm_calls WHERE call_id = 'c1'",
+    );
+    expect(Number(rows[0].cache_read_tokens)).toBe(0);
+    expect(rows[0].cache_write_tokens).toBeNull();
+    expect(rows[0].reasoning_tokens).toBeNull();
+  });
+
+  it("stores attribution the box was not allowed to assert", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution, [measurement("c1")]);
+    const [rows] = await getDb().query<Array<Record<string, unknown>>>(
+      "SELECT session_id, user_id, agent_id FROM llm_calls WHERE call_id = 'c1'",
+    );
+    expect(rows[0]).toMatchObject({ session_id: "sess-1", user_id: "user-1", agent_id: "agent-1" });
+  });
+
+  it("never writes a cost while prices are unverified", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution, [measurement("c1")]);
+    const [rows] = await getDb().query<Array<{ cost_micros: unknown }>>(
+      "SELECT cost_micros FROM llm_calls WHERE call_id = 'c1'",
+    );
+    expect(rows[0].cost_micros).toBeNull();
+  });
+
+  it("keeps inconsistencies as evidence, and omits them when there are none", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution, [
+      measurement("c1", { inconsistencies: [{ field: "cache_vs_input", detail: "cached 120 exceeds input total 100" }] }),
+      measurement("c2"),
+    ]);
+    const [rows] = await getDb().query<Array<{ call_id: string; inconsistencies: string | null }>>(
+      "SELECT call_id, inconsistencies FROM llm_calls ORDER BY call_id",
+    );
+    expect(rows[0].inconsistencies).toContain("cache_vs_input");
+    expect(rows[1].inconsistencies).toBeNull();
+  });
+
+  it("takes the request correlation from the producer, not from attribution", async () => {
+    // Only the box knows which turn a call served. The attribution carried by the
+    // receiver cannot tell one request from the next within a conversation, so a
+    // measurement that names its own request must win over it.
+    await persistLlmCallMeasurements(getDb(), attribution, [
+      measurement("c1", { root_request_id: "turn-abc" }),
+    ]);
+    const [rows] = await getDb().query<Array<{ root_request_id: unknown }>>(
+      "SELECT root_request_id FROM llm_calls WHERE call_id = 'c1'",
+    );
+    expect(rows[0].root_request_id).toBe("turn-abc");
+  });
+
+  it("stores NULL when an older box sends no correlation", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution, [measurement("c1")]);
+    const [rows] = await getDb().query<Array<{ root_request_id: unknown; parent_call_id: unknown }>>(
+      "SELECT root_request_id, parent_call_id FROM llm_calls WHERE call_id = 'c1'",
+    );
+    expect(rows[0].root_request_id).toBeNull();
+    expect(rows[0].parent_call_id).toBeNull();
+  });
+
+  it("keeps which call dispatched a sub-agent, separately from which request it served", async () => {
+    // A shared root says the calls belong to one request; it cannot say WHICH of
+    // the parent's calls spawned the child. Both come from the producer.
+    await persistLlmCallMeasurements(getDb(), attribution, [
+      measurement("c1", { root_request_id: "turn-abc", parent_call_id: "call-round-2" }),
+    ]);
+    const [rows] = await getDb().query<Array<{ root_request_id: unknown; parent_call_id: unknown }>>(
+      "SELECT root_request_id, parent_call_id FROM llm_calls WHERE call_id = 'c1'",
+    );
+    expect(rows[0]).toMatchObject({ root_request_id: "turn-abc", parent_call_id: "call-round-2" });
+  });
+
+  it("records an untagged producer as unattributed, not as conversation", async () => {
+    // Folding an un-taught producer into conversation would let a whole new
+    // subsystem's spend show up as chat growth, with nothing to notice.
+    await persistLlmCallMeasurements(getDb(), attribution, [
+      measurement("c1"),                                  // older box: no tag
+      measurement("c2", { workload: "knowledge_compile" }),
+    ]);
+    const [rows] = await getDb().query<Array<{ call_id: string; workload: string }>>(
+      "SELECT call_id, workload FROM llm_calls ORDER BY call_id",
+    );
+    expect(rows[0]).toMatchObject({ call_id: "c1", workload: "unattributed" });
+    expect(rows[1]).toMatchObject({ call_id: "c2", workload: "knowledge_compile" });
+  });
+
+  it("keeps the request fingerprint for cache-stability analysis", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution, [
+      measurement("c1", {
+        request_snapshot: {
+          model_settings: { model: "gpt-5" }, system_sha256: "sys", tools_sha256: "tools",
+          history_prefix_sha256: "prefix", history_message_count: 3, payload_sha256: "payload",
+          prompt_cache_key: "key-1", cache_retention_sent: "24h",
+        },
+      }),
+    ]);
+    const [rows] = await getDb().query<Array<{ request_snapshot: string }>>(
+      "SELECT request_snapshot FROM llm_calls WHERE call_id = 'c1'",
+    );
+    const snapshot = JSON.parse(rows[0].request_snapshot);
+    expect(snapshot).toMatchObject({ payload_sha256: "payload", prompt_cache_key: "key-1", cache_retention_sent: "24h" });
+  });
+});

--- a/src/portal/llm-call-repo.ts
+++ b/src/portal/llm-call-repo.ts
@@ -1,0 +1,106 @@
+/**
+ * Persists LLM-call measurements.
+ *
+ * Writes are IDEMPOTENT on `call_id`. The sender deliberately keeps no
+ * "already delivered" state — it cannot, since a response can be lost after the
+ * row was committed — so a redelivery has to be harmless here instead.
+ *
+ * Insert-ignore rather than upsert: the first delivery is the measurement taken
+ * at the provider boundary, and a later copy of the same call has nothing newer
+ * to say. Overwriting would let a retry of an older batch replace a row.
+ *
+ * NULL is preserved end to end. A token column left NULL means the provider did
+ * not report that field; writing 0 instead would destroy the one distinction
+ * this whole pipeline exists to keep.
+ */
+
+import type { Db } from "../gateway/db.js";
+import { insertIgnorePrefix } from "../gateway/dialect-helpers.js";
+import { isLlmWorkload } from "../shared/llm-call-record.js";
+import type { LlmCallMeasurement, LlmCallAttribution } from "../shared/llm-call-record.js";
+
+export interface PersistResult {
+  /** Rows newly written. */
+  inserted: number;
+  /** Rows already present — a redelivery, not an error. */
+  duplicates: number;
+}
+
+/** Serialize a nullable structure without turning "absent" into "{}" . */
+function jsonOrNull(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write a batch. Each row is inserted independently so one malformed row cannot
+ * discard its neighbours — a metering write must never take down more data than
+ * the row it is about.
+ */
+export async function persistLlmCallMeasurements(
+  db: Db,
+  attribution: LlmCallAttribution,
+  measurements: readonly LlmCallMeasurement[],
+): Promise<PersistResult> {
+  let inserted = 0;
+  let duplicates = 0;
+  const prefix = insertIgnorePrefix(db);
+
+  for (const m of measurements) {
+    const [result] = (await db.query(
+      `${prefix} INTO llm_calls (
+        call_id, session_id, prompt_id, root_request_id, parent_call_id,
+        org_id, user_id, agent_id, agent_type, session_origin,
+        workload, kind, round, attempt, network_attempts,
+        provider, model_id, api_type,
+        usage_status, usage_source, reported_fields,
+        input_tokens_total, output_tokens_total, reasoning_tokens,
+        cache_read_tokens, cache_write_tokens,
+        payload_bytes, payload_tokens_estimated, cost_micros,
+        request_snapshot, inconsistencies,
+        request_at, response_end_at, since_prev_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        m.call_id, attribution.session_id, m.prompt_id,
+        // The PRODUCER's correlation wins: only the box knows which user request
+        // a call served. `undefined` (an older box) becomes null — never a value
+        // reconstructed from session lineage, which cannot tell one request from
+        // the next within a conversation.
+        m.root_request_id ?? attribution.root_request_id ?? null,
+        // Same rule, same reason: only the box knows which of the parent's calls
+        // dispatched this child. The receiver can see the child session exists;
+        // it cannot see which call spawned it.
+        m.parent_call_id ?? attribution.parent_call_id ?? null,
+        attribution.org_id, attribution.user_id, attribution.agent_id,
+        attribution.agent_type, attribution.session_origin,
+        // An older box sends no workload. It becomes `unattributed` — a visible
+        // value — rather than being folded into `conversation`, which would let
+        // an un-taught producer masquerade as ordinary chat traffic.
+        isLlmWorkload(m.workload) ? m.workload : "unattributed",
+        m.kind, m.round, m.attempt, m.network_attempts,
+        m.provider, m.model_id, m.api_type,
+        m.usage_status, m.usage_source, m.reported_fields.join(","),
+        m.input_tokens_total, m.output_tokens_total, m.reasoning_tokens,
+        m.cache_read_tokens, m.cache_write_tokens,
+        m.payload_bytes, m.payload_tokens_estimated,
+        // Always NULL for now: prices are unverified, and a wrong cost is worse
+        // than an absent one because it looks authoritative.
+        null,
+        jsonOrNull(m.request_snapshot),
+        m.inconsistencies && m.inconsistencies.length > 0 ? jsonOrNull(m.inconsistencies) : null,
+        m.request_at, m.response_end_at, m.since_prev_ms,
+      ],
+    )) as any;
+    // mysql2 reports affectedRows; node:sqlite reports changes. Either way zero
+    // means the row was already there.
+    const affected = Number(result?.affectedRows ?? result?.changes ?? 0);
+    if (affected > 0) inserted += 1;
+    else duplicates += 1;
+  }
+
+  return { inserted, duplicates };
+}

--- a/src/portal/llm-usage-repo.test.ts
+++ b/src/portal/llm-usage-repo.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Aggregation is where the write side's carefully preserved distinctions get
+ * destroyed, so these run against a REAL database rather than a stub: the two
+ * failures that matter (SUM skipping NULLs, and protocols disagreeing on what
+ * `input_tokens` covers) are properties of the SQL, not of the TypeScript.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { initDb, closeDb, getDb } from "../gateway/db.js";
+import { runPortalMigrations } from "./migrate.js";
+import { persistLlmCallMeasurements } from "./llm-call-repo.js";
+import { usageByModel, usageByActor } from "./llm-usage-repo.js";
+import type { LlmCallMeasurement, LlmCallAttribution } from "../shared/llm-call-record.js";
+
+const WINDOW = { from: new Date("2026-09-01T00:00:00.000Z"), to: new Date("2026-09-30T00:00:00.000Z") };
+
+const attribution = (over: Partial<LlmCallAttribution> = {}): LlmCallAttribution => ({
+  session_id: "sess-1", org_id: "", user_id: "user-1",
+  agent_id: "agent-1", agent_type: "sre", session_origin: "web",
+  root_request_id: null, parent_call_id: null,
+  ...over,
+});
+
+const measurement = (callId: string, over: Partial<LlmCallMeasurement> = {}): LlmCallMeasurement => ({
+  call_id: callId, prompt_id: "p1", kind: "agent",
+  round: 1, attempt: 1, network_attempts: 1,
+  provider: "example-gateway", model_id: "gpt-5", api_type: "openai-responses",
+  usage_status: "reported", usage_source: "provider",
+  reported_fields: ["input", "output"],
+  input_tokens_total: 1_000, output_tokens_total: 200,
+  reasoning_tokens: null, cache_read_tokens: 0, cache_write_tokens: null,
+  payload_bytes: 900, payload_tokens_estimated: 225,
+  request_snapshot: {
+    model_settings: {}, system_sha256: "s", tools_sha256: "t",
+    history_prefix_sha256: "h", history_message_count: 3,
+  },
+  request_at: "2026-09-13T00:00:00.000Z", response_end_at: "2026-09-13T00:00:01.000Z",
+  since_prev_ms: null, cost_micros: null, inconsistencies: [],
+  ...over,
+});
+
+async function session(id: string, row: Partial<{
+  user_id: string; origin: string; sender_external_id: string | null; parent_session_id: string | null;
+}> = {}): Promise<void> {
+  await getDb().query(
+    `INSERT INTO chat_sessions (id, agent_id, user_id, origin, sender_external_id, parent_session_id)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [id, "agent-1", row.user_id ?? "user-1", row.origin ?? "web",
+     row.sender_external_id ?? null, row.parent_session_id ?? null],
+  );
+}
+
+describe("usageByModel", () => {
+  beforeEach(async () => { initDb("sqlite::memory:"); await runPortalMigrations(); });
+  afterEach(async () => { await closeDb(); });
+
+  it("ranks provider × model by charged tokens, heaviest first", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution(), [
+      measurement("c1", { model_id: "small", input_tokens_total: 100, output_tokens_total: 10 }),
+      measurement("c2", { model_id: "big", input_tokens_total: 9_000, output_tokens_total: 900 }),
+      measurement("c3", { model_id: "mid", input_tokens_total: 1_000, output_tokens_total: 100 }),
+    ]);
+
+    const { groups } = await usageByModel(getDb(), WINDOW);
+    expect(groups.map((g) => g.modelId)).toEqual(["big", "mid", "small"]);
+    expect(groups[0]).toMatchObject({ provider: "example-gateway", calls: 1, billable: 9_900 });
+  });
+
+  it("keeps each protocol's own arithmetic — cache is inside input on one, beside it on the other", async () => {
+    // The same five numbers mean different totals per protocol. Summing the
+    // columns uniformly would double-count 500 cached tokens on the first row.
+    await persistLlmCallMeasurements(getDb(), attribution(), [
+      measurement("c1", {
+        api_type: "openai-responses", model_id: "m-a",
+        input_tokens_total: 1_000, output_tokens_total: 100,
+        cache_read_tokens: 500, cache_write_tokens: null,
+      }),
+      measurement("c2", {
+        api_type: "anthropic-messages", model_id: "m-b",
+        input_tokens_total: 1_000, output_tokens_total: 100,
+        cache_read_tokens: 500, cache_write_tokens: 0,
+      }),
+    ]);
+
+    const { groups } = await usageByModel(getDb(), WINDOW);
+    const byModel = Object.fromEntries(groups.map((g) => [g.modelId, g.billable]));
+    expect(byModel["m-a"]).toBe(1_100);   // cache already counted inside input
+    expect(byModel["m-b"]).toBe(1_600);   // cache charged on top of input
+  });
+
+  it("reports the basis of every sum, because SUM silently skips what was never reported", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution(), [
+      measurement("c1", { reasoning_tokens: 50 }),
+      measurement("c2", { reasoning_tokens: null }), // provider never reported it
+    ]);
+
+    const [group] = (await usageByModel(getDb(), WINDOW)).groups;
+    expect(group.calls).toBe(2);
+    expect(group.reasoning.total).toBe(50);
+    // The number is over ONE of two calls. Without this a reader would take 50
+    // as the window's reasoning total.
+    expect(group.reasoning.reportedCalls).toBe(1);
+    expect(group.input.reportedCalls).toBe(2);
+  });
+
+  it("returns null, not zero, for a field no call reported", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution(), [measurement("c1", { cache_write_tokens: null })]);
+    const [group] = (await usageByModel(getDb(), WINDOW)).groups;
+    expect(group.cacheWrite.total).toBeNull();
+    expect(group.cacheWrite.reportedCalls).toBe(0);
+    // A reported zero stays a zero — the distinction the whole pipeline exists for.
+    expect(group.cacheRead.total).toBe(0);
+    expect(group.cacheRead.reportedCalls).toBe(1);
+  });
+
+  it("excludes untrustworthy rows from the sums and says how many it excluded", async () => {
+    // An SDK-default row is all zeros. Summing it would quietly deflate the
+    // averages and make coverage look complete.
+    await persistLlmCallMeasurements(getDb(), attribution(), [
+      measurement("c1", { input_tokens_total: 1_000, output_tokens_total: 100 }),
+      measurement("c2", {
+        usage_source: "sdk_default", usage_status: "missing", reported_fields: [],
+        input_tokens_total: null, output_tokens_total: null, cache_read_tokens: null,
+      }),
+      measurement("c3", {
+        usage_source: "unknown", usage_status: "unknown", reported_fields: [],
+        input_tokens_total: null, output_tokens_total: null, cache_read_tokens: null,
+      }),
+    ]);
+
+    const { groups, coverage } = await usageByModel(getDb(), WINDOW);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].calls).toBe(1);
+    expect(coverage).toEqual({ trustworthy: 1, excluded: 2 });
+  });
+
+  it("sorts an unpriceable group last rather than treating unknown as zero", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution(), [
+      measurement("c1", { model_id: "known", input_tokens_total: 10, output_tokens_total: 1 }),
+      // Reported something, but not output — so the total cannot be computed.
+      measurement("c2", {
+        model_id: "unpriceable", usage_status: "partial", reported_fields: ["input"],
+        input_tokens_total: 999_999, output_tokens_total: null, cache_read_tokens: null,
+      }),
+    ]);
+
+    const { groups } = await usageByModel(getDb(), WINDOW);
+    expect(groups.map((g) => g.modelId)).toEqual(["known", "unpriceable"]);
+    expect(groups[1].billable).toBeNull();
+  });
+
+  it("honours the window", async () => {
+    await persistLlmCallMeasurements(getDb(), attribution(), [
+      measurement("c1", { request_at: "2026-08-01T00:00:00.000Z" }),
+      measurement("c2", { request_at: "2026-09-13T00:00:00.000Z" }),
+    ]);
+    const { groups, coverage } = await usageByModel(getDb(), WINDOW);
+    expect(groups[0].calls).toBe(1);
+    expect(coverage.trustworthy).toBe(1);
+  });
+});
+
+describe("usageByActor", () => {
+  beforeEach(async () => { initDb("sqlite::memory:"); await runPortalMigrations(); });
+  afterEach(async () => { await closeDb(); });
+
+  it("attributes a channel turn to the sender, not to the owning account", async () => {
+    await session("chan-1", { origin: "channel", sender_external_id: "ou_alice", user_id: "svc-account" });
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "chan-1" }), [
+      measurement("c1", { input_tokens_total: 1_000, output_tokens_total: 100 }),
+    ]);
+
+    const { actors } = await usageByActor(getDb(), WINDOW);
+    expect(actors).toHaveLength(1);
+    expect(actors[0]).toMatchObject({ kind: "channel", id: "ou_alice", calls: 1, billable: 1_100 });
+  });
+
+  it("breaks each actor down by field, so a cache-heavy user is visible as such", async () => {
+    await session("s-a", { user_id: "user-a" });
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-a" }), [
+      measurement("c1", {
+        input_tokens_total: 1_000, output_tokens_total: 100,
+        cache_read_tokens: 400, cache_write_tokens: 600,
+      }),
+      measurement("c2", {
+        input_tokens_total: 2_000, output_tokens_total: 200,
+        cache_read_tokens: 100, cache_write_tokens: null, // never reported
+      }),
+    ]);
+
+    const [actor] = (await usageByActor(getDb(), WINDOW)).actors;
+    expect(actor.input).toEqual({ total: 3_000, reportedCalls: 2 });
+    expect(actor.output).toEqual({ total: 300, reportedCalls: 2 });
+    expect(actor.cacheRead).toEqual({ total: 500, reportedCalls: 2 });
+    // Summed over ONE call — the count says so rather than the number pretending
+    // to cover both.
+    expect(actor.cacheWrite).toEqual({ total: 600, reportedCalls: 1 });
+  });
+
+  it("ranks by the requested metric, not always by the total", async () => {
+    await session("s-a", { user_id: "heavy-total" });
+    await session("s-b", { user_id: "heavy-cache-write" });
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-a" }), [
+      measurement("c1", { input_tokens_total: 9_000, output_tokens_total: 900, cache_write_tokens: 1 }),
+    ]);
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-b" }), [
+      measurement("c2", { input_tokens_total: 100, output_tokens_total: 10, cache_write_tokens: 5_000 }),
+    ]);
+
+    const byTotal = await usageByActor(getDb(), WINDOW);
+    expect(byTotal.actors.map((a) => a.id)).toEqual(["heavy-total", "heavy-cache-write"]);
+
+    const byCacheWrite = await usageByActor(getDb(), { ...WINDOW, sort: "cacheWrite" });
+    expect(byCacheWrite.actors.map((a) => a.id)).toEqual(["heavy-cache-write", "heavy-total"]);
+  });
+
+  it("applies the cap AFTER the requested ranking", async () => {
+    // The reason sorting is server-side: with the cap applied first, "top by
+    // cache write" would be computed over rows chosen by a different metric.
+    await session("s-a", { user_id: "big-total" });
+    await session("s-b", { user_id: "big-cache-write" });
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-a" }), [
+      measurement("c1", { input_tokens_total: 9_000, output_tokens_total: 900, cache_write_tokens: 0 }),
+    ]);
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-b" }), [
+      measurement("c2", { input_tokens_total: 10, output_tokens_total: 1, cache_write_tokens: 7_000 }),
+    ]);
+
+    const top1 = await usageByActor(getDb(), { ...WINDOW, sort: "cacheWrite", limit: 1 });
+    expect(top1.actors.map((a) => a.id)).toEqual(["big-cache-write"]);
+  });
+
+  it("bills a sub-agent's calls to the actor who asked, not to the child session", async () => {
+    // This is the spend Portal never saw at all. A child session carries no
+    // sender of its own, so without the parent hop it would vanish from every
+    // channel figure the moment someone filtered by sender.
+    await session("chan-1", { origin: "channel", sender_external_id: "ou_alice" });
+    await session("child-1", { origin: "subagent", sender_external_id: null, parent_session_id: "chan-1" });
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "chan-1" }), [
+      measurement("c1", { input_tokens_total: 1_000, output_tokens_total: 100 }),
+    ]);
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "child-1" }), [
+      measurement("c2", { input_tokens_total: 5_000, output_tokens_total: 500 }),
+    ]);
+
+    const { actors } = await usageByActor(getDb(), WINDOW);
+    expect(actors).toHaveLength(1);
+    expect(actors[0]).toMatchObject({ kind: "channel", id: "ou_alice", calls: 2, billable: 6_600 });
+  });
+
+  it("ranks actors by spend, heaviest first", async () => {
+    await session("s-a", { user_id: "user-a" });
+    await session("s-b", { user_id: "user-b" });
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-a" }), [
+      measurement("c1", { input_tokens_total: 100, output_tokens_total: 10 }),
+    ]);
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-b" }), [
+      measurement("c2", { input_tokens_total: 9_000, output_tokens_total: 900 }),
+    ]);
+
+    const { actors } = await usageByActor(getDb(), WINDOW);
+    expect(actors.map((a) => a.id)).toEqual(["user-b", "user-a"]);
+  });
+
+  it("marks an actor whose calls span protocols, and refuses a half-known total", async () => {
+    await session("s-a", { user_id: "user-a" });
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "s-a" }), [
+      measurement("c1", { api_type: "openai-responses", input_tokens_total: 1_000, output_tokens_total: 100 }),
+      measurement("c2", {
+        api_type: "anthropic-messages", input_tokens_total: 1_000, output_tokens_total: 100,
+        cache_read_tokens: 500, cache_write_tokens: 0,
+      }),
+    ]);
+
+    const { actors } = await usageByActor(getDb(), WINDOW);
+    expect(actors[0]).toMatchObject({ id: "user-a", calls: 2, billable: 2_700, mixedProtocols: true });
+  });
+
+  it("does not invent an actor for a row whose session is gone", async () => {
+    // No chat_sessions row at all: the join yields nothing, and an empty actor
+    // id would otherwise collect every orphan under one meaningless bucket.
+    await persistLlmCallMeasurements(getDb(), attribution({ session_id: "vanished" }), [measurement("c1")]);
+    const { actors, coverage } = await usageByActor(getDb(), WINDOW);
+    expect(actors).toEqual([]);
+    // …but the call is still counted as observed, so coverage stays honest.
+    expect(coverage.trustworthy).toBe(1);
+  });
+});

--- a/src/portal/llm-usage-repo.ts
+++ b/src/portal/llm-usage-repo.ts
@@ -1,0 +1,322 @@
+/**
+ * Reads token usage out of `llm_calls`.
+ *
+ * The write side went to great lengths to keep "the provider reported 0" apart
+ * from "the provider reported nothing". An aggregate is exactly where that
+ * distinction gets thrown away again, in two ways, so both are designed against
+ * here rather than left to each caller:
+ *
+ *   1. `SUM(col)` SKIPS NULLs. A column that was never reported on half the
+ *      calls therefore produces a number that LOOKS like a total and is not.
+ *      Every field is returned as a sum PLUS the count of rows that actually
+ *      reported it, so a caller can see the sum's basis instead of assuming it.
+ *   2. Rows whose usage is untrustworthy (`sdk_default`, `rehydrated`,
+ *      `unknown`) would contribute zeros and silently deflate every figure.
+ *      They are EXCLUDED from the sums and counted separately, so a page can
+ *      state its coverage rather than present a partial total as complete.
+ *
+ * Grouping always includes `api_type`, because the protocols disagree about
+ * what `input_tokens` covers — see {@link billableTokens}. Without it one sum
+ * would mix two different meanings.
+ */
+
+import type { Db } from "../gateway/db.js";
+import { billableTokens } from "../shared/llm-call-record.js";
+import { parentAttributedOriginPredicate } from "./session-origin.js";
+
+/** Sums are over reporting rows only; the counts say how many those were. */
+export interface TokenFieldTotals {
+  /** Sum over rows that reported this field; null when none did. */
+  total: number | null;
+  /** How many calls reported it — compare against `calls` to judge the sum. */
+  reportedCalls: number;
+}
+
+export interface UsageGroup {
+  provider: string;
+  modelId: string;
+  apiType: string;
+  /** Calls with trustworthy usage — the basis of every figure below. */
+  calls: number;
+  input: TokenFieldTotals;
+  output: TokenFieldTotals;
+  reasoning: TokenFieldTotals;
+  cacheRead: TokenFieldTotals;
+  cacheWrite: TokenFieldTotals;
+  /**
+   * Charged tokens for this group, computed per protocol. Null when a required
+   * component was never reported — the ranking then places the group last
+   * rather than treating unknown as zero.
+   */
+  billable: number | null;
+}
+
+export interface UsageCoverage {
+  /** Calls in the window whose usage is provider-reported and safe to sum. */
+  trustworthy: number;
+  /** Calls excluded: the provider never reported, or provenance is unknown. */
+  excluded: number;
+}
+
+export interface UsageByModel {
+  groups: UsageGroup[];
+  coverage: UsageCoverage;
+}
+
+/** An actor is a platform user, or a channel sender with no platform account. */
+export interface UsageActor {
+  kind: "user" | "channel";
+  /** User id, or the channel's external sender id. */
+  id: string;
+  calls: number;
+  input: TokenFieldTotals;
+  output: TokenFieldTotals;
+  cacheRead: TokenFieldTotals;
+  cacheWrite: TokenFieldTotals;
+  billable: number | null;
+  /** Set when one actor's calls span protocols with different billing shapes. */
+  mixedProtocols: boolean;
+}
+
+/**
+ * What a ranking is ordered by.
+ *
+ * Server-side because the result is CAPPED: sorting a truncated page in the
+ * browser would rank the wrong rows — "top spenders by cache write" computed
+ * over the top 50 by total is not the same list.
+ */
+export type UsageSortKey = "billable" | "input" | "output" | "cacheRead" | "cacheWrite" | "calls";
+
+export const USAGE_SORT_KEYS: readonly UsageSortKey[] = [
+  "billable", "input", "output", "cacheRead", "cacheWrite", "calls",
+];
+
+function sortValue(row: { calls: number; billable: number | null } & Partial<Record<Exclude<UsageSortKey, "billable" | "calls">, TokenFieldTotals>>, key: UsageSortKey): number | null {
+  if (key === "calls") return row.calls;
+  if (key === "billable") return row.billable;
+  return row[key]?.total ?? null;
+}
+
+/**
+ * Descending, with UNKNOWN last.
+ *
+ * A null total is not "the smallest" — it is the one we could not compute, and
+ * ranking it as zero would put a possibly-huge spender at the bottom of a page
+ * whose whole purpose is to find the big ones. Ties fall back to call count so
+ * the order is stable rather than arbitrary.
+ */
+function byMetricDesc<T extends { calls: number; billable: number | null }>(key: UsageSortKey) {
+  return (a: T, b: T): number => {
+    const av = sortValue(a as never, key);
+    const bv = sortValue(b as never, key);
+    if (av === null && bv === null) return b.calls - a.calls;
+    if (av === null) return 1;
+    if (bv === null) return -1;
+    return bv - av || b.calls - a.calls;
+  };
+}
+
+export interface UsageByActor {
+  actors: UsageActor[];
+  coverage: UsageCoverage;
+}
+
+export interface UsageWindow {
+  from: Date;
+  to: Date;
+  /** Cap on returned groups; the rest are omitted, never merged into an "other". */
+  limit?: number;
+  /** Ranking metric; the cap applies AFTER it. Defaults to charged tokens. */
+  sort?: UsageSortKey;
+}
+
+/**
+ * Rows safe to aggregate: the provider actually answered.
+ *
+ * `partial` is included — it means SOME contracted fields were reported, and
+ * each field's own count already says which. Excluding it would discard real
+ * provider numbers; including it without the per-field counts would overstate
+ * them. Both halves are needed, which is why they ship together.
+ */
+function trustworthy(alias = ""): string {
+  const p = alias ? `${alias}.` : "";
+  return `${p}usage_source = 'provider' AND ${p}usage_status IN ('reported','partial')`;
+}
+
+/** `SUM(x)` over reporting rows, plus how many rows those were. */
+function fieldSql(column: string, alias: string): string {
+  return `SUM(${column}) AS ${alias}_sum, COUNT(${column}) AS ${alias}_n`;
+}
+
+function toNumber(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** null stays null: an absent sum means nothing reported, not zero. */
+function toTotals(sum: unknown, count: unknown): TokenFieldTotals {
+  const reportedCalls = toNumber(count);
+  return { total: reportedCalls > 0 ? toNumber(sum) : null, reportedCalls };
+}
+
+/**
+ * Combine two slices of one field.
+ *
+ * A null side contributes nothing — it reported nothing, so it cannot lower the
+ * other side's total. Two nulls stay null: still nothing reported, which is not
+ * the same claim as zero.
+ */
+function addTotals(a: TokenFieldTotals, b: TokenFieldTotals): TokenFieldTotals {
+  const reportedCalls = a.reportedCalls + b.reportedCalls;
+  if (a.total === null) return { total: b.total, reportedCalls };
+  if (b.total === null) return { total: a.total, reportedCalls };
+  return { total: a.total + b.total, reportedCalls };
+}
+
+/**
+ * Coverage for the window — computed in the same query shape as the sums so the
+ * two cannot describe different row sets.
+ */
+async function readCoverage(db: Db, window: UsageWindow): Promise<UsageCoverage> {
+  const [rows] = (await db.query(
+    `SELECT SUM(CASE WHEN ${trustworthy()} THEN 1 ELSE 0 END) AS ok,
+            COUNT(*) AS total
+       FROM llm_calls
+      WHERE request_at >= ? AND request_at <= ?`,
+    [window.from.toISOString(), window.to.toISOString()],
+  )) as any;
+  const row = rows?.[0] ?? {};
+  const usable = toNumber(row.ok);
+  return { trustworthy: usable, excluded: Math.max(0, toNumber(row.total) - usable) };
+}
+
+/**
+ * Usage per provider × model, heaviest first.
+ *
+ * Ordering is done HERE rather than in SQL: the sort key is `billableTokens`,
+ * which is protocol-dependent, and expressing it in SQL would be a second
+ * answer to a question the shared contract already answers. Group counts are
+ * small (providers × models), so the cost is nil.
+ */
+export async function usageByModel(db: Db, window: UsageWindow): Promise<UsageByModel> {
+  const [rows] = (await db.query(
+    `SELECT provider, model_id, api_type, COUNT(*) AS calls,
+            ${fieldSql("input_tokens_total", "input")},
+            ${fieldSql("output_tokens_total", "output")},
+            ${fieldSql("reasoning_tokens", "reasoning")},
+            ${fieldSql("cache_read_tokens", "cache_read")},
+            ${fieldSql("cache_write_tokens", "cache_write")}
+       FROM llm_calls
+      WHERE request_at >= ? AND request_at <= ? AND ${trustworthy()}
+      GROUP BY provider, model_id, api_type`,
+    [window.from.toISOString(), window.to.toISOString()],
+  )) as [Array<Record<string, unknown>>, unknown];
+
+  const groups: UsageGroup[] = rows.map((r) => {
+    const input = toTotals(r.input_sum, r.input_n);
+    const output = toTotals(r.output_sum, r.output_n);
+    const cacheRead = toTotals(r.cache_read_sum, r.cache_read_n);
+    const cacheWrite = toTotals(r.cache_write_sum, r.cache_write_n);
+    const apiType = String(r.api_type ?? "");
+    return {
+      provider: String(r.provider ?? ""),
+      modelId: String(r.model_id ?? ""),
+      apiType,
+      calls: toNumber(r.calls),
+      input,
+      output,
+      reasoning: toTotals(r.reasoning_sum, r.reasoning_n),
+      cacheRead,
+      cacheWrite,
+      billable: billableTokens(apiType, {
+        input: input.total, output: output.total,
+        cacheRead: cacheRead.total, cacheWrite: cacheWrite.total,
+      }),
+    };
+  });
+
+  groups.sort(byMetricDesc(window.sort ?? "billable"));
+
+  const limit = window.limit ?? 100;
+  return { groups: groups.slice(0, limit), coverage: await readCoverage(db, window) };
+}
+
+/**
+ * Usage per actor, heaviest first.
+ *
+ * The actor is read from the SESSION, parent-aware: `sender_external_id` is
+ * stamped on the channel session only, so a sub-agent's rows — the ones this
+ * work exists to capture — would fall out of every channel figure without the
+ * COALESCE. Attributing a child's spend to the parent's actor is the intent:
+ * the person who asked is who it cost.
+ */
+export async function usageByActor(db: Db, window: UsageWindow): Promise<UsageByActor> {
+  // A trace child has its OWN origin ('subagent' / 'delegation'), so a
+  // per-column COALESCE never reaches the parent — the child's own non-null
+  // origin wins and its calls land under a platform user instead of the channel
+  // sender who actually asked. Switch on WHOSE identity applies first, then read
+  // every column from that side.
+  const inherits = `(${parentAttributedOriginPredicate("s")} AND parent_s.id IS NOT NULL)`;
+  const origin = `CASE WHEN ${inherits} THEN parent_s.origin ELSE s.origin END`;
+  const sender = `CASE WHEN ${inherits} THEN parent_s.sender_external_id ELSE s.sender_external_id END`;
+  const user = `CASE WHEN ${inherits} THEN parent_s.user_id ELSE s.user_id END`;
+  const [rows] = (await db.query(
+    `SELECT CASE WHEN ${origin} = 'channel' AND ${sender} IS NOT NULL THEN 'channel' ELSE 'user' END AS actor_kind,
+            CASE WHEN ${origin} = 'channel' AND ${sender} IS NOT NULL THEN ${sender} ELSE ${user} END AS actor_id,
+            c.api_type,
+            COUNT(*) AS calls,
+            ${fieldSql("c.input_tokens_total", "input")},
+            ${fieldSql("c.output_tokens_total", "output")},
+            ${fieldSql("c.cache_read_tokens", "cache_read")},
+            ${fieldSql("c.cache_write_tokens", "cache_write")}
+       FROM llm_calls c
+       LEFT JOIN chat_sessions s ON s.id = c.session_id
+       LEFT JOIN chat_sessions parent_s ON parent_s.id = s.parent_session_id
+      WHERE c.request_at >= ? AND c.request_at <= ? AND ${trustworthy("c")}
+      GROUP BY actor_kind, actor_id, c.api_type`,
+    [window.from.toISOString(), window.to.toISOString()],
+  )) as [Array<Record<string, unknown>>, unknown];
+
+  // Per (actor, api_type) from SQL, folded to per-actor here — the fold has to
+  // happen AFTER billableTokens, since that is what makes two protocols'
+  // numbers comparable in the first place.
+  const byActor = new Map<string, UsageActor>();
+  for (const r of rows) {
+    const kind = r.actor_kind === "channel" ? "channel" : "user";
+    const id = String(r.actor_id ?? "");
+    if (!id) continue; // an unattributable row belongs to no actor; do not invent one
+    const key = `${kind}:${id}`;
+    const input = toTotals(r.input_sum, r.input_n);
+    const output = toTotals(r.output_sum, r.output_n);
+    const cacheRead = toTotals(r.cache_read_sum, r.cache_read_n);
+    const cacheWrite = toTotals(r.cache_write_sum, r.cache_write_n);
+    const slice = billableTokens(String(r.api_type ?? ""), {
+      input: input.total, output: output.total,
+      cacheRead: cacheRead.total, cacheWrite: cacheWrite.total,
+    });
+    const existing = byActor.get(key);
+    if (!existing) {
+      byActor.set(key, {
+        kind, id, calls: toNumber(r.calls),
+        input, output, cacheRead, cacheWrite,
+        billable: slice, mixedProtocols: false,
+      });
+      continue;
+    }
+    existing.calls += toNumber(r.calls);
+    existing.mixedProtocols = true;
+    existing.input = addTotals(existing.input, input);
+    existing.output = addTotals(existing.output, output);
+    existing.cacheRead = addTotals(existing.cacheRead, cacheRead);
+    existing.cacheWrite = addTotals(existing.cacheWrite, cacheWrite);
+    // One unknown slice makes the actor's total unknown. Adding the known part
+    // alone would report a number that is definitely too small as if it were
+    // the total.
+    existing.billable = existing.billable === null || slice === null ? null : existing.billable + slice;
+  }
+
+  const actors = [...byActor.values()].sort(byMetricDesc(window.sort ?? "billable"));
+
+  const limit = window.limit ?? 100;
+  return { actors: actors.slice(0, limit), coverage: await readCoverage(db, window) };
+}

--- a/src/portal/migrate-sqlite.test.ts
+++ b/src/portal/migrate-sqlite.test.ts
@@ -76,6 +76,10 @@ describe("runPortalMigrations on SQLite :memory:", () => {
       "idx_chat_sessions_parent",
       "idx_chat_sessions_delegation",
       "idx_chat_messages_session",
+      // Token metering: per-request cost, per-model spend, per-user consumption.
+      "idx_llm_calls_session",
+      "idx_llm_calls_model",
+      "idx_llm_calls_user",
       "idx_chat_messages_session_seq",
       "idx_chat_messages_audit",
       "idx_chat_messages_parent",

--- a/src/portal/migrate.ts
+++ b/src/portal/migrate.ts
@@ -334,6 +334,54 @@ const PORTAL_SCHEMA_SQLS: string[] = [
     deleted_at TIMESTAMP NULL DEFAULT NULL
   )`,
 
+  // One row per model call. `call_id` is the PRIMARY KEY, which is what makes a
+  // redelivered batch idempotent: the sender holds no "already sent" state, so
+  // dedup has to live here.
+  //
+  // Token columns are NULLable on purpose — NULL means "the provider did not
+  // report this", which is a different fact from a reported 0. A NOT NULL
+  // DEFAULT 0 here would erase that distinction at the last possible moment.
+  //
+  // No JSON columns (SQLite compatibility); `request_snapshot` is TEXT holding
+  // serialized JSON, and `cost_micros` stays NULL until prices are verified.
+  `CREATE TABLE IF NOT EXISTS llm_calls (
+    call_id VARCHAR(64) PRIMARY KEY,
+    session_id CHAR(36) NOT NULL,
+    prompt_id VARCHAR(64) NOT NULL,
+    root_request_id VARCHAR(64) DEFAULT NULL,
+    parent_call_id VARCHAR(64) DEFAULT NULL,
+    org_id CHAR(36) DEFAULT NULL,
+    user_id CHAR(36) DEFAULT NULL,
+    agent_id CHAR(36) DEFAULT NULL,
+    agent_type VARCHAR(64) DEFAULT NULL,
+    session_origin VARCHAR(32) DEFAULT NULL,
+    workload VARCHAR(32) NOT NULL DEFAULT 'unattributed',
+    kind VARCHAR(16) NOT NULL,
+    round INT NOT NULL DEFAULT 0,
+    attempt INT NOT NULL DEFAULT 1,
+    network_attempts INT NOT NULL DEFAULT 0,
+    provider VARCHAR(128) NOT NULL DEFAULT '',
+    model_id VARCHAR(128) NOT NULL DEFAULT '',
+    api_type VARCHAR(50) NOT NULL DEFAULT '',
+    usage_status VARCHAR(16) NOT NULL,
+    usage_source VARCHAR(16) NOT NULL,
+    reported_fields VARCHAR(255) NOT NULL DEFAULT '',
+    input_tokens_total BIGINT DEFAULT NULL,
+    output_tokens_total BIGINT DEFAULT NULL,
+    reasoning_tokens BIGINT DEFAULT NULL,
+    cache_read_tokens BIGINT DEFAULT NULL,
+    cache_write_tokens BIGINT DEFAULT NULL,
+    payload_bytes BIGINT DEFAULT NULL,
+    payload_tokens_estimated BIGINT DEFAULT NULL,
+    cost_micros BIGINT DEFAULT NULL,
+    request_snapshot TEXT,
+    inconsistencies TEXT,
+    request_at VARCHAR(40) NOT NULL,
+    response_end_at VARCHAR(40) NOT NULL,
+    since_prev_ms BIGINT DEFAULT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+  )`,
+
   `CREATE TABLE IF NOT EXISTS chat_messages (
     id CHAR(36) PRIMARY KEY,
     session_id CHAR(36) NOT NULL,
@@ -578,6 +626,11 @@ async function createIndexes(): Promise<void> {
   await ensureIndex(db, "chat_sessions", "idx_chat_sessions_delegation", "delegation_id");
   // chat_messages
   await ensureIndex(db, "chat_messages", "idx_chat_messages_session", "session_id, created_at");
+  // The three questions this table exists to answer: what did one request cost,
+  // what does a provider/model cost over time, and what does a user consume.
+  await ensureIndex(db, "llm_calls", "idx_llm_calls_session", "session_id, created_at");
+  await ensureIndex(db, "llm_calls", "idx_llm_calls_model", "provider, model_id, created_at");
+  await ensureIndex(db, "llm_calls", "idx_llm_calls_user", "user_id, created_at");
   await ensureIndex(db, "chat_messages", "idx_chat_messages_audit", "role, created_at");
   await ensureIndex(db, "chat_messages", "idx_chat_messages_parent", "parent_session_id, created_at");
   await ensureIndex(db, "chat_messages", "idx_chat_messages_delegation", "delegation_id");

--- a/src/portal/siclaw-api.ts
+++ b/src/portal/siclaw-api.ts
@@ -61,6 +61,7 @@ import { nonTraceOriginPredicate, traceOriginSqlList } from "./session-origin.js
 import { humanPromptPredicate } from "./human-prompt.js";
 import { transcriptVisiblePredicate } from "./transcript-rows.js";
 import { summariseLatency, extractLlmCallMs } from "./metrics-timing.js";
+import { usageByModel, usageByActor, USAGE_SORT_KEYS, type UsageSortKey } from "./llm-usage-repo.js";
 import {
   assembleExporterHeaders,
   maskExporterAuth,
@@ -4084,6 +4085,46 @@ export function registerSiclawRoutes(router: RestRouter, config: SiclawConfig, c
       total: summariseLatency(totalValues),
       tools,
       truncated: aRows.length > TIMING_ROW_LIMIT || tRows.length > TIMING_ROW_LIMIT,
+    });
+  });
+
+  // GET /api/v1/siclaw/metrics/token-usage — token spend per provider × model,
+  // and per actor. Reads the `llm_calls` fact table, NOT message metadata: the
+  // latter never covered sub-agent calls, which is the spend this exists to show.
+  //
+  // The response carries `coverage` alongside every figure, and each field
+  // carries the count of calls that reported it. That is not decoration: sums
+  // over partially-reported data look identical to complete ones, and a page
+  // that cannot see the difference will present a gap as a fact.
+  router.get("/api/v1/siclaw/metrics/token-usage", async (req, res) => {
+    const admin = requireAdmin(req, config.jwtSecret);
+    if (!admin) { sendJson(res, 403, { error: "Forbidden: admin only" }); return; }
+
+    const query = parseQuery(req.url ?? "");
+    const window = resolveWindow(query);
+    if (!window) { sendJson(res, 400, { error: "Invalid time range" }); return; }
+    const limit = Math.min(200, Math.max(1, parseInt(query.limit || "50", 10)));
+    // Ranking metric is server-side because the result is CAPPED: re-sorting a
+    // truncated page in the browser ranks the wrong rows — "top spenders by
+    // cache write" over the top 50 by total is a different list.
+    const sort = USAGE_SORT_KEYS.includes(query.sort as never) ? (query.sort as UsageSortKey) : undefined;
+    const db = getDb();
+    const scope = { from: window.from, to: window.to, limit, sort };
+
+    const [byModel, byActor] = await Promise.all([
+      usageByModel(db, scope),
+      // Skipped when only the model breakdown was asked for — it is the more
+      // expensive of the two (two session joins).
+      query.actors === "0" ? Promise.resolve(null) : usageByActor(db, scope),
+    ]);
+
+    sendJson(res, 200, {
+      from: window.from.toISOString(),
+      to: window.to.toISOString(),
+      sort: sort ?? "billable",
+      models: byModel.groups,
+      actors: byActor?.actors ?? null,
+      coverage: byModel.coverage,
     });
   });
 

--- a/src/shared/llm-call-record.test.ts
+++ b/src/shared/llm-call-record.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveUsageStatus,
+  outputNonReasoningTokens,
+  inputTokensUncached,
+  hasTrustworthyUsage,
+  validateUsageConsistency,
+  USAGE_FIELD_CONTRACTS,
+  type LlmCallRecord,
+  type UsageField,
+} from "./llm-call-record.js";
+
+/** What a healthy standard Responses call reports — note: no cache_write. */
+const RESPONSES_FULL = USAGE_FIELD_CONTRACTS["openai-responses"].required as readonly UsageField[];
+
+describe("resolveUsageStatus", () => {
+  it("marks a full provider report as reported", () => {
+    expect(resolveUsageStatus("openai-responses", RESPONSES_FULL, "provider")).toBe("reported");
+  });
+
+  it("marks a subset of the contract as partial", () => {
+    expect(resolveUsageStatus("openai-responses", ["input", "output"], "provider")).toBe("partial");
+  });
+
+  it("does not demand all five fields of a protocol that reports four", () => {
+    // anthropic-messages has no separate reasoning field; requiring it would
+    // mark every healthy Claude call `partial` forever.
+    expect(resolveUsageStatus("anthropic-messages", ["input", "output", "cache_read", "cache_write"], "provider"))
+      .toBe("reported");
+  });
+
+  it("does not require cache_write from standard Responses", () => {
+    // Standard OpenAI ResponseUsage has no cache-write figure at all. Demanding
+    // one marked every ordinary call `partial`.
+    expect(resolveUsageStatus("openai-responses", ["input", "output", "reasoning", "cache_read"], "provider"))
+      .toBe("reported");
+  });
+
+  it("refuses to judge an api_type it has no contract for", () => {
+    expect(resolveUsageStatus("some-future-api", ["input", "output"], "provider")).toBe("unknown");
+  });
+
+  it("treats the SDK's pre-request placeholder as missing, not as zeros", () => {
+    expect(resolveUsageStatus("openai-responses", [], "sdk_default")).toBe("missing");
+  });
+
+  it("treats a rehydrated record as unknown even when fields look present", () => {
+    // A rebuilt transcript can carry a complete-looking ZERO_USAGE object.
+    expect(resolveUsageStatus("openai-responses", RESPONSES_FULL, "rehydrated")).toBe("unknown");
+  });
+
+  it("treats unmarked history as unknown", () => {
+    expect(resolveUsageStatus("openai-responses", [], "unknown")).toBe("unknown");
+  });
+});
+
+describe("outputNonReasoningTokens", () => {
+  it("subtracts reasoning from the raw output total", () => {
+    expect(outputNonReasoningTokens({ output_tokens_total: 900, reasoning_tokens: 400 })).toBe(500);
+  });
+
+  it("returns null when either input is unknown", () => {
+    expect(outputNonReasoningTokens({ output_tokens_total: null, reasoning_tokens: 400 })).toBeNull();
+    expect(outputNonReasoningTokens({ output_tokens_total: 900, reasoning_tokens: null })).toBeNull();
+  });
+
+  it("keeps a reported zero as a real value, not as unknown", () => {
+    expect(outputNonReasoningTokens({ output_tokens_total: 900, reasoning_tokens: 0 })).toBe(900);
+  });
+});
+
+describe("inputTokensUncached", () => {
+  it("subtracts both cache figures under openai-responses", () => {
+    // That protocol's input_tokens INCLUDES cached and cache-write tokens.
+    expect(inputTokensUncached({
+      api_type: "openai-responses",
+      input_tokens_total: 10_000,
+      cache_read_tokens: 7_000,
+      cache_write_tokens: 1_000,
+    })).toBe(2_000);
+  });
+
+  it("passes the anthropic figure through, since it already excludes cache", () => {
+    expect(inputTokensUncached({
+      api_type: "anthropic-messages",
+      input_tokens_total: 2_000,
+      cache_read_tokens: 7_000,
+      cache_write_tokens: 1_000,
+    })).toBe(2_000);
+  });
+
+  it("returns null for a protocol whose convention is unknown", () => {
+    expect(inputTokensUncached({
+      api_type: "some-future-api",
+      input_tokens_total: 10_000,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    })).toBeNull();
+  });
+
+  it("propagates null rather than treating a missing cache figure as zero", () => {
+    expect(inputTokensUncached({
+      api_type: "openai-responses",
+      input_tokens_total: 10_000,
+      cache_read_tokens: null,
+      cache_write_tokens: 0,
+    })).toBeNull();
+  });
+
+  it("distinguishes a reported cache_read of 0 from an unreported one", () => {
+    const reportedZero = inputTokensUncached({
+      api_type: "openai-responses",
+      input_tokens_total: 500,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    });
+    const unreported = inputTokensUncached({
+      api_type: "openai-responses",
+      input_tokens_total: 500,
+      cache_read_tokens: null,
+      cache_write_tokens: null,
+    });
+    expect(reportedZero).toBe(500);
+    expect(unreported).toBeNull();
+  });
+});
+
+describe("impossible figures are unknown, never clamped to zero", () => {
+  it("reports null when reasoning exceeds output", () => {
+    // Clamping to 0 would assert "no non-reasoning output" as fact and destroy
+    // the only evidence that the two figures disagree.
+    expect(outputNonReasoningTokens({ output_tokens_total: 10, reasoning_tokens: 20 })).toBeNull();
+  });
+
+  it("reports null when cached input exceeds the input total", () => {
+    expect(inputTokensUncached({
+      api_type: "openai-responses",
+      input_tokens_total: 100,
+      cache_read_tokens: 120,
+      cache_write_tokens: 0,
+    })).toBeNull();
+  });
+
+  it("surfaces both contradictions as inconsistencies", () => {
+    const problems = validateUsageConsistency({
+      api_type: "openai-responses",
+      input_tokens_total: 100,
+      output_tokens_total: 10,
+      reasoning_tokens: 20,
+      cache_read_tokens: 120,
+      cache_write_tokens: 0,
+    });
+    expect(problems.map((p) => p.field).sort()).toEqual(["cache_vs_input", "reasoning_vs_output"]);
+  });
+
+  it("reports nothing for internally consistent figures", () => {
+    expect(validateUsageConsistency({
+      api_type: "openai-responses",
+      input_tokens_total: 1_000,
+      output_tokens_total: 500,
+      reasoning_tokens: 200,
+      cache_read_tokens: 800,
+      cache_write_tokens: null,
+    })).toEqual([]);
+  });
+});
+
+describe("extension fields do not poison derivation", () => {
+  it("derives uncached input for standard Responses without any cache_write", () => {
+    // cache_write is an extension there, so its absence means "not applicable",
+    // not "unknown" — treating it as unknown returned null for healthy calls.
+    expect(inputTokensUncached({
+      api_type: "openai-responses",
+      input_tokens_total: 10_000,
+      cache_read_tokens: 7_000,
+      cache_write_tokens: null,
+    })).toBe(3_000);
+  });
+
+  it("still returns null when a REQUIRED cache figure is unreported", () => {
+    expect(inputTokensUncached({
+      api_type: "openai-responses",
+      input_tokens_total: 10_000,
+      cache_read_tokens: null,
+      cache_write_tokens: 1_000,
+    })).toBeNull();
+  });
+});
+
+describe("hasTrustworthyUsage", () => {
+  it("accepts provider-reported records", () => {
+    expect(hasTrustworthyUsage({ usage_status: "reported", usage_source: "provider" })).toBe(true);
+    expect(hasTrustworthyUsage({ usage_status: "partial", usage_source: "provider" })).toBe(true);
+  });
+
+  it("rejects placeholders and rebuilt history", () => {
+    expect(hasTrustworthyUsage({ usage_status: "missing", usage_source: "sdk_default" })).toBe(false);
+    expect(hasTrustworthyUsage({ usage_status: "unknown", usage_source: "rehydrated" })).toBe(false);
+    expect(hasTrustworthyUsage({ usage_status: "unknown", usage_source: "unknown" })).toBe(false);
+  });
+});
+
+// ── The five counter-examples the design is built around ────────────────────
+// Each one makes a naive implementation record a zero it should have recorded
+// as "unknown" — i.e. silently understate spend in exactly the direction that
+// hides the problem we are hunting.
+describe("counter-examples that must not be read as zero usage", () => {
+  const base = {
+    api_type: "openai-responses",
+    input_tokens_total: 0,
+    output_tokens_total: 0,
+    reasoning_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+  } satisfies Pick<LlmCallRecord,
+    "api_type" | "input_tokens_total" | "output_tokens_total" | "reasoning_tokens" | "cache_read_tokens" | "cache_write_tokens">;
+
+  it("1. a call that settled as `stop` but never got usage back", () => {
+    // The stop reason is NOT the discriminator: pi can finish normally while the
+    // provider reported nothing, leaving its pre-request zeros in place.
+    const status = resolveUsageStatus(base.api_type, [], "sdk_default");
+    expect(status).toBe("missing");
+    expect(hasTrustworthyUsage({ usage_status: status, usage_source: "sdk_default" })).toBe(false);
+  });
+
+  it("2. initialisation zeros left behind by a failed or aborted call", () => {
+    const status = resolveUsageStatus(base.api_type, [], "sdk_default");
+    expect(status).toBe("missing");
+  });
+
+  it("3. history rebuilt without any handoff (eviction / missing local history)", () => {
+    const status = resolveUsageStatus(base.api_type, RESPONSES_FULL, "rehydrated");
+    expect(status).toBe("unknown");
+  });
+
+  it("4. rebuilt and real calls coexisting in one session are judged per record", () => {
+    const rebuilt = resolveUsageStatus(base.api_type, RESPONSES_FULL, "rehydrated");
+    const real = resolveUsageStatus(base.api_type, RESPONSES_FULL, "provider");
+    expect(rebuilt).toBe("unknown");
+    expect(real).toBe("reported");
+  });
+
+  it("5. an explicitly reported cache_read of 0 stays a real zero", () => {
+    const status = resolveUsageStatus(base.api_type, RESPONSES_FULL, "provider");
+    expect(status).toBe("reported");
+    expect(hasTrustworthyUsage({ usage_status: status, usage_source: "provider" })).toBe(true);
+    // and it survives derivation rather than collapsing to null
+    expect(inputTokensUncached({ ...base, input_tokens_total: 120 })).toBe(120);
+  });
+});

--- a/src/shared/llm-call-record.ts
+++ b/src/shared/llm-call-record.ts
@@ -1,0 +1,548 @@
+/**
+ * One measured LLM call — the P0 metering record.
+ *
+ * Design contract (see docs/design/2026-09-12-token-cost-analysis.zh-CN.md §7.8.2b):
+ *
+ *   Provenance is RECORDED AT THE POINT OF PRODUCTION, never inferred afterwards.
+ *
+ * That rule exists because four different code paths can produce an all-zero
+ * usage object, and they are indistinguishable once written:
+ *
+ *   1. pi initialises `usage` to all-zero BEFORE the request leaves
+ *      (`openai-responses.js:94-101`, stopReason "pending" at that moment) — and a
+ *      call that never gets usage back can still settle as `stop`, so the stop
+ *      reason does not identify it.
+ *   2. A rehydrated transcript fills `ZERO_USAGE` (`session-rehydrate.ts`). This is
+ *      NOT only a handoff path: eviction, or simply missing local history after a
+ *      pod restart, rebuilds from the control plane too — and rebuilt messages can
+ *      sit in the same session as later real calls, so a per-SESSION verdict is
+ *      always wrong. Marking is per-record.
+ *   3. `Math.max(0, …)` clamping of a derived input figure
+ *      (`openai-responses-shared.js:445`).
+ *   4. A genuine zero — `cache_read = 0` is a perfectly ordinary answer.
+ *
+ * Hence `null` and `0` mean different things here and must never be folded
+ * together: `0` is a reported zero, `null` is "not reported".
+ *
+ * WHERE `reported_fields` MUST COME FROM
+ * -------------------------------------
+ * From observing the provider's RAW response, not from pi's normalised `usage`.
+ * Two reasons, both measured rather than reasoned:
+ *
+ *   - pi's `Usage` declares input/output/cacheRead/cacheWrite as REQUIRED and
+ *     zero-fills them before the request goes out, so "reported 0" and "never
+ *     reported" are identical at the streamFn boundary.
+ *   - `reasoning?` is optional in the type, and its doc comment says providers
+ *     that do not report it leave it undefined — but a fixture reporting only
+ *     `input_tokens=17` came back with reasoning set to `0`. The optionality is
+ *     NOT a usable signal; deriving provenance from it would misreport.
+ *
+ * The supported path is a per-call `options.fetch` (a public pi input) that
+ * observes the raw SSE bytes and passes them through untouched. A transport not
+ * yet wired that way records `unknown` rather than a guess.
+ *
+ * A derived figure that comes out impossible (reasoning > output, cache > input)
+ * is reported as `null` plus a `UsageInconsistency`, never clamped to 0 — the
+ * clamp is precisely how the upstream adapter loses the same evidence.
+ */
+
+/** How complete the provider's usage report was for this call. */
+export type UsageStatus =
+  /** Every field this API is contracted to report was present. */
+  | "reported"
+  /** Some contracted fields present, others absent. */
+  | "partial"
+  /** The provider reported nothing; what is stored is an SDK placeholder. */
+  | "missing"
+  /** Provenance could not be established — never treat as zero. */
+  | "unknown";
+
+/** Where the usage numbers on this record came from. */
+export type UsageSource =
+  /** Read off the provider's response. */
+  | "provider"
+  /** The SDK's pre-request zero object; the provider never reported. */
+  | "sdk_default"
+  /** Reconstructed from the control plane; original record no longer exists. */
+  | "rehydrated"
+  /** Historical record with no provenance marker. */
+  | "unknown";
+
+/** Usage fields a provider may report. `reported_fields` holds the subset actually seen. */
+export type UsageField =
+  | "input"
+  | "output"
+  | "reasoning"
+  | "cache_read"
+  | "cache_write";
+
+/**
+ * What each wire protocol is contracted to report.
+ *
+ * `required` — present on a healthy response from that API. A missing one means
+ *   the report really is incomplete.
+ * `extension` — NOT part of the standard response shape; some compatible
+ *   implementations add it. Absent means "does not apply here", which is a
+ *   different thing from "unknown", and must not drag a healthy call to
+ *   `partial` or poison a derivation.
+ *
+ * Deliberately NOT "all five for everybody": standard OpenAI `ResponseUsage`
+ * has no cache-write figure at all, so requiring one marks every ordinary
+ * Responses call `partial`. An api_type absent from this table yields `unknown`
+ * rather than a guess — see `resolveUsageStatus`.
+ *
+ * Correct these against observed traffic; do not extend speculatively.
+ */
+export interface UsageFieldContract {
+  required: readonly UsageField[];
+  extension: readonly UsageField[];
+}
+
+export const USAGE_FIELD_CONTRACTS: Readonly<Record<string, UsageFieldContract>> = {
+  // Standard ResponseUsage: input_tokens, input_tokens_details.cached_tokens,
+  // output_tokens, output_tokens_details.reasoning_tokens. No cache-write field —
+  // pi reads one only because Anthropic-compatible gateways may supply it.
+  "openai-responses": {
+    required: ["input", "output", "reasoning", "cache_read"],
+    extension: ["cache_write"],
+  },
+  // anthropic-messages.js:409-413 reads input_tokens, cache_read_input_tokens,
+  // cache_creation_input_tokens and output. Reasoning is not a separate field.
+  "anthropic-messages": {
+    required: ["input", "output", "cache_read", "cache_write"],
+    extension: [],
+  },
+  "openai-completions": {
+    required: ["input", "output"],
+    // cache_write must appear even though this protocol never sends one:
+    // omitting it left the field neither required nor an extension, so an absent
+    // value read as "unknown" and returned null from every derivation on an
+    // otherwise healthy call.
+    extension: ["cache_read", "cache_write"],
+  },
+};
+
+/**
+ * What a correlation id can hold — `root_request_id` and `parent_call_id`, both
+ * VARCHAR(64).
+ *
+ * A turn id is normally a UUID, but it is caller-supplied at the Runtime
+ * boundary, so an over-long one is possible. The producer stores NULL rather than
+ * a prefix: a truncated id would silently join calls from different requests,
+ * which is worse than admitting we could not carry the correlation. Losing a
+ * correlation must never cost the measurement itself.
+ */
+export const MAX_CORRELATION_ID_LENGTH = 64;
+
+/**
+ * Which part of the product spent this call.
+ *
+ * A CLOSED registry, not a free string, for the reason `session-origin.ts`
+ * documents from experience: a second spelling of the same workload splits an
+ * aggregate SILENTLY — the total still adds up, one bucket is just short, and
+ * nothing errors. Adding a workload is an edit HERE, which is a compile error
+ * at every producer rather than a comment nobody reads.
+ *
+ * It is carried by the PRODUCER and never derived at the receiver. Session
+ * origin answers this only for calls that HAVE a session; a compile box or any
+ * other non-conversational caller arrives with no session identity at all, and
+ * the receiver has no way to tell a knowledge compile from a feedback
+ * classification.
+ *
+ * `unattributed` is a real member, not a default to fall into: a producer that
+ * has not been taught its workload must be VISIBLE as such. Folding it into
+ * `conversation` would let a whole new subsystem show up as conversation growth.
+ */
+export const LLM_WORKLOADS = [
+  "conversation",
+  "analysis",
+  "knowledge_compile",
+  "unattributed",
+] as const;
+
+export type LlmWorkload = (typeof LLM_WORKLOADS)[number];
+
+export function isLlmWorkload(value: unknown): value is LlmWorkload {
+  return typeof value === "string" && (LLM_WORKLOADS as readonly string[]).includes(value);
+}
+
+/** Snapshot of the request as sent — the evidence cache and pruning checks read. */
+export interface LlmRequestSnapshot {
+  /**
+   * Value sent as `prompt_cache_key`.
+   *
+   * ABSENT (undefined) = the request was never inspected.
+   * `null` = inspected, and the field was not present.
+   * These are different facts; conflating them would let "we did not look" read
+   * as "the runtime sent no cache key".
+   */
+  prompt_cache_key?: string | null;
+  /**
+   * Which cache-retention shape actually went out.
+   *
+   * ABSENT = not inspected. `null` = inspected and NEITHER field was sent, which
+   * is the ordinary case for pi's default `short`.
+   */
+  cache_retention_sent?: "none" | "24h" | "ttl_30m" | null;
+  /** Thinking level, max tokens, and anything else that changes request shape. */
+  model_settings: Record<string, unknown>;
+  /** null = the sent request carried no system prompt (distinct from unknown). */
+  system_sha256: string | null;
+  tools_sha256: string;
+  /**
+   * Fingerprint of the history prefix as sent. A change here between adjacent
+   * calls of one prompt is what distinguishes "history was rewritten/pruned"
+   * from "history merely grew".
+   */
+  history_prefix_sha256: string;
+  history_message_count: number;
+  /**
+   * Hash of the complete serialized request body as sent.
+   *
+   * The definitive cache-stability signal: `system_sha256` and `tools_sha256`
+   * are derived from the SDK's input context, which `onPayload` can still
+   * rewrite. When present, these fields describe the ACTUAL request; absent
+   * means the body could not be inspected. Hashes only — no content is stored.
+   */
+  payload_sha256?: string;
+}
+
+export interface LlmCallRecord {
+  /** Contradictions found among the reported figures; empty when consistent. */
+  inconsistencies?: UsageInconsistency[];
+
+  // ── Identity ──────────────────────────────────────────────────────────────
+  /**
+   * Stable id for ONE real call's lifecycle. Delivery retries deduplicate on it.
+   * Not derivable from round/attempt: `round` restarts per prompt and is 0 for
+   * aux calls, so those two cannot identify a call.
+   */
+  call_id: string;
+  session_id: string;
+  /** One accepted prompt execution — spans its agent rounds, aux calls and route retries. */
+  prompt_id: string;
+  /** Root request, linking a parent and the sub-agents it spawned. */
+  root_request_id: string | null;
+  /** The call that spawned this sub-agent, when this record belongs to one. */
+  parent_call_id: string | null;
+
+  /**
+   * Which part of the product spent this. See {@link LLM_WORKLOADS} for why it
+   * is a closed set and why it travels with the producer.
+   */
+  workload: LlmWorkload;
+
+  // ── Classification (diagnostic only — never used as identity) ─────────────
+  kind: "agent" | "aux";
+  /** 1-based within the prompt; 0 for aux. Resets every prompt. */
+  round: number;
+  /** Model-routing attempt. */
+  attempt: number;
+  /** Transport-level retries folded into this call; they do NOT mint new call_ids. */
+  network_attempts: number;
+
+  // ── Model ─────────────────────────────────────────────────────────────────
+  provider: string;
+  model_id: string;
+  api_type: string;
+
+  // ── Usage — provider values as reported, never normalised ─────────────────
+  usage_status: UsageStatus;
+  usage_source: UsageSource;
+  reported_fields: UsageField[];
+  /**
+   * Provider's raw input figure. NOTE the protocols disagree on what it covers:
+   * under openai-responses it INCLUDES cached and cache-write tokens, under
+   * anthropic-messages it does not. Store raw; derive with `inputTokensUncached`.
+   */
+  input_tokens_total: number | null;
+  /** Provider's raw output figure — includes reasoning where the protocol nests it. */
+  output_tokens_total: number | null;
+  reasoning_tokens: number | null;
+  cache_read_tokens: number | null;
+  cache_write_tokens: number | null;
+
+  // ── Request measurement — three separate yardsticks, none substitutes ─────
+  /** Bytes actually put on the wire. */
+  payload_bytes: number | null;
+  /** Local estimate, for budgeting only. */
+  payload_tokens_estimated: number | null;
+  request_snapshot: LlmRequestSnapshot;
+
+  // ── Timing ────────────────────────────────────────────────────────────────
+  request_at: string;
+  response_end_at: string;
+  /** For round 1 this is setup time, NOT the gap since the user's last message. */
+  since_prev_ms: number | null;
+
+  // ── Attribution ───────────────────────────────────────────────────────────
+  org_id: string;
+  user_id: string | null;
+  agent_id: string;
+  agent_type: string;
+  session_origin: string;
+
+  /** Left null for P0: unit prices are unverified, and a wrong price is worse than none. */
+  cost_micros: null;
+}
+
+/**
+ * Decide `usage_status` from what the provider actually reported.
+ *
+ * `reported` requires every field this api_type is contracted to report — not
+ * all five, since no protocol reports all five. An unknown api_type cannot be
+ * judged, so it stays `unknown` instead of being guessed into `reported`.
+ *
+ * An EMPTY `reported_fields` cannot separate `missing` from `unknown` on its
+ * own, which is exactly why `source` is a required argument here.
+ */
+export function resolveUsageStatus(apiType: string, reported: readonly UsageField[], source: UsageSource): UsageStatus {
+  if (source === "rehydrated" || source === "unknown") return "unknown";
+  if (source === "sdk_default") return "missing";
+  const contract = USAGE_FIELD_CONTRACTS[apiType];
+  if (!contract) return "unknown";
+  if (reported.length === 0) return "missing";
+  const seen = new Set(reported);
+  // Only `required` decides completeness. An absent extension field means the
+  // API has no such concept, not that the report is short.
+  return contract.required.every((field) => seen.has(field)) ? "reported" : "partial";
+}
+
+/** A usage figure that contradicts another — kept as evidence, never silently clamped. */
+export interface UsageInconsistency {
+  field: "reasoning_vs_output" | "cache_vs_input";
+  detail: string;
+}
+
+/**
+ * Report figures that cannot both be true.
+ *
+ * Callers persist these alongside the record. The point is that an impossible
+ * pair is a DATA QUALITY signal; folding it to zero (as `Math.max(0, …)` would)
+ * destroys the only evidence that something upstream is wrong — the same
+ * failure mode we already catalogued in pi's own adapter.
+ */
+export function validateUsageConsistency(
+  record: Pick<LlmCallRecord,
+    "api_type" | "input_tokens_total" | "output_tokens_total" | "reasoning_tokens" | "cache_read_tokens" | "cache_write_tokens">,
+): UsageInconsistency[] {
+  const problems: UsageInconsistency[] = [];
+  const { output_tokens_total: output, reasoning_tokens: reasoning } = record;
+  if (output !== null && reasoning !== null && reasoning > output) {
+    problems.push({
+      field: "reasoning_vs_output",
+      detail: `reasoning ${reasoning} exceeds output ${output}; reasoning is a subset of output`,
+    });
+  }
+  // Only meaningful where the protocol counts cache INSIDE the input total.
+  // Under anthropic-messages it does not, so cache_read far exceeding input is
+  // ordinary (a large cached prefix with a short new turn) and flagging it would
+  // manufacture a data-quality alert out of a healthy call.
+  if (cacheCountsInsideInput(record.api_type)) {
+    const cached = cacheChargedAgainstInput(record);
+    const { input_tokens_total: input } = record;
+    if (input !== null && cached !== null && cached > input) {
+      problems.push({
+        field: "cache_vs_input",
+        detail: `cached ${cached} exceeds input total ${input}`,
+      });
+    }
+  }
+  return problems;
+}
+
+/**
+ * Whether this protocol's `input_tokens` INCLUDES the cache figures.
+ *
+ * openai-responses does (pi subtracts them back out); anthropic-messages reports
+ * input exclusive of cache. Getting this backwards either invents impossible
+ * readings or hides real ones.
+ */
+export function cacheCountsInsideInput(apiType: string): boolean {
+  return apiType === "openai-responses" || apiType === "openai-completions";
+}
+
+/**
+ * Tokens the provider actually charged for, from one api_type's field sums.
+ *
+ * Exists because "total tokens" is NOT the same arithmetic across protocols:
+ * under openai-responses the cache figures are already INSIDE `input`, under
+ * anthropic-messages they are not. Summing the five columns uniformly
+ * double-counts every cached token on one protocol and undercounts on the
+ * other — which is why an aggregate must group by api_type and call this per
+ * group, rather than express the rule a second time in SQL.
+ *
+ * `null` when a component this protocol requires was never reported: the answer
+ * is then unknown, and a plausible-looking number would be worse than a gap.
+ * An unreported EXTENSION field contributes 0 (the API has no such concept).
+ */
+export function billableTokens(
+  apiType: string,
+  sums: {
+    input: number | null;
+    output: number | null;
+    cacheRead: number | null;
+    cacheWrite: number | null;
+  },
+): number | null {
+  const contract = USAGE_FIELD_CONTRACTS[apiType];
+  if (!contract) return null; // unknown convention — do not guess at the shape
+  if (sums.input === null || sums.output === null) return null;
+  if (cacheCountsInsideInput(apiType)) return sums.input + sums.output;
+  const part = (field: UsageField, value: number | null): number | null =>
+    value !== null ? value : (contract.extension.includes(field) ? 0 : null);
+  const read = part("cache_read", sums.cacheRead);
+  const write = part("cache_write", sums.cacheWrite);
+  if (read === null || write === null) return null;
+  return sums.input + sums.output + read + write;
+}
+
+/**
+ * Cache tokens that this protocol counts INSIDE `input_tokens_total`.
+ * Returns null when a required component is unreported; an inapplicable
+ * extension field contributes 0 rather than making the whole sum unknown.
+ */
+function cacheChargedAgainstInput(
+  record: Pick<LlmCallRecord, "api_type" | "cache_read_tokens" | "cache_write_tokens">,
+): number | null {
+  const contract = USAGE_FIELD_CONTRACTS[record.api_type];
+  if (!contract) return null;
+  const part = (field: UsageField, value: number | null): number | null => {
+    if (value !== null) return value;
+    // Unreported but merely an extension of this API ⇒ not applicable ⇒ 0.
+    return contract.extension.includes(field) ? 0 : null;
+  };
+  const read = part("cache_read", record.cache_read_tokens);
+  const write = part("cache_write", record.cache_write_tokens);
+  if (read === null || write === null) return null;
+  return read + write;
+}
+
+/**
+ * Output tokens excluding reasoning.
+ *
+ * Under Responses `reasoning` is a SUBSET of output, so the two must never be
+ * summed. Deriving it here — rather than documenting "do not add these" — is
+ * what keeps every consumer from having to remember the rule.
+ */
+export function outputNonReasoningTokens(
+  record: Pick<LlmCallRecord, "output_tokens_total" | "reasoning_tokens">,
+): number | null {
+  const { output_tokens_total: total, reasoning_tokens: reasoning } = record;
+  if (total === null || reasoning === null) return null;
+  const remainder = total - reasoning;
+  // A negative remainder means the two figures contradict each other. Clamping
+  // it to 0 would present a fabricated number as fact and hide the conflict —
+  // surface it as unknown and let `validateUsageConsistency` carry the evidence.
+  return remainder < 0 ? null : remainder;
+}
+
+/**
+ * Input tokens that were NOT served from cache.
+ *
+ * Protocol-dependent by necessity (see `input_tokens_total`). An api_type whose
+ * convention is unknown returns null rather than assuming either shape — picking
+ * wrong here silently mis-sizes every cost figure downstream.
+ */
+export function inputTokensUncached(
+  record: Pick<LlmCallRecord, "api_type" | "input_tokens_total" | "cache_read_tokens" | "cache_write_tokens">,
+): number | null {
+  const { api_type: apiType, input_tokens_total: total } = record;
+  if (total === null) return null;
+  if (apiType === "anthropic-messages") return total; // already excludes cache
+  if (!USAGE_FIELD_CONTRACTS[apiType]) return null;   // unknown convention — do not guess
+  const cached = cacheChargedAgainstInput(record);
+  if (cached === null) return null;
+  const uncached = total - cached;
+  // Same rule as above: an impossible split is unknown, not zero.
+  return uncached < 0 ? null : uncached;
+}
+
+/**
+ * The part of a record the runtime core can fill in on its own.
+ *
+ * Core produces this as a structured event and hands it over; attribution
+ * (org/user/agent/session) is added by the layer that owns those identities, and
+ * persistence happens there too — core never writes to a database.
+ */
+export type LlmCallMeasurement = Omit<
+  LlmCallRecord,
+  | "session_id" | "org_id" | "user_id" | "agent_id" | "agent_type"
+  | "session_origin" | "root_request_id" | "parent_call_id" | "workload"
+> & {
+  /**
+   * Which part of the product spent this call. Optional on the WIRE so an older
+   * box keeps working; absent is stored as `unattributed`, never as
+   * `conversation` — see {@link LLM_WORKLOADS}.
+   */
+  workload?: LlmWorkload;
+  /**
+   * The LLM call that spawned this sub-agent, when this record belongs to one.
+   *
+   * Like `root_request_id`, carried by the PRODUCER: the receiver can see that a
+   * child session exists but not WHICH of the parent's calls dispatched it, and
+   * neither a tool-call id (it names the invocation, not the call that emitted
+   * it) nor session lineage can answer that. Absent on an older box ⇒ null.
+   */
+  parent_call_id?: string | null;
+  /** Contradictions found in the reported figures; empty when consistent. */
+  inconsistencies: UsageInconsistency[];
+  /**
+   * The user request this call serves, when the producer knows it.
+   *
+   * Carried by the PRODUCER rather than derived at the receiver: only the box
+   * knows which turn a call belongs to, and a sub-agent inherits its parent's
+   * value so one request's main and child calls share an id. Absent on an older
+   * box — the receiver then stores null rather than inventing a correlation.
+   */
+  root_request_id?: string | null;
+};
+
+/**
+ * Attribution the runtime adds to complete a record.
+ *
+ * Separate because core genuinely does not know these: a recorder sits at the
+ * provider boundary and has no session, tenant or agent identity in hand.
+ */
+export interface LlmCallAttribution {
+  session_id: string;
+  org_id: string;
+  user_id: string | null;
+  agent_id: string;
+  agent_type: string;
+  session_origin: string;
+  root_request_id: string | null;
+  parent_call_id: string | null;
+}
+
+/**
+ * One delivery of measurements from a box to the Runtime.
+ *
+ * Batched because a turn settles several calls in quick succession, and keyed on
+ * `call_id` at the receiving end so a redelivery after a lost response cannot
+ * double-count — the measurement itself carries no "already sent" state.
+ */
+export interface LlmCallMeasurementBatch {
+  session_id: string;
+  measurements: LlmCallMeasurement[];
+}
+
+/** Join a core measurement with the attribution only the runtime knows. */
+export function completeLlmCallRecord(
+  measurement: LlmCallMeasurement,
+  attribution: LlmCallAttribution,
+): LlmCallRecord {
+  // Inconsistencies are carried through, not dropped: they are the evidence
+  // that a figure cannot be trusted, and discarding them at the join would
+  // leave a record that looks clean while its numbers contradict each other.
+  // Absent workload becomes `unattributed`, matching the persist path. Both
+  // join sites must agree, or a record read through one looks conversational
+  // and through the other does not.
+  return { workload: "unattributed", ...measurement, ...attribution };
+}
+
+/** True when this record carries provider-reported numbers safe to aggregate. */
+export function hasTrustworthyUsage(record: Pick<LlmCallRecord, "usage_status" | "usage_source">): boolean {
+  return record.usage_source === "provider" &&
+    (record.usage_status === "reported" || record.usage_status === "partial");
+}

--- a/src/shared/llm-call-validation.test.ts
+++ b/src/shared/llm-call-validation.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import { validateMeasurementBatch, validateMeasurement, MAX_MEASUREMENTS_PER_BATCH } from "./llm-call-validation.js";
+
+const valid = () => ({
+  call_id: "c1", prompt_id: "p1", kind: "agent",
+  round: 1, attempt: 1, network_attempts: 1,
+  provider: "example-gateway", model_id: "gpt-5", api_type: "openai-responses",
+  usage_status: "reported", usage_source: "provider",
+  // A COMPLETE openai-responses report: the contract requires all four.
+  reported_fields: ["input", "output", "reasoning", "cache_read"],
+  input_tokens_total: 10, output_tokens_total: 5,
+  reasoning_tokens: 0, cache_read_tokens: 0, cache_write_tokens: null,
+  payload_bytes: 100, payload_tokens_estimated: 25,
+  request_snapshot: { system_sha256: "s", tools_sha256: "t", history_prefix_sha256: "h", history_message_count: 1, model_settings: {} },
+  request_at: "2026-09-13T00:00:00.000Z", response_end_at: "2026-09-13T00:00:01.000Z",
+  since_prev_ms: null, cost_micros: null,
+});
+
+describe("validateMeasurement", () => {
+  it("accepts a well-formed measurement", () => {
+    expect(validateMeasurement(valid())).toBeNull();
+  });
+
+  it("accepts an all-null record when nothing claims to have been reported", () => {
+    // The honest shape of "we could not observe this call".
+    expect(validateMeasurement({
+      ...valid(),
+      usage_status: "unknown", usage_source: "unknown", reported_fields: [],
+      input_tokens_total: null, output_tokens_total: null, reasoning_tokens: null,
+      cache_read_tokens: null, cache_write_tokens: null,
+      payload_bytes: null, payload_tokens_estimated: null,
+    })).toBeNull();
+  });
+
+  it("refuses the false-trustworthy-zero shape", () => {
+    // provider + reported + nothing named + all zeros: individually well-typed,
+    // collectively impossible, and `hasTrustworthyUsage` would have banked it.
+    expect(validateMeasurement({
+      ...valid(),
+      usage_status: "reported", usage_source: "provider", reported_fields: [],
+      input_tokens_total: 0, output_tokens_total: 0, reasoning_tokens: 0,
+      cache_read_tokens: 0, cache_write_tokens: 0,
+    })).toMatch(/at least one reported field/);
+  });
+
+  it("refuses a reported status whose source is not the provider", () => {
+    expect(validateMeasurement({ ...valid(), usage_status: "reported", usage_source: "rehydrated" }))
+      .toMatch(/requires usage_source=provider/);
+  });
+
+  it("validates every status, not only `reported`", () => {
+    // `provider + [input]` filed as `missing` asserts the provider said nothing
+    // about a call where it demonstrably spoke.
+    expect(validateMeasurement({
+      ...valid(), usage_status: "missing", reported_fields: ["input"],
+      output_tokens_total: null, reasoning_tokens: null, cache_read_tokens: null,
+    })).toMatch(/contradicts/);
+    // An unreadable-stream evidence row filed as `missing` makes the same claim.
+    expect(validateMeasurement({
+      ...valid(), usage_status: "missing", usage_source: "unknown", reported_fields: [],
+      input_tokens_total: 100, output_tokens_total: null, reasoning_tokens: null,
+      cache_read_tokens: null, cache_write_tokens: null,
+    })).toMatch(/contradicts/);
+  });
+
+  it("refuses a field named as reported but carrying no value", () => {
+    expect(validateMeasurement({ ...valid(), reported_fields: ["input", "output", "reasoning", "cache_read", "cache_write"] }))
+      .toMatch(/cache_write is in reported_fields/);
+  });
+
+  it("refuses `reported` that does not satisfy the protocol contract", () => {
+    // Responses requires input+output+reasoning+cache_read; naming only two and
+    // calling it complete is how a partial report gets banked as a full one.
+    expect(validateMeasurement({
+      ...valid(), reported_fields: ["input", "output"], reasoning_tokens: null, cache_read_tokens: null,
+    })).toMatch(/contradicts the openai-responses contract/);
+  });
+
+  it("accepts the observer's evidence row: values kept, read marked untrustworthy", () => {
+    // A stream that broke part-way. The producer keeps what it read and marks it
+    // `unknown`; rejecting this made the receiver refuse the whole batch.
+    expect(validateMeasurement({
+      ...valid(),
+      usage_status: "unknown", usage_source: "unknown", reported_fields: [],
+      input_tokens_total: 100, output_tokens_total: null, reasoning_tokens: null,
+      cache_read_tokens: null, cache_write_tokens: null,
+    })).toBeNull();
+  });
+
+
+
+  it("refuses a numeric-looking STRING rather than coercing it", () => {
+    // Coercion is how an unknown quietly becomes a number; this endpoint must
+    // never be the place that invents a value.
+    expect(validateMeasurement({ ...valid(), input_tokens_total: "10" })).toMatch(/input_tokens_total/);
+  });
+
+  it("refuses NaN, Infinity and negative counts", () => {
+    expect(validateMeasurement({ ...valid(), output_tokens_total: NaN })).toMatch(/output_tokens_total/);
+    expect(validateMeasurement({ ...valid(), output_tokens_total: Infinity })).toMatch(/output_tokens_total/);
+    expect(validateMeasurement({ ...valid(), output_tokens_total: -1 })).toMatch(/output_tokens_total/);
+  });
+
+  it("refuses an undefined token field, which is not the same as null", () => {
+    const m: Record<string, unknown> = valid();
+    delete m.input_tokens_total;
+    expect(validateMeasurement(m)).toMatch(/input_tokens_total/);
+  });
+
+  it("refuses unknown enum values", () => {
+    expect(validateMeasurement({ ...valid(), usage_status: "probably" })).toMatch(/usage_status/);
+    expect(validateMeasurement({ ...valid(), usage_source: "vibes" })).toMatch(/usage_source/);
+    expect(validateMeasurement({ ...valid(), kind: "other" })).toMatch(/kind/);
+    expect(validateMeasurement({ ...valid(), reported_fields: ["input", "made_up"] })).toMatch(/reported_fields/);
+  });
+
+  it("refuses a priced row — P0 stores no cost", () => {
+    expect(validateMeasurement({ ...valid(), cost_micros: 1234 })).toMatch(/cost_micros/);
+  });
+
+  it("requires the identifiers a row cannot be filed without", () => {
+    expect(validateMeasurement({ ...valid(), call_id: "" })).toMatch(/call_id/);
+    expect(validateMeasurement({ ...valid(), prompt_id: "" })).toMatch(/prompt_id/);
+  });
+});
+
+describe("the optional request correlation", () => {
+  it("accepts absent, null and an id — an older box must keep working", () => {
+    expect(validateMeasurement(valid())).toBeNull();
+    expect(validateMeasurement({ ...valid(), root_request_id: null })).toBeNull();
+    expect(validateMeasurement({ ...valid(), root_request_id: "turn-abc" })).toBeNull();
+  });
+
+  it("refuses a value the column cannot hold, rather than letting it be truncated", () => {
+    // A silently shortened id would correlate calls from different requests.
+    expect(validateMeasurement({ ...valid(), root_request_id: "x".repeat(65) })).toMatch(/root_request_id/);
+  });
+
+  it("refuses an empty string — neither an id nor an absence", () => {
+    expect(validateMeasurement({ ...valid(), root_request_id: "" })).toMatch(/root_request_id/);
+    expect(validateMeasurement({ ...valid(), root_request_id: 7 })).toMatch(/root_request_id/);
+  });
+
+  it("holds parent_call_id to the same rules, and names the offending field", () => {
+    expect(validateMeasurement({ ...valid(), parent_call_id: null })).toBeNull();
+    expect(validateMeasurement({ ...valid(), parent_call_id: "call-1" })).toBeNull();
+    expect(validateMeasurement({ ...valid(), parent_call_id: "" })).toMatch(/parent_call_id/);
+    expect(validateMeasurement({ ...valid(), parent_call_id: "x".repeat(65) })).toMatch(/parent_call_id/);
+  });
+});
+
+describe("the workload tag", () => {
+  it("accepts absent and every registered value", () => {
+    expect(validateMeasurement(valid())).toBeNull();
+    for (const workload of ["conversation", "analysis", "knowledge_compile", "unattributed"]) {
+      expect(validateMeasurement({ ...valid(), workload })).toBeNull();
+    }
+  });
+
+  it("refuses an unregistered value instead of storing it", () => {
+    // A second spelling splits an aggregate silently: the total still adds up,
+    // one bucket is short, and nothing errors. Refusing at the boundary is the
+    // only place that shows up.
+    expect(validateMeasurement({ ...valid(), workload: "kb-compile" })).toMatch(/workload/);
+    expect(validateMeasurement({ ...valid(), workload: "" })).toMatch(/workload/);
+    expect(validateMeasurement({ ...valid(), workload: 3 })).toMatch(/workload/);
+  });
+
+  it("names the registered values, so a rejected producer can be fixed", () => {
+    expect(validateMeasurement({ ...valid(), workload: "nope" })).toContain("knowledge_compile");
+  });
+});
+
+describe("validateMeasurementBatch", () => {
+  it("accepts a batch and hands back the typed value", () => {
+    const result = validateMeasurementBatch({ session_id: "s1", measurements: [valid()] });
+    expect(result.ok).toBe(true);
+    expect(result.batch?.measurements).toHaveLength(1);
+  });
+
+  it("refuses a batch without a session", () => {
+    expect(validateMeasurementBatch({ measurements: [valid()] }).error).toMatch(/session_id/);
+  });
+
+  it("refuses an oversized batch instead of truncating it", () => {
+    const measurements = Array.from({ length: MAX_MEASUREMENTS_PER_BATCH + 1 }, () => valid());
+    expect(validateMeasurementBatch({ session_id: "s1", measurements }).error).toMatch(/at most/);
+  });
+
+  it("names the offending index so a skewed sender is diagnosable", () => {
+    const result = validateMeasurementBatch({
+      session_id: "s1",
+      measurements: [valid(), { ...valid(), usage_status: "nope" }],
+    });
+    expect(result.error).toMatch(/measurements\[1\]/);
+  });
+
+  it("refuses an empty batch and a non-object body", () => {
+    expect(validateMeasurementBatch({ session_id: "s1", measurements: [] }).ok).toBe(false);
+    expect(validateMeasurementBatch(null).ok).toBe(false);
+    expect(validateMeasurementBatch("{}").ok).toBe(false);
+  });
+});

--- a/src/shared/llm-call-validation.ts
+++ b/src/shared/llm-call-validation.ts
@@ -1,0 +1,192 @@
+/**
+ * Wire contract for the metering endpoint, shared by sender and receiver.
+ *
+ * The receiver cannot trust the shape it is handed — a box runs a different
+ * image version than the Runtime for the whole duration of a rollout — so every
+ * field is checked here rather than cast.
+ *
+ * The validation rule that matters: a token field is accepted ONLY as a finite
+ * non-negative number or `null`. Anything else (a string, NaN, undefined) is
+ * rejected rather than coerced, because coercion is how an unknown quietly
+ * becomes a zero — the exact confusion the whole record type exists to prevent.
+ */
+
+import { LLM_WORKLOADS, MAX_CORRELATION_ID_LENGTH, isLlmWorkload, resolveUsageStatus } from "./llm-call-record.js";
+import type { LlmCallMeasurement, UsageField, UsageSource, UsageStatus } from "./llm-call-record.js";
+
+export const LLM_CALL_MEASUREMENTS_PATH = "/api/internal/llm-call-measurements";
+
+/** Cap per delivery; a larger batch is rejected rather than silently truncated. */
+export const MAX_MEASUREMENTS_PER_BATCH = 64;
+
+const USAGE_STATUSES: readonly UsageStatus[] = ["reported", "partial", "missing", "unknown"];
+const USAGE_SOURCES: readonly UsageSource[] = ["provider", "sdk_default", "rehydrated", "unknown"];
+const USAGE_FIELDS: readonly UsageField[] = ["input", "output", "reasoning", "cache_read", "cache_write"];
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: string;
+  batch?: { session_id: string; measurements: LlmCallMeasurement[] };
+}
+
+const isNonEmptyString = (v: unknown): v is string => typeof v === "string" && v.length > 0;
+
+/** A token count: finite, non-negative, or explicitly unknown. Never coerced. */
+function isTokenValue(v: unknown): v is number | null {
+  if (v === null) return true;
+  return typeof v === "number" && Number.isFinite(v) && v >= 0;
+}
+
+function isCount(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v >= 0;
+}
+
+/** Validate one delivery. Returns the typed batch, or the first reason it was refused. */
+export function validateMeasurementBatch(body: unknown): ValidationResult {
+  if (!body || typeof body !== "object") return { ok: false, error: "body must be an object" };
+  const b = body as Record<string, unknown>;
+  if (!isNonEmptyString(b.session_id)) return { ok: false, error: "session_id is required" };
+  if (!Array.isArray(b.measurements)) return { ok: false, error: "measurements must be an array" };
+  if (b.measurements.length === 0) return { ok: false, error: "measurements must not be empty" };
+  if (b.measurements.length > MAX_MEASUREMENTS_PER_BATCH) {
+    return { ok: false, error: `at most ${MAX_MEASUREMENTS_PER_BATCH} measurements per batch` };
+  }
+
+  for (const [index, raw] of b.measurements.entries()) {
+    const error = validateMeasurement(raw);
+    if (error) return { ok: false, error: `measurements[${index}]: ${error}` };
+  }
+  return { ok: true, batch: b as unknown as { session_id: string; measurements: LlmCallMeasurement[] } };
+}
+
+/** Returns a reason string when invalid, or null when acceptable. */
+export function validateMeasurement(raw: unknown): string | null {
+  if (!raw || typeof raw !== "object") return "must be an object";
+  const m = raw as Record<string, unknown>;
+
+  if (!isNonEmptyString(m.call_id)) return "call_id is required";
+  if (!isNonEmptyString(m.prompt_id)) return "prompt_id is required";
+  // Optional: an older box sends nothing, and that must keep working. Present it
+  // must be a string that FITS the column (VARCHAR(64)) — a longer value would be
+  // silently truncated by MySQL and quietly correlate to the wrong request, or in
+  // strict mode reject the row. `null` is the explicit "no request", and is
+  // accepted; an empty string is not, since it is neither an id nor an absence.
+  for (const field of ["root_request_id", "parent_call_id"] as const) {
+    const value = m[field];
+    if (value === undefined || value === null) continue;
+    if (!isNonEmptyString(value)) return `${field} must be a non-empty string or null`;
+    if (value.length > MAX_CORRELATION_ID_LENGTH) {
+      return `${field} exceeds ${MAX_CORRELATION_ID_LENGTH} characters`;
+    }
+  }
+  if (m.kind !== "agent" && m.kind !== "aux") return "kind must be agent or aux";
+  // Absent is tolerated for an older box and becomes `unattributed` at the
+  // write, which is visible. A PRESENT but unknown value is refused rather
+  // than stored: an unrecognised spelling would sit in the table splitting the
+  // aggregate it belongs to, and nothing downstream would report it.
+  if (m.workload !== undefined && !isLlmWorkload(m.workload)) {
+    return `workload is not a known value (expected one of: ${LLM_WORKLOADS.join(", ")})`;
+  }
+  if (!isCount(m.round)) return "round must be a non-negative integer";
+  if (!isCount(m.attempt)) return "attempt must be a non-negative integer";
+  if (!isCount(m.network_attempts)) return "network_attempts must be a non-negative integer";
+  if (typeof m.provider !== "string") return "provider must be a string";
+  if (typeof m.model_id !== "string") return "model_id must be a string";
+  if (typeof m.api_type !== "string") return "api_type must be a string";
+
+  if (!USAGE_STATUSES.includes(m.usage_status as UsageStatus)) return "usage_status is not a known value";
+  if (!USAGE_SOURCES.includes(m.usage_source as UsageSource)) return "usage_source is not a known value";
+  if (!Array.isArray(m.reported_fields) || m.reported_fields.some((f) => !USAGE_FIELDS.includes(f as UsageField))) {
+    return "reported_fields contains an unknown field";
+  }
+
+  for (const field of [
+    "input_tokens_total", "output_tokens_total", "reasoning_tokens",
+    "cache_read_tokens", "cache_write_tokens", "payload_bytes", "payload_tokens_estimated",
+  ]) {
+    if (!isTokenValue(m[field])) return `${field} must be a non-negative number or null`;
+  }
+
+  if (!isNonEmptyString(m.request_at)) return "request_at is required";
+  if (!isNonEmptyString(m.response_end_at)) return "response_end_at is required";
+  if (m.since_prev_ms !== null && !isTokenValue(m.since_prev_ms)) return "since_prev_ms must be a number or null";
+  if (m.cost_micros !== null && m.cost_micros !== undefined) return "cost_micros must be null (unpriced)";
+  if (!m.request_snapshot || typeof m.request_snapshot !== "object") return "request_snapshot is required";
+  return validateUsageCoherence(m);
+}
+
+/**
+ * Reject combinations that are individually well-typed but cannot all be true.
+ *
+ * Type checks alone let a skewed sender file the one record this design exists
+ * to prevent: `source: provider` + `status: reported` + no reported fields + all
+ * zeros. `hasTrustworthyUsage` would accept it, and a dashboard would show a
+ * free call. Version skew during a rollout is exactly when that gets written, so
+ * the receiver has to refuse it rather than trust the producer's discipline.
+ */
+function validateUsageCoherence(m: Record<string, unknown>): string | null {
+  const fields = m.reported_fields as UsageField[];
+  const source = m.usage_source as UsageSource;
+  const status = m.usage_status as UsageStatus;
+
+  // Claiming the provider reported, while naming nothing it reported.
+  if (source === "provider" && fields.length === 0) {
+    return "usage_source=provider requires at least one reported field";
+  }
+  // `reported`/`partial` assert a provider answer; the other sources are by
+  // definition the absence of one.
+  if ((status === "reported" || status === "partial") && source !== "provider") {
+    return `usage_status=${status} requires usage_source=provider`;
+  }
+  // NOTE: values WITHOUT reported_fields are legitimate and must be accepted.
+  // That is exactly what the observer produces when a stream broke part-way: it
+  // keeps the figures it managed to read as EVIDENCE while marking the read
+  // untrustworthy (`unknown`). Rejecting it made the receiver refuse the whole
+  // batch — taking the healthy records alongside it — over a row the producer
+  // was right to send. Only `provider` may not name nothing (checked above).
+  //
+  // A field named as reported must still carry a value: there the claim and the
+  // data contradict each other outright.
+  for (const [field, column] of FIELD_COLUMNS) {
+    if (fields.includes(field) && (m[column] === null || m[column] === undefined)) {
+      return `${field} is in reported_fields but ${column} is null`;
+    }
+  }
+  // The evidence exception is for UNTRUSTWORTHY reads only. On a record that
+  // aggregation will bank (`provider`), or one asserting the provider stayed
+  // silent (`sdk_default`), every value must be one the provider actually named
+  // — otherwise `partial` + `reported_fields: [input]` could smuggle in a
+  // `cache_read: 0` nobody reported, and `hasTrustworthyUsage` would accept it.
+  if (source === "provider" || source === "sdk_default") {
+    for (const [field, column] of FIELD_COLUMNS) {
+      if (!fields.includes(field) && m[column] !== null && m[column] !== undefined) {
+        return `${column} is present but ${field} is not in reported_fields`;
+      }
+    }
+  }
+  // Validate the status against the SAME derivation the producer used, for all
+  // four values rather than just `reported`. Checking only the complete case
+  // still let `provider + [input]` be filed as `missing`, and an unknown-source
+  // evidence row be filed as `missing` — both of which assert "the provider
+  // reported nothing" about a call where it demonstrably did.
+  //
+  // The one exception is the evidence row itself: an unreadable stream is
+  // `unknown` by construction, and the derivation agrees, so it needs no
+  // special case — but a row claiming `unknown` while naming fields from a
+  // provider read would be caught here.
+  const derived = resolveUsageStatus(m.api_type as string, fields, source);
+  if (derived !== status) {
+    return `usage_status=${status} contradicts the ${String(m.api_type)} contract for source=${source} ` +
+      `and fields=[${fields.join(",")}] (expected ${derived})`;
+  }
+  return null;
+}
+
+/** Reported-field name → the column carrying its value. */
+const FIELD_COLUMNS: ReadonlyArray<readonly [UsageField, string]> = [
+  ["input", "input_tokens_total"],
+  ["output", "output_tokens_total"],
+  ["reasoning", "reasoning_tokens"],
+  ["cache_read", "cache_read_tokens"],
+  ["cache_write", "cache_write_tokens"],
+];

--- a/src/shared/metrics.ts
+++ b/src/shared/metrics.ts
@@ -107,6 +107,29 @@ const sessionsActive = new Gauge({
   registers: [metricsRegistry],
 });
 
+/**
+ * UPPER BOUND on measurements that failed to reach the Runtime.
+ *
+ * An upper bound, not a count of losses: the box gives up on a batch when its
+ * budget runs out, but an abandoned request can still land afterwards — and
+ * because the receiver is idempotent on `call_id`, it lands correctly. So this
+ * counts "we stopped waiting", which is a superset of "it was lost".
+ *
+ * Worth exporting anyway: without it an under-collected day is indistinguishable
+ * from a cheap one, and a coverage report built on `llm_calls` alone would state
+ * a total it cannot vouch for. Read it as "up to N measurements may be missing".
+ */
+const meteringUnconfirmedTotal = new Counter({
+  name: "siclaw_metering_unconfirmed_total",
+  help: "Upper bound on LLM-call measurements not confirmed delivered (queue overflow, exhausted retries, close deadline); an abandoned send may still have landed",
+  registers: [metricsRegistry],
+});
+
+/** Record measurements whose delivery was never confirmed. */
+export function recordMeteringLoss(count: number): void {
+  if (count > 0) meteringUnconfirmedTotal.inc(count);
+}
+
 const toolCallsTotal = new Counter({
   name: "siclaw_tool_calls_total",
   help: "Total tool invocations",

--- a/src/shared/session-rehydrate.test.ts
+++ b/src/shared/session-rehydrate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { REHYDRATED_MODEL, toRehydratedMessages, type RehydrateRow } from "./session-rehydrate.js";
+import { REHYDRATED_MODEL, isRehydratedUsage, toRehydratedMessages, type RehydrateRow } from "./session-rehydrate.js";
 
 const at = "2026-09-05T01:02:03.000Z";
 const row = (r: Partial<RehydrateRow> & { role: string }): RehydrateRow => ({ content: "", createdAt: at, ...r });
@@ -107,5 +107,34 @@ describe("toRehydratedMessages", () => {
     expect(out[0].usage).not.toBe(out[1].usage);
     expect(out[0].usage?.cost).not.toBe(out[1].usage?.cost);
     expect(out[0].usage).toMatchObject({ totalTokens: 0, cost: { total: 0 } });
+  });
+});
+
+describe("usage provenance marking", () => {
+  it("marks a rebuilt tool call so its zeros are never read as a report", () => {
+    const [assistant] = toRehydratedMessages([
+      row({ role: "tool", content: "ok", toolName: "bash", toolInput: "{}", outcome: "success" }),
+    ]);
+    expect(isRehydratedUsage(assistant)).toBe(true);
+  });
+
+  it("marks a rebuilt assistant even when api/provider were restored to the originals", () => {
+    // The case api/provider cannot detect: restored values make the message look
+    // native, so this mark is the only surviving evidence of a rebuild.
+    const [assistant] = toRehydratedMessages([
+      row({
+        role: "assistant",
+        content: "hello",
+        metadata: { assistant_item: { api: "openai-responses", provider: "example-gateway", model: "gpt-5" } },
+      }),
+    ]);
+    expect(assistant).toMatchObject({ api: "openai-responses", model: "gpt-5" });
+    expect(isRehydratedUsage(assistant)).toBe(true);
+  });
+
+  it("does not mark a message it did not synthesise", () => {
+    expect(isRehydratedUsage({ role: "assistant", usage: { input: 0 } })).toBe(false);
+    expect(isRehydratedUsage(null)).toBe(false);
+    expect(isRehydratedUsage("assistant")).toBe(false);
   });
 });

--- a/src/shared/session-rehydrate.ts
+++ b/src/shared/session-rehydrate.ts
@@ -71,6 +71,8 @@ export type RehydratedMessage =
       };
       stopReason: "stop" | "toolUse";
       timestamp: number;
+      /** Present only on messages this module synthesised — see REHYDRATED_USAGE_MARK. */
+      siclaw_usage_provenance?: typeof REHYDRATED_PROVENANCE;
     }
   | {
       role: "toolResult";
@@ -85,6 +87,34 @@ const ZERO_USAGE = {
   input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
+
+/**
+ * Marks a message whose usage numbers are reconstruction placeholders, not a
+ * provider's report. Persisted with the message so a later reader can still
+ * tell — the zeros themselves are indistinguishable from a genuine zero, and
+ * from the SDK's pre-request initialisation.
+ *
+ * `api`/`provider` cannot carry this: the assistant-text branch restores the
+ * ORIGINAL values from `assistant_item` when they were recorded, so a rebuilt
+ * message can look native. This field is never overwritten.
+ */
+export const REHYDRATED_USAGE_MARK = "siclaw_usage_provenance" as const;
+
+/** The mark's value on every message this module synthesises. */
+export const REHYDRATED_PROVENANCE = "rehydrated" as const;
+
+/** True when this message's usage is a rebuild placeholder rather than a report. */
+export function isRehydratedUsage(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  return (message as Record<string, unknown>)[REHYDRATED_USAGE_MARK] === REHYDRATED_PROVENANCE;
+}
+
+type RehydratedUsage = Extract<RehydratedMessage, { role: "assistant" }>["usage"];
+
+/** Fresh placeholder object per message — callers must not share one instance. */
+function rehydratedUsage(): RehydratedUsage {
+  return { ...ZERO_USAGE, cost: { ...ZERO_USAGE.cost } };
+}
 
 function tsOf(row: RehydrateRow): number {
   const raw = row.createdAt;
@@ -145,7 +175,8 @@ export function toRehydratedMessages(
         role: "assistant",
         content: [{ type: "toolCall", id: callId, name, arguments: parseArgs(row.toolInput) }],
         api: "rehydrated", provider: "rehydrated", model: REHYDRATED_MODEL,
-        usage: { ...ZERO_USAGE, cost: { ...ZERO_USAGE.cost } },
+        usage: rehydratedUsage(),
+        [REHYDRATED_USAGE_MARK]: REHYDRATED_PROVENANCE,
         stopReason: "toolUse",
         timestamp,
       });
@@ -169,7 +200,10 @@ export function toRehydratedMessages(
       role: "assistant",
       content: [{ type: "text", text: row.content, ...(typeof item?.textSignature === "string" ? { textSignature: item.textSignature } : {}) }],
       api: source("api", "rehydrated"), provider: source("provider", "rehydrated"), model: source("model", REHYDRATED_MODEL),
-      usage: { ...ZERO_USAGE, cost: { ...ZERO_USAGE.cost } },
+      usage: rehydratedUsage(),
+      // Marked even though api/provider may have been restored to their originals —
+      // that restoration is exactly what makes a rebuild otherwise invisible here.
+      [REHYDRATED_USAGE_MARK]: REHYDRATED_PROVENANCE,
       stopReason: "stop",
       timestamp,
     });


### PR DESCRIPTION
## Why

Billing showed an unexplained `cache_write` share, and nothing in the product could answer where the tokens went. Message metadata never covered sub-agent calls, and the one usage figure Portal stored was never aggregated.

## The hard part is not summing tokens

It is keeping **absence** honest. Four different code paths produce an all-zero usage object and they are indistinguishable once written:

1. The SDK zero-fills `usage` **before the request leaves**, so at the streamFn boundary "reported 0" and "never reported" are the same value.
2. A rehydrated transcript fills `ZERO_USAGE` — and not only on handoff: eviction and a pod restart rebuild from the control plane too, so a per-session verdict is always wrong.
3. A derived figure gets `Math.max(0, …)` clamped.
4. A provider genuinely reports zero. `cache_read = 0` is an ordinary answer.

So provenance is **recorded at the point of production and never inferred**. Usage is read from the raw response at the HTTP boundary via `options.fetch` (a public SDK input; the response body is tee'd and the original bytes pass through untouched), and `null` and `0` stay different values end to end. A derived figure that comes out impossible — reasoning > output, cache > input — is reported as `null` plus an inconsistency record, never clamped: the clamp is exactly how the upstream adapter loses the same evidence.

## Correlation follows the same rule

`root_request_id` and `parent_call_id` are carried by the **producer**, because only the box knows which turn a call served and which of its calls spawned a child. Deriving either from session lineage collapses every request in a conversation into one id.

- `turnId` is reused rather than minting a second identifier — it already names one accepted prompt execution and survives model-routing retries.
- The **channel and scheduled entries now mint one at the entry**. They called `AgentBoxClient` directly and carried no id at all, so every call they made was uncorrelated. It cannot be minted inside the client: a turn id names a turn, while the client runs once per *attempt*, and a busy-retry would split one message into two correlations.
- `parent_call_id` is the agent call that just sealed — the round whose tools are executing. Aux calls are skipped: a summarisation issues no tools, so naming it would attribute a spawn to a call that could not have made it.

## Reading it back

Portal aggregates per provider × model and per user. Two rules carry the collection work through to the screen:

- **Every sum ships with the count of calls that reported it.** `SUM` skips NULLs, so a total over half the calls looks exactly like a complete one.
- **Ranking is server-side**, because the result is capped: the top 50 by total tokens is not the set holding the top 50 by cache write.

Untrustworthy rows (`sdk_default`, `rehydrated`, `unknown`) are excluded from the sums and counted separately, so the page states its coverage instead of implying completeness.

## Deploy order

Reverse of the data flow — receiver first: control plane (DDL + persist handler) → Runtime (route, validation, authorization) → AgentBox. Each stage degrades rather than breaking: a new box against an old Runtime retries, drops, and increments `siclaw_metering_unconfirmed_total`, and no conversation is affected. `imagePullPolicy: Always` only pulls on pod CREATE, so verifying against an existing session proves nothing.

Full analysis and contracts: `docs/design/2026-09-12-token-cost-analysis.zh-CN.md`.

## Testing

373 files / 7596 tests passing, `tsc --noEmit` clean. portal-web: 32 files / 280 tests, `tsc` clean.

Not yet verified end to end against a real box → Runtime; `cost_micros` stays `null` until unit prices are confirmed, because a wrong cost is worse than an absent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
